### PR TITLE
Feature/added scrollto after object is deleted (issue #655)

### DIFF
--- a/webui/src/actions/objects.js
+++ b/webui/src/actions/objects.js
@@ -1,5 +1,7 @@
 import * as api from "./api";
 import {AsyncActionType} from "./request";
+import { Link,  Element, Events, scrollSpy, scroller, animateScroll as scroll } from "react-scroll";
+import * as Scroll from 'react-scroll';
 
 export const PAGINATION_AMOUNT = 300;
 export const OBJECTS_LIST_TREE = new AsyncActionType('OBJECTS_GET_TREE');
@@ -31,14 +33,31 @@ export const uploadDone = () => {
     return OBJECTS_UPLOAD.resetAction();
 };
 
+let yoffset = 0;
 
 export const deleteObject = (repoId, branchId, path) => {
+    constructor(props) {
+      super(props);
+      this.state = {yoffset: 0};
+    }
+    storeScroll = () => {
+      console.log(window.pageYOffset);
+      yoffset = window.pageYOffset;
+      this.setState({yoffset: window.pageYOffset});
+    };
     return OBJECTS_DELETE.execute(async () => {
+        this.storeScroll;
         return await api.objects.delete(repoId, branchId, path);
     });
 };
 
 export const deleteObjectDone = () => {
-    return OBJECTS_DELETE.resetAction();
+    scrollToPageOffset = offset_val => e =>  {
+      scroll.scrollTo(offset_val);
+    };
+    return (
+      OBJECTS_DELETE.resetAction();
+      this.scrollToPageOffset(yoffset);
+      yoffset = 0;
+    )
 };
-

--- a/webui/src/actions/objects.js
+++ b/webui/src/actions/objects.js
@@ -1,6 +1,6 @@
 import * as api from "./api";
 import {AsyncActionType} from "./request";
-import { Link,  Element, Events, scrollSpy, scroller, animateScroll as scroll } from "react-scroll";
+import { Element, Events, scrollSpy, scroller, animateScroll as scroll } from "react-scroll";
 import * as Scroll from 'react-scroll';
 
 export const PAGINATION_AMOUNT = 300;
@@ -34,30 +34,26 @@ export const uploadDone = () => {
 };
 
 let yoffset = 0;
+function storeScroll(){
+  console.log(window.pageYOffset);
+  yoffset = window.pageYOffset;
+};
+
+function scrollToPageOffset(){
+  scroll.scrollTo(yoffset);
+  yoffset = 0;
+};
 
 export const deleteObject = (repoId, branchId, path) => {
-    constructor(props) {
-      super(props);
-      this.state = {yoffset: 0};
-    }
-    storeScroll = () => {
-      console.log(window.pageYOffset);
-      yoffset = window.pageYOffset;
-      this.setState({yoffset: window.pageYOffset});
-    };
     return OBJECTS_DELETE.execute(async () => {
-        this.storeScroll;
+        storeScroll;
         return await api.objects.delete(repoId, branchId, path);
     });
 };
 
 export const deleteObjectDone = () => {
-    scrollToPageOffset = offset_val => e =>  {
-      scroll.scrollTo(offset_val);
-    };
     return (
       OBJECTS_DELETE.resetAction();
-      this.scrollToPageOffset(yoffset);
-      yoffset = 0;
-    )
+      scrollToPageOffset;
+    );
 };

--- a/webui/src/actions/objects.js
+++ b/webui/src/actions/objects.js
@@ -53,7 +53,7 @@ function scrollToPageOffset(){
 };
 export const deleteObjectDone = () => {
     return (
-      OBJECTS_DELETE.resetAction(), 
-      scrollToPageOffset,
+      scrollToPageOffset;
+      OBJECTS_DELETE.resetAction();
     );
 };

--- a/webui/src/actions/objects.js
+++ b/webui/src/actions/objects.js
@@ -53,7 +53,7 @@ function scrollToPageOffset(){
 };
 export const deleteObjectDone = () => {
     return (
-      OBJECTS_DELETE.resetAction();
+      OBJECTS_DELETE.resetAction(), 
       scrollToPageOffset;
     );
 };

