### PR TITLE
Allow goroutines to run through end of branch locker test

### DIFF
--- a/graveler/errors.go
+++ b/graveler/errors.go
@@ -37,6 +37,7 @@ var (
 	ErrDirtyBranch             = errors.New("can't apply meta-range on dirty branch")
 	ErrMetaRangeNotFound       = errors.New("metarange not found")
 	ErrLockNotAcquired         = errors.New("lock not acquired")
+	ErrAlreadyLocked           = wrapError(ErrLockNotAcquired, "already locked")
 	ErrRevertMergeCommit       = errors.New("revert merge commit unsupported")
 )
 

--- a/graveler/ref/branch_locker.go
+++ b/graveler/ref/branch_locker.go
@@ -32,7 +32,7 @@ func (l *BranchLocker) Writer(ctx context.Context, repositoryID graveler.Reposit
 			return nil, fmt.Errorf("%w (%d): %s", graveler.ErrLockNotAcquired, writerLockKey, err)
 		}
 		if !locked {
-			return nil, fmt.Errorf("%w (%d)", graveler.ErrLockNotAcquired, writerLockKey)
+			return nil, fmt.Errorf("%w (%d)", graveler.ErrAlreadyLocked, writerLockKey)
 		}
 		return lockedFn()
 	}, db.WithContext(ctx), db.WithIsolationLevel(pgx.ReadCommitted))
@@ -51,7 +51,7 @@ func (l *BranchLocker) MetadataUpdater(ctx context.Context, repositoryID gravele
 			return nil, fmt.Errorf("%w (%d): %s", graveler.ErrLockNotAcquired, committerLockKey, err)
 		}
 		if !locked {
-			return nil, fmt.Errorf("%w (%d)", graveler.ErrLockNotAcquired, writerLockKey)
+			return nil, fmt.Errorf("%w (%d)", graveler.ErrAlreadyLocked, writerLockKey)
 		}
 		// lock writer key
 		_, err = tx.Exec(`SELECT pg_advisory_xact_lock($1);`, writerLockKey)


### PR DESCRIPTION
All `testing.Fa*` routines are dangerous because they leave goroutines running but call
`t.Finish()` routines.  That might deadlock the finish routine against a goroutine.  So
instead error rather than fatal out of the `committer_wait_for_writers` test.  Once the
test flakes out again, we may have more information.

Also emit `ErrAlreadyLocked` (which wraps `ErrLockNotAcquired`) if locking branch fails
because of existing lock.

Relevant to #1373 but does not fix it.