### PR TITLE
Action hook run results fix listing hooks order

### DIFF
--- a/actions/service_test.go
+++ b/actions/service_test.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"strconv"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -154,11 +153,9 @@ hooks:
 	now := time.Now()
 	actionsService := actions.NewService(conn, testSource, testOutputWriter)
 
-	// serial run id generator to have expected results
-	var hookRunIDCounter int64
-	actionsService.RunIDGenerator = func() string {
-		id := atomic.AddInt64(&hookRunIDCounter, 1)
-		return strconv.Itoa(int(id))
+	// override hook run id generator to remove time from expected results
+	actionsService.HookRunIDGenerator = func(id int) string {
+		return strconv.Itoa(id)
 	}
 
 	err := actionsService.Run(ctx, record)

--- a/actions/service_test.go
+++ b/actions/service_test.go
@@ -9,7 +9,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-	"strconv"
 	"testing"
 	"time"
 
@@ -113,7 +112,7 @@ hooks:
 
 	ctx := context.Background()
 	testOutputWriter := mock.NewMockOutputWriter(ctrl)
-	expectedHookRunID := "1"
+	expectedHookRunID := actions.NewHookRunID(0, 0)
 	var lastManifest *actions.RunManifest
 	var writerBytes []byte
 	testOutputWriter.EXPECT().
@@ -152,11 +151,6 @@ hooks:
 	// run actions
 	now := time.Now()
 	actionsService := actions.NewService(conn, testSource, testOutputWriter)
-
-	// override hook run id generator to remove time from expected results
-	actionsService.HookRunIDGenerator = func(id int) string {
-		return strconv.Itoa(id)
-	}
 
 	err := actionsService.Run(ctx, record)
 	if err != nil {


### PR DESCRIPTION
Fix #1532

Remove the random part from the hook run ID, in order to get a consistent and more meaningful order of the list of hook results.
Kept the task allocation and ID assignment at the same place - used a sequence number to assign IDs.
