### PR TITLE
Generate BatchWriterClosers as needed, not via MetaRangeManager

### DIFF
--- a/graveler/committed/batch_write_closer.go
+++ b/graveler/committed/batch_write_closer.go
@@ -23,7 +23,7 @@ type BatchWriterCloser interface {
 	// CloseWriterAsync adds MetaRangeWriter instance for the BatchWriterCloser to handle.
 	// Any writes executed to the writer after this call are not guaranteed to succeed.
 	// If Wait() has already been called, returns an error.
-	CloseWriterAsync(RangeWriter) error
+	CloseWriterAsync(ResultCloser) error
 
 	// Wait returns when all Writers finished.
 	// Any failure to close a single MetaRangeWriter will return with a nil results slice and an error.

--- a/graveler/committed/meta_range_writer.go
+++ b/graveler/committed/meta_range_writer.go
@@ -32,7 +32,7 @@ func NewGeneralMetaRangeWriter(rangeManager, metaRangeManager RangeManager, appr
 	return &GeneralMetaRangeWriter{
 		rangeManager:              rangeManager,
 		metaRangeManager:          metaRangeManager,
-		batchWriteCloser:          rangeManager.GetBatchWriter(),
+		batchWriteCloser:          NewBatchCloser(),
 		approximateRangeSizeBytes: approximateRangeSizeBytes,
 		namespace:                 namespace,
 	}
@@ -124,7 +124,7 @@ func (w *GeneralMetaRangeWriter) Close() (*graveler.MetaRangeID, error) {
 	}
 	ranges = append(ranges, w.ranges...)
 	sort.Slice(ranges, func(i, j int) bool {
-		return bytes.Compare(ranges[i].MinKey, ranges[j].MinKey) < 0
+		return bytes.Compare(ranges[i].MaxKey, ranges[j].MaxKey) < 0
 	})
 	w.ranges = ranges
 	return w.writeRangesToMetaRange()

--- a/graveler/committed/range_manager.go
+++ b/graveler/committed/range_manager.go
@@ -1,5 +1,9 @@
 package committed
 
+import (
+	"errors"
+)
+
 //go:generate mockgen -source=range_manager.go -destination=mock/range_manager.go -package=mock
 
 // ID is an identifier for a Range
@@ -24,19 +28,23 @@ type ValueIterator interface {
 	Close()
 }
 
-type RangeManager interface {
-	// GetValue returns the value matching the key in the Range referenced by the id.
-	// If path not found, (nil, ErrPathNotFound) is returned.
-	GetValue(ns Namespace, pid ID, key Key) (*Record, error)
+var (
+	ErrNotFound = errors.New("not found")
+)
 
-	// NewRangeIterator takes a Range ID and returns an ValueIterator seeked to >= "from" value
+type RangeManager interface {
+	// Exists returns true if id references a Range.
+	Exists(ns Namespace, id ID) (bool, error)
+
+	// GetValue returns the value matching key in the Range referenced by id.  If id not
+	// found, it return (nil, ErrNotFound).
+	GetValue(ns Namespace, id ID, key Key) (*Record, error)
+
+	// NewRangeIterator returns an iterator over values in the Range with ID.
 	NewRangeIterator(ns Namespace, pid ID) (ValueIterator, error)
 
 	// GetWriter returns a new Range writer instance
 	GetWriter(ns Namespace) (RangeWriter, error)
-
-	// GetBatchWriter returns a BatchWriterCloser instance
-	GetBatchWriter() BatchWriterCloser
 }
 
 // WriteResult is the result of a completed write of a Range

--- a/graveler/sstable/manager.go
+++ b/graveler/sstable/manager.go
@@ -30,11 +30,6 @@ var (
 	_ committed.RangeManager = &Manager{}
 )
 
-// TODO(ariels): This method is going away!
-func (*Manager) GetBatchWriter() committed.BatchWriterCloser {
-	return NewBatchCloser()
-}
-
 func (m *Manager) Exists(ns committed.Namespace, id committed.ID) (bool, error) {
 	return m.cache.Exists(string(ns), id)
 }


### PR DESCRIPTION
There is no dependency on RangeManager.  Removing it makes it easier to write a
MetaRangeManager and *improves* the current tests -- which can now use a proper
BatchWriterCloser rather than a mock.

Remove TestWriter_SortOnClose: it tests some correctness.  But it is quite hard
to test correctly, and ends up only verifying that one `sort.Slice` line exists
in the code.  Better test this during integration.