### PR TITLE
Add new ReadConfigAction auth action for reading config

### DIFF
--- a/api/api_controller.go
+++ b/api/api_controller.go
@@ -2230,9 +2230,7 @@ func (c *Controller) ConfigGetConfigHandler() configop.GetConfigHandler {
 	return configop.GetConfigHandlerFunc(func(params configop.GetConfigParams, user *models.User) middleware.Responder {
 		deps, err := c.setupRequest(user, params.HTTPRequest, []permissions.Permission{
 			{
-				// Should use repository creation permission but it is coupled to a repo id
-				// TODO(#764): Add a new action for reading configs?
-				Action:   permissions.ListRepositoriesAction,
+				Action:   permissions.ReadConfigAction,
 				Resource: permissions.All,
 			},
 		})

--- a/docs/reference/authorization.md
+++ b/docs/reference/authorization.md
@@ -160,6 +160,7 @@ For the full list of actions and their required permissions see the following ta
 |List Group Policies            |`auth:ReadGroup`        |`arn:lakefs:auth:::group/{groupId}`                                     |GET /auth/groups/{groupId}/policies                                                |-                                                                    |
 |Attach Policy To Group         |`auth:AttachPolicy`     |`arn:lakefs:auth:::group/{groupId}`                                     |PUT /auth/groups/{groupId}/policies/{policyId}                                     |-                                                                    |
 |Detach Policy From Group       |`auth:DetachPolicy`     |`arn:lakefs:auth:::group/{groupId}`                                     |DELETE /auth/groups/{groupId}/policies/{policyId}                                  |-                                                                    |
+|List Config                    |`auth:ReadConfig`       |`*`                                                                     |GET /config                                                                        |-                                                                    |
 
 
 ### Preconfigured Policies

--- a/permissions/actions.go
+++ b/permissions/actions.go
@@ -52,6 +52,7 @@ const (
 	CreateCredentialsAction = "auth:CreateCredentials"
 	DeleteCredentialsAction = "auth:DeleteCredentials"
 	ListCredentialsAction   = "auth:ListCredentials"
+	ReadConfigAction        = "auth:ReadConfig"
 )
 
 var serviceSet = map[string]struct{}{


### PR DESCRIPTION
This PR creates `ReadConfigAction`, a new auth action for reading config, instead of `ListRepositoriesAction`.

Closes #764 