### PR TITLE
Spark Client: simplify cross build

### DIFF
--- a/clients/spark/build.sbt
+++ b/clients/spark/build.sbt
@@ -29,7 +29,7 @@ lazy val core =
       sharedSettings,
       settingsToCompileIn("core"),
       PB.targets := Seq(
-        scalapb.gen() -> (Compile / sourceManaged).value / "scalapb",
+        scalapb.gen() -> (Compile / sourceManaged).value / "scalapb"
       ),
       libraryDependencies ++= Seq(
         "org.rocksdb" % "rocksdbjni" % "6.6.4",
@@ -41,7 +41,7 @@ lazy val core =
         "org.json4s" %% "json4s-native" % "3.7.0-M8",
         "com.google.guava" % "guava" % "16.0.1",
         "com.google.guava" % "failureaccess" % "1.0.1",
-      ),
+      )
     )
 
 lazy val examples =
@@ -52,9 +52,6 @@ lazy val examples =
       settingsToCompileIn("examples"),
       assembly / mainClass := Some("io.treeverse.examples.List"),
     ).dependsOn(core)
-
-//lazy val core3 = generateCoreProject(spark3Type)
-//lazy val examples3 = generateExamplesProject(spark3Type).dependsOn(core3)
 
 lazy val root = (project in file(".")).aggregate(core, examples)
 
@@ -95,14 +92,13 @@ lazy val commonSettings = Seq(
           "org.apache.spark" %% "spark-sql" % "2.4.7" % "provided"
         )
     }
-  },
+  }
 )
 
 lazy val publishSettings = Seq(
   publishTo := {
     val nexus = "https://s01.oss.sonatype.org/"
-    if (isSnapshot.value)
-      Some("snapshots" at nexus + "content/repositories/snapshots")
+    if (isSnapshot.value) Some("snapshots" at nexus + "content/repositories/snapshots")
     else Some("releases" at nexus + "service/local/staging/deploy/maven2")
   },
   // Remove all additional repository other than Maven Central from POM
@@ -114,33 +110,33 @@ lazy val sharedSettings = commonSettings ++ assemblySettings ++ publishSettings
 ThisBuild / scmInfo := Some(
   ScmInfo(
     url("https://github.com/treeverse/lakeFS/clients/spark"),
-    "scm:git@github.com:treeverse/lakeFS.git",
-  ),
+    "scm:git@github.com:treeverse/lakeFS.git"
+  )
 )
 ThisBuild / developers := List(
   Developer(
-    id = "ariels",
-    name = "Ariel Shaqed (Scolnicov)",
+    id    = "ariels",
+    name  = "Ariel Shaqed (Scolnicov)",
     email = "ariels@treeverse.io",
-    url = url("https://github.com/arielshaqed"),
+    url   = url("https://github.com/arielshaqed")
   ),
   Developer(
-    id = "baraktr",
-    name = "B. A.",
+    id    = "baraktr",
+    name  = "B. A.",
     email = "barak.amar@treeverse.io",
-    url = url("https://github.com/nopcoder"),
+    url   = url("https://github.com/nopcoder"),
   ),
   Developer(
-    id = "ozkatz",
-    name = "Oz Katz",
+    id    = "ozkatz",
+    name  = "Oz Katz",
     email = "oz.katz@treeverse.io",
-    url = url("https://github.com/ozkatz"),
+    url   = url("https://github.com/ozkatz"),
   ),
   Developer(
-    id = "johnnyaug",
-    name = "J. A.",
+    id    = "johnnyaug",
+    name  = "J. A.",
     email = "yoni.augarten@treeverse.io",
-    url = url("https://github.com/johnnyaug"),
+    url   = url("https://github.com/johnnyaug"),
   ),
 )
 
@@ -154,7 +150,5 @@ ThisBuild / organization := "io.treeverse"
 ThisBuild / organizationName := "Treeverse Labs"
 ThisBuild / organizationHomepage := Some(url("http://treeverse.io"))
 ThisBuild / description := "Spark client for lakeFS object metadata."
-ThisBuild / licenses := List(
-  "Apache 2" -> new URL("http://www.apache.org/licenses/LICENSE-2.0.txt"),
-)
+ThisBuild / licenses := List("Apache 2" -> new URL("http://www.apache.org/licenses/LICENSE-2.0.txt"))
 ThisBuild / homepage := Some(url("https://github.com/treeverse/spark-client"))

--- a/clients/spark/build.sbt
+++ b/clients/spark/build.sbt
@@ -1,8 +1,6 @@
-import build.BuildType
-
 lazy val baseName = "lakefs-spark"
 
-lazy val projectVersion = "0.1.0-SNAPSHOT.4"
+lazy val projectVersion = "0.1.0-SNAPSHOT.5"
 isSnapshot := true
 
 // Spark versions 2.4.7 and 3.0.1 use different Scala versions.  Changing this is a deep
