### PR TITLE
check pgx error wrapper support

### DIFF
--- a/db/pg.go
+++ b/db/pg.go
@@ -1,6 +1,8 @@
 package db
 
 import (
+	"errors"
+
 	"github.com/jackc/pgconn"
 	"github.com/jackc/pgerrcode"
 )
@@ -14,7 +16,8 @@ func IsUniqueViolation(err error) bool {
 }
 
 func isPGCode(err error, code string) bool {
-	if pgErr, ok := err.(*pgconn.PgError); ok {
+	var pgErr *pgconn.PgError
+	if err != nil && errors.As(err, &pgErr) {
 		return pgErr.Code == code
 	}
 	return false


### PR DESCRIPTION
This one should fix the case where in our transaction we got a serialization error and returned a wrapped error. The retry mechanism should now identify and extract the relevant information. 