### PR TITLE
Changes in Logo Size

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ lakeFS supports AWS S3 or Google Cloud Storage as its underlying storage service
 <p align="center">
   <img src="docs/assets/img/wrapper.png"/>
 </p>
+<!-- Increase the font size in the notebooks images, i.e. Increase the size of Jupyter and the Apache Zeppelin notebooks logo -->
 
 For more information see the [Official Documentation](https://docs.lakefs.io).
 


### PR DESCRIPTION
In the image attached decribing about LakeFS, although the image is very interesting and describes the function of LakeFS very properly, the font in the notebooks tab appears to be very small compared to others. I would suggest that the font for the Apache and the Jupyter logo be increased  so that it becomes readily visible to everyone.
Contributing for HacktoberFest