### PR TITLE
Add simple marshalling for graveler.Value

### DIFF
--- a/graveler/value.go
+++ b/graveler/value.go
@@ -1,0 +1,88 @@
+package graveler
+
+import (
+	"bytes"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+)
+
+/*
+ * Value is serialized in a trivial fixed-order format:
+ *
+ *    | len(Identity) | Identity | len(Value) | Value |
+ *
+ * where each length is serialized as a varint and additional bytes after Value are silently
+ * ignored.
+ */
+
+func writeVarint(w io.Writer, i int) error {
+	e := make([]byte, binary.MaxVarintLen64)
+	l := binary.PutVarint(e, int64(i))
+	_, err := w.Write(e[:l])
+	return err
+}
+
+func writeBytes(tag string, w io.Writer, b []byte) error {
+	if err := writeVarint(w, len(b)); err != nil {
+		return fmt.Errorf("write %s length: %w", tag, err)
+	}
+	if _, err := w.Write(b); err != nil {
+		return fmt.Errorf("write %s: %w", tag, err)
+	}
+	return nil
+}
+
+// MarshalValue returns bytes that uniquely unmarshal into a Value equal to v.
+func MarshalValue(v *Value) ([]byte, error) {
+	var w = &bytes.Buffer{}
+
+	if err := writeBytes("identity", w, v.Identity); err != nil {
+		return nil, err
+	}
+	if err := writeBytes("data", w, v.Data); err != nil {
+		return nil, err
+	}
+	return w.Bytes(), nil
+}
+
+// ErrBadValueBytes is an error that is probably returned when unmarshalling bytes that are
+// supposed to encode a Value.
+var ErrBadValueBytes = errors.New("bad bytes format for graveler.Value")
+
+func getBytes(tag string, b *[]byte) ([]byte, error) {
+	l, o := binary.Varint(*b)
+	if o <= 0 {
+		return nil, fmt.Errorf("read %s length: %w", tag, ErrBadValueBytes)
+	}
+	*b = (*b)[o:]
+	if len(*b) < int(l) {
+		return nil, fmt.Errorf("not enough bytes to read %d bytes for %s: %w", l, tag, ErrBadValueBytes)
+	}
+	if l < 0 {
+		return nil, fmt.Errorf("impossible negative length %d for %s: %w", l, tag, ErrBadValueBytes)
+	}
+	ret := make([]byte, l)
+	copy(ret, (*b)[:l])
+	*b = (*b)[l:]
+	return ret, nil
+}
+
+func UnmarshalValue(b []byte) (*Value, error) {
+	ret := &Value{}
+	var err error
+	if ret.Identity, err = getBytes("identifier", &b); err != nil {
+		return nil, err
+	}
+	if ret.Data, err = getBytes("data", &b); err != nil {
+		return nil, err
+	}
+	return ret, nil
+}
+
+// UnmarshalIdentity returns *only* the Identity field encoded by b.  It does not even examine
+// any bytes beyond the prefix of b holding Identity.
+func UnmarshalIdentity(b []byte) ([]byte, error) {
+	return getBytes("identifier", &b)
+}

