### PR TITLE
Correctly validate branchnames, allow short names

### DIFF
--- a/catalog/validate.go
+++ b/catalog/validate.go
@@ -9,7 +9,7 @@ import (
 var (
 	ErrInvalidValue = errors.New("invalid value")
 
-	validBranchNameRegexp     = regexp.MustCompile(`^[a-zA-Z0-9\\-]{2,}$`)
+	validBranchNameRegexp     = regexp.MustCompile(`^\w[-\w]*$`)
 	validRepositoryNameRegexp = regexp.MustCompile(`^[a-z0-9][a-z0-9-]{2,62}$`)
 )
 

--- a/catalog/validate_test.go
+++ b/catalog/validate_test.go
@@ -68,9 +68,13 @@ func TestIsValidBranchName(t *testing.T) {
 	}{
 		{name: "simple", input: "branch", want: true},
 		{name: "empty", input: "", want: false},
-		{name: "short", input: "a", want: false},
+		{name: "short", input: "a", want: true},
 		{name: "space", input: "got space", want: false},
 		{name: "special", input: "/branch", want: false},
+		{name: "dash", input: "a-branch", want: true},
+		{name: "leading-dash", input: "-branch", want: false},
+		{name: "underscores", input: "__", want: true},
+		{name: "backslash", input: "a\\branch", want: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
- Allow short (nonempty) branch names.  They do *not* have special
  expression in S3, not reason to treat them specially here.
- Disallow backslashes in branch names.  Does not seem intentional
  in existing code.
- Disallow leading dashes (`-`) in branch names.  This mirrors git
  (probably done there to avoid confusion with CLI flags, of which
  it has many)
- Allow underscored (`_`) in branch names.  `c_people_like_snakes`
  and so do Pythonista.