### PR TITLE
Added Pull request template as stated in issue #687

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,18 @@
+### Short headline of your PR (Optional)
+
+## Fixed #.
+#### Changes proposed in the pull request:
+- 
+- 
+
+### Root cause of the problem (Optional if your bug is not for solving any bug)
+-
+-
+
+#### Risk Impact
+- 
+-
+
+## Test cases passed (Optional)
+-
+-


### PR DESCRIPTION
I added the Pull request template i.e. file named pull_request_template.md #687 for this repository
Also, I was willing to add a issue template too, but i found out [here](https://docs.github.com/en/free-pro-team@latest/github/building-a-strong-community/configuring-issue-templates-for-your-repository) that it is possible only for the repository administrator to do this.
I suggest to add a template for issue also.

Pardon and correct me if i did any mistake,
Happy Hacktoberfest !