### PR TITLE
added a stage object operation to the API to allow adding arbitrary object metadata

### DIFF
--- a/api/client.go
+++ b/api/client.go
@@ -82,6 +82,7 @@ type RepositoryClient interface {
 	ListObjects(ctx context.Context, repository, ref, prefix, from string, amount int) ([]*models.ObjectStats, *models.Pagination, error)
 	GetObject(ctx context.Context, repository, ref, path string, w io.Writer) (*objects.GetObjectOK, error)
 	UploadObject(ctx context.Context, repository, branchID, path string, r io.Reader) (*models.ObjectStats, error)
+	StageObject(ctx context.Context, repository, branchID, path string, stats *models.ObjectStats) (*models.ObjectStats, error)
 	DeleteObject(ctx context.Context, repository, branchID, path string) error
 
 	DiffRefs(ctx context.Context, repository, leftRef, rightRef string, after string, amount int) ([]*models.Diff, *models.Pagination, error)
@@ -710,6 +711,20 @@ func (c *client) GetObject(ctx context.Context, repoID, ref, path string, writer
 		return nil, err
 	}
 	return resp, nil
+}
+
+func (c *client) StageObject(ctx context.Context, repoID, branchID, path string, stats *models.ObjectStats) (*models.ObjectStats, error) {
+	resp, err := c.remote.Objects.StageObject(&objects.StageObjectParams{
+		Branch:     branchID,
+		Path:       path,
+		Repository: repoID,
+		Stats:      stats,
+		Context:    ctx,
+	}, c.auth)
+	if err != nil {
+		return nil, err
+	}
+	return resp.GetPayload(), nil
 }
 
 func (c *client) UploadObject(ctx context.Context, repoID, branchID, path string, r io.Reader) (*models.ObjectStats, error) {

--- a/api/client.go
+++ b/api/client.go
@@ -82,7 +82,7 @@ type RepositoryClient interface {
 	ListObjects(ctx context.Context, repository, ref, prefix, from string, amount int) ([]*models.ObjectStats, *models.Pagination, error)
 	GetObject(ctx context.Context, repository, ref, path string, w io.Writer) (*objects.GetObjectOK, error)
 	UploadObject(ctx context.Context, repository, branchID, path string, r io.Reader) (*models.ObjectStats, error)
-	StageObject(ctx context.Context, repository, branchID, path string, stats *models.ObjectStats) (*models.ObjectStats, error)
+	StageObject(ctx context.Context, repository, branchID, path string, object *models.ObjectStageCreation) (*models.ObjectStats, error)
 	DeleteObject(ctx context.Context, repository, branchID, path string) error
 
 	DiffRefs(ctx context.Context, repository, leftRef, rightRef string, after string, amount int) ([]*models.Diff, *models.Pagination, error)
@@ -713,12 +713,12 @@ func (c *client) GetObject(ctx context.Context, repoID, ref, path string, writer
 	return resp, nil
 }
 
-func (c *client) StageObject(ctx context.Context, repoID, branchID, path string, stats *models.ObjectStats) (*models.ObjectStats, error) {
+func (c *client) StageObject(ctx context.Context, repoID, branchID, path string, object *models.ObjectStageCreation) (*models.ObjectStats, error) {
 	resp, err := c.remote.Objects.StageObject(&objects.StageObjectParams{
 		Branch:     branchID,
 		Path:       path,
 		Repository: repoID,
-		Stats:      stats,
+		Object:     object,
 		Context:    ctx,
 	}, c.auth)
 	if err != nil {

--- a/api/controller.go
+++ b/api/controller.go
@@ -1547,6 +1547,9 @@ func (c *Controller) ObjectsStageObjectHandler() objects.StageObjectHandler {
 			Size:            swag.Int64Value(params.Object.SizeBytes),
 			Checksum:        swag.StringValue(params.Object.Checksum),
 		}
+		if len(params.Object.Metadata) > 0 {
+			entry.Metadata = params.Object.Metadata
+		}
 
 		err = cataloger.CreateEntry(deps.ctx, repo.Name, params.Branch, entry)
 		if errors.Is(err, db.ErrNotFound) {

--- a/api/controller.go
+++ b/api/controller.go
@@ -1546,7 +1546,6 @@ func (c *Controller) ObjectsStageObjectHandler() objects.StageObjectHandler {
 			CreationDate:    writeTime,
 			Size:            swag.Int64Value(params.Object.SizeBytes),
 			Checksum:        swag.StringValue(params.Object.Checksum),
-			Metadata:        params.Object.Metadata,
 		}
 
 		err = cataloger.CreateEntry(deps.ctx, repo.Name, params.Branch, entry)

--- a/api/controller_test.go
+++ b/api/controller_test.go
@@ -1219,10 +1219,9 @@ func TestController_ObjectsStageObjectHandler(t *testing.T) {
 			WithRepository("repo1").
 			WithBranch("master").
 			WithPath("foo/bar").
-			WithStats(&models.ObjectStats{
-				Checksum:        "afb0689fe58b82c5f762991453edbbec",
-				Path:            "foo/bar",
-				PhysicalAddress: "s3://another-bucket/some/location",
+			WithObject(&models.ObjectStageCreation{
+				Checksum:        swag.String("afb0689fe58b82c5f762991453edbbec"),
+				PhysicalAddress: swag.String("s3://another-bucket/some/location"),
 				SizeBytes:       swag.Int64(38),
 			}), bauth)
 
@@ -1254,10 +1253,9 @@ func TestController_ObjectsStageObjectHandler(t *testing.T) {
 			WithRepository("repo1").
 			WithBranch("master1234").
 			WithPath("foo/bar").
-			WithStats(&models.ObjectStats{
-				Checksum:        "afb0689fe58b82c5f762991453edbbec",
-				Path:            "foo/bar",
-				PhysicalAddress: "s3://another-bucket/some/location",
+			WithObject(&models.ObjectStageCreation{
+				Checksum:        swag.String("afb0689fe58b82c5f762991453edbbec"),
+				PhysicalAddress: swag.String("s3://another-bucket/some/location"),
 				SizeBytes:       swag.Int64(38),
 			}), bauth)
 		if _, ok := err.(*objects.StageObjectNotFound); !ok {
@@ -1270,10 +1268,9 @@ func TestController_ObjectsStageObjectHandler(t *testing.T) {
 			WithRepository("repo1").
 			WithBranch("master1234").
 			WithPath("foo/bar").
-			WithStats(&models.ObjectStats{
-				Checksum:        "afb0689fe58b82c5f762991453edbbec",
-				Path:            "foo/bar",
-				PhysicalAddress: "gs://another-bucket/some/location",
+			WithObject(&models.ObjectStageCreation{
+				Checksum:        swag.String("afb0689fe58b82c5f762991453edbbec"),
+				PhysicalAddress: swag.String("gs://another-bucket/some/location"),
 				SizeBytes:       swag.Int64(38),
 			}), bauth)
 		if _, ok := err.(*objects.StageObjectBadRequest); !ok {

--- a/api/controller_test.go
+++ b/api/controller_test.go
@@ -1201,6 +1201,87 @@ func TestController_ObjectsUploadObjectHandler(t *testing.T) {
 	})
 }
 
+func TestController_ObjectsStageObjectHandler(t *testing.T) {
+	clt, deps := setupClient(t, "s3")
+
+	// create user
+	creds := createDefaultAdminUser(t, clt)
+	bauth := httptransport.BasicAuth(creds.AccessKeyID, creds.AccessSecretKey)
+
+	ctx := context.Background()
+	_, err := deps.cataloger.CreateRepository(ctx, "repo1", "s3://bucket/prefix", "master")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("stage object", func(t *testing.T) {
+		resp, err := clt.Objects.StageObject(objects.NewStageObjectParams().
+			WithRepository("repo1").
+			WithBranch("master").
+			WithPath("foo/bar").
+			WithStats(&models.ObjectStats{
+				Checksum:        "afb0689fe58b82c5f762991453edbbec",
+				Path:            "foo/bar",
+				PhysicalAddress: "s3://another-bucket/some/location",
+				SizeBytes:       swag.Int64(38),
+			}), bauth)
+
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if swag.Int64Value(resp.Payload.SizeBytes) != 38 {
+			t.Fatalf("expected 38 bytes to be written, got back %d", resp.Payload.SizeBytes)
+		}
+
+		// get back info
+		got, err := clt.Objects.StatObject(objects.NewStatObjectParams().
+			WithRepository("repo1").
+			WithRef("master").
+			WithPath("foo/bar"), bauth)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if got.Payload.PhysicalAddress != "s3://another-bucket/some/location" {
+			t.Fatalf("unexpected physical address: %s", got.Payload.PhysicalAddress)
+		}
+	})
+
+	t.Run("upload object missing branch", func(t *testing.T) {
+
+		_, err := clt.Objects.StageObject(objects.NewStageObjectParams().
+			WithRepository("repo1").
+			WithBranch("master1234").
+			WithPath("foo/bar").
+			WithStats(&models.ObjectStats{
+				Checksum:        "afb0689fe58b82c5f762991453edbbec",
+				Path:            "foo/bar",
+				PhysicalAddress: "s3://another-bucket/some/location",
+				SizeBytes:       swag.Int64(38),
+			}), bauth)
+		if _, ok := err.(*objects.StageObjectNotFound); !ok {
+			t.Fatal("Missing branch should return not found")
+		}
+	})
+
+	t.Run("wrong storage adapter", func(t *testing.T) {
+		_, err := clt.Objects.StageObject(objects.NewStageObjectParams().
+			WithRepository("repo1").
+			WithBranch("master1234").
+			WithPath("foo/bar").
+			WithStats(&models.ObjectStats{
+				Checksum:        "afb0689fe58b82c5f762991453edbbec",
+				Path:            "foo/bar",
+				PhysicalAddress: "gs://another-bucket/some/location",
+				SizeBytes:       swag.Int64(38),
+			}), bauth)
+		if _, ok := err.(*objects.StageObjectBadRequest); !ok {
+			t.Fatal("Wrong storage adapter should return 400")
+		}
+	})
+}
+
 func TestController_ObjectsDeleteObjectHandler(t *testing.T) {
 	clt, deps := setupClient(t, "")
 

--- a/api/controller_test.go
+++ b/api/controller_test.go
@@ -1248,7 +1248,6 @@ func TestController_ObjectsStageObjectHandler(t *testing.T) {
 	})
 
 	t.Run("upload object missing branch", func(t *testing.T) {
-
 		_, err := clt.Objects.StageObject(objects.NewStageObjectParams().
 			WithRepository("repo1").
 			WithBranch("master1234").

--- a/api/controller_test.go
+++ b/api/controller_test.go
@@ -1199,6 +1199,22 @@ func TestController_ObjectsUploadObjectHandler(t *testing.T) {
 			t.Fatal("Missing branch should return not found")
 		}
 	})
+
+	t.Run("upload object missing repo", func(t *testing.T) {
+		buf := new(bytes.Buffer)
+		buf.WriteString("hello world this is my awesome content")
+		_, err := clt.Objects.UploadObject(
+			objects.NewUploadObjectParamsWithTimeout(timeout).
+				WithBranch("master").
+				WithContent(runtime.NamedReader("content", buf)).
+				WithPath("foo/bar").
+				WithRepository("repo55555"),
+			bauth)
+		if _, ok := err.(*objects.UploadObjectNotFound); !ok {
+			t.Fatal("Missing branch should return not found")
+		}
+	})
+
 }
 
 func TestController_ObjectsStageObjectHandler(t *testing.T) {

--- a/block/namespace.go
+++ b/block/namespace.go
@@ -22,21 +22,9 @@ var (
 	ErrInvalidNamespace = errors.New("invalid namespace")
 )
 
-type QualifiedKey struct {
-	StorageType      StorageType
-	StorageNamespace string
-	Key              string
-}
-
-type QualifiedPrefix struct {
-	StorageType      StorageType
-	StorageNamespace string
-	Prefix           string
-}
-
-func (qk QualifiedKey) Format() string {
+func (s StorageType) String() string {
 	scheme := ""
-	switch qk.StorageType {
+	switch s {
 	case StorageTypeMem:
 		scheme = "mem"
 	case StorageTypeLocal:
@@ -50,8 +38,23 @@ func (qk QualifiedKey) Format() string {
 	default:
 		panic("unknown storage type")
 	}
+	return scheme
+}
 
-	return fmt.Sprintf("%s://%s", scheme, path.Join(qk.StorageNamespace, qk.Key))
+type QualifiedKey struct {
+	StorageType      StorageType
+	StorageNamespace string
+	Key              string
+}
+
+type QualifiedPrefix struct {
+	StorageType      StorageType
+	StorageNamespace string
+	Prefix           string
+}
+
+func (qk QualifiedKey) Format() string {
+	return fmt.Sprintf("%s://%s", qk.StorageType, path.Join(qk.StorageNamespace, qk.Key))
 }
 
 func GetStorageType(namespaceURL *url.URL) (StorageType, error) {

--- a/cmd/lakectl/cmd/fs.go
+++ b/cmd/lakectl/cmd/fs.go
@@ -159,6 +159,36 @@ var fsUploadCmd = &cobra.Command{
 	},
 }
 
+var fsStageCmd = &cobra.Command{
+	Use:    "stage <path uri>",
+	Short:  "stage an object at the specified URI",
+	Hidden: true,
+	Args: cmdutils.ValidationChain(
+		cobra.ExactArgs(1),
+		cmdutils.FuncValidator(0, uri.ValidatePathURI),
+	),
+	Run: func(cmd *cobra.Command, args []string) {
+		client := getClient()
+		pathURI := uri.Must(uri.Parse(args[0]))
+		size, _ := cmd.Flags().GetInt64("size")
+		location, _ := cmd.Flags().GetString("location")
+		cksum, _ := cmd.Flags().GetString("checksum")
+
+		stat, err := client.StageObject(context.Background(), pathURI.Repository, pathURI.Ref, pathURI.Path, &models.ObjectStats{
+			Checksum:        cksum,
+			Path:            pathURI.Path,
+			PathType:        models.ObjectStatsPathTypeObject,
+			PhysicalAddress: location,
+			SizeBytes:       swag.Int64(size),
+		})
+		if err != nil {
+			DieErr(err)
+		}
+
+		Write(fsStatTemplate, stat)
+	},
+}
+
 var fsRmCmd = &cobra.Command{
 	Use:   "rm <path uri>",
 	Short: "delete object",
@@ -189,9 +219,17 @@ func init() {
 	fsCmd.AddCommand(fsListCmd)
 	fsCmd.AddCommand(fsCatCmd)
 	fsCmd.AddCommand(fsUploadCmd)
+	fsCmd.AddCommand(fsStageCmd)
 	fsCmd.AddCommand(fsRmCmd)
 
 	fsUploadCmd.Flags().StringP("source", "s", "", "local file to upload, or \"-\" for stdin")
 	fsUploadCmd.Flags().BoolP("recursive", "r", false, "recursively copy all files under local source")
 	_ = fsUploadCmd.MarkFlagRequired("source")
+
+	fsStageCmd.Flags().String("location", "", "fully qualified storage location (i.e. \"s3://bucket/path/to/object\")")
+	fsStageCmd.Flags().Int64("size", 0, "Object size in bytes")
+	fsStageCmd.Flags().String("checksum", "", "Object MD5 checksum as a hexadecimal string")
+	_ = fsStageCmd.MarkFlagRequired("location")
+	_ = fsStageCmd.MarkFlagRequired("size")
+	_ = fsStageCmd.MarkFlagRequired("checksum")
 }

--- a/cmd/lakectl/cmd/fs.go
+++ b/cmd/lakectl/cmd/fs.go
@@ -173,12 +173,18 @@ var fsStageCmd = &cobra.Command{
 		size, _ := cmd.Flags().GetInt64("size")
 		location, _ := cmd.Flags().GetString("location")
 		checksum, _ := cmd.Flags().GetString("checksum")
+		meta, metaErr := getKV(cmd, "meta")
 
-		stat, err := client.StageObject(context.Background(), pathURI.Repository, pathURI.Ref, pathURI.Path, &models.ObjectStageCreation{
+		obj := &models.ObjectStageCreation{
 			Checksum:        swag.String(checksum),
 			PhysicalAddress: swag.String(location),
 			SizeBytes:       swag.Int64(size),
-		})
+		}
+		if metaErr == nil {
+			obj.Metadata = meta
+		}
+
+		stat, err := client.StageObject(context.Background(), pathURI.Repository, pathURI.Ref, pathURI.Path, obj)
 		if err != nil {
 			DieErr(err)
 		}
@@ -227,6 +233,7 @@ func init() {
 	fsStageCmd.Flags().String("location", "", "fully qualified storage location (i.e. \"s3://bucket/path/to/object\")")
 	fsStageCmd.Flags().Int64("size", 0, "Object size in bytes")
 	fsStageCmd.Flags().String("checksum", "", "Object MD5 checksum as a hexadecimal string")
+	fsStageCmd.Flags().StringSlice("meta", []string{}, "key value pairs in the form of key=value")
 
 	_ = fsStageCmd.MarkFlagRequired("location")
 	_ = fsStageCmd.MarkFlagRequired("size")

--- a/docs/assets/js/swagger.yml
+++ b/docs/assets/js/swagger.yml
@@ -134,6 +134,10 @@ definitions:
       size_bytes:
         type: integer
         format: int64
+      metadata:
+        type: object
+        additionalProperties:
+          type: string
 
   underlying_object_properties:
     type: object

--- a/docs/assets/js/swagger.yml
+++ b/docs/assets/js/swagger.yml
@@ -115,9 +115,25 @@ definitions:
       size_bytes:
         type: integer
         format: int64
+        x-nullable: true
       path_type:
         type: string
         enum: [ common_prefix, object ]
+
+  object_stage_creation:
+    type: object
+    required:
+      - physical_address
+      - checksum
+      - size_bytes
+    properties:
+      physical_address:
+        type: string
+      checksum:
+        type: string
+      size_bytes:
+        type: integer
+        format: int64
 
   underlying_object_properties:
     type: object
@@ -1909,6 +1925,40 @@ paths:
           schema:
             $ref: "#/definitions/error"
 
+  /repositories/{repository}/commits/{commitId}/runs:
+    parameters:
+      - in: path
+        name: repository
+        required: true
+        type: string
+      - in: path
+        name: commitId
+        required: true
+        type: string
+    get:
+      tags:
+        - commits
+      operationId: listCommitRuns
+      summary: list commit runs
+      responses:
+        200:
+          description: list action runs
+          schema:
+            type: array
+            items:
+              $ref: "#/definitions/action_run"
+        401:
+          $ref: "#/responses/Unauthorized"
+        404:
+          description: commit not found
+          schema:
+            $ref: "#/definitions/error"
+        default:
+          description: generic error response
+          schema:
+            $ref: "#/definitions/error"
+
+
   /repositories/{repository}/refs/{ref}/objects:
     parameters:
       - in: path
@@ -1975,6 +2025,36 @@ paths:
         name: path
         required: true
         type: string
+
+    put:
+      tags:
+        - objects
+      operationId: stageObject
+      summary: stage an object's metadata for the given branch
+      parameters:
+        - in: body
+          name: object
+          schema:
+            $ref: "#/definitions/object_stage_creation"
+      responses:
+        201:
+          description: object metadata
+          schema:
+            $ref: "#/definitions/object_stats"
+        400:
+          description: invalid object metadata
+          schema:
+            $ref: "#/definitions/error"
+        401:
+          $ref: "#/responses/Unauthorized"
+        404:
+          description: repository or branch not found
+          schema:
+            $ref: "#/definitions/error"
+        default:
+          description: generic error response
+          schema:
+            $ref: "#/definitions/error"
     post:
       tags:
         - objects
@@ -2339,14 +2419,6 @@ paths:
           description: run hook output
           schema:
             type: file
-          headers:
-            Content-Length:
-              type: integer
-              format: int64
-            Last-Modified:
-              type: string
-            Content-Disposition:
-              type: string
         401:
           $ref: "#/responses/Unauthorized"
         404:

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1404,7 +1404,7 @@ lakectl fs rm <path uri> [flags]
 **note:** This command is a lakeFS plumbing command. Don't use it unless you're really sure you know what you're doing.
 {: .note .note-warning }
 
-stage an object at the specified URI
+stages a reference to an existing object, to be managed in lakeFS
 
 ```
 lakectl fs stage <path uri> [flags]

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -60,6 +60,205 @@ lakectl is a CLI tool allowing exploration and manipulation of a lakeFS environm
 
 
 
+### lakectl abuse
+
+**note:** This command is a lakeFS plumbing command. Don't use it unless you're really sure you know what you're doing.
+{: .note .note-warning }
+
+abuse a running lakeFS instance. See sub commands for more info.
+
+#### Options
+
+```
+  -h, --help   help for abuse
+```
+
+
+
+### lakectl abuse create-branches
+
+Create a lot of branches very quickly.
+
+```
+lakectl abuse create-branches <source ref uri> [flags]
+```
+
+#### Options
+
+```
+      --amount int             amount of things to do (default 1000000)
+      --branch-prefix string   prefix to create branches under (default "abuse-")
+      --clean-only             only clean up past runs
+  -h, --help                   help for create-branches
+      --parallelism int        amount of things to do in parallel (default 100)
+```
+
+
+
+### lakectl abuse help
+
+Help about any command
+
+#### Synopsis
+
+Help provides help for any command in the application.
+Simply type abuse help [path to command] for full details.
+
+```
+lakectl abuse help [command] [flags]
+```
+
+#### Options
+
+```
+  -h, --help   help for help
+```
+
+
+
+### lakectl abuse random-read
+
+Read keys from a file and generate random reads from the source ref for those keys.
+
+```
+lakectl abuse random-read <source ref uri> [flags]
+```
+
+#### Options
+
+```
+      --amount int         amount of reads to do (default 1000000)
+      --from-file string   read keys from this file ("-" for stdin)
+  -h, --help               help for random-read
+      --parallelism int    amount of reads to do in parallel (default 100)
+```
+
+
+
+### lakectl actions
+
+Manage Actions commands
+
+#### Options
+
+```
+  -h, --help   help for actions
+```
+
+
+
+### lakectl actions help
+
+Help about any command
+
+#### Synopsis
+
+Help provides help for any command in the application.
+Simply type actions help [path to command] for full details.
+
+```
+lakectl actions help [command] [flags]
+```
+
+#### Options
+
+```
+  -h, --help   help for help
+```
+
+
+
+### lakectl actions runs
+
+Explore runs information
+
+#### Options
+
+```
+  -h, --help   help for runs
+```
+
+
+
+### lakectl actions runs describe
+
+Describe run results
+
+#### Synopsis
+
+Show information about the run and all the hooks that were executed as part of the run
+
+```
+lakectl actions runs describe [flags]
+```
+
+#### Examples
+
+```
+lakectl actions runs describe lakefs://<repository> <run_id>
+```
+
+#### Options
+
+```
+      --after string   show results after this value (used for pagination)
+      --amount int     how many results to return, or '-1' for default (used for pagination) (default -1)
+  -h, --help           help for describe
+```
+
+
+
+### lakectl actions runs help
+
+Help about any command
+
+#### Synopsis
+
+Help provides help for any command in the application.
+Simply type runs help [path to command] for full details.
+
+```
+lakectl actions runs help [command] [flags]
+```
+
+#### Options
+
+```
+  -h, --help   help for help
+```
+
+
+
+### lakectl actions runs list
+
+List runs
+
+#### Synopsis
+
+List all runs on a repository optional filter by branch or commit
+
+```
+lakectl actions runs list [flags]
+```
+
+#### Examples
+
+```
+lakectl actions runs list lakefs://<repository> [--branch <branch>] [--commit <commit_id>]
+```
+
+#### Options
+
+```
+      --after string    show results after this value (used for pagination)
+      --amount int      how many results to return, or '-1' for default (used for pagination) (default -1)
+      --branch string   show results for specific branch
+      --commit string   show results for specific commit ID
+  -h, --help            help for list
+```
+
+
+
 ### lakectl auth
 
 manage authentication and authorization
@@ -863,7 +1062,7 @@ lakectl branch list lakefs://<repository>
 
 ```
       --after string   show results after this value (used for pagination)
-      --amount int     how many results to return, or-1 for all results (used for pagination) (default -1)
+      --amount int     how many results to return, or '-1' for default (used for pagination) (default -1)
   -h, --help           help for list
 ```
 
@@ -927,6 +1126,31 @@ lakectl branch show <branch uri> [flags]
 
 ```
   -h, --help   help for show
+```
+
+
+
+### lakectl cat-hook-output
+
+**note:** This command is a lakeFS plumbing command. Don't use it unless you're really sure you know what you're doing.
+{: .note .note-warning }
+
+Cat actions hook output
+
+```
+lakectl cat-hook-output [flags]
+```
+
+#### Examples
+
+```
+lakectl cat-hook-output lakefs://<repository> <run_id> <run_hook_id>
+```
+
+#### Options
+
+```
+  -h, --help   help for cat-hook-output
 ```
 
 
@@ -1175,6 +1399,28 @@ lakectl fs rm <path uri> [flags]
 
 
 
+### lakectl fs stage
+
+**note:** This command is a lakeFS plumbing command. Don't use it unless you're really sure you know what you're doing.
+{: .note .note-warning }
+
+stage an object at the specified URI
+
+```
+lakectl fs stage <path uri> [flags]
+```
+
+#### Options
+
+```
+      --checksum string   Object MD5 checksum as a hexadecimal string
+  -h, --help              help for stage
+      --location string   fully qualified storage location (i.e. "s3://bucket/path/to/object")
+      --size int          Object size in bytes
+```
+
+
+
 ### lakectl fs stat
 
 view object metadata
@@ -1242,7 +1488,7 @@ lakectl log <branch uri> [flags]
 
 ```
       --after string         show results after this value (used for pagination)
-      --amount int           how many results to return, or-1 for all results (used for pagination) (default -1)
+      --amount int           how many results to return, or '-1' for default (used for pagination) (default -1)
   -h, --help                 help for log
       --show-meta-range-id   also show meta range ID
 ```
@@ -1409,6 +1655,13 @@ lakectl refs-dump <repository uri> [flags]
 
 restores refs (branches, commits, tags) from the underlying object store to a bare repository
 
+#### Synopsis
+
+restores refs (branches, commits, tags) from the underlying object store to a bare repository.
+
+This command is expected to run on a bare repository (i.e. one created with 'lakectl repo create-bare').
+Since a bare repo is expected, in case of transient failure, delete the repository and recreate it as bare and retry.
+
 ```
 lakectl refs-restore <repository uri> [flags]
 ```
@@ -1527,7 +1780,7 @@ lakectl repo list [flags]
 
 ```
       --after string   show results after this value (used for pagination)
-      --amount int     how many results to return, or-1 for all results (used for pagination) (default -1)
+      --amount int     how many results to return, or '-1' for default (used for pagination) (default -1)
   -h, --help           help for list
 ```
 
@@ -1638,7 +1891,7 @@ lakectl tag list lakefs://<repository>
 
 ```
       --after string   show results after this value (used for pagination)
-      --amount int     how many results to return, or-1 for all results (used for pagination) (default -1)
+      --amount int     how many results to return, or '-1' for default (used for pagination) (default -1)
   -h, --help           help for list
 ```
 

--- a/swagger.yml
+++ b/swagger.yml
@@ -134,6 +134,10 @@ definitions:
       size_bytes:
         type: integer
         format: int64
+      metadata:
+        type: object
+        additionalProperties:
+          type: string
 
   underlying_object_properties:
     type: object

--- a/swagger.yml
+++ b/swagger.yml
@@ -120,6 +120,25 @@ definitions:
         type: string
         enum: [ common_prefix, object ]
 
+  object_stage_creation:
+    type: object
+    required:
+      - physical_address
+      - checksum
+      - size_bytes
+    properties:
+      physical_address:
+        type: string
+      checksum:
+        type: string
+      size_bytes:
+        type: integer
+        format: int64
+      metadata:
+        type: object
+        additionalProperties:
+          type: string
+
   underlying_object_properties:
     type: object
     properties:
@@ -2018,9 +2037,9 @@ paths:
       summary: stage an object's metadata for the given branch
       parameters:
         - in: body
-          name: stats
+          name: object
           schema:
-            $ref: "#/definitions/object_stats"
+            $ref: "#/definitions/object_stage_creation"
       responses:
         201:
           description: object metadata

--- a/swagger.yml
+++ b/swagger.yml
@@ -2010,6 +2010,36 @@ paths:
         name: path
         required: true
         type: string
+
+    put:
+      tags:
+        - objects
+      operationId: stageObject
+      summary: stage an object's metadata for the given branch
+      parameters:
+        - in: body
+          name: stats
+          schema:
+            $ref: "#/definitions/object_stats"
+      responses:
+        201:
+          description: object metadata
+          schema:
+            $ref: "#/definitions/object_stats"
+        400:
+          description: invalid object metadata
+          schema:
+            $ref: "#/definitions/error"
+        401:
+          $ref: "#/responses/Unauthorized"
+        404:
+          description: repository or branch not found
+          schema:
+            $ref: "#/definitions/error"
+        default:
+          description: generic error response
+          schema:
+            $ref: "#/definitions/error"
     post:
       tags:
         - objects

--- a/swagger.yml
+++ b/swagger.yml
@@ -134,10 +134,6 @@ definitions:
       size_bytes:
         type: integer
         format: int64
-      metadata:
-        type: object
-        additionalProperties:
-          type: string
 
   underlying_object_properties:
     type: object


### PR DESCRIPTION
Adds the ability to register an external location to a lakefs branch+path.
Expected input is a physical address, size and checksum.
If the physical address is not in the configured block adapter, operation will fail with a 400.

Additinoally, adds a plumbing command `lakectl fs stage` that wraps this API operation.