### PR TITLE
Correct slice body when reporting a response for trace

### DIFF
--- a/httputil/tracing.go
+++ b/httputil/tracing.go
@@ -100,6 +100,13 @@ func (r *requestBodyTracer) Close() error {
 	return r.body.Close()
 }
 
+func presentBody(body []byte) string {
+	if len(body) > MaxBodyBytes {
+		body = body[:MaxBodyBytes]
+	}
+	return string(body)
+}
+
 func TracingMiddleware(requestIDHeaderName string, fields logging.Fields, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		startTime := time.Now()
@@ -131,7 +138,7 @@ func TracingMiddleware(requestIDHeaderName string, fields logging.Fields, next h
 			"sent_bytes":       responseWriter.ResponseSize,
 			"request_body":     requestBodyTracer.bodyRecorder.Buffer,
 			"request_headers":  r.Header,
-			"response_body":    string(responseWriter.BodyRecorder.Buffer[:MaxBodyBytes]),
+			"response_body":    presentBody(responseWriter.BodyRecorder.Buffer),
 			"response_headers": responseWriter.Header(),
 		}).Trace("HTTP call ended")
 	})


### PR DESCRIPTION
This actually crashes when the response is short-ish, need to do this.