### PR TITLE
Configure SSTable reader cache by default

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -167,6 +167,7 @@ func setDefaults() {
 	viper.SetDefault(CommittedPermanentStorageMinRangeSizeKey, DefaultCommittedPermanentMinRangeSizeBytes)
 	viper.SetDefault(CommittedPermanentStorageMaxRangeSizeKey, DefaultCommittedPermanentMaxRangeSizeBytes)
 	viper.SetDefault(CommittedPermanentStorageRangeRaggednessKey, DefaultCommittedPermanentRangeRaggednessEntries)
+	viper.SetDefault(CommittedPebbleSSTableCacheSizeBytesKey, DefaultCommittedPebbleSSTableCacheSizeBytes)
 
 	viper.SetDefault(GatewaysS3DomainNameKey, DefaultS3GatewayDomainName)
 	viper.SetDefault(GatewaysS3RegionKey, DefaultS3GatewayRegion)


### PR DESCRIPTION
Hook configuration up for `committed.sstable.memory.cache_size_bytes`.  Because it was
missing, the "fail-safe" noCache option was used... which is apparently unsafe or just exposes
some *other* issue with calling too many SSTable readers.

Relevant for #1238.