### PR TITLE
Allow manual triggering of benchmark and nessie CI workflows

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
 
 jobs:
   deploy-executor-image:

--- a/.github/workflows/nessie.yaml
+++ b/.github/workflows/nessie.yaml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
 
 jobs:
   check-secrets:


### PR DESCRIPTION
These are not hermetic, re-triggering makes sense.