### PR TITLE
[1158] Control metadata range file sizes

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -422,9 +422,9 @@ func (c *Config) GetCommittedTierFSParams() (*pyramidparams.ExtParams, error) {
 
 func (c *Config) GetCommittedParams() *committed.Params {
 	return &committed.Params{
-		MinRangeSizeBytes:   viper.GetUint64(CommittedPermanentStorageMinRangeSizeKey),
-		MaxRangeSizeBytes:   viper.GetUint64(CommittedPermanentStorageMaxRangeSizeKey),
-		RangeSizeRaggedness: viper.GetFloat64(CommittedPermanentStorageRangeRaggednessKey),
+		MinRangeSizeBytes:          viper.GetUint64(CommittedPermanentStorageMinRangeSizeKey),
+		MaxRangeSizeBytes:          viper.GetUint64(CommittedPermanentStorageMaxRangeSizeKey),
+		RangeSizeEntriesRaggedness: viper.GetFloat64(CommittedPermanentStorageRangeRaggednessKey),
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -34,17 +34,19 @@ const (
 	DefaultBlockStoreS3StreamingChunkSize    = 2 << 19         // 1MiB by default per chunk
 	DefaultBlockStoreS3StreamingChunkTimeout = time.Second * 1 // or 1 seconds, whatever comes first
 
-	DefaultCommittedLocalCacheRangePercent      = 0.9
-	DefaultCommittedLocalCacheMetaRangePercent  = 0.1
-	DefaultCommittedLocalCacheBytes             = 1 * 1024 * 1024 * 1024
-	DefaultCommittedLocalCacheDir               = "~/lakefs/local_tier"
-	DefaultCommittedMetaRangeReaderCacheSize    = 20
-	DefaultCommittedMetaRangeReaderNumShards    = 6
-	DefaultCommittedRangeReaderCacheSize        = 100
-	DefaultCommittedRangeReaderNumShards        = 12
-	DefaultCommittedPebbleSSTableCacheSizeBytes = 200_000_000
-	DefaultCommittedBlockStoragePrefix          = "_lakefs"
-	DefaultCommittedPermanentRangeSizeBytes     = 10 * 1024 * 1024
+	DefaultCommittedLocalCacheRangePercent          = 0.9
+	DefaultCommittedLocalCacheMetaRangePercent      = 0.1
+	DefaultCommittedLocalCacheBytes                 = 1 * 1024 * 1024 * 1024
+	DefaultCommittedLocalCacheDir                   = "~/lakefs/local_tier"
+	DefaultCommittedMetaRangeReaderCacheSize        = 20
+	DefaultCommittedMetaRangeReaderNumShards        = 6
+	DefaultCommittedRangeReaderCacheSize            = 100
+	DefaultCommittedRangeReaderNumShards            = 12
+	DefaultCommittedPebbleSSTableCacheSizeBytes     = 200_000_000
+	DefaultCommittedBlockStoragePrefix              = "_lakefs"
+	DefaultCommittedPermanentMinRangeSizeBytes      = 0
+	DefaultCommittedPermanentMaxRangeSizeBytes      = 20 * 1024 * 1024
+	DefaultCommittedPermanentRangeRaggednessEntries = 50_000
 
 	DefaultBlockStoreGSS3Endpoint = "https://storage.googleapis.com"
 
@@ -108,16 +110,18 @@ const (
 	BlockstoreS3StreamingChunkTimeoutKey = "blockstore.s3.streaming_chunk_timeout"
 	BlockstoreS3MaxRetriesKey            = "blockstore.s3.max_retries"
 
-	CommittedLocalCacheSizeBytesKey        = "committed.local_cache.size_bytes"
-	CommittedLocalCacheDirKey              = "committed.local_cache.dir"
-	CommittedLocalCacheRangeProportion     = "committed.local_cache.range_proportion"
-	CommittedRangeReaderCacheSize          = "committed.local_cache.range.open_readers"
-	CommittedRangeReaderCacheNumShards     = "committed.local_cache.range.num_shards"
-	CommittedLocalCacheMetaRangeProportion = "committed.local_cache.metarange_proportion"
-	CommittedMetaRangeReaderCacheSize      = "committed.local_cache.metarange.open_readers"
-	CommittedMetaRangeReaderCacheNumShards = "committed.local_cache.metarange.num_shards"
-	CommittedBlockStoragePrefixKey         = "committed.block_storage_prefix"
-	CommittedPermanentStorageRangeSizeKey  = "committed.permanent.approximate_range_size_bytes"
+	CommittedLocalCacheSizeBytesKey             = "committed.local_cache.size_bytes"
+	CommittedLocalCacheDirKey                   = "committed.local_cache.dir"
+	CommittedLocalCacheRangeProportion          = "committed.local_cache.range_proportion"
+	CommittedRangeReaderCacheSize               = "committed.local_cache.range.open_readers"
+	CommittedRangeReaderCacheNumShards          = "committed.local_cache.range.num_shards"
+	CommittedLocalCacheMetaRangeProportion      = "committed.local_cache.metarange_proportion"
+	CommittedMetaRangeReaderCacheSize           = "committed.local_cache.metarange.open_readers"
+	CommittedMetaRangeReaderCacheNumShards      = "committed.local_cache.metarange.num_shards"
+	CommittedBlockStoragePrefixKey              = "committed.block_storage_prefix"
+	CommittedPermanentStorageMinRangeSizeKey    = "committed.permanent.min_range_size_bytes"
+	CommittedPermanentStorageMaxRangeSizeKey    = "committed.permanent.max_range_size_bytes"
+	CommittedPermanentStorageRangeRaggednessKey = "committed.permanent.range_raggedness_entries"
 
 	CommittedPebbleSSTableCacheSizeBytesKey = "committed.sstable.memory.cache_size_bytes"
 
@@ -160,7 +164,9 @@ func setDefaults() {
 	viper.SetDefault(CommittedMetaRangeReaderCacheNumShards, DefaultCommittedMetaRangeReaderNumShards)
 
 	viper.SetDefault(CommittedBlockStoragePrefixKey, DefaultCommittedBlockStoragePrefix)
-	viper.SetDefault(CommittedPermanentStorageRangeSizeKey, DefaultCommittedPermanentRangeSizeBytes)
+	viper.SetDefault(CommittedPermanentStorageMinRangeSizeKey, DefaultCommittedPermanentMinRangeSizeBytes)
+	viper.SetDefault(CommittedPermanentStorageMaxRangeSizeKey, DefaultCommittedPermanentMaxRangeSizeBytes)
+	viper.SetDefault(CommittedPermanentStorageRangeRaggednessKey, DefaultCommittedPermanentRangeRaggednessEntries)
 
 	viper.SetDefault(GatewaysS3DomainNameKey, DefaultS3GatewayDomainName)
 	viper.SetDefault(GatewaysS3RegionKey, DefaultS3GatewayRegion)
@@ -416,7 +422,9 @@ func (c *Config) GetCommittedTierFSParams() (*pyramidparams.ExtParams, error) {
 
 func (c *Config) GetCommittedParams() *committed.Params {
 	return &committed.Params{
-		ApproximateRangeSizeBytes: viper.GetUint64(CommittedPermanentStorageRangeSizeKey),
+		MinRangeSizeBytes:   viper.GetUint64(CommittedPermanentStorageMinRangeSizeKey),
+		MaxRangeSizeBytes:   viper.GetUint64(CommittedPermanentStorageMaxRangeSizeKey),
+		RangeSizeRaggedness: viper.GetFloat64(CommittedPermanentStorageRangeRaggednessKey),
 	}
 }
 

--- a/graveler/committed/meta_range_manager.go
+++ b/graveler/committed/meta_range_manager.go
@@ -10,9 +10,16 @@ import (
 )
 
 type Params struct {
-	// ApproximateRangeSizeBytes is a target for sizes of range partitions.  It should be
-	// kept fixed to maximize re-use of range partitions.
-	ApproximateRangeSizeBytes uint64
+	// MinRangeSizeBytes is the smallest size for splitting a range partition as a result
+	// of adding a record.  Smaller ranges are still possible due to re-using an existing
+	MinRangeSizeBytes uint64
+	// MaxRangeSizeBytes is the largest size of a range partition.  In practice the range
+	// is split only after an additional record.
+	MaxRangeSizeBytes uint64
+	// RangeSizeRaggedness allows raggedness in splitting range partitions.  It is
+	// the expected number of records after MinRangeSizeBytes at which to split the range
+	// -- ranges are split at the first key with hash divisible by this raggedness.
+	RangeSizeRaggedness float64
 }
 
 type metaRangeManager struct {
@@ -68,7 +75,7 @@ func (m *metaRangeManager) GetValue(ctx context.Context, ns graveler.StorageName
 }
 
 func (m *metaRangeManager) NewWriter(ctx context.Context, ns graveler.StorageNamespace) MetaRangeWriter {
-	return NewGeneralMetaRangeWriter(ctx, m.rangeManager, m.metaManager, m.params.ApproximateRangeSizeBytes, Namespace(ns))
+	return NewGeneralMetaRangeWriter(ctx, m.rangeManager, m.metaManager, &m.params, Namespace(ns))
 }
 
 func (m *metaRangeManager) NewMetaRangeIterator(ctx context.Context, ns graveler.StorageNamespace, id graveler.MetaRangeID) (Iterator, error) {

--- a/graveler/committed/meta_range_manager.go
+++ b/graveler/committed/meta_range_manager.go
@@ -16,10 +16,10 @@ type Params struct {
 	// MaxRangeSizeBytes is the largest size of a range partition.  In practice the range
 	// is split only after an additional record.
 	MaxRangeSizeBytes uint64
-	// RangeSizeRaggedness allows raggedness in splitting range partitions.  It is
+	// RangeSizeEntriesRaggedness allows raggedness in splitting range partitions.  It is
 	// the expected number of records after MinRangeSizeBytes at which to split the range
 	// -- ranges are split at the first key with hash divisible by this raggedness.
-	RangeSizeRaggedness float64
+	RangeSizeEntriesRaggedness float64
 }
 
 type metaRangeManager struct {

--- a/graveler/committed/meta_range_writer.go
+++ b/graveler/committed/meta_range_writer.go
@@ -142,7 +142,7 @@ func (w *GeneralMetaRangeWriter) shouldBreakAtKey(key graveler.Key) bool {
 	h := fnv.New64a()
 	// FNV always reads all bytes and never fails; ignore its return values
 	_, _ = h.Write(key)
-	r := h.Sum64() % uint64(w.params.RangeSizeRaggedness)
+	r := h.Sum64() % uint64(w.params.RangeSizeEntriesRaggedness)
 	return r == 0
 }
 

--- a/graveler/committed/meta_range_writer.go
+++ b/graveler/committed/meta_range_writer.go
@@ -13,15 +13,15 @@ import (
 )
 
 type GeneralMetaRangeWriter struct {
-	ctx                       context.Context
-	namespace                 Namespace
-	metaRangeManager          RangeManager
-	rangeManager              RangeManager
-	rangeWriter               RangeWriter // writer for the current range
-	lastKey                   Key
-	approximateRangeSizeBytes uint64 // indicates when to break the ranges
-	batchWriteCloser          BatchWriterCloser
-	ranges                    []Range
+	ctx              context.Context
+	params           *Params // for breaking ranges
+	namespace        Namespace
+	metaRangeManager RangeManager
+	rangeManager     RangeManager
+	rangeWriter      RangeWriter // writer for the current range
+	lastKey          Key
+	batchWriteCloser BatchWriterCloser
+	ranges           []Range
 }
 
 var (
@@ -29,14 +29,14 @@ var (
 	ErrNilValue     = errors.New("record value should not be nil")
 )
 
-func NewGeneralMetaRangeWriter(ctx context.Context, rangeManager, metaRangeManager RangeManager, approximateRangeSizeBytes uint64, namespace Namespace) *GeneralMetaRangeWriter {
+func NewGeneralMetaRangeWriter(ctx context.Context, rangeManager, metaRangeManager RangeManager, params *Params, namespace Namespace) *GeneralMetaRangeWriter {
 	return &GeneralMetaRangeWriter{
-		ctx:                       ctx,
-		rangeManager:              rangeManager,
-		metaRangeManager:          metaRangeManager,
-		batchWriteCloser:          NewBatchCloser(),
-		approximateRangeSizeBytes: approximateRangeSizeBytes,
-		namespace:                 namespace,
+		ctx:              ctx,
+		rangeManager:     rangeManager,
+		metaRangeManager: metaRangeManager,
+		batchWriteCloser: NewBatchCloser(),
+		params:           params,
+		namespace:        namespace,
 	}
 }
 
@@ -66,11 +66,8 @@ func (w *GeneralMetaRangeWriter) WriteRecord(record graveler.ValueRecord) error 
 		return fmt.Errorf("write record to range: %w", err)
 	}
 	w.lastKey = Key(record.Key)
-	breakpoint, err := w.shouldBreakAtKey(record.Key)
-	if err != nil {
-		return err
-	}
-	if breakpoint {
+
+	if w.shouldBreakAtKey(record.Key) {
 		return w.closeCurrentRange()
 	}
 	return nil
@@ -133,14 +130,20 @@ func (w *GeneralMetaRangeWriter) Close() (*graveler.MetaRangeID, error) {
 }
 
 // shouldBreakAtKey returns true if should break range after the given key
-func (w *GeneralMetaRangeWriter) shouldBreakAtKey(key graveler.Key) (bool, error) {
-	h := fnv.New64a()
-	_, err := h.Write(key)
-	if err != nil {
-		return false, err
+func (w *GeneralMetaRangeWriter) shouldBreakAtKey(key graveler.Key) bool {
+	approximateSize := w.rangeWriter.GetApproximateSize()
+	if approximateSize < w.params.MinRangeSizeBytes {
+		return false
 	}
-	n := h.Sum64() % w.approximateRangeSizeBytes
-	return n == 0, nil
+	if approximateSize >= w.params.MaxRangeSizeBytes {
+		return true
+	}
+
+	h := fnv.New64a()
+	// FNV always reads all bytes and never fails; ignore its return values
+	_, _ = h.Write(key)
+	r := h.Sum64() % uint64(w.params.RangeSizeRaggedness)
+	return r == 0
 }
 
 // writeRangesToMetaRange writes all ranges to a MetaRange and returns the MetaRangeID

--- a/graveler/committed/meta_range_writer_test.go
+++ b/graveler/committed/meta_range_writer_test.go
@@ -19,6 +19,12 @@ func getExpected(t *testing.T, record graveler.ValueRecord) committed.Record {
 	return committed.Record{Key: committed.Key(record.Key), Value: expectedValue}
 }
 
+var params = committed.Params{
+	MinRangeSizeBytes:   0,
+	MaxRangeSizeBytes:   50_000,
+	RangeSizeRaggedness: 100,
+}
+
 func TestWriter_WriteRecords(t *testing.T) {
 	ctx := context.Background()
 	ctrl := gomock.NewController(t)
@@ -27,8 +33,10 @@ func TestWriter_WriteRecords(t *testing.T) {
 	rangeManager := mock.NewMockRangeManager(ctrl)
 	mockWriter := mock.NewMockRangeWriter(ctrl)
 	rangeManager.EXPECT().GetWriter(gomock.Any(), gomock.Any()).Return(mockWriter, nil).MinTimes(1)
+	// Never attempt to split files.
+	mockWriter.EXPECT().GetApproximateSize().Return(uint64(0)).AnyTimes()
 	namespace := committed.Namespace("ns")
-	w := committed.NewGeneralMetaRangeWriter(ctx, rangeManager, rangeManager, 100, namespace)
+	w := committed.NewGeneralMetaRangeWriter(ctx, rangeManager, rangeManager, &params, namespace)
 
 	// Add first record
 	firstRecord := graveler.ValueRecord{
@@ -75,7 +83,7 @@ func TestWriter_OverlappingRanges(t *testing.T) {
 	namespace := committed.Namespace("ns")
 	rng := committed.Range{MinKey: committed.Key("a"), MaxKey: committed.Key("g")}
 	rng2 := committed.Range{MinKey: committed.Key("c"), MaxKey: committed.Key("l")}
-	w := committed.NewGeneralMetaRangeWriter(ctx, rangeManager, rangeManager, 100, namespace)
+	w := committed.NewGeneralMetaRangeWriter(ctx, rangeManager, rangeManager, &params, namespace)
 	err := w.WriteRange(rng)
 	if err != nil {
 		t.Fatal("unexpected error %w", err)
@@ -104,6 +112,11 @@ func TestWriter_RecordRangeAndClose(t *testing.T) {
 	// get writer - once for record writer, once for range writer
 	rangeManager.EXPECT().GetWriter(gomock.Any(), gomock.Any()).Return(mockWriter, nil)
 	rangeManagerMeta.EXPECT().GetWriter(gomock.Any(), gomock.Any()).Return(mockMetaWriter, nil)
+
+	// Never attempt to split files.
+	mockWriter.EXPECT().GetApproximateSize().Return(uint64(0)).AnyTimes()
+	mockMetaWriter.EXPECT().GetApproximateSize().Return(uint64(0)).AnyTimes()
+
 	// write two records on MetaRange and one for Range
 	mockWriter.EXPECT().WriteRecord(gomock.Any())
 	mockMetaWriter.EXPECT().WriteRecord(gomock.Any()).Times(2)
@@ -112,7 +125,7 @@ func TestWriter_RecordRangeAndClose(t *testing.T) {
 	mockWriter.EXPECT().Abort().AnyTimes()
 	mockMetaWriter.EXPECT().Abort().AnyTimes()
 
-	w := committed.NewGeneralMetaRangeWriter(ctx, rangeManager, rangeManagerMeta, 100, namespace)
+	w := committed.NewGeneralMetaRangeWriter(ctx, rangeManager, rangeManagerMeta, &params, namespace)
 	err := w.WriteRecord(record)
 	if err != nil {
 		t.Fatal("unexpected error %w", err)

--- a/graveler/committed/meta_range_writer_test.go
+++ b/graveler/committed/meta_range_writer_test.go
@@ -20,9 +20,9 @@ func getExpected(t *testing.T, record graveler.ValueRecord) committed.Record {
 }
 
 var params = committed.Params{
-	MinRangeSizeBytes:   0,
-	MaxRangeSizeBytes:   50_000,
-	RangeSizeRaggedness: 100,
+	MinRangeSizeBytes:          0,
+	MaxRangeSizeBytes:          50_000,
+	RangeSizeEntriesRaggedness: 100,
 }
 
 func TestWriter_WriteRecords(t *testing.T) {

--- a/graveler/committed/range_manager.go
+++ b/graveler/committed/range_manager.go
@@ -74,8 +74,11 @@ type WriteResult struct {
 // RangeWriter is an abstraction for writing Ranges.
 // Written records must be sorted by key.
 type RangeWriter interface {
-	// WriteRecord appends the given record to the Range
+	// WriteRecord appends the given record to the Range.
 	WriteRecord(record Record) error
+
+	// GetApproximateSize returns an estimate of the current written size of the Range.
+	GetApproximateSize() uint64
 
 	// Close flushes all records to the disk and returns the WriteResult.
 	Close() (*WriteResult, error)

--- a/graveler/sstable/writer.go
+++ b/graveler/sstable/writer.go
@@ -70,6 +70,10 @@ func (dw *DiskWriter) WriteRecord(record committed.Record) error {
 	return dw.writeHashWithLen(record.Value)
 }
 
+func (dw *DiskWriter) GetApproximateSize() uint64 {
+	return dw.w.EstimatedSize()
+}
+
 func (dw *DiskWriter) writeHashWithLen(buf []byte) error {
 	if _, err := dw.hash.Write([]byte(strconv.Itoa(len(buf)))); err != nil {
 		return err


### PR DESCRIPTION
See [issue comment](https://github.com/treeverse/lakeFS/1158#issuecomment-758640791) for full details.

Add 3 parameters:

* minimum range size (bytes)
* maximum range size (bytes)
* raggedness factor (entries)

Close (split) a range after adding an entry if any of these holds:

* Next need to add an entire range (TODO: collect data to see whether we want to buffer some range entries to avoid this creating very small ranges). OR...
* The current range size is >= maximum range size. (SO the maximum is not really a maximum, we go one whole entry above it). OR...
* The current range is >= minimum range size and hash(entry.Key) / maxHashValue > 1/raggedness.

(Initial) default min range size is 0 to avoid forcing the non-essential change.  We shall
change at least the parameters, and possibly the entire logic.  Making this change requires
data, and data requires a working system, so do this for now.

Fixes #1158.