### PR TITLE
Remove unused GCS parameters

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -30,9 +30,7 @@ const (
 	DefaultBlockStoreS3StreamingChunkSize    = 2 << 19         // 1MiB by default per chunk
 	DefaultBlockStoreS3StreamingChunkTimeout = time.Second * 1 // or 1 seconds, whatever comes first
 
-	DefaultBlockStoreGSS3Endpoint            = "https://storage.googleapis.com"
-	DefaultBlockStoreGSStreamingChunkSize    = 2 << 19         // 1MiB by default per chunk
-	DefaultBlockStoreGSStreamingChunkTimeout = time.Second * 1 // or 1 seconds, whatever comes first
+	DefaultBlockStoreGSS3Endpoint = "https://storage.googleapis.com"
 
 	DefaultAuthCacheEnabled = true
 	DefaultAuthCacheSize    = 1024
@@ -96,8 +94,6 @@ func setDefaults() {
 	viper.SetDefault("gateways.s3.region", DefaultS3GatewayRegion)
 
 	viper.SetDefault("blockstore.gs.s3_endpoint", DefaultBlockStoreGSS3Endpoint)
-	viper.SetDefault("blockstore.gs.streaming_chunk_size", DefaultBlockStoreGSStreamingChunkSize)
-	viper.SetDefault("blockstore.gs.streaming_chunk_timeout", DefaultBlockStoreGSStreamingChunkTimeout)
 
 	viper.SetDefault("stats.enabled", DefaultStatsEnabled)
 	viper.SetDefault("stats.address", DefaultStatsAddr)


### PR DESCRIPTION
This PR is just to remove the unused parameters, thanks @arielshaqed.
I'm in favor that if we all agree that viper will be the configuration solution for the project each module that will require a configuration will use viper to extract the configuration.
In order not to have it all over the place, and have our services configured by Params/Config struct - we can have a function in the module scope that will use viper and initialized these structs.