### PR TITLE
Validate dependencies licenses

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,8 @@ all: build
 clean:
 	@rm -rf $(API_BUILD_DIR) $(UI_BUILD_DIR) ddl/statik.go statik $(LAKEFS_BINARY_NAME) $(LAKECTL_BINARY_NAME)
 
+check-licenses: check-licenses-go-mod check-licenses-npm
+
 check-licenses-go-mod:
 	go get github.com/google/go-licenses
 	$(GOBINPATH)/go-licenses check ./cmd/$(LAKEFS_BINARY_NAME)

--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,11 @@ check-licenses-go-mod:
 	$(GOBINPATH)/go-licenses check ./cmd/$(LAKEFS_BINARY_NAME)
 	$(GOBINPATH)/go-licenses check ./cmd/$(LAKECTL_BINARY_NAME)
 
+check-licenses-npm:
+	go get github.com/senseyeio/diligent/cmd/diligent
+	# The -i arg is a workaround to ignore NPM scoped packages until https://github.com/senseyeio/diligent/issues/77 is fixed
+	$(GOBINPATH)/diligent check -w permissive -i ^@[^/]+?/[^/]+ $(UI_DIR)
+
 docs/assets/js/swagger.yml: swagger.yml
 	@cp swagger.yml docs/assets/js/swagger.yml
 

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,11 @@ all: build
 clean:
 	@rm -rf $(API_BUILD_DIR) $(UI_BUILD_DIR) ddl/statik.go statik $(LAKEFS_BINARY_NAME) $(LAKECTL_BINARY_NAME)
 
+check-licenses-go-mod:
+	go get github.com/google/go-licenses
+	$(GOBINPATH)/go-licenses check ./cmd/$(LAKEFS_BINARY_NAME)
+	$(GOBINPATH)/go-licenses check ./cmd/$(LAKECTL_BINARY_NAME)
+
 docs/assets/js/swagger.yml: swagger.yml
 	@cp swagger.yml docs/assets/js/swagger.yml
 

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -3313,9 +3313,9 @@
       }
     },
     "base-64": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/base-64/-/base-64-0.1.0.tgz",
