### PR TITLE
[parade] Move DDL under ddl/

### DIFF
--- a/db/database.go
+++ b/db/database.go
@@ -25,6 +25,7 @@ type Database interface {
 	Metadata() (map[string]string, error)
 	Stats() sql.DBStats
 	WithContext(ctx context.Context) Database
+	Pool() *pgxpool.Pool
 }
 
 type QueryOptions struct {
@@ -67,6 +68,10 @@ func (d *PgxDatabase) WithContext(ctx context.Context) Database {
 
 func (d *PgxDatabase) Close() {
 	d.db.Close()
+}
+
+func (d *PgxDatabase) Pool() *pgxpool.Pool {
+	return d.db
 }
 
 // performAndReport performs fn and logs a "done" report if its duration was long enough.

--- a/ddl/000011_parade.down.sql
+++ b/ddl/000011_parade.down.sql
@@ -1,0 +1,14 @@
+BEGIN;
+
+DROP FUNCTION IF EXISTS delete_tasks;
+DROP TYPE IF EXISTS tasks_recurse_value;
+DROP FUNCTION IF EXISTS remove_task_dependencies;
+DROP FUNCTION IF EXISTS return_task;
+DROP FUNCTION IF EXISTS no_more_tries;
+DROP FUNCTION IF EXISTS extend_task_deadline;
+DROP FUNCTION IF EXISTS own_tasks;
+DROP FUNCTION IF EXISTS can_allocate_task;
+DROP TABLE IF EXISTS tasks;
+DROP TYPE IF EXISTS task_status_code_value;
+
+END;

--- a/parade/parade.go
+++ b/parade/parade.go
@@ -66,12 +66,12 @@ func NewParadeDB(pool *pgxpool.Pool) Parade {
 	return (*ParadeDB)(pool)
 }
 
-func (p *ParadeDB) pgxPool() *pgxpool.Pool {
+func (p *ParadeDB) PgxPool() *pgxpool.Pool {
 	return (*pgxpool.Pool)(p)
 }
 
 func (p *ParadeDB) InsertTasks(ctx context.Context, tasks []TaskData) error {
-	conn, err := p.pgxPool().Acquire(ctx)
+	conn, err := p.PgxPool().Acquire(ctx)
 	if err != nil {
 		return fmt.Errorf("acquire conn: %w", err)
 	}
@@ -81,7 +81,7 @@ func (p *ParadeDB) InsertTasks(ctx context.Context, tasks []TaskData) error {
 
 func (p *ParadeDB) OwnTasks(actor ActorID, maxTasks int, actions []string, maxDuration *time.Duration) ([]OwnedTaskData, error) {
 	ctx := context.Background()
-	conn, err := p.pgxPool().Acquire(ctx)
+	conn, err := p.PgxPool().Acquire(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("acquire conn: %w", err)
 	}
@@ -92,7 +92,7 @@ func (p *ParadeDB) OwnTasks(actor ActorID, maxTasks int, actions []string, maxDu
 
 func (p *ParadeDB) ExtendTaskDeadline(taskID TaskID, token PerformanceToken, maxDuration time.Duration) error {
 	ctx := context.Background()
-	conn, err := p.pgxPool().Acquire(ctx)
+	conn, err := p.PgxPool().Acquire(ctx)
 	if err != nil {
 		return fmt.Errorf("acquire conn: %w", err)
 	}
@@ -103,7 +103,7 @@ func (p *ParadeDB) ExtendTaskDeadline(taskID TaskID, token PerformanceToken, max
 
 func (p *ParadeDB) ReturnTask(taskID TaskID, token PerformanceToken, resultStatus string, resultStatusCode TaskStatusCodeValue) error {
 	ctx := context.Background()
-	conn, err := p.pgxPool().Acquire(ctx)
+	conn, err := p.PgxPool().Acquire(ctx)
 	if err != nil {
 		return fmt.Errorf("acquire conn: %w", err)
 	}
@@ -113,7 +113,7 @@ func (p *ParadeDB) ReturnTask(taskID TaskID, token PerformanceToken, resultStatu
 }
 
 func (p *ParadeDB) NewWaiter(ctx context.Context, taskID TaskID) (Waiter, error) {
-	conn, err := p.pgxPool().Acquire(ctx)
+	conn, err := p.PgxPool().Acquire(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("get conn to for waiter: %w", err)
 	}
@@ -123,7 +123,7 @@ func (p *ParadeDB) NewWaiter(ctx context.Context, taskID TaskID) (Waiter, error)
 }
 
 func (p *ParadeDB) DeleteTasks(ctx context.Context, taskIDs []TaskID) error {
-	conn, err := p.pgxPool().Acquire(ctx)
+	conn, err := p.PgxPool().Acquire(ctx)
 	if err != nil {
 		return fmt.Errorf("acquire conn: %w", err)
 	}

--- a/parade/parade_test.go
+++ b/parade/parade_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math/rand"
 	"os"
@@ -17,7 +16,6 @@ import (
 	"github.com/go-test/deep"
 	"github.com/jackc/pgtype"
 	"github.com/jackc/pgx/v4/pgxpool"
-	dbwrapper "github.com/treeverse/lakefs/db"
 	"github.com/treeverse/lakefs/parade"
 	"github.com/treeverse/lakefs/testutil"
 
@@ -32,9 +30,8 @@ const (
 var (
 	pool        *dockertest.Pool
 	databaseURI string
-	db          *pgxpool.Pool
 
-	postgresUrl = flag.String("postgres-url", "", "Postgres connection string.  If unset, run a Postgres in a Docker container.  If set, should have ddl.sql already loaded.")
+	postgresUrl = flag.String("postgres-url", "", "Postgres connection string.  If unset, run a Postgres in a Docker container.")
 	parallelism = flag.Int("parallelism", 16, "Number of concurrent client worker goroutines.")
 	bulk        = flag.Int("bulk", 2_000, "Number of tasks to acquire at once in each client goroutine.")
 	taskFactor  = flag.Int("task-factor", 20_000, "Scale benchmark N by this many tasks")
@@ -48,68 +45,6 @@ func (p taskIDSlice) Len() int           { return len(p) }
 func (p taskIDSlice) Less(i, j int) bool { return p[i] < p[j] }
 func (p taskIDSlice) Swap(i, j int)      { p[i], p[j] = p[j], p[i] }
 
-// runDBInstance starts a test Postgres server inside container pool, and returns a connection
-// URI and a closer function.
-func runDBInstance(pool *dockertest.Pool) (string, func()) {
-	if *postgresUrl != "" {
-		return *postgresUrl, nil
-	}
-
-	resource, err := pool.Run("postgres", "11", []string{
-		"POSTGRES_USER=parade",
-		"POSTGRES_PASSWORD=parade",
-		"POSTGRES_DB=parade_db",
-	})
-	if err != nil {
-		log.Fatalf("could not start postgresql: %s", err)
-	}
-
-	// set cleanup
-	closer := func() {
-		err := pool.Purge(resource)
-		if err != nil {
-			log.Fatalf("could not kill postgres container")
-		}
-	}
-
-	// expire, just to make sure
-	err = resource.Expire(dbContainerTimeoutSeconds)
-	if err != nil {
-		log.Fatalf("could not expire postgres container")
-	}
-
-	ctx := context.Background()
-
-	// create connection
-	var pgPool *pgxpool.Pool
-	uri := fmt.Sprintf("postgres://parade:parade@localhost:%s/"+dbName+"?sslmode=disable", resource.GetPort("5432/tcp"))
-	err = pool.Retry(func() error {
-		var err error
-		pgPool, err = pgxpool.Connect(ctx, uri)
-		if err != nil {
-			return err
-		}
-		return dbwrapper.Ping(ctx, pgPool)
-	})
-	if err != nil {
-		log.Fatalf("could not connect to postgres: %s", err)
-	}
-
-	// Run the DDL
-	contents, err := ioutil.ReadFile("./ddl.sql")
-	if err != nil {
-		log.Fatalf("read DDL file ./ddl.sql: %s", err)
-	}
-	if _, err = pgPool.Exec(ctx, string(contents)); err != nil {
-		log.Fatalf("exec command file ./ddl.sql: %s", err)
-	}
-
-	pgPool.Close()
-
-	// return DB URI
-	return uri, closer
-}
-
 var keepDB bool
 
 func TestMain(m *testing.M) {
@@ -120,18 +55,9 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		log.Fatalf("could not connect to Docker: %s", err)
 	}
-	ctx := context.Background()
 	var dbCleanup func()
-	databaseURI, dbCleanup = runDBInstance(pool)
-	if keepDB {
-		fmt.Println("Test DB URL: ", databaseURI)
-	}
+	databaseURI, dbCleanup = testutil.GetDBInstance(pool)
 	defer dbCleanup() // In case we don't reach the cleanup action.
-	db, err = pgxpool.Connect(ctx, databaseURI)
-	if err != nil {
-		log.Fatalf("open PostgreSQL pool: %s", err)
-	}
-	defer db.Close()
 	code := m.Run()
 	if !keepDB && dbCleanup != nil {
 		dbCleanup() // os.Exit() below won't call the defered cleanup, do it now.
@@ -151,10 +77,10 @@ func intAddr(i int) *int {
 	return &i
 }
 
-func scanIDs(t *testing.T, prefix string) []parade.TaskID {
+func scanIDs(t *testing.T, pool *pgxpool.Pool, prefix string) []parade.TaskID {
 	t.Helper()
 	ctx := context.Background()
-	rows, err := db.Query(ctx, `SELECT id FROM tasks WHERE id LIKE format('%s%%', $1::text)`, prefix)
+	rows, err := pool.Query(ctx, `SELECT id FROM tasks WHERE id LIKE format('%s%%', $1::text)`, prefix)
 	if err != nil {
 		t.Fatalf("[I] select remaining IDs for prefix %s: %s", prefix, err)
 	}
@@ -282,7 +208,12 @@ func TestTaskStatusCodeValueScan(t *testing.T) {
 }
 
 func makeParadePrefix(t testing.TB) *parade.ParadePrefix {
-	return &parade.ParadePrefix{parade.NewParadeDB(db), t.Name()}
+	db, handlerDatabaseURI := testutil.GetDB(t, databaseURI)
+	pool := db.Pool()
+	if keepDB {
+		t.Log("Test DB URL: ", handlerDatabaseURI)
+	}
+	return &parade.ParadePrefix{parade.NewParadeDB(pool), t.Name()}
 }
 
 // makeCleanup returns a cleanup for tasks that you can defer, that ignores any changes to tasks
@@ -782,7 +713,8 @@ func TestDeleteTasks(t *testing.T) {
 				t.Errorf("DeleteTasks failed: %s", err)
 			}
 
-			gotRemaining := scanIDs(t, casePrefix)
+			pool := pp.Base.(*parade.ParadeDB).PgxPool()
+			gotRemaining := scanIDs(t, pool, casePrefix)
 			sort.Sort(taskIDSlice(gotRemaining))
 			expectedRemaining := c.expectedRemaining
 			if expectedRemaining == nil {


### PR DESCRIPTION
Requires some changes, most notably an ability to get a the pgx pool from a database.  This
should eventually vanish: we could either use pgx more directly, or export enough functionality
from Database to enable Parade directly on top.