### PR TITLE
batch hot paths for a very short duration

### DIFF
--- a/pkg/batch/executor.go
+++ b/pkg/batch/executor.go
@@ -1,0 +1,87 @@
+package batch
+
+import (
+	"time"
+
+	"github.com/treeverse/lakefs/pkg/logging"
+)
+
+type BatchFn func() (interface{}, error)
+
+type Batcher interface {
+	BatchFor(key string, dur time.Duration, fn BatchFn) (interface{}, error)
+}
+
+type response struct {
+	v   interface{}
+	err error
+}
+
+type request struct {
+	key              string
+	dur              time.Duration
+	fn               BatchFn
+	responseCallback chan *response
+}
+
+type Executor struct {
+	requests chan *request
+	execs    chan string
+	keys     map[string][]*request
+	logger   logging.Logger
+}
+
+func NewExecutor(logger logging.Logger) *Executor {
+	e := &Executor{
+		requests: make(chan *request),
+		execs:    make(chan string),
+		keys:     make(map[string][]*request),
+		logger:   logger,
+	}
+	go e.Run() // TODO(ozkatz): should probably be managed by the user (also, allow stopping it)
+	return e
+}
+
+func (e *Executor) BatchFor(key string, dur time.Duration, fn BatchFn) (interface{}, error) {
+	cb := make(chan *response)
+	e.requests <- &request{
+		key:              key,
+		dur:              dur,
+		fn:               fn,
+		responseCallback: cb,
+	}
+	response := <-cb
+	return response.v, response.err
+}
+
+func (e *Executor) Run() {
+	for {
+		select {
+		case req := <-e.requests:
+			// see if we have it scheduled already
+			if _, exists := e.keys[req.key]; !exists {
+				// this is a new key, let's fire a timer for it
+				go func(req *request) {
+					time.Sleep(req.dur)
+					e.execs <- req.key
+				}(req)
+			}
+			e.keys[req.key] = append(e.keys[req.key], req)
+		case execKey := <-e.execs:
+			// let's take all callbacks
+			waiters := e.keys[execKey]
+			delete(e.keys, execKey)
+			go func(key string) {
+				// execute and call all mapped callbacks
+				v, err := waiters[0].fn()
+				e.logger.WithFields(logging.Fields{
+					"waiters": len(waiters),
+					"key":     key,
+				}).Trace("dispatched BatchFn")
+				for _, waiter := range waiters {
+					waiter.responseCallback <- &response{v, err}
+				}
+			}(execKey)
+		}
+	}
+}

