### PR TITLE
Add current export state DB API to cataloger

### DIFF
--- a/catalog/cataloger.go
+++ b/catalog/cataloger.go
@@ -175,9 +175,12 @@ type ExportStateHandler interface {
 	// clean it up by removing and adding the "next export" withint this transaction.  If
 	// another transaction concurrently runs ExportMarkStart on branchID, one blocks until
 	// the other is done.
-	ExportMarkStart(tx db.Tx, repo string, branch string, newRef string) (string, CatalogBranchExportStatus, error)
-	// Delete any export state for repo.  Mostly useful in tests: in a living system the
-	// export state is part of the state of the world.
+	ExportStateMarkStart(tx db.Tx, repo string, branch string, newRef string) (string, CatalogBranchExportStatus, error)
+	// ExportMarkEnd verifies that the current export is of ref and ends an export operation
+	// on branch of repo.
+	ExportStateMarkEnd(tx db.Tx, repo string, branch string, ref string, newState CatalogBranchExportStatus, newMessage *string) error
+	// ExportStateDelete deletes any export state for repo.  Mostly useful in tests: in a
+	// living system the export state is part of the state of the world.
 	ExportStateDelete(tx db.Tx, repo string, branch string) error
 }
 

--- a/catalog/cataloger_export.go
+++ b/catalog/cataloger_export.go
@@ -1,8 +1,11 @@
 package catalog
 
 import (
+	"database/sql/driver"
+	"errors"
 	"fmt"
 	"regexp"
+	"strings"
 
 	"github.com/georgysavva/scany/pgxscan"
 	"github.com/lib/pq"
@@ -27,6 +30,49 @@ type ExportConfigurationForBranch struct {
 	Path                   string         `db:"export_path"`
 	StatusPath             string         `db:"export_status_path"`
 	LastKeysInPrefixRegexp pq.StringArray `db:"last_keys_in_prefix_regexp"`
+}
+
+type CatalogBranchExportStatus string
+
+const (
+	ExportStatusInProgress = CatalogBranchExportStatus("in-progress")
+	ExportStatusSuccess    = CatalogBranchExportStatus("exported-successfully")
+	ExportStatusFailed     = CatalogBranchExportStatus("export-failed")
+	ExportStatusUnknown    = CatalogBranchExportStatus("[unknown]")
+)
+
+// ExportStatus describes the current export status of a branch, as passed on wire, used
+// internally, and stored in DB.
+type ExportStatus struct {
+	CurrentRef string `db:"current_ref"`
+	State      CatalogBranchExportStatus
+}
+
+var ErrBadTypeConversion = errors.New("bad type")
+
+// nolint: stylecheck
+func (dst *CatalogBranchExportStatus) Scan(src interface{}) error {
+	var sc CatalogBranchExportStatus
+	switch s := src.(type) {
+	case string:
+		sc = CatalogBranchExportStatus(strings.ToLower(s))
+	case []byte:
+		sc = CatalogBranchExportStatus(strings.ToLower(string(s)))
+	default:
+		return fmt.Errorf("cannot convert %T to CatalogBranchExportStatus: %w", src, ErrBadTypeConversion)
+	}
+
+	if !(sc == ExportStatusInProgress || sc == ExportStatusSuccess || sc == ExportStatusFailed) {
+		// not a failure, "just" be a newer enum value than known
+		*dst = ExportStatusUnknown
+		return nil
+	}
+	*dst = sc
+	return nil
+}
+
+func (src CatalogBranchExportStatus) Value() (driver.Value, error) {
+	return string(src), nil
 }
 
 func (c *cataloger) GetExportConfigurationForBranch(repository string, branch string) (ExportConfiguration, error) {

--- a/catalog/cataloger_export.go
+++ b/catalog/cataloger_export.go
@@ -204,7 +204,7 @@ func (c *cataloger) ExportStateMarkEnd(tx db.Tx, repo string, branch string, ref
 		return fmt.Errorf("ExportMarkEnd: end export: %w", err)
 	}
 	if tag.RowsAffected() != 1 {
-		err = fmt.Errorf("ExportMarkEnd: could not find export to end: %s %w", tag, ErrExportFailed)
+		return fmt.Errorf("ExportMarkEnd: could not find export to end: %s %w", tag, ErrExportFailed)
 	}
 	return nil
 }

--- a/db/database.go
+++ b/db/database.go
@@ -302,9 +302,8 @@ func (d *PgxDatabase) Stats() sql.DBStats {
 		// waiting.  The two are close enough (but race each other).
 		WaitCount: stat.EmptyAcquireCount(),
 		// Time to acquire is close enough to time spent waiting; fudge.
-		WaitDuration:      stat.AcquireDuration(),
-		MaxIdleClosed:     0, // TODO(ariels): Does pgx have this anywhere?
-		MaxIdleTimeClosed: 0, // TODO(ariels): Could generate this with post-connect/release hooks
-		MaxLifetimeClosed: 0, // TODO(ariels): Is this even possible in pgx?
+		WaitDuration: stat.AcquireDuration(),
+		// Not clear that pgx can report MaxIdleClosed, MaxIdleTimeClosed,
+		// MaxLifetimeClosed.
 	}
 }

