### PR TITLE
Fix JSON parsing in "auth policies create"

### DIFF
--- a/cmd/lakectl/cmd/auth.go
+++ b/cmd/lakectl/cmd/auth.go
@@ -532,21 +532,21 @@ var authPoliciesCreate = &cobra.Command{
 			}
 		}
 
-		var policy *models.Policy
-		err = json.NewDecoder(fp).Decode(policy)
+		var policy models.Policy
+		err = json.NewDecoder(fp).Decode(&policy)
 		if err != nil {
 			DieFmt("could not parse policy document: %v", err)
 		}
 
-		policy, err = clt.CreatePolicy(context.Background(), policy)
+		createdPolicy, err := clt.CreatePolicy(context.Background(), &policy)
 		if err != nil {
 			DieErr(err)
 		}
 
-		Write(policyCreatedTemplate, policy)
+		Write(policyCreatedTemplate, createdPolicy)
 
 		rows := make([][]interface{}, 0)
-		for i, statement := range policy.Statement {
+		for i, statement := range createdPolicy.Statement {
 			ts := time.Unix(policy.CreationDate, 0).String()
 			rows = append(rows, []interface{}{policy.ID, ts, i, statement.Resource, statement.Effect, strings.Join(statement.Action, ", ")})
 		}


### PR DESCRIPTION
Tested by creating a policy (before the fix it would segfault on a nil
pointer access).

Note that there are many pointers in the output table, and it is not
clear to this user whether that is understandable.

```
ariels@ariels:~/Dev/lakeFS$ echo '{"id": "foo", "statement": [{"action": ["auth:*"], "effect": "Allow", "resource": "arn:::::"}]}' | ./lakectl auth policies create --policy-document -
Policy created successfully.
ID: 0xc00043c020
Creation Date: 2020-07-08 12:16:26 +0300 IDT
Statements:

+--------------+-------------------------------+-------------+--------------+--------------+---------+
| POLICY ID    | CREATION DATE                 | STATEMENT # | RESOURCE     | EFFECT       | ACTIONS |
+--------------+-------------------------------+-------------+--------------+--------------+---------+
| 0xc0004d2590 | 1970-01-01 02:00:00 +0200 IST |           0 | 0xc00043c040 | 0xc00043c030 | auth:*  |
+--------------+-------------------------------+-------------+--------------+--------------+---------+
```