### PR TITLE
Add post-{commit,merge}

### DIFF
--- a/catalog/cataloger.go
+++ b/catalog/cataloger.go
@@ -159,7 +159,7 @@ type Merger interface {
 }
 
 type Hookser interface {
-	GetHooks() *CatalogerHooks
+	Hooks() *CatalogerHooks
 }
 
 type ExportConfigurator interface {
@@ -452,6 +452,6 @@ func (c *cataloger) dedupBatch(batch []*dedupRequest) {
 	}
 }
 
-func (c *cataloger) GetHooks() *CatalogerHooks {
+func (c *cataloger) Hooks() *CatalogerHooks {
 	return &c.hooks
 }

--- a/catalog/cataloger.go
+++ b/catalog/cataloger.go
@@ -158,6 +158,10 @@ type Merger interface {
 	Merge(ctx context.Context, repository, leftBranch, rightBranch, committer, message string, metadata Metadata) (*MergeResult, error)
 }
 
+type Hookser interface {
+	GetHooks() *CatalogerHooks
+}
+
 type ExportConfigurator interface {
 	GetExportConfigurationForBranch(repository string, branch string) (ExportConfiguration, error)
 	GetExportConfigurations() ([]ExportConfigurationForBranch, error)
@@ -172,6 +176,7 @@ type Cataloger interface {
 	MultipartUpdateCataloger
 	Differ
 	Merger
+	Hookser
 	ExportConfigurator
 	io.Closer
 }
@@ -191,6 +196,28 @@ type CacheConfig struct {
 	Jitter  time.Duration
 }
 
+// CatalogerHooks describes the hooks available for some operations on the catalog.  Hooks are
+// called in a current transaction context; if they return an error the transaction is rolled
+// back.  Because these transactions are current, the hook can see the effect the operation only
+// on the passed transaction.
+type CatalogerHooks struct {
+	// PostCommit hooks are called at the end of a commit.
+	PostCommit []func(ctx context.Context, tx db.Tx, commitLog *CommitLog) error
+
+	// PostMerge hooks are called at the end of a merge.
+	PostMerge []func(ctx context.Context, tx db.Tx, mergeResult *MergeResult) error
+}
+
+func (h *CatalogerHooks) AddPostCommit(f func(context.Context, db.Tx, *CommitLog) error) *CatalogerHooks {
+	h.PostCommit = append(h.PostCommit, f)
+	return h
+}
+
+func (h *CatalogerHooks) AddPostMerge(f func(context.Context, db.Tx, *MergeResult) error) *CatalogerHooks {
+	h.PostMerge = append(h.PostMerge, f)
+	return h
+}
+
 // cataloger main catalog implementation based on mvcc
 type cataloger struct {
 	params.Catalog
@@ -202,6 +229,7 @@ type cataloger struct {
 	dedupReportEnabled   bool
 	dedupReportCh        chan *DedupReport
 	readEntryRequestChan chan *readRequest
+	hooks                CatalogerHooks
 }
 
 type CatalogerOption func(*cataloger)
@@ -422,4 +450,8 @@ func (c *cataloger) dedupBatch(batch []*dedupRequest) {
 			}
 		}
 	}
+}
+
+func (c *cataloger) GetHooks() *CatalogerHooks {
+	return &c.hooks
 }

