### PR TITLE
Publish coverage from integration tests too

### DIFF
--- a/.github/workflows/nessie.yaml
+++ b/.github/workflows/nessie.yaml
@@ -184,7 +184,7 @@ jobs:
       - name: Run Nessie S3 with local API key
         env:
           NESSIE_STORAGE_NAMESPACE: s3://nessie-system-testing/${{ github.run_number }}-${{ matrix.cataloger }}-local-api-key
-        run: go test -v ./nessie --system-tests --use-local-credentials
+        run: go test -v ./nessie --system-tests --use-local-credentials --coverprofile=nessie-cover.out --cover
       - name: Run lakeFS GS
         env:
           TAG: ${{ steps.version.outputs.tag }}
@@ -209,4 +209,8 @@ jobs:
         if: ${{ failure() }}
         continue-on-error: true
         run: docker-compose -f nessie/ops/docker-compose.yaml logs --tail=1000 lakefs
-
+      - name: Publish coverage
+        uses: codecov/codecov-action@v1
+        with:
+          files: ./nessie-cover.out
+          fail_ci_if_error: false


### PR DESCRIPTION
Some parts of the system are exercised only by integration tests.  This will help us know what
parts of the glue code are *not* exercised.  Also code coverage number go up.