### PR TITLE
git leaks

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -16,7 +16,7 @@ jobs:
         run: |
           make checks-validator
       - name: gitLeaks
-        uses: treeverse/gitleaks-action@v5.0.1
+        uses: zricethezav/gitleaks-action@v1.1.2
 
   test:
     name: Run Test Suite


### PR DESCRIPTION
was considering using our own docker instance - it will require us to republish the docker under a different github action.  I am not sure it will be good as the github marketplace already holds this one.
we are opening the source, the action is based on open source too. when the build fail because of a key it will require us to replace the key. so I'm not worried about using the public github action of gitleaks.