### PR TITLE
Improve documentation by fixing mistakes

### DIFF
--- a/docs/branching/model.md
+++ b/docs/branching/model.md
@@ -19,7 +19,7 @@ At its core, lakeFS uses a Git-like branching model.
 
 ### Repositories
 
-In lakeFS, a repository is a logical namespace used to group together objects, branches and commits. It is the equivalent of a Bucket in S3, and a repositoriy in Git.
+In lakeFS, a repository is a logical namespace used to group together objects, branches and commits. It is the equivalent of a Bucket in S3, and a repository in Git.
 
 ### Branches
 
@@ -49,4 +49,4 @@ Unlike Git, lakeFS does not care about the contents of an object - if we try to 
 This is because lakeFS doesn't assume anything about the structure of the object and so cannot try to merge both changesets into a single object (additionally, this operation makes little sense for machine generated files, and data in general).
 
 The actual data itself is not stored inside lakeFS directly, but rather stored in an underlying object store. lakeFS will manage these writes, and will store a pointer to the object in its metadata database.
-Addressing the object in the underlying object store is done using a dedupe ID - objects with the same content will receive the same ID, thus stored only once.
+Addressing the object in the underlying object store is done using a deduplication ID - objects with the same content will receive the same ID, thus stored only once.

--- a/docs/branching/recommendations.md
+++ b/docs/branching/recommendations.md
@@ -106,7 +106,7 @@ In production data pipelines, we require the following guarantees:
    # output:
    # created branch 'pipeline-raw-data-grouping', pointing to commit ID: '~43aP3nUrR17LcX'
    ```
-1. Now, for each job that takes part in the pipeline, we'll create a `job` branch that is **derived from the `pipline` branch**:
+1. Now, for each job that takes part in the pipeline, we'll create a `job` branch that is **derived from the `pipeline` branch**:
    
    ```shell
    lakectl branch create \

--- a/docs/deploying/install.md
+++ b/docs/deploying/install.md
@@ -66,7 +66,7 @@ If you can't provide such access, lakeFS can be configured to use an AWS key-pai
 | `lakefsConfig`                              | lakeFS config YAML stringified, as shown above. See [reference](../reference/configuration.md) for available configurations.                                                               |             |
 | `replicaCount`                              | Number of lakeFS pods                                                                                      | `1`         |
 | `resources`                                 | Pod resource requests & limits                                                                             | `{}`        |
-| `service.type`                              | Kuberenetes service type                                                                                   | ClusterIP   |
+| `service.type`                              | Kubernetes service type                                                                                   | ClusterIP   |
 | `service.port`                              | Kubernetes service external port                                                                           | 80          |
 
 ## Docker

--- a/docs/quickstart/repository.md
+++ b/docs/quickstart/repository.md
@@ -9,7 +9,7 @@ has_children: false
 # Setting up a Repository
 {: .no_toc }
 
-Once you have a running lakeFS instance, we'll need to set up an initial admin user in order to log in to the UI and make our first steps in lakeFS! In this guide, we're going to run an inital setup and then create a new [repository](../branching/model.md#repositories).
+Once you have a running lakeFS instance, we'll need to set up an initial admin user in order to log in to the UI and make our first steps in lakeFS! In this guide, we're going to run an initial setup and then create a new [repository](../branching/model.md#repositories).
 
 Once we have a repository created, we can start [copying and modifying objects](./aws_cli.md), [commit](../reference/commands.md#lakectl-commit) and [revert](../reference/commands.md#lakectl-branch-revert) changes - and even communicate with this repository from [Spark](../using/spark.md), [Presto](../using/presto.md) or other S3-compatible tools using our [S3 Gateway API](../architecture.md#s3-gateway).
 

--- a/docs/reference/authorization.md
+++ b/docs/reference/authorization.md
@@ -70,7 +70,7 @@ When a user makes a request to perform that action, the following process takes 
 
 1. Authentication - The credentials passed in the request are evaluated, and the user's identity is extracted.
 2. Action permission resolution - lakeFS would then calculate the set of allowed actions and resources that this request requires.
-3. Effective policy resolution - the user's policies (either attached directly or through group memeberships) are calculated
+3. Effective policy resolution - the user's policies (either attached directly or through group memberships) are calculated
 4. Policy/Permission evaluation - lakeFS will compare the given user policies with the request actions and determine whether or not the request is allowed to continue
 
 ### Policy Precedence

--- a/docs/using/glue_hive_metastore.md
+++ b/docs/using/glue_hive_metastore.md
@@ -102,22 +102,22 @@ In case the destination table already exists, the command will only merge the ch
 Example:
 
 Suppose we have the table `example_by_dt` on branch `master` on schema `default`.
-We create a new branch `exmpale_branch` .
+We create a new branch `example_branch` .
 we would like to create a copy of the table `example_by_dt` in schema `example_branch` pointing to the new branch.   
 
 Recommended:
 ``` bash
-lakectl metastore copy  --from-schema default --from-table exmpale_by_dt --to-branch example_branch 
+lakectl metastore copy  --from-schema default --from-table example_by_dt --to-branch example_branch 
 ```
 
 Glue:
 ``` bash
-lakectl metastore copy --type glue --address 123456789012 --from-schema default --from-table exmpale_by_dt --to-schema default --to-table branch_example_by_dt --to-branch example_branch 
+lakectl metastore copy --type glue --address 123456789012 --from-schema default --from-table example_by_dt --to-schema default --to-table branch_example_by_dt --to-branch example_branch 
 ```
 
 Hive:
 ``` bash
-lakectl metastore copy --type hive --address thrift://hive-metastore:9083 --from-schema default --from-table example_by_dt --to-schema default --to-table branch_example_by_dt --to-branch exmample-branch
+lakectl metastore copy --type hive --address thrift://hive-metastore:9083 --from-schema default --from-table example_by_dt --to-schema default --to-table branch_example_by_dt --to-branch example-branch
 ```
 
 ### Copy partition
@@ -161,7 +161,7 @@ Shows added`+` , removed`-` and changed`~` partitions and columns.
 
 Example:
 
-Suppose that we made some changes on the copied table `exmample_by_dt` on schema `example_branch` and we want to see the changes before merging back to `example_by_dt` on schema `default`. 
+Suppose that we made some changes on the copied table `example_by_dt` on schema `example_branch` and we want to see the changes before merging back to `example_by_dt` on schema `default`. 
 
 Recommended:
 ``` bash


### PR DESCRIPTION
- Made some changes that involved fixing typos for certain words that are irrespective of differences in regionalized spellings and for certain packages (i.e. Kubernetes)

- Changed name designations for certain branches, tables, and other entities with misspellings or mismatched names to make references to these entities more consistent in the documentation