### PR TITLE
Check if tracing logs are emitted before constructing costly loggers

### DIFF
--- a/cloud/aws/s3inventory/orc_utils.go
+++ b/cloud/aws/s3inventory/orc_utils.go
@@ -85,7 +85,7 @@ func downloadRange(ctx context.Context, svc s3iface.S3API, logger logging.Logger
 				"download_from_bucket": bucket,
 				"download_from_key":    key,
 				"download_to":          f.Name(),
-			}).Trace("error when downloading orc file")
+			}).Debug("error when downloading orc file")
 		return nil, err
 	}
 	logger.Debugf("finished downloading %s to local file %s", key, f.Name())

--- a/httputil/tracing.go
+++ b/httputil/tracing.go
@@ -132,14 +132,16 @@ func TracingMiddleware(requestIDHeaderName string, fields logging.Fields, next h
 
 		next.ServeHTTP(responseWriter, r) // handle the request
 
-		logging.FromContext(r.Context()).WithFields(logging.Fields{
-			"took":             time.Since(startTime),
-			"status_code":      responseWriter.StatusCode,
-			"sent_bytes":       responseWriter.ResponseSize,
-			"request_body":     requestBodyTracer.bodyRecorder.Buffer,
-			"request_headers":  r.Header,
-			"response_body":    presentBody(responseWriter.BodyRecorder.Buffer),
-			"response_headers": responseWriter.Header(),
-		}).Trace("HTTP call ended")
+		if logging.Default().IsTracing() {
+			logging.FromContext(r.Context()).WithFields(logging.Fields{
+				"took":             time.Since(startTime),
+				"status_code":      responseWriter.StatusCode,
+				"sent_bytes":       responseWriter.ResponseSize,
+				"request_body":     requestBodyTracer.bodyRecorder.Buffer,
+				"request_headers":  r.Header,
+				"response_body":    presentBody(responseWriter.BodyRecorder.Buffer),
+				"response_headers": responseWriter.Header(),
+			}).Trace("HTTP call ended")
+		}
 	})
 }

--- a/logging/dummy.go
+++ b/logging/dummy.go
@@ -84,6 +84,10 @@ func (d DummyLogger) Panicf(format string, args ...interface{}) {
 
 }
 
+func (d DummyLogger) IsTracing() bool {
+	return true
+}
+
 func Dummy() Logger {
 	return DummyLogger{}
 }

--- a/logging/logger.go
+++ b/logging/logger.go
@@ -45,6 +45,7 @@ type Logger interface {
 	Errorf(format string, args ...interface{})
 	Fatalf(format string, args ...interface{})
 	Panicf(format string, args ...interface{})
+	IsTracing() bool
 }
 
 type logrusEntryWrapper struct {
@@ -132,6 +133,10 @@ func (l *logrusEntryWrapper) Fatalf(format string, args ...interface{}) {
 
 func (l *logrusEntryWrapper) Panicf(format string, args ...interface{}) {
 	l.e.Panicf(format, args...)
+}
+
+func (l *logrusEntryWrapper) IsTracing() bool {
+	return l.e.Level < logrus.TraceLevel
 }
 
 type logrusCallerFormatter struct {

--- a/stats/sender.go
+++ b/stats/sender.go
@@ -94,18 +94,22 @@ func (s *HTTPSender) SendEvent(ctx context.Context, installationID, processID st
 type dummySender struct{}
 
 func (s *dummySender) SendEvent(_ context.Context, installationID, processID string, metrics []Metric) error {
-	logging.Default().WithFields(logging.Fields{
-		"installation_id": installationID,
-		"process_id":      processID,
-		"metrics":         spew.Sdump(metrics),
-	}).Trace("dummy sender received metrics")
+	if logging.Default().IsTracing() {
+		logging.Default().WithFields(logging.Fields{
+			"installation_id": installationID,
+			"process_id":      processID,
+			"metrics":         spew.Sdump(metrics),
+		}).Trace("dummy sender received metrics")
+	}
 	return nil
 }
 
 func (s *dummySender) UpdateMetadata(ctx context.Context, m Metadata) error {
-	logging.Default().WithFields(logging.Fields{
-		"metadata": spew.Sdump(m),
-	}).Trace("dummy sender received metadata")
+	if logging.Default().IsTracing() {
+		logging.Default().WithFields(logging.Fields{
+			"metadata": spew.Sdump(m),
+		}).Trace("dummy sender received metadata")
+	}
 	return nil
 }
 


### PR DESCRIPTION
Rules for putting something inside `if log.Tracing() ...`:
* Calls to `.Tracef` or `.Trace` with parameters, especially if any parameters require
  computation (but we should not be using `log.*f` at all
* Calls to `.With*()`, they construct a new logger

* Plain calls to `.Trace` need not be wrapped, that's the only thing that they do.