-      "integrity": "sha1-eAqZyE59YAJgNhURxId2E78k9rs="
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
+      "integrity": "sha512-kwDPIFCGx0NZHog36dj+tHiwP4QMzsZ3AgMViUBKI0+V5n4U0ufTCUMhnQ04diaRI8EX/QcPfql7zlhZ7j4zgg=="
     },
     "base64-js": {
       "version": "1.3.1",

--- a/webui/package.json
+++ b/webui/package.json
@@ -8,7 +8,7 @@
     "@testing-library/react": "^10.4.8",
     "@testing-library/user-event": "^10.3.1",
     "acorn": ">=7.1.1",
-    "base-64": "^0.1.0",
+    "base-64": "^1.0.0",
     "bootstrap": "^4.5.2",
     "bootswatch": "^4.5.2",
     "http-proxy-middleware": "^1.0.5",


### PR DESCRIPTION
Closes #449 

This PR adds `Makefile` tasks to validate `go-mod` and `npm` dependency licenses to ensure they are compatible with the project's license (`Apache-2.0`).

I used [go-licenses](https://github.com/google/go-licenses) for validating `go-mod` dependencies, and [diligent](https://github.com/senseyeio/diligent) for validating `npm` dependencies.

Currently, I have only added the tasks to the `Makefile`, but I haven't added them to the GitHub Actions workflow file(s). Which workflow should I bind it to?

Ideally I would've liked to use [diligent](https://github.com/senseyeio/diligent) for both `go-mod` and `npm` dependencies, as it claims to be able to do so, but unfortunately I couldn't get it to work with `go-mod`.

Since I couldn't use a single tool for both `go-mod` and `npm`, I could've used a different tool for validating `npm` dependencies, however I couldn't find another one than [diligent](https://github.com/senseyeio/diligent) that allowed specifying the license type (eg. `permissive`). [diligent](https://github.com/senseyeio/diligent) also has the advantage of being a Go module.

Also, I had to update `base-64` to `1.0.0` because it had the license information in the wrong place, which was causing [diligent](https://github.com/senseyeio/diligent) to detect it as `license: none` (see mathiasbynens/base64#24).

Also, note that there is an issue with [diligent](https://github.com/senseyeio/diligent) that prevents it from working with NPM scoped packages (eg. `@primer/octicons-react`). I have created an issue for this (senseyeio/diligent/issues/77). As a workaround, I have configured [diligent](https://github.com/senseyeio/diligent) to ignore scoped packages.

Note that [go-licenses](https://github.com/google/go-licenses) ignores Go modules without any license (or modules that it fails to detect a license for), whereas [diligent](https://github.com/senseyeio/diligent) will fail validation if it cannot find an NPM package or a license for an NPM package (which is why the workaround above to ignore scoped packages is required).

Example `make check-licenses-go-mod` output (this is considered passing despite all the warnings):
```
/home/daniel-shuy/.asdf/installs/golang/1.15.3/packages/bin/go-licenses check ./cmd/lakefs
E1019 00:27:15.115029   31731 library.go:108] Failed to find license for github.com/josharian/intern: no file/directory matching regexp "^(LICEN(S|C)E|COPYING|README|NOTICE)(\\..+)?$" found for /home/daniel-shuy/.asdf/installs/golang/1.15.3/packages/pkg/mod/github.com/josharian/intern@v1.0.0
E1019 00:27:20.032481   31731 library.go:108] Failed to find license for github.com/vbauerster/mpb/v5: no file/directory matching regexp "^(LICEN(S|C)E|COPYING|README|NOTICE)(\\..+)?$" found for /home/daniel-shuy/.asdf/installs/golang/1.15.3/packages/pkg/mod/github.com/vbauerster/mpb/v5@v5.3.0
E1019 00:27:20.048400   31731 library.go:108] Failed to find license for github.com/vbauerster/mpb/v5/cwriter: no file/directory matching regexp "^(LICEN(S|C)E|COPYING|README|NOTICE)(\\..+)?$" found for /home/daniel-shuy/.asdf/installs/golang/1.15.3/packages/pkg/mod/github.com/vbauerster/mpb/v5@v5.3.0/cwriter
E1019 00:27:20.059830   31731 library.go:108] Failed to find license for github.com/vbauerster/mpb/v5/decor: no file/directory matching regexp "^(LICEN(S|C)E|COPYING|README|NOTICE)(\\..+)?$" found for /home/daniel-shuy/.asdf/installs/golang/1.15.3/packages/pkg/mod/github.com/vbauerster/mpb/v5@v5.3.0/decor
E1019 00:27:20.078421   31731 library.go:108] Failed to find license for github.com/vbauerster/mpb/v5/internal: no file/directory matching regexp "^(LICEN(S|C)E|COPYING|README|NOTICE)(\\..+)?$" found for /home/daniel-shuy/.asdf/installs/golang/1.15.3/packages/pkg/mod/github.com/vbauerster/mpb/v5@v5.3.0/internal
E1019 00:27:20.686697   31731 library.go:108] Failed to find license for github.com/cznic/mathutil: no file/directory matching regexp "^(LICEN(S|C)E|COPYING|README|NOTICE)(\\..+)?$" found for /home/daniel-shuy/.asdf/installs/golang/1.15.3/packages/pkg/mod/github.com/cznic/mathutil@v0.0.0-20180504122225-ca4c9f2c1369
/home/daniel-shuy/.asdf/installs/golang/1.15.3/packages/bin/go-licenses check ./cmd/lakectl
E1019 00:27:33.077803   32116 library.go:108] Failed to find license for github.com/josharian/intern: no file/directory matching regexp "^(LICEN(S|C)E|COPYING|README|NOTICE)(\\..+)?$" found for /home/daniel-shuy/.asdf/installs/golang/1.15.3/packages/pkg/mod/github.com/josharian/intern@v1.0.0
E1019 00:27:40.884138   32116 library.go:108] Failed to find license for github.com/vbauerster/mpb/v5: no file/directory matching regexp "^(LICEN(S|C)E|COPYING|README|NOTICE)(\\..+)?$" found for /home/daniel-shuy/.asdf/installs/golang/1.15.3/packages/pkg/mod/github.com/vbauerster/mpb/v5@v5.3.0
E1019 00:27:40.898762   32116 library.go:108] Failed to find license for github.com/vbauerster/mpb/v5/cwriter: no file/directory matching regexp "^(LICEN(S|C)E|COPYING|README|NOTICE)(\\..+)?$" found for /home/daniel-shuy/.asdf/installs/golang/1.15.3/packages/pkg/mod/github.com/vbauerster/mpb/v5@v5.3.0/cwriter
E1019 00:27:40.910413   32116 library.go:108] Failed to find license for github.com/vbauerster/mpb/v5/decor: no file/directory matching regexp "^(LICEN(S|C)E|COPYING|README|NOTICE)(\\..+)?$" found for /home/daniel-shuy/.asdf/installs/golang/1.15.3/packages/pkg/mod/github.com/vbauerster/mpb/v5@v5.3.0/decor
E1019 00:27:40.925479   32116 library.go:108] Failed to find license for github.com/vbauerster/mpb/v5/internal: no file/directory matching regexp "^(LICEN(S|C)E|COPYING|README|NOTICE)(\\..+)?$" found for /home/daniel-shuy/.asdf/installs/golang/1.15.3/packages/pkg/mod/github.com/vbauerster/mpb/v5@v5.3.0/internal
E1019 00:27:41.558124   32116 library.go:108] Failed to find license for github.com/cznic/mathutil: no file/directory matching regexp "^(LICEN(S|C)E|COPYING|README|NOTICE)(\\..+)?$" found for /home/daniel-shuy/.asdf/installs/golang/1.15.3/packages/pkg/mod/github.com/cznic/mathutil@v0.0.0-20180504122225-ca4c9f2c1369
```

Example `check-licenses-npm` output:
```
# The -i arg is a workaround to ignore NPM scoped packages until https://github.com/senseyeio/diligent/issues/77 is fixed
/home/daniel-shuy/.asdf/installs/golang/1.15.3/packages/bin/diligent check -w permissive -i ^@[^/]+?/[^/]+ webui
acorn                      MIT License
base-64                    MIT License
bootstrap                  MIT License
bootswatch                 MIT License
http-proxy-middleware      MIT License
moment                     MIT License
react                      MIT License
react-bootstrap            MIT License
react-bootstrap-typeahead  MIT License
react-dom                  MIT License
react-redux                MIT License
react-router-dom           MIT License
react-scripts              MIT License
redux                      MIT License
redux-thunk                MIT License
```