### PR TITLE
Generate {application,text}/xml headers on gateway by client's choice

### DIFF
--- a/gateway/handler.go
+++ b/gateway/handler.go
@@ -350,16 +350,24 @@ func notFound(w http.ResponseWriter, _ *http.Request) {
 
 var commaSeparator = regexp.MustCompile(`,\s*`)
 
+var (
+	contentTypeApplicationXML = "application/xml"
+	contentTypeTextXML        = "text/xml"
+)
+
 func selectContentType(acceptable []string) *string {
 	for _, acceptableTypes := range acceptable {
 		acceptable := commaSeparator.Split(acceptableTypes, -1)
 		for _, a := range acceptable {
-			if a == "text/xml" || a == "application/xml" {
-				return &a
+			switch a {
+			case contentTypeTextXML:
+				return &contentTypeTextXML
+			case contentTypeApplicationXML:
+				return &contentTypeApplicationXML
 			}
 		}
 	}
-	return nil
+	return &contentTypeApplicationXML
 }
 
 func setContentType(w http.ResponseWriter, r *http.Request) {

--- a/gateway/handler.go
+++ b/gateway/handler.go
@@ -374,16 +374,16 @@ func setDefaultContentType(w http.ResponseWriter, r *http.Request) {
 	acceptable, ok := r.Header["Accept"]
 	if ok {
 		defaultContentType := selectContentType(acceptable)
-		// No requested content type matched.  This is OK at least for a GET or
-		// HEAD, so set up to auto-detect.
 		if defaultContentType != nil {
 			w.Header().Set("Content-Type", *defaultContentType)
 		}
+		// If no requested content type matched, still OK at least for proxied content
+		// (GET or HEAD), so set up to auto-detect.
 	} else {
-		// For all proxied content the type will be reset according to whatever headers
-		// arrive.  This includes setting an empty content-type if none is specified by
-		// the adapter.
 		w.Header().Set("Content-Type", contentTypeApplicationXML)
+		// For proxied content (GET or HEAD) the type will be reset according to
+		// whatever headers arrive, including setting up to auto-detect content-type if
+		// none is specified by the adapter.
 	}
 }
 

--- a/gateway/operations/base.go
+++ b/gateway/operations/base.go
@@ -116,6 +116,11 @@ func (o *Operation) SetHeader(key, value string) {
 	o.ResponseWriter.Header()[key] = []string{value}
 }
 
+// DeleteHeader deletes a header from the response
+func (o *Operation) DeleteHeader(key string) {
+	o.ResponseWriter.Header().Del(key)
+}
+
 // SetHeaders sets a map of headers on the response while preserving the header's case
 func (o *Operation) SetHeaders(headers map[string]string) {
 	for k, v := range headers {

--- a/gateway/operations/getobject.go
+++ b/gateway/operations/getobject.go
@@ -99,6 +99,9 @@ func (controller *GetObject) Handle(o *PathOperation) {
 	if rng.StartOffset != -1 {
 		o.SetHeader("Content-Range", fmt.Sprintf("bytes %d-%d/%d", rng.StartOffset, rng.EndOffset, entry.Size))
 	}
+	// Delete the default content-type header so http.Server will detect it from contents
+	// TODO(ariels): After/if we add content-type support to adapter, use *that*.
+	o.DeleteHeader("Content-Type")
 	_, err = io.Copy(o.ResponseWriter, data)
 	if err != nil {
 		o.Log().WithError(err).Error("could not write response body for object")


### PR DESCRIPTION
If no header is specified, none is explicitly generated.  Then the Go http server generates
one by scanning content, it happens to be text/xml.  If either of these headers is
specified, generate that requested content type.  If (only) other headers are generated,
respond "Not Acceptable".

This does not break backwards compatibility with clients that do not generate such a
header (boto, mc).  This should improve compatibility with a client that explicitly asks for
application/xml (the Akka S3 client alpakka only accepts that Content-Type, so it had better
ask for it).  It *will* break a lying client that requests only anything-but-standard-XML.