--- a/graveler/value.go
+++ b/graveler/value.go
@@ -51,17 +51,17 @@ func MarshalValue(v *Value) ([]byte, error) {
 // supposed to encode a Value.
 var ErrBadValueBytes = errors.New("bad bytes format for graveler.Value")
 
-func getBytes(tag string, b *[]byte) ([]byte, error) {
+func getBytes(b *[]byte) ([]byte, error) {
 	l, o := binary.Varint(*b)
 	if o <= 0 {
-		return nil, fmt.Errorf("read %s length: %w", tag, ErrBadValueBytes)
+		return nil, fmt.Errorf("read length: %w", ErrBadValueBytes)
 	}
 	*b = (*b)[o:]
 	if len(*b) < int(l) {
-		return nil, fmt.Errorf("not enough bytes to read %d bytes for %s: %w", l, tag, ErrBadValueBytes)
+		return nil, fmt.Errorf("not enough bytes to read %d bytes: %w", l, ErrBadValueBytes)
 	}
 	if l < 0 {
-		return nil, fmt.Errorf("impossible negative length %d for %s: %w", l, tag, ErrBadValueBytes)
+		return nil, fmt.Errorf("impossible negative length %d: %w", l, ErrBadValueBytes)
 	}
 	ret := make([]byte, l)
 	copy(ret, (*b)[:l])
@@ -72,11 +72,11 @@ func getBytes(tag string, b *[]byte) ([]byte, error) {
 func UnmarshalValue(b []byte) (*Value, error) {
 	ret := &Value{}
 	var err error
-	if ret.Identity, err = getBytes("identifier", &b); err != nil {
-		return nil, err
+	if ret.Identity, err = getBytes(&b); err != nil {
+		return nil, fmt.Errorf("identity field: %w", err)
 	}
-	if ret.Data, err = getBytes("data", &b); err != nil {
-		return nil, err
+	if ret.Data, err = getBytes(&b); err != nil {
+		return nil, fmt.Errorf("data field: %w", err)
 	}
 	return ret, nil
 }
@@ -84,5 +84,5 @@ func UnmarshalValue(b []byte) (*Value, error) {
 // UnmarshalIdentity returns *only* the Identity field encoded by b.  It does not even examine
 // any bytes beyond the prefix of b holding Identity.
 func UnmarshalIdentity(b []byte) ([]byte, error) {
-	return getBytes("identifier", &b)
+	return getBytes(&b)
 }

--- a/graveler/value_test.go
+++ b/graveler/value_test.go
@@ -1,0 +1,108 @@
+package graveler_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/go-test/deep"
+	"github.com/treeverse/lakefs/graveler"
+)
+
+func TestGravelerValueMarshal(t *testing.T) {
+	cases := []struct {
+		name string
+		v    graveler.Value
+		b    []byte
+	}{
+		{name: "empty", v: graveler.Value{}, b: []byte{0, 0}},
+		{name: "identity", v: graveler.Value{Identity: []byte("foo")}, b: []byte{6, 102, 111, 111, 0}},
+		{name: "data", v: graveler.Value{Data: []byte("the quick brown fox")}, b: []byte{0, 38, 116, 104, 101, 32, 113, 117, 105, 99, 107, 32, 98, 114, 111, 119, 110, 32, 102, 111, 120}},
+		{name: "identityAndData", v: graveler.Value{Identity: []byte("foo"), Data: []byte("the quick brown fox")}, b: []byte{6, 102, 111, 111, 38, 116, 104, 101, 32, 113, 117, 105, 99, 107, 32, 98, 114, 111, 119, 110, 32, 102, 111, 120}},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			b, err := graveler.MarshalValue(&c.v)
+			if err != nil {
+				t.Error(err)
+			}
+			if diffs := deep.Equal(b, c.b); diffs != nil {
+				t.Error("bad bytes: ", diffs)
+			}
+		})
+	}
+}
+
+func TestGravelerValueUnmarshal(t *testing.T) {
+	cases := []struct {
+		name string
+		v    *graveler.Value
+		b    []byte
+		err  error
+	}{
+		{name: "empty", v: &graveler.Value{}, b: []byte{0, 0}},
+		{name: "identity", v: &graveler.Value{Identity: []byte("foo")}, b: []byte{6, 102, 111, 111, 0}},
+		{name: "data", v: &graveler.Value{Data: []byte("the quick brown fox")}, b: []byte{0, 38, 116, 104, 101, 32, 113, 117, 105, 99, 107, 32, 98, 114, 111, 119, 110, 32, 102, 111, 120}},
+		{name: "identityAndData", v: &graveler.Value{Identity: []byte("foo"), Data: []byte("the quick brown fox")}, b: []byte{6, 102, 111, 111, 38, 116, 104, 101, 32, 113, 117, 105, 99, 107, 32, 98, 114, 111, 119, 110, 32, 102, 111, 120}},
+		{name: "failIdentityNegativeLength", b: []byte{3, 102, 111, 111, 0}, err: graveler.ErrBadValueBytes},
+		{name: "failIdentityTooShort", b: []byte{4, 102, 111, 111, 0}, err: graveler.ErrBadValueBytes},
+		{name: "failIdentityTooLong", b: []byte{16, 102, 111, 111, 0}, err: graveler.ErrBadValueBytes},
+		{name: "failIdentityDataNegativeLength", b: []byte{6, 102, 111, 111, 17, 116, 104, 101, 32, 113, 117, 105, 99, 107, 32, 98, 114, 111, 119, 110, 32, 102, 111, 120}, err: graveler.ErrBadValueBytes},
+		{name: "identityAndDataAndLeftovers", v: &graveler.Value{Identity: []byte("foo"), Data: []byte("the quick brown fox")}, b: []byte{6, 102, 111, 111, 38, 116, 104, 101, 32, 113, 117, 105, 99, 107, 32, 98, 114, 111, 119, 110, 32, 102, 111, 120, 1, 2, 3, 4, 5, 6, 7, 8, 9}},
+		{name: "failIdentityDataTooLong", b: []byte{6, 102, 111, 111, 250, 116, 104, 101, 32, 113, 117, 105, 99, 107, 32, 98, 114, 111, 119, 110, 32, 102, 111, 120}, err: graveler.ErrBadValueBytes},
+	}
+
+	for _, c := range cases {
+		if c.v != nil && c.v.Identity == nil {
+			c.v.Identity = make([]byte, 0)
+		}
+		if c.v != nil && c.v.Data == nil {
+			c.v.Data = make([]byte, 0)
+		}
+		t.Run(c.name, func(t *testing.T) {
+			v, err := graveler.UnmarshalValue(c.b)
+			if !errors.Is(err, c.err) {
+				t.Errorf("got error %s != %s", err, c.err)
+			}
+			if diffs := deep.Equal(v, c.v); diffs != nil {
+				t.Errorf("bad value %+v: %s", v, diffs)
+			}
+		})
+	}
+}
+
+func TestGravelerValueIdentityUnmarshal(t *testing.T) {
+	cases := []struct {
+		name string
+		id   []byte
+		b    []byte
+		err  error
+	}{
+		{name: "empty", b: []byte{0, 0}},
+		{name: "identity", id: []byte("foo"), b: []byte{6, 102, 111, 111, 0}},
+		{name: "data", b: []byte{0, 38, 116, 104, 101, 32, 113, 117, 105, 99, 107, 32, 98, 114, 111, 119, 110, 32, 102, 111, 120}},
+		{name: "identityAndData", id: []byte("foo"), b: []byte{6, 102, 111, 111, 38, 116, 104, 101, 32, 113, 117, 105, 99, 107, 32, 98, 114, 111, 119, 110, 32, 102, 111, 120}},
+		{name: "failIdentityNegativeLength", b: []byte{3, 102, 111, 111, 0}, err: graveler.ErrBadValueBytes},
+		{name: "okIdentityTooShort", id: []byte("fo"), b: []byte{4, 102, 111, 111, 0}},
+		{name: "failIdentityTooLong", b: []byte{16, 102, 111, 111, 0}, err: graveler.ErrBadValueBytes},
+		{name: "okIdentityDataNegativeLength", id: []byte("foo"), b: []byte{6, 102, 111, 111, 17, 116, 104, 101, 32, 113, 117, 105, 99, 107, 32, 98, 114, 111, 119, 110, 32, 102, 111, 120}},
+		{name: "okIdentityDataTooLong", id: []byte("foo"), b: []byte{6, 102, 111, 111, 250, 116, 104, 101, 32, 113, 117, 105, 99, 107, 32, 98, 114, 111, 119, 110, 32, 102, 111, 120}},
+	}
+
+	for _, c := range cases {
+		if c.id == nil {
+			c.id = make([]byte, 0)
+		}
+		t.Run(c.name, func(t *testing.T) {
+			id, err := graveler.UnmarshalIdentity(c.b)
+			if !errors.Is(err, c.err) {
+				t.Errorf("got error %s != %s", err, c.err)
+			}
+			if err == nil {
+				if diffs := deep.Equal(id, c.id); diffs != nil {
+					t.Errorf("bad value %+v: %s", id, diffs)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
As discussed f2f this allows separating graveler from the underlying trees wrapper, making each
unaware of the others.  Use our own trivial serialization format that allows high-speed
operation with no copying: in particular there is no need to copy data, or to deserialize more
than Identity.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/treeverse/lakefs/1067)
<!-- Reviewable:end -->
