### PR TITLE
Run Go CI tests also on merge-to-master

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -2,7 +2,7 @@ name: Go
 on:
   push:
     branches:
-      -master
+      - master
   pull_request:
 jobs:
   validator:


### PR DESCRIPTION
1. We regularly _merge_ PRs, so a tested PR can create an untested
   master.
1. Low overhead: many fewer merges to master than PR events.
1. Allows e.g. coverage and *🦄 badges 🦄*.