### PR TITLE
Add type to URI parser state

### DIFF
--- a/uri/parser.go
+++ b/uri/parser.go
@@ -5,6 +5,8 @@ import (
 	"strings"
 )
 
+type state int
+
 const (
 	ProtocolSeparator = "://"
 	LakeFSProtocol    = "lakefs"
@@ -12,7 +14,7 @@ const (
 	RefSeparator  = '@'
 	PathSeparator = '/'
 
-	stateInRepo = iota
+	stateInRepo state = iota
 	stateInRef
 	stateInPath
 )


### PR DESCRIPTION
Now they're not assignable to/from `int`s, which is safer.