### PR TITLE
Run protoc as part of a makefile step optional

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -22,8 +22,6 @@ jobs:
         run: make gen
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
-      - name: Install the protocol compiler plugins for Go
-        run: go get google.golang.org/protobuf/cmd/protoc-gen-go google.golang.org/grpc/cmd/protoc-gen-go-grpc
       - name: Checks validator
         run: make checks-validator
         env:

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -20,6 +20,8 @@ jobs:
         id: go
       - name: Generated code
         run: make gen
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
       - name: Checks validator
         run: make checks-validator
         env:

--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -22,6 +22,8 @@ jobs:
         run: make gen
       - name: Install Protoc
         uses: arduino/setup-protoc@v1
+      - name: Install the protocol compiler plugins for Go
+        run: go get google.golang.org/protobuf/cmd/protoc-gen-go google.golang.org/grpc/cmd/protoc-gen-go-grpc
       - name: Checks validator
         run: make checks-validator
         env:

--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ gen-mockgen: $(GOBINPATH)/mockgen ## Run the generator for inline commands
 	$(GOGENERATE) ./graveler/committed/...
 	$(GOGENERATE) ./pyramid
 
-validate-swagger: $(GOBINPATH)/swagger  ## Validate swagger.yaml
+swagger-validator: $(GOBINPATH)/swagger  ## Validate swagger.yaml
 	$(GOBINPATH)/swagger validate swagger.yml
 
 LD_FLAGS := "-X github.com/treeverse/lakefs/config.Version=$(VERSION)-$(REVISION)"
@@ -136,7 +136,7 @@ fmt-validator:  ## Validate go format
 proto-validator: ## build proto and check if diff found
 	@git diff --quiet -- catalog/rocks/catalog.pb.go
 
-checks-validator: lint fmt-validator validate-swagger proto-validator ## Run all validation/linting steps
+checks-validator: lint fmt-validator swagger-validator proto-validator ## Run all validation/linting steps
 
 $(UI_DIR)/node_modules:
 	cd $(UI_DIR) && $(NPM) install

--- a/Makefile
+++ b/Makefile
@@ -75,6 +75,8 @@ go-install: go-mod-download ## Install dependencies
 	$(GOCMD) install github.com/golang/mock/mockgen
 	$(GOCMD) install github.com/golangci/golangci-lint/cmd/golangci-lint
 	$(GOCMD) install github.com/rakyll/statik
+	$(GOCMD) install google.golang.org/protobuf/cmd/protoc-gen-go
+
 
 gen-api: go-install del-gen-api ## Run the go-swagger code generator
 	$(GOGENERATE) ./api/...

--- a/Makefile
+++ b/Makefile
@@ -90,7 +90,7 @@ gen-mockgen: go-install ## Run the generator for inline commands
 	$(GOGENERATE) ./graveler/committed/...
 	$(GOGENERATE) ./pyramid
 
-swagger-validator: go-install ## Validate swagger.yaml
+validate-swagger: go-install ## Validate swagger.yaml
 	$(GOBINPATH)/swagger validate swagger.yml
 
 LD_FLAGS := "-X github.com/treeverse/lakefs/config.Version=$(VERSION)-$(REVISION)"
@@ -123,7 +123,7 @@ gofmt:  ## gofmt code formating
 	@echo Running go formating with the following command:
 	$(GOFMT) -e -s -w .
 
-fmt-validator:  ## Validate go format
+validate-fmt:  ## Validate go format
 	@echo checking gofmt...
 	@res=$$($(GOFMT) -d -e -s $$(find . -type d \( -path ./ddl \) -prune -o \( -path ./statik \) -prune -o \( -path ./api/gen \) -prune -o -name '*.go' -print)); \
 	if [ -n "$${res}" ]; then \
@@ -134,11 +134,11 @@ fmt-validator:  ## Validate go format
 		echo Your code formatting is according to gofmt standards; \
 	fi
 
-.PHONY: proto-validator
-proto-validator: proto ## build proto and check if diff found
-	@git diff --quiet -- catalog/rocks/catalog.pb.go
+.PHONY: validate-proto
+validate-proto: proto  ## build proto and check if diff found
+	git diff --quiet -- catalog/rocks/catalog.pb.go
 
-checks-validator: lint fmt-validator swagger-validator proto-validator ## Run all validation/linting steps
+checks-validator: lint validate-fmt validate-swagger validate-proto  ## Run all validation/linting steps
 
 $(UI_DIR)/node_modules:
 	cd $(UI_DIR) && $(NPM) install

--- a/Makefile
+++ b/Makefile
@@ -133,7 +133,7 @@ fmt-validator:  ## Validate go format
 	fi
 
 .PHONY: proto-validator
-proto-validator: ## build proto and check if diff found
+proto-validator: proto ## build proto and check if diff found
 	@git diff --quiet -- catalog/rocks/catalog.pb.go
 
 checks-validator: lint fmt-validator swagger-validator proto-validator ## Run all validation/linting steps

--- a/catalog/rocks/catalog.proto
+++ b/catalog/rocks/catalog.proto
@@ -11,5 +11,5 @@ message Entry {
 	int64 size = 3;
 	bytes e_tag = 4;
 	map<string,string> metadata = 5;
-	stam string = 6;
+	string stam = 6;
 }

--- a/catalog/rocks/catalog.proto
+++ b/catalog/rocks/catalog.proto
@@ -11,5 +11,4 @@ message Entry {
 	int64 size = 3;
 	bytes e_tag = 4;
 	map<string,string> metadata = 5;
-	string stam = 6;
 }

--- a/catalog/rocks/catalog.proto
+++ b/catalog/rocks/catalog.proto
@@ -11,4 +11,5 @@ message Entry {
 	int64 size = 3;
 	bytes e_tag = 4;
 	map<string,string> metadata = 5;
+	stam string = 6;
 }

--- a/catalog/rocks/entry_catalog.go
+++ b/catalog/rocks/entry_catalog.go
@@ -1,7 +1,5 @@
 package rocks
 
-//go:generate protoc --proto_path=. --go_out=. --go_opt=paths=source_relative catalog.proto
-
 import (
 	"context"
 

--- a/tools.go
+++ b/tools.go
@@ -7,6 +7,5 @@ import (
 	_ "github.com/golang/mock/mockgen"
 	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
 	_ "github.com/rakyll/statik"
-	_ "google.golang.org/grpc/cmd/protoc-gen-go-grpc"
 	_ "google.golang.org/protobuf/cmd/protoc-gen-go"
 )

--- a/tools.go
+++ b/tools.go
@@ -7,4 +7,6 @@ import (
 	_ "github.com/golang/mock/mockgen"
 	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
 	_ "github.com/rakyll/statik"
+	_ "google.golang.org/grpc/cmd/protoc-gen-go-grpc"
+	_ "google.golang.org/protobuf/cmd/protoc-gen-go"
 )


### PR DESCRIPTION
In order to use `go generate` when possible - running `go generate` as part of the build and describe how to build proto files using the same technic collides. The protoc is not required in the build process as a native binary, so in this change we move the build outside the `go generate` into our Makefile.

- move protoc compile as a makefile step (not run by default)
- validator will validate protoc generated output matched the checked-in source code 