### PR TITLE
Apply server-side default log amount limit always

### DIFF
--- a/api/api_controller.go
+++ b/api/api_controller.go
@@ -349,7 +349,7 @@ func (c *Controller) ListRepositoriesHandler() repositories.ListRepositoriesHand
 func getPaginationParams(swagAfter *string, swagAmount *int64) (string, int) {
 	// amount
 	amount := MaxResultsPerPage
-	if swagAmount != nil {
+	if swagAmount != nil && 0 <= *swagAmount && *swagAmount <= MaxResultsPerPage {
 		amount = int(swag.Int64Value(swagAmount))
 	}
 


### PR DESCRIPTION
`lakectl` command explicitly passes -1 limit value, which bypasses the Swagger default.  So
apply the server-side default value when that value is passed.

Fixes #1181.