### PR TITLE
Remove remove user local storage cache and fix UI cache

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -152,7 +152,7 @@ ui-build: $(UI_DIR)/node_modules  ## Build UI app
 	cd $(UI_DIR) && $(NPM) run build
 
 ui-bundle: ui-build go-install ## Bundle static built UI app
-	$(GOBINPATH)/statik -ns webui -m -f -src=$(UI_BUILD_DIR)
+	$(GOBINPATH)/statik -ns webui -f -src=$(UI_BUILD_DIR)
 
 gen-ui: ui-bundle
 

--- a/api/ui_handler.go
+++ b/api/ui_handler.go
@@ -24,21 +24,6 @@ type loginData struct {
 	AccessSecretKey string `json:"secret_access_key"`
 }
 
-var noCacheHeaders = map[string]string{
-	"Expires":         time.Unix(0, 0).Format(time.RFC1123),
-	"Cache-Control":   "no-store",
-	"X-Accel-Expires": "0",
-}
-
-func NoCache(h http.Handler) http.Handler {
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		for k, v := range noCacheHeaders {
-			w.Header().Set(k, v)
-		}
-		h.ServeHTTP(w, r)
-	})
-}
-
 func UIHandler(authService auth.Service) http.Handler {
 	mux := http.NewServeMux()
 
@@ -102,7 +87,7 @@ func UIHandler(authService auth.Service) http.Handler {
 	})
 
 	staticFiles, _ := fs.NewWithNamespace(statik.Webui)
-	mux.Handle("/", NoCache(HandlerWithDefault(staticFiles, http.FileServer(staticFiles), "/")))
+	mux.Handle("/", HandlerWithDefault(staticFiles, http.FileServer(staticFiles), "/"))
 	return mux
 }
 

--- a/api/ui_handler.go
+++ b/api/ui_handler.go
@@ -26,24 +26,22 @@ type loginData struct {
 
 var noCacheHeaders = map[string]string{
 	"Expires":         time.Unix(0, 0).Format(time.RFC1123),
-	"Cache-Control":   "no-cache, private, max-age=0",
-	"Pragma":          "no-cache",
+	"Cache-Control":   "no-store",
 	"X-Accel-Expires": "0",
 }
 
 func NoCache(h http.Handler) http.Handler {
-	fn := func(w http.ResponseWriter, r *http.Request) {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		for k, v := range noCacheHeaders {
 			w.Header().Set(k, v)
 		}
 		h.ServeHTTP(w, r)
-	}
-	return http.HandlerFunc(fn)
+	})
 }
 
 func UIHandler(authService auth.Service) http.Handler {
 	mux := http.NewServeMux()
-	staticFiles, _ := fs.NewWithNamespace(statik.Webui)
+
 	mux.HandleFunc("/auth/login", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			w.WriteHeader(http.StatusMethodNotAllowed)
@@ -87,6 +85,7 @@ func UIHandler(authService auth.Service) http.Handler {
 			SameSite: http.SameSiteStrictMode,
 		})
 	})
+
 	mux.HandleFunc("/auth/logout", func(w http.ResponseWriter, r *http.Request) {
 		if r.Method != http.MethodPost {
 			w.WriteHeader(http.StatusMethodNotAllowed)
@@ -101,6 +100,8 @@ func UIHandler(authService auth.Service) http.Handler {
 			SameSite: http.SameSiteStrictMode,
 		})
 	})
+
+	staticFiles, _ := fs.NewWithNamespace(statik.Webui)
 	mux.Handle("/", NoCache(HandlerWithDefault(staticFiles, http.FileServer(staticFiles), "/")))
 	return mux
 }

--- a/webui/src/store/auth.js
+++ b/webui/src/store/auth.js
@@ -1,4 +1,3 @@
-
 import {
     AUTH_LOGIN,
     AUTH_LOGOUT,
@@ -29,17 +28,8 @@ import {
 
 import * as async from "./async";
 
-
-
-const hydrateUser = () => {
-    if (window.localStorage['user'] !== undefined) {
-        return JSON.parse(window.localStorage['user']);
-    }
-    return null;
-};
-
 const initialState = {
-    user: hydrateUser(),
+    user: null,
     loginError: null,
     redirectTo: null,
     usersList: async.initialState,
@@ -107,8 +97,6 @@ const store = (state = initialState, action) => {
                 loginError: action.error,
             };
         case AUTH_LOGIN.success:
-            // also save to localstorage
-            window.localStorage['user'] = JSON.stringify({...action.payload.user, accessKeyId: action.payload.accessKeyId}, null, "");
             return {
                 ...state,
                 user: {...action.payload.user, accessKeyId: action.payload.accessKeyId},
@@ -116,7 +104,6 @@ const store = (state = initialState, action) => {
                 loginError: null,
             };
         case AUTH_LOGOUT.success:
-            window.localStorage.removeItem('user');
             return {
                 ...initialState,
                 user: null,


### PR DESCRIPTION
Fix #1356
Fix #1357

- On every page load we load the user auth, removed the cache in order to get an error in case the user is no login valid, and redirect to the login page is required. When the data was cache, the API calls got a 403, and the default alert UI popup appeared.
- WebUI static resources should be embedded using the file modification time to handle proper cache by the browser.