### PR TITLE
Change export tasks generation to be iterative 

### DIFF
--- a/export/export_handler.go
+++ b/export/export_handler.go
@@ -32,7 +32,7 @@ type TaskBody struct {
 }
 
 func PathToPointer(path string) (block.ObjectPointer, error) {
-	u, err := url.Parse(path) // TODO: add verify path on create task
+	u, err := url.Parse(path) // TODO(guys): add verify path on create task
 	if err != nil {
 		return block.ObjectPointer{}, err
 	}
@@ -55,7 +55,7 @@ func (h *Handler) copy(body *string) error {
 	if err != nil {
 		return err
 	}
-	return h.adapter.Copy(from, to) // todo(guys): add wait for copy in handler
+	return h.adapter.Copy(from, to) // TODO(guys): add wait for copy in handler
 }
 
 func (h *Handler) remove(body *string) error {
@@ -96,7 +96,7 @@ func (h *Handler) Handle(action string, body *string) parade.ActorResult {
 	case TouchAction:
 		err = h.touch(body)
 	case DoneAction:
-		// todo(guys): handle done action
+		// TODO(guys): handle done action
 	default:
 		err = errUnknownAction
 	}

--- a/export/tasks_generator.go
+++ b/export/tasks_generator.go
@@ -262,7 +262,7 @@ func NewTasksGenerator(exportID string, dstPrefix string, generateSuccessFor fun
 func (e *TasksGenerator) Add(diffs catalog.Differences) ([]parade.TaskData, error) {
 	const initialSize = 1_000
 
-	one := 1 // Number of dependencies of many tasks.  This will *not* change.
+	zero := 0
 
 	ret := make([]parade.TaskData, 0, initialSize)
 
@@ -275,7 +275,7 @@ func (e *TasksGenerator) Add(diffs catalog.Differences) ([]parade.TaskData, erro
 		task := parade.TaskData{
 			StatusCode:        parade.TaskPending,
 			MaxTries:          &e.NumTries,
-			TotalDependencies: &one, // Depends only on a start task
+			TotalDependencies: &zero, // Depends only on a start task
 		}
 		err := makeDiffTaskBody(&task, e.idGen, diff, e.makeDestination)
 		if err != nil {

--- a/export/tasks_generator.go
+++ b/export/tasks_generator.go
@@ -240,6 +240,7 @@ type TasksGenerator struct {
 // dstPrefix.  It generates success files for files in directories matched by
 // "generateSuccessFor".
 func NewTasksGenerator(exportID string, dstPrefix string, generateSuccessFor func(path string) bool) *TasksGenerator {
+	const numTries = 5
 	dstPrefix = strings.TrimRight(dstPrefix, "/")
 	makeDestination := func(path string) string {
 		return fmt.Sprintf("%s/%s", dstPrefix, path)
@@ -249,7 +250,7 @@ func NewTasksGenerator(exportID string, dstPrefix string, generateSuccessFor fun
 		ExportID:           exportID,
 		DstPrefix:          dstPrefix,
 		GenerateSuccessFor: generateSuccessFor,
-		NumTries:           5,
+		NumTries:           numTries,
 		makeDestination:    makeDestination,
 		idGen:              taskIDGenerator(exportID),
 		successTasksGenerator: NewSuccessTasksTreeGenerator(

--- a/export/tasks_generator.go
+++ b/export/tasks_generator.go
@@ -226,13 +226,13 @@ func makeDiffTaskBody(out *parade.TaskData, idGen taskIDGenerator, diff catalog.
 
 // TasksGenerator generates tasks from diffs iteratively.
 type TasksGenerator struct {
-	ExportID string
-	DstPrefix string
+	ExportID           string
+	DstPrefix          string
 	GenerateSuccessFor func(path string) bool
-	NumTries int
+	NumTries           int
 
-	makeDestination func(string) string
-	idGen taskIDGenerator
+	makeDestination       func(string) string
+	idGen                 taskIDGenerator
 	successTasksGenerator SuccessTasksTreeGenerator
 }
 
@@ -246,12 +246,12 @@ func NewTasksGenerator(exportID string, dstPrefix string, generateSuccessFor fun
 	}
 
 	return &TasksGenerator{
-		ExportID: exportID,
-		DstPrefix: dstPrefix,
+		ExportID:           exportID,
+		DstPrefix:          dstPrefix,
 		GenerateSuccessFor: generateSuccessFor,
-		NumTries: 5,
-		makeDestination: makeDestination,
-		idGen: taskIDGenerator(exportID),
+		NumTries:           5,
+		makeDestination:    makeDestination,
+		idGen:              taskIDGenerator(exportID),
 		successTasksGenerator: NewSuccessTasksTreeGenerator(
 			exportID, generateSuccessFor, makeDestination),
 	}

--- a/export/tasks_generator_test.go
+++ b/export/tasks_generator_test.go
@@ -279,7 +279,7 @@ func TestTasksGenerator_Simple(t *testing.T) {
 				To:   "testfs://prefix/add1",
 			}),
 			StatusCode:        parade.TaskPending,
-			TotalDependencies: &one,
+			TotalDependencies: &zero,
 			ToSignalAfter:     []parade.TaskID{"simple:finished"},
 		},
 		&parade.TaskData{
@@ -290,7 +290,7 @@ func TestTasksGenerator_Simple(t *testing.T) {
 				To:   "testfs://prefix/change1",
 			}),
 			StatusCode:        parade.TaskPending,
-			TotalDependencies: &one,
+			TotalDependencies: &zero,
 			ToSignalAfter:     []parade.TaskID{"simple:finished"},
 		},
 	}, copyTasks); diffs != nil {
@@ -305,7 +305,7 @@ func TestTasksGenerator_Simple(t *testing.T) {
 				File: "testfs://prefix/remove1",
 			}),
 			StatusCode:        parade.TaskPending,
-			TotalDependencies: &one,
+			TotalDependencies: &zero,
 			ToSignalAfter:     []parade.TaskID{"simple:finished"},
 		}}, deleteTasks); diffs != nil {
 		t.Error("unexpected delete tasks", diffs)
@@ -385,7 +385,7 @@ func TestTasksGenerator_SuccessFiles(t *testing.T) {
 	tasksWithIDs := make([]parade.TaskData, 0, len(catalogDiffs))
 
 	for o := 0; o < len(catalogDiffs); o += 3 {
-		end := o+3
+		end := o + 3
 		if end > len(catalogDiffs) {
 			end = len(catalogDiffs)
 		}

--- a/export/tasks_generator_test.go
+++ b/export/tasks_generator_test.go
@@ -200,11 +200,12 @@ var zero int = 0
 var one int = 1
 
 func TestTasksGenerator_Empty(t *testing.T) {
-	tasks, err := export.GenerateTasksFromDiffs(
+	gen := export.NewTasksGenerator(
 		"empty",
 		"testfs://prefix/",
-		catalog.Differences{},
 		func(_ string) bool { return true })
+
+	tasks, err := gen.Finish()
 	if err != nil {
 		t.Fatalf("failed to GenerateTasksFromDiffs: %s", err)
 	}
@@ -253,15 +254,19 @@ func TestTasksGenerator_Simple(t *testing.T) {
 		Type:  catalog.DifferenceTypeRemoved,
 		Entry: catalog.Entry{Path: "remove1", PhysicalAddress: "/remove1"},
 	}}
-	tasksWithIDs, err := export.GenerateTasksFromDiffs(
+	gen := export.NewTasksGenerator(
 		"simple",
 		"testfs://prefix/",
-		catalogDiffs,
 		func(_ string) bool { return false })
+	tasksWithIDs, err := gen.Add(catalogDiffs)
 	if err != nil {
-		t.Fatalf("failed to GenerateTasksFromDiffs: %s", err)
+		t.Fatalf("failed to add tasks: %s", err)
 	}
-
+	finishTasks, err := gen.Finish()
+	if err != nil {
+		t.Fatalf("failed to finish generating tasks: %s", err)
+	}
+	tasksWithIDs = append(tasksWithIDs, finishTasks...)
 	tasks := cleanup(tasksWithIDs)
 
 	copyTasks := getTasks(isCopy, tasks)
@@ -371,15 +376,31 @@ func TestTasksGenerator_SuccessFiles(t *testing.T) {
 		{before: "foo:delete:/remove5", after: "foo:make-success:a/plain", avoid: true},
 		{before: "foo:delete:/remove5", after: "foo:finished"},
 	}
-	tasksWithIDs, err := export.GenerateTasksFromDiffs(
+	gen := export.NewTasksGenerator(
 		"foo",
 		"testfs://prefix/",
-		catalogDiffs,
 		func(path string) bool { return strings.HasSuffix(path, "success") },
 	)
-	if err != nil {
-		t.Fatalf("failed to GenerateTasksFromDiffs: %s", err)
+
+	tasksWithIDs := make([]parade.TaskData, 0, len(catalogDiffs))
+
+	for o := 0; o < len(catalogDiffs); o += 3 {
+		end := o+3
+		if end > len(catalogDiffs) {
+			end = len(catalogDiffs)
+		}
+		slice := catalogDiffs[o:end]
+		moreTasks, err := gen.Add(slice)
+		if err != nil {
+			t.Fatalf("failed to add tasks %d..%d: %+v: %s", o, end, catalogDiffs[o:o+3], err)
+		}
+		tasksWithIDs = append(tasksWithIDs, moreTasks...)
 	}
+	moreTasks, err := gen.Finish()
+	if err != nil {
+		t.Fatalf("failed to finish generating tasks: %s", err)
+	}
+	tasksWithIDs = append(tasksWithIDs, moreTasks...)
 
 	for i, task := range tasksWithIDs {
 		t.Logf("task %d: %+v", i, task)


### PR DESCRIPTION
Part of #534.

Still requires memory linear in # of success directories, but makes it easier to work with
iterating over diffs.