### PR TITLE
Pin terraform-aws-rds module version

### DIFF
--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - master
-  pull_request:
 
 jobs:
   deploy-executor-image:

--- a/.github/workflows/benchmark.yaml
+++ b/.github/workflows/benchmark.yaml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - master
+  pull_request:
 
 jobs:
   deploy-executor-image:

--- a/benchmarks/terraform/benchmark-env.tf
+++ b/benchmarks/terraform/benchmark-env.tf
@@ -2,7 +2,7 @@
 # DB
 #####
 module "db" {
-  source = "github.com/terraform-aws-modules/terraform-aws-rds"
+  source = "git::https://github.com/terraform-aws-modules/terraform-aws-rds.git?ref=v2.22.0"
 
   identifier = "benchmarks-postgres-${var.tag}"
 


### PR DESCRIPTION
Latest version introduced a new required field that failed our workflow.
We don't use any new features so we might as well declare the specific version that works for us.