@@ -24,47 +22,41 @@ def settingsToCompileIn(dir: String) = {
   )
 }
 
-def generateCoreProject(buildType: BuildType) =
-  Project(s"${baseName}-client-${buildType.name}", file(s"target/core-${buildType.name}"))
+lazy val core =
+  (project in file(s"core"))
     .settings(
+      name := "lakefs-spark-client",
       sharedSettings,
       settingsToCompileIn("core"),
-      scalaVersion := buildType.scalaVersion,
       PB.targets := Seq(
-        scalapb.gen() -> (Compile / sourceManaged).value / "scalapb"
+        scalapb.gen() -> (Compile / sourceManaged).value / "scalapb",
       ),
-      libraryDependencies ++= Seq("org.rocksdb" % "rocksdbjni" % "6.6.4",
+      libraryDependencies ++= Seq(
+        "org.rocksdb" % "rocksdbjni" % "6.6.4",
         "commons-codec" % "commons-codec" % "1.15",
-        "org.apache.spark" %% "spark-sql" % buildType.sparkVersion % "provided",
         "com.thesamet.scalapb" %% "scalapb-runtime" % scalapb.compiler.Version.scalapbVersion % "protobuf",
-        "org.apache.hadoop" % "hadoop-aws" % buildType.hadoopVersion,
-        "org.apache.hadoop" % "hadoop-common" % buildType.hadoopVersion,
+        "org.apache.hadoop" % "hadoop-aws" % "2.7.7",
+        "org.apache.hadoop" % "hadoop-common" % "2.7.7",
         "org.scalaj" %% "scalaj-http" % "2.4.2",
         "org.json4s" %% "json4s-native" % "3.7.0-M8",
         "com.google.guava" % "guava" % "16.0.1",
         "com.google.guava" % "failureaccess" % "1.0.1",
-      )
+      ),
     )
 
-def generateExamplesProject(buildType: BuildType) =
-  Project(s"${baseName}-examples-${buildType.name}", file(s"target/examples-${buildType.name}"))
+lazy val examples =
+  (project in file(s"examples"))
     .settings(
+      name := "lakefs-spark-example",
       sharedSettings,
       settingsToCompileIn("examples"),
-      scalaVersion := buildType.scalaVersion,
-      libraryDependencies += "org.apache.spark" %% "spark-sql" % buildType.sparkVersion % "provided",
       mainClass in assembly := Some("io.treeverse.examples.List"),
-    )
+    ).dependsOn(core)
 
-lazy val spark2Type = new BuildType("247", scala211Version, "2.4.7", "0.9.8", "2.7.7")
-lazy val spark3Type = new BuildType("301", scala212Version, "3.0.1", "0.10.11", "2.7.7")
+//lazy val core3 = generateCoreProject(spark3Type)
+//lazy val examples3 = generateExamplesProject(spark3Type).dependsOn(core3)
 
-lazy val core2 = generateCoreProject(spark2Type)
-lazy val core3 = generateCoreProject(spark3Type)
-lazy val examples2 = generateExamplesProject(spark2Type).dependsOn(core2)
-lazy val examples3 = generateExamplesProject(spark3Type).dependsOn(core3)
-
-lazy val root = (project in file(".")).aggregate(core2, core3, examples2, examples3)
+lazy val root = (project in file(".")).aggregate(core, examples)
 
 // Use an older JDK to be Spark compatible
 javacOptions ++= Seq("-source", "1.8", "-target", "1.8")
