### PR TITLE
General guidelines for Hacktoberfest on the front page

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,37 @@ lakeFS supports AWS S3 or Google Cloud Storage as its underlying storage service
 
 For more information see the [Official Documentation](https://docs.lakefs.io).
 
+<aside>
+# A Hacktoberfest update
+
+Welcome Hacktoberfest participants!  We commit to actively seek, help, and merge your
+improvements to lakeFS.  We've labelled some [issues with the hacktoberfest
+label](https://github.com/treeverse/lakeFS/issues?q=is%3Aissue+is%3Aopen+label%3Ahacktoberfest).
+Please check out our [contributing guide](https://docs.lakefs.io/contributing).
+
+*We know you like badges, stickers, and T-shirts*, because **we like them too!** But, like many
+other open-source projects, we are seeing an influx of lower quality PRs.  During October will
+be unable to accept PRs if they:
+
+1. Only change punctuation or grammar, unless accompanied by an explanation or are clearly
+   better.
+1. Repeat an existing PR, or try to merge branches authored by other contributors that are under
+   active work.
+1. Do not affect generated code or documentation in any way.
+1. Are detrimental: do not compile or cause harm when run.
+1. Change text or code that should be changed upstream, such as licenses, code of conduct, or
+   React boilerplate.
+
+We shall close such PRs and label them `x/invalid`; Digital Ocean _will not count_ those PRs
+towards Hacktoberfest progress, so such PRs only waste your time and ours.
+
+You can **help us accept your PR** by adding a clear title and description to the PR and to
+commits in that PR.  "Fixes #1234" or "update README.md" are not as good as "Make lakeFS run 3x
+faster" or "Add update regarding Hacktoberfest".  Communication is key: If you are uncertain,
+please open a discussion: ask us on the PR or on the issue.
+
+Thanks!
+</aside>
 
 ## Capabilities
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ lakeFS supports AWS S3 or Google Cloud Storage as its underlying storage service
 
 For more information see the [Official Documentation](https://docs.lakefs.io).
 
-<aside>
+<div style="background: #ffdddd border: 3px solid #dd4444; margine: 15px;">
+
 # A Hacktoberfest update
 
 Welcome Hacktoberfest participants!  We commit to actively seek, help, and merge your
@@ -53,7 +54,7 @@ faster" or "Add update regarding Hacktoberfest".  Communication is key: If you a
 please open a discussion: ask us on the PR or on the issue.
 
 Thanks!
-</aside>
+</div>
 
 ## Capabilities
 


### PR DESCRIPTION
This should be removed on or shortly after 2020-11-01, of course.

Explain what PRs will be rejected, and how to avoid falling into one of those categories.

Includes an attempt at styling, but that appears invisible in GFM in a PR.