### PR TITLE
Close pebble SSTable iterators only once

### DIFF
--- a/graveler/sstable/iterator.go
+++ b/graveler/sstable/iterator.go
@@ -61,11 +61,16 @@ func (iter *Iterator) Err() error {
 }
 
 func (iter *Iterator) Close() {
+	if iter.it == nil {
+		return
+	}
 	err := iter.it.Close()
 	iter.updateOnNilErr(err)
 
 	err = iter.derefer()
 	iter.updateOnNilErr(err)
+
+	iter.it = nil
 }
 
 func (iter *Iterator) updateOnNilErr(err error) {


### PR DESCRIPTION
Unlike our iterators, it is unsafe to close a pebble SSTable multiple times.  (CockroachDB is
the most sensitive roach EVER.)  So don't do that.

Fixes #1238.  Apparently -- it's a flaky situation.