### PR TITLE
557 import tool usability

### DIFF
--- a/block/inventory.go
+++ b/block/inventory.go
@@ -23,7 +23,7 @@ type InventoryObject struct {
 	Bucket          string
 	Key             string
 	Size            int64
-	LastModified    time.Time
+	LastModified    *time.Time
 	Checksum        string
 	PhysicalAddress string
 }

--- a/block/s3/inventory_iterator.go
+++ b/block/s3/inventory_iterator.go
@@ -94,8 +94,7 @@ func (it *InventoryIterator) fillBuffer() bool {
 			it.logger.Errorf("failed to close manifest file reader. file=%s, err=%w", it.Manifest.Files[it.inventoryFileIndex].Key, err)
 		}
 	}()
-	it.buffer = make([]s3inventory.InventoryObject, rdr.GetNumRows())
-	err = rdr.Read(&it.buffer)
+	it.buffer, err = rdr.Read(int(rdr.GetNumRows()))
 	if err != nil {
 		it.err = err
 		return false

--- a/block/s3/inventory_iterator.go
+++ b/block/s3/inventory_iterator.go
@@ -105,23 +105,16 @@ func (it *InventoryIterator) fillBuffer() bool {
 func (it *InventoryIterator) nextFromBuffer() *block.InventoryObject {
 	for i := it.valIndexInBuffer + 1; i < len(it.buffer); i++ {
 		obj := it.buffer[i]
-		if (obj.IsLatest != nil && !*obj.IsLatest) ||
-			(obj.IsDeleteMarker != nil && *obj.IsDeleteMarker) {
+		if !obj.IsLatest || obj.IsDeleteMarker {
 			continue
 		}
 		res := block.InventoryObject{
 			Bucket:          obj.Bucket,
 			Key:             obj.Key,
 			PhysicalAddress: obj.GetPhysicalAddress(),
-		}
-		if obj.Size != nil {
-			res.Size = *obj.Size
-		}
-		if obj.LastModifiedMillis != nil {
-			res.LastModified = time.Unix(*obj.LastModifiedMillis/int64(time.Second/time.Millisecond), 0)
-		}
-		if obj.Checksum != nil {
-			res.Checksum = *obj.Checksum
+			Size:            obj.Size,
+			LastModified:    obj.LastModified,
+			Checksum:        obj.Checksum,
 		}
 		it.valIndexInBuffer = i
 		return &res

--- a/block/s3/inventory_iterator.go
+++ b/block/s3/inventory_iterator.go
@@ -17,7 +17,7 @@ type InventoryIterator struct {
 	*Inventory
 	err                   error
 	val                   *block.InventoryObject
-	buffer                []s3inventory.InventoryObject
+	buffer                []*s3inventory.InventoryObject
 	inventoryFileIndex    int
 	valIndexInBuffer      int
 	inventoryFileProgress *cmdutils.Progress

--- a/block/s3/inventory_test.go
+++ b/block/s3/inventory_test.go
@@ -246,13 +246,13 @@ func (m *mockInventoryFileReader) Close() error {
 	return nil
 }
 
-func (m *mockInventoryFileReader) Read(n int) ([]s3inventory.InventoryObject, error) {
-	res := make([]s3inventory.InventoryObject, 0, len(m.rows))
+func (m *mockInventoryFileReader) Read(n int) ([]*s3inventory.InventoryObject, error) {
+	res := make([]*s3inventory.InventoryObject, 0, len(m.rows))
 	for i := m.nextIdx; i < len(m.rows) && i < m.nextIdx+n; i++ {
 		if m.rows[i] == nil {
 			return nil, ErrReadFile // for test - simulate file with error
 		}
-		res = append(res, *m.rows[i])
+		res = append(res, m.rows[i])
 	}
 	m.nextIdx = m.nextIdx + len(res)
 	return res, nil

--- a/block/s3/inventory_test.go
+++ b/block/s3/inventory_test.go
@@ -30,10 +30,10 @@ func rows(keys []string, lastModified map[string]time.Time) []*s3inventory.Inven
 		if key != "" {
 			res[i] = new(s3inventory.InventoryObject)
 			res[i].Key = key
-			res[i].IsLatest = swag.Bool(!strings.Contains(key, "_expired"))
-			res[i].IsDeleteMarker = swag.Bool(strings.Contains(key, "_del"))
+			res[i].IsLatest = !strings.Contains(key, "_expired")
+			res[i].IsDeleteMarker = strings.Contains(key, "_del")
 			if lastModified != nil {
-				res[i].LastModifiedMillis = swag.Int64(lastModified[key].Unix() * 1000)
+				res[i].LastModified = swag.Time(lastModified[key])
 			}
 		}
 	}
@@ -196,9 +196,8 @@ func TestIterator(t *testing.T) {
 			if obj.Key != test.ExpectedObjects[i] {
 				t.Fatalf("at index %d: expected=%s, got=%s", i, test.ExpectedObjects[i], obj.Key)
 			}
-			expectedLastModified := lastModified[obj.Key].Truncate(time.Second)
-			if obj.LastModified != expectedLastModified {
-				t.Fatalf("last modified for object in index %d different than expected. expected=%v, got=%v", i, expectedLastModified, obj.LastModified)
+			if *obj.LastModified != lastModified[obj.Key] {
+				t.Fatalf("last modified for object in index %d different than expected. expected=%v, got=%v", i, lastModified[obj.Key], obj.LastModified)
 			}
 		}
 	}

--- a/block/s3/inventory_test.go
+++ b/block/s3/inventory_test.go
@@ -246,18 +246,16 @@ func (m *mockInventoryFileReader) Close() error {
 	return nil
 }
 
-func (m *mockInventoryFileReader) Read(dstInterface interface{}) error {
+func (m *mockInventoryFileReader) Read(n int) ([]s3inventory.InventoryObject, error) {
 	res := make([]s3inventory.InventoryObject, 0, len(m.rows))
-	dst := dstInterface.(*[]s3inventory.InventoryObject)
-	for i := m.nextIdx; i < len(m.rows) && i < m.nextIdx+len(*dst); i++ {
+	for i := m.nextIdx; i < len(m.rows) && i < m.nextIdx+n; i++ {
 		if m.rows[i] == nil {
-			return ErrReadFile // for test - simulate file with error
+			return nil, ErrReadFile // for test - simulate file with error
 		}
 		res = append(res, *m.rows[i])
 	}
 	m.nextIdx = m.nextIdx + len(res)
-	*dst = res
-	return nil
+	return res, nil
 }
 
 func (m *mockInventoryFileReader) GetNumRows() int64 {

--- a/cloud/aws/s3inventory/parquet_reader.go
+++ b/cloud/aws/s3inventory/parquet_reader.go
@@ -2,6 +2,7 @@ package s3inventory
 
 import (
 	"fmt"
+	"time"
 
 	"github.com/cznic/mathutil"
 	"github.com/go-openapi/swag"
@@ -66,7 +67,7 @@ func (p *ParquetInventoryFileReader) Read(n int) ([]*InventoryObject, error) {
 				continue
 			}
 			if res[i] == nil {
-				res[i] = new(InventoryObject)
+				res[i] = NewInventoryObject()
 			}
 			err := set(res[i], fieldName, v)
 			if err != nil {
@@ -81,33 +82,21 @@ func set(o *InventoryObject, f string, v interface{}) error {
 	var err error
 	switch f {
 	case bucketFieldName:
-		var bucket string
-		bucket, err = cast.ToStringE(v)
-		o.Bucket = bucket
+		o.Bucket, err = cast.ToStringE(v)
 	case keyFieldName:
-		var key string
-		key, err = cast.ToStringE(v)
-		o.Key = key
+		o.Key, err = cast.ToStringE(v)
 	case isLatestFieldName:
-		var isLatest bool
-		isLatest, err = cast.ToBoolE(v)
-		o.IsLatest = swag.Bool(isLatest)
+		o.IsLatest, err = cast.ToBoolE(v)
 	case isDeleteMarkerFieldName:
-		var isDeleteMarker bool
-		isDeleteMarker, err = cast.ToBoolE(v)
-		o.IsDeleteMarker = swag.Bool(isDeleteMarker)
+		o.IsDeleteMarker, err = cast.ToBoolE(v)
 	case sizeFieldName:
-		var size int64
-		size, err = cast.ToInt64E(v)
-		o.Size = swag.Int64(size)
+		o.Size, err = cast.ToInt64E(v)
 	case lastModifiedDateFieldName:
 		var lastModifiedMillis int64
 		lastModifiedMillis, err = cast.ToInt64E(v)
-		o.LastModifiedMillis = swag.Int64(lastModifiedMillis)
+		o.LastModified = swag.Time(time.Unix(lastModifiedMillis/int64(time.Second/time.Millisecond), 0))
 	case eTagFieldName:
-		var checksum string
-		checksum, err = cast.ToStringE(v)
-		o.Checksum = swag.String(checksum)
+		o.Checksum, err = cast.ToStringE(v)
 	}
 	return err
 }

--- a/cloud/aws/s3inventory/parquet_reader.go
+++ b/cloud/aws/s3inventory/parquet_reader.go
@@ -97,6 +97,8 @@ func set(o *InventoryObject, f string, v interface{}) error {
 		o.LastModified = swag.Time(time.Unix(lastModifiedMillis/int64(time.Second/time.Millisecond), 0))
 	case eTagFieldName:
 		o.Checksum, err = cast.ToStringE(v)
+	default:
+		return fmt.Errorf("%w: %s", ErrUnknownField, f)
 	}
 	return err
 }

--- a/cloud/aws/s3inventory/parquet_reader.go
+++ b/cloud/aws/s3inventory/parquet_reader.go
@@ -1,6 +1,15 @@
 package s3inventory
 
-import "github.com/xitongsys/parquet-go/reader"
+import (
+	"fmt"
+	"sync"
+
+	"github.com/go-openapi/swag"
+	"github.com/spf13/cast"
+	"github.com/xitongsys/parquet-go/reader"
+)
+
+var inventoryFields = []string{"bucket", "key", "size", "last_modified_date", "e_tag", "is_delete_marker", "is_latest"}
 
 type ParquetInventoryFileReader struct {
 	reader.ParquetReader
@@ -17,4 +26,88 @@ func (p *ParquetInventoryFileReader) FirstObjectKey() string {
 
 func (p *ParquetInventoryFileReader) LastObjectKey() string {
 	return string(p.Footer.RowGroups[0].Columns[0].GetMetaData().GetStatistics().GetMaxValue())
+}
+
+func (p *ParquetInventoryFileReader) Read(n int) ([]InventoryObject, error) {
+	res := make([]InventoryObject, n)
+	actualFields := p.getActualFields()
+	var wg sync.WaitGroup
+	errChan := make(chan error, len(actualFields))
+	for fieldName, path := range actualFields {
+		wg.Add(1)
+		path := path
+		fieldName := fieldName
+		go func() {
+			defer wg.Done()
+			columnRes, _, _, err := p.ReadColumnByPath(path, int64(n))
+			if err != nil {
+				errChan <- fmt.Errorf("failed to read parquet column %s: %w", fieldName, err)
+				return
+			}
+			for i, v := range columnRes {
+				err := set(&res[i], fieldName, v)
+				if err != nil {
+					errChan <- fmt.Errorf("failed to read parquet column %s: %w", fieldName, err)
+					return
+				}
+			}
+		}()
+	}
+	wg.Wait()
+	select {
+	case err := <-errChan:
+		return nil, err
+	default:
+	}
+	close(errChan)
+	return res, nil
+}
+
+func set(o *InventoryObject, f string, v interface{}) error {
+	var err error
+	switch f {
+	case "bucket":
+		var bucket string
+		bucket, err = cast.ToStringE(v)
+		o.Bucket = bucket
+	case "key":
+		var key string
+		key, err = cast.ToStringE(v)
+		o.Key = key
+	case "is_latest":
+		var isLatest bool
+		isLatest, err = cast.ToBoolE(v)
+		o.IsLatest = swag.Bool(isLatest)
+	case "is_delete_marker":
+		var isDeleteMarker bool
+		isDeleteMarker, err = cast.ToBoolE(v)
+		o.IsDeleteMarker = swag.Bool(isDeleteMarker)
+	case "size":
+		var size int64
+		size, err = cast.ToInt64E(v)
+		o.Size = swag.Int64(size)
+	case "last_modified_date":
+		var lastModifiedMillis int64
+		lastModifiedMillis, err = cast.ToInt64E(v)
+		o.LastModifiedMillis = swag.Int64(lastModifiedMillis)
+	case "e_tag":
+		var checksum string
+		checksum, err = cast.ToStringE(v)
+		o.Checksum = swag.String(checksum)
+	}
+	return err
+}
+
+// getActualFields returns parquet schema fields as a mapping from their base column name to their path in ParquetReader
+// only known inventory fields are returned
+func (p *ParquetInventoryFileReader) getActualFields() map[string]string {
+	res := make(map[string]string)
+	for i, fieldInfo := range p.SchemaHandler.Infos {
+		for _, r := range inventoryFields {
+			if fieldInfo.ExName == r {
+				res[r] = p.SchemaHandler.IndexMap[int32(i)]
+			}
+		}
+	}
+	return res
 }

--- a/cloud/aws/s3inventory/parquet_reader.go
+++ b/cloud/aws/s3inventory/parquet_reader.go
@@ -4,15 +4,30 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/cznic/mathutil"
+
 	"github.com/go-openapi/swag"
 	"github.com/spf13/cast"
 	"github.com/xitongsys/parquet-go/reader"
 )
 
-var inventoryFields = []string{"bucket", "key", "size", "last_modified_date", "e_tag", "is_delete_marker", "is_latest"}
-
 type ParquetInventoryFileReader struct {
-	reader.ParquetReader
+	*reader.ParquetReader
+	nextRow      int64
+	actualFields map[string]string
+}
+
+func NewParquetInventoryFileReader(parquetReader *reader.ParquetReader) (*ParquetInventoryFileReader, error) {
+	res := &ParquetInventoryFileReader{
+		ParquetReader: parquetReader,
+	}
+	res.actualFields = res.getActualFields()
+	for _, required := range requiredFields {
+		if _, ok := res.actualFields[required]; !ok {
+			return nil, fmt.Errorf("%w: %s", ErrRequiredFieldNotFound, required)
+		}
+	}
+	return res, nil
 }
 
 func (p *ParquetInventoryFileReader) Close() error {
@@ -21,79 +36,82 @@ func (p *ParquetInventoryFileReader) Close() error {
 }
 
 func (p *ParquetInventoryFileReader) FirstObjectKey() string {
-	return string(p.Footer.RowGroups[0].Columns[0].GetMetaData().GetStatistics().GetMinValue())
+	for i, c := range p.Footer.RowGroups[0].Columns {
+		if c.MetaData.PathInSchema[len(c.GetMetaData().GetPathInSchema())-1] == "Key" {
+			return string(p.Footer.RowGroups[0].Columns[i].GetMetaData().GetStatistics().GetMin())
+		}
+	}
+	return string(p.Footer.RowGroups[0].Columns[1].GetMetaData().GetStatistics().GetMin())
 }
 
 func (p *ParquetInventoryFileReader) LastObjectKey() string {
-	return string(p.Footer.RowGroups[0].Columns[0].GetMetaData().GetStatistics().GetMaxValue())
+	for i, c := range p.Footer.RowGroups[0].Columns {
+		if c.MetaData.PathInSchema[len(c.MetaData.PathInSchema)-1] == "Key" {
+			return string(p.Footer.RowGroups[0].Columns[i].GetMetaData().GetStatistics().GetMax())
+		}
+	}
+	return string(p.Footer.RowGroups[0].Columns[1].GetMetaData().GetStatistics().GetMax())
 }
 
-func (p *ParquetInventoryFileReader) Read(n int) ([]InventoryObject, error) {
-	res := make([]InventoryObject, n)
-	actualFields := p.getActualFields()
+func (p *ParquetInventoryFileReader) Read(n int) ([]*InventoryObject, error) {
 	var wg sync.WaitGroup
-	errChan := make(chan error, len(actualFields))
-	for fieldName, path := range actualFields {
+	num := mathutil.MinInt64(int64(n), p.GetNumRows()-p.nextRow)
+	p.nextRow += num
+	res := make([]*InventoryObject, num)
+	for fieldName, path := range p.actualFields {
 		wg.Add(1)
 		path := path
 		fieldName := fieldName
-		go func() {
-			defer wg.Done()
-			columnRes, _, dls, err := p.ReadColumnByPath(path, int64(n))
+
+		columnRes, _, dls, err := p.ReadColumnByPath(path, num)
+		if err != nil {
+			return nil, fmt.Errorf("failed to read parquet column %s: %w", fieldName, err)
+		}
+		for i, v := range columnRes {
+			if !isRequired(fieldName) && dls[i] == 0 {
+				// got no value for non-required field, move on
+				continue
+			}
+			if res[i] == nil {
+				res[i] = new(InventoryObject)
+			}
+			err := set(res[i], fieldName, v)
 			if err != nil {
-				errChan <- fmt.Errorf("failed to read parquet column %s: %w", fieldName, err)
-				return
+				return nil, fmt.Errorf("failed to read parquet column %s: %w", fieldName, err)
 			}
-			for i, v := range columnRes {
-				if dls[i] == 0 && fieldName != "key" && fieldName != "bucket" {
-					continue
-				}
-				err := set(&res[i], fieldName, v)
-				if err != nil {
-					errChan <- fmt.Errorf("failed to read parquet column %s: %w", fieldName, err)
-					return
-				}
-			}
-		}()
+		}
 	}
-	wg.Wait()
-	select {
-	case err := <-errChan:
-		return nil, err
-	default:
-	}
-	close(errChan)
 	return res, nil
 }
 
 func set(o *InventoryObject, f string, v interface{}) error {
 	var err error
 	switch f {
-	case "bucket":
+	case bucketFieldName:
 		var bucket string
 		bucket, err = cast.ToStringE(v)
 		o.Bucket = bucket
-	case "key":
+	case keyFieldName:
 		var key string
 		key, err = cast.ToStringE(v)
 		o.Key = key
-	case "is_latest":
+	case isLatestFieldName:
 		var isLatest bool
 		isLatest, err = cast.ToBoolE(v)
 		o.IsLatest = swag.Bool(isLatest)
-	case "is_delete_marker":
+	case isDeleteMarkerFieldName:
 		var isDeleteMarker bool
 		isDeleteMarker, err = cast.ToBoolE(v)
 		o.IsDeleteMarker = swag.Bool(isDeleteMarker)
-	case "size":
+	case sizeFieldName:
 		var size int64
 		size, err = cast.ToInt64E(v)
 		o.Size = swag.Int64(size)
-	case "last_modified_date":
+	case lastModifiedDateFieldName:
 		var lastModifiedMillis int64
 		lastModifiedMillis, err = cast.ToInt64E(v)
 		o.LastModifiedMillis = swag.Int64(lastModifiedMillis)
-	case "e_tag":
+	case eTagFieldName:
 		var checksum string
 		checksum, err = cast.ToStringE(v)
 		o.Checksum = swag.String(checksum)
@@ -106,9 +124,9 @@ func set(o *InventoryObject, f string, v interface{}) error {
 func (p *ParquetInventoryFileReader) getActualFields() map[string]string {
 	res := make(map[string]string)
 	for i, fieldInfo := range p.SchemaHandler.Infos {
-		for _, r := range inventoryFields {
-			if fieldInfo.ExName == r {
-				res[r] = p.SchemaHandler.IndexMap[int32(i)]
+		for _, field := range inventoryFields {
+			if fieldInfo.ExName == field {
+				res[field] = p.SchemaHandler.IndexMap[int32(i)]
 			}
 		}
 	}

--- a/cloud/aws/s3inventory/parquet_reader.go
+++ b/cloud/aws/s3inventory/parquet_reader.go
@@ -94,7 +94,9 @@ func set(o *InventoryObject, f string, v interface{}) error {
 	case lastModifiedDateFieldName:
 		var lastModifiedMillis int64
 		lastModifiedMillis, err = cast.ToInt64E(v)
-		o.LastModified = swag.Time(time.Unix(lastModifiedMillis/int64(time.Second/time.Millisecond), 0))
+		seconds := lastModifiedMillis / int64(time.Second/time.Millisecond)
+		ns := (lastModifiedMillis % 1000) * int64(time.Millisecond/time.Nanosecond)
+		o.LastModified = swag.Time(time.Unix(seconds, ns))
 	case eTagFieldName:
 		o.Checksum, err = cast.ToStringE(v)
 	default:

--- a/cloud/aws/s3inventory/parquet_reader.go
+++ b/cloud/aws/s3inventory/parquet_reader.go
@@ -39,12 +39,15 @@ func (p *ParquetInventoryFileReader) Read(n int) ([]InventoryObject, error) {
 		fieldName := fieldName
 		go func() {
 			defer wg.Done()
-			columnRes, _, _, err := p.ReadColumnByPath(path, int64(n))
+			columnRes, _, dls, err := p.ReadColumnByPath(path, int64(n))
 			if err != nil {
 				errChan <- fmt.Errorf("failed to read parquet column %s: %w", fieldName, err)
 				return
 			}
 			for i, v := range columnRes {
+				if dls[i] == 0 && fieldName != "key" && fieldName != "bucket" {
+					continue
+				}
 				err := set(&res[i], fieldName, v)
 				if err != nil {
 					errChan <- fmt.Errorf("failed to read parquet column %s: %w", fieldName, err)

--- a/cloud/aws/s3inventory/reader.go
+++ b/cloud/aws/s3inventory/reader.go
@@ -43,6 +43,7 @@ const (
 var (
 	ErrUnsupportedInventoryFormat = errors.New("unsupported inventory type. supported types: parquet, orc")
 	ErrRequiredFieldNotFound      = errors.New("required field not found in inventory")
+	ErrUnknownField               = errors.New("unknown field")
 )
 
 type IReader interface {

--- a/cloud/aws/s3inventory/reader.go
+++ b/cloud/aws/s3inventory/reader.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"time"
 
 	"github.com/aws/aws-sdk-go/service/s3/s3iface"
 	"github.com/scritchley/orc"
@@ -50,13 +51,17 @@ type IReader interface {
 }
 
 type InventoryObject struct {
-	Bucket             string
-	Key                string
-	IsLatest           *bool
-	IsDeleteMarker     *bool
-	Size               *int64
-	LastModifiedMillis *int64
-	Checksum           *string
+	Bucket         string
+	Key            string
+	IsLatest       bool
+	IsDeleteMarker bool
+	Size           int64
+	LastModified   *time.Time
+	Checksum       string
+}
+
+func NewInventoryObject() *InventoryObject {
+	return &InventoryObject{IsLatest: true}
 }
 
 func (o *InventoryObject) GetPhysicalAddress() string {

--- a/cloud/aws/s3inventory/reader.go
+++ b/cloud/aws/s3inventory/reader.go
@@ -27,13 +27,13 @@ type IReader interface {
 }
 
 type InventoryObject struct {
-	Bucket             string  `parquet:"name=bucket, type=UTF8"`
-	Key                string  `parquet:"name=key, type=UTF8"`
-	IsLatest           *bool   `parquet:"name=is_latest, type=BOOLEAN"`
-	IsDeleteMarker     *bool   `parquet:"name=is_delete_marker, type=BOOLEAN"`
-	Size               *int64  `parquet:"name=size, type=INT_64"`
-	LastModifiedMillis *int64  `parquet:"name=last_modified_date, type=TIMESTAMP_MILLIS"`
-	Checksum           *string `parquet:"name=e_tag, type=UTF8"`
+	Bucket             string
+	Key                string
+	IsLatest           *bool
+	IsDeleteMarker     *bool
+	Size               *int64
+	LastModifiedMillis *int64
+	Checksum           *string
 }
 
 func (o *InventoryObject) GetPhysicalAddress() string {
@@ -55,7 +55,7 @@ type MetadataReader interface {
 
 type FileReader interface {
 	MetadataReader
-	Read(dstInterface interface{}) error
+	Read(n int) ([]InventoryObject, error)
 }
 
 func NewReader(ctx context.Context, svc s3iface.S3API, logger logging.Logger) IReader {
@@ -87,8 +87,7 @@ func (o *Reader) getParquetReader(bucket string, key string) (FileReader, error)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create parquet file reader: %w", err)
 	}
-	var rawObject InventoryObject
-	pr, err := reader.NewParquetReader(pf, &rawObject, 4)
+	pr, err := reader.NewParquetReader(pf, nil, 4)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create parquet reader: %w", err)
 	}

--- a/cloud/aws/s3inventory/reader_test.go
+++ b/cloud/aws/s3inventory/reader_test.go
@@ -167,11 +167,13 @@ func TestInventoryReader(t *testing.T) {
 			t.Fatalf("unexpected result from LastObjectKey. expected=%s, got=%s", test.ExpectedMaxValue, maxValueResult)
 		}
 		readBatchSize := 1000
-		res := make([]InventoryObject, readBatchSize)
 		offset := 0
 		readCount := 0
 		for {
-			err = fileReader.Read(&res)
+			res, err := fileReader.Read(readBatchSize)
+			if err != nil {
+				t.Fatal(err)
+			}
 			for i := offset; i < mathutil.Min(offset+readBatchSize, test.ObjectNum); i++ {
 				if res[i-offset].Key != fmt.Sprintf("f%05d", i) {
 					t.Fatalf("result in index %d different than expected. expected=%s, got=%s (batch #%d, index %d)", i, fmt.Sprintf("f%05d", i), res[i-offset].Key, offset/readBatchSize, i-offset)
@@ -183,9 +185,6 @@ func TestInventoryReader(t *testing.T) {
 			}
 			offset += len(res)
 			readCount += len(res)
-			if err != nil {
-				t.Fatal(err)
-			}
 			if len(res) != readBatchSize {
 				break
 			}

--- a/cloud/aws/s3inventory/reader_test.go
+++ b/cloud/aws/s3inventory/reader_test.go
@@ -2,115 +2,169 @@ package s3inventory
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
-	"net/http/httptest"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-	"github.com/aws/aws-sdk-go/aws/credentials"
-	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
-	"github.com/aws/aws-sdk-go/service/s3/s3iface"
-	"github.com/aws/aws-sdk-go/service/s3/s3manager"
 	"github.com/cznic/mathutil"
 	"github.com/go-openapi/swag"
-	"github.com/johannesboyne/gofakes3"
-	"github.com/johannesboyne/gofakes3/backend/s3mem"
 	"github.com/scritchley/orc"
 	"github.com/treeverse/lakefs/logging"
+	"github.com/xitongsys/parquet-go-source/local"
+	"github.com/xitongsys/parquet-go/schema"
+	"github.com/xitongsys/parquet-go/writer"
 )
 
 const inventoryBucketName = "inventory-bucket"
 
-func generateOrc(t *testing.T, objs <-chan *InventoryObject) string {
-	f, err := ioutil.TempFile("", "orctest")
+type TestObject struct {
+	Bucket             string  `parquet:"name=bucket, type=UTF8"`
+	Key                string  `parquet:"name=key, type=UTF8"`
+	IsLatest           *bool   `parquet:"name=is_latest, type=BOOLEAN"`
+	IsDeleteMarker     *bool   `parquet:"name=is_delete_marker, type=BOOLEAN"`
+	Size               *int64  `parquet:"name=size, type=INT_64"`
+	LastModifiedMillis *int64  `parquet:"name=last_modified_date, type=TIMESTAMP_MILLIS"`
+	Checksum           *string `parquet:"name=e_tag, type=UTF8"`
+}
+
+func parquetSchema(fieldToRemove string) *schema.JSONSchemaItemType {
+	fieldMap := map[string]string{
+		bucketFieldName:           "name=bucket, inname=Bucket, type=UTF8, repetitiontype=REQUIRED, fieldid=1",
+		keyFieldName:              "name=key, inname=Key, type=UTF8, repetitiontype=REQUIRED, fieldid=2",
+		isLatestFieldName:         "name=is_latest, inname=IsLatest, type=BOOLEAN, repetitiontype=OPTIONAL, fieldid=3",
+		isDeleteMarkerFieldName:   "name=is_delete_marker, inname=IsDeleteMarker, type=BOOLEAN, repetitiontype=OPTIONAL, fieldid=4",
+		sizeFieldName:             "name=size, inname=Size, type=INT64, repetitiontype=OPTIONAL, fieldid=5",
+		lastModifiedDateFieldName: "name=last_modified_date, inname=LastModifiedMillis, type=INT64, repetitiontype=OPTIONAL, fieldid=6",
+		eTagFieldName:             "name=e_tag, inname=Checksum, type=UTF8, repetitiontype=OPTIONAL, fieldid=7",
+	}
+	fields := make([]*schema.JSONSchemaItemType, 0, len(fieldMap))
+	for field, tag := range fieldMap {
+		if field == fieldToRemove {
+			continue
+		}
+		fields = append(fields, &schema.JSONSchemaItemType{Tag: tag})
+	}
+	return &schema.JSONSchemaItemType{
+		Tag:    "name=s3inventory, repetitiontype=REQUIRED",
+		Fields: fields,
+	}
+}
+
+func generateParquet(t *testing.T, objs <-chan *TestObject, fieldToRemove string) *os.File {
+	f, err := ioutil.TempFile("", "parquettest")
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("failed to create temp file: %v", err)
 	}
 	defer func() {
-		_ = f.Close()
+		_ = os.Remove(f.Name())
 	}()
-	schema, err := orc.ParseSchema("struct<bucket:string,key:string,size:int,last_modified_date:timestamp,e_tag:string>")
+	fw, err := local.NewLocalFileWriter(f.Name())
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("failed to create parquet file writer: %v", err)
 	}
-	w, err := orc.NewWriter(f, orc.SetSchema(schema), orc.SetStripeTargetSize(100))
+	defer func() {
+		_ = fw.Close()
+	}()
+	jsonSchema, err := json.Marshal(parquetSchema(fieldToRemove))
+	jsonSchemaStr := string(jsonSchema)
+	pw, err := writer.NewParquetWriter(fw, jsonSchemaStr, 4)
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("failed to create parquet writer: %v", err)
+	}
+	for obj := range objs {
+		err = pw.Write(obj)
+		if err != nil {
+			t.Fatalf("failed to write object to parquet: %v", err)
+		}
+	}
+	err = pw.WriteStop()
+	if err != nil {
+		t.Fatalf("failed to stop parquet writer: %v", err)
+	}
+	return f
+}
+
+func orcSchema(fieldToRemove string) string {
+	fieldTypes := map[string]string{
+		bucketFieldName:           "string",
+		keyFieldName:              "string",
+		isLatestFieldName:         "boolean",
+		isDeleteMarkerFieldName:   "boolean",
+		sizeFieldName:             "int",
+		lastModifiedDateFieldName: "timestamp",
+		eTagFieldName:             "string",
+	}
+	var orcSchema strings.Builder
+	orcSchema.WriteString("struct<")
+	isFirst := true
+	for _, field := range inventoryFields {
+		if fieldToRemove == field {
+			continue
+		}
+		if !isFirst {
+			orcSchema.WriteString(",")
+		}
+		isFirst = false
+		orcSchema.WriteString(fmt.Sprintf("%s:%s", field, fieldTypes[field]))
+	}
+	orcSchema.WriteString(">")
+	return orcSchema.String()
+}
+
+func generateOrc(t *testing.T, objs <-chan *TestObject, fieldToRemove string) *os.File {
+	f, err := ioutil.TempFile("", "orctest")
+	if err != nil {
+		t.Fatalf("failed to create temp file: %v", err)
+	}
+	defer func() {
+		_ = os.Remove(f.Name())
+	}()
+	orcSchema := orcSchema(fieldToRemove)
+	s, err := orc.ParseSchema(orcSchema)
+	if err != nil {
+		t.Fatalf("failed to parse orc schema: %v", err)
+	}
+	w, err := orc.NewWriter(f, orc.SetSchema(s), orc.SetStripeTargetSize(100))
+	if err != nil {
+		t.Fatalf("failed to create orc writer: %v", err)
 	}
 	for o := range objs {
-		err = w.Write(o.Bucket, o.Key, *o.Size, time.Unix(*o.LastModifiedMillis/1000, 0), *o.Checksum)
+		fieldValues := map[string]interface{}{
+			bucketFieldName:           o.Bucket,
+			keyFieldName:              o.Key,
+			isLatestFieldName:         o.IsLatest == nil || swag.BoolValue(o.IsLatest),
+			isDeleteMarkerFieldName:   swag.BoolValue(o.IsDeleteMarker),
+			sizeFieldName:             swag.Int64Value(o.Size),
+			lastModifiedDateFieldName: time.Unix(swag.Int64Value(o.LastModifiedMillis)/1000, 0),
+			eTagFieldName:             swag.StringValue(o.Checksum),
+		}
+		values := make([]interface{}, 0, len(fieldValues))
+		for _, field := range inventoryFields {
+			if fieldToRemove == field {
+				continue
+			}
+			values = append(values, fieldValues[field])
+		}
+		err = w.Write(values...)
 		if err != nil {
-			t.Fatal(err)
+			t.Fatalf("failed to write object to orc: %v", err)
 		}
 	}
 	err = w.Close()
 	if err != nil {
-		t.Fatal(err)
+		t.Fatalf("failed to close orc writer: %v", err)
 	}
-	return f.Name()
+	_, _ = f.Seek(0, 0)
+	return f
 }
 
-func getS3Fake(t *testing.T) (s3iface.S3API, *httptest.Server) {
-	backend := s3mem.New()
-	faker := gofakes3.New(backend)
-	ts := httptest.NewServer(faker.Server())
-	// configure S3 client
-	s3Config := &aws.Config{
-		Credentials:      credentials.NewStaticCredentials("YOUR-ACCESSKEYID", "YOUR-SECRETACCESSKEY", ""),
-		Endpoint:         aws.String(ts.URL),
-		Region:           aws.String("eu-central-1"),
-		DisableSSL:       aws.Bool(true),
-		S3ForcePathStyle: aws.Bool(true),
-	}
-	newSession, err := session.NewSession(s3Config)
-	if err != nil {
-		t.Fatal(err)
-	}
-	return s3.New(newSession), ts
-}
-
-func objs(num int, lastModified []time.Time) <-chan *InventoryObject {
-	out := make(chan *InventoryObject)
-	go func() {
-		defer close(out)
-		for i := 0; i < num; i++ {
-			out <- &InventoryObject{
-				Bucket:             inventoryBucketName,
-				Key:                fmt.Sprintf("f%05d", i),
-				Size:               swag.Int64(500),
-				LastModifiedMillis: swag.Int64(lastModified[i%len(lastModified)].Unix() * 1000),
-				Checksum:           swag.String("abcdefg"),
-			}
-		}
-	}()
-	return out
-}
-
-func uploadFile(t *testing.T, s3 s3iface.S3API, inventoryBucket string, inventoryFilename string, objs <-chan *InventoryObject) {
-	localOrcFile := generateOrc(t, objs)
-	f, err := os.Open(localOrcFile)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		_ = f.Close()
-	}()
-	uploader := s3manager.NewUploaderWithClient(s3)
-	_, err = uploader.Upload(&s3manager.UploadInput{
-		Bucket: aws.String(inventoryBucket),
-		Key:    aws.String(inventoryFilename),
-		Body:   f,
-	})
-	if err != nil {
-		t.Fatal(err)
-	}
-}
-
-func TestInventoryReader(t *testing.T) {
+func TestReaders(t *testing.T) {
 	svc, testServer := getS3Fake(t)
 	defer testServer.Close()
 	_, err := svc.CreateBucket(&s3.CreateBucketInput{
@@ -119,81 +173,180 @@ func TestInventoryReader(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	testdata := []struct {
+	testdata := map[string]struct {
 		ObjectNum           int
 		ExpectedReadObjects int
 		ExpectedMaxValue    string
 		ExpectedMinValue    string
+		ExcludeField        string
+		Format              string
 	}{
-		{
+		"parquet with 2 objects": {
 			ObjectNum:           2,
 			ExpectedReadObjects: 2,
 			ExpectedMinValue:    "f00000",
 			ExpectedMaxValue:    "f00001",
+			Format:              "Parquet",
 		},
-		{
+		"parquet with 12500 objects": {
 			ObjectNum:           12500,
 			ExpectedReadObjects: 12500,
 			ExpectedMinValue:    "f00000",
 			ExpectedMaxValue:    "f12499",
+			Format:              "Parquet",
 		},
-		{
+		"parquet with 100 objects": {
 			ObjectNum:           100,
 			ExpectedReadObjects: 100,
 			ExpectedMinValue:    "f00000",
 			ExpectedMaxValue:    "f00099",
+			Format:              "Parquet",
+		},
+		"parquet without size field": {
+			ObjectNum:           12500,
+			ExpectedReadObjects: 12500,
+			ExpectedMinValue:    "f00000",
+			ExpectedMaxValue:    "f12499",
+			ExcludeField:        "size",
+			Format:              "Parquet",
+		},
+		"parquet without is_latest field": {
+			ObjectNum:           12500,
+			ExpectedReadObjects: 12500,
+			ExpectedMinValue:    "f00000",
+			ExpectedMaxValue:    "f12499",
+			ExcludeField:        "is_latest",
+			Format:              "Parquet",
+		},
+		"parquet without is_delete_marker field": {
+			ObjectNum:           12500,
+			ExpectedReadObjects: 12500,
+			ExpectedMinValue:    "f00000",
+			ExpectedMaxValue:    "f12499",
+			ExcludeField:        "is_delete_marker",
+			Format:              "Parquet",
+		},
+		"parquet without e_tag field": {
+			ObjectNum:           100,
+			ExpectedReadObjects: 100,
+			ExpectedMinValue:    "f00000",
+			ExpectedMaxValue:    "f00099",
+			ExcludeField:        "e_tag",
+			Format:              "Parquet",
+		},
+		"orc with 2 objects": {
+			ObjectNum:           2,
+			ExpectedReadObjects: 2,
+			ExpectedMinValue:    "f00000",
+			ExpectedMaxValue:    "f00001",
+			Format:              "ORC",
+		},
+		"orc with 12500 objects": {
+			ObjectNum:           12500,
+			ExpectedReadObjects: 12500,
+			ExpectedMinValue:    "f00000",
+			ExpectedMaxValue:    "f12499",
+			Format:              "ORC",
+		},
+		"orc with 100 objects": {
+			ObjectNum:           100,
+			ExpectedReadObjects: 100,
+			ExpectedMinValue:    "f00000",
+			ExpectedMaxValue:    "f00099",
+			Format:              "ORC",
+		},
+		"orc without size field": {
+			ObjectNum:           100,
+			ExpectedReadObjects: 100,
+			ExpectedMinValue:    "f00000",
+			ExpectedMaxValue:    "f00099",
+			Format:              "ORC",
+			ExcludeField:        "size",
+		},
+		"orc without is_latest field": {
+			ObjectNum:           100,
+			ExpectedReadObjects: 100,
+			ExpectedMinValue:    "f00000",
+			ExpectedMaxValue:    "f00099",
+			Format:              "ORC",
+			ExcludeField:        "is_latest",
+		},
+		"orc without is_delete_marker field": {
+			ObjectNum:           100,
+			ExpectedReadObjects: 100,
+			ExpectedMinValue:    "f00000",
+			ExpectedMaxValue:    "f00099",
+			Format:              "ORC",
+			ExcludeField:        "is_delete_marker",
 		},
 	}
-
-	for _, test := range testdata {
-		now := time.Now()
-		lastModified := []time.Time{now, now.Add(-1 * time.Hour), now.Add(-2 * time.Hour), now.Add(-3 * time.Hour)}
-		uploadFile(t, svc, inventoryBucketName, "myFile.orc", objs(test.ObjectNum, lastModified))
-		reader := NewReader(context.Background(), svc, logging.Default())
-		fileReader, err := reader.GetFileReader("ORC", inventoryBucketName, "myFile.orc")
-		if err != nil {
-			t.Fatal(err)
-		}
-		numRowsResult := int(fileReader.GetNumRows())
-		if test.ObjectNum != numRowsResult {
-			t.Fatalf("unexpected result from GetNumRows. expected=%d, got=%d", test.ObjectNum, numRowsResult)
-		}
-		minValueResult := fileReader.FirstObjectKey()
-		if test.ExpectedMinValue != minValueResult {
-			t.Fatalf("unexpected result from FirstObjectKey. expected=%s, got=%s", test.ExpectedMinValue, minValueResult)
-		}
-		maxValueResult := fileReader.LastObjectKey()
-		if test.ExpectedMaxValue != maxValueResult {
-			t.Fatalf("unexpected result from LastObjectKey. expected=%s, got=%s", test.ExpectedMaxValue, maxValueResult)
-		}
-		readBatchSize := 1000
-		offset := 0
-		readCount := 0
-		for {
-			res, err := fileReader.Read(readBatchSize)
+	for testName, test := range testdata {
+		t.Run(testName, func(t *testing.T) {
+			now := time.Now()
+			lastModified := []time.Time{now, now.Add(-1 * time.Hour), now.Add(-2 * time.Hour), now.Add(-3 * time.Hour)}
+			var localFile *os.File
+			if test.Format == "ORC" {
+				localFile = generateOrc(t, objs(test.ObjectNum, lastModified), test.ExcludeField)
+			} else if test.Format == "Parquet" {
+				localFile = generateParquet(t, objs(test.ObjectNum, lastModified), test.ExcludeField)
+			}
+			uploadFile(t, svc, inventoryBucketName, "myFile.inv", localFile)
+			reader := NewReader(context.Background(), svc, logging.Default())
+			fileReader, err := reader.GetFileReader(test.Format, inventoryBucketName, "myFile.inv")
 			if err != nil {
-				t.Fatal(err)
+				t.Fatalf("failed to create file reader: %v", err)
 			}
-			for i := offset; i < mathutil.Min(offset+readBatchSize, test.ObjectNum); i++ {
-				if res[i-offset].Key != fmt.Sprintf("f%05d", i) {
-					t.Fatalf("result in index %d different than expected. expected=%s, got=%s (batch #%d, index %d)", i, fmt.Sprintf("f%05d", i), res[i-offset].Key, offset/readBatchSize, i-offset)
+			numRowsResult := int(fileReader.GetNumRows())
+			if test.ObjectNum != numRowsResult {
+				t.Fatalf("unexpected result from GetNumRows. expected=%d, got=%d", test.ObjectNum, numRowsResult)
+			}
+			minValueResult := fileReader.FirstObjectKey()
+			if test.ExpectedMinValue != minValueResult {
+				t.Fatalf("unexpected result from FirstObjectKey. expected=%s, got=%s", test.ExpectedMinValue, minValueResult)
+			}
+			maxValueResult := fileReader.LastObjectKey()
+			if test.ExpectedMaxValue != maxValueResult {
+				t.Fatalf("unexpected result from LastObjectKey. expected=%s, got=%s", test.ExpectedMaxValue, maxValueResult)
+			}
+			readBatchSize := 1000
+			offset := 0
+			readCount := 0
+			for {
+				res, err := fileReader.Read(readBatchSize)
+				if err != nil {
+					t.Fatalf("failed to read from file reader: %v", err)
 				}
-				expectedLastModified := lastModified[i%len(lastModified)].Unix() * 1000
-				if *res[i-offset].LastModifiedMillis != expectedLastModified {
-					t.Fatalf("unexpected timestamp for result in index %d. expected=%d, got=%d (batch #%d, index %d)", i, expectedLastModified, *res[i-offset].LastModifiedMillis, offset/readBatchSize, i-offset)
+				expectedSize := swag.Int64(500)
+				if test.ExcludeField == "size" {
+					expectedSize = nil
+				}
+				expectedChecksum := swag.String("abcdefg")
+				if test.ExcludeField == "e_tag" {
+					expectedChecksum = nil
+				}
+				for i := offset; i < mathutil.Min(offset+readBatchSize, test.ObjectNum); i++ {
+					verifyObject(t, res[i-offset], &TestObject{
+						Bucket:             inventoryBucketName,
+						Key:                fmt.Sprintf("f%05d", i),
+						IsLatest:           swag.Bool(true),
+						IsDeleteMarker:     swag.Bool(false),
+						Size:               expectedSize,
+						LastModifiedMillis: swag.Int64(lastModified[i%len(lastModified)].Unix() * 1000),
+						Checksum:           expectedChecksum,
+					}, i, offset/readBatchSize, i-offset)
+				}
+				offset += len(res)
+				readCount += len(res)
+				if len(res) != readBatchSize {
+					break
 				}
 			}
-			offset += len(res)
-			readCount += len(res)
-			if len(res) != readBatchSize {
-				break
+			if test.ExpectedReadObjects != readCount {
+				t.Fatalf("read unexpected number of keys from inventory. expected=%d, got=%d", test.ExpectedReadObjects, readCount)
 			}
-		}
-		if test.ExpectedReadObjects != readCount {
-			t.Fatalf("read unexpected number of keys from inventory. expected=%d, got=%d", test.ExpectedReadObjects, readCount)
-		}
-		if fileReader.Close() != nil {
-			t.Fatalf("failed to close file reader")
-		}
+			if fileReader.Close() != nil {
+				t.Fatalf("failed to close file reader")
+			}
+		})
 	}
 }

--- a/cloud/aws/s3inventory/utils_test.go
+++ b/cloud/aws/s3inventory/utils_test.go
@@ -19,28 +19,27 @@ import (
 	"github.com/go-openapi/swag"
 )
 
-func verifyObject(t *testing.T, actual *InventoryObject, expected *TestObject, index int, batchId int, indexInBatch int) {
+func verifyObject(t *testing.T, actual *InventoryObject, expected *InventoryObject, index int, batchId int, indexInBatch int) {
 	if expected.Bucket != actual.Bucket {
 		t.Fatalf("bucket in index %d different than expected. expected=%s, got=%s (batch #%d, index %d)", index, expected.Bucket, actual.Bucket, batchId, indexInBatch)
 	}
 	if expected.Key != actual.Key {
 		t.Fatalf("object key in index %d different than expected. expected=%s, got=%s (batch #%d, index %d)", index, expected.Key, actual.Key, batchId, indexInBatch)
 	}
-	if swag.Int64Value(expected.Size) != actual.Size {
-		t.Fatalf("size in index %d different than expected. expected=%d, got=%d (batch #%d, index %d)", index, swag.Int64Value(expected.Size), actual.Size, batchId, indexInBatch)
+	if expected.Size != actual.Size {
+		t.Fatalf("size in index %d different than expected. expected=%d, got=%d (batch #%d, index %d)", index, expected.Size, actual.Size, batchId, indexInBatch)
 	}
-	if swag.StringValue(expected.Checksum) != actual.Checksum {
-		t.Fatalf("e_tag in index %d different than expected. expected=%s, got=%s (batch #%d, index %d)", index, swag.StringValue(expected.Checksum), actual.Checksum, batchId, indexInBatch)
+	if expected.Checksum != actual.Checksum {
+		t.Fatalf("e_tag in index %d different than expected. expected=%s, got=%s (batch #%d, index %d)", index, expected.Checksum, actual.Checksum, batchId, indexInBatch)
 	}
-	actualLastModifiedMillis := actual.LastModified.Unix() * int64(time.Second/time.Millisecond)
-	if *expected.LastModifiedMillis != actualLastModifiedMillis {
-		t.Fatalf("last_modified_time in index %d different than expected. expected=%d, got=%d (batch #%d, index %d)", index, *expected.LastModifiedMillis, actualLastModifiedMillis, batchId, indexInBatch)
+	if !expected.LastModified.Equal(*actual.LastModified) {
+		t.Fatalf("last_modified_time in index %d different than expected. expected=%v, got=%v (batch #%d, index %d)", index, expected.LastModified, actual.LastModified, batchId, indexInBatch)
 	}
-	if *expected.IsDeleteMarker != actual.IsDeleteMarker {
-		t.Fatalf("is_delete_marker in index %d different than expected. expected=%v, got=%v (batch #%d, index %d)", index, *expected.IsDeleteMarker, actual.IsDeleteMarker, batchId, indexInBatch)
+	if expected.IsDeleteMarker != actual.IsDeleteMarker {
+		t.Fatalf("is_delete_marker in index %d different than expected. expected=%v, got=%v (batch #%d, index %d)", index, expected.IsDeleteMarker, actual.IsDeleteMarker, batchId, indexInBatch)
 	}
-	if actual.IsLatest != *expected.IsLatest {
-		t.Fatalf("is_latest in index %d different than expected. expected=%v, got=%v (batch #%d, index %d)", index, *expected.IsLatest, actual.IsLatest, batchId, indexInBatch)
+	if actual.IsLatest != expected.IsLatest {
+		t.Fatalf("is_latest in index %d different than expected. expected=%v, got=%v (batch #%d, index %d)", index, expected.IsLatest, actual.IsLatest, batchId, indexInBatch)
 	}
 }
 
@@ -53,7 +52,7 @@ func objs(num int, lastModified []time.Time) <-chan *TestObject {
 				Bucket:             inventoryBucketName,
 				Key:                fmt.Sprintf("f%05d", i),
 				Size:               swag.Int64(500),
-				LastModifiedMillis: swag.Int64(lastModified[i%len(lastModified)].Unix() * 1000),
+				LastModifiedMillis: swag.Int64(lastModified[i%len(lastModified)].UnixNano() / 1_000_000),
 				Checksum:           swag.String("abcdefg"),
 			}
 		}

--- a/cloud/aws/s3inventory/utils_test.go
+++ b/cloud/aws/s3inventory/utils_test.go
@@ -1,0 +1,98 @@
+package s3inventory
+
+import (
+	"fmt"
+	"net/http/httptest"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/aws/aws-sdk-go/aws/session"
+	"github.com/aws/aws-sdk-go/service/s3"
+	"github.com/aws/aws-sdk-go/service/s3/s3iface"
+	"github.com/aws/aws-sdk-go/service/s3/s3manager"
+	"github.com/johannesboyne/gofakes3"
+	"github.com/johannesboyne/gofakes3/backend/s3mem"
+
+	"github.com/go-openapi/swag"
+)
+
+func verifyObject(t *testing.T, actual *InventoryObject, expected *TestObject, index int, batchId int, indexInBatch int) {
+	if expected.Bucket != actual.Bucket {
+		t.Fatalf("bucket in index %d different than expected. expected=%s, got=%s (batch #%d, index %d)", index, expected.Bucket, actual.Bucket, batchId, indexInBatch)
+	}
+	if expected.Key != actual.Key {
+		t.Fatalf("object key in index %d different than expected. expected=%s, got=%s (batch #%d, index %d)", index, expected.Key, actual.Key, batchId, indexInBatch)
+	}
+	if swag.Int64Value(expected.Size) != swag.Int64Value(actual.Size) {
+		t.Fatalf("size in index %d different than expected. expected=%d, got=%d (batch #%d, index %d)", index, swag.Int64Value(expected.Size), swag.Int64Value(actual.Size), batchId, indexInBatch)
+	}
+	if swag.StringValue(expected.Checksum) != swag.StringValue(actual.Checksum) {
+		t.Fatalf("e_tag in index %d different than expected. expected=%s, got=%s (batch #%d, index %d)", index, swag.StringValue(expected.Checksum), swag.StringValue(actual.Checksum), batchId, indexInBatch)
+	}
+	if *expected.LastModifiedMillis != *actual.LastModifiedMillis {
+		t.Fatalf("last_modified_time in index %d different than expected. expected=%d, got=%d (batch #%d, index %d)", index, *expected.LastModifiedMillis, *actual.LastModifiedMillis, batchId, indexInBatch)
+	}
+	if *expected.IsDeleteMarker != swag.BoolValue(actual.IsDeleteMarker) {
+		t.Fatalf("is_delete_marker in index %d different than expected. expected=%v, got=%v (batch #%d, index %d)", index, *expected.IsDeleteMarker, *actual.IsDeleteMarker, batchId, indexInBatch)
+	}
+	if actual.IsLatest == nil && !*expected.IsLatest {
+		t.Fatalf("is_latest in index %d different than expected. expected=%v, got=%v (batch #%d, index %d)", index, *expected.IsLatest, nil, batchId, indexInBatch)
+	}
+	if actual.IsLatest != nil && *expected.IsLatest != swag.BoolValue(actual.IsLatest) {
+		t.Fatalf("is_latest in index %d different than expected. expected=%v, got=%v (batch #%d, index %d)", index, *expected.IsLatest, *actual.IsLatest, batchId, indexInBatch)
+	}
+}
+
+func objs(num int, lastModified []time.Time) <-chan *TestObject {
+	out := make(chan *TestObject)
+	go func() {
+		defer close(out)
+		for i := 0; i < num; i++ {
+			out <- &TestObject{
+				Bucket:             inventoryBucketName,
+				Key:                fmt.Sprintf("f%05d", i),
+				Size:               swag.Int64(500),
+				LastModifiedMillis: swag.Int64(lastModified[i%len(lastModified)].Unix() * 1000),
+				Checksum:           swag.String("abcdefg"),
+			}
+		}
+	}()
+	return out
+}
+
+func uploadFile(t *testing.T, s3 s3iface.S3API, inventoryBucket string, inventoryFilename string, f *os.File) {
+	defer func() {
+		_ = f.Close()
+	}()
+	uploader := s3manager.NewUploaderWithClient(s3)
+	_, err := uploader.Upload(&s3manager.UploadInput{
+		Bucket: aws.String(inventoryBucket),
+		Key:    aws.String(inventoryFilename),
+		Body:   f,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+func getS3Fake(t *testing.T) (s3iface.S3API, *httptest.Server) {
+	backend := s3mem.New()
+	faker := gofakes3.New(backend)
+	ts := httptest.NewServer(faker.Server())
+	// configure S3 client
+	s3Config := &aws.Config{
+		Credentials:      credentials.NewStaticCredentials("YOUR-ACCESSKEYID", "YOUR-SECRETACCESSKEY", ""),
+		Endpoint:         aws.String(ts.URL),
+		Region:           aws.String("eu-central-1"),
+		DisableSSL:       aws.Bool(true),
+		S3ForcePathStyle: aws.Bool(true),
+	}
+	newSession, err := session.NewSession(s3Config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return s3.New(newSession), ts
+}

--- a/cloud/aws/s3inventory/utils_test.go
+++ b/cloud/aws/s3inventory/utils_test.go
@@ -26,23 +26,21 @@ func verifyObject(t *testing.T, actual *InventoryObject, expected *TestObject, i
 	if expected.Key != actual.Key {
 		t.Fatalf("object key in index %d different than expected. expected=%s, got=%s (batch #%d, index %d)", index, expected.Key, actual.Key, batchId, indexInBatch)
 	}
-	if swag.Int64Value(expected.Size) != swag.Int64Value(actual.Size) {
-		t.Fatalf("size in index %d different than expected. expected=%d, got=%d (batch #%d, index %d)", index, swag.Int64Value(expected.Size), swag.Int64Value(actual.Size), batchId, indexInBatch)
+	if swag.Int64Value(expected.Size) != actual.Size {
+		t.Fatalf("size in index %d different than expected. expected=%d, got=%d (batch #%d, index %d)", index, swag.Int64Value(expected.Size), actual.Size, batchId, indexInBatch)
 	}
-	if swag.StringValue(expected.Checksum) != swag.StringValue(actual.Checksum) {
-		t.Fatalf("e_tag in index %d different than expected. expected=%s, got=%s (batch #%d, index %d)", index, swag.StringValue(expected.Checksum), swag.StringValue(actual.Checksum), batchId, indexInBatch)
+	if swag.StringValue(expected.Checksum) != actual.Checksum {
+		t.Fatalf("e_tag in index %d different than expected. expected=%s, got=%s (batch #%d, index %d)", index, swag.StringValue(expected.Checksum), actual.Checksum, batchId, indexInBatch)
 	}
-	if *expected.LastModifiedMillis != *actual.LastModifiedMillis {
-		t.Fatalf("last_modified_time in index %d different than expected. expected=%d, got=%d (batch #%d, index %d)", index, *expected.LastModifiedMillis, *actual.LastModifiedMillis, batchId, indexInBatch)
+	actualLastModifiedMillis := actual.LastModified.Unix() * int64(time.Second/time.Millisecond)
+	if *expected.LastModifiedMillis != actualLastModifiedMillis {
+		t.Fatalf("last_modified_time in index %d different than expected. expected=%d, got=%d (batch #%d, index %d)", index, *expected.LastModifiedMillis, actualLastModifiedMillis, batchId, indexInBatch)
 	}
-	if *expected.IsDeleteMarker != swag.BoolValue(actual.IsDeleteMarker) {
-		t.Fatalf("is_delete_marker in index %d different than expected. expected=%v, got=%v (batch #%d, index %d)", index, *expected.IsDeleteMarker, *actual.IsDeleteMarker, batchId, indexInBatch)
+	if *expected.IsDeleteMarker != actual.IsDeleteMarker {
+		t.Fatalf("is_delete_marker in index %d different than expected. expected=%v, got=%v (batch #%d, index %d)", index, *expected.IsDeleteMarker, actual.IsDeleteMarker, batchId, indexInBatch)
 	}
-	if actual.IsLatest == nil && !*expected.IsLatest {
-		t.Fatalf("is_latest in index %d different than expected. expected=%v, got=%v (batch #%d, index %d)", index, *expected.IsLatest, nil, batchId, indexInBatch)
-	}
-	if actual.IsLatest != nil && *expected.IsLatest != swag.BoolValue(actual.IsLatest) {
-		t.Fatalf("is_latest in index %d different than expected. expected=%v, got=%v (batch #%d, index %d)", index, *expected.IsLatest, *actual.IsLatest, batchId, indexInBatch)
+	if actual.IsLatest != *expected.IsLatest {
+		t.Fatalf("is_latest in index %d different than expected. expected=%v, got=%v (batch #%d, index %d)", index, *expected.IsLatest, actual.IsLatest, batchId, indexInBatch)
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -66,6 +66,7 @@ require (
 	github.com/sirupsen/logrus v1.6.0
 	github.com/smartystreets/assertions v1.1.1 // indirect
 	github.com/spf13/afero v1.3.4 // indirect
+	github.com/spf13/cast v1.3.1
 	github.com/spf13/cobra v1.0.0
 	github.com/spf13/pflag v1.0.5
 	github.com/spf13/viper v1.7.1

--- a/onboard/catalog_actions.go
+++ b/onboard/catalog_actions.go
@@ -93,7 +93,7 @@ func (c *CatalogRepoActions) ApplyImport(ctx context.Context, it Iterator, dryRu
 		entry := catalog.Entry{
 			Path:            obj.Key,
 			PhysicalAddress: obj.PhysicalAddress,
-			CreationDate:    obj.LastModified,
+			CreationDate:    *obj.LastModified,
 			Size:            obj.Size,
 			Checksum:        obj.Checksum,
 		}

--- a/onboard/inventory_test.go
+++ b/onboard/inventory_test.go
@@ -154,7 +154,7 @@ func TestDiff(t *testing.T) {
 			if actualAdded[i].Key != expectedAdded {
 				t.Fatalf("added object in diff index %d different than expected. expected: %s, got: %s", i, expectedAdded, actualAdded[i].Key)
 			}
-			if actualAdded[i].LastModified != times[expectedAdded] {
+			if *actualAdded[i].LastModified != times[expectedAdded] {
 				t.Fatalf("modified time for key %s different than expected. expected: %v, got: %v", expectedAdded, times[expectedAdded], actualAdded[i].LastModified)
 			}
 		}
@@ -162,7 +162,7 @@ func TestDiff(t *testing.T) {
 			if actualDeleted[i].Key != expectedDeleted {
 				t.Fatalf("deleted object in diff index %d different than expected. expected: %s, got: %s", i, expectedDeleted, actualDeleted[i].Key)
 			}
-			if actualDeleted[i].LastModified != times[expectedDeleted] {
+			if *actualDeleted[i].LastModified != times[expectedDeleted] {
 				t.Fatalf("modified time for key %s different than expected. expected: %v, got: %v", expectedDeleted, times[expectedDeleted], actualDeleted[i].LastModified)
 			}
 		}
@@ -170,7 +170,7 @@ func TestDiff(t *testing.T) {
 			if actualChanged[i].Key != expectedChanged {
 				t.Fatalf("changed object in diff index %d different than expected. expected: %s, got: %s", i, expectedChanged, actualChanged[i].Key)
 			}
-			if actualChanged[i].LastModified != times[expectedChanged] {
+			if *actualChanged[i].LastModified != times[expectedChanged] {
 				t.Fatalf("modified time for key %s different than expected. expected: %v, got: %v", expectedChanged, times[expectedChanged], actualChanged[i].LastModified)
 			}
 		}

--- a/onboard/utils_test.go
+++ b/onboard/utils_test.go
@@ -6,6 +6,7 @@ import (
 	"sort"
 	"time"
 
+	"github.com/go-openapi/swag"
 	"github.com/treeverse/lakefs/block"
 	"github.com/treeverse/lakefs/catalog"
 	"github.com/treeverse/lakefs/cmdutils"
@@ -66,7 +67,7 @@ func (m *mockInventory) rows() []block.InventoryObject {
 	}
 	for i, key := range m.keys {
 
-		res = append(res, block.InventoryObject{Key: key, LastModified: m.lastModified[i%len(m.lastModified)], Checksum: m.checksum(key)})
+		res = append(res, block.InventoryObject{Key: key, LastModified: swag.Time(m.lastModified[i%len(m.lastModified)]), Checksum: m.checksum(key)})
 	}
 	return res
 }


### PR DESCRIPTION
Implements #557 

1. Align inventory column requirements between Parquet in ORC: make all columns except bucket and key optional in Parquet.
2. Add tests to parquet reader
