### PR TITLE
Make entries.is_expired required -- NOT NULL

### DIFF
--- a/ddl/000001_initial.up.sql
+++ b/ddl/000001_initial.up.sql
@@ -148,7 +148,7 @@ CREATE TABLE entries (
     min_commit bigint DEFAULT 0 NOT NULL,
     max_commit bigint DEFAULT max_commit_id() NOT NULL,
     -- If set, entry has expired.  Requests to retrieve may return "410 Gone".
-    is_expired BOOLEAN DEFAULT false
+    is_expired BOOLEAN DEFAULT false NOT NULL
 );
 ALTER TABLE ONLY entries ALTER COLUMN path SET STATISTICS 10000;
 


### PR DESCRIPTION
Its default value is FALSE, which is exactly enough.  See explanation
[here](https://treeverseio.slack.com/archives/CRYTTLV7D/p1595851999004700).