### PR TITLE
Create extension pgcrypto in "public" schema

### DIFF
--- a/ddl/000011_parade.up.sql
+++ b/ddl/000011_parade.up.sql
@@ -1,6 +1,6 @@
 BEGIN;
 
-CREATE EXTENSION IF NOT EXISTS pgcrypto SCHEMA public;
+CREATE EXTENSION IF NOT EXISTS pgcrypto SCHEMA public CASCADE;
 
 CREATE TYPE task_status_code_value AS ENUM (
     'pending',          -- waiting for an actor to perform it (new or being retried)

--- a/ddl/000011_parade.up.sql
+++ b/ddl/000011_parade.up.sql
@@ -1,7 +1,6 @@
 BEGIN;
 
-CREATE SCHEMA IF NOT EXISTS extensions;
-CREATE EXTENSION IF NOT EXISTS pgcrypto SCHEMA extensions;
+CREATE EXTENSION IF NOT EXISTS pgcrypto SCHEMA public;
 
 CREATE TYPE task_status_code_value AS ENUM (
     'pending',          -- waiting for an actor to perform it (new or being retried)
@@ -58,7 +57,7 @@ LANGUAGE sql VOLATILE AS $$
     SET actor_id = owner_id,
         status_code = 'in-progress',
         num_tries = num_tries + 1,
-        performance_token = extensions.gen_random_uuid(),
+        performance_token = gen_random_uuid(),
         action_deadline = NOW() + max_duration -- NULL if max_duration IS NULL
     WHERE id IN (
         SELECT id

--- a/testutil/db.go
+++ b/testutil/db.go
@@ -128,7 +128,7 @@ func GetDB(t testing.TB, uri string, opts ...GetDBOption) (db.Database, string) 
 		strings.ReplaceAll(uuid.New().String(), "-", ""))
 
 	// create connection
-	connURI := fmt.Sprintf("%s&search_path=%s", uri, generatedSchema)
+	connURI := fmt.Sprintf("%s&search_path=%s,public", uri, generatedSchema)
 	pool, err := pgxpool.Connect(ctx, connURI)
 	if err != nil {
 		t.Fatalf("could not connect to PostgreSQL: %s", err)


### PR DESCRIPTION
The issue is that extension pgcrypto might already exist in the database, and we still need to
access it.  So we cannot choose to locate the extension in a schema of our choice.  On the other
hand it must be in the *same* schema each time because each _test_ uses a different schema, and
it is not possible to redefine the same extension there.  So `public` is a good choice.