### PR TITLE
Remove gender from familial nouns

### DIFF
--- a/catalog/cataloger_create_branch.go
+++ b/catalog/cataloger_create_branch.go
@@ -61,10 +61,10 @@ func (c *cataloger) CreateBranch(ctx context.Context, repository, branch string,
 		commitMsg := fmt.Sprintf(createBranchCommitMessageFormat, branch, sourceBranch)
 		err = tx.Get(&insertReturns, `INSERT INTO catalog_commits (branch_id,commit_id,previous_commit_id,committer,message,
 			creation_date,merge_source_branch,merge_type,lineage_commits,merge_source_commit)
-			VALUES ($1,nextval('catalog_commit_id_seq'),0,$2,$3,$4,$5,'from_father',
+			VALUES ($1,nextval('catalog_commit_id_seq'),0,$2,$3,$4,$5,'from_parent',
 				(select (select max(commit_id) from catalog_commits where branch_id=$5)|| 
 					(select distinct on (branch_id) lineage_commits from catalog_commits 
-						where branch_id=$5 and merge_type='from_father' order by branch_id,commit_id desc))
+						where branch_id=$5 and merge_type='from_parent' order by branch_id,commit_id desc))
 						,(select max(commit_id) from catalog_commits where branch_id=$5 ))
 			RETURNING commit_id,merge_source_commit`,
 			branchID, CatalogerCommitter, commitMsg, creationDate, sourceBranchID)

--- a/catalog/cataloger_diff.go
+++ b/catalog/cataloger_diff.go
@@ -47,10 +47,10 @@ func (c *cataloger) doDiff(tx db.Tx, leftID, rightID int64) (Differences, error)
 
 func (c *cataloger) doDiffByRelation(tx db.Tx, relation RelationType, leftID, rightID int64) (Differences, error) {
 	switch relation {
-	case RelationTypeFromFather:
-		return c.diffFromFather(tx, leftID, rightID)
-	case RelationTypeFromSon:
-		return c.diffFromSon(tx, leftID, rightID)
+	case RelationTypeFromParent:
+		return c.diffFromParent(tx, leftID, rightID)
+	case RelationTypeFromChild:
+		return c.diffFromChild(tx, leftID, rightID)
 	case RelationTypeNotDirect:
 		return c.diffNonDirect(tx, leftID, rightID)
 	default:
@@ -63,39 +63,39 @@ func (c *cataloger) doDiffByRelation(tx db.Tx, relation RelationType, leftID, ri
 	}
 }
 
-func (c *cataloger) diffFromFather(tx db.Tx, fatherID, sonID int64) (Differences, error) {
-	// get the last son commit number of the last father merge
+func (c *cataloger) diffFromParent(tx db.Tx, parentID, childID int64) (Differences, error) {
+	// get the last child commit number of the last parent merge
 	// if there is none - then it is  the first merge
-	var maxSonMerge CommitID
-	sonLineage, err := getLineage(tx, sonID, UncommittedID)
+	var maxChildMerge CommitID
+	childLineage, err := getLineage(tx, childID, UncommittedID)
 	if err != nil {
-		return nil, fmt.Errorf("son lineage failed: %w", err)
+		return nil, fmt.Errorf("child lineage failed: %w", err)
 	}
-	fatherLineage, err := getLineage(tx, fatherID, CommittedID)
+	parentLineage, err := getLineage(tx, parentID, CommittedID)
 	if err != nil {
-		return nil, fmt.Errorf("father lineage failed: %w", err)
+		return nil, fmt.Errorf("parent lineage failed: %w", err)
 	}
-	maxSonQuery, args, err := sq.Select("MAX(commit_id) as max_son_commit").
+	maxChildQuery, args, err := sq.Select("MAX(commit_id) as max_child_commit").
 		From("catalog_commits").
-		Where("branch_id = ? AND merge_type = 'from_father'", sonID).
+		Where("branch_id = ? AND merge_type = 'from_parent'", childID).
 		PlaceholderFormat(sq.Dollar).
 		ToSql()
 	if err != nil {
-		return nil, fmt.Errorf("get son last commit sql: %w", err)
+		return nil, fmt.Errorf("get child last commit sql: %w", err)
 	}
-	err = tx.Get(&maxSonMerge, maxSonQuery, args...)
+	err = tx.Get(&maxChildMerge, maxChildQuery, args...)
 	if err != nil {
-		return nil, fmt.Errorf("get son last commit failed: %w", err)
+		return nil, fmt.Errorf("get child last commit failed: %w", err)
 	}
-	diffFromFatherSQL, args, err := sqDiffFromFatherV(fatherID, sonID, maxSonMerge, fatherLineage, sonLineage).
+	diffFromParentSQL, args, err := sqDiffFromParentV(parentID, childID, maxChildMerge, parentLineage, childLineage).
 		Prefix(`CREATE TEMP TABLE ` + diffResultsTableName + " ON COMMIT DROP AS ").
 		PlaceholderFormat(sq.Dollar).
 		ToSql()
 	if err != nil {
-		return nil, fmt.Errorf("diff from father sql: %w", err)
+		return nil, fmt.Errorf("diff from parent sql: %w", err)
 	}
-	if _, err := tx.Exec(diffFromFatherSQL, args...); err != nil {
-		return nil, fmt.Errorf("select diff from father: %w", err)
+	if _, err := tx.Exec(diffFromParentSQL, args...); err != nil {
+		return nil, fmt.Errorf("select diff from parent: %w", err)
 	}
 	return diffReadDifferences(tx)
 }
@@ -108,20 +108,20 @@ func diffReadDifferences(tx db.Tx) (Differences, error) {
 	return result, nil
 }
 
-func (c *cataloger) diffFromSon(tx db.Tx, sonID, fatherID int64) (Differences, error) {
+func (c *cataloger) diffFromChild(tx db.Tx, childID, parentID int64) (Differences, error) {
 	// read last merge commit numbers from commit table
-	// if it is the first son-to-father commit, than those commit numbers are calculated as follows:
-	// the son is 0, as any change in the some was never merged to the father.
-	// the father is lhe effective commit number of the first lineage record of the son that points to the father
-	// it is possible that the son the have already done from_father merge. so we have to take the minimal effective commit
+	// if it is the first child-to-parent commit, than those commit numbers are calculated as follows:
+	// the child is 0, as any change in the child was never merged to the parent.
+	// the parent is the effective commit number of the first lineage record of the child that points to the parent
+	// it is possible that the child the have already done from_parent merge. so we have to take the minimal effective commit
 	effectiveCommits := struct {
-		FatherEffectiveCommit CommitID `db:"father_effective_commit"` // last commit father synchronized with son. If non - it is the commit where the son was branched
-		SonEffectiveCommit    CommitID `db:"son_effective_commit"`    // last commit son synchronized to father. if never - than it is 1 (everything in the son is a change)
+		ParentEffectiveCommit CommitID `db:"parent_effective_commit"` // last commit parent synchronized with child. If non - it is the commit where the child was branched
+		ChildEffectiveCommit  CommitID `db:"child_effective_commit"`  // last commit child synchronized to parent. if never - than it is 1 (everything in the child is a change)
 	}{}
 
-	effectiveCommitsQuery, args, err := sq.Select(`commit_id AS father_effective_commit`, `merge_source_commit AS son_effective_commit`).
+	effectiveCommitsQuery, args, err := sq.Select(`commit_id AS parent_effective_commit`, `merge_source_commit AS child_effective_commit`).
 		From("catalog_commits").
-		Where("branch_id = ? AND merge_source_branch = ? AND merge_type = 'from_son'", fatherID, sonID).
+		Where("branch_id = ? AND merge_source_branch = ? AND merge_type = 'from_child'", parentID, childID).
 		OrderBy(`commit_id DESC`).
 		Limit(1).
 		PlaceholderFormat(sq.Dollar).
@@ -135,42 +135,42 @@ func (c *cataloger) diffFromSon(tx db.Tx, sonID, fatherID int64) (Differences, e
 		return nil, fmt.Errorf("select effective commit: %w", err)
 	}
 	if effectiveCommitsNotFound {
-		effectiveCommits.SonEffectiveCommit = 1 // we need all commits from the son. so any small number will do
-		fatherEffectiveQuery, args, err := psql.Select("commit_id as father_effective_commit").
+		effectiveCommits.ChildEffectiveCommit = 1 // we need all commits from the child. so any small number will do
+		parentEffectiveQuery, args, err := psql.Select("commit_id as parent_effective_commit").
 			From("catalog_commits").
-			Where("branch_id = ? AND merge_source_branch = ?", sonID, fatherID).
+			Where("branch_id = ? AND merge_source_branch = ?", childID, parentID).
 			OrderBy("commit_id").
 			Limit(1).
 			ToSql()
 		if err != nil {
-			return nil, fmt.Errorf("father effective commit sql: %w", err)
+			return nil, fmt.Errorf("parent effective commit sql: %w", err)
 		}
-		err = tx.Get(&effectiveCommits.FatherEffectiveCommit, fatherEffectiveQuery, args...)
+		err = tx.Get(&effectiveCommits.ParentEffectiveCommit, parentEffectiveQuery, args...)
 		if err != nil {
-			return nil, fmt.Errorf("select father effective commit: %w", err)
+			return nil, fmt.Errorf("select parent effective commit: %w", err)
 		}
 	}
 
-	fatherLineage, err := getLineage(tx, fatherID, UncommittedID)
+	parentLineage, err := getLineage(tx, parentID, UncommittedID)
 	if err != nil {
-		return nil, fmt.Errorf("father lineage failed: %w", err)
+		return nil, fmt.Errorf("parent lineage failed: %w", err)
 	}
-	sonLineage, err := getLineage(tx, sonID, CommittedID)
+	childLineage, err := getLineage(tx, childID, CommittedID)
 	if err != nil {
-		return nil, fmt.Errorf("son lineage failed: %w", err)
+		return nil, fmt.Errorf("child lineage failed: %w", err)
 	}
 
-	sonLineageValues := getLineageAsValues(sonLineage, sonID)
-	mainDiffFromSon := sqDiffFromSonV(fatherID, sonID, effectiveCommits.FatherEffectiveCommit, effectiveCommits.SonEffectiveCommit, fatherLineage, sonLineageValues)
-	diffFromSonSQL, args, err := mainDiffFromSon.
+	childLineageValues := getLineageAsValues(childLineage, childID)
+	mainDiffFromChild := sqDiffFromChildV(parentID, childID, effectiveCommits.ParentEffectiveCommit, effectiveCommits.ChildEffectiveCommit, parentLineage, childLineageValues)
+	diffFromChildSQL, args, err := mainDiffFromChild.
 		Prefix("CREATE TEMP TABLE " + diffResultsTableName + " ON COMMIT DROP AS").
 		PlaceholderFormat(sq.Dollar).
 		ToSql()
 	if err != nil {
-		return nil, fmt.Errorf("diff from son sql: %w", err)
+		return nil, fmt.Errorf("diff from child sql: %w", err)
 	}
-	if _, err := tx.Exec(diffFromSonSQL, args...); err != nil {
-		return nil, fmt.Errorf("exec diff from son: %w", err)
+	if _, err := tx.Exec(diffFromChildSQL, args...); err != nil {
+		return nil, fmt.Errorf("exec diff from child: %w", err)
 	}
 	return diffReadDifferences(tx)
 }

--- a/catalog/cataloger_diff_test.go
+++ b/catalog/cataloger_diff_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/treeverse/lakefs/testutil"
 )
 
-func TestCataloger_Diff_FromSonThreeBranches(t *testing.T) {
+func TestCataloger_Diff_FromChildThreeBranches(t *testing.T) {
 	ctx := context.Background()
 	c := testCataloger(t)
 	repository := testCatalogerRepo(t, ctx, c, "repo", "master")

--- a/catalog/cataloger_list_entries.go
+++ b/catalog/cataloger_list_entries.go
@@ -129,7 +129,7 @@ func loopByLevel(tx db.Tx, prefix, after, delimiter string, limit, branchBatchSi
 		topCommitID = MaxCommitID
 	}
 
-	// list of branches ordered form son to ancestors
+	// list of branches ordered from child to ancestors
 	branchPriorityMap := make(map[int64]int, len(lineage)+1)
 	branchPriorityMap[branchID] = 0
 	for i, l := range lineage {

--- a/catalog/cataloger_merge_test.go
+++ b/catalog/cataloger_merge_test.go
@@ -10,7 +10,7 @@ import (
 	"github.com/treeverse/lakefs/testutil"
 )
 
-func TestCataloger_Merge_FromFatherNoChangesInChild(t *testing.T) {
+func TestCataloger_Merge_FromParentNoChangesInChild(t *testing.T) {
 	ctx := context.Background()
 	c := testCataloger(t)
 	repository := testCatalogerRepo(t, ctx, c, "repo", "master")
@@ -73,7 +73,7 @@ func TestCataloger_Merge_FromFatherNoChangesInChild(t *testing.T) {
 	}
 }
 
-func TestCataloger_Merge_FromFatherConflicts(t *testing.T) {
+func TestCataloger_Merge_FromParentConflicts(t *testing.T) {
 	ctx := context.Background()
 	c := testCataloger(t)
 	repository := testCatalogerRepo(t, ctx, c, "repo", "master")
@@ -132,7 +132,7 @@ func TestCataloger_Merge_FromFatherConflicts(t *testing.T) {
 	}
 }
 
-func TestCataloger_Merge_FromFatherNoChangesInFather(t *testing.T) {
+func TestCataloger_Merge_FromParentNoChangesInParent(t *testing.T) {
 	ctx := context.Background()
 	c := testCataloger(t)
 	repository := testCatalogerRepo(t, ctx, c, "repo", "master")
@@ -150,7 +150,7 @@ func TestCataloger_Merge_FromFatherNoChangesInFather(t *testing.T) {
 	}
 }
 
-func TestCataloger_Merge_FromFatherChangesInBoth(t *testing.T) {
+func TestCataloger_Merge_FromParentChangesInBoth(t *testing.T) {
 	ctx := context.Background()
 	c := testCataloger(t)
 	repository := testCatalogerRepo(t, ctx, c, "repo", "master")
@@ -216,7 +216,7 @@ func TestCataloger_Merge_FromFatherChangesInBoth(t *testing.T) {
 	})
 }
 
-func TestCataloger_Merge_FromFatherThreeBranches(t *testing.T) {
+func TestCataloger_Merge_FromParentThreeBranches(t *testing.T) {
 	ctx := context.Background()
 	c := testCataloger(t)
 	repository := testCatalogerRepo(t, ctx, c, "repo", "master")
@@ -279,7 +279,7 @@ func TestCataloger_Merge_FromFatherThreeBranches(t *testing.T) {
 	})
 }
 
-func TestCataloger_Merge_FromSonNoChanges(t *testing.T) {
+func TestCataloger_Merge_FromChildNoChanges(t *testing.T) {
 	ctx := context.Background()
 	c := testCataloger(t)
 	repository := testCatalogerRepo(t, ctx, c, "repo", "master")
@@ -305,7 +305,7 @@ func TestCataloger_Merge_FromSonNoChanges(t *testing.T) {
 	}
 }
 
-func TestCataloger_Merge_FromSonChangesOnSon(t *testing.T) {
+func TestCataloger_Merge_FromChildChangesOnChild(t *testing.T) {
 	ctx := context.Background()
 	c := testCataloger(t)
 	repository := testCatalogerRepo(t, ctx, c, "repo", "master")
@@ -333,7 +333,7 @@ func TestCataloger_Merge_FromSonChangesOnSon(t *testing.T) {
 	const overFilename = "/file2"
 	testCatalogerCreateEntry(t, ctx, c, repository, "branch1", overFilename, nil, "seed1")
 
-	// commit changes on son and merge
+	// commit changes on child and merge
 	_, err = c.Commit(ctx, repository, "branch1", "First commit to branch1", "tester", nil)
 	testutil.MustDo(t, "First commit to branch1", err)
 
@@ -362,7 +362,7 @@ func TestCataloger_Merge_FromSonChangesOnSon(t *testing.T) {
 	}
 }
 
-func TestCataloger_Merge_FromSonThreeBranches(t *testing.T) {
+func TestCataloger_Merge_FromChildThreeBranches(t *testing.T) {
 	ctx := context.Background()
 	c := testCataloger(t)
 	repository := testCatalogerRepo(t, ctx, c, "repo", "master")
@@ -461,7 +461,7 @@ func TestCataloger_Merge_FromSonThreeBranches(t *testing.T) {
 	})
 }
 
-func TestCataloger_Merge_FromSonNewDelSameEntry(t *testing.T) {
+func TestCataloger_Merge_FromChildNewDelSameEntry(t *testing.T) {
 	ctx := context.Background()
 	c := testCataloger(t)
 	repository := testCatalogerRepo(t, ctx, c, "repo", "master")
@@ -511,7 +511,7 @@ func TestCataloger_Merge_FromSonNewDelSameEntry(t *testing.T) {
 	}
 }
 
-func TestCataloger_Merge_FromSonNewEntrySameEntry(t *testing.T) {
+func TestCataloger_Merge_FromChildNewEntrySameEntry(t *testing.T) {
 	ctx := context.Background()
 	c := testCataloger(t)
 	repository := testCatalogerRepo(t, ctx, c, "repo", "master")
@@ -557,7 +557,7 @@ func TestCataloger_Merge_FromSonNewEntrySameEntry(t *testing.T) {
 	}
 }
 
-func TestCataloger_Merge_FromSonDelModifyGrandfatherFiles(t *testing.T) {
+func TestCataloger_Merge_FromChildDelModifyGrandparentFiles(t *testing.T) {
 	ctx := context.Background()
 	c := testCataloger(t)
 	repository := testCatalogerRepo(t, ctx, c, "repo", "master")
@@ -601,7 +601,7 @@ func TestCataloger_Merge_FromSonDelModifyGrandfatherFiles(t *testing.T) {
 	}
 }
 
-func TestCataloger_Merge_FromSonConflicts(t *testing.T) {
+func TestCataloger_Merge_FromChildConflicts(t *testing.T) {
 	ctx := context.Background()
 	c := testCataloger(t)
 	repository := testCatalogerRepo(t, ctx, c, "repo", "master")
@@ -638,7 +638,7 @@ func TestCataloger_Merge_FromSonConflicts(t *testing.T) {
 	}
 }
 
-func TestCataloger_Merge_FromFatherThreeBranchesExtended1(t *testing.T) {
+func TestCataloger_Merge_FromParentThreeBranchesExtended1(t *testing.T) {
 	ctx := context.Background()
 	c := testCataloger(t)
 	repository := testCatalogerRepo(t, ctx, c, "repo", "master")
@@ -699,7 +699,7 @@ func TestCataloger_Merge_FromFatherThreeBranchesExtended1(t *testing.T) {
 		{Path: overFilename, Seed: "seed1"},
 		{Path: delFilename, Deleted: true},
 	})
-	// test that an object deleted at master becomes deleted at branch2 only after merges from both fathers
+	// test that an object deleted at master becomes deleted at branch2 only after merges from both parents
 	testutil.MustDo(t, "delete committed file on master",
 		c.DeleteEntry(ctx, repository, "master", "/file0"))
 	_, err = c.Commit(ctx, repository, "master", "commit file0 deletion", "tester", nil)
@@ -723,7 +723,7 @@ func TestCataloger_Merge_FromFatherThreeBranchesExtended1(t *testing.T) {
 	testCatalogerGetEntry(t, ctx, c, repository, "branch1", "/file0", false)
 	testCatalogerGetEntry(t, ctx, c, repository, "master", "/file0", false)
 
-	// test that the same object with the same name does not create a conflict in son to father , and is not a change
+	// test that the same object with the same name does not create a conflict in child to parent , and is not a change
 
 	testCatalogerCreateEntry(t, ctx, c, repository, "branch2", "/file0", nil, "seed1")
 	_, _ = c.Commit(ctx, repository, "branch2", "commit file0 creation", "tester", nil)
@@ -749,7 +749,7 @@ func TestCataloger_Merge_FromFatherThreeBranchesExtended1(t *testing.T) {
 		t.Errorf("unexpected Merge differences = %s", spew.Sdump(res.Differences))
 	}
 
-	// deletion in master will force  physically delete in grandson
+	// deletion in master will force  physically delete in grandchild
 	testutil.MustDo(t, "delete committed file on master",
 		c.DeleteEntry(ctx, repository, "master", "/file0"))
 	_, err = c.Commit(ctx, repository, "master", "commit file0 deletion", "tester", nil)
@@ -773,7 +773,7 @@ func TestCataloger_Merge_FromFatherThreeBranchesExtended1(t *testing.T) {
 		t.Errorf("Merge differences = %s, expected %s", spew.Sdump(res.Differences), spew.Sdump(expectedDifferences))
 	}
 
-	//identical entries created in son and grandfather do not create conflict - even when grandfather is uncommitted
+	//identical entries created in child and grandparent do not create conflict - even when grandparent is uncommitted
 	_, err = c.Merge(ctx, repository, "branch2", "branch1", "tester", "empty updates", nil)
 	testutil.MustDo(t, "merge branch2 to branch1", err)
 

--- a/catalog/db.go
+++ b/catalog/db.go
@@ -85,11 +85,11 @@ func getBranchesRelationType(tx db.Tx, sourceBranchID, destinationBranchID int64
 		return RelationTypeNone, nil
 	}
 	if sourceBranchID > destinationBranchID {
-		possibleRelation = RelationTypeFromSon
+		possibleRelation = RelationTypeFromChild
 		youngerBranch = sourceBranchID
 		olderBranch = destinationBranchID
 	} else {
-		possibleRelation = RelationTypeFromFather
+		possibleRelation = RelationTypeFromParent
 		youngerBranch = destinationBranchID
 		olderBranch = sourceBranchID
 	}
@@ -132,7 +132,7 @@ func getLineage(tx db.Tx, branchID int64, commitID CommitID) ([]lineageCommit, e
 	}
 	sql := `SELECT * FROM UNNEST(
 				(SELECT lineage from catalog_branches WHERE id=$1),
-				(SELECT lineage_commits FROM catalog_commits WHERE branch_id=$1 AND merge_type='from_father' AND commit_id <= $2 ORDER BY commit_id DESC LIMIT 1)
+				(SELECT lineage_commits FROM catalog_commits WHERE branch_id=$1 AND merge_type='from_parent' AND commit_id <= $2 ORDER BY commit_id DESC LIMIT 1)
 			) as t(branch_id, commit_id)`
 	var requestedLineage []lineageCommit
 	err := tx.Select(&requestedLineage, sql, branchID, effectiveCommit)

--- a/catalog/relation_type.go
+++ b/catalog/relation_type.go
@@ -4,7 +4,7 @@ type RelationType string
 
 const (
 	RelationTypeNone       RelationType = "none"
-	RelationTypeFromFather RelationType = "from_father"
-	RelationTypeFromSon    RelationType = "from_son"
+	RelationTypeFromParent RelationType = "from_parent"
+	RelationTypeFromChild  RelationType = "from_child"
 	RelationTypeNotDirect  RelationType = "non_direct"
 )

--- a/catalog/views.go
+++ b/catalog/views.go
@@ -97,13 +97,13 @@ func sqEntriesLineageV(branchID int64, requestedCommit CommitID, lineage []linea
 	return baseSelect
 }
 
-func sqDiffFromSonV(fatherID, sonID int64, fatherEffectiveCommit, sonEffectiveCommit CommitID, fatherUncommittedLineage []lineageCommit, sonLineageValues string) sq.SelectBuilder {
-	lineage := sqEntriesLineage(fatherID, UncommittedID, fatherUncommittedLineage)
-	sqFather := sq.Select("*").
+func sqDiffFromChildV(parentID, childID int64, parentEffectiveCommit, childEffectiveCommit CommitID, parentUncommittedLineage []lineageCommit, childLineageValues string) sq.SelectBuilder {
+	lineage := sqEntriesLineage(parentID, UncommittedID, parentUncommittedLineage)
+	sqParent := sq.Select("*").
 		FromSelect(lineage, "z").
-		Where("displayed_branch = ?", fatherID)
+		Where("displayed_branch = ?", parentID)
 	// Can diff with expired files, just not usefully!
-	fromSonInternalQ := sq.Select("s.path",
+	fromChildInternalQ := sq.Select("s.path",
 		"s.is_deleted AS DifferenceTypeRemoved",
 		"f.path IS NOT NULL AND NOT f.is_deleted AS DifferenceTypeChanged",
 		"COALESCE(f.is_deleted, true) AND s.is_deleted AS both_deleted",
@@ -112,27 +112,27 @@ func sqDiffFromSonV(fatherID, sonID int64, fatherEffectiveCommit, sonEffectiveCo
 		"f.source_branch",
 	).
 		//Conflict detection
-		Column(`-- father either created or deleted after last merge  - conflict
+		Column(`-- parent either created or deleted after last merge  - conflict
 			f.path IS NOT NULL AND ( NOT f.is_committed OR -- uncommitted entries always new
-									(f.source_branch = ? AND  -- it is the father branch - not from lineage
+									(f.source_branch = ? AND  -- it is the parent branch - not from lineage
 									( f.min_commit > ? OR -- created after last merge
 									 (f.max_commit >= ? AND f.is_deleted))) -- deleted after last merge
-									OR (f.source_branch != ? AND  -- an entry from father lineage
-				-- negative proof - if the son could see this object - than this is NOT a conflict
-				-- done by examining the son lineage against the father object
-									 NOT EXISTS ( SELECT * FROM`+sonLineageValues+` WHERE
+									OR (f.source_branch != ? AND  -- an entry from parent lineage
+				-- negative proof - if the child could see this object - than this is NOT a conflict
+				-- done by examining the child lineage against the parent object
+									 NOT EXISTS ( SELECT * FROM`+childLineageValues+` WHERE
 											l.branch_id = f.source_branch AND
-										-- prove that ancestor entry  was observable by the son
+										-- prove that ancestor entry  was observable by the child
 											(l.commit_id >= f.min_commit AND
 											 (l.commit_id > f.max_commit OR NOT f.is_deleted))
-										   ))) 
-											AS DifferenceTypeConflict`, fatherID, fatherEffectiveCommit, fatherEffectiveCommit, fatherID).
+										   )))
+											AS DifferenceTypeConflict`, parentID, parentEffectiveCommit, parentEffectiveCommit, parentID).
 		FromSelect(sqEntriesV(CommittedID).Distinct().
 			Options(" on (branch_id,path)").
 			OrderBy("branch_id", "path", "min_commit desc").
-			Where("branch_id = ? AND (min_commit >= ? OR max_commit >= ? and is_deleted)", sonID, sonEffectiveCommit, sonEffectiveCommit), "s").
-		JoinClause(sqFather.Prefix("LEFT JOIN (").Suffix(") AS f ON f.path = s.path"))
-	RemoveNonRelevantQ := sq.Select("*").FromSelect(fromSonInternalQ, "t").Where("NOT (same_object OR both_deleted)")
+			Where("branch_id = ? AND (min_commit >= ? OR max_commit >= ? and is_deleted)", childID, childEffectiveCommit, childEffectiveCommit), "s").
+		JoinClause(sqParent.Prefix("LEFT JOIN (").Suffix(") AS f ON f.path = s.path"))
+	RemoveNonRelevantQ := sq.Select("*").FromSelect(fromChildInternalQ, "t").Where("NOT (same_object OR both_deleted)")
 	return sq.Select().
 		Column(sq.Alias(sq.Case().When("DifferenceTypeConflict", "3").
 			When("DifferenceTypeRemoved", "1").
@@ -146,14 +146,14 @@ func sqDiffFromSonV(fatherID, sonID int64, fatherEffectiveCommit, sonEffectiveCo
 		FromSelect(RemoveNonRelevantQ, "t1")
 }
 
-func sqDiffFromFatherV(fatherID, sonID int64, lastSonMergeWithFather CommitID, fatherUncommittedLineage, sonUncommittedLineage []lineageCommit) sq.SelectBuilder {
-	sonLineageValues := getLineageAsValues(sonUncommittedLineage, sonID)
-	sonLineage := sqEntriesLineage(sonID, UncommittedID, sonUncommittedLineage)
-	sqSon := sq.Select("*").
-		FromSelect(sonLineage, "s").
-		Where("displayed_branch = ?", sonID)
+func sqDiffFromParentV(parentID, childID int64, lastChildMergeWithParent CommitID, parentUncommittedLineage, childUncommittedLineage []lineageCommit) sq.SelectBuilder {
+	childLineageValues := getLineageAsValues(childUncommittedLineage, childID)
+	childLineage := sqEntriesLineage(childID, UncommittedID, childUncommittedLineage)
+	sqChild := sq.Select("*").
+		FromSelect(childLineage, "s").
+		Where("displayed_branch = ?", childID)
 
-	fatherLineage := sqEntriesLineage(fatherID, CommittedID, fatherUncommittedLineage)
+	parentLineage := sqEntriesLineage(parentID, CommittedID, parentUncommittedLineage)
 	// Can diff with expired files, just not usefully!
 	internalV := sq.Select("f.path",
 		"f.entry_ctid",
@@ -162,25 +162,25 @@ func sqDiffFromFatherV(fatherID, sonID int64, lastSonMergeWithFather CommitID, f
 		"COALESCE(s.is_deleted, true) AND f.is_deleted AS both_deleted",
 		//both point to same object, and have the same deletion status
 		"s.path IS NOT NULL AND f.physical_address = s.physical_address AND f.is_deleted = s.is_deleted AS same_object").
-		Column(`f.min_commit > l.commit_id  -- father created after commit
-			OR f.max_commit >= l.commit_id AND f.is_deleted -- father deleted after commit
-									AS father_changed`). // father was changed if son could no "see" it
+		Column(`f.min_commit > l.commit_id  -- parent created after commit
+			OR f.max_commit >= l.commit_id AND f.is_deleted -- parent deleted after commit
+									AS parent_changed`). // parent was changed if child could no "see" it
 		// this happens if min_commit is larger than the lineage commit
 		// or entry deletion max_commit is larger or equal than lineage commit
-		Column("s.path IS NOT NULL AND s.source_branch = ? as entry_in_son", sonID).
+		Column("s.path IS NOT NULL AND s.source_branch = ? as entry_in_child", childID).
 		Column(`s.path IS NOT NULL AND s.source_branch = ? AND
 							(NOT s.is_committed -- uncommitted is new
 							 OR s.min_commit > ? -- created after last merge
                            OR (s.max_commit >= ? AND s.is_deleted)) -- deleted after last merge
-						  AS DifferenceTypeConflict`, sonID, lastSonMergeWithFather, lastSonMergeWithFather).
-		FromSelect(fatherLineage, "f").
-		Where("f.displayed_branch = ?", fatherID).
-		JoinClause(sqSon.Prefix("LEFT JOIN (").Suffix(") AS s ON f.path = s.path")).
-		Join(`(SELECT * FROM ` + sonLineageValues + `) l ON f.source_branch = l.branch_id`)
+						  AS DifferenceTypeConflict`, childID, lastChildMergeWithParent, lastChildMergeWithParent).
+		FromSelect(parentLineage, "f").
+		Where("f.displayed_branch = ?", parentID).
+		JoinClause(sqChild.Prefix("LEFT JOIN (").Suffix(") AS s ON f.path = s.path")).
+		Join(`(SELECT * FROM ` + childLineageValues + `) l ON f.source_branch = l.branch_id`)
 
 	RemoveNonRelevantQ := sq.Select("*").
 		FromSelect(internalV, "t").
-		Where("father_changed AND NOT (same_object OR both_deleted)")
+		Where("parent_changed AND NOT (same_object OR both_deleted)")
 
 	return sq.Select().
 		Column(sq.Alias(sq.Case().When("DifferenceTypeConflict", "3").
@@ -189,7 +189,7 @@ func sqDiffFromFatherV(fatherID, sonID int64, lastSonMergeWithFather CommitID, f
 			Else("0"), "diff_type")).
 		Column("path").
 		Column(sq.Alias(sq.Case().
-			When("DifferenceTypeChanged AND entry_in_son", "entry_ctid").
+			When("DifferenceTypeChanged AND entry_in_child", "entry_ctid").
 			Else("NULL"), "entry_ctid")).
 		FromSelect(RemoveNonRelevantQ, "t1")
 }

--- a/ddl/000003_degender.down.sql
+++ b/ddl/000003_degender.down.sql
@@ -1,0 +1,2 @@
+ALTER TYPE catalog_merge_type RENAME VALUE 'from_parent' TO 'from_father';
+ALTER TYPE catalog_merge_type RENAME VALUE 'from_child' TO 'from_son';

--- a/ddl/000003_degender.up.sql
+++ b/ddl/000003_degender.up.sql
@@ -1,0 +1,2 @@
+ALTER TYPE catalog_merge_type RENAME VALUE 'from_father' TO 'from_parent';
+ALTER TYPE catalog_merge_type RENAME VALUE 'from_son' TO 'from_child';

--- a/docs/assets/js/swagger.yml
+++ b/docs/assets/js/swagger.yml
@@ -372,6 +372,7 @@ paths:
         - setup
       operationId: setupLakeFS
       summary: setup lakeFS and create the first user
+      security: []
       parameters:
         - in: body
           name: user


### PR DESCRIPTION
Change "son" and "father" to "child" and "parent" wherever possible.
After this commit only the v.1 DDL retains these names (and upgrading
to v3 changes them).

"Son" and "father" are natural to Hebrew-speakers (because Hebrew is
very much a gendered language).  But they are considerably less so in
the wider technical community.  Technical English uses "child" and
"parent" almost exclusively.
https://en.wikipedia.org/wiki/Tree_structure#Terminology_and_properties
says

> The gender-neutral names "parent" and "child" have largely displaced
> the older "father" and "son" terminology.

Even so, I was hard-pressed to find anything later than 1975 that uses
these terms.  E.g Cormen's _Algorithms_ uses "parent" and "child".