### PR TITLE
docs: add contributors file

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -1,0 +1,140 @@
+{
+  "projectName": "lakeFS",
+  "projectOwner": "treeverse",
+  "repoType": "github",
+  "repoHost": "https://github.com",
+  "files": [
+    "CONTRIBUTORS.md"
+  ],
+  "imageSize": 350,
+  "commitConvention": "angular",
+  "contributors": [
+    {
+      "login": "ozkatz",
+      "name": "Oz Katz",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/205955?v=4",
+      "profile": "https://lakefs.io/",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "nopcoder",
+      "name": "Barak Amar",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/8110?v=4",
+      "profile": "https://github.com/nopcoder",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "tzahij",
+      "name": "tzahij",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/5455113?v=4",
+      "profile": "https://github.com/tzahij",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "guy-har",
+      "name": "guy-har",
+      "avatar_url": "https://avatars3.githubusercontent.com/u/60321938?v=4",
+      "profile": "https://github.com/guy-har",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "arielshaqed",
+      "name": "arielshaqed",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/7802932?v=4",
+      "profile": "https://github.com/arielshaqed",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "johnnyaug",
+      "name": "johnnyaug",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/3149885?v=4",
+      "profile": "https://github.com/johnnyaug",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "itaiad200",
+      "name": "itaiad200",
+      "avatar_url": "https://avatars1.githubusercontent.com/u/9861474?v=4",
+      "profile": "https://github.com/itaiad200",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "YaelRiv",
+      "name": "YaelRiv",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/67264175?v=4",
+      "profile": "https://github.com/YaelRiv",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "einato",
+      "name": "Einat Orr",
+      "avatar_url": "https://avatars3.githubusercontent.com/u/56227795?v=4",
+      "profile": "https://github.com/einato",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "kzuri",
+      "name": "Devarsh Patel",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/65841886?v=4",
+      "profile": "https://github.com/kzuri",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "sourhub226",
+      "name": "Sourabh Sathe",
+      "avatar_url": "https://avatars0.githubusercontent.com/u/58329492?v=4",
+      "profile": "https://github.com/sourhub226",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "jengjeng",
+      "name": "Wittawat Patcharinsak",
+      "avatar_url": "https://avatars2.githubusercontent.com/u/6948085?v=4",
+      "profile": "https://github.com/jengjeng",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "d-harel",
+      "name": "d-harel",
+      "avatar_url": "https://avatars3.githubusercontent.com/u/11721947?v=4",
+      "profile": "https://github.com/d-harel",
+      "contributions": [
+        "code"
+      ]
+    },
+    {
+      "login": "dependabot[bot]",
+      "name": "dependabot[bot]",
+      "avatar_url": "https://avatars0.githubusercontent.com/in/29110?v=4",
+      "profile": "https://github.com/apps/dependabot",
+      "contributions": [
+        "code"
+      ]
+    }
+  ],
+  "contributorsPerLine": 7
+}

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,28 @@
+<!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
+<!-- prettier-ignore-start -->
+<!-- markdownlint-disable -->
+<table>
+  <tr>
+    <td align="center"><a href="https://lakefs.io/"><img src="https://avatars2.githubusercontent.com/u/205955?v=4?s=350" width="350px;" alt=""/><br /><sub><b>Oz Katz</b></sub></a><br /><a href="https://github.com/treeverse/lakeFS/commits?author=ozkatz" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/nopcoder"><img src="https://avatars1.githubusercontent.com/u/8110?v=4?s=350" width="350px;" alt=""/><br /><sub><b>Barak Amar</b></sub></a><br /><a href="https://github.com/treeverse/lakeFS/commits?author=nopcoder" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/tzahij"><img src="https://avatars1.githubusercontent.com/u/5455113?v=4?s=350" width="350px;" alt=""/><br /><sub><b>tzahij</b></sub></a><br /><a href="https://github.com/treeverse/lakeFS/commits?author=tzahij" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/guy-har"><img src="https://avatars3.githubusercontent.com/u/60321938?v=4?s=350" width="350px;" alt=""/><br /><sub><b>guy-har</b></sub></a><br /><a href="https://github.com/treeverse/lakeFS/commits?author=guy-har" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/arielshaqed"><img src="https://avatars0.githubusercontent.com/u/7802932?v=4?s=350" width="350px;" alt=""/><br /><sub><b>arielshaqed</b></sub></a><br /><a href="https://github.com/treeverse/lakeFS/commits?author=arielshaqed" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/johnnyaug"><img src="https://avatars1.githubusercontent.com/u/3149885?v=4?s=350" width="350px;" alt=""/><br /><sub><b>johnnyaug</b></sub></a><br /><a href="https://github.com/treeverse/lakeFS/commits?author=johnnyaug" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/itaiad200"><img src="https://avatars1.githubusercontent.com/u/9861474?v=4?s=350" width="350px;" alt=""/><br /><sub><b>itaiad200</b></sub></a><br /><a href="https://github.com/treeverse/lakeFS/commits?author=itaiad200" title="Code">💻</a></td>
+  </tr>
+  <tr>
+    <td align="center"><a href="https://github.com/YaelRiv"><img src="https://avatars2.githubusercontent.com/u/67264175?v=4?s=350" width="350px;" alt=""/><br /><sub><b>YaelRiv</b></sub></a><br /><a href="https://github.com/treeverse/lakeFS/commits?author=YaelRiv" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/einato"><img src="https://avatars3.githubusercontent.com/u/56227795?v=4?s=350" width="350px;" alt=""/><br /><sub><b>Einat Orr</b></sub></a><br /><a href="https://github.com/treeverse/lakeFS/commits?author=einato" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/kzuri"><img src="https://avatars2.githubusercontent.com/u/65841886?v=4?s=350" width="350px;" alt=""/><br /><sub><b>Devarsh Patel</b></sub></a><br /><a href="https://github.com/treeverse/lakeFS/commits?author=kzuri" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/sourhub226"><img src="https://avatars0.githubusercontent.com/u/58329492?v=4?s=350" width="350px;" alt=""/><br /><sub><b>Sourabh Sathe</b></sub></a><br /><a href="https://github.com/treeverse/lakeFS/commits?author=sourhub226" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/jengjeng"><img src="https://avatars2.githubusercontent.com/u/6948085?v=4?s=350" width="350px;" alt=""/><br /><sub><b>Wittawat Patcharinsak</b></sub></a><br /><a href="https://github.com/treeverse/lakeFS/commits?author=jengjeng" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/d-harel"><img src="https://avatars3.githubusercontent.com/u/11721947?v=4?s=350" width="350px;" alt=""/><br /><sub><b>d-harel</b></sub></a><br /><a href="https://github.com/treeverse/lakeFS/commits?author=d-harel" title="Code">💻</a></td>
+    <td align="center"><a href="https://github.com/apps/dependabot"><img src="https://avatars0.githubusercontent.com/in/29110?v=4?s=350" width="350px;" alt=""/><br /><sub><b>dependabot[bot]</b></sub></a><br /><a href="https://github.com/treeverse/lakeFS/commits?author=dependabot[bot]" title="Code">💻</a></td>
+  </tr>
+</table>
+
+<!-- markdownlint-restore -->
+<!-- prettier-ignore-end -->
+
+<!-- ALL-CONTRIBUTORS-LIST:END -->