--- a/catalog/cataloger_commit_test.go
+++ b/catalog/cataloger_commit_test.go
@@ -284,7 +284,7 @@ func TestCataloger_CommitTombstoneShouldNotChangeHistory(t *testing.T) {
 	ent, err := c.GetEntry(ctx, repository, branchCommit.Reference, "file42", GetEntryParams{})
 	testutil.MustDo(t, "get entry from create branch commit - branch1", err)
 
-	checksumFile42 := testCreateEntryCalcChecksum("file42", t.Name())
+	checksumFile42 := testCreateEntryCalcChecksum("file42", t.Name(), "")
 	if ent.Checksum != checksumFile42 {
 		t.Fatalf("get entry from branch commit checksum=%s, expected, %s", ent.Checksum, checksumFile42)
 	}
@@ -300,7 +300,7 @@ func TestCataloger_CommitHooks(t *testing.T) {
 		var logs [2][]*CommitLog
 		for i := 0; i < 2; i++ {
 			j := i
-			c.GetHooks().AddPostCommit(func(_ context.Context, _ db.Tx, l *CommitLog) error {
+			c.Hooks().AddPostCommit(func(_ context.Context, _ db.Tx, l *CommitLog) error {
 				logs[j] = append(logs[j], l)
 				return nil
 			})
@@ -327,7 +327,7 @@ func TestCataloger_CommitHooks(t *testing.T) {
 		repository := testCatalogerRepo(t, ctx, c, "repository", "master")
 		testCatalogerCreateEntry(t, ctx, c, repository, "master", "/file1", nil, "")
 		testingErr := fmt.Errorf("you know, for testing!")
-		c.GetHooks().AddPostCommit(func(_ context.Context, _ db.Tx, _ *CommitLog) error {
+		c.Hooks().AddPostCommit(func(_ context.Context, _ db.Tx, _ *CommitLog) error {
 			return testingErr
 		})
 

--- a/catalog/cataloger_commit_test.go
+++ b/catalog/cataloger_commit_test.go
@@ -306,7 +306,7 @@ func (h *CommitHookLogger) Hook(_ context.Context, _ db.Tx, log *CommitLog) erro
 }
 
 func TestCataloger_CommitHooks(t *testing.T) {
-	errHookFailed := errors.New("hook failed")
+	errHookFailed := errors.New("for testing")
 	tests := []struct {
 		name    string
 		path    string
@@ -326,8 +326,6 @@ func TestCataloger_CommitHooks(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
 			c := testCataloger(t)
-			repository := testCatalogerRepo(t, ctx, c, "repository", "master")
-			_ = testCatalogerCreateEntry(t, ctx, c, repository, DefaultBranchName, "/file1", nil, "")
 
 			// register hooks (more than one to verify all get called)
 			hooks := []CommitHookLogger{
@@ -337,6 +335,9 @@ func TestCataloger_CommitHooks(t *testing.T) {
 			for i := range hooks {
 				c.Hooks().AddPostCommit(hooks[i].Hook)
 			}
+
+			repository := testCatalogerRepo(t, ctx, c, "repository", "master")
+			_ = testCatalogerCreateEntry(t, ctx, c, repository, DefaultBranchName, "/file1", nil, "")
 
 			commitLog, err := c.Commit(ctx, repository, "master", "commit "+t.Name(), "tester", Metadata{"foo": "bar"})
 			// check that hook err is the commit error

--- a/catalog/cataloger_commit_test.go
+++ b/catalog/cataloger_commit_test.go
@@ -296,14 +296,7 @@ func TestCataloger_CommitHooks(t *testing.T) {
 
 	t.Run("commit hooks run and see commit", func(t *testing.T) {
 		repository := testCatalogerRepo(t, ctx, c, "repository", "master")
-		if err := c.CreateEntry(ctx, repository, "master", Entry{
-			Path:            "/file1",
-			Checksum:        "abcdef",
-			PhysicalAddress: "/addr/1",
-			Size:            17,
-		}, CreateEntryParams{}); err != nil {
-			t.Fatalf("create entry for commit: %s", err)
-		}
+		testCatalogerCreateEntry(t, ctx, c, repository, DefaultBranchName, "file1", nil, "")
 		var logs [2][]*CommitLog
 		for i := 0; i < 2; i++ {
 			j := i

--- a/catalog/cataloger_list_entries_test.go
+++ b/catalog/cataloger_list_entries_test.go
@@ -816,7 +816,7 @@ func testListEntriesCreateEntries(t *testing.T, ctx context.Context, c Cataloger
 		for j := 0; j < numEntries; j += skip {
 			path := fmt.Sprintf("my_entry%03d", j)
 			seed := strconv.Itoa(i)
-			checksum := testCreateEntryCalcChecksum(path, seed)
+			checksum := testCreateEntryCalcChecksum(path, t.Name(), seed)
 			err := c.CreateEntry(ctx, repo, branch, Entry{Path: path, Checksum: checksum, PhysicalAddress: checksum, Size: int64(i)}, CreateEntryParams{})
 			if err != nil {
 				t.Fatalf("Failed to create entry %s on branch %s, repository %s: %s", path, branch, repo, err)

--- a/catalog/cataloger_merge.go
+++ b/catalog/cataloger_merge.go
@@ -91,6 +91,15 @@ func (c *cataloger) Merge(ctx context.Context, repository, leftBranch, rightBran
 			return nil, err
 		}
 		mergeResult.Reference = MakeReference(rightBranch, commitID)
+
+		for _, hook := range c.hooks.PostMerge {
+			err = hook(ctx, tx, mergeResult)
+			if err != nil {
+				// Roll tx back if a hook failed
+				return nil, err
+			}
+		}
+
 		return nil, nil
 	}, c.txOpts(ctx)...)
 	return mergeResult, err

--- a/catalog/cataloger_merge_test.go
+++ b/catalog/cataloger_merge_test.go
@@ -14,125 +14,81 @@ import (
 	"github.com/treeverse/lakefs/testutil"
 )
 
-func validateMergeWithHooks(
-	t *testing.T,
-	setup func(t *testing.T, ctx context.Context, c Cataloger, repository string),
-	leftBranch, rightBranch, committer, message string,
-	verifySuccess func(t *testing.T, ctx context.Context, c Cataloger, repository string, res *MergeResult, err error),
-) {
-	t.Helper()
-	t.Run("with success hook", func(t *testing.T) {
-		ctx := context.Background()
-		c := testCataloger(t)
-		var resultLogs []*MergeResult
-		c.GetHooks().AddPostMerge(func(_ context.Context, _ db.Tx, mergeResult *MergeResult) error {
-			resultLogs = append(resultLogs, mergeResult)
-			return nil
-		})
-		repository := testCatalogerRepo(t, ctx, c, "repo", leftBranch)
-		setup(t, ctx, c, repository)
-		res, err := c.Merge(ctx, repository, leftBranch, rightBranch, committer, message, nil)
-		verifySuccess(t, ctx, c, repository, res, err)
-		if diffs := deep.Equal([]*MergeResult{res}, resultLogs); diffs != nil {
-			t.Error("unexpected hook calls", diffs)
-		}
-	})
-	t.Run("with failure hook", func(t *testing.T) {
-		ctx := context.Background()
-		c := testCataloger(t)
-		testingErr := fmt.Errorf("you know, for testing!")
-		c.GetHooks().AddPostMerge(func(_ context.Context, _ db.Tx, _ *MergeResult) error {
-			return testingErr
-		})
-		repository := testCatalogerRepo(t, ctx, c, "repo", leftBranch)
-		setup(t, ctx, c, repository)
-		_, err := c.Merge(ctx, repository, leftBranch, rightBranch, committer, message, nil)
-		if !errors.Is(err, testingErr) {
-			t.Errorf("expected merge to fail on testing but got %s", err)
-		}
-	})
-}
-
 func TestCataloger_Merge_FromParentNoChangesInChild(t *testing.T) {
-	const (
-		newFilename  = "/file5"
-		delFilename  = "/file1"
-		overFilename = "/file2"
-	)
+	ctx := context.Background()
+	c := testCataloger(t)
+	repository := testCatalogerRepo(t, ctx, c, "repo", "master")
 
-	validateMergeWithHooks(
-		t,
-		func(t *testing.T, ctx context.Context, c Cataloger, repository string) {
-			// create 3 files on master and commit
-			for i := 0; i < 3; i++ {
-				testCatalogerCreateEntry(t, ctx, c, repository, "master", "/file"+strconv.Itoa(i), nil, "")
-			}
-			_, err := c.Commit(ctx, repository, "master", "commit to master", "tester", nil)
-			testutil.MustDo(t, "commit to master", err)
+	// create 3 files on master and commit
+	for i := 0; i < 3; i++ {
+		testCatalogerCreateEntry(t, ctx, c, repository, "master", "/file"+strconv.Itoa(i), nil, "")
+	}
+	_, err := c.Commit(ctx, repository, "master", "commit to master", "tester", nil)
+	testutil.MustDo(t, "commit to master", err)
 
-			// create branch based on master
-			testCatalogerBranch(t, ctx, c, repository, "branch1", "master")
+	// create branch based on master
+	testCatalogerBranch(t, ctx, c, repository, "branch1", "master")
 
-			// add new file
-			testCatalogerCreateEntry(t, ctx, c, repository, "master", newFilename, nil, "")
+	// add new file
+	const newFilename = "/file5"
+	testCatalogerCreateEntry(t, ctx, c, repository, "master", newFilename, nil, "")
 
-			// delete committed file
-			testutil.MustDo(t, "delete committed file on master",
-				c.DeleteEntry(ctx, repository, "master", delFilename))
+	// delete committed file
+	const delFilename = "/file1"
+	testutil.MustDo(t, "delete committed file on master",
+		c.DeleteEntry(ctx, repository, "master", delFilename))
 
-			// change/override committed file
-			testCatalogerCreateEntry(t, ctx, c, repository, "master", overFilename, nil, "seed1")
+	// change/override committed file
+	const overFilename = "/file2"
+	testCatalogerCreateEntry(t, ctx, c, repository, "master", overFilename, nil, "seed1")
 
-			// commit
-			_, err = c.Commit(ctx, repository, "master", "second commit to master", "tester", nil)
-			testutil.MustDo(t, "second commit to master", err)
+	// commit, merge and verify
+	_, err = c.Commit(ctx, repository, "master", "second commit to master", "tester", nil)
+	testutil.MustDo(t, "second commit to master", err)
 
-			// before the merge - make sure we see the deleted file
-			_, err = c.GetEntry(ctx, repository, "branch1:HEAD", delFilename, GetEntryParams{})
-			if err != nil {
-				t.Fatalf("Get entry %s, expected to be found: %s", delFilename, err)
-			}
-		},
-		"master", "branch1", "tester", "",
-		func(t *testing.T, ctx context.Context, c Cataloger, repository string, res *MergeResult, err error) {
-			if err != nil {
-				t.Fatal("Merge from master to branch1 failed:", err)
-			}
-			if !IsValidReference(res.Reference) {
-				t.Fatalf("Merge reference = %s, expected valid reference", res.Reference)
-			}
+	// before the merge - make sure we see the deleted file
+	_, err = c.GetEntry(ctx, repository, "branch1:HEAD", delFilename, GetEntryParams{})
+	if err != nil {
+		t.Fatalf("Get entry %s, expected to be found: %s", delFilename, err)
+	}
 
-			testVerifyEntries(t, ctx, c, repository, "branch1", []testEntryInfo{
-				{Path: newFilename},
-				{Path: overFilename, Seed: "seed1"},
-				{Path: delFilename, Deleted: true},
-			})
+	// merge master to branch1
+	res, err := c.Merge(ctx, repository, "master", "branch1", "tester", "", nil)
+	if err != nil {
+		t.Fatal("Merge from master to branch1 failed:", err)
+	}
+	if !IsValidReference(res.Reference) {
+		t.Fatalf("Merge reference = %s, expected valid reference", res.Reference)
+	}
 
-			commitLog, err := c.GetCommit(ctx, repository, res.Reference)
-			testutil.MustDo(t, "get merge commit reference", err)
-			if len(commitLog.Parents) != 2 {
-				t.Fatal("merge commit log should have two parents")
-			}
-			if diff := deep.Equal(res.Summary, map[DifferenceType]int{
-				DifferenceTypeRemoved: 1,
-				DifferenceTypeChanged: 1,
-				DifferenceTypeAdded:   1,
-			}); diff != nil {
-				t.Fatal("Merge Summary", diff)
-			}
-			// TODO(barak): enable test after diff between commits is supported
-			//differences, _, err := c.Diff(ctx, repository, commitLog.Parents[0], commitLog.Parents[1], -1, "")
-			//testutil.MustDo(t, "diff merge changes", err)
-			//expectedDifferences := Differences{
-			//	Difference{Type: DifferenceTypeChanged, Path: "/file2"},
-			//	Difference{Type: DifferenceTypeAdded, Path: "/file5"},
-			//	Difference{Type: DifferenceTypeRemoved, Path: "/file1"},
-			//}
-			//if !differences.Equal(expectedDifferences) {
-			//	t.Fatalf("Merge differences = %s, expected %s", spew.Sdump(differences), spew.Sdump(expectedDifferences))
-			//}
-		},
-	)
+	testVerifyEntries(t, ctx, c, repository, "branch1", []testEntryInfo{
+		{Path: newFilename},
+		{Path: overFilename, Seed: "seed1"},
+		{Path: delFilename, Deleted: true},
+	})
+
+	commitLog, err := c.GetCommit(ctx, repository, res.Reference)
+	testutil.MustDo(t, "get merge commit reference", err)
+	if len(commitLog.Parents) != 2 {
+		t.Fatal("merge commit log should have two parents")
+	}
+	if diff := deep.Equal(res.Summary, map[DifferenceType]int{
+		DifferenceTypeRemoved: 1,
+		DifferenceTypeChanged: 1,
+		DifferenceTypeAdded:   1,
+	}); diff != nil {
+		t.Fatal("Merge Summary", diff)
+	}
+	// TODO(barak): enable test after diff between commits is supported
+	//differences, _, err := c.Diff(ctx, repository, commitLog.Parents[0], commitLog.Parents[1], -1, "")
+	//testutil.MustDo(t, "diff merge changes", err)
+	//expectedDifferences := Differences{
+	//	Difference{Type: DifferenceTypeChanged, Path: "/file2"},
+	//	Difference{Type: DifferenceTypeAdded, Path: "/file5"},
+	//	Difference{Type: DifferenceTypeRemoved, Path: "/file1"},
+	//}
+	//if !differences.Equal(expectedDifferences) {
+	//	t.Fatalf("Merge differences = %s, expected %s", spew.Sdump(differences), spew.Sdump(expectedDifferences))}
 }
 
 func TestCataloger_Merge_FromParentConflicts(t *testing.T) {
@@ -1151,7 +1107,7 @@ func TestCataloger_MergeOverDeletedEntries(t *testing.T) {
 	testutil.MustDo(t, "merge master to b1", err)
 	ent, err := c.GetEntry(ctx, repository, "b1", "fileX", GetEntryParams{})
 	testutil.MustDo(t, "get entry again from b1", err)
-	expectedChecksum := testCreateEntryCalcChecksum("fileX", "master2")
+	expectedChecksum := testCreateEntryCalcChecksum("fileX", t.Name(), "master2")
 	if ent.Checksum != expectedChecksum {
 		t.Fatalf("Get file checksum after merge=%s, expected %s", ent.Checksum, expectedChecksum)
 	}
@@ -1243,5 +1199,62 @@ func TestCataloger_MergeFromChildAfterMergeFromParent(t *testing.T) {
 	_, err = c.Merge(ctx, repository, "b1", "master", "tester", "merge nothing from master to b1", nil)
 	if err != nil {
 		t.Fatalf("Merge err=%s, expected none", err)
+	}
+}
+
+func TestCataloger_Merge_Hooks(t *testing.T) {
+	for _, success := range []bool{true, false} {
+		test := "pass"
+		if !success {
+			test = "fail"
+		}
+		testingErr := fmt.Errorf("you know, for testing!")
+		t.Run(test, func(t *testing.T) {
+			ctx := context.Background()
+			c := testCataloger(t)
+			var gotMergeResult *MergeResult
+			if success {
+				c.Hooks().AddPostMerge(
+					func(_ context.Context, _ db.Tx, mergeResult *MergeResult) error {
+						if gotMergeResult != nil {
+							return fmt.Errorf("success merge hook called twice, %+v then %+v", gotMergeResult, mergeResult)
+						}
+						gotMergeResult = mergeResult
+						return nil
+					})
+			} else {
+				c.Hooks().AddPostMerge(
+					func(_ context.Context, _ db.Tx, _ *MergeResult) error {
+						return testingErr
+					})
+			}
+
+			repository := testCatalogerRepo(t, ctx, c, "repo", "master")
+
+			// create branch based on master
+			testCatalogerBranch(t, ctx, c, repository, "branch1", "master")
+
+			// create file to merge
+			testCatalogerCreateEntry(t, ctx, c, repository, "branch1", "/file1", nil, "")
+			_, err := c.Commit(ctx, repository, "branch1", "commit to master", "tester", nil)
+			testutil.MustDo(t, "commit to branch1", err)
+
+			res, err := c.Merge(ctx, repository, "master", "branch1", "tester", "", nil)
+			if success {
+				if err != nil {
+					t.Error("Merge from master to branch1 failed:", err)
+				}
+				testVerifyEntries(t, ctx, c, repository, "branch1", []testEntryInfo{
+					{Path: "/file1"},
+				})
+				if diffs := deep.Equal(res, gotMergeResult); diffs != nil {
+					t.Error("hook received unexpected merge result: ", diffs)
+				}
+			} else {
+				if !errors.Is(err, testingErr) {
+					t.Error("hook did not fail merge: ", err)
+				}
+			}
+		})
 	}
 }

--- a/catalog/cataloger_test.go
+++ b/catalog/cataloger_test.go
@@ -53,9 +53,10 @@ func testCatalogerBranch(t testing.TB, ctx context.Context, c Cataloger, reposit
 	}
 }
 
-func testCatalogerCreateEntry(t testing.TB, ctx context.Context, c Cataloger, repository, branch, path string, metadata Metadata, seed string) {
+// testCatalogerCreateEntry creates a test entry on cataloger, returning a (fake) checksum based on the path, the test name, and a seed.
+func testCatalogerCreateEntry(t testing.TB, ctx context.Context, c Cataloger, repository, branch, path string, metadata Metadata, seed string) string {
 	t.Helper()
-	checksum := testCreateEntryCalcChecksum(path, seed)
+	checksum := testCreateEntryCalcChecksum(path, t.Name()+seed)
 	var size int64
 	for i := range checksum {
 		size += int64(checksum[i])
@@ -70,6 +71,7 @@ func testCatalogerCreateEntry(t testing.TB, ctx context.Context, c Cataloger, re
 	if err != nil {
 		t.Fatalf("Failed to create entry %s on branch %s, repository %s: %s", path, branch, repository, err)
 	}
+	return checksum
 }
 
 func testCatalogerGetEntry(t testing.TB, ctx context.Context, c Cataloger, repository, reference, path string, expect bool) {

--- a/catalog/cataloger_test.go
+++ b/catalog/cataloger_test.go
@@ -56,7 +56,7 @@ func testCatalogerBranch(t testing.TB, ctx context.Context, c Cataloger, reposit
 // testCatalogerCreateEntry creates a test entry on cataloger, returning a (fake) checksum based on the path, the test name, and a seed.
 func testCatalogerCreateEntry(t testing.TB, ctx context.Context, c Cataloger, repository, branch, path string, metadata Metadata, seed string) string {
 	t.Helper()
-	checksum := testCreateEntryCalcChecksum(path, t.Name()+seed)
+	checksum := testCreateEntryCalcChecksum(path, t.Name(), seed)
 	var size int64
 	for i := range checksum {
 		size += int64(checksum[i])
@@ -85,9 +85,9 @@ func testCatalogerGetEntry(t testing.TB, ctx context.Context, c Cataloger, repos
 	}
 }
 
-func testCreateEntryCalcChecksum(key string, seed string) string {
+func testCreateEntryCalcChecksum(key string, testName string, seed string) string {
 	h := sha256.New()
-	_, _ = h.Write([]byte(seed))
+	_, _ = h.Write([]byte(testName + seed))
 	_, _ = h.Write([]byte(key))
 	checksum := hex.EncodeToString(h.Sum(nil))
 	return checksum
@@ -103,7 +103,7 @@ func testVerifyEntries(t testing.TB, ctx context.Context, c Cataloger, repositor
 			}
 		} else {
 			testutil.MustDo(t, fmt.Sprintf("Get entry=%s, repository=%s, reference=%s", entry.Path, repository, reference), err)
-			expectedAddr := testCreateEntryCalcChecksum(entry.Path, entry.Seed)
+			expectedAddr := testCreateEntryCalcChecksum(entry.Path, t.Name(), entry.Seed)
 			if ent.PhysicalAddress != expectedAddr {
 				t.Fatalf("Get entry %s, addr = %s, expected %s", entry.Path, ent.PhysicalAddress, expectedAddr)
 			}


### PR DESCRIPTION
Part of #534 but will be useful elsewhere.  Allows loosely-coupled components, will be used to
support export.