### PR TITLE
Simplify example Spark code

### DIFF
--- a/docs/using/spark.md
+++ b/docs/using/spark.md
@@ -64,12 +64,12 @@ val branch = "master"
 val dataPath = s"s3a://${repo}/${branch}/example-path/example-file.parquet"
 ...
 ...
-val basics = spark.read.option("header", "true").parquet(dataPath)
+val basics = spark.read.parquet(dataPath)
 ```
 
 ## Creating Objects
 
 If we would like to create new parquet files partitioned by column `example-column`
 ```scala
-basics.toDF().write.partitionBy("example-column").parquet(outputPath)
+basics.write.partitionBy("example-column").parquet(outputPath)
 ```


### PR DESCRIPTION
This very small PR cleans up the example Spark code in the docs, with the following changes:

1. The header option for the DataframeReader with Parquet is ignored, and therefore unnecessary.
2. Running the toDF() method on an existing Dataframe is not necessary.