### PR TITLE
Try to generate some coverage for real with Nessie

### DIFF
--- a/.github/workflows/nessie.yaml
+++ b/.github/workflows/nessie.yaml
@@ -86,13 +86,13 @@ jobs:
           ECR_REPOSITORY_LAKEFS: lakefs
         run: |
           set +e
-          describe_image="$( aws ecr describe-images --repository-name $ECR_REPOSITORY_LAKEFS --image-ids imageTag=${{ steps.version.outputs.tag }})"
+          describe_image="$( aws ecr describe-images --repository-name $ECR_REPOSITORY_LAKEFS --image-ids imageTag=${{ steps.version.outputs.tag }}-cover)"
           if [ $? -eq 0 ]; then
             echo "Image exists"
           else
             echo "Image doesn't exist"
-            docker build -t $ECR_REGISTRY/$ECR_REPOSITORY_LAKEFS:${{ steps.version.outputs.tag }} --build-arg VERSION=${{ steps.version.outputs.tag }} .
-            docker push $ECR_REGISTRY/$ECR_REPOSITORY_LAKEFS:${{ steps.version.outputs.tag }}
+            docker build -t $ECR_REGISTRY/$ECR_REPOSITORY_LAKEFS:${{ steps.version.outputs.tag }}-cover --build-arg VERSION=${{ steps.version.outputs.tag }}-cover .
+            docker push $ECR_REGISTRY/$ECR_REPOSITORY_LAKEFS:${{ steps.version.outputs.tag }}-cover
           fi
 
   run-system:
@@ -145,7 +145,7 @@ jobs:
           NESSIE_STORAGE_NAMESPACE: s3://nessie-system-testing/${{ github.run_number }}-${{ matrix.cataloger }}
           NESSIE_AWS_ACCESS_KEY_ID: ${{ secrets.NESSIE_AWS_ACCESS_KEY_ID }}
           NESSIE_AWS_SECRET_ACCESS_KEY: ${{ secrets.NESSIE_AWS_SECRET_ACCESS_KEY }}
-        run: go test -v --coverprofile=nessie-s3-cover.out --cover ./nessie --system-tests
+        run: go test -v --system-tests
       - name: Check files in S3 bucket
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.NESSIE_AWS_ACCESS_KEY_ID }}
@@ -157,6 +157,10 @@ jobs:
         if: ${{ failure() }}
         continue-on-error: true
         run: docker-compose -f nessie/ops/docker-compose.yaml logs --tail=1000 lakefs
+      - name: Extract lakeFS coverage from container
+        run: |
+          docker cp lakefs:cov.out ./nessie-s3-cover.out
+        continue-on-error: true
       - name: Export DB
         if: ${{ always() }}
         env:
@@ -208,8 +212,12 @@ jobs:
         if: ${{ failure() }}
         continue-on-error: true
         run: docker-compose -f nessie/ops/docker-compose.yaml logs --tail=1000 lakefs
+      - name: Extract lakeFS coverage from container
+        run: |
+          docker cp lakefs:cov.out ./nessie-gs-cover.out
+        continue-on-error: true
       - name: Publish coverage
         uses: codecov/codecov-action@v1
         with:
-          files: nessie-s3-cover.out,nessie-s3-local-cover.out,nessie-gs-cover.out
+          files: nessie-s3-cover.out,nessie-gs-cover.out
           fail_ci_if_error: false

--- a/.github/workflows/nessie.yaml
+++ b/.github/workflows/nessie.yaml
@@ -86,13 +86,13 @@ jobs:
           ECR_REPOSITORY_LAKEFS: lakefs
         run: |
           set +e
-          describe_image="$( aws ecr describe-images --repository-name $ECR_REPOSITORY_LAKEFS --image-ids imageTag=${{ steps.version.outputs.tag }}-cover)"
+          describe_image="$( aws ecr describe-images --repository-name $ECR_REPOSITORY_LAKEFS --image-ids imageTag=${{ steps.version.outputs.tag }})"
           if [ $? -eq 0 ]; then
             echo "Image exists"
           else
             echo "Image doesn't exist"
-            docker build -t $ECR_REGISTRY/$ECR_REPOSITORY_LAKEFS:${{ steps.version.outputs.tag }}-cover --build-arg VERSION=${{ steps.version.outputs.tag }}-cover .
-            docker push $ECR_REGISTRY/$ECR_REPOSITORY_LAKEFS:${{ steps.version.outputs.tag }}-cover
+            docker build -t $ECR_REGISTRY/$ECR_REPOSITORY_LAKEFS:${{ steps.version.outputs.tag }} --build-arg VERSION=${{ steps.version.outputs.tag }} .
+            docker push $ECR_REGISTRY/$ECR_REPOSITORY_LAKEFS:${{ steps.version.outputs.tag }}
           fi
 
   run-system:

--- a/.github/workflows/nessie.yaml
+++ b/.github/workflows/nessie.yaml
@@ -145,7 +145,7 @@ jobs:
           NESSIE_STORAGE_NAMESPACE: s3://nessie-system-testing/${{ github.run_number }}-${{ matrix.cataloger }}
           NESSIE_AWS_ACCESS_KEY_ID: ${{ secrets.NESSIE_AWS_ACCESS_KEY_ID }}
           NESSIE_AWS_SECRET_ACCESS_KEY: ${{ secrets.NESSIE_AWS_SECRET_ACCESS_KEY }}
-        run: go test -v --system-tests
+        run: go test -v ./nessie --system-tests
       - name: Check files in S3 bucket
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.NESSIE_AWS_ACCESS_KEY_ID }}
@@ -187,7 +187,7 @@ jobs:
       - name: Run Nessie S3 with local API key
         env:
           NESSIE_STORAGE_NAMESPACE: s3://nessie-system-testing/${{ github.run_number }}-${{ matrix.cataloger }}-local-api-key