--- a/ddl/000009_export_current.down.sql
+++ b/ddl/000009_export_current.down.sql
@@ -1,0 +1,6 @@
+BEGIN;
+
+DROP TABLE catalog_branches_export_state;
+DROP TYPE catalog_branches_export_status;
+
+END;

--- a/ddl/000009_export_current.down.sql
+++ b/ddl/000009_export_current.down.sql
@@ -1,6 +1,6 @@
 BEGIN;
 
-DROP TABLE catalog_branches_export_state;
+DROP TABLE IF EXISTS catalog_branches_export_state;
 DROP TYPE catalog_branches_export_status;
 
 END;

--- a/ddl/000009_export_current.up.sql
+++ b/ddl/000009_export_current.up.sql
@@ -1,0 +1,25 @@
+BEGIN;
+
+CREATE TYPE catalog_branch_export_status AS ENUM (
+    'in-progress',
+    'exported-successfully',
+    'export-failed'
+);
+
+CREATE TABLE IF NOT EXISTS catalog_branches_export_state (
+    branch_id integer PRIMARY KEY,
+    current_ref VARCHAR,	-- If NULL, nothing currently exported (will export everything)
+    state catalog_branch_export_status,
+    error_message TEXT		-- If status='export-failed'
+);
+
+ALTER TABLE catalog_branches_export_state
+    ADD CONSTRAINT branches_export_state_branches_fk
+    FOREIGN KEY (branch_id) REFERENCES catalog_branches(id)
+    ON DELETE CASCADE;
+
+ALTER TABLE catalog_branches_export_state
+    ADD CONSTRAINT catalog_branches_export_error_on_failure
+    CHECK ((state = 'export-failed') = (error_message IS NOT NULL));
+
+END;

--- a/ddl/000009_export_current.up.sql
+++ b/ddl/000009_export_current.up.sql
@@ -16,10 +16,14 @@ CREATE TABLE IF NOT EXISTS catalog_branches_export_state (
 ALTER TABLE catalog_branches_export_state
     ADD CONSTRAINT branches_export_state_branches_fk
     FOREIGN KEY (branch_id) REFERENCES catalog_branches(id)
+    -- Does *not* reference catalog_branches_export - state is independent of configuration,
+    -- e.g. when configuration is changed.
     ON DELETE CASCADE;
 
 ALTER TABLE catalog_branches_export_state
     ADD CONSTRAINT catalog_branches_export_error_on_failure
     CHECK ((state = 'export-failed') = (error_message IS NOT NULL));
+
+-- BUG(ariels): reset export state when catalog_branches_export changes it physical address.
 
 END;

--- a/docs/assets/js/swagger.yml
+++ b/docs/assets/js/swagger.yml
@@ -86,10 +86,10 @@ definitions:
   repository_creation:
     type: object
     required:
-      - id
+      - name
       - storage_namespace
     properties:
-      id:
+      name:
         type: string
       storage_namespace:
         type: string

--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/jackc/pgerrcode v0.0.0-20190803225404-afa3381909a6
 	github.com/jackc/pgproto3/v2 v2.0.4 // indirect
 	github.com/jackc/pgtype v1.4.2
+	github.com/jackc/pgx v3.6.2+incompatible
 	github.com/jackc/pgx/v4 v4.8.1
 	github.com/jamiealquiza/tachymeter v2.0.0+incompatible
 	github.com/jedib0t/go-pretty v4.3.0+incompatible


### PR DESCRIPTION
Add DB cataloger API to manage current export state.  This takes an actual _transaction_, to allow adding tasks within that same transaction.  Otherwise racing occurs when 2 exports are triggered concurrently.