### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,9 +43,9 @@ All reads from that branch are    guaranteed to always return the same results.
 1. Ensure you have Docker installed on your computer. The MacOS and Windows installations include Docker Compose by default.
 
 2. Clone the repository:
-```bash
-git clone git@github.com:treeverse/lakeFS.git
-```
+  ```bash
+  git clone git@github.com:treeverse/lakeFS.git
+  ```
 
 3. From the root of the cloned repository, run:
 

--- a/README.md
+++ b/README.md
@@ -42,30 +42,9 @@ All reads from that branch are    guaranteed to always return the same results.
 
 1. Ensure you have Docker installed on your computer. The MacOS and Windows installations include Docker Compose by default.
 
-2. Create a `docker-compose.yaml` file, containing the following configuration:
-    ```yaml
-    ---
-    version: '3'
-    services:
-      lakefs:
-        image: "treeverse/lakefs:latest"
-        ports: ["8000:8000"]
-        links: ["postgres"]
-        environment:
-          LAKEFS_AUTH_ENCRYPT_SECRET_KEY: "some random secret string"
-          LAKEFS_DATABASE_CONNECTION_STRING: postgres://lakefs:lakefs@postgres/postgres?sslmode=disable
-          LAKEFS_BLOCKSTORE_TYPE: local
-          LAKEFS_BLOCKSTORE_LOCAL_PATH: /home/lakefs
-          LAKEFS_GATEWAYS_S3_DOMAIN_NAME: s3.local.lakefs.io:8000
-        entrypoint: ["/app/wait-for", "postgres:5432", "--", "/app/lakefs", "run"]
-      postgres:
-        image: "postgres:11"
-        environment:
-          POSTGRES_USER: lakefs
-          POSTGRES_PASSWORD: lakefs
-    ```
+2. Clone the lakeFS repository.
 
-3. From the directory that contains our new docker-compose.yaml file, run the following command:
+3. From the root of the cloned repository, run:
 
    ```bash
    $ docker-compose up

--- a/README.md
+++ b/README.md
@@ -43,9 +43,10 @@ All reads from that branch are    guaranteed to always return the same results.
 1. Ensure you have Docker installed on your computer. The MacOS and Windows installations include Docker Compose by default.
 
 2. Clone the repository:
-  ```bash
-  git clone git@github.com:treeverse/lakeFS.git
-  ```
+
+   ```bash
+   git clone git@github.com:treeverse/lakeFS.git
+   ```
 
 3. From the root of the cloned repository, run:
 

--- a/README.md
+++ b/README.md
@@ -42,7 +42,10 @@ All reads from that branch are    guaranteed to always return the same results.
 
 1. Ensure you have Docker installed on your computer. The MacOS and Windows installations include Docker Compose by default.
 
-2. Clone the lakeFS repository.
+2. Clone the repository:
+```bash
+git clone git@github.com:treeverse/lakeFS.git
+```
 
 3. From the root of the cloned repository, run:
 


### PR DESCRIPTION
We already have a working docker compose file which works out-of-the-box, so I suggest this change.

I understand that this "method" requires the installer to have git on their machine, but I think in the github README it's reasonable to assume. 
In our quickstart section of the docs I left it the way it was, we can discuss it down the road.