### PR TITLE
Double-up catalog and graveler errors in api

### DIFF
--- a/api/api_controller.go
+++ b/api/api_controller.go
@@ -850,7 +850,6 @@ func (c *Controller) RefsDiffRefsHandler() refs.DiffRefsHandler {
 			Limit: limit,
 			After: after,
 		})
-		// TODO(ariels): check if yoni added something for here!
 		if errors.Is(err, catalog.ErrFeatureNotSupported) {
 			return refs.NewDiffRefsDefault(http.StatusNotImplemented).WithPayload(responseError(err.Error()))
 		}


### PR DESCRIPTION
There are currently double errors for catalog and for graveler.  This *temporary* solution
just checks each error on both.  Once mvcc goes away, we can stay with the graveler error,
catalog will go away with mvcc.

Fixes #1212 (verified manually -- compare UI works).