### PR TITLE
publish spark client to s3

### DIFF
--- a/clients/spark/project/plugins.sbt
+++ b/clients/spark/project/plugins.sbt
@@ -1,2 +1,4 @@
 addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.15.0")
 addSbtPlugin("com.github.sbt" % "sbt-pgp" % "2.1.2")
+addSbtPlugin("laughedelic" % "sbt-publish-more" % "0.1.0")
+addSbtPlugin("com.frugalmechanic" % "fm-sbt-s3-resolver" % "0.19.0")

--- a/clients/spark/project/types.scala
+++ b/clients/spark/project/types.scala
@@ -1,9 +1,0 @@
-package build
-
-class BuildType(
-  val name: String,
-  val scalaVersion: String,
-  val sparkVersion: String,
-  val scalapbVersion: String,
-  val hadoopVersion: String,
-)


### PR DESCRIPTION
* Publish artifacts to S3 bucket `treeverse-clients-us-east`.
* Simplify Scala cross build, at the price of coupling the Scala version with the Spark version. This is suitable for all relevant Databricks and EMR versions, so IMO it's enough for now. What we gain is:
  * Better `build.sbt` readability.
  * Simpler artifact naming (the "247"/"301" are ommitted)
  * Ability to import into IntelliJ.
  * By default, sbt only compiles / builds / publishes for the Scala version used to run sbt. Can use `sbt +compile` /  `sbt +publish` / etc. to compile for all (both) versions.
