### PR TITLE
[cleanup] Use "/" build.sbt alias instead of "in"

### DIFF
--- a/clients/spark/build.sbt
+++ b/clients/spark/build.sbt
@@ -53,7 +53,7 @@ def generateExamplesProject(buildType: BuildType) =
       settingsToCompileIn("examples"),
       scalaVersion := buildType.scalaVersion,
       libraryDependencies += "org.apache.spark" %% "spark-sql" % buildType.sparkVersion % "provided",
-      mainClass in assembly := Some("io.treeverse.examples.List"),
+      assembly / mainClass := Some("io.treeverse.examples.List"),
     )
 
 lazy val spark2Type = new BuildType("247", scala211Version, "2.4.7", "0.9.8", "2.7.7")


### PR DESCRIPTION
More consistent with rest of file, most examples.