### PR TITLE
Test per-range skip/enter in diff iterator

### DIFF
--- a/graveler/committed/apply_test.go
+++ b/graveler/committed/apply_test.go
@@ -25,7 +25,7 @@ func TestApplyAdd(t *testing.T) {
 	defer ctrl.Finish()
 
 	range2 := &committed.Range{ID: "two", MaxKey: committed.Key("dz")}
-	source := testutil.NewFakeIterator()
+	source := testutil.NewFakeIterator(t)
 	source.
 		AddRange(&committed.Range{ID: "one", MaxKey: committed.Key("cz")}).
 		AddValueRecords(makeV("a", "source:a"), makeV("c", "source:c")).
@@ -53,7 +53,7 @@ func TestApplyReplace(t *testing.T) {
 	defer ctrl.Finish()
 
 	range2 := &committed.Range{ID: "two", MaxKey: committed.Key("dz")}
-	source := testutil.NewFakeIterator()
+	source := testutil.NewFakeIterator(t)
 	source.
 		AddRange(&committed.Range{ID: "one", MaxKey: committed.Key("cz")}).
 		AddValueRecords(makeV("a", "source:a"), makeV("b", "source:b"), makeV("c", "source:c")).
@@ -81,7 +81,7 @@ func TestApplyDelete(t *testing.T) {
 	defer ctrl.Finish()
 
 	range2 := &committed.Range{ID: "two", MaxKey: committed.Key("dz")}
-	source := testutil.NewFakeIterator()
+	source := testutil.NewFakeIterator(t)
 	source.
 		AddRange(&committed.Range{ID: "one", MaxKey: committed.Key("cz")}).
 		AddValueRecords(makeV("a", "source:a"), makeV("b", "source:b"), makeV("c", "source:c")).
@@ -107,7 +107,7 @@ func TestApplyCopiesLeftoverDiffs(t *testing.T) {
 	defer ctrl.Finish()
 
 	range2 := &committed.Range{ID: "two", MaxKey: committed.Key("dz")}
-	source := testutil.NewFakeIterator()
+	source := testutil.NewFakeIterator(t)
 	source.
 		AddRange(&committed.Range{ID: "one", MaxKey: committed.Key("cz")}).
 		AddValueRecords(makeV("a", "source:a"), makeV("b", "source:b"), makeV("c", "source:c")).
@@ -137,7 +137,7 @@ func TestApplyCopiesLeftoverSources(t *testing.T) {
 	range1 := &committed.Range{ID: "one", MaxKey: committed.Key("cz")}
 	range2 := &committed.Range{ID: "two", MaxKey: committed.Key("dz")}
 	range4 := &committed.Range{ID: "four", MaxKey: committed.Key("hz")}
-	source := testutil.NewFakeIterator()
+	source := testutil.NewFakeIterator(t)
 	source.
 		AddRange(range1).
 		AddValueRecords(makeV("a", "source:a"), makeV("b", "source:b"), makeV("c", "source:c")).

--- a/graveler/committed/merge_iterator_test.go
+++ b/graveler/committed/merge_iterator_test.go
@@ -120,7 +120,7 @@ func TestMerge(t *testing.T) {
 		t.Run(name, func(t *testing.T) {
 			diffIt := testutil.NewDiffIter(tst.diffs)
 			defer diffIt.Close()
-			base := makeBaseIterator(tst.baseKeys)
+			base := makeBaseIterator(t, tst.baseKeys)
 			it, err := committed.NewMergeIterator(diffIt, base)
 			if err != nil {
 				t.Fatalf("unexpected error: %s", err)
@@ -170,7 +170,7 @@ func TestMergeSeek(t *testing.T) {
 	}
 	diffIt := testutil.NewDiffIter(diffs)
 	baseKeys := []string{"k2", "k3", "k4", "k6"}
-	base := makeBaseIterator(baseKeys)
+	base := makeBaseIterator(t, baseKeys)
 	it, err := committed.NewMergeIterator(diffIt, base)
 	if err != nil {
 		t.Fatalf("unexpected error: %s", err)
@@ -265,8 +265,8 @@ func TestMergeSeek(t *testing.T) {
 	}
 }
 
-func makeBaseIterator(keys []string) *testutil.FakeIterator {
-	base := testutil.NewFakeIterator()
+func makeBaseIterator(t testing.TB, keys []string) *testutil.FakeIterator {
+	base := testutil.NewFakeIterator(t)
 	if len(keys) == 0 {
 		return base
 	}


### PR DESCRIPTION
By explicitly forbidding diff iterator from entering some ranges we can be more explicit what
should happen where.  Indeed, this hints at a bug (marked) that a range is needlessly entered
after SeekGE.