### PR TITLE
change compose execution in quickstart and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,23 +43,30 @@ For more information see the [Official Documentation](https://docs.lakefs.io).
 
 ## Getting Started
 
-#### Docker
+#### Docker (MacOS, Linux)
 
-1. Ensure you have Docker installed on your computer. The MacOS and Windows installations include Docker Compose by default.
+1. Ensure you have Docker & docker-compose installed on your computer
 
-2. Clone the repository:
-
-   ```bash
-   git clone git@github.com:treeverse/lakeFS.git
-   ```
-
-3. From the root of the cloned repository, run:
+2. Run the following command:
 
    ```bash
-   $ docker-compose up
+   curl https://compose.lakefs.io | docker-compose -f - up
    ```
 
-4. Open [http://127.0.0.1:8000/setup](http://127.0.0.1:8000/setup) in your web browser to set up an initial admin user, used to login and send API requests.
+3. Open [http://127.0.0.1:8000/setup](http://127.0.0.1:8000/setup) in your web browser to set up an initial admin user, used to login and send API requests.
+
+
+#### Docker (Windows)
+
+1. Ensure you have Docker installed
+
+2. Run the following command in PowerShell:
+
+   ```shell script
+   Invoke-WebRequest https://compose.lakefs.io | Select-Object -ExpandProperty Content | docker-compose -f - up
+   ``` 
+
+3. Open [http://127.0.0.1:8000/setup](http://127.0.0.1:8000/setup) in your web browser to set up an initial admin user, used to login and send API requests.
 
 #### Download the Binary
 
@@ -70,9 +77,9 @@ Binaries are available at [https://github.com/treeverse/lakeFS/releases](https:/
 
 #### Setting up a repository
 
-Please follow the [Guide to Get Started](https://docs.lakefs.io/quickstart.html#setting-up-a-repository) to set up your local lakeFS installation.
+Please follow the [Guide to Get Started](https://docs.lakefs.io/quickstart/repository) to set up your local lakeFS installation.
 
-For more detailed inforamation on how to setup lakeFS, please visit [the documentation](https://docs.lakefs.io)
+For more detailed information on how to set up lakeFS, please visit [the documentation](https://docs.lakefs.io)
 
 ## Community
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ For more information see the [Official Documentation](https://docs.lakefs.io).
 
 #### Docker (MacOS, Linux)
 
-1. Ensure you have Docker & docker-compose installed on your computer
+1. Ensure you have Docker & Docker Compose installed on your computer.
 
 2. Run the following command:
 

--- a/docs/quickstart/installing.md
+++ b/docs/quickstart/installing.md
@@ -15,25 +15,18 @@ For a production suitable deployment, see [Deploying on AWS](../deploying/index.
 
 ## Using docker-compose
 {: .no_toc }
-If you wish to install your lakeFS using Kubernetes or just install it manually, check out [Other Installations](other_installations.md) page.
+
+If you wish to install your lakeFS using Kubernetes, install it manually, or install it on Windows, check out [Other Installations](other_installations.md) page.
 {: .note .note-info }
 
-To run a local lakeFS instance, you can clone the repository and run [Docker Compose](https://docs.docker.com/compose/){:target="_blank"} application:
+To run a local lakeFS instance using [Docker Compose](https://docs.docker.com/compose/){:target="_blank"}:
 
-1. Ensure you have Docker installed on your computer. The MacOS and Windows installations include [Docker Compose](https://docs.docker.com/compose/){:target="_blank"} by default.
+1. Ensure you have Docker & Docker Compose installed on your computer.
 
-1. Clone the lakeFS repository:
-
-   ```bash
-   git clone https://github.com/treeverse/lakeFS
-   ```
-
-1. Navigate to the directory: `cd lakeFS`.
-
-1. Run the following command:
+1. Run the following command in your terminal:
 
    ```bash
-   docker-compose up
+   curl https://compose.lakefs.io | docker-compose -f - up
    ```
 
 1. Check your installation by opening [http://127.0.0.1:8000/setup](http://127.0.0.1:8000/setup){:target="_blank"} in your web browser.

--- a/docs/quickstart/other_installations.md
+++ b/docs/quickstart/other_installations.md
@@ -15,6 +15,21 @@ has_children: false
 1. TOC
 {:toc}
 
+## Docker on Windows
+
+To run a local lakeFS instance using [Docker Compose](https://docs.docker.com/compose/){:target="_blank"}:
+
+1. Ensure you have Docker installed on your computer.
+
+1. Run the following command in your terminal:
+
+   ```bash
+   Invoke-WebRequest https://compose.lakefs.io | Select-Object -ExpandProperty Content | docker-compose -f - up
+   ```
+
+1. Check your installation by opening [http://127.0.0.1:8000/setup](http://127.0.0.1:8000/setup){:target="_blank"} in your web browser.
+
+
 ## On Kubernetes with Helm
 
 You can install lakeFS on a Kubernetes cluster with the following commands:


### PR DESCRIPTION
This PR changes the quickstart guide and the README to use compose.lakefs.io - this eliminates the step of cloning the repo and makes our quickstart essentially a 1-liner.