### PR TITLE
Share a single Pebble SSTable cache between all SSTable readers

### DIFF
--- a/catalog/rocks/entry_catalog.go
+++ b/catalog/rocks/entry_catalog.go
@@ -105,10 +105,10 @@ func NewEntryCatalog(cfg *config.Config, db db.Database) (*EntryCatalog, error) 
 	}
 
 	pebbleSSTableCache := pebble.NewCache(tierFSParams.PebbleSSTableCacheSizeBytes)
+	defer pebbleSSTableCache.Unref()
 	metaRangeCache := sstable.NewCache(*cfg.GetCommittedRangeSSTableCacheParams(),
 		metaRangeFS,
 		pebble_sst.ReaderOptions{Cache: pebbleSSTableCache})
-	pebbleSSTableCache.Ref() // rangeCache keeps a second reference.
 	rangeCache := sstable.NewCache(*cfg.GetCommittedMetaRangeSSTableCacheParams(),
 		rangeFS,
 		pebble_sst.ReaderOptions{Cache: pebbleSSTableCache})

--- a/config/config.go
+++ b/config/config.go
@@ -34,16 +34,17 @@ const (
 	DefaultBlockStoreS3StreamingChunkSize    = 2 << 19         // 1MiB by default per chunk
 	DefaultBlockStoreS3StreamingChunkTimeout = time.Second * 1 // or 1 seconds, whatever comes first
 
-	DefaultCommittedLocalCacheRangePercent     = 0.9
-	DefaultCommittedLocalCacheMetaRangePercent = 0.1
-	DefaultCommittedLocalCacheBytes            = 1 * 1024 * 1024 * 1024
-	DefaultCommittedLocalCacheDir              = "~/lakefs/local_tier"
-	DefaultCommittedMetaRangeReaderCacheSize   = 20
-	DefaultCommittedMetaRangeReaderNumShards   = 6
-	DefaultCommittedRangeReaderCacheSize       = 100
-	DefaultCommittedRangeReaderNumShards       = 12
-	DefaultCommittedBlockStoragePrefix         = "_lakefs"
-	DefaultCommittedPermanentRangeSizeBytes    = 10 * 1024 * 1024
+	DefaultCommittedLocalCacheRangePercent      = 0.9
+	DefaultCommittedLocalCacheMetaRangePercent  = 0.1
+	DefaultCommittedLocalCacheBytes             = 1 * 1024 * 1024 * 1024
+	DefaultCommittedLocalCacheDir               = "~/lakefs/local_tier"
+	DefaultCommittedMetaRangeReaderCacheSize    = 20
+	DefaultCommittedMetaRangeReaderNumShards    = 6
+	DefaultCommittedRangeReaderCacheSize        = 100
+	DefaultCommittedRangeReaderNumShards        = 12
+	DefaultCommittedPebbleSSTableCacheSizeBytes = 200_000_000
+	DefaultCommittedBlockStoragePrefix          = "_lakefs"
+	DefaultCommittedPermanentRangeSizeBytes     = 10 * 1024 * 1024
 
 	DefaultBlockStoreGSS3Endpoint = "https://storage.googleapis.com"
 
@@ -117,8 +118,11 @@ const (
 	CommittedMetaRangeReaderCacheNumShards = "committed.local_cache.metarange.num_shards"
 	CommittedBlockStoragePrefixKey         = "committed.block_storage_prefix"
 	CommittedPermanentStorageRangeSizeKey  = "committed.permanent.approximate_range_size_bytes"
-	GatewaysS3DomainNameKey                = "gateways.s3.domain_name"
-	GatewaysS3RegionKey                    = "gateways.s3.region"
+
+	CommittedPebbleSSTableCacheSizeBytesKey = "committed.sstable.memory.cache_size_bytes"
+
+	GatewaysS3DomainNameKey = "gateways.s3.domain_name"
+	GatewaysS3RegionKey     = "gateways.s3.region"
 
 	BlockstoreGSS3EndpointKey = "blockstore.gs.s3_endpoint"
 
@@ -405,6 +409,7 @@ func (c *Config) GetCommittedTierFSParams() (*pyramidparams.ExtParams, error) {
 				BaseDir:             localCacheDir,
 				TotalAllocatedBytes: viper.GetInt64(CommittedLocalCacheSizeBytesKey),
 			},
+			PebbleSSTableCacheSizeBytes: viper.GetInt64(CommittedPebbleSSTableCacheSizeBytesKey),
 		},
 	}, nil
 }

--- a/graveler/committed/iterator.go
+++ b/graveler/committed/iterator.go
@@ -104,11 +104,11 @@ func (rvi *iterator) Err() error {
 }
 
 func (rvi *iterator) Close() {
+	rvi.rangesIt.Close()
 	if rvi.it == nil {
 		return
 	}
 	rvi.it.Close()
-	rvi.rangesIt.Close()
 }
 
 func (rvi *iterator) SeekGE(key graveler.Key) {

--- a/graveler/committed/manager.go
+++ b/graveler/committed/manager.go
@@ -29,6 +29,7 @@ func (c *committedManager) Get(ctx context.Context, ns graveler.StorageNamespace
 		return nil, err
 	}
 	valIt := NewValueIterator(it)
+	defer valIt.Close()
 	valIt.SeekGE(key)
 	// return the next value
 	if !valIt.Next() {
@@ -106,6 +107,7 @@ func (c *committedManager) Apply(ctx context.Context, ns graveler.StorageNamespa
 	if err != nil {
 		return "", fmt.Errorf("get metarange ns=%s id=%s: %w", ns, rangeID, err)
 	}
+	defer metaRangeIterator.Close()
 	err = Apply(ctx, mwWriter, metaRangeIterator, diffs)
 	if err != nil {
 		return "", fmt.Errorf("apply ns=%s id=%s: %w", ns, rangeID, err)

--- a/pyramid/params/params.go
+++ b/pyramid/params/params.go
@@ -44,9 +44,13 @@ type SharedParams struct {
 	// the blockstore.
 	BlockStoragePrefix string
 
-	// eviction is the cache to use to evict objects from local storage.  Only
+	// Eviction is the cache to use to evict objects from local storage.  Only
 	// configurable in testing.
 	Eviction Eviction
+
+	// PebbleSSTableCacheSizeBytes is the size (in bytes) of the cache used by the Pebble
+	// SSTable library.  This cache is shared between all readers active on the system.
+	PebbleSSTableCacheSizeBytes int64
 }
 
 type ExtParams struct {


### PR DESCRIPTION
Fixes #1177 (probably): the single cache is never finalized and should be OK.

Configure a pebble SSTable cache and use _that_.  This lets the admin control the amount of
RAM used to cache SSTable blocks.  Using a single cache makes *more* sense than giving each
reader its own cache: reading a block from an open reader costs the same no matter which it
is, so a single cache maximizes throughput.  There is no design goal to minimze latency per
reader (and this would *not* translate to minimizing latency per operation, rather it would
lower throughput on ranges that are heavily used).

This single cache has 2 references, one from the metarange readers cache and the other from
the range readers cache.  Because we never release those caches the Pebble SSTable cache is
never finalized until the program stops running.  (A panic is *still* possible then; fixing
that would require writing a finalizer.  This noncomposability of pebble SSTables indicates
just how hard that is to get right.)

There may well still be SSTable reader leaks which caused the original bug.  Here we merely
prevent those leaks from failing lakefs with a panic.