### PR TITLE
EntryCatalog without interface

### DIFF
--- a/catalog/rocks/cataloger.go
+++ b/catalog/rocks/cataloger.go
@@ -12,7 +12,7 @@ import (
 )
 
 type cataloger struct {
-	EntryCatalog EntryCatalog
+	EntryCatalog *EntryCatalog
 	log          logging.Logger
 	dummyDedupCh chan *catalog.DedupReport
 	hooks        catalog.CatalogerHooks
@@ -655,7 +655,19 @@ func listDiffHelper(it EntryDiffIterator, limit int, after string) (catalog.Diff
 }
 
 func (c *cataloger) Merge(ctx context.Context, repository string, leftBranch string, rightBranch string, committer string, message string, metadata catalog.Metadata) (*catalog.MergeResult, error) {
-	panic("not implemented") // TODO: Implement
+	repositoryID := graveler.RepositoryID(repository)
+	leftRef := graveler.Ref(leftBranch)
+	rightBranchID := graveler.BranchID(rightBranch)
+	meta := graveler.Metadata(metadata)
+	commitID, err := c.EntryCatalog.Merge(ctx, repositoryID, leftRef, rightBranchID, committer, message, meta)
+	if err != nil {
+		return nil, err
+	}
+	return &catalog.MergeResult{
+		// TODO(barak): require implementation by graveler's merge
+		Summary:   map[catalog.DifferenceType]int{},
+		Reference: commitID.String(),
+	}, nil
 }
 
 func (c *cataloger) Hooks() *catalog.CatalogerHooks {

--- a/catalog/rocks/cataloger_test.go
+++ b/catalog/rocks/cataloger_test.go
@@ -91,7 +91,7 @@ func Test_cataloger_ListRepositories(t *testing.T) {
 				RepositoryIterator: NewFakeRepositoryIterator(gravelerData),
 			}
 			c := &cataloger{
-				EntryCatalog: &entryCatalog{
+				EntryCatalog: &EntryCatalog{
 					store: gravelerMock,
 				},
 			}
@@ -186,7 +186,7 @@ func TestCataloger_ListBranches(t *testing.T) {
 				BranchIterator: NewFakeBranchIterator(gravelerData),
 			}
 			c := &cataloger{
-				EntryCatalog: &entryCatalog{
+				EntryCatalog: &EntryCatalog{
 					store: gravelerMock,
 				},
 			}
@@ -309,7 +309,7 @@ func TestCataloger_ListEntries(t *testing.T) {
 				ListIterator: NewFakeValueIterator(gravelerData),
 			}
 			c := &cataloger{
-				EntryCatalog: &entryCatalog{
+				EntryCatalog: &EntryCatalog{
 					store: gravelerMock,
 				},
 			}

--- a/catalog/rocks/entry_catalog.go
+++ b/catalog/rocks/entry_catalog.go
@@ -51,96 +51,6 @@ type EntryDiffIterator interface {
 	Close()
 }
 
-// EntryCatalog
-type EntryCatalog interface {
-	// GetRepository returns the Repository metadata object for the given RepositoryID
-	GetRepository(ctx context.Context, repositoryID graveler.RepositoryID) (*graveler.Repository, error)
-
-	// CreateRepository stores a new Repository under RepositoryID with the given Branch as default branch
-	CreateRepository(ctx context.Context, repositoryID graveler.RepositoryID, storageNamespace graveler.StorageNamespace, branchID graveler.BranchID) (*graveler.Repository, error)
-
-	// ListRepositories returns iterator to scan repositories
-	ListRepositories(ctx context.Context) (graveler.RepositoryIterator, error)
-
-	// DeleteRepository deletes the repository
-	DeleteRepository(ctx context.Context, repositoryID graveler.RepositoryID) error
-
-	// CreateBranch creates branch on repository pointing to ref
-	CreateBranch(ctx context.Context, repositoryID graveler.RepositoryID, branchID graveler.BranchID, ref graveler.Ref) (*graveler.Branch, error)
-
-	// UpdateBranch updates branch on repository pointing to ref
-	UpdateBranch(ctx context.Context, repositoryID graveler.RepositoryID, branchID graveler.BranchID, ref graveler.Ref) (*graveler.Branch, error)
-
-	// GetBranch gets branch information by branch / repository id
-	GetBranch(ctx context.Context, repositoryID graveler.RepositoryID, branchID graveler.BranchID) (*graveler.Branch, error)
-
-	// GetTag gets tag's commit id
-	GetTag(ctx context.Context, repositoryID graveler.RepositoryID, tagID graveler.TagID) (*graveler.CommitID, error)
-
-	// CreateTag creates tag on a repository pointing to a commit id
-	CreateTag(ctx context.Context, repositoryID graveler.RepositoryID, tagID graveler.TagID, commitID graveler.CommitID) error
-
-	// DeleteTag remove tag from a repository
-	DeleteTag(ctx context.Context, repositoryID graveler.RepositoryID, tagID graveler.TagID) error
-
-	// ListTags lists tags on a repository
-	ListTags(ctx context.Context, repositoryID graveler.RepositoryID, from graveler.TagID) (graveler.TagIterator, error)
-
-	// Log returns an iterator starting at commit ID up to repository root
-	Log(ctx context.Context, repositoryID graveler.RepositoryID, commitID graveler.CommitID) (graveler.CommitIterator, error)
-
-	// ListBranches lists branches on repositories
-	ListBranches(ctx context.Context, repositoryID graveler.RepositoryID) (graveler.BranchIterator, error)
-
-	// DeleteBranch deletes branch from repository
-	DeleteBranch(ctx context.Context, repositoryID graveler.RepositoryID, branchID graveler.BranchID) error
-
-	// Commit the staged data and returns a commit ID that references that change
-	//   ErrNothingToCommit in case there is no data in stage
-	Commit(ctx context.Context, repositoryID graveler.RepositoryID, branchID graveler.BranchID, committer string, message string, metadata graveler.Metadata) (graveler.CommitID, error)
-
-	// GetCommit returns the Commit metadata object for the given CommitID
-	GetCommit(ctx context.Context, repositoryID graveler.RepositoryID, commitID graveler.CommitID) (*graveler.Commit, error)
-
-	// Dereference returns the commit ID based on 'ref' reference
-	Dereference(ctx context.Context, repositoryID graveler.RepositoryID, ref graveler.Ref) (graveler.CommitID, error)
-
-	// Reset throw all staged data on the repository / branch
-	Reset(ctx context.Context, repositoryID graveler.RepositoryID, branchID graveler.BranchID) error
-
-	// Reset throws all staged data under the specified path on the repository / branch
-	ResetKey(ctx context.Context, repositoryID graveler.RepositoryID, branchID graveler.BranchID, path Path) error
-
-	// Reset throws all staged data starting with the given prefix on the repository / branch
-	ResetPrefix(ctx context.Context, repositoryID graveler.RepositoryID, branchID graveler.BranchID, prefix Path) error
-
-	// Revert commits a change that will revert all the changes make from 'ref' specified
-	Revert(ctx context.Context, repositoryID graveler.RepositoryID, branchID graveler.BranchID, ref graveler.Ref) (graveler.CommitID, error)
-
-	// Merge merge 'from' with 'to' branches under repository returns the new commit id on 'to' branch
-	Merge(ctx context.Context, repositoryID graveler.RepositoryID, from graveler.Ref, to graveler.BranchID) (graveler.CommitID, error)
-
-	// DiffUncommitted returns iterator to scan the changes made on the branch
-	DiffUncommitted(ctx context.Context, repositoryID graveler.RepositoryID, branchID graveler.BranchID) (EntryDiffIterator, error)
-
-	// Diff returns the changes between 'left' and 'right' ref
-	Diff(ctx context.Context, repositoryID graveler.RepositoryID, left, right graveler.Ref) (EntryDiffIterator, error)
-
-	// Get returns entry from repository / reference by path, nil entry is a valid entry for tombstone
-	// returns error if entry does not exist
-	GetEntry(ctx context.Context, repositoryID graveler.RepositoryID, ref graveler.Ref, path Path) (*Entry, error)
-
-	// Set stores entry on repository / branch by path. nil entry is a valid entry for tombstone
-	SetEntry(ctx context.Context, repositoryID graveler.RepositoryID, branchID graveler.BranchID, path Path, entry *Entry) error
-
-	// DeleteEntry deletes entry from repository / branch by path
-	DeleteEntry(ctx context.Context, repositoryID graveler.RepositoryID, branchID graveler.BranchID, path Path) error
-
-	// List lists entries on repository / ref will filter by prefix, from path 'from'.
-	//   When 'delimiter' is set the listing will include common prefixes based on the delimiter
-	ListEntries(ctx context.Context, repositoryID graveler.RepositoryID, ref graveler.Ref, prefix, delimiter Path) (EntryListingIterator, error)
-}
-
 func NewPath(id string) (Path, error) {
 	return Path(id), nil
 }
@@ -149,57 +59,57 @@ func (id Path) String() string {
 	return string(id)
 }
 
-type entryCatalog struct {
+type EntryCatalog struct {
 	store graveler.Graveler
 }
 
-func NewEntryCatalog() EntryCatalog {
-	return &entryCatalog{
+func NewEntryCatalog() *EntryCatalog {
+	return &EntryCatalog{
 		store: graveler.NewGraveler(nil, nil, nil),
 	}
 }
 
-func (e *entryCatalog) GetRepository(ctx context.Context, repositoryID graveler.RepositoryID) (*graveler.Repository, error) {
+func (e *EntryCatalog) GetRepository(ctx context.Context, repositoryID graveler.RepositoryID) (*graveler.Repository, error) {
 	return e.store.GetRepository(ctx, repositoryID)
 }
 
-func (e *entryCatalog) CreateRepository(ctx context.Context, repositoryID graveler.RepositoryID, storageNamespace graveler.StorageNamespace, branchID graveler.BranchID) (*graveler.Repository, error) {
+func (e *EntryCatalog) CreateRepository(ctx context.Context, repositoryID graveler.RepositoryID, storageNamespace graveler.StorageNamespace, branchID graveler.BranchID) (*graveler.Repository, error) {
 	return e.store.CreateRepository(ctx, repositoryID, storageNamespace, branchID)
 }
 
-func (e *entryCatalog) ListRepositories(ctx context.Context) (graveler.RepositoryIterator, error) {
+func (e *EntryCatalog) ListRepositories(ctx context.Context) (graveler.RepositoryIterator, error) {
 	return e.store.ListRepositories(ctx)
 }
 
-func (e *entryCatalog) DeleteRepository(ctx context.Context, repositoryID graveler.RepositoryID) error {
+func (e *EntryCatalog) DeleteRepository(ctx context.Context, repositoryID graveler.RepositoryID) error {
 	return e.store.DeleteRepository(ctx, repositoryID)
 }
 
-func (e *entryCatalog) CreateBranch(ctx context.Context, repositoryID graveler.RepositoryID, branchID graveler.BranchID, ref graveler.Ref) (*graveler.Branch, error) {
+func (e *EntryCatalog) CreateBranch(ctx context.Context, repositoryID graveler.RepositoryID, branchID graveler.BranchID, ref graveler.Ref) (*graveler.Branch, error) {
 	return e.store.CreateBranch(ctx, repositoryID, branchID, ref)
 }
 
-func (e *entryCatalog) UpdateBranch(ctx context.Context, repositoryID graveler.RepositoryID, branchID graveler.BranchID, ref graveler.Ref) (*graveler.Branch, error) {
+func (e *EntryCatalog) UpdateBranch(ctx context.Context, repositoryID graveler.RepositoryID, branchID graveler.BranchID, ref graveler.Ref) (*graveler.Branch, error) {
 	return e.store.UpdateBranch(ctx, repositoryID, branchID, ref)
 }
 
-func (e *entryCatalog) GetBranch(ctx context.Context, repositoryID graveler.RepositoryID, branchID graveler.BranchID) (*graveler.Branch, error) {
+func (e *EntryCatalog) GetBranch(ctx context.Context, repositoryID graveler.RepositoryID, branchID graveler.BranchID) (*graveler.Branch, error) {
 	return e.store.GetBranch(ctx, repositoryID, branchID)
 }
 
-func (e *entryCatalog) GetTag(ctx context.Context, repositoryID graveler.RepositoryID, tagID graveler.TagID) (*graveler.CommitID, error) {
+func (e *EntryCatalog) GetTag(ctx context.Context, repositoryID graveler.RepositoryID, tagID graveler.TagID) (*graveler.CommitID, error) {
 	return e.store.GetTag(ctx, repositoryID, tagID)
 }
 
-func (e *entryCatalog) CreateTag(ctx context.Context, repositoryID graveler.RepositoryID, tagID graveler.TagID, commitID graveler.CommitID) error {
+func (e *EntryCatalog) CreateTag(ctx context.Context, repositoryID graveler.RepositoryID, tagID graveler.TagID, commitID graveler.CommitID) error {
 	return e.store.CreateTag(ctx, repositoryID, tagID, commitID)
 }
 
-func (e *entryCatalog) DeleteTag(ctx context.Context, repositoryID graveler.RepositoryID, tagID graveler.TagID) error {
+func (e *EntryCatalog) DeleteTag(ctx context.Context, repositoryID graveler.RepositoryID, tagID graveler.TagID) error {
 	return e.store.DeleteTag(ctx, repositoryID, tagID)
 }
 
-func (e *entryCatalog) ListTags(ctx context.Context, repositoryID graveler.RepositoryID, from graveler.TagID) (graveler.TagIterator, error) {
+func (e *EntryCatalog) ListTags(ctx context.Context, repositoryID graveler.RepositoryID, from graveler.TagID) (graveler.TagIterator, error) {
 	it, err := e.store.ListTags(ctx, repositoryID)
 	if err != nil {
 		return nil, err
@@ -210,59 +120,53 @@ func (e *entryCatalog) ListTags(ctx context.Context, repositoryID graveler.Repos
 	return it, nil
 }
 
-func (e *entryCatalog) Log(ctx context.Context, repositoryID graveler.RepositoryID, commitID graveler.CommitID) (graveler.CommitIterator, error) {
+func (e *EntryCatalog) Log(ctx context.Context, repositoryID graveler.RepositoryID, commitID graveler.CommitID) (graveler.CommitIterator, error) {
 	return e.store.Log(ctx, repositoryID, commitID)
 }
 
-func (e *entryCatalog) ListBranches(ctx context.Context, repositoryID graveler.RepositoryID) (graveler.BranchIterator, error) {
+func (e *EntryCatalog) ListBranches(ctx context.Context, repositoryID graveler.RepositoryID) (graveler.BranchIterator, error) {
 	return e.store.ListBranches(ctx, repositoryID)
 }
 
-func (e *entryCatalog) DeleteBranch(ctx context.Context, repositoryID graveler.RepositoryID, branchID graveler.BranchID) error {
+func (e *EntryCatalog) DeleteBranch(ctx context.Context, repositoryID graveler.RepositoryID, branchID graveler.BranchID) error {
 	return e.store.DeleteBranch(ctx, repositoryID, branchID)
 }
 
-func (e *entryCatalog) Commit(ctx context.Context, repositoryID graveler.RepositoryID, branchID graveler.BranchID, committer string, message string, metadata graveler.Metadata) (graveler.CommitID, error) {
+func (e *EntryCatalog) Commit(ctx context.Context, repositoryID graveler.RepositoryID, branchID graveler.BranchID, committer string, message string, metadata graveler.Metadata) (graveler.CommitID, error) {
 	return e.store.Commit(ctx, repositoryID, branchID, committer, message, metadata)
 }
 
-func (e *entryCatalog) GetCommit(ctx context.Context, repositoryID graveler.RepositoryID, commitID graveler.CommitID) (*graveler.Commit, error) {
+func (e *EntryCatalog) GetCommit(ctx context.Context, repositoryID graveler.RepositoryID, commitID graveler.CommitID) (*graveler.Commit, error) {
 	return e.store.GetCommit(ctx, repositoryID, commitID)
 }
 
-func (e *entryCatalog) Dereference(ctx context.Context, repositoryID graveler.RepositoryID, ref graveler.Ref) (graveler.CommitID, error) {
+func (e *EntryCatalog) Dereference(ctx context.Context, repositoryID graveler.RepositoryID, ref graveler.Ref) (graveler.CommitID, error) {
 	return e.store.Dereference(ctx, repositoryID, ref)
 }
 
-func (e *entryCatalog) Reset(ctx context.Context, repositoryID graveler.RepositoryID, branchID graveler.BranchID) error {
+func (e *EntryCatalog) Reset(ctx context.Context, repositoryID graveler.RepositoryID, branchID graveler.BranchID) error {
 	return e.store.Reset(ctx, repositoryID, branchID)
 }
 
-func (e *entryCatalog) ResetKey(ctx context.Context, repositoryID graveler.RepositoryID, branchID graveler.BranchID, path Path) error {
-	key, err := graveler.NewKey(path.String())
-	if err != nil {
-		return err
-	}
+func (e *EntryCatalog) ResetKey(ctx context.Context, repositoryID graveler.RepositoryID, branchID graveler.BranchID, path Path) error {
+	key := graveler.Key(path)
 	return e.store.ResetKey(ctx, repositoryID, branchID, key)
 }
 
-func (e *entryCatalog) ResetPrefix(ctx context.Context, repositoryID graveler.RepositoryID, branchID graveler.BranchID, prefix Path) error {
-	keyPrefix, err := graveler.NewKey(prefix.String())
-	if err != nil {
-		return err
-	}
+func (e *EntryCatalog) ResetPrefix(ctx context.Context, repositoryID graveler.RepositoryID, branchID graveler.BranchID, prefix Path) error {
+	keyPrefix := graveler.Key(prefix)
 	return e.store.ResetPrefix(ctx, repositoryID, branchID, keyPrefix)
 }
 
-func (e *entryCatalog) Revert(ctx context.Context, repositoryID graveler.RepositoryID, branchID graveler.BranchID, ref graveler.Ref) (graveler.CommitID, error) {
+func (e *EntryCatalog) Revert(ctx context.Context, repositoryID graveler.RepositoryID, branchID graveler.BranchID, ref graveler.Ref) (graveler.CommitID, error) {
 	return e.store.Revert(ctx, repositoryID, branchID, ref)
 }
 
-func (e *entryCatalog) Merge(ctx context.Context, repositoryID graveler.RepositoryID, from graveler.Ref, to graveler.BranchID) (graveler.CommitID, error) {
-	return e.store.Merge(ctx, repositoryID, from, to)
+func (e *EntryCatalog) Merge(ctx context.Context, repositoryID graveler.RepositoryID, from graveler.Ref, to graveler.BranchID, committer string, message string, metadata graveler.Metadata) (graveler.CommitID, error) {
+	return e.store.Merge(ctx, repositoryID, from, to, committer, message, metadata)
 }
 
-func (e *entryCatalog) DiffUncommitted(ctx context.Context, repositoryID graveler.RepositoryID, branchID graveler.BranchID) (EntryDiffIterator, error) {
+func (e *EntryCatalog) DiffUncommitted(ctx context.Context, repositoryID graveler.RepositoryID, branchID graveler.BranchID) (EntryDiffIterator, error) {
 	iter, err := e.store.DiffUncommitted(ctx, repositoryID, branchID)
 	if err != nil {
 		return nil, err
@@ -270,7 +174,7 @@ func (e *entryCatalog) DiffUncommitted(ctx context.Context, repositoryID gravele
 	return NewEntryDiffIterator(iter), nil
 }
 
-func (e *entryCatalog) Diff(ctx context.Context, repositoryID graveler.RepositoryID, left, right graveler.Ref) (EntryDiffIterator, error) {
+func (e *EntryCatalog) Diff(ctx context.Context, repositoryID graveler.RepositoryID, left, right graveler.Ref) (EntryDiffIterator, error) {
 	iter, err := e.store.Diff(ctx, repositoryID, left, right)
 	if err != nil {
 		return nil, err
@@ -278,7 +182,7 @@ func (e *entryCatalog) Diff(ctx context.Context, repositoryID graveler.Repositor
 	return NewEntryDiffIterator(iter), nil
 }
 
-func (e *entryCatalog) GetEntry(ctx context.Context, repositoryID graveler.RepositoryID, ref graveler.Ref, path Path) (*Entry, error) {
+func (e *EntryCatalog) GetEntry(ctx context.Context, repositoryID graveler.RepositoryID, ref graveler.Ref, path Path) (*Entry, error) {
 	val, err := e.store.Get(ctx, repositoryID, ref, graveler.Key(path))
 	if err != nil {
 		return nil, err
@@ -286,11 +190,8 @@ func (e *entryCatalog) GetEntry(ctx context.Context, repositoryID graveler.Repos
 	return ValueToEntry(val)
 }
 
-func (e *entryCatalog) SetEntry(ctx context.Context, repositoryID graveler.RepositoryID, branchID graveler.BranchID, path Path, entry *Entry) error {
-	key, err := graveler.NewKey(path.String())
-	if err != nil {
-		return err
-	}
+func (e *EntryCatalog) SetEntry(ctx context.Context, repositoryID graveler.RepositoryID, branchID graveler.BranchID, path Path, entry *Entry) error {
+	key := graveler.Key(path)
 	value, err := EntryToValue(entry)
 	if err != nil {
 		return err
@@ -298,15 +199,12 @@ func (e *entryCatalog) SetEntry(ctx context.Context, repositoryID graveler.Repos
 	return e.store.Set(ctx, repositoryID, branchID, key, *value)
 }
 
-func (e *entryCatalog) DeleteEntry(ctx context.Context, repositoryID graveler.RepositoryID, branchID graveler.BranchID, path Path) error {
-	key, err := graveler.NewKey(path.String())
-	if err != nil {
-		return err
-	}
+func (e *EntryCatalog) DeleteEntry(ctx context.Context, repositoryID graveler.RepositoryID, branchID graveler.BranchID, path Path) error {
+	key := graveler.Key(path)
 	return e.store.Delete(ctx, repositoryID, branchID, key)
 }
 
-func (e *entryCatalog) ListEntries(ctx context.Context, repositoryID graveler.RepositoryID, ref graveler.Ref, prefix, delimiter Path) (EntryListingIterator, error) {
+func (e *EntryCatalog) ListEntries(ctx context.Context, repositoryID graveler.RepositoryID, ref graveler.Ref, prefix, delimiter Path) (EntryListingIterator, error) {
 	iter, err := e.store.List(ctx, repositoryID, ref)
 	if err != nil {
 		return nil, err

--- a/catalog/rocks/entry_catalog_test.go
+++ b/catalog/rocks/entry_catalog_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestEntryCatalog_GetEntry_NotFound(t *testing.T) {
 	gravelerMock := &FakeGraveler{Err: graveler.ErrNotFound}
-	cat := entryCatalog{store: gravelerMock}
+	cat := EntryCatalog{store: gravelerMock}
 	ctx := context.Background()
 	got, err := cat.GetEntry(ctx, "repo", "ref", "path1")
 	if !errors.Is(err, graveler.ErrNotFound) {
@@ -26,7 +26,7 @@ func TestEntryCatalog_GetEntry_NotFound(t *testing.T) {
 func TestEntryCatalog_GetEntry_Found(t *testing.T) {
 	entry := &Entry{Address: "addr1"}
 	gravelerMock := &FakeGraveler{KeyValue: map[string]*graveler.Value{"repo1/master/file1": MustEntryToValue(entry)}}
-	cat := entryCatalog{store: gravelerMock}
+	cat := EntryCatalog{store: gravelerMock}
 	ctx := context.Background()
 	got, err := cat.GetEntry(ctx, "repo1", "master", "file1")
 	testutil.MustDo(t, "get entry", err)
@@ -37,7 +37,7 @@ func TestEntryCatalog_GetEntry_Found(t *testing.T) {
 
 func TestEntryCatalog_SetEntry(t *testing.T) {
 	gravelerMock := &FakeGraveler{KeyValue: make(map[string]*graveler.Value)}
-	cat := entryCatalog{store: gravelerMock}
+	cat := EntryCatalog{store: gravelerMock}
 	ctx := context.Background()
 	entry := &Entry{Address: "addr1"}
 	err := cat.SetEntry(ctx, "repo", "ref", "path1", entry)
@@ -60,7 +60,7 @@ func TestEntryCatalog_ListEntries_NoDelimiter(t *testing.T) {
 	gravelerMock := &FakeGraveler{
 		ListIterator: NewFakeValueIterator(listingData),
 	}
-	cat := entryCatalog{store: gravelerMock}
+	cat := EntryCatalog{store: gravelerMock}
 	ctx := context.Background()
 	entries, err := cat.ListEntries(ctx, "repo", "ref", "", "")
 	testutil.MustDo(t, "list entries", err)
@@ -95,7 +95,7 @@ func TestEntryCatalog_ListEntries_WithDelimiter(t *testing.T) {
 	gravelerMock := &FakeGraveler{
 		ListIterator: NewFakeValueIterator(gravelerData),
 	}
-	cat := entryCatalog{store: gravelerMock}
+	cat := EntryCatalog{store: gravelerMock}
 	ctx := context.Background()
 
 	t.Run("root", func(t *testing.T) {
@@ -149,7 +149,7 @@ func TestEntryCatalog_Diff(t *testing.T) {
 	gravelerMock := &FakeGraveler{
 		DiffIterator: NewFakeDiffIterator(diffData),
 	}
-	cat := entryCatalog{store: gravelerMock}
+	cat := EntryCatalog{store: gravelerMock}
 	ctx := context.Background()
 	diffs, err := cat.Diff(ctx, "repo", "left", "right")
 	testutil.MustDo(t, "diff", err)

--- a/catalog/rocks/fake_graveler_test.go
+++ b/catalog/rocks/fake_graveler_test.go
@@ -143,7 +143,7 @@ func (g *FakeGraveler) Revert(ctx context.Context, repositoryID graveler.Reposit
 	panic("implement me")
 }
 
-func (g *FakeGraveler) Merge(ctx context.Context, repositoryID graveler.RepositoryID, from graveler.Ref, to graveler.BranchID) (graveler.CommitID, error) {
+func (g *FakeGraveler) Merge(ctx context.Context, repositoryID graveler.RepositoryID, from graveler.Ref, to graveler.BranchID, committer string, message string, metadata graveler.Metadata) (graveler.CommitID, error) {
 	panic("implement me")
 }
 

--- a/graveler/graveler.go
+++ b/graveler/graveler.go
@@ -252,7 +252,7 @@ type VersionController interface {
 	Revert(ctx context.Context, repositoryID RepositoryID, branchID BranchID, ref Ref) (CommitID, error)
 
 	// Merge merge 'from' with 'to' branches under repository returns the new commit id on 'to' branch
-	Merge(ctx context.Context, repositoryID RepositoryID, from Ref, to BranchID) (CommitID, error)
+	Merge(ctx context.Context, repositoryID RepositoryID, from Ref, to BranchID, committer string, message string, metadata Metadata) (CommitID, error)
 
 	// DiffUncommitted returns iterator to scan the changes made on the branch
 	DiffUncommitted(ctx context.Context, repositoryID RepositoryID, branchID BranchID) (DiffIterator, error)
@@ -405,7 +405,7 @@ type CommittedManager interface {
 	// Merge receives two trees and a 3rd merge base tree used to resolve the change type
 	// it applies that changes from left to right, resulting in a new tree that
 	// is expected to be immediately addressable
-	Merge(ctx context.Context, ns StorageNamespace, left, right, base TreeID) (TreeID, error)
+	Merge(ctx context.Context, ns StorageNamespace, left, right, base TreeID, committer string, message string, metadata Metadata) (TreeID, error)
 
 	// Apply is the act of taking an existing tree (snapshot) and applying a set of changes to it.
 	// A change is either an entity to write/overwrite, or a tombstone to mark a deletion
@@ -884,7 +884,7 @@ func (g *graveler) Revert(_ context.Context, _ RepositoryID, _ BranchID, _ Ref) 
 	panic("implement me")
 }
 
-func (g *graveler) Merge(ctx context.Context, repositoryID RepositoryID, from Ref, to BranchID) (CommitID, error) {
+func (g *graveler) Merge(ctx context.Context, repositoryID RepositoryID, from Ref, to BranchID, committer string, message string, metadata Metadata) (CommitID, error) {
 	cancel, err := g.branchLocker.AquireMetadataUpdate(repositoryID, to)
 	if err != nil {
 		return "", err
@@ -908,17 +908,17 @@ func (g *graveler) Merge(ctx context.Context, repositoryID RepositoryID, from Re
 		return "", err
 	}
 
-	treeID, err := g.CommittedManager.Merge(ctx, repo.StorageNamespace, fromCommit.TreeID, toCommit.TreeID, baseCommit.TreeID)
+	treeID, err := g.CommittedManager.Merge(ctx, repo.StorageNamespace, fromCommit.TreeID, toCommit.TreeID, baseCommit.TreeID, committer, message, metadata)
 	if err != nil {
 		return "", err
 	}
 	commit := Commit{
-		Committer:    "unknown",       // TODO(Guys): pass committer or enter default value
-		Message:      "merge message", // TODO(Guys): get merge message
+		Committer:    committer,
+		Message:      message,
 		TreeID:       treeID,
 		CreationDate: time.Time{},
 		Parents:      []CommitID{fromCommit.CommitID, toCommit.CommitID},
-		Metadata:     nil, // TODO(Guys): pass metadata
+		Metadata:     metadata,
 	}
 	return g.RefManager.AddCommit(ctx, repositoryID, commit)
 }

--- a/graveler/testutil/fakes.go
+++ b/graveler/testutil/fakes.go
@@ -48,7 +48,7 @@ func (c *CommittedFake) Diff(ctx context.Context, ns graveler.StorageNamespace, 
 	return c.diffIterator, nil
 }
 
-func (c *CommittedFake) Merge(_ context.Context, _ graveler.StorageNamespace, _, _, _ graveler.TreeID) (graveler.TreeID, error) {
+func (c *CommittedFake) Merge(_ context.Context, _ graveler.StorageNamespace, _, _, _ graveler.TreeID, _, _ string, _ graveler.Metadata) (graveler.TreeID, error) {
 	if c.Err != nil {
 		return "", c.Err
 	}


### PR DESCRIPTION
- remove the EntryCatalog interface and turn the implementation to public
- implement missing merge message and pass missing fields