### PR TITLE
Fix metarange and range cache params mixup, and boost caches sizes

### DIFF
--- a/catalog/rocks/entry_catalog.go
+++ b/catalog/rocks/entry_catalog.go
@@ -111,11 +111,11 @@ func NewEntryCatalog(cfg *config.Config, db db.Database) (*EntryCatalog, error) 
 
 	pebbleSSTableCache := pebble.NewCache(tierFSParams.PebbleSSTableCacheSizeBytes)
 	defer pebbleSSTableCache.Unref()
-	metaRangeCache := sstable.NewCache(*cfg.GetCommittedRangeSSTableCacheParams(),
-		metaRangeFS,
-		pebblesst.ReaderOptions{Cache: pebbleSSTableCache})
-	rangeCache := sstable.NewCache(*cfg.GetCommittedMetaRangeSSTableCacheParams(),
+	rangeCache := sstable.NewCache(*cfg.GetCommittedRangeSSTableCacheParams(),
 		rangeFS,
+		pebblesst.ReaderOptions{Cache: pebbleSSTableCache})
+	metaRangeCache := sstable.NewCache(*cfg.GetCommittedMetaRangeSSTableCacheParams(),
+		metaRangeFS,
 		pebblesst.ReaderOptions{Cache: pebbleSSTableCache})
 
 	sstableManager := sstable.NewPebbleSSTableRangeManager(rangeCache, rangeFS, hashAlg)

--- a/config/config.go
+++ b/config/config.go
@@ -38,10 +38,10 @@ const (
 	DefaultCommittedLocalCacheMetaRangePercent      = 0.1
 	DefaultCommittedLocalCacheBytes                 = 1 * 1024 * 1024 * 1024
 	DefaultCommittedLocalCacheDir                   = "~/lakefs/local_tier"
-	DefaultCommittedMetaRangeReaderCacheSize        = 20
-	DefaultCommittedMetaRangeReaderNumShards        = 6
-	DefaultCommittedRangeReaderCacheSize            = 100
-	DefaultCommittedRangeReaderNumShards            = 12
+	DefaultCommittedMetaRangeReaderCacheSize        = 50
+	DefaultCommittedMetaRangeReaderNumShards        = 10
+	DefaultCommittedRangeReaderCacheSize            = 500
+	DefaultCommittedRangeReaderNumShards            = 30
 	DefaultCommittedPebbleSSTableCacheSizeBytes     = 200_000_000
 	DefaultCommittedBlockStoragePrefix              = "_lakefs"
 	DefaultCommittedPermanentMinRangeSizeBytes      = 0


### PR DESCRIPTION
Was mixing them up, and they're really rather small.