### PR TITLE
Add logging before connecting to the DB

### DIFF
--- a/db/connect.go
+++ b/db/connect.go
@@ -9,18 +9,21 @@ import (
 )
 
 func ConnectDB(driver string, uri string) (Database, error) {
+	log := logging.Default().WithFields(logging.Fields{
+		"driver": driver,
+		"uri":    uri,
+	})
+
+	log.Info("connecting to the DB")
 	conn, err := sqlx.Connect(driver, uri)
 	if err != nil {
-		return nil, fmt.Errorf("could not open database: %w", err)
+		return nil, fmt.Errorf("could not open DB: %w", err)
 	}
 
 	conn.SetMaxOpenConns(25)
 	conn.SetMaxIdleConns(25)
 	conn.SetConnMaxLifetime(5 * time.Minute)
 
-	logging.Default().WithFields(logging.Fields{
-		"driver": driver,
-		"uri":    uri,
-	}).Info("initialized DB connection")
+	log.Info("initialized DB connection")
 	return NewSqlxDatabase(conn), nil
 }


### PR DESCRIPTION
Connection might timeout after ~30 seconds without indication of the long operation.