### PR TITLE
running tests without integration tests if needed

### DIFF
--- a/gateway/gateway_test.go
+++ b/gateway/gateway_test.go
@@ -1,0 +1,5 @@
+package gateway_test
+
+import "flag"
+
+var integrationTest = flag.Bool("integration-test", true, "Run the integration tests")

--- a/gateway/playback_test.go
+++ b/gateway/playback_test.go
@@ -33,6 +33,9 @@ const (
 )
 
 func TestGatewayRecording(t *testing.T) {
+	if !*integrationTest {
+		t.Skip("Not running integration tests")
+	}
 	testData := []string{
 		"s3://lakefs-recordings/presto.zip",
 		"s3://lakefs-recordings/aws.zip",


### PR DESCRIPTION
go test -integration-test=false will skip running recording the same can apply to other integration tests in our project