-        run: go test -v --coverprofile=nessie-s3-local-cover.out --cover ./nessie --system-tests --use-local-credentials
+        run: go test -v ./nessie --system-tests --use-local-credentials
       - name: Run lakeFS GS
         env:
           TAG: ${{ steps.version.outputs.tag }}
@@ -207,7 +207,7 @@ jobs:
       - name: Run Nessie GS
         env:
           NESSIE_STORAGE_NAMESPACE: gs://nessie-system-testing/${{ github.run_number }}-${{ matrix.cataloger }}
-        run: go test -v  --coverprofile=nessie-gs-cover.out --cover ./nessie --system-tests
+        run: go test -v ./nessie --system-tests
       - name: lakeFS Logs on GS failure
         if: ${{ failure() }}
         continue-on-error: true

--- a/.github/workflows/nessie.yaml
+++ b/.github/workflows/nessie.yaml
@@ -145,7 +145,7 @@ jobs:
           NESSIE_STORAGE_NAMESPACE: s3://nessie-system-testing/${{ github.run_number }}-${{ matrix.cataloger }}
           NESSIE_AWS_ACCESS_KEY_ID: ${{ secrets.NESSIE_AWS_ACCESS_KEY_ID }}
           NESSIE_AWS_SECRET_ACCESS_KEY: ${{ secrets.NESSIE_AWS_SECRET_ACCESS_KEY }}
-        run: go test -v ./nessie --system-tests
+        run: go test -v --coverprofile=nessie-s3-cover.out --cover ./nessie --system-tests
       - name: Check files in S3 bucket
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.NESSIE_AWS_ACCESS_KEY_ID }}
@@ -183,7 +183,7 @@ jobs:
       - name: Run Nessie S3 with local API key
         env:
           NESSIE_STORAGE_NAMESPACE: s3://nessie-system-testing/${{ github.run_number }}-${{ matrix.cataloger }}-local-api-key
-        run: go test -v ./nessie --system-tests --use-local-credentials --coverprofile=nessie-cover.out --cover
+        run: go test -v --coverprofile=nessie-s3-local-cover.out --cover ./nessie --system-tests --use-local-credentials
       - name: Run lakeFS GS
         env:
           TAG: ${{ steps.version.outputs.tag }}
@@ -203,7 +203,7 @@ jobs:
       - name: Run Nessie GS
         env:
           NESSIE_STORAGE_NAMESPACE: gs://nessie-system-testing/${{ github.run_number }}-${{ matrix.cataloger }}
-        run: go test -v ./nessie --system-tests
+        run: go test -v  --coverprofile=nessie-gs-cover.out --cover ./nessie --system-tests
       - name: lakeFS Logs on GS failure
         if: ${{ failure() }}
         continue-on-error: true
@@ -211,5 +211,5 @@ jobs:
       - name: Publish coverage
         uses: codecov/codecov-action@v1
         with:
-          files: ./nessie-cover.out
+          files: nessie-s3-cover.out,nessie-s3-local-cover.out,nessie-gs-cover.out
           fail_ci_if_error: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,9 @@ RUN go build -ldflags "-X github.com/treeverse/lakefs/config.Version=${VERSION}"
 RUN go build -ldflags "-X github.com/treeverse/lakefs/config.Version=${VERSION}" -o lakectl ./cmd/lakectl
 RUN go build -ldflags "-X github.com/treeverse/lakefs/config.Version=${VERSION}" -o benchmark-executor ./benchmarks
 
+# Build chimera that can collect coverage.  Run it with e.g. --test.coverprofile=out.cov.
+RUN go test -ldflags "-X github.com/treeverse/lakefs/config.Version=${VERSION}" -tags buildcover --coverpkg=github.com/treeverse/lakefs/... --cover  -c -o lakefs.cover ./cmd/lakefs
+
 # lakectl image
 FROM alpine:3.12.0 AS lakectl
 WORKDIR /app

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,7 +48,7 @@ RUN apk add netcat-openbsd
 WORKDIR /app
 COPY ./wait-for ./
 ENV PATH /app:$PATH
-COPY --from=build /build/lakefs /build/lakectl ./
+COPY --from=build /build/lakefs /build/lakefs.cover /build/lakectl ./
 
 EXPOSE 8000/tcp
 

--- a/cmd/lakefs/cover_test.go
+++ b/cmd/lakefs/cover_test.go
@@ -1,0 +1,14 @@
+// Helps generate coverage for main pretending it is really a test.  Otherwise NO COVERAGE FOR
+// YOU.  See https://blog.cloudflare.com/go-coverage-with-external-tests/
+//
+// +build buildcover
+
+package main
+
+import (
+	"testing"
+)
+
+func TestRunMain(*testing.T) {
+	main()
+}

--- a/nessie/ops/docker-compose.yaml
+++ b/nessie/ops/docker-compose.yaml
@@ -18,7 +18,7 @@ services:
       - LAKEFS_BLOCKSTORE_GS_CREDENTIALS_JSON
       - LAKEFS_STATS_ENABLED
       - LAKEFS_CATALOGER_TYPE
-    entrypoint: ["/app/wait-for", "postgres:5432", "--", "/app/lakefs", "run"]
+    entrypoint: ["/app/wait-for", "postgres:5432", "--", "/app/lakefs.cover", "run", "--test.coverprofile=cov.out"]
   postgres:
     image: "postgres:11"
     ports:


### PR DESCRIPTION
`go test` args should be sooner rather than later.  And might as well upload and merge _all_
Nessie tests -- interesting to see block adapter coverage, too!