### PR TITLE
Fix range record parsing

### DIFF
--- a/graveler/committed/iterator.go
+++ b/graveler/committed/iterator.go
@@ -38,13 +38,19 @@ func (rvi *iterator) NextRange() bool {
 		return rvi.NextRange()
 	}
 
-	rng, err := UnmarshalRange(rngRecord.Value)
+	gv, err := UnmarshalValue(rngRecord.Value)
+	if err != nil {
+		rvi.err = fmt.Errorf("unmarshal value for %s: %w", string(rngRecord.Key), err)
+		return false
+	}
+
+	rng, err := UnmarshalRange(gv.Data)
 	if err != nil {
 		rvi.err = fmt.Errorf("unmarshal %s: %w", string(rngRecord.Key), err)
 		return false
 	}
 
-	rng.ID = ID(rngRecord.Key)
+	rng.ID = ID(gv.Identity)
 	rvi.rng = &rng
 
 	it, err := rvi.manager.NewRangeIterator(rvi.namespace, rvi.rng.ID)

--- a/graveler/committed/value.go
+++ b/graveler/committed/value.go
@@ -51,7 +51,7 @@ func MustMarshalValue(v *graveler.Value) []byte {
 
 func getBytes(b *[]byte) ([]byte, error) {
 	l, o := binary.Varint(*b)
-	if o <= 0 {
+	if o < 0 {
 		return nil, fmt.Errorf("read length: %w", ErrBadValueBytes)
 	}
 	*b = (*b)[o:]


### PR DESCRIPTION
On top of `feature/empty-repo`, this allows (some) listing.  We still get an empty record, but at least the parse succeeds!