### PR TITLE
Add CacheWithDisposal to cache resources that require disposal

### DIFF
--- a/cache/refcnted.go
+++ b/cache/refcnted.go
@@ -26,6 +26,7 @@ type CacheWithDisposal interface {
 
 type ParamsWithDisposal struct {
 	Name   string
+	Logger logging.Logger
 	Size   int
 	Shards int
 	// OnDispose disposes of an entry.  It is called when the last reference to an entry
@@ -108,10 +109,7 @@ func NewSingleThreadedCacheWithDisposal(p ParamsWithDisposal) *SingleThreadedCac
 	onEvict := func(k interface{}, v interface{}) {
 		entry := v.(*cacheEntry)
 		err := entry.release(ret)
-		logging.Default().WithFields(logging.Fields{
-			"key":   k,
-			"value": v,
-		}).WithError(err).Error("[internal] failed to release during eviction")
+		p.Logger.WithField("key", k).WithError(err).Error("[internal] failed to release during eviction")
 	}
 	ret.p = &p
 	var err error

--- a/cache/refcnted.go
+++ b/cache/refcnted.go
@@ -1,0 +1,113 @@
+package cache
+
+import (
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+
+	"github.com/hnlq715/golang-lru/simplelru"
+
+	"github.com/treeverse/lakefs/logging"
+)
+
+// Derefer is the type of a function that returns an object to the cache, possibly causing
+// its eviction.
+type Derefer func() error
+
+// CacheWithDisposal is a cache that calls a disposal callback when an entry has been evicted
+// and is no longer in use.  Because of the structure of Go, it uses release callbacks and is
+// not a Cache.
+type CacheWithDisposal interface {
+	Name() string
+	GetOrSet(k interface{}, setFn SetFn) (v interface{}, disposer Derefer, err error)
+}
+
+type ParamsWithDisposal struct {
+	Name string
+	Size int
+	// OnDispose disposes of an entry.  It is called when the last reference to an entry
+	// is released.  If it fails not much can be done.
+	OnDispose func(value interface{}) error
+}
+
+// SingleThreadedCacheWithDisposal is a CacheWithDisposal that uses a single critical section
+// to prevent concurrent access to the cache and to reference counts on values.
+type SingleThreadedCacheWithDisposal struct {
+	p    *ParamsWithDisposal
+	name string
+	mu   sync.Mutex // protects lru
+	lru  *simplelru.LRU
+}
+
+// cacheEntry is a single entry in the cache.  It uses only atomic operations on refs and is
+// safe for concurrent use.
+type cacheEntry struct {
+	refs  int32
+	value interface{}
+}
+
+var ErrNegativeReferenceCount = errors.New("internal error: negative reference count")
+
+// release releases one reference count from e, releasing it from cd if that was the last
+// reference.
+func (e *cacheEntry) release(c *SingleThreadedCacheWithDisposal) error {
+	refs := atomic.AddInt32(&e.refs, -1)
+	if refs < 0 {
+		return fmt.Errorf("release from %s: %w %d; may leak or fail", c.Name(), ErrNegativeReferenceCount, refs)
+	}
+	if refs > 0 {
+		return nil
+	}
+
+	return c.p.OnDispose(e.value)
+}
+
+// acquire acquires another reference on e.
+func (e *cacheEntry) acquire() {
+	atomic.AddInt32(&e.refs, +1)
+}
+
+func (c *SingleThreadedCacheWithDisposal) Name() string {
+	return c.name
+}
+
+func NewCacheWithDisposal(p ParamsWithDisposal) *SingleThreadedCacheWithDisposal {
+	ret := &SingleThreadedCacheWithDisposal{
+		name: p.Name,
+	}
+	onEvict := func(k interface{}, v interface{}) {
+		entry := v.(*cacheEntry)
+		err := entry.release(ret)
+		logging.Default().WithFields(logging.Fields{
+			"key":   k,
+			"value": v,
+		}).WithError(err).Error("[internal] failed to release during eviction")
+	}
+	ret.p = &p
+	var err error
+	ret.lru, err = simplelru.NewLRU(p.Size, onEvict)
+	if err != nil {
+		panic(err)
+	}
+	return ret
+}
+
+func (c *SingleThreadedCacheWithDisposal) GetOrSet(k interface{}, setFn SetFn) (interface{}, Derefer, error) {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	var entry *cacheEntry
+	if e, ok := c.lru.Get(k); ok {
+		entry = e.(*cacheEntry)
+		entry.acquire()
+	} else {
+		v, err := setFn()
+		if err != nil {
+			return nil, nil, err
+		}
+		entry = &cacheEntry{refs: 1, value: v}
+	}
+	return entry.value, func() error {
+		return entry.release(c)
+	}, nil
+}

--- a/cache/refcnted.go
+++ b/cache/refcnted.go
@@ -59,7 +59,7 @@ func (s *shardedCacheWithDisposal) GetOrSet(k interface{}, setFn SetFn) (interfa
 	// (Explicitly ignore return value from hash.WriteString: its godoc says "it always
 	// writes all of s and never fails; the count and error result are for implementing
 	// io.StringWriter."
-	_, _ = hash.WriteString(fmt.Sprint(k))
+	_, _ = hash.WriteString(fmt.Sprintf("%+#v", k))
 	hashVal := hash.Sum64() % uint64(len(s.Shards))
 	return s.Shards[hashVal].GetOrSet(k, setFn)
 }

--- a/cache/refcnted.go
+++ b/cache/refcnted.go
@@ -56,7 +56,10 @@ func NewCacheWithDisposal(p ParamsWithDisposal) *shardedCacheWithDisposal {
 func (s *shardedCacheWithDisposal) GetOrSet(k interface{}, setFn SetFn) (interface{}, Derefer, error) {
 	hash := maphash.Hash{}
 	hash.SetSeed(s.Seed)
-	hash.WriteString(fmt.Sprint(k))
+	// (Explicitly ignore return value from hash.WriteString: its godoc says "it always
+	// writes all of s and never fails; the count and error result are for implementing
+	// io.StringWriter."
+	_, _ = hash.WriteString(fmt.Sprint(k))
 	hashVal := hash.Sum64() % uint64(len(s.Shards))
 	return s.Shards[hashVal].GetOrSet(k, setFn)
 }

--- a/cache/refcnted_test.go
+++ b/cache/refcnted_test.go
@@ -33,8 +33,9 @@ func TestCacheWithDisposal(t *testing.T) {
 		close(allErrs)
 	}()
 	p := cache.ParamsWithDisposal{
-		Name: t.Name(),
-		Size: size,
+		Name:   t.Name(),
+		Shards: 3,
+		Size:   size,
 		OnDispose: func(v interface{}) error {
 			element := v.(*record)
 			if n := atomic.AddInt32(&element.disposed, 1); n != 1 {

--- a/cache/refcnted_test.go
+++ b/cache/refcnted_test.go
@@ -1,0 +1,94 @@
+package cache_test
+
+import (
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/treeverse/lakefs/cache"
+)
+
+func TestCacheWithDisposal(t *testing.T) {
+	const (
+		size        = 7
+		parallelism = 100
+		repeats     = 2000
+	)
+	type record struct {
+		key      int
+		disposed int32
+		live     int32
+	}
+	var elements [size]*record
+	ch := make(chan error, parallelism*2)
+	allErrs := make(chan []error)
+	go func() {
+		errs := make([]error, 0)
+		for err := range ch {
+			errs = append(errs, err)
+		}
+		allErrs <- errs
+		close(allErrs)
+	}()
+	p := cache.ParamsWithDisposal{
+		Name: t.Name(),
+		Size: size,
+		OnDispose: func(v interface{}) error {
+			element := v.(*record)
+			if n := atomic.AddInt32(&element.disposed, 1); n != 1 {
+				ch <- fmt.Errorf("%d disposals of %+v", n, *element)
+			}
+			if l := atomic.CompareAndSwapInt32(&element.live, 1, 0); !l {
+				ch <- fmt.Errorf("disposal of already-dead %+v", *element)
+			}
+			return nil
+		},
+	}
+	c := cache.NewCacheWithDisposal(p)
+
+	numCreated := int32(0)
+
+	wg := sync.WaitGroup{}
+	for i := 0; i < parallelism; i++ {
+		wg.Add(1)
+		go func(i int) {
+			for j := 0; j < repeats; j++ {
+				k := j % size
+				v, release, err := c.GetOrSet(
+					k, func() (interface{}, error) {
+						e := &record{
+							key:      k,
+							disposed: 0,
+							live:     1,
+						}
+						elements[k] = e
+						atomic.AddInt32(&numCreated, int32(1))
+						return e, nil
+					})
+				if err != nil {
+					ch <- err
+				}
+				e := v.(*record)
+				if e.key != k {
+					ch <- fmt.Errorf("got %v not %d", v, k)
+				}
+				if e.live == 0 {
+					ch <- fmt.Errorf("got dead element %+v at %d", v, k)
+				}
+				if (j*repeats+i)%113 == 17 {
+					time.Sleep(17 * time.Millisecond)
+				}
+				release()
+			}
+			wg.Done()
+		}(i)
+	}
+	wg.Wait()
+	close(ch)
+	errs := <-allErrs
+	for _, err := range errs {
+		t.Error(err)
+	}
+}

--- a/cache/refcnted_test.go
+++ b/cache/refcnted_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/treeverse/lakefs/cache"
+	"github.com/treeverse/lakefs/logging"
 )
 
 func TestCacheWithDisposal(t *testing.T) {
@@ -34,6 +35,7 @@ func TestCacheWithDisposal(t *testing.T) {
 	}()
 	p := cache.ParamsWithDisposal{
 		Name:   t.Name(),
+		Logger: logging.Default().WithField("testing", true),
 		Shards: 3,
 		Size:   size,
 		OnDispose: func(v interface{}) error {


### PR DESCRIPTION
Whenever an element is fetched from the cache, a value is returned along with a deref function
that must be called to allow the element to be returned.  Once evicted, the object can only be
disposed of after all its references have been returned to the cache.

The implementation is mostly just mixing a reference count onto each entry in the cache.

And now, a rant.

Caching resources that require disposal (such as anything with a file descriptor) is difficult
in garbage-collected languages, _because_ of garbage collection.  Only memory presure triggers
GC, so it is entirely inappropriate for handling other resources.  But the lack of destructors
leaves no way to force resource cleanups.  Instead we have to return an explicit function that
returns the object to the pool.  A language such as C++ calls destructors at clear places, and
would allow returning special object references that handle lifetimes.  In fact it already has
`shared_ptr` in the standard library.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/treeverse/lakefs/1044)
<!-- Reviewable:end -->
