### PR TITLE
Get access key ID from AWS session

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -155,14 +155,26 @@ func (c *Config) GetAwsConfig() *aws.Config {
 	return cfg
 }
 
+func GetAwsAccessKeyID(awsConfig *aws.Config) (string, error) {
+	awsCredentials, err := awsConfig.Credentials.Get()
+	if err != nil {
+		return "", fmt.Errorf("access AWS credentials: %w", err)
+	}
+	return awsCredentials.AccessKeyID, nil
+}
+
 func GetAccount(awsConfig *aws.Config) (string, error) {
+	accessKeyID, err := GetAwsAccessKeyID(awsConfig)
+	if err != nil {
+		return "", err
+	}
 	sess, err := session.NewSession(awsConfig)
 	if err != nil {
 		return "", fmt.Errorf("get AWS session: %w", err)
 	}
 	sess.ClientConfig(sts.ServiceName)
 	svc := sts.New(sess)
-	accessKeyID := viper.GetString("blockstore.s3.credentials.access_key_id")
+
 	account, err := svc.GetAccessKeyInfo(&sts.GetAccessKeyInfoInput{
 		AccessKeyId: aws.String(accessKeyID),
 	})


### PR DESCRIPTION
This is potentially unavailable -- but then we cannot expire anyway.
When it is available it allows expiry to use all supported AWS
identification methods -- not merely static in config YAML file.