### PR TITLE
Format precondition error in commit as in merge

### DIFF
--- a/webui/src/components/ChangesPage.js
+++ b/webui/src/components/ChangesPage.js
@@ -10,6 +10,7 @@ import {resetRevertBranch, revertBranch} from "../actions/branches";
 import ConfirmationModal from "./ConfirmationModal";
 import {doCommit, resetCommit} from "../actions/commits";
 import Alert from "react-bootstrap/Alert";
+import {formatAlertText} from "./PreconditionErr";
 
 const CommitButton = connect(
     ({ commits }) => ({ commitState: commits.commit }),
@@ -27,6 +28,7 @@ const CommitButton = connect(
         if (commitDisabled) return;
         setShow(false);
         setMetadataFields([]);
+        resetCommit();
     };
 
     useEffect(() => {
@@ -52,9 +54,10 @@ const CommitButton = connect(
         return <span/>;
     }
 
+    const alertText = formatAlertText(repo.id, commitState.error);
     return (
         <>
-            <Modal show={show} onHide={onHide}>
+            <Modal show={show} onHide={onHide} size="lg">
                 <Modal.Header closeButton>
                     <Modal.Title>Commit Changes</Modal.Title>
                 </Modal.Header>
@@ -104,7 +107,7 @@ const CommitButton = connect(
                             Add Metadata field
                         </Button>
                     </Form>
-                    {(!!commitState.error) ? (<Alert variant="danger">{commitState.error}</Alert>) : (<span/>)}
+                    {(alertText) ? (<Alert variant="danger">{alertText}</Alert>) : (<span/>)}
                 </Modal.Body>
                 <Modal.Footer>
                     <Button variant="secondary" disabled={commitDisabled} onClick={onHide}>

--- a/webui/src/components/PreconditionErr.js
+++ b/webui/src/components/PreconditionErr.js
@@ -1,0 +1,40 @@
+import {Alert} from "react-bootstrap";
+import {API_ENDPOINT} from "../actions/api";
+import ClipboardButton from "./ClipboardButton";
+import React from "react";
+
+function extractActionRunID(err) {
+    const m = /^Error: (\S+) hook aborted, run id '([^']+)'/.exec(err);
+    return m ? m[2] : '';
+}
+
+function extractActionHookRunID(err) {
+    const m = /^\t\* hook run id '([^']+)' failed/.exec(err);
+    return m ? m[1] : '';
+}
+
+export function formatAlertText(repositoryId, err) {
+    if (!err) {
+        return '';
+    }
+    const lines = err.split('\n');
+    if (lines.length === 1) {
+        return <Alert.Heading>{err}</Alert.Heading>;
+    }
+    const runID = extractActionRunID(err);
+    let result = lines.map((line, i) => {
+        if (runID) {
+            const hookRunID = extractActionHookRunID(line);
+            if (hookRunID) {
+                const link = `${API_ENDPOINT}/repositories/${repositoryId}/actions/runs/${runID}/hooks/${hookRunID}/output`;
+                return <p key={i}><Alert.Link target="_blank" download={runID+'-'+hookRunID+'.log'} href={link}>{line}</Alert.Link></p>;
+            }
+        }
+        return <p key={i}>{line}</p>;
+    });
+    if (runID) {
+        const cmd = `lakectl actions runs describe lakefs://${repositoryId} ${runID}`;
+        result = <>{result}<hr/>For detailed information run:<br/>{cmd}<ClipboardButton variant="link" text={cmd} tooltip="Copy"/></>;
+    }
+    return result;
+}

--- a/webui/src/components/PreconditionErr.js
+++ b/webui/src/components/PreconditionErr.js
@@ -3,6 +3,7 @@ import {API_ENDPOINT} from "../actions/api";
 import ClipboardButton from "./ClipboardButton";
 import React from "react";
 
+
 function extractActionRunID(err) {
     const m = /^Error: (\S+) hook aborted, run id '([^']+)'/.exec(err);
     return m ? m[2] : '';


### PR DESCRIPTION
Share code with previous RP where we handle alert formatting for precondition fail error.

- Common code, reduce to one function call
- Download log with <run id>-<hook run id>.log
- Use large dialog for Commit to have a better rendering of large error messages