@@ -75,8 +67,12 @@ lazy val assemblySettings = Seq(
   assembly / assemblyShadeRules := Seq(
     ShadeRule.rename("org.apache.http.**" -> "org.apache.httpShaded@1").inAll,
     ShadeRule.rename("com.google.protobuf.**" -> "shadeproto.@1").inAll,
-    ShadeRule.rename("com.google.common.**" -> "shadegooglecommon.@1")
-      .inLibrary("com.google.guava" % "guava" % "30.1-jre", "com.google.guava" % "failureaccess" % "1.0.1")
+    ShadeRule
+      .rename("com.google.common.**" -> "shadegooglecommon.@1")
+      .inLibrary(
+        "com.google.guava" % "guava" % "30.1-jre",
+        "com.google.guava" % "failureaccess" % "1.0.1",
+      )
       .inProject,
     ShadeRule.rename("scala.collection.compat.**" -> "shadecompat.@1").inAll,
   ),
@@ -86,13 +82,27 @@ lazy val assemblySettings = Seq(
 root / publish / skip := true
 
 lazy val commonSettings = Seq(
-  version := projectVersion
+  version := projectVersion,
+  crossScalaVersions := Seq(scala211Version, scala212Version),
+  libraryDependencies ++= {
+    CrossVersion.partialVersion(scalaVersion.value) match {
+      case Some((2, scalaMajor)) if scalaMajor >= 12 =>
+        Seq(
+          "org.apache.spark" %% "spark-sql" % "3.0.1" % "provided"
+        )
+      case Some((2, scalaMajor)) if scalaMajor >= 11 =>
+        libraryDependencies.value ++ Seq(
+          "org.apache.spark" %% "spark-sql" % "2.4.7" % "provided"
+        )
+    }
+  },
 )
 
 lazy val publishSettings = Seq(
   publishTo := {
     val nexus = "https://s01.oss.sonatype.org/"
-    if (isSnapshot.value) Some("snapshots" at nexus + "content/repositories/snapshots")
+    if (isSnapshot.value)
+      Some("snapshots" at nexus + "content/repositories/snapshots")
     else Some("releases" at nexus + "service/local/staging/deploy/maven2")
   },
   // Remove all additional repository other than Maven Central from POM
@@ -104,33 +114,33 @@ lazy val sharedSettings = commonSettings ++ assemblySettings ++ publishSettings
 ThisBuild / scmInfo := Some(
   ScmInfo(
     url("https://github.com/treeverse/lakeFS/clients/spark"),
-    "scm:git@github.com:treeverse/lakeFS.git"
-  )
+    "scm:git@github.com:treeverse/lakeFS.git",
+  ),
 )
 ThisBuild / developers := List(
   Developer(
-    id    = "ariels",
-    name  = "Ariel Shaqed (Scolnicov)",
+    id = "ariels",
+    name = "Ariel Shaqed (Scolnicov)",
     email = "ariels@treeverse.io",
-    url   = url("https://github.com/arielshaqed")
+    url = url("https://github.com/arielshaqed"),
   ),
   Developer(
-    id    = "baraktr",
-    name  = "B. A.",
+    id = "baraktr",
+    name = "B. A.",
     email = "barak.amar@treeverse.io",
-    url   = url("https://github.com/nopcoder"),
+    url = url("https://github.com/nopcoder"),
   ),
   Developer(
-    id    = "ozkatz",
-    name  = "Oz Katz",
+    id = "ozkatz",
+    name = "Oz Katz",
     email = "oz.katz@treeverse.io",
-    url   = url("https://github.com/ozkatz"),
+    url = url("https://github.com/ozkatz"),
   ),
   Developer(
-    id    = "johnnyaug",
-    name  = "J. A.",
+    id = "johnnyaug",
+    name = "J. A.",
     email = "yoni.augarten@treeverse.io",
-    url   = url("https://github.com/johnnyaug"),
+    url = url("https://github.com/johnnyaug"),
   ),
 )
 
@@ -144,5 +154,7 @@ ThisBuild / organization := "io.treeverse"
 ThisBuild / organizationName := "Treeverse Labs"
 ThisBuild / organizationHomepage := Some(url("http://treeverse.io"))
 ThisBuild / description := "Spark client for lakeFS object metadata."
-ThisBuild / licenses := List("Apache 2" -> new URL("http://www.apache.org/licenses/LICENSE-2.0.txt"))
+ThisBuild / licenses := List(
+  "Apache 2" -> new URL("http://www.apache.org/licenses/LICENSE-2.0.txt"),
+)
 ThisBuild / homepage := Some(url("https://github.com/treeverse/spark-client"))

--- a/clients/spark/build.sbt
+++ b/clients/spark/build.sbt
@@ -64,12 +64,8 @@ lazy val assemblySettings = Seq(
   assembly / assemblyShadeRules := Seq(
     ShadeRule.rename("org.apache.http.**" -> "org.apache.httpShaded@1").inAll,
     ShadeRule.rename("com.google.protobuf.**" -> "shadeproto.@1").inAll,
-    ShadeRule
-      .rename("com.google.common.**" -> "shadegooglecommon.@1")
-      .inLibrary(
-        "com.google.guava" % "guava" % "30.1-jre",
-        "com.google.guava" % "failureaccess" % "1.0.1",
-      )
+    ShadeRule.rename("com.google.common.**" -> "shadegooglecommon.@1")
+      .inLibrary("com.google.guava" % "guava" % "30.1-jre", "com.google.guava" % "failureaccess" % "1.0.1")
       .inProject,
     ShadeRule.rename("scala.collection.compat.**" -> "shadecompat.@1").inAll,
   ),

--- a/clients/spark/project/types.scala
+++ b/clients/spark/project/types.scala
@@ -1,9 +1,0 @@
-package build
-
-class BuildType(
-  val name: String,
-  val scalaVersion: String,
-  val sparkVersion: String,
-  val scalapbVersion: String,
-  val hadoopVersion: String,
-)


### PR DESCRIPTION
_Not tested yet, opening as draft so we can discuss f2f_

The current build.sbt doesn't use the _crossScalaVersions_ feature, causing difficulties when running locally, especially within IntelliJ. After this change, IntelliJ should recognize both `core` and `examples` as modules, and be able to compile/run them.