### PR DESCRIPTION
Resolves #628 

Check the file : https://github.com/daniloff200/lakeFS/blob/add-contributions-file/CONTRIBUTORS.md

### Description
That PR adds all-contributors-cli, according to [installation guide](https://allcontributors.org/docs/en/cli/installation)
Unfortunately, it uses JS, so, I added this dependency locally in **webui** folder, when package.json exists, but, that was made only for initial setup, so, I don't think, that it's required for repo

There are 2 ways to update this contributing.md file : 

**1)** Do it manually sometimes, with couple of scripts, described [https://allcontributors.org/docs/en/cli/usage](here)

First of all, `npm all-contributors check`
It will generate list of users, which are not added for now in the file

Then, add each one from the list, with the 
`npx all-contributors add GITHUB_USER_NAME code (doc, tests, whatever)`

And then use `npx all-contributors generate`, for CONTRIBUTION.md file update

Also, it's possible to add some scripts in `package.json`

{
```
  "scripts": {
    "contributors:add": "all-contributors add",
    "contributors:generate": "all-contributors generate"
  }
}
```

**2)**  Add bot to github repo
It will create a separate commit with the update 

Described here : https://allcontributors.org/docs/en/bot/overview

[How to install bot](https://allcontributors.org/docs/en/bot/installation)


Looking for your thoughts and feedback ;) 