### PR TITLE
 Write "last-modified" date to entries on staging 

### DIFF
--- a/catalog/rocks/cataloger.go
+++ b/catalog/rocks/cataloger.go
@@ -249,7 +249,7 @@ func (c *cataloger) GetEntry(ctx context.Context, repository string, reference s
 	return &catalogEntry, nil
 }
 
-func entryFromCatalogEntry(entry *catalog.Entry) *Entry {
+func entryFromCatalogEntry(entry catalog.Entry) *Entry {
 	return &Entry{
 		Address:      entry.PhysicalAddress,
 		Metadata:     map[string]string(entry.Metadata),
@@ -262,7 +262,7 @@ func entryFromCatalogEntry(entry *catalog.Entry) *Entry {
 func (c *cataloger) CreateEntry(ctx context.Context, repository string, branch string, entry catalog.Entry, _ catalog.CreateEntryParams) error {
 	repositoryID := graveler.RepositoryID(repository)
 	branchID := graveler.BranchID(branch)
-	ent := entryFromCatalogEntry(&entry)
+	ent := entryFromCatalogEntry(entry)
 	return c.EntryCatalog.SetEntry(ctx, repositoryID, branchID, Path(entry.Path), ent)
 }
 
@@ -270,7 +270,7 @@ func (c *cataloger) CreateEntries(ctx context.Context, repository string, branch
 	repositoryID := graveler.RepositoryID(repository)
 	branchID := graveler.BranchID(branch)
 	for _, entry := range entries {
-		ent := entryFromCatalogEntry(&entry)
+		ent := entryFromCatalogEntry(entry)
 		if err := c.EntryCatalog.SetEntry(ctx, repositoryID, branchID, Path(entry.Path), ent); err != nil {
 			return err
 		}

--- a/catalog/rocks/entry_catalog_test.go
+++ b/catalog/rocks/entry_catalog_test.go
@@ -4,10 +4,12 @@ import (
 	"context"
 	"errors"
 	"testing"
+	"time"
 
 	"github.com/go-test/deep"
 	"github.com/treeverse/lakefs/graveler"
 	"github.com/treeverse/lakefs/testutil"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func TestEntryCatalog_GetEntry_NotFound(t *testing.T) {
@@ -39,7 +41,20 @@ func TestEntryCatalog_SetEntry(t *testing.T) {
 	gravelerMock := &FakeGraveler{KeyValue: make(map[string]*graveler.Value)}
 	cat := EntryCatalog{store: gravelerMock}
 	ctx := context.Background()
-	entry := &Entry{Address: "addr1"}
+	var (
+		addr           = "addr1"
+		now            = time.Now()
+		size     int64 = 1234
+		tag            = "quick brown fox"
+		metadata       = map[string]string{"one": "1", "two": "2"}
+	)
+	entry := &Entry{
+		Address:      addr,
+		LastModified: timestamppb.New(now),
+		Size:         size,
+		ETag:         tag,
+		Metadata:     metadata,
+	}
 	err := cat.SetEntry(ctx, "repo", "ref", "path1", entry)
 	testutil.MustDo(t, "set entry", err)
 	// verify that mock got the right entry


### PR DESCRIPTION
Fixes #1190.

Note that *all previous commits are wrong*.  Relevant for extant testing environments.

Verified by listing with `aws s3 ls` and also via the GUI.