### PR TITLE
Pass context all the way from API controller through pyramid

### DIFF
--- a/api/api_controller.go
+++ b/api/api_controller.go
@@ -120,13 +120,6 @@ func NewController(cataloger catalog.Cataloger, auth auth.Service, blockAdapter 
 	return c
 }
 
-func (c *Controller) Context() context.Context {
-	if c.deps.ctx != nil {
-		return c.deps.ctx
-	}
-	return context.Background()
-}
-
 // Configure attaches our API operations to a generated swagger API stub
 // Adding new handlers requires also adding them here so that the generated server will use them
 func (c *Controller) Configure(api *operations.LakefsAPI) {
@@ -312,7 +305,7 @@ func (c *Controller) ListRepositoriesHandler() repositories.ListRepositoriesHand
 
 		after, amount := getPaginationParams(params.After, params.Amount)
 
-		repos, hasMore, err := deps.Cataloger.ListRepositories(c.Context(), amount, after)
+		repos, hasMore, err := deps.Cataloger.ListRepositories(deps.ctx, amount, after)
 		if err != nil {
 			return repositories.NewListRepositoriesDefault(http.StatusInternalServerError).
 				WithPayload(responseError("error listing repositories: %s", err))
@@ -372,7 +365,7 @@ func (c *Controller) GetRepoHandler() repositories.GetRepositoryHandler {
 			return repositories.NewGetRepositoryUnauthorized().WithPayload(responseErrorFrom(err))
 		}
 		deps.LogAction("get_repo")
-		repo, err := deps.Cataloger.GetRepository(c.Context(), params.Repository)
+		repo, err := deps.Cataloger.GetRepository(deps.ctx, params.Repository)
 		if errors.Is(err, db.ErrNotFound) {
 			return repositories.NewGetRepositoryNotFound().
 				WithPayload(responseError("repository not found"))
@@ -404,7 +397,7 @@ func (c *Controller) GetCommitHandler() commits.GetCommitHandler {
 			return commits.NewGetCommitUnauthorized().WithPayload(responseErrorFrom(err))
 		}
 		deps.LogAction("get_commit")
-		commit, err := deps.Cataloger.GetCommit(c.Context(), params.Repository, params.CommitID)
+		commit, err := deps.Cataloger.GetCommit(deps.ctx, params.Repository, params.CommitID)
 		if errors.Is(err, db.ErrNotFound) {
 			return commits.NewGetCommitNotFound().WithPayload(responseError("commit not found"))
 		}
@@ -440,7 +433,7 @@ func (c *Controller) CommitHandler() commits.CommitHandler {
 		}
 		committer := userModel.Username
 		commitMessage := swag.StringValue(params.Commit.Message)
-		commit, err := deps.Cataloger.Commit(c.Context(), params.Repository,
+		commit, err := deps.Cataloger.Commit(deps.ctx, params.Repository,
 			params.Branch, commitMessage, committer, params.Commit.Metadata)
 		if err != nil {
 			return commits.NewCommitDefault(http.StatusInternalServerError).WithPayload(responseErrorFrom(err))
@@ -472,7 +465,7 @@ func (c *Controller) CommitsGetBranchCommitLogHandler() commits.GetBranchCommitL
 
 		after, amount := getPaginationParams(params.After, params.Amount)
 		// get commit log
-		commitLog, hasMore, err := cataloger.ListCommits(c.Context(), params.Repository, params.Branch, after, amount)
+		commitLog, hasMore, err := cataloger.ListCommits(deps.ctx, params.Repository, params.Branch, after, amount)
 		switch {
 		case errors.Is(err, catalog.ErrBranchNotFound) || errors.Is(err, graveler.ErrBranchNotFound):
 			return commits.NewGetBranchCommitLogNotFound().WithPayload(responseError("branch '%s' not found.", params.Branch))
@@ -552,7 +545,7 @@ func (c *Controller) CreateRepositoryHandler() repositories.CreateRepositoryHand
 			return repositories.NewCreateRepositoryBadRequest().
 				WithPayload(responseError("error creating repository: could not access storage namespace"))
 		}
-		repo, err := deps.Cataloger.CreateRepository(c.Context(),
+		repo, err := deps.Cataloger.CreateRepository(deps.ctx,
 			swag.StringValue(params.Repository.Name),
 			swag.StringValue(params.Repository.StorageNamespace),
 			params.Repository.DefaultBranch)
@@ -582,7 +575,7 @@ func (c *Controller) DeleteRepositoryHandler() repositories.DeleteRepositoryHand
 			return repositories.NewDeleteRepositoryUnauthorized().WithPayload(responseErrorFrom(err))
 		}
 		deps.LogAction("delete_repo")
-		err = deps.Cataloger.DeleteRepository(c.Context(), params.Repository)
+		err = deps.Cataloger.DeleteRepository(deps.ctx, params.Repository)
 		if errors.Is(err, db.ErrNotFound) {
 			return repositories.NewDeleteRepositoryNotFound().WithPayload(responseError("repository not found"))
 		}
@@ -610,7 +603,7 @@ func (c *Controller) ListBranchesHandler() branches.ListBranchesHandler {
 
 		after, amount := getPaginationParams(params.After, params.Amount)
 
-		res, hasMore, err := cataloger.ListBranches(c.Context(), params.Repository, "", amount, after)
+		res, hasMore, err := cataloger.ListBranches(deps.ctx, params.Repository, "", amount, after)
 		if err != nil {
 			return branches.NewListBranchesDefault(http.StatusInternalServerError).
 				WithPayload(responseError("could not list branches: %s", err))
@@ -654,7 +647,7 @@ func (c *Controller) GetBranchHandler() branches.GetBranchHandler {
 			return branches.NewGetBranchUnauthorized().WithPayload(responseErrorFrom(err))
 		}
 		deps.LogAction("get_branch")
-		reference, err := deps.Cataloger.GetBranchReference(c.Context(), params.Repository, params.Branch)
+		reference, err := deps.Cataloger.GetBranchReference(deps.ctx, params.Repository, params.Branch)
 
 		switch {
 		case errors.Is(err, catalog.ErrBranchNotFound) || errors.Is(err, graveler.ErrBranchNotFound):
@@ -685,7 +678,7 @@ func (c *Controller) CreateBranchHandler() branches.CreateBranchHandler {
 		deps.LogAction("create_branch")
 		cataloger := deps.Cataloger
 		sourceRef := swag.StringValue(params.Branch.Source)
-		commitLog, err := cataloger.CreateBranch(c.Context(), repository, branch, sourceRef)
+		commitLog, err := cataloger.CreateBranch(deps.ctx, repository, branch, sourceRef)
 		if err != nil {
 			return branches.NewCreateBranchDefault(http.StatusInternalServerError).WithPayload(responseErrorFrom(err))
 		}
@@ -706,7 +699,7 @@ func (c *Controller) DeleteBranchHandler() branches.DeleteBranchHandler {
 		}
 		deps.LogAction("delete_branch")
 		cataloger := deps.Cataloger
-		err = cataloger.DeleteBranch(c.Context(), params.Repository, params.Branch)
+		err = cataloger.DeleteBranch(deps.ctx, params.Repository, params.Branch)
 		switch {
 		case errors.Is(err, catalog.ErrBranchNotFound) || errors.Is(err, graveler.ErrBranchNotFound):
 			return branches.NewDeleteBranchNotFound().WithPayload(responseError("branch '%s' not found.", params.Branch))
@@ -742,7 +735,7 @@ func (c *Controller) MergeMergeIntoBranchHandler() refs.MergeIntoBranchHandler {
 			message = params.Merge.Message
 			metadata = params.Merge.Metadata
 		}
-		res, err := deps.Cataloger.Merge(c.Context(),
+		res, err := deps.Cataloger.Merge(deps.ctx,
 			params.Repository, params.SourceRef, params.DestinationRef,
 			userModel.Username,
 			message,
@@ -808,7 +801,7 @@ func (c *Controller) BranchesDiffBranchHandler() branches.DiffBranchHandler {
 		cataloger := deps.Cataloger
 		limit := int(swag.Int64Value(params.Amount))
 		after := swag.StringValue(params.After)
-		diff, hasMore, err := cataloger.DiffUncommitted(c.Context(), params.Repository, params.Branch, limit, after)
+		diff, hasMore, err := cataloger.DiffUncommitted(deps.ctx, params.Repository, params.Branch, limit, after)
 		if err != nil {
 			return branches.NewDiffBranchDefault(http.StatusInternalServerError).
 				WithPayload(responseError("could not diff branch: %s", err))
@@ -849,7 +842,7 @@ func (c *Controller) RefsDiffRefsHandler() refs.DiffRefsHandler {
 		cataloger := deps.Cataloger
 		limit := int(swag.Int64Value(params.Amount))
 		after := swag.StringValue(params.After)
-		diff, hasMore, err := cataloger.Diff(c.Context(), params.Repository, params.LeftRef, params.RightRef, catalog.DiffParams{
+		diff, hasMore, err := cataloger.Diff(deps.ctx, params.Repository, params.LeftRef, params.RightRef, catalog.DiffParams{
 			Limit: limit,
 			After: after,
 		})
@@ -895,7 +888,7 @@ func (c *Controller) ObjectsStatObjectHandler() objects.StatObjectHandler {
 		deps.LogAction("stat_object")
 		cataloger := deps.Cataloger
 
-		entry, err := cataloger.GetEntry(c.Context(), params.Repository, params.Ref, params.Path, catalog.GetEntryParams{ReturnExpired: true})
+		entry, err := cataloger.GetEntry(deps.ctx, params.Repository, params.Ref, params.Path, catalog.GetEntryParams{ReturnExpired: true})
 		if errors.Is(err, db.ErrNotFound) {
 			return objects.NewStatObjectNotFound().WithPayload(responseError("resource not found"))
 		}
@@ -903,7 +896,7 @@ func (c *Controller) ObjectsStatObjectHandler() objects.StatObjectHandler {
 			return objects.NewStatObjectDefault(http.StatusInternalServerError).WithPayload(responseErrorFrom(err))
 		}
 
-		repo, err := cataloger.GetRepository(c.Context(), params.Repository)
+		repo, err := cataloger.GetRepository(deps.ctx, params.Repository)
 		if err != nil {
 			return objects.NewStatObjectDefault(http.StatusInternalServerError).WithPayload(responseErrorFrom(err))
 		}
@@ -945,7 +938,7 @@ func (c *Controller) ObjectsGetUnderlyingPropertiesHandler() objects.GetUnderlyi
 		cataloger := deps.Cataloger
 
 		// read repo
-		repo, err := cataloger.GetRepository(c.Context(), params.Repository)
+		repo, err := cataloger.GetRepository(deps.ctx, params.Repository)
 		if errors.Is(err, db.ErrNotFound) {
 			return objects.NewGetUnderlyingPropertiesNotFound().WithPayload(responseError("resource not found"))
 		}
@@ -953,7 +946,7 @@ func (c *Controller) ObjectsGetUnderlyingPropertiesHandler() objects.GetUnderlyi
 			return objects.NewGetUnderlyingPropertiesDefault(http.StatusInternalServerError).WithPayload(responseErrorFrom(err))
 		}
 
-		entry, err := cataloger.GetEntry(c.Context(), params.Repository, params.Ref, params.Path, catalog.GetEntryParams{})
+		entry, err := cataloger.GetEntry(deps.ctx, params.Repository, params.Ref, params.Path, catalog.GetEntryParams{})
 		if errors.Is(err, db.ErrNotFound) {
 			return objects.NewGetUnderlyingPropertiesNotFound().WithPayload(responseError("resource not found"))
 		}
@@ -989,7 +982,7 @@ func (c *Controller) ObjectsGetObjectHandler() objects.GetObjectHandler {
 		cataloger := deps.Cataloger
 
 		// read repo
-		repo, err := cataloger.GetRepository(c.Context(), params.Repository)
+		repo, err := cataloger.GetRepository(deps.ctx, params.Repository)
 		if errors.Is(err, db.ErrNotFound) {
 			return objects.NewGetObjectNotFound().WithPayload(responseError("resource not found"))
 		}
@@ -998,7 +991,7 @@ func (c *Controller) ObjectsGetObjectHandler() objects.GetObjectHandler {
 		}
 
 		// read the FS entry
-		entry, err := cataloger.GetEntry(c.Context(), params.Repository, params.Ref, params.Path, catalog.GetEntryParams{ReturnExpired: true})
+		entry, err := cataloger.GetEntry(deps.ctx, params.Repository, params.Ref, params.Path, catalog.GetEntryParams{ReturnExpired: true})
 		if errors.Is(err, db.ErrNotFound) {
 			return objects.NewGetObjectNotFound().WithPayload(responseError("resource not found"))
 		}
@@ -1042,7 +1035,7 @@ func (c *Controller) MetadataCreateSymlinkHandler() metadataop.CreateSymlinkHand
 		cataloger := deps.Cataloger
 
 		// read repo
-		repo, err := cataloger.GetRepository(c.Context(), params.Repository)
+		repo, err := cataloger.GetRepository(deps.ctx, params.Repository)
 		if errors.Is(err, db.ErrNotFound) {
 			return metadataop.NewCreateSymlinkNotFound().WithPayload(responseError("resource not found"))
 		}
@@ -1057,7 +1050,7 @@ func (c *Controller) MetadataCreateSymlinkHandler() metadataop.CreateSymlinkHand
 		hasMore := true
 		for hasMore {
 			entries, hasMore, err = cataloger.ListEntries(
-				c.Context(),
+				deps.ctx,
 				params.Repository,
 				params.Branch,
 				swag.StringValue(params.Location),
@@ -1136,7 +1129,7 @@ func (c *Controller) ObjectsListObjectsHandler() objects.ListObjectsHandler {
 
 		delimiter := catalog.DefaultPathDelimiter
 		res, hasMore, err := cataloger.ListEntries(
-			c.Context(),
+			deps.ctx,
 			params.Repository,
 			params.Ref,
 			swag.StringValue(params.Prefix),
@@ -1151,7 +1144,7 @@ func (c *Controller) ObjectsListObjectsHandler() objects.ListObjectsHandler {
 				WithPayload(responseError("error while listing objects: %s", err))
 		}
 
-		repo, err := cataloger.GetRepository(c.Context(), params.Repository)
+		repo, err := cataloger.GetRepository(deps.ctx, params.Repository)
 		if err != nil {
 			return objects.NewStatObjectDefault(http.StatusInternalServerError).WithPayload(responseErrorFrom(err))
 		}
@@ -1215,7 +1208,7 @@ func (c *Controller) ObjectsUploadObjectHandler() objects.UploadObjectHandler {
 		deps.LogAction("put_object")
 		cataloger := deps.Cataloger
 
-		repo, err := cataloger.GetRepository(c.Context(), params.Repository)
+		repo, err := cataloger.GetRepository(deps.ctx, params.Repository)
 		if errors.Is(err, db.ErrNotFound) {
 			return objects.NewUploadObjectNotFound().WithPayload(responseError("repository not found"))
 		}
@@ -1223,7 +1216,7 @@ func (c *Controller) ObjectsUploadObjectHandler() objects.UploadObjectHandler {
 			return objects.NewUploadObjectDefault(http.StatusInternalServerError).WithPayload(responseErrorFrom(err))
 		}
 		// check if branch exists - it is still a possibility, but we don't want to upload large object when the branch was not there in the first place
-		branchExists, err := cataloger.BranchExists(c.Context(), params.Repository, params.Branch)
+		branchExists, err := cataloger.BranchExists(deps.ctx, params.Repository, params.Branch)
 		if err != nil {
 			return objects.NewUploadObjectDefault(http.StatusInternalServerError).WithPayload(responseErrorFrom(err))
 		}
@@ -1252,7 +1245,7 @@ func (c *Controller) ObjectsUploadObjectHandler() objects.UploadObjectHandler {
 			Size:            blob.Size,
 			Checksum:        blob.Checksum,
 		}
-		err = cataloger.CreateEntry(c.Context(), repo.Name, params.Branch, entry,
+		err = cataloger.CreateEntry(deps.ctx, repo.Name, params.Branch, entry,
 			catalog.CreateEntryParams{
 				Dedup: catalog.DedupParams{
 					ID:               blob.DedupID,
@@ -1296,7 +1289,7 @@ func (c *Controller) ObjectsDeleteObjectHandler() objects.DeleteObjectHandler {
 		deps.LogAction("delete_object")
 		cataloger := deps.Cataloger
 
-		err = cataloger.DeleteEntry(c.Context(), params.Repository, params.Branch, params.Path)
+		err = cataloger.DeleteEntry(deps.ctx, params.Repository, params.Branch, params.Path)
 		if errors.Is(err, db.ErrNotFound) {
 			return objects.NewDeleteObjectNotFound().WithPayload(responseError("resource not found"))
 		}
@@ -1322,7 +1315,7 @@ func (c *Controller) RevertBranchHandler() branches.RevertBranchHandler {
 		deps.LogAction("revert_branch")
 		cataloger := deps.Cataloger
 
-		ctx := c.Context()
+		ctx := deps.ctx
 		switch swag.StringValue(params.Revert.Type) {
 		case models.RevertCreationTypeCommit:
 			err = cataloger.RollbackCommit(ctx, params.Repository, params.Branch, params.Revert.Commit)

--- a/cache/reference_counted.go
+++ b/cache/reference_counted.go
@@ -1,6 +1,7 @@
 package cache
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"hash/maphash"
@@ -20,7 +21,7 @@ type Derefer func() error
 // not a Cache.
 type CacheWithDisposal interface {
 	Name() string
-	GetOrSet(k interface{}, setFn SetFn) (v interface{}, disposer Derefer, err error)
+	GetOrSet(ctx context.Context, k interface{}, setFn SetFn) (v interface{}, disposer Derefer, err error)
 }
 
 type ParamsWithDisposal struct {
@@ -57,7 +58,7 @@ func (s *shardedCacheWithDisposal) Name() string {
 	return s.name
 }
 
-func (s *shardedCacheWithDisposal) GetOrSet(k interface{}, setFn SetFn) (interface{}, Derefer, error) {
+func (s *shardedCacheWithDisposal) GetOrSet(ctx context.Context, k interface{}, setFn SetFn) (interface{}, Derefer, error) {
 	hash := maphash.Hash{}
 	hash.SetSeed(s.Seed)
 	// (Explicitly ignore return value from hash.WriteString: its godoc says "it always
@@ -65,7 +66,7 @@ func (s *shardedCacheWithDisposal) GetOrSet(k interface{}, setFn SetFn) (interfa
 	// io.StringWriter."
 	_, _ = hash.WriteString(fmt.Sprintf("%+#v", k))
 	hashVal := hash.Sum64() % uint64(len(s.Shards))
-	return s.Shards[hashVal].GetOrSet(k, setFn)
+	return s.Shards[hashVal].GetOrSet(ctx, k, setFn)
 }
 
 // SingleThreadedCacheWithDisposal is a CacheWithDisposal that uses a single critical section
@@ -127,7 +128,7 @@ func NewSingleThreadedCacheWithDisposal(p ParamsWithDisposal) *SingleThreadedCac
 	return ret
 }
 
-func (c *SingleThreadedCacheWithDisposal) GetOrSet(k interface{}, setFn SetFn) (interface{}, Derefer, error) {
+func (c *SingleThreadedCacheWithDisposal) GetOrSet(ctx context.Context, k interface{}, setFn SetFn) (interface{}, Derefer, error) {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 	var entry *cacheEntry

--- a/cache/reference_counted_test.go
+++ b/cache/reference_counted_test.go
@@ -1,6 +1,7 @@
 package cache_test
 
 import (
+	"context"
 	"fmt"
 	"sync"
 	"sync/atomic"
@@ -22,6 +23,7 @@ func TestCacheWithDisposal(t *testing.T) {
 		disposed int32
 		live     int32
 	}
+	ctx := context.Background()
 	var elements [size]*record
 	ch := make(chan error, parallelism*2)
 	allErrs := make(chan []error)
@@ -60,6 +62,7 @@ func TestCacheWithDisposal(t *testing.T) {
 			for j := 0; j < repeats; j++ {
 				k := j % size
 				v, release, err := c.GetOrSet(
+					ctx,
 					k, func() (interface{}, error) {
 						e := &record{
 							key:      k,

--- a/graveler/sstable/cache.go
+++ b/graveler/sstable/cache.go
@@ -111,7 +111,7 @@ type namespaceID struct {
 }
 
 func (c *lruCache) GetOrOpen(ctx context.Context, namespace string, id committed.ID) (*sstable.Reader, Derefer, error) {
-	e, derefer, err := c.c.GetOrSet(namespaceID{namespace, id}, func() (interface{}, error) {
+	e, derefer, err := c.c.GetOrSet(ctx, namespaceID{namespace, id}, func() (interface{}, error) {
 		r, err := c.open(ctx, namespace, string(id))
 		if err != nil {
 			return nil, fmt.Errorf("open SSTable %s after fetch from next tier: %w", id, err)

--- a/logging/logger.go
+++ b/logging/logger.go
@@ -52,7 +52,10 @@ type logrusEntryWrapper struct {
 }
 
 func (l *logrusEntryWrapper) WithContext(ctx context.Context) Logger {
-	return &logrusEntryWrapper{l.e.WithContext(ctx)}
+	return addFromContext(
+		&logrusEntryWrapper{l.e.WithContext(ctx)},
+		ctx,
+	)
 }
 
 func (l *logrusEntryWrapper) WithField(key string, value interface{}) Logger {
@@ -151,14 +154,17 @@ func Default() Logger {
 	}
 }
 
-func FromContext(ctx context.Context) Logger {
-	log := Default()
+func addFromContext(log Logger, ctx context.Context) Logger {
 	fields := ctx.Value(LogFieldsContextKey)
-	if fields != nil {
-		loggerFields := fields.(Fields)
-		return log.WithFields(loggerFields)
+	if fields == nil {
+		return log
 	}
-	return log
+	loggerFields := fields.(Fields)
+	return log.WithFields(loggerFields)
+}
+
+func FromContext(ctx context.Context) Logger {
+	return addFromContext(Default(), ctx)
 }
 
 func AddFields(ctx context.Context, fields Fields) context.Context {


### PR DESCRIPTION
:point_right:  **Pull after #1258.**

- Use context in `tier_fs`: pass it through `GetOrSet` commands.
- Use context in API controller: use the request context rather than the startup context at the time of creation.

This improves logs and allows cancellation, as well as being more Goful and correct.