### PR TITLE
removing redundent complex calculation from merge_from_parent

### DIFF
--- a/catalog/cataloger_merge.go
+++ b/catalog/cataloger_merge.go
@@ -150,10 +150,8 @@ func (c *cataloger) mergeFromParent(ctx context.Context, tx db.Tx, previousMaxCo
 	_, err = tx.Exec(`INSERT INTO catalog_entries (branch_id,path,physical_address,creation_date,size,checksum,metadata,min_commit)
 				SELECT $1,path,physical_address,creation_date,size,checksum,metadata,$2 AS min_commit
 				FROM catalog_entries e
-				WHERE e.ctid IN (SELECT d.entry_ctid FROM `+diffResultsTableName+` d WHERE d.diff_type=$3 
- 				-- the or condition - diff will see an entry as new if it is deleted in child. but merge still need to copy it
-				OR d.diff_type=$4 and d.path in (SELECT e1.path FROM catalog_entries e1 WHERE e1.branch_id=$1 and e1.max_commit != $5))`,
-		childID, nextCommitID, DifferenceTypeChanged, DifferenceTypeAdded, MaxCommitID)
+				WHERE e.ctid IN (SELECT d.entry_ctid FROM `+diffResultsTableName+` d WHERE d.diff_type in ($3,$4) )`,
+		childID, nextCommitID, DifferenceTypeChanged, DifferenceTypeAdded)
 	if err != nil {
 		return err
 	}

--- a/catalog/cataloger_merge.go
+++ b/catalog/cataloger_merge.go
@@ -150,7 +150,7 @@ func (c *cataloger) mergeFromParent(ctx context.Context, tx db.Tx, previousMaxCo
 	_, err = tx.Exec(`INSERT INTO catalog_entries (branch_id,path,physical_address,creation_date,size,checksum,metadata,min_commit)
 				SELECT $1,path,physical_address,creation_date,size,checksum,metadata,$2 AS min_commit
 				FROM catalog_entries e
-				WHERE e.ctid IN (SELECT d.entry_ctid FROM `+diffResultsTableName+` d WHERE d.diff_type in ($3,$4) )`,
+				WHERE e.ctid IN (SELECT d.entry_ctid FROM `+diffResultsTableName+` d WHERE d.diff_type in ($3,$4))`,
 		childID, nextCommitID, DifferenceTypeChanged, DifferenceTypeAdded)
 	if err != nil {
 		return err


### PR DESCRIPTION
last part of merge from father is copying changed items to the child. It includes some overly complex logic that is now simpler