### PR TITLE
Control number of concurrent range writer uploaders

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -108,8 +108,8 @@ const (
 	CommittedLocalCacheSizeBytesKey             = "committed.local_cache.size_bytes"
 	CommittedLocalCacheDirKey                   = "committed.local_cache.dir"
 	CommittedLocalCacheNumUploadersKey          = "committed.local_cache.max_uploaders_per_writer"
-	CommittedLocalCacheRangeProportion          = "committed.local_cache.range_proportion"
-	CommittedLocalCacheMetaRangeProportion      = "committed.local_cache.metarange_proportion"
+	CommittedLocalCacheRangeProportionKey       = "committed.local_cache.range_proportion"
+	CommittedLocalCacheMetaRangeProportionKey   = "committed.local_cache.metarange_proportion"
 	CommittedBlockStoragePrefixKey              = "committed.block_storage_prefix"
 	CommittedPermanentStorageMinRangeSizeKey    = "committed.permanent.min_range_size_bytes"
 	CommittedPermanentStorageMaxRangeSizeKey    = "committed.permanent.max_range_size_bytes"
@@ -149,8 +149,8 @@ func setDefaults() {
 	viper.SetDefault(CommittedLocalCacheSizeBytesKey, DefaultCommittedLocalCacheBytes)
 	viper.SetDefault(CommittedLocalCacheDirKey, DefaultCommittedLocalCacheDir)
 	viper.SetDefault(CommittedLocalCacheNumUploadersKey, DefaultCommittedLocalCacheNumUploaders)
-	viper.SetDefault(CommittedLocalCacheRangeProportion, DefaultCommittedLocalCacheRangePercent)
-	viper.SetDefault(CommittedLocalCacheMetaRangeProportion, DefaultCommittedLocalCacheMetaRangePercent)
+	viper.SetDefault(CommittedLocalCacheRangeProportionKey, DefaultCommittedLocalCacheRangePercent)
+	viper.SetDefault(CommittedLocalCacheMetaRangeProportionKey, DefaultCommittedLocalCacheMetaRangePercent)
 
 	viper.SetDefault(CommittedBlockStoragePrefixKey, DefaultCommittedBlockStoragePrefix)
 	viper.SetDefault(CommittedPermanentStorageMinRangeSizeKey, DefaultCommittedPermanentMinRangeSizeBytes)
@@ -371,8 +371,8 @@ func (c *Config) GetCommittedTierFSParams() (*pyramidparams.ExtParams, error) {
 	if err != nil {
 		return nil, fmt.Errorf("build block adapter: %w", err)
 	}
-	rangePro := viper.GetFloat64(CommittedLocalCacheRangeProportion)
-	metaRangePro := viper.GetFloat64(CommittedLocalCacheMetaRangeProportion)
+	rangePro := viper.GetFloat64(CommittedLocalCacheRangeProportionKey)
+	metaRangePro := viper.GetFloat64(CommittedLocalCacheMetaRangeProportionKey)
 
 	if math.Abs(rangePro+metaRangePro-1) > floatSumTolerance {
 		return nil, fmt.Errorf("range_proportion(%f) and metarange_proportion(%f): %w", rangePro, metaRangePro, ErrInvalidProportion)

--- a/config/config.go
+++ b/config/config.go
@@ -37,6 +37,7 @@ const (
 	DefaultCommittedLocalCacheBytes                 = 1 * 1024 * 1024 * 1024
 	DefaultCommittedLocalCacheDir                   = "~/data/lakefs/cache"
 	DefaultCommittedPebbleSSTableCacheSizeBytes     = 400_000_000
+	DefaultCommittedLocalCacheNumUploaders          = 10
 	DefaultCommittedBlockStoragePrefix              = "_lakefs"
 	DefaultCommittedPermanentMinRangeSizeBytes      = 0
 	DefaultCommittedPermanentMaxRangeSizeBytes      = 20 * 1024 * 1024
@@ -104,11 +105,11 @@ const (
 	BlockstoreS3StreamingChunkTimeoutKey = "blockstore.s3.streaming_chunk_timeout"
 	BlockstoreS3MaxRetriesKey            = "blockstore.s3.max_retries"
 
-	CommittedLocalCacheSizeBytesKey        = "committed.local_cache.size_bytes"
-	CommittedLocalCacheDirKey              = "committed.local_cache.dir"
-	CommittedLocalCacheRangeProportion     = "committed.local_cache.range_proportion"
-	CommittedLocalCacheMetaRangeProportion = "committed.local_cache.metarange_proportion"
-
+	CommittedLocalCacheSizeBytesKey             = "committed.local_cache.size_bytes"
+	CommittedLocalCacheDirKey                   = "committed.local_cache.dir"
+	CommittedLocalCacheNumUploadersKey          = "committed.local_cache.max_uploaders_per_writer"
+	CommittedLocalCacheRangeProportion          = "committed.local_cache.range_proportion"
+	CommittedLocalCacheMetaRangeProportion      = "committed.local_cache.metarange_proportion"
 	CommittedBlockStoragePrefixKey              = "committed.block_storage_prefix"
 	CommittedPermanentStorageMinRangeSizeKey    = "committed.permanent.min_range_size_bytes"
 	CommittedPermanentStorageMaxRangeSizeKey    = "committed.permanent.max_range_size_bytes"
@@ -147,6 +148,7 @@ func setDefaults() {
 
 	viper.SetDefault(CommittedLocalCacheSizeBytesKey, DefaultCommittedLocalCacheBytes)
 	viper.SetDefault(CommittedLocalCacheDirKey, DefaultCommittedLocalCacheDir)
+	viper.SetDefault(CommittedLocalCacheNumUploadersKey, DefaultCommittedLocalCacheNumUploaders)
 	viper.SetDefault(CommittedLocalCacheRangeProportion, DefaultCommittedLocalCacheRangePercent)
 	viper.SetDefault(CommittedLocalCacheMetaRangeProportion, DefaultCommittedLocalCacheMetaRangePercent)
 
@@ -403,6 +405,7 @@ func (c *Config) GetCommittedParams() *committed.Params {
 		MinRangeSizeBytes:          viper.GetUint64(CommittedPermanentStorageMinRangeSizeKey),
 		MaxRangeSizeBytes:          viper.GetUint64(CommittedPermanentStorageMaxRangeSizeKey),
 		RangeSizeEntriesRaggedness: viper.GetFloat64(CommittedPermanentStorageRangeRaggednessKey),
+		MaxUploaders:               viper.GetInt(CommittedLocalCacheNumUploadersKey),
 	}
 }
 

--- a/graveler/committed/batch.go
+++ b/graveler/committed/batch.go
@@ -10,21 +10,28 @@ type ResultCloser interface {
 }
 
 type BatchCloser struct {
+	// mu protects results and error
+	mu      sync.Mutex
 	results []WriteResult
 	err     error
 
 	wg sync.WaitGroup
 
-	// lock locks any access to the results and error
-	lock sync.Mutex
+	ch chan ResultCloser
 }
 
 // NewBatchCloser returns a new BatchCloser
-func NewBatchCloser() *BatchCloser {
-	return &BatchCloser{
-		wg:   sync.WaitGroup{},
-		lock: sync.Mutex{},
+func NewBatchCloser(numClosers int) *BatchCloser {
+	ret := &BatchCloser{
+		// Block when all closer goroutines are busy.
+		ch: make(chan ResultCloser),
 	}
+
+	for i := 0; i < numClosers; i++ {
+		go ret.handleClose()
+	}
+
+	return ret
 }
 
 var (
@@ -35,8 +42,8 @@ var (
 // Any writes executed to the writer after this call are not guaranteed to succeed.
 // If Wait() has already been called, returns an error.
 func (bc *BatchCloser) CloseWriterAsync(w ResultCloser) error {
-	bc.lock.Lock()
-	defer bc.lock.Unlock()
+	bc.mu.Lock()
+	defer bc.mu.Unlock()
 
 	if bc.err != nil {
 		// Don't accept new writers if previous error occurred.
@@ -45,9 +52,15 @@ func (bc *BatchCloser) CloseWriterAsync(w ResultCloser) error {
 	}
 
 	bc.wg.Add(1)
-	go bc.closeWriter(w)
+	bc.ch <- w
 
 	return nil
+}
+
+func (bc *BatchCloser) handleClose() {
+	for w := range bc.ch {
+		bc.closeWriter(w)
+	}
 }
 
 func (bc *BatchCloser) closeWriter(w ResultCloser) {
@@ -55,8 +68,8 @@ func (bc *BatchCloser) closeWriter(w ResultCloser) {
 	res, err := w.Close()
 
 	// long operation is over, we can lock to have synchronized access to err and results
-	bc.lock.Lock()
-	defer bc.lock.Unlock()
+	bc.mu.Lock()
+	defer bc.mu.Unlock()
 
 	if err != nil {
 		if bc.nilErrOrMultipleCalls() {
@@ -69,22 +82,24 @@ func (bc *BatchCloser) closeWriter(w ResultCloser) {
 	bc.results = append(bc.results, *res)
 }
 
-// Wait returns when all Writers finished.
-// Any failure to close a single RangeWriter will return with a nil results slice and an error.
+// Wait returns when all Writers finished.  Returns a nil results slice and an error if *any*
+// RangeWriter failed to close and upload.
 func (bc *BatchCloser) Wait() ([]WriteResult, error) {
-	bc.lock.Lock()
+	bc.mu.Lock()
 	if bc.err != nil {
-		defer bc.lock.Unlock()
+		defer bc.mu.Unlock()
 		return nil, bc.err
 	}
 	bc.err = ErrMultipleWaitCalls
-	bc.lock.Unlock()
+	bc.mu.Unlock()
+
+	close(bc.ch)
 
 	bc.wg.Wait()
 
 	// all writers finished
-	bc.lock.Lock()
-	defer bc.lock.Unlock()
+	bc.mu.Lock()
+	defer bc.mu.Unlock()
 	if !bc.nilErrOrMultipleCalls() {
 		return nil, bc.err
 	}

--- a/graveler/committed/meta_range_manager.go
+++ b/graveler/committed/meta_range_manager.go
@@ -30,12 +30,17 @@ type metaRangeManager struct {
 	rangeManager RangeManager // For ranges
 }
 
-func NewMetaRangeManager(params Params, metaManager, rangeManager RangeManager) MetaRangeManager {
+var ErrNeedBatchClosers = errors.New("need at least 1 batch uploaded")
+
+func NewMetaRangeManager(params Params, metaManager, rangeManager RangeManager) (MetaRangeManager, error) {
+	if params.MaxUploaders < 1 {
+		return nil, fmt.Errorf("only %d async closers: %w", params.MaxUploaders, ErrNeedBatchClosers)
+	}
 	return &metaRangeManager{
 		params:       params,
 		metaManager:  metaManager,
 		rangeManager: rangeManager,
-	}
+	}, nil
 }
 
 func (m *metaRangeManager) Exists(ctx context.Context, ns graveler.StorageNamespace, id graveler.MetaRangeID) (bool, error) {

--- a/graveler/committed/meta_range_manager.go
+++ b/graveler/committed/meta_range_manager.go
@@ -20,6 +20,8 @@ type Params struct {
 	// the expected number of records after MinRangeSizeBytes at which to split the range
 	// -- ranges are split at the first key with hash divisible by this raggedness.
 	RangeSizeEntriesRaggedness float64
+	// MaxUploaders is the maximal number of uploaders to use in a single metarange writer.
+	MaxUploaders int
 }
 
 type metaRangeManager struct {

--- a/graveler/committed/meta_range_writer.go
+++ b/graveler/committed/meta_range_writer.go
@@ -79,12 +79,7 @@ func (w *GeneralMetaRangeWriter) WriteRecord(record graveler.ValueRecord) error 
 	return nil
 }
 
-var ErrNeedBatchClosers = errors.New("need at least 1 batch uploaded")
-
 func (w *GeneralMetaRangeWriter) closeCurrentRange() error {
-	if w.params.MaxUploaders < 1 {
-		return fmt.Errorf("only %d async closers: %w", w.params.MaxUploaders, ErrNeedBatchClosers)
-	}
 	if w.rangeWriter == nil {
 		return nil
 	}


### PR DESCRIPTION
Fixes #1319.

Requires replacing use of mock range writers with fake range writers!  Goroutines, go testing
and go mocks cannot work together: if a mock receives an unexpected parameter it cannot throw
an exception (because Go...), so it calls some `testing.t.Fa*`.  Unfortunately testing cannot
support failing in goroutines.