### PR TITLE
Stabilize TestExecutor__BatchFor

### DIFF
--- a/pkg/batch/executor.go
+++ b/pkg/batch/executor.go
@@ -28,7 +28,7 @@ func (b BatchFn) Execute() (interface{}, error) {
 type DelayFn func(dur time.Duration)
 
 type Batcher interface {
-	BatchFor(key string, dur time.Duration, fn BatchFn) (interface{}, error)
+	BatchFor(key string, dur time.Duration, exec Executable) (interface{}, error)
 }
 
 type nonBatchingExecutor struct {
@@ -47,7 +47,6 @@ type request struct {
 	key        string
 	timeout    time.Duration
 	exec       Executable
-	onBatched  chan *response
 	onResponse chan *response
 }
 

--- a/pkg/batch/executor.go
+++ b/pkg/batch/executor.go
@@ -16,7 +16,7 @@ type Executer interface {
 }
 
 type BatchTracker interface {
-	// This method should be called on adding a request to an existing batch
+	// Batched is called when a request is added to an existing batch.
 	Batched()
 }
 
@@ -35,8 +35,8 @@ type Batcher interface {
 type nonBatchingExecutor struct {
 }
 
-func (n *nonBatchingExecutor) BatchFor(_ string, _ time.Duration, ft Executer) (interface{}, error) {
-	return ft.Execute()
+func (n *nonBatchingExecutor) BatchFor(_ string, _ time.Duration, exec Executer) (interface{}, error) {
+	return exec.Execute()
 }
 
 type response struct {

--- a/pkg/batch/executor_test.go
+++ b/pkg/batch/executor_test.go
@@ -158,6 +158,7 @@ func testBatchExpiration(t *testing.T) {
 			t.Errorf("r1 should have triggered a single db call, but access count= #{ac}")
 		}
 		close(read1Done)
+
 	}()
 
 	go func() {
@@ -237,8 +238,8 @@ func testBatchByKey(t *testing.T) {
 
 func TestExecutor_BatchFor(t *testing.T) {
 	var wg sync.WaitGroup
-	wg.Add(1)
-	for i := 0; i < 1; i++ {
+	wg.Add(50)
+	for i := 0; i < 50; i++ {
 		go func() {
 			defer wg.Done()
 			testReadAfterWrite(t)

--- a/pkg/batch/executor_test.go
+++ b/pkg/batch/executor_test.go
@@ -130,7 +130,7 @@ func testReadAfterWrite(t *testing.T) {
 		}
 
 		if accessCount := db.GetAccessCount(); accessCount != 1 {
-			t.Errorf("db should only be accessed once, but was accessed %d timess", accessCount)
+			t.Errorf("db should only be accessed once, but was accessed %d times", accessCount)
 		}
 		close(read2Done)
 	}()

--- a/pkg/batch/executor_test.go
+++ b/pkg/batch/executor_test.go
@@ -11,6 +11,51 @@ import (
 	"github.com/treeverse/lakefs/pkg/logging"
 )
 
+const accessedOnce = 1
+const accessedTwice = 2
+
+
+type reader struct {
+	Ch         chan bool
+	IsExecuted bool
+	Fn ExecFn
+}
+
+type ExecFn func() (interface{}, error)
+
+func (r *reader) Execute() (interface{}, error) {
+	r.IsExecuted = true
+	return r.Fn()
+}
+
+func (r *reader) Batched() {
+	close(r.Ch)
+}
+
+type db struct {
+	KvStore sync.Map
+	AccessCount int
+}
+
+type Dao interface {
+	Insert(key string, val string)
+	Get(key string) string
+	GetCount() int
+}
+
+func (d *db) Insert(key string, val string) {
+	d.KvStore.Store(key	, val)
+}
+
+func (d *db) Get(key string) (interface{}, bool) {
+	d.AccessCount++
+	return d.KvStore.Load(key)
+}
+
+func (d *db) GetAccessCount() int {
+	return d.AccessCount
+}
+
 func testReadAfterWrite(t *testing.T) {
 	// Setup executor
 	exec := batch.NewExecutor(logging.Default())
@@ -24,12 +69,13 @@ func testReadAfterWrite(t *testing.T) {
 	// 3. writer (w1) returns (Current version: v1)
 	// 4. reader (r2) starts
 	// 5. both readers (r1,r2) return with v1 as their response.
-	var db = sync.Map{}
-	db.Store("v", "v0")
+	var db = &db{sync.Map{}, 0}
+	db.Insert("v", "v0")
 
 	read1Done := make(chan bool)
 	write1Done := make(chan bool)
 	read2Done := make(chan bool)
+	read2Batched := make(chan bool)
 
 	// we pass a custom delay func that ensures we make the write only after
 	//  reader1 started
@@ -40,21 +86,22 @@ func testReadAfterWrite(t *testing.T) {
 		if delaysDone == 1 {
 			close(waitWrite)
 		}
-		time.Sleep(dur)
+		// We want to make sure that r2 is in the same batch with r1
+		<-read2Batched
 	}
 	exec.Delay = delayFn
 
 	// reader1 starts
 	go func() {
-		r1, _ := exec.BatchFor("k", time.Millisecond*50, func() (interface{}, error) {
-			version, _ := db.Load("v")
+		r1, _ := exec.BatchFor("k", time.Millisecond*50, batch.BatchFn(func() (interface{}, error) {
+			version, _ := db.Get("v")
 			return version, nil
-		})
+		}))
 		r1v := r1.(string)
 		if r1v != "v1" {
-			// reader1, while it could have returned either v0 or v1 without violating read-after-write conisistency,
+			// reader1, while it could have returned either v0 or v1 without violating read-after-write consistency,
 			// is expected to return v1 with this batching logic
-			t.Fatalf("expected r1 to get v1, got %s instead", r1v)
+			t.Errorf("expected r1 to get v1, got %s instead", r1v)
 		}
 		close(read1Done)
 	}()
@@ -62,21 +109,20 @@ func testReadAfterWrite(t *testing.T) {
 	// Writer1 writes
 	go func() {
 		<-waitWrite
-		db.Store("v", "v1")
+		db.Insert("v", "v1")
 		close(write1Done)
 	}()
 
 	// following that write, another reader starts, and must read the updated value
 	go func() {
 		<-write1Done // ensure we start AFTER write1 has completed
-		r2, _ := exec.BatchFor("k", time.Millisecond*50, func() (interface{}, error) {
-			t.Error("this should not be called, only r1's")
-			version, _ := db.Load("v")
-			return version, nil
-		})
-		r2v := r2.(string)
-		if r2v != "v1" {
-			t.Fatalf("expected r2 to get v1, got %s instead", r2v)
+		r := reader{Ch: read2Batched, Fn: func() (interface{}, error) {
+			return nil, nil
+		}}
+		_, _ = exec.BatchFor("k", 50*time.Millisecond, &r)
+		// We expect r2's exec function to no execute because it should join r1's batch
+		if r.IsExecuted || db.GetAccessCount() != accessedOnce {
+			t.Error("r2's exec function should not be called, only r1's")
 		}
 		close(read2Done)
 	}()
@@ -85,13 +131,119 @@ func testReadAfterWrite(t *testing.T) {
 	<-read2Done
 }
 
+func testBatchExpiration(t *testing.T) {
+	// Setup executor
+	exec := batch.NewExecutor(logging.Default())
+	go exec.Run(context.Background())
+
+	// Confirm that batches expire after a delay period, and hence requests don't hang
+	// To test this, let's simulate the following scenario:
+	// 1. reader (r1) makes request with key 'k'
+	// 2. reader 1 returns
+	// 3. reader (r2) makes request with key 'k'
+	// 4. a new batch is used to making r2's db request
+	var db = &db{sync.Map{}, 0}
+
+	read1Done := make(chan bool)
+	read2Done := make(chan bool)
+
+	// reader1 starts
+	go func() {
+		exec.BatchFor("k", time.Millisecond*50, batch.BatchFn(func() (interface{}, error) {
+			version, _ := db.Get("v")
+			return version, nil
+		}))
+		ac := db.GetAccessCount()
+		if (ac != accessedOnce) {
+			t.Errorf("r1 should have triggered a single db call, but access count= #{ac}")
+		}
+		close(read1Done)
+	}()
+
+	go func() {
+		<-read1Done // ensure r2 starts after r1 has returned
+		exec.BatchFor("k", time.Millisecond*50, batch.BatchFn(func() (interface{}, error) {
+			version, _ := db.Get("v")
+			return version, nil
+		}))
+		ac := db.GetAccessCount()
+		if ac != accessedTwice {
+			t.Errorf("r2 should have triggered the second db call, but access count= #{ac}")
+		}
+		close(read2Done)
+	}()
+
+	<-read2Done
+}
+
+func testBatchByKey(t *testing.T) {
+	// Setup executor
+	exec := batch.NewExecutor(logging.Default())
+	go exec.Run(context.Background())
+
+	// Confirm that requests are batched by key.
+	// To test this, let's simulate the following scenario:
+	// 1. reader (r1) makes request with key 'k1'
+	// 2. reader (r2) makes request with key 'k2' before r1's batch has been expired
+	// 3. Two batches are created and two requests are executed
+	read1Done := make(chan bool)
+	read2Done := make(chan bool)
+	req2Done := make(chan bool)
+
+	// we pass a custom delay func that ensures r2 starts only after r1 started, and that r1 executes only
+	// after r2 made a request
+	waitRead2 := make(chan bool)
+	delays := int32(0)
+	delayFn := func(dur time.Duration) {
+		delaysDone := atomic.AddInt32(&delays, 1)
+		if delaysDone == 1 {
+			close(waitRead2)
+			<-req2Done
+		}
+	}
+	exec.Delay = delayFn
+
+	r1 := reader{Fn: func() (interface{}, error) {
+		return nil, nil
+	}}
+	r2 := reader{Fn: func() (interface{}, error) {
+		close(req2Done)
+		return nil, nil
+	}}
+
+	// reader1 starts
+	go func(r *reader) {
+		_, _ = exec.BatchFor("k1", 50*time.Millisecond, r)
+		close(read1Done)
+	}(&r1)
+
+	go func(r *reader) {
+		<-waitRead2 // ensure we start AFTER r2 started
+		//close(read2Started)
+		exec.BatchFor("k2", 0, r)
+		close(read2Done)
+	}(&r2)
+
+	<-read1Done
+	<-read2Done
+
+	r1Succeeded := r1.IsExecuted
+	r2Succeeded := r2.IsExecuted
+	if !(r1Succeeded && r2Succeeded) {
+		t.Error("both r1 and r2's exec functions should be executed but r1Succeeded=#{r1Succeeded} " +
+			"and r2Succeeded=#{r1Succeeded}")
+	}
+}
+
 func TestExecutor_BatchFor(t *testing.T) {
 	var wg sync.WaitGroup
-	wg.Add(50)
-	for i := 0; i < 50; i++ {
+	wg.Add(1)
+	for i := 0; i < 1; i++ {
 		go func() {
 			defer wg.Done()
 			testReadAfterWrite(t)
+			testBatchByKey(t)
+			testBatchExpiration(t)
 		}()
 	}
 	wg.Wait()

--- a/pkg/batch/executor_test.go
+++ b/pkg/batch/executor_test.go
@@ -215,7 +215,7 @@ func testBatchByKey(t *testing.T) {
 
 	// reader2 starts
 	go func(te *trackableExecuter) {
-		<-waitRead2 // ensure we start AFTER te2 started
+		<-waitRead2 // ensure we start AFTER r1 started a new batch
 		exec.BatchFor("k2", 0, te)
 		close(read2Done)
 	}(&te2)
@@ -225,7 +225,7 @@ func testBatchByKey(t *testing.T) {
 	r1Succeeded := te1.WasExecuted()
 	r2Succeeded := te2.WasExecuted()
 	if !(r1Succeeded && r2Succeeded) {
-		t.Error("both r and r2's exec functions should be executed but r1Succeeded=#{r1Succeeded} " +
+		t.Error("both r1's and r2's exec functions should be executed but r1Succeeded=#{r1Succeeded} " +
 			"and r2Succeeded=#{r2Succeeded}")
 	}
 }

--- a/pkg/batch/executor_test.go
+++ b/pkg/batch/executor_test.go
@@ -14,11 +14,10 @@ import (
 const accessedOnce = 1
 const accessedTwice = 2
 
-
 type reader struct {
 	Ch         chan bool
 	IsExecuted bool
-	Fn ExecFn
+	Fn         ExecFn
 }
 
 type ExecFn func() (interface{}, error)
@@ -33,7 +32,7 @@ func (r *reader) Batched() {
 }
 
 type db struct {
-	KvStore sync.Map
+	KvStore     sync.Map
 	AccessCount int
 }
 
@@ -44,7 +43,7 @@ type Dao interface {
 }
 
 func (d *db) Insert(key string, val string) {
-	d.KvStore.Store(key	, val)
+	d.KvStore.Store(key, val)
 }
 
 func (d *db) Get(key string) (interface{}, bool) {
@@ -154,7 +153,7 @@ func testBatchExpiration(t *testing.T) {
 			return version, nil
 		}))
 		ac := db.GetAccessCount()
-		if (ac != accessedOnce) {
+		if ac != accessedOnce {
 			t.Errorf("r1 should have triggered a single db call, but access count= #{ac}")
 		}
 		close(read1Done)

--- a/pkg/batch/executor_test.go
+++ b/pkg/batch/executor_test.go
@@ -125,8 +125,12 @@ func testReadAfterWrite(t *testing.T) {
 		}
 
 		// We expect r2's exec function to not execute because it should join r1's batch
-		if te.WasExecuted() || db.GetAccessCount() != 1 {
-			t.Error("r2's exec function should not be called, only r1's")
+		if te.WasExecuted() {
+			t.Errorf("r2's exec function should not be called, only r1's")
+		}
+
+		if accessCount := db.GetAccessCount(); accessCount != 1 {
+			t.Errorf("db should only be accessed once, but was accessed %d timess", accessCount)
 		}
 		close(read2Done)
 	}()
@@ -157,7 +161,7 @@ func testBatchExpiration(t *testing.T) {
 			return "v1", nil
 		}))
 		if r1 != "v1" {
-			t.Errorf("expected r1 to get v1 but got #{r1} instead")
+			t.Errorf("expected r1 to get v1 but got %s instead", r1)
 		}
 		close(read1Done)
 	}()
@@ -168,7 +172,7 @@ func testBatchExpiration(t *testing.T) {
 			return "v2", nil
 		}))
 		if r2 != "v2" {
-			t.Errorf("expected r2 to get v2 but got #{r2} instead")
+			t.Errorf("expected r2 to get v2 but got %s instead", r2)
 		}
 		close(read2Done)
 	}()
@@ -225,8 +229,8 @@ func testBatchByKey(t *testing.T) {
 	r1Succeeded := te1.WasExecuted()
 	r2Succeeded := te2.WasExecuted()
 	if !(r1Succeeded && r2Succeeded) {
-		t.Error("both r1's and r2's exec functions should be executed but r1Succeeded=#{r1Succeeded} " +
-			"and r2Succeeded=#{r2Succeeded}")
+		t.Error("both r1's and r2's exec functions should be executed but r1Succeeded=%t "+
+			"and r2Succeeded=%t", r1Succeeded, r2Succeeded)
 	}
 }
 


### PR DESCRIPTION
fix #1647

**Background**
To reduce db access frequency, the executor intends to batch identical requests that are made in a pre-defined delay, and TestExecutor_BatchFor is to prove that read after write consistency is preserved with the batching logic. 
In this unit test, we simulate the following scenario: 
1. reader (r1) starts (Current version: v0)
2. writer (w1) writes v1
3. writer (w1) returns (Current version: v1)
4. reader (r2) starts
5. both readers (r1,r2) return with v1 as their response.

The root cause for the bug was that the test didn't guarantee that r1 and r2 are part of the same batch, causing r2 to trigger an additional call to the db. 

**Change list** 
1. Stabilize TestExecutor_BatchFor by forcing reader1 and reader2 to be part of the same batch. 
2. Fix the test failures in https://github.com/treeverse/lakeFS/runs/2119092066?check_suite_focus=true by eliminating the usage of t.Fatalf
3. Add two more unit tests for the batcher functionality. 