--- a/pkg/batch/executor.go
+++ b/pkg/batch/executor.go
@@ -32,18 +32,21 @@ type response struct {
 }
 
 type request struct {
-	key              string
-	dur              time.Duration
-	fn               BatchFn
-	responseCallback chan *response
+	key        string
+	timeout    time.Duration
+	fn         BatchFn
+	onResponse chan *response
 }
 
 type Executor struct {
+	// requests is the channel accepting inbound requests
 	requests chan *request
-	execs    chan string
-	keys     map[string][]*request
-	Logger   logging.Logger
-	Delayer  DelayFn
+	// execs is the internal channel used to dispatch the callback functions.
+	// Several requests with the same key in a given duration will trigger a single write to exec said key.
+	execs        chan string
+	waitingOnKey map[string][]*request
+	Logger       logging.Logger
+	Delay        DelayFn
 }
 
 func NopExecutor() *nonBatchingExecutor {
@@ -52,21 +55,21 @@ func NopExecutor() *nonBatchingExecutor {
 
 func NewExecutor(logger logging.Logger) *Executor {
 	return &Executor{
-		requests: make(chan *request, RequestBufferSize),
-		execs:    make(chan string, RequestBufferSize),
-		keys:     make(map[string][]*request),
-		Logger:   logger,
-		Delayer:  time.Sleep,
+		requests:     make(chan *request, RequestBufferSize),
+		execs:        make(chan string, RequestBufferSize),
+		waitingOnKey: make(map[string][]*request),
+		Logger:       logger,
+		Delay:        time.Sleep,
 	}
 }
 
-func (e *Executor) BatchFor(key string, dur time.Duration, fn BatchFn) (interface{}, error) {
+func (e *Executor) BatchFor(key string, timeout time.Duration, fn BatchFn) (interface{}, error) {
 	cb := make(chan *response)
 	e.requests <- &request{
-		key:              key,
-		dur:              dur,
-		fn:               fn,
-		responseCallback: cb,
+		key:        key,
+		timeout:    timeout,
+		fn:         fn,
+		onResponse: cb,
 	}
 	response := <-cb
 	return response.v, response.err
@@ -79,27 +82,29 @@ func (e *Executor) Run(ctx context.Context) {
 			return
 		case req := <-e.requests:
 			// see if we have it scheduled already
-			if _, exists := e.keys[req.key]; !exists {
+			if _, exists := e.waitingOnKey[req.key]; !exists {
 				// this is a new key, let's fire a timer for it
 				go func(req *request) {
-					e.Delayer(req.dur)
+					e.Delay(req.timeout)
 					e.execs <- req.key
 				}(req)
 			}
-			e.keys[req.key] = append(e.keys[req.key], req)
+			e.waitingOnKey[req.key] = append(e.waitingOnKey[req.key], req)
 		case execKey := <-e.execs:
 			// let's take all callbacks
-			waiters := e.keys[execKey]
-			delete(e.keys, execKey)
+			waiters := e.waitingOnKey[execKey]
+			delete(e.waitingOnKey, execKey)
 			go func(key string) {
 				// execute and call all mapped callbacks
 				v, err := waiters[0].fn()
-				e.Logger.WithFields(logging.Fields{
-					"waiters": len(waiters),
-					"key":     key,
-				}).Trace("dispatched BatchFn")
+				if e.Logger.IsTracing() {
+					e.Logger.WithFields(logging.Fields{
+						"waiters": len(waiters),
+						"key":     key,
+					}).Trace("dispatched BatchFn")
+				}
 				for _, waiter := range waiters {
-					waiter.responseCallback <- &response{v, err}
+					waiter.onResponse <- &response{v, err}
 				}
 			}(execKey)
 		}

--- a/pkg/batch/executor.go
+++ b/pkg/batch/executor.go
@@ -7,6 +7,10 @@ import (
 	"github.com/treeverse/lakefs/pkg/logging"
 )
 
+// RequestBufferSize is the amount of requests users can dispatch that haven't been processed yet before
+// dispatching new ones would start blocking.
+const RequestBufferSize = 1 << 17
+
 type BatchFn func() (interface{}, error)
 
 type DelayFn func(dur time.Duration)
@@ -48,8 +52,8 @@ func NopExecutor() *nonBatchingExecutor {
 
 func NewExecutor(logger logging.Logger) *Executor {
 	return &Executor{
-		requests: make(chan *request),
-		execs:    make(chan string),
+		requests: make(chan *request, RequestBufferSize),
+		execs:    make(chan string, RequestBufferSize),
 		keys:     make(map[string][]*request),
 		Logger:   logger,
 		Delayer:  time.Sleep,

--- a/pkg/batch/executor_test.go
+++ b/pkg/batch/executor_test.go
@@ -1,0 +1,85 @@
+package batch_test
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/treeverse/lakefs/pkg/batch"
+	"github.com/treeverse/lakefs/pkg/logging"
+)
+
+func TestExecutor_BatchFor(t *testing.T) {
+	// Setup executor
+	exec := batch.NewExecutor(logging.Dummy())
+	go exec.Run(context.Background())
+	// Prove the executor does not violate read-after-write consistency.
+	// First, let's define read-after-write consistency:
+	// 	Any read that started after a successful write has returned, must return the updated value.
+	// to test this, let's simulate the following scenario:
+	// 1. reader (r1) starts (Current version: v0)
+	// 2. writer (w1) writes v1
+	// 3. writer (w1) returns (Current version: v1)
+	// 4. reader (r2) starts
+	// 5. both readers (r1,r2) return with v1 as their response.
+	var db = sync.Map{}
+	db.Store("v", "v0")
+
+	read1Done := make(chan bool)
+	write1Done := make(chan bool)
+	read2Done := make(chan bool)
+
+	// we pass a custom delay func that ensures we make the write only after
+	//  reader1 started
+	waitWrite := make(chan bool)
+	delays := int32(0)
+	delayFn := func(dur time.Duration) {
+		delaysDone := atomic.AddInt32(&delays, 1)
+		if delaysDone == 1 {
+			close(waitWrite)
+		}
+		time.Sleep(dur)
+	}
+	exec.Delayer = delayFn
+
+	// reader1 starts
+	go func() {
+		r1, _ := exec.BatchFor("k", time.Millisecond*50, func() (interface{}, error) {
+			version, _ := db.Load("v")
+			return version, nil
+		})
+		r1v := r1.(string)
+		if r1v != "v1" {
+			// reader1, while it could have returned either v0 or v1 without violating read-after-write conisistency,
+			// is expected to return v1 with this batching logic
+			t.Fatalf("expected r1 to get v1, got %s instead", r1v)
+		}
+		close(read1Done)
+	}()
+
+	// Writer1 writes
+	go func() {
+		<-waitWrite
+		db.Store("v", "v1")
+		close(write1Done)
+	}()
+
+	// following that write, another reader starts, and must read the updated value
+	go func() {
+		<-write1Done // ensure we start AFTER write1 has completed
+		r2, _ := exec.BatchFor("k", time.Millisecond*50, func() (interface{}, error) {
+			version, _ := db.Load("v")
+			return version, nil
+		})
+		r2v := r2.(string)
+		if r2v != "v1" {
+			t.Fatalf("expected r2 to get v1, got %s instead", r2v)
+		}
+		close(read2Done)
+	}()
+
+	<-read1Done
+	<-read2Done
+}

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -118,11 +118,11 @@ const (
 var ErrUnknownDiffType = errors.New("unknown graveler difference type")
 
 type ctxCloser struct {
-	fn context.CancelFunc
+	close context.CancelFunc
 }
 
 func (c *ctxCloser) Close() error {
-	go c.fn()
+	go c.close()
 	return nil
 }
 

--- a/pkg/graveler/ref/main_test.go
+++ b/pkg/graveler/ref/main_test.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"testing"
 
+	"github.com/treeverse/lakefs/pkg/batch"
+
 	"github.com/treeverse/lakefs/pkg/ident"
 
 	"github.com/ory/dockertest/v3"
@@ -23,19 +25,19 @@ var (
 func testRefManager(t testing.TB) *ref.Manager {
 	t.Helper()
 	conn, _ := testutil.GetDB(t, databaseURI, testutil.WithGetDBApplyDDL(true))
-	return ref.NewPGRefManager(conn, ident.NewHexAddressProvider())
+	return ref.NewPGRefManager(batch.NopExecutor(), conn, ident.NewHexAddressProvider())
 }
 
 func testRefManagerWithDB(t testing.TB) (*ref.Manager, db.Database) {
 	t.Helper()
 	conn, _ := testutil.GetDB(t, databaseURI, testutil.WithGetDBApplyDDL(true))
-	return ref.NewPGRefManager(conn, ident.NewHexAddressProvider()), conn
+	return ref.NewPGRefManager(batch.NopExecutor(), conn, ident.NewHexAddressProvider()), conn
 }
 
 func testRefManagerWithAddressProvider(t testing.TB, addressProvider ident.AddressProvider) *ref.Manager {
 	t.Helper()
 	conn, _ := testutil.GetDB(t, databaseURI, testutil.WithGetDBApplyDDL(true))
-	return ref.NewPGRefManager(conn, addressProvider)
+	return ref.NewPGRefManager(batch.NopExecutor(), conn, addressProvider)
 }
 
 func TestMain(m *testing.M) {

--- a/pkg/graveler/ref/manager.go
+++ b/pkg/graveler/ref/manager.go
@@ -7,7 +7,6 @@ import (
 	"time"
 
 	"github.com/treeverse/lakefs/pkg/batch"
-
 	"github.com/treeverse/lakefs/pkg/db"
 	"github.com/treeverse/lakefs/pkg/graveler"
 	"github.com/treeverse/lakefs/pkg/ident"

--- a/pkg/graveler/ref/manager.go
+++ b/pkg/graveler/ref/manager.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/treeverse/lakefs/pkg/logging"
-
 	"github.com/treeverse/lakefs/pkg/batch"
 
 	"github.com/treeverse/lakefs/pkg/db"
@@ -26,11 +24,11 @@ type Manager struct {
 	batchExecutor   batch.Batcher
 }
 
-func NewPGRefManager(db db.Database, addressProvider ident.AddressProvider) *Manager {
+func NewPGRefManager(executor batch.Batcher, db db.Database, addressProvider ident.AddressProvider) *Manager {
 	return &Manager{
 		db:              db,
 		addressProvider: addressProvider,
-		batchExecutor:   batch.NewExecutor(logging.Default()),
+		batchExecutor:   executor,
 	}
 }
 

--- a/pkg/graveler/ref/manager.go
+++ b/pkg/graveler/ref/manager.go
@@ -15,6 +15,11 @@ import (
 // IteratorPrefetchSize is the amount of records to maybeFetch from PG
 const IteratorPrefetchSize = 1000
 
+// 3ms was chosen as a max delay time for critical path queries.
+// It trades off amount of queries per second (and thus effectiveness of the batching mechanism) with added latency.
+// Since reducing # of expensive operations is only beneficial when there are a lot of concurrent requests,
+// 	the sweet spot is probably between 1-5 milliseconds (representing 200-1000 requests/second to the data store).
+// 3ms of delay with ~300 requests/second per resource sounds like a reasonable tradeoff.
 const MaxBatchDelay = time.Millisecond * 3
 
 type Manager struct {


### PR DESCRIPTION
Looking at the access pattern for critical path operations, we mostly call PostgreSQL with the same exact queries many times.

For GetObject, StatObject, ListObjects (which probably make up the majority of data lake calls), we ALWAYS start by doing the same set of roundtrips to PG:

- Get the repository (to extract the storage namespace)
- Resolve the ref (i.e. figure out if this is a commit/commit prefix/branch/tag)
- Resolve the underlying commit ID (if a branch, prefix or tag)

Our access pattern is such that many requests at a given point in time are extremely likely to not only share the same repository details, but also the same branch/commit/tag, as big data systems tend to be bursty in nature.

Since caching is not an option since it sacrifices consistency (in the sense that reading after a successful write returns - might return a stale value), instead of keeping the result around for a while, we can keep the requests around for a while.

This is what this PR does: for a given type of request (i.e. to a specific branch/repo/tag, etc), wait a couple of milliseconds: if other identical requests arive in that time, do a single roundtrip and return the results once for all those requests.

Testing this on the same environment used for the sizing guide (2 x c5ad.xlarge AWS instances), I now get the following results:

- lakectl abuse random-read on a commit ID: throughput goes up from **8-10k requests/second** to **45k requests/second**
- Amount of DB queries drops from ~20k/s to less than 1k/s.

I'm OK with not accepting this due to it being a premature optimization (it is!), but I feel the added complexity is relatively small and the gain is pretty big (if only to show better numbers per core as possible). 
 