### PR TITLE
Remove DedupFoundCallback type

### DIFF
--- a/catalog/cataloger.go
+++ b/catalog/cataloger.go
@@ -143,8 +143,6 @@ type Cataloger interface {
 	io.Closer
 }
 
-type DedupFoundCallback func(repository string, dedupID string, previousAddress, newAddress string)
-
 type dedupRequest struct {
 	Repository       string
 	StorageNamespace string


### PR DESCRIPTION
We've been using channels for a while, now.