### PR TITLE
Cache node_modules between runs

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -56,10 +56,13 @@ jobs:
         with:
           go-version: 1.15.2
         id: go
+
+      # No way to share code between workflows :-( If you change this, find and change the
+      # same code wherever "Find Go module and build caches" appears!
       - name: Find Go module and build caches
         run: |
           echo GOMODCACHE=`go env GOMODCACHE` >> $GITHUB_ENV
-          echo GOCACHE=`go env COCACHE` >> $GITHUB_ENV
+          echo GOCACHE=`go env GOCACHE` >> $GITHUB_ENV
           cat $GITHUB_ENV
       - name: Cache Go modules and builds
         uses: actions/cache@v2
@@ -69,11 +72,12 @@ jobs:
           path: |
             ${{ env.GOMODCACHE }}
             ${{ env.GOCACHE }}
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('go.mod go.sum') }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('go.mod', 'go.sum') }}
           restore-keys:
             ${{ runner.os }}-build-${{ env.cache-name }}-
             ${{ runner.os }}-build-
             ${{ runner.os }}-
+
       - name: Run tests
         run: |
           make test

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: '10.x'
-      - name: Cache node_modules
+      - name: Cache node_modules # TODO(ariels): Share with UI build
         uses: actions/cache@v2
         env:
           cache-name: cache-node-modules
@@ -56,6 +56,24 @@ jobs:
         with:
           go-version: 1.15.2
         id: go
+      - name: Find Go module and build caches
+        run: |
+          echo GOMODCACHE=`go env GOMODCACHE` >> $GITHUB_ENV
+          echo GOCACHE=`go env COCACHE` >> $GITHUB_ENV
+          cat $GITHUB_ENV
+      - name: Cache Go modules and builds
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-go-modules
+        with:
+          path: |
+            ${{ env.GOMODCACHE }}
+            ${{ env.GOCACHE }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('go.mod go.sum') }}
+          restore-keys:
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
       - name: Run tests
         run: |
           make test

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -37,7 +37,18 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: '10.x'
-      - name: install UI dependencies
+      - name: Cache node_modules
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-node-modules
+        with:
+          path: node_modules/
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('webui/package-lock.json') }}
+          restore-keys:
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+      - name: Install UI dependencies
         run: npm install
         working-directory: ./webui
       - name: Setup Go

--- a/.github/workflows/nessie.yaml
+++ b/.github/workflows/nessie.yaml
@@ -39,6 +39,27 @@ jobs:
           go-version: 1.15.2
         id: go
 
+      # No way to share code between workflows :-( If you change this, find and change the
+      # same code wherever "Find Go module and build caches" appears!
+      - name: Find Go module and build caches
+        run: |
+          echo GOMODCACHE=`go env GOMODCACHE` >> $GITHUB_ENV
+          echo GOCACHE=`go env GOCACHE` >> $GITHUB_ENV
+          cat $GITHUB_ENV
+      - name: Cache Go modules and builds
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-go-modules
+        with:
+          path: |
+            ${{ env.GOMODCACHE }}
+            ${{ env.GOCACHE }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('go.mod', 'go.sum') }}
+          restore-keys:
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
       - name: Generate code
         run: |
           make gen


### PR DESCRIPTION
See
[the manual](https://docs.github.com/en/free-pro-team@latest/actions/guides/caching-dependencies-to-speed-up-workflows)
for details of how the GitHub actions cache works.