### PR TITLE
Wrap all up/down DB migration scripts in a transaction

### DIFF
--- a/ddl/000001_initial.down.sql
+++ b/ddl/000001_initial.down.sql
@@ -1,3 +1,5 @@
+BEGIN;
+
 DROP TABLE IF EXISTS auth_credentials;
 DROP TABLE IF EXISTS auth_group_policies;
 DROP TABLE IF EXISTS auth_user_policies;
@@ -20,3 +22,5 @@ DROP SEQUENCE IF EXISTS catalog_repositories_id_seq;
 DROP SEQUENCE IF EXISTS catalog_branches_id_seq;
 DROP SEQUENCE IF EXISTS catalog_commit_id_seq;
 DROP FUNCTION IF EXISTS catalog_max_commit_id;
+
+COMMIT;

--- a/ddl/000001_initial.up.sql
+++ b/ddl/000001_initial.up.sql
@@ -1,3 +1,5 @@
+BEGIN;
+
 -- auth schema, containing information about lakeFS authentication and authorization
 CREATE TABLE IF NOT EXISTS auth_users (
     id serial NOT NULL PRIMARY KEY,
@@ -244,3 +246,4 @@ ALTER TABLE ONLY catalog_object_dedup
 ALTER TABLE ONLY catalog_repositories
     ADD CONSTRAINT catalog_repositories_branches_id_fk FOREIGN KEY (default_branch) REFERENCES catalog_branches(id) DEFERRABLE INITIALLY DEFERRED NOT VALID;
 
+COMMIT;

--- a/ddl/000002_retention.up.sql
+++ b/ddl/000002_retention.up.sql
@@ -1,3 +1,5 @@
+BEGIN;
+
 ALTER TABLE catalog_object_dedup
     DROP CONSTRAINT IF EXISTS catalog_object_dedup_pk,
     ADD COLUMN IF NOT EXISTS deleting boolean DEFAULT false NOT NULL,
@@ -8,3 +10,5 @@ Set before deleting an object to indicate it is going to be
 removed by an AWS S3 batch operation and cannot be used for new
 dedupes.
 $$;
+
+END;


### PR DESCRIPTION
This prevents half-successful migration scripts from leaving the DB in an unusable state.

Bad migration scripts (e.g. missing DDL removal in a down script) may still break things and
require manual fixing.  To fix that we would need to use the single-command `CREATE TABLE` form
with `FOREIGN KEY`s and `CONSTRAINT`s.  We initially made an undocumented decision not to do so,
and this commit continues that tradition.