--- a/webui/src/actions/objects.js
+++ b/webui/src/actions/objects.js
@@ -39,7 +39,7 @@ export const deleteObject = (repoId, branchId, path) => {
     constructor(props) {
       super(props);
       this.state = {yoffset: 0};
-    }
+    };
     storeScroll = () => {
       console.log(window.pageYOffset);
       yoffset = window.pageYOffset;

--- a/webui/src/actions/objects.js
+++ b/webui/src/actions/objects.js
@@ -33,15 +33,11 @@ export const uploadDone = () => {
     return OBJECTS_UPLOAD.resetAction();
 };
 
+
 let yoffset = 0;
 function storeScroll(){
   console.log(window.pageYOffset);
   yoffset = window.pageYOffset;
-};
-
-function scrollToPageOffset(){
-  scroll.scrollTo(yoffset);
-  yoffset = 0;
 };
 
 export const deleteObject = (repoId, branchId, path) => {
@@ -51,6 +47,10 @@ export const deleteObject = (repoId, branchId, path) => {
     });
 };
 
+function scrollToPageOffset(){
+  scroll.scrollTo(yoffset);
+  yoffset = 0;
+};
 export const deleteObjectDone = () => {
     return (
       OBJECTS_DELETE.resetAction();

--- a/webui/src/actions/objects.js
+++ b/webui/src/actions/objects.js
@@ -1,7 +1,5 @@
 import * as api from "./api";
 import {AsyncActionType} from "./request";
-import { Element, Events, scrollSpy, scroller, animateScroll as scroll } from "react-scroll";
-import * as Scroll from 'react-scroll';
 
 export const PAGINATION_AMOUNT = 300;
 export const OBJECTS_LIST_TREE = new AsyncActionType('OBJECTS_GET_TREE');
@@ -48,7 +46,7 @@ export const deleteObject = (repoId, branchId, path) => {
 };
 
 function scrollToPageOffset(){
-  scroll.scrollTo(yoffset);
+  window.scrollTo(0,yoffset);
   yoffset = 0;
 };
 export const deleteObjectDone = () => {

--- a/webui/src/actions/objects.js
+++ b/webui/src/actions/objects.js
@@ -54,6 +54,6 @@ function scrollToPageOffset(){
 export const deleteObjectDone = () => {
     return (
       OBJECTS_DELETE.resetAction(), 
-      scrollToPageOffset;
+      scrollToPageOffset,
     );
 };

--- a/webui/src/actions/objects.js
+++ b/webui/src/actions/objects.js
@@ -36,8 +36,8 @@ export const uploadDone = () => {
 let yoffset = 0;
 
 export const deleteObject = (repoId, branchId, path) => {
-    constructor(props) {
-      super(props);
+    constructor() {
+      super();
       this.state = {yoffset: 0};
     };
     storeScroll = () => {

--- a/webui/src/actions/objects.js
+++ b/webui/src/actions/objects.js
@@ -36,10 +36,10 @@ export const uploadDone = () => {
 let yoffset = 0;
 
 export const deleteObject = (repoId, branchId, path) => {
-    constructor() {
-      super();
+    constructor(props) {
+      super(props);
       this.state = {yoffset: 0};
-    };
+    }
     storeScroll = () => {
       console.log(window.pageYOffset);
       yoffset = window.pageYOffset;

--- a/webui/src/actions/objects.js
+++ b/webui/src/actions/objects.js
@@ -52,8 +52,9 @@ function scrollToPageOffset(){
   yoffset = 0;
 };
 export const deleteObjectDone = () => {
-    return (
-      scrollToPageOffset;
-      OBJECTS_DELETE.resetAction();
-    );
+    return OBJECTS_DELETE.execute(async () => {
+        resetAction();
+        scrollToPageOffset;
+    });
 };
+


### PR DESCRIPTION
added scrollTo feature. When any object is deleted its scroll position is stored and after it is deleted scrollTo is triggered to restore previous scroll state. 
Uses react scrollTo from "react-scroll" library.
issue #655 

This feature update is working fine in my local environment.
If there is any error, while running , please let me know. 
Also if the code snippet is not placed optimally, please tell me about that too, I was very much confused about that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/treeverse/lakefs/966)
<!-- Reviewable:end -->
