### PR TITLE
Compute applied diff summary and pass it out on cataloger merge

### DIFF
--- a/catalog/rocks/cataloger.go
+++ b/catalog/rocks/cataloger.go
@@ -556,7 +556,7 @@ func (c *cataloger) Revert(ctx context.Context, repository string, branch string
 	repositoryID := graveler.RepositoryID(repository)
 	branchID := graveler.BranchID(branch)
 	ref := graveler.Ref(reference)
-	_, err := c.EntryCatalog.Revert(ctx, repositoryID, branchID, ref, committer, fmt.Sprintf("Revert %s", reference), nil)
+	_, _, err := c.EntryCatalog.Revert(ctx, repositoryID, branchID, ref, committer, fmt.Sprintf("Revert %s", reference), nil)
 	return err
 }
 
@@ -606,7 +606,10 @@ func listDiffHelper(it EntryDiffIterator, limit int, after string) (catalog.Diff
 		if v.Path == afterPath {
 			continue
 		}
-		diff := newDifferenceFromEntryDiff(v)
+		diff, err := newDifferenceFromEntryDiff(v)
+		if err != nil {
+			return nil, false, fmt.Errorf("[I] %w", err)
+		}
 		diffs = append(diffs, diff)
 		if len(diffs) >= limit+1 {
 			break
@@ -628,7 +631,7 @@ func (c *cataloger) Merge(ctx context.Context, repository string, leftBranch str
 	leftRef := graveler.Ref(leftBranch)
 	rightBranchID := graveler.BranchID(rightBranch)
 	meta := graveler.Metadata(metadata)
-	commitID, err := c.EntryCatalog.Merge(ctx, repositoryID, leftRef, rightBranchID, committer, message, meta)
+	commitID, summary, err := c.EntryCatalog.Merge(ctx, repositoryID, leftRef, rightBranchID, committer, message, meta)
 	if errors.Is(err, graveler.ErrConflictFound) {
 		// for compatibility with old cataloger
 		return &catalog.MergeResult{
@@ -638,9 +641,18 @@ func (c *cataloger) Merge(ctx context.Context, repository string, leftBranch str
 	if err != nil {
 		return nil, err
 	}
+	count := make(map[catalog.DifferenceType]int)
+	if summary.Count != nil {
+		for k, v := range summary.Count {
+			kk, err := catalogDiffType(k)
+			if err != nil {
+				return nil, err
+			}
+			count[kk] = v
+		}
+	}
 	return &catalog.MergeResult{
-		// TODO(barak): require implementation by graveler's merge
-		Summary:   map[catalog.DifferenceType]int{},
+		Summary:   count,
 		Reference: commitID.String(),
 	}, nil
 }
@@ -691,18 +703,29 @@ func newCatalogEntryFromEntry(commonPrefix bool, path string, ent *Entry) catalo
 	return catEnt
 }
 
-func newDifferenceFromEntryDiff(v *EntryDiff) catalog.Difference {
-	var diff catalog.Difference
-	switch v.Type {
+var ErrUnknownDiffType = errors.New("unknown graveler difference type")
+
+func catalogDiffType(typ graveler.DiffType) (catalog.DifferenceType, error) {
+	switch typ {
 	case graveler.DiffTypeAdded:
-		diff.Type = catalog.DifferenceTypeAdded
+		return catalog.DifferenceTypeAdded, nil
 	case graveler.DiffTypeRemoved:
-		diff.Type = catalog.DifferenceTypeRemoved
+		return catalog.DifferenceTypeRemoved, nil
 	case graveler.DiffTypeChanged:
-		diff.Type = catalog.DifferenceTypeChanged
+		return catalog.DifferenceTypeChanged, nil
 	case graveler.DiffTypeConflict:
-		diff.Type = catalog.DifferenceTypeConflict
+		return catalog.DifferenceTypeConflict, nil
+	default:
+		return catalog.DifferenceTypeNone, fmt.Errorf("%d: %w", typ, ErrUnknownDiffType)
 	}
+}
+
+func newDifferenceFromEntryDiff(v *EntryDiff) (catalog.Difference, error) {
+	var (
+		diff catalog.Difference
+		err  error
+	)
 	diff.Entry = newCatalogEntryFromEntry(false, v.Path.String(), v.Entry)
-	return diff
+	diff.Type, err = catalogDiffType(v.Type)
+	return diff, err
 }

--- a/catalog/rocks/cataloger.go
+++ b/catalog/rocks/cataloger.go
@@ -29,6 +29,8 @@ const (
 	ListEntriesLimitMax      = 10000
 )
 
+var ErrUnknownDiffType = errors.New("unknown graveler difference type")
+
 func NewCataloger(db db.Database, cfg *config.Config) (catalog.Cataloger, error) {
 	entryCatalog, err := NewEntryCatalog(cfg, db)
 	if err != nil {
@@ -642,14 +644,12 @@ func (c *cataloger) Merge(ctx context.Context, repository string, leftBranch str
 		return nil, err
 	}
 	count := make(map[catalog.DifferenceType]int)
-	if summary.Count != nil {
-		for k, v := range summary.Count {
-			kk, err := catalogDiffType(k)
-			if err != nil {
-				return nil, err
-			}
-			count[kk] = v
+	for k, v := range summary.Count {
+		kk, err := catalogDiffType(k)
+		if err != nil {
+			return nil, err
 		}
+		count[kk] = v
 	}
 	return &catalog.MergeResult{
 		Summary:   count,
@@ -702,8 +702,6 @@ func newCatalogEntryFromEntry(commonPrefix bool, path string, ent *Entry) catalo
 	}
 	return catEnt
 }
-
-var ErrUnknownDiffType = errors.New("unknown graveler difference type")
 
 func catalogDiffType(typ graveler.DiffType) (catalog.DifferenceType, error) {
 	switch typ {

--- a/catalog/rocks/entry_catalog.go
+++ b/catalog/rocks/entry_catalog.go
@@ -346,7 +346,7 @@ func (e *EntryCatalog) ResetPrefix(ctx context.Context, repositoryID graveler.Re
 	return e.Store.ResetPrefix(ctx, repositoryID, branchID, keyPrefix)
 }
 
-func (e *EntryCatalog) Revert(ctx context.Context, repositoryID graveler.RepositoryID, branchID graveler.BranchID, ref graveler.Ref, committer string, message string, metadata graveler.Metadata) (graveler.CommitID, error) {
+func (e *EntryCatalog) Revert(ctx context.Context, repositoryID graveler.RepositoryID, branchID graveler.BranchID, ref graveler.Ref, committer string, message string, metadata graveler.Metadata) (graveler.CommitID, graveler.DiffSummary, error) {
 	if err := Validate([]ValidateArg{
 		{"repositoryID", repositoryID, ValidateRepositoryID},
 		{"branchID", branchID, ValidateBranchID},
@@ -354,12 +354,12 @@ func (e *EntryCatalog) Revert(ctx context.Context, repositoryID graveler.Reposit
 		{"committer", committer, ValidateRequiredString},
 		{"message", message, ValidateRequiredString},
 	}); err != nil {
-		return "", err
+		return "", graveler.DiffSummary{}, err
 	}
 	return e.Store.Revert(ctx, repositoryID, branchID, ref, committer, message, metadata)
 }
 
-func (e *EntryCatalog) Merge(ctx context.Context, repositoryID graveler.RepositoryID, from graveler.Ref, to graveler.BranchID, committer string, message string, metadata graveler.Metadata) (graveler.CommitID, error) {
+func (e *EntryCatalog) Merge(ctx context.Context, repositoryID graveler.RepositoryID, from graveler.Ref, to graveler.BranchID, committer string, message string, metadata graveler.Metadata) (graveler.CommitID, graveler.DiffSummary, error) {
 	if message == "" {
 		message = fmt.Sprintf("Merge '%s' into '%s'", from, to)
 	}
@@ -370,7 +370,7 @@ func (e *EntryCatalog) Merge(ctx context.Context, repositoryID graveler.Reposito
 		{"committer", committer, ValidateRequiredString},
 		{"message", message, ValidateRequiredString},
 	}); err != nil {
-		return "", err
+		return "", graveler.DiffSummary{}, err
 	}
 	return e.Store.Merge(ctx, repositoryID, from, to, committer, message, metadata)
 }

--- a/catalog/rocks/fake_graveler_test.go
+++ b/catalog/rocks/fake_graveler_test.go
@@ -159,11 +159,11 @@ func (g *FakeGraveler) ResetPrefix(ctx context.Context, repositoryID graveler.Re
 	panic("implement me")
 }
 
-func (g *FakeGraveler) Revert(_ context.Context, _ graveler.RepositoryID, _ graveler.BranchID, _ graveler.Ref, _, _ string, _ graveler.Metadata) (graveler.CommitID, error) {
+func (g *FakeGraveler) Revert(_ context.Context, _ graveler.RepositoryID, _ graveler.BranchID, _ graveler.Ref, _, _ string, _ graveler.Metadata) (graveler.CommitID, graveler.DiffSummary, error) {
 	panic("implement me")
 }
 
-func (g *FakeGraveler) Merge(ctx context.Context, repositoryID graveler.RepositoryID, from graveler.Ref, to graveler.BranchID, committer string, message string, metadata graveler.Metadata) (graveler.CommitID, error) {
+func (g *FakeGraveler) Merge(ctx context.Context, repositoryID graveler.RepositoryID, from graveler.Ref, to graveler.BranchID, committer string, message string, metadata graveler.Metadata) (graveler.CommitID, graveler.DiffSummary, error) {
 	panic("implement me")
 }
 

--- a/cmd/lakectl/cmd/merge.go
+++ b/cmd/lakectl/cmd/merge.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+	"github.com/treeverse/lakefs/api/gen/models"
 	"github.com/treeverse/lakefs/catalog"
 	"github.com/treeverse/lakefs/cmdutils"
 	"github.com/treeverse/lakefs/uri"
@@ -15,6 +16,18 @@ const (
 	mergeCmdMinArgs = 2
 	mergeCmdMaxArgs = 2
 )
+
+var mergeCreateTemplate = `Merged "{{.Merge.FromRef|yellow}}" into "{{.Merge.ToRef|yellow}}".
+
+Added: {{.Summary.Added}}
+Changed: {{.Summary.Changed}}
+Removed: {{.Summary.Removed}}
+
+`
+
+type FromTo struct {
+	FromRef, ToRef string
+}
 
 // mergeCmd represents the merge command
 var mergeCmd = &cobra.Command{
@@ -43,7 +56,14 @@ var mergeCmd = &cobra.Command{
 		if err != nil {
 			DieErr(err)
 		}
-		_, _ = fmt.Printf("new: %d modified: %d removed: %d\n", result.Summary.Added, result.Summary.Changed, result.Summary.Removed)
+
+		Write(mergeCreateTemplate, struct {
+			Merge   FromTo
+			Summary *models.MergeResultSummary
+		}{
+			FromTo{FromRef: leftRefURI.Ref, ToRef: rightRefURI.Ref},
+			result.Summary,
+		})
 	},
 }
 

--- a/cmd/lakectl/cmd/merge.go
+++ b/cmd/lakectl/cmd/merge.go
@@ -37,12 +37,13 @@ var mergeCmd = &cobra.Command{
 
 		result, err := client.Merge(context.Background(), leftRefURI.Repository, leftRefURI.Ref, rightRefURI.Ref)
 		if errors.Is(err, catalog.ErrConflictFound) {
-			DieFmt("%d conflict(s) found\n", result.Summary.Conflict)
+			_, _ = fmt.Printf("Conflicts: %d\n", result.Summary.Conflict)
+			return
 		}
 		if err != nil {
 			DieErr(err)
 		}
-		fmt.Printf("Merged %s\n", result.Reference)
+		_, _ = fmt.Printf("new: %d modified: %d removed: %d\n", result.Summary.Added, result.Summary.Changed, result.Summary.Removed)
 	},
 }
 

--- a/cmd/lakectl/cmd/merge.go
+++ b/cmd/lakectl/cmd/merge.go
@@ -17,11 +17,11 @@ const (
 	mergeCmdMaxArgs = 2
 )
 
-var mergeCreateTemplate = `Merged "{{.Merge.FromRef|yellow}}" into "{{.Merge.ToRef|yellow}}".
+var mergeCreateTemplate = `Merged "{{.Merge.FromRef|yellow}}" into "{{.Merge.ToRef|yellow}}" to get "{{.Result.Reference|green}}".
 
-Added: {{.Summary.Added}}
-Changed: {{.Summary.Changed}}
-Removed: {{.Summary.Removed}}
+Added: {{.Result.Summary.Added}}
+Changed: {{.Result.Summary.Changed}}
+Removed: {{.Result.Summary.Removed}}
 
 `
 
@@ -58,11 +58,11 @@ var mergeCmd = &cobra.Command{
 		}
 
 		Write(mergeCreateTemplate, struct {
-			Merge   FromTo
-			Summary *models.MergeResultSummary
+			Merge  FromTo
+			Result *models.MergeResult
 		}{
 			FromTo{FromRef: leftRefURI.Ref, ToRef: rightRefURI.Ref},
-			result.Summary,
+			result,
 		})
 	},
 }

--- a/docs/assets/js/swagger.yml
+++ b/docs/assets/js/swagger.yml
@@ -127,6 +127,17 @@ definitions:
         x-nullable: true
         type: string
 
+  ref:
+    type: object
+    required:
+      - id
+      - commit_id
+    properties:
+      id:
+        type: string
+      commit_id:
+        type: string
+
   diff:
     type: object
     properties:
@@ -138,8 +149,11 @@ definitions:
       path_type:
         type: string
         enum: [ common_prefix, object ]
-
-  revert_creation:
+  diff_type: &DIFF_TYPE
+    type: string
+    enum: [two_dot, three_dot]
+    default: three_dot
+  reset_creation:
     type: object
     required:
       - type
@@ -168,6 +182,8 @@ definitions:
       creation_date:
         type: integer
         format: int64
+      meta_range_id:
+        type: string
       metadata:
         type: object
         additionalProperties:
@@ -204,6 +220,17 @@ definitions:
       name:
         type: string
       source:
+        type: string
+
+  tag_creation:
+    type: object
+    required:
+      - id
+      - ref
+    properties:
+      id:
+        type: string
+      ref:
         type: string
 
   error:
@@ -1312,6 +1339,121 @@ paths:
           schema:
             $ref: "#/definitions/error"
 
+  /repositories/{repository}/tags:
+    parameters:
+      - in: path
+        name: repository
+        required: true
+        type: string
+    get:
+      tags:
+        - tags
+      operationId: listTags
+      summary: list tags
+      parameters:
+        - in: query
+          name: after
+          type: string
+          default: ""
+        - in: query
+          name: amount
+          type: integer
+          default: 100
+      responses:
+        200:
+          description: tag list
+          schema:
+            type: object
+            properties:
+              pagination:
+                $ref: "#/definitions/pagination"
+              results:
+                type: array
+                items:
+                  $ref: "#/definitions/ref"
+        401:
+          $ref: "#/responses/Unauthorized"
+        default:
+          description: generic error response
+          schema:
+            $ref: "#/definitions/error"
+    post:
+      tags:
+        - tags
+      operationId: createTag
+      summary: create tag
+      parameters:
+        - in: body
+          name: tag
+          schema:
+            $ref: "#/definitions/tag_creation"
+      responses:
+        201:
+          description: tag
+          schema:
+            type: object
+            $ref: "#/definitions/ref"
+        400:
+          description: validation error
+          schema:
+            $ref: "#/definitions/error"
+        401:
+          $ref: "#/responses/Unauthorized"
+        default:
+          description: generic error response
+          schema:
+            $ref: "#/definitions/error"
+
+  /repositories/{repository}/tags/{tag}:
+    parameters:
+      - in: path
+        name: repository
+        required: true
+        type: string
+      - in: path
+        name: tag
+        required: true
+        type: string
+    get:
+      tags:
+        - tags
+      operationId: getTag
+      summary: get tag
+      responses:
+        200:
+          description: tag
+          schema:
+            type: object
+            $ref: "#/definitions/ref"
+        401:
+          $ref: "#/responses/Unauthorized"
+        404:
+          description: tag not found
+          schema:
+            $ref: "#/definitions/error"
+        default:
+          description: generic error response
+          schema:
+            $ref: "#/definitions/error"
+    delete:
+      tags:
+        - tags
+      operationId: deleteTag
+      summary: delete tag
+      responses:
+        204:
+          description: tag deleted successfully
+        401:
+          $ref: "#/responses/Unauthorized"
+        404:
+          description: branch not found
+          schema:
+            $ref: "#/definitions/error"
+        default:
+          description: generic error response
+          schema:
+            $ref: "#/definitions/error"
+
   /repositories/{repository}/branches:
     parameters:
       - in: path
@@ -1343,7 +1485,7 @@ paths:
               results:
                 type: array
                 items:
-                  type: string
+                  $ref: "#/definitions/ref"
         401:
           $ref: "#/responses/Unauthorized"
         default:
@@ -1468,7 +1610,8 @@ paths:
         200:
           description: branch
           schema:
-            type: string
+            type: object
+            $ref: "#/definitions/ref"
         401:
           $ref: "#/responses/Unauthorized"
         404:
@@ -1500,17 +1643,55 @@ paths:
     put:
       tags:
         - branches
-      operationId: revertBranch
-      summary: revert branch
+      operationId: resetBranch
+      summary: reset branch
+      parameters:
+        - in: body
+          name: reset
+          description: "reset parameters"
+          schema:
+            $ref: "#/definitions/reset_creation"
+      responses:
+        204:
+          description: reset successful
+        401:
+          $ref: "#/responses/Unauthorized"
+        404:
+          description: resource not found
+          schema:
+            $ref: "#/definitions/error"
+        default:
+          description: generic error response
+          schema:
+            $ref: "#/definitions/error"
+
+  /repositories/{repository}/branches/{branch}/revert:
+    parameters:
+      - in: path
+        name: repository
+        required: true
+        type: string
+      - in: path
+        name: branch
+        required: true
+        type: string
+    post:
+      tags:
+        - branches
+      operationId: revert
+      summary: revert
       parameters:
         - in: body
           name: revert
-          description: "revert parameters"
           schema:
-            $ref: "#/definitions/revert_creation"
+            type: object
+            properties:
+              ref:
+                type: string
+                description: the commit to revert, given by a ref
       responses:
         204:
-          description: reverted
+          description: revert successful
         401:
           $ref: "#/responses/Unauthorized"
         404:
@@ -1642,6 +1823,10 @@ paths:
         name: amount
         type: integer
         default: 100
+      - in: query
+        name: type
+        type: string
+        <<: *DIFF_TYPE
     get:
       tags:
         - refs
@@ -2169,4 +2354,3 @@ paths:
             $ref: "#/definitions/config"
         401:
           $ref: "#/responses/Unauthorized"
-

--- a/graveler/committed/apply.go
+++ b/graveler/committed/apply.go
@@ -14,6 +14,18 @@ type ApplyOptions struct {
 	AllowEmpty bool
 }
 
+func add(d *graveler.DiffSummary, typ graveler.DiffType, n int) {
+	if d.Count != nil {
+		d.Count[typ] += n
+	}
+}
+
+func inc(d *graveler.DiffSummary, typ graveler.DiffType) {
+	add(d, typ, 1)
+}
+
+// ReferenceType represents the type of the reference
+
 // applyFromSource applies all changes from source to writer.
 func applyFromSource(logger logging.Logger, writer MetaRangeWriter, source Iterator) error {
 	for {
@@ -50,12 +62,11 @@ func applyFromSource(logger logging.Logger, writer MetaRangeWriter, source Itera
 	return source.Err()
 }
 
-// applyFromDiffs applies all changes from diffs to writer and returns true if it made any
-// changes.
-func applyFromDiffs(logger logging.Logger, writer MetaRangeWriter, diffs graveler.ValueIterator) (bool, error) {
-	changed := false
+// applyFromDiffs applies all changes from diffs to writer and returns the number elements it
+// added.
+func applyFromDiffs(logger logging.Logger, writer MetaRangeWriter, diffs graveler.ValueIterator) (int, error) {
+	numAdded := 0
 	for {
-		changed = true
 		diffValue, haveDiffs := diffs.Value(), diffs.Next()
 		if diffValue.IsTombstone() {
 			// internal error but no data lost: deletion requested of a
@@ -71,17 +82,19 @@ func applyFromDiffs(logger logging.Logger, writer MetaRangeWriter, diffs gravele
 			}).Trace("write key from diffs at end")
 		}
 		if err := writer.WriteRecord(*diffValue); err != nil {
-			return false, fmt.Errorf("write added record: %w", err)
+			return 0, fmt.Errorf("write added record: %w", err)
 		}
+		numAdded++
 		if !haveDiffs {
 			break
 		}
 	}
-	return changed, nil
+	return numAdded, nil
 }
 
-func Apply(ctx context.Context, writer MetaRangeWriter, source Iterator, diffs graveler.ValueIterator, opts *ApplyOptions) error {
+func Apply(ctx context.Context, writer MetaRangeWriter, source Iterator, diffs graveler.ValueIterator, opts *ApplyOptions) (graveler.DiffSummary, error) {
 	logger := logging.FromContext(ctx)
+	ret := graveler.DiffSummary{Count: make(map[graveler.DiffType]int)}
 	haveSource, haveDiffs := source.Next(), diffs.Next()
 	changed := false
 	for haveSource && haveDiffs {
@@ -100,7 +113,7 @@ func Apply(ctx context.Context, writer MetaRangeWriter, source Iterator, diffs g
 				}
 
 				if err := writer.WriteRange(*sourceRange); err != nil {
-					return fmt.Errorf("copy source range %s: %w", sourceRange.ID, err)
+					return ret, fmt.Errorf("copy source range %s: %w", sourceRange.ID, err)
 				}
 				haveSource = source.NextRange()
 			} else {
@@ -119,12 +132,13 @@ func Apply(ctx context.Context, writer MetaRangeWriter, source Iterator, diffs g
 				}).Trace("write key from source")
 			}
 			if err := writer.WriteRecord(*sourceValue); err != nil {
-				return fmt.Errorf("write source record: %w", err)
+				return ret, fmt.Errorf("write source record: %w", err)
 			}
 		} else {
 			// select record from diffs, possibly (c==0) overwriting source
 			changed = true
-			if !diffValue.IsTombstone() {
+			switch {
+			case !diffValue.IsTombstone():
 				if logger.IsTracing() {
 					logger.WithFields(logging.Fields{
 						"key":       string(diffValue.Key),
@@ -133,12 +147,20 @@ func Apply(ctx context.Context, writer MetaRangeWriter, source Iterator, diffs g
 					}).Trace("write key from diffs")
 				}
 				if err := writer.WriteRecord(*diffValue); err != nil {
-					return fmt.Errorf("write added record: %w", err)
+					return ret, fmt.Errorf("write added record: %w", err)
 				}
-			} else if c > 0 {
+				diffType := graveler.DiffTypeAdded
+				if c == 0 {
+					diffType = graveler.DiffTypeChanged
+				}
+				inc(&ret, diffType)
+			case c > 0:
 				// internal error but no data lost: deletion requested of a
 				// file that was not there.
 				logger.WithField("id", string(diffValue.Identity)).Warn("[I] unmatched delete")
+			default:
+				// Delete: simply don't copy to output.
+				inc(&ret, graveler.DiffTypeRemoved)
 			}
 		}
 		if c >= 0 {
@@ -151,27 +173,28 @@ func Apply(ctx context.Context, writer MetaRangeWriter, source Iterator, diffs g
 		}
 	}
 	if err := source.Err(); err != nil {
-		return err
+		return ret, err
 	}
 	if err := diffs.Err(); err != nil {
-		return err
+		return ret, err
 	}
 	if haveSource {
 		if err := applyFromSource(logger, writer, source); err != nil {
-			return err
+			return ret, err
 		}
 	}
 
 	if haveDiffs {
-		diffsChanged, err := applyFromDiffs(logger, writer, diffs)
+		numAdded, err := applyFromDiffs(logger, writer, diffs)
 		if err != nil {
-			return err
+			return ret, err
 		}
-		changed = changed || diffsChanged
+		changed = changed || (numAdded > 0)
+		add(&ret, graveler.DiffTypeAdded, numAdded)
 	}
 
 	if !opts.AllowEmpty && !changed {
-		return graveler.ErrNoChanges
+		return ret, graveler.ErrNoChanges
 	}
-	return diffs.Err()
+	return ret, diffs.Err()
 }

--- a/graveler/committed/apply.go
+++ b/graveler/committed/apply.go
@@ -14,14 +14,14 @@ type ApplyOptions struct {
 	AllowEmpty bool
 }
 
-func add(d *graveler.DiffSummary, typ graveler.DiffType, n int) {
+func addIntoDiffSummary(d *graveler.DiffSummary, typ graveler.DiffType, n int) {
 	if d.Count != nil {
 		d.Count[typ] += n
 	}
 }
 
-func inc(d *graveler.DiffSummary, typ graveler.DiffType) {
-	add(d, typ, 1)
+func incrementDiffSummary(d *graveler.DiffSummary, typ graveler.DiffType) {
+	addIntoDiffSummary(d, typ, 1)
 }
 
 // ReferenceType represents the type of the reference
@@ -153,14 +153,14 @@ func Apply(ctx context.Context, writer MetaRangeWriter, source Iterator, diffs g
 				if c == 0 {
 					diffType = graveler.DiffTypeChanged
 				}
-				inc(&ret, diffType)
+				incrementDiffSummary(&ret, diffType)
 			case c > 0:
 				// internal error but no data lost: deletion requested of a
 				// file that was not there.
 				logger.WithField("id", string(diffValue.Identity)).Warn("[I] unmatched delete")
 			default:
 				// Delete: simply don't copy to output.
-				inc(&ret, graveler.DiffTypeRemoved)
+				incrementDiffSummary(&ret, graveler.DiffTypeRemoved)
 			}
 		}
 		if c >= 0 {
@@ -190,7 +190,7 @@ func Apply(ctx context.Context, writer MetaRangeWriter, source Iterator, diffs g
 			return ret, err
 		}
 		changed = changed || (numAdded > 0)
-		add(&ret, graveler.DiffTypeAdded, numAdded)
+		addIntoDiffSummary(&ret, graveler.DiffTypeAdded, numAdded)
 	}
 
 	if !opts.AllowEmpty && !changed {

--- a/graveler/committed/manager.go
+++ b/graveler/committed/manager.go
@@ -92,15 +92,15 @@ func (c *committedManager) Diff(ctx context.Context, ns graveler.StorageNamespac
 	return NewDiffIterator(leftIt, rightIt), nil
 }
 
-func (c *committedManager) Merge(ctx context.Context, ns graveler.StorageNamespace, theirs, ours, base graveler.MetaRangeID) (graveler.MetaRangeID, error) {
+func (c *committedManager) Merge(ctx context.Context, ns graveler.StorageNamespace, theirs, ours, base graveler.MetaRangeID) (graveler.MetaRangeID, graveler.DiffSummary, error) {
 	diffIt, err := c.Diff(ctx, ns, theirs, ours)
 	if err != nil {
-		return "", fmt.Errorf("diff: %w", err)
+		return "", graveler.DiffSummary{}, fmt.Errorf("diff: %w", err)
 	}
 	defer diffIt.Close()
 	baseIt, err := c.metaRangeManager.NewMetaRangeIterator(ctx, ns, base)
 	if err != nil {
-		return "", fmt.Errorf("get base iterator: %w", err)
+		return "", graveler.DiffSummary{}, fmt.Errorf("get base iterator: %w", err)
 	}
 	defer baseIt.Close()
 	patchIterator := NewMergeIterator(diffIt, baseIt)
@@ -108,7 +108,7 @@ func (c *committedManager) Merge(ctx context.Context, ns graveler.StorageNamespa
 	return c.Apply(ctx, ns, theirs, patchIterator)
 }
 
-func (c *committedManager) Apply(ctx context.Context, ns graveler.StorageNamespace, rangeID graveler.MetaRangeID, diffs graveler.ValueIterator) (graveler.MetaRangeID, error) {
+func (c *committedManager) Apply(ctx context.Context, ns graveler.StorageNamespace, rangeID graveler.MetaRangeID, diffs graveler.ValueIterator) (graveler.MetaRangeID, graveler.DiffSummary, error) {
 	mwWriter := c.metaRangeManager.NewWriter(ctx, ns)
 	defer func() {
 		err := mwWriter.Abort()
@@ -118,21 +118,21 @@ func (c *committedManager) Apply(ctx context.Context, ns graveler.StorageNamespa
 	}()
 	metaRangeIterator, err := c.metaRangeManager.NewMetaRangeIterator(ctx, ns, rangeID)
 	if err != nil {
-		return "", fmt.Errorf("get metarange ns=%s id=%s: %w", ns, rangeID, err)
+		return "", graveler.DiffSummary{}, fmt.Errorf("get metarange ns=%s id=%s: %w", ns, rangeID, err)
 	}
 	defer metaRangeIterator.Close()
-	err = Apply(ctx, mwWriter, metaRangeIterator, diffs, &ApplyOptions{})
+	summary, err := Apply(ctx, mwWriter, metaRangeIterator, diffs, &ApplyOptions{})
 	if err != nil {
 		if !errors.Is(err, graveler.ErrUserVisible) {
 			err = fmt.Errorf("apply ns=%s id=%s: %w", ns, rangeID, err)
 		}
-		return "", err
+		return "", graveler.DiffSummary{}, err
 	}
 	newID, err := mwWriter.Close()
 	if newID == nil {
-		return "", fmt.Errorf("close writer ns=%s id=%s: %w", ns, rangeID, err)
+		return "", graveler.DiffSummary{}, fmt.Errorf("close writer ns=%s id=%s: %w", ns, rangeID, err)
 	}
-	return *newID, err
+	return *newID, summary, err
 }
 
 func (c *committedManager) Compare(ctx context.Context, ns graveler.StorageNamespace, theirs, ours, base graveler.MetaRangeID) (graveler.DiffIterator, error) {

--- a/graveler/graveler.go
+++ b/graveler/graveler.go
@@ -1117,10 +1117,10 @@ func (g *Graveler) Revert(ctx context.Context, repositoryID RepositoryID, branch
 		}
 		return &CommitIDAndSummary{commitID, summary}, nil
 	})
-	c := res.(*CommitIDAndSummary)
 	if err != nil {
 		return "", DiffSummary{}, err
 	}
+	c := res.(*CommitIDAndSummary)
 	return c.ID, c.Summary, nil
 }
 
@@ -1171,10 +1171,10 @@ func (g *Graveler) Merge(ctx context.Context, repositoryID RepositoryID, from Re
 		}
 		return &CommitIDAndSummary{commitID, summary}, nil
 	})
-	c := res.(*CommitIDAndSummary)
 	if err != nil {
 		return "", DiffSummary{}, err
 	}
+	c := res.(*CommitIDAndSummary)
 	return c.ID, c.Summary, nil
 }
 

--- a/graveler/testutil/fakes.go
+++ b/graveler/testutil/fakes.go
@@ -23,6 +23,7 @@ type CommittedFake struct {
 	DiffIterator  graveler.DiffIterator
 	Err           error
 	MetaRangeID   graveler.MetaRangeID
+	DiffSummary   graveler.DiffSummary
 	AppliedData   AppliedData
 }
 
@@ -73,20 +74,20 @@ func (c *CommittedFake) Compare(context.Context, graveler.StorageNamespace, grav
 	return c.DiffIterator, nil
 }
 
-func (c *CommittedFake) Merge(_ context.Context, _ graveler.StorageNamespace, _, _, _ graveler.MetaRangeID) (graveler.MetaRangeID, error) {
+func (c *CommittedFake) Merge(_ context.Context, _ graveler.StorageNamespace, _, _, _ graveler.MetaRangeID) (graveler.MetaRangeID, graveler.DiffSummary, error) {
 	if c.Err != nil {
-		return "", c.Err
+		return "", graveler.DiffSummary{}, c.Err
 	}
-	return c.MetaRangeID, nil
+	return c.MetaRangeID, c.DiffSummary, nil
 }
 
-func (c *CommittedFake) Apply(_ context.Context, _ graveler.StorageNamespace, metaRangeID graveler.MetaRangeID, values graveler.ValueIterator) (graveler.MetaRangeID, error) {
+func (c *CommittedFake) Apply(_ context.Context, _ graveler.StorageNamespace, metaRangeID graveler.MetaRangeID, values graveler.ValueIterator) (graveler.MetaRangeID, graveler.DiffSummary, error) {
 	if c.Err != nil {
-		return "", c.Err
+		return "", graveler.DiffSummary{}, c.Err
 	}
 	c.AppliedData.Values = values
 	c.AppliedData.MetaRangeID = metaRangeID
-	return c.MetaRangeID, nil
+	return c.MetaRangeID, c.DiffSummary, nil
 }
 
 func (c *CommittedFake) WriteMetaRange(ctx context.Context, ns graveler.StorageNamespace, it graveler.ValueIterator) (*graveler.MetaRangeID, error) {


### PR DESCRIPTION
The summary is still thrown away for commits and for reverts, but _could_ be used there too (or to supply a status summary by passing a non-writing writer).

Fixes #1300.