### PR TITLE
[export] refactor generate tasks from diffs

### DIFF
--- a/export/tasks_generator.go
+++ b/export/tasks_generator.go
@@ -153,7 +153,7 @@ func (s *SuccessTasksTreeGenerator) AddFor(path string) (parade.TaskID, error) {
 			// Initialize a new task
 			task.ID = s.idGen.makeSuccessTaskID(d)
 			task.Action = TouchAction
-			data := SuccessData{File: s.makeDestination(d)}
+			data := SuccessData{File: s.makeDestination(d + "/" + successFilename)}
 			body, err := json.Marshal(data)
 			if err != nil {
 				return "", fmt.Errorf("failed to serialize %+v: %w", data, err)

--- a/export/tasks_generator.go
+++ b/export/tasks_generator.go
@@ -94,6 +94,105 @@ func NewDirMatchCache(pred func(path string) bool) *DirMatchCache {
 	return &DirMatchCache{pred: pred, upMatchCache: make(map[string]*string)}
 }
 
+// taskIdGenerator generates IDs for export tasks based on its exportID.
+type taskIdGenerator string
+
+func (exportID taskIdGenerator) makeSuccessTaskID(path string) parade.TaskID {
+	return parade.TaskID(fmt.Sprintf("%s:make-success:%s", exportID, path))
+}
+
+func (exportID taskIdGenerator) finishedTaskID() parade.TaskID {
+	return parade.TaskID(fmt.Sprintf("%s:finished", exportID))
+}
+
+func (exportID taskIdGenerator) copyTaskID(physicalAddress string) parade.TaskID {
+	return parade.TaskID(fmt.Sprintf("%s:copy:%s", exportID, physicalAddress))
+}
+
+func (exportID taskIdGenerator) deleteTaskID(physicalAddress string) parade.TaskID {
+	return parade.TaskID(fmt.Sprintf("%s:delete:%s", exportID, physicalAddress))
+}
+
+// SuccessTasksTreeGenerator accumulates success tasks during task generator.  It is exported
+// (only) for testing.
+type SuccessTasksTreeGenerator struct {
+	idGen                   taskIdGenerator
+	successDirectoriesCache *DirMatchCache
+	makeDestination         func(string) string
+	finishedTask            parade.TaskData
+	successTaskForDirectory map[string]parade.TaskData
+}
+
+func NewSuccessTasksTreeGenerator(exportID string, generateSuccessFor func(path string) bool, makeDestination func(string) string) SuccessTasksTreeGenerator {
+	idGen := taskIdGenerator(exportID)
+	zero, one := 0, 1
+	return SuccessTasksTreeGenerator{
+		idGen:                   idGen,
+		successDirectoriesCache: NewDirMatchCache(generateSuccessFor),
+		makeDestination:         makeDestination,
+		finishedTask: parade.TaskData{
+			ID:                idGen.finishedTaskID(),
+			Action:            DoneAction,
+			Body:              nil,
+			StatusCode:        parade.TaskPending,
+			MaxTries:          &one,
+			TotalDependencies: &zero,
+		},
+		successTaskForDirectory: make(map[string]parade.TaskData),
+	}
+}
+
+// AddFor adds a dependency task for path (there will always be exactly one, either to create a
+// success file after path, or to finish everything), and returns its task ID for the caller to
+// signal when done.
+func (s *SuccessTasksTreeGenerator) AddFor(path string) (parade.TaskID, error) {
+	numTouchTries := 5
+	if d, ok := s.successDirectoriesCache.Lookup(path); ok {
+		task, ok := s.successTaskForDirectory[d]
+		if !ok {
+			// Initialize a new task
+			task.ID = s.idGen.makeSuccessTaskID(d)
+			task.Action = TouchAction
+			data := SuccessData{File: s.makeDestination(d)}
+			body, err := json.Marshal(data)
+			if err != nil {
+				return "", fmt.Errorf("failed to serialize %+v: %w", data, err)
+			}
+			bodyStr := string(body)
+			task.Body = &bodyStr
+			task.StatusCode = parade.TaskPending
+			task.MaxTries = &numTouchTries
+
+			// Success task also has a dependency
+			parentID, err := s.AddFor(d)
+			if err != nil {
+				return "", fmt.Errorf("create parent for %s: %w", d, err)
+			}
+			task.ToSignalAfter = []parade.TaskID{parentID}
+			count := 0
+			task.TotalDependencies = &count
+		}
+		(*task.TotalDependencies)++
+		s.successTaskForDirectory[d] = task
+		return task.ID, nil
+	}
+	(*s.finishedTask.TotalDependencies)++
+	return s.finishedTask.ID, nil
+}
+
+// GenerateTasksTo generates and appends all success tasks and the finished task to tasks,
+// returning a new tasks slice.
+func (s *SuccessTasksTreeGenerator) GenerateTasksTo(tasks []parade.TaskData) []parade.TaskData {
+	off := len(tasks)
+	tasks = tasks[:off+1+len(s.successTaskForDirectory)]
+	for _, task := range s.successTaskForDirectory {
+		tasks[off] = task
+		off++
+	}
+	tasks[off] = s.finishedTask
+	return tasks
+}
+
 // GenerateTasksFromDiffs converts diffs into many tasks that depend on startTaskID, with a
 // "generate success" task after generating all files in each directory that matches
 // generateSuccessFor.
@@ -107,46 +206,25 @@ func GenerateTasksFromDiffs(exportID string, dstPrefix string, diffs catalog.Dif
 	makeDestination := func(path string) string {
 		return fmt.Sprintf("%s/%s", dstPrefix, path)
 	}
-	makeSuccessTaskID := func(path string) parade.TaskID {
-		return parade.TaskID(fmt.Sprintf("%s:make-success:%s", exportID, path))
-	}
 
-	finishedTaskID := parade.TaskID(fmt.Sprintf("%s:finished", exportID))
-	finishedTask := parade.TaskData{
-		ID:         finishedTaskID,
-		Action:     DoneAction,
-		Body:       nil,
-		StatusCode: parade.TaskPending,
-		MaxTries:   &one,
-		// TotalDependencies filled in later
-	}
-	totalTasks := 0
+	idGen := taskIdGenerator(exportID)
 
-	successDirectoriesCache := NewDirMatchCache(generateSuccessFor)
-	successForDirectory := make(map[string]struct {
-		count    int
-		toSignal []parade.TaskID
-	})
+	successTasksGenerator := NewSuccessTasksTreeGenerator(
+		exportID, generateSuccessFor, makeDestination)
 
 	makeTaskForDiff := func(diff catalog.Difference) (parade.TaskData, error) {
 		var (
-			body     []byte
-			action   string
-			taskID   parade.TaskID
-			toSignal []parade.TaskID
-			err      error
+			body   []byte
+			action string
+			taskID parade.TaskID
+			err    error
 		)
 
-		if d, ok := successDirectoriesCache.Lookup(diff.Path); ok {
-			s := successForDirectory[d]
-			s.count++
-			successForDirectory[d] = s
-
-			toSignal = append(toSignal, makeSuccessTaskID(d))
+		id, err := successTasksGenerator.AddFor(diff.Path)
+		if err != nil {
+			return parade.TaskData{}, fmt.Errorf("generate tasks after %+v: %w", diff, err)
 		}
-		if len(toSignal) == 0 {
-			toSignal = []parade.TaskID{finishedTaskID}
-		}
+		toSignal := []parade.TaskID{id}
 
 		switch diff.Type {
 		case catalog.DifferenceTypeAdded, catalog.DifferenceTypeChanged:
@@ -158,7 +236,7 @@ func GenerateTasksFromDiffs(exportID string, dstPrefix string, diffs catalog.Dif
 			if err != nil {
 				return parade.TaskData{}, fmt.Errorf("%+v: failed to serialize %+v: %w", diff, data, err)
 			}
-			taskID = parade.TaskID(fmt.Sprintf("%s:copy:%s", exportID, diff.PhysicalAddress))
+			taskID = idGen.copyTaskID(diff.PhysicalAddress)
 			action = CopyAction
 		case catalog.DifferenceTypeRemoved:
 			data := DeleteData{
@@ -168,7 +246,7 @@ func GenerateTasksFromDiffs(exportID string, dstPrefix string, diffs catalog.Dif
 			if err != nil {
 				return parade.TaskData{}, fmt.Errorf("%+v: failed to serialize %+v: %w", diff, data, err)
 			}
-			taskID = parade.TaskID(fmt.Sprintf("%s:delete:%s", exportID, diff.PhysicalAddress))
+			taskID = idGen.deleteTaskID(diff.PhysicalAddress)
 			action = DeleteAction
 		case catalog.DifferenceTypeConflict:
 			return parade.TaskData{}, fmt.Errorf("%+v: %w", diff, ErrConflict)
@@ -197,62 +275,10 @@ func GenerateTasksFromDiffs(exportID string, dstPrefix string, diffs catalog.Dif
 		if err != nil {
 			return nil, err
 		}
-		totalTasks++
-
 		ret = append(ret, task)
 	}
 
-	// Add higher-level success directories, e.g. "a/b-success" for "a/b-success/c/d-success/x".
-	todoDirs := make([]string, 0, len(successForDirectory))
-	for successDirectory := range successForDirectory {
-		todoDirs = append(todoDirs, successDirectory)
-	}
-	for len(todoDirs) > 0 {
-		var d string
-		todoDirs, d = todoDirs[:len(todoDirs)-1], todoDirs[len(todoDirs)-1]
-		if upD, ok := successDirectoriesCache.Lookup(d); ok {
-			s := successForDirectory[upD]
-			s.count++
-			successForDirectory[upD] = s
-
-			s = successForDirectory[d]
-			s.toSignal = append(s.toSignal, makeSuccessTaskID(upD))
-			successForDirectory[d] = s
-		}
-	}
-
-	// Create any needed "success file" tasks
-	for successDirectory, td := range successForDirectory {
-		successPath := fmt.Sprintf("%s/%s", successDirectory, successFilename)
-		data := SuccessData{
-			File: makeDestination(successPath),
-		}
-		body, err := json.Marshal(data)
-		if err != nil {
-			return nil, fmt.Errorf("%s: failed to serialize %+v: %w", successPath, data, err)
-		}
-		bodyStr := string(body)
-		totalDependencies := td // copy to get new address each time
-
-		toSignal := totalDependencies.toSignal
-		if len(toSignal) == 0 {
-			toSignal = []parade.TaskID{finishedTaskID}
-		}
-
-		ret = append(ret, parade.TaskData{
-			ID:                makeSuccessTaskID(successDirectory),
-			Action:            TouchAction,
-			Body:              &bodyStr,
-			StatusCode:        parade.TaskPending,
-			MaxTries:          &numTries,
-			TotalDependencies: &totalDependencies.count,
-			ToSignalAfter:     toSignal,
-		})
-		totalTasks++
-	}
-
-	finishedTask.TotalDependencies = &totalTasks
-	ret = append(ret, finishedTask)
+	ret = successTasksGenerator.GenerateTasksTo(ret)
 
 	return ret, nil
 }

--- a/export/tasks_generator.go
+++ b/export/tasks_generator.go
@@ -183,23 +183,21 @@ func (s *SuccessTasksTreeGenerator) AddFor(path string) (parade.TaskID, error) {
 // GenerateTasksTo generates and appends all success tasks and the finished task to tasks,
 // returning a new tasks slice.
 func (s *SuccessTasksTreeGenerator) GenerateTasksTo(tasks []parade.TaskData) []parade.TaskData {
-	off := len(tasks)
-	tasks = tasks[:off+1+len(s.successTaskForDirectory)]
+	l := len(tasks)
+	ret := make([]parade.TaskData, l, l+1+len(s.successTaskForDirectory))
+	copy(ret, tasks)
+	tasks = ret
 	for _, task := range s.successTaskForDirectory {
-		tasks[off] = task
-		off++
+		tasks = append(tasks, task)
 	}
-	tasks[off] = s.finishedTask
+	tasks = append(tasks, s.finishedTask)
 	return tasks
 }
 
 // makeDiffTaskBody fills TaskData *out with id, action and a body to make it a task to
 // perform diff.
 func makeDiffTaskBody(out *parade.TaskData, idGen taskIDGenerator, diff catalog.Difference, makeDestination func(string) string) error {
-	var (
-		data interface{}
-		err  error
-	)
+	var data interface{}
 	switch diff.Type {
 	case catalog.DifferenceTypeAdded, catalog.DifferenceTypeChanged:
 		data = CopyData{

--- a/export/tasks_generator.go
+++ b/export/tasks_generator.go
@@ -95,28 +95,28 @@ func NewDirMatchCache(pred func(path string) bool) *DirMatchCache {
 }
 
 // taskIdGenerator generates IDs for export tasks based on its exportID.
-type taskIdGenerator string
+type taskIDGenerator string
 
-func (exportID taskIdGenerator) makeSuccessTaskID(path string) parade.TaskID {
+func (exportID taskIDGenerator) makeSuccessTaskID(path string) parade.TaskID {
 	return parade.TaskID(fmt.Sprintf("%s:make-success:%s", exportID, path))
 }
 
-func (exportID taskIdGenerator) finishedTaskID() parade.TaskID {
+func (exportID taskIDGenerator) finishedTaskID() parade.TaskID {
 	return parade.TaskID(fmt.Sprintf("%s:finished", exportID))
 }
 
-func (exportID taskIdGenerator) copyTaskID(physicalAddress string) parade.TaskID {
+func (exportID taskIDGenerator) copyTaskID(physicalAddress string) parade.TaskID {
 	return parade.TaskID(fmt.Sprintf("%s:copy:%s", exportID, physicalAddress))
 }
 
-func (exportID taskIdGenerator) deleteTaskID(physicalAddress string) parade.TaskID {
+func (exportID taskIDGenerator) deleteTaskID(physicalAddress string) parade.TaskID {
 	return parade.TaskID(fmt.Sprintf("%s:delete:%s", exportID, physicalAddress))
 }
 
 // SuccessTasksTreeGenerator accumulates success tasks during task generator.  It is exported
 // (only) for testing.
 type SuccessTasksTreeGenerator struct {
-	idGen                   taskIdGenerator
+	idGen                   taskIDGenerator
 	successDirectoriesCache *DirMatchCache
 	makeDestination         func(string) string
 	finishedTask            parade.TaskData
@@ -124,7 +124,7 @@ type SuccessTasksTreeGenerator struct {
 }
 
 func NewSuccessTasksTreeGenerator(exportID string, generateSuccessFor func(path string) bool, makeDestination func(string) string) SuccessTasksTreeGenerator {
-	idGen := taskIdGenerator(exportID)
+	idGen := taskIDGenerator(exportID)
 	zero, one := 0, 1
 	return SuccessTasksTreeGenerator{
 		idGen:                   idGen,
@@ -195,7 +195,7 @@ func (s *SuccessTasksTreeGenerator) GenerateTasksTo(tasks []parade.TaskData) []p
 
 // makeDiffTaskBody fills TaskData *out with id, action and a body to make it a task to
 // perform diff.
-func makeDiffTaskBody(out *parade.TaskData, idGen taskIdGenerator, diff catalog.Difference, makeDestination func(string) string) error {
+func makeDiffTaskBody(out *parade.TaskData, idGen taskIDGenerator, diff catalog.Difference, makeDestination func(string) string) error {
 	var (
 		data interface{}
 		err  error
@@ -240,7 +240,7 @@ func GenerateTasksFromDiffs(exportID string, dstPrefix string, diffs catalog.Dif
 		return fmt.Sprintf("%s/%s", dstPrefix, path)
 	}
 
-	idGen := taskIdGenerator(exportID)
+	idGen := taskIDGenerator(exportID)
 
 	successTasksGenerator := NewSuccessTasksTreeGenerator(
 		exportID, generateSuccessFor, makeDestination)


### PR DESCRIPTION
Relevant to #534 (but not blocking it)

Extract long `makeTaskForDiff` internal function by separating tree-builder that builds the success file tasks from the actual diff tasks generation.

Hope it's easier on the eyes!