### PR TITLE
[bug] Link correct physical address in client direct upload

### DIFF
--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -167,7 +167,7 @@ func (c *Controller) LinkPhysicalAddress(w http.ResponseWriter, r *http.Request,
 	entry := catalog.DBEntry{
 		CommonLevel:     false,
 		Path:            params.Path,
-		PhysicalAddress: params.Path,
+		PhysicalAddress: *body.Staging.PhysicalAddress,
 		CreationDate:    writeTime,
 		Size:            body.SizeBytes,
 		Checksum:        body.Checksum,
@@ -2162,6 +2162,7 @@ func (c *Controller) GetObject(w http.ResponseWriter, r *http.Request, repositor
 	if handleAPIError(w, err) {
 		return
 	}
+	c.Logger.Tracef("get repo %s ref %s path %s: %+v", repository, ref, params.Path, entry)
 	if entry.Expired {
 		writeError(w, http.StatusGone, "resource expired")
 		return


### PR DESCRIPTION
2nd phase `LinkPhysicalAddress` was incorrectly repeating the lakeFS path.  Use the requested
upload location instead.

Probably broken during the OpenAPI 2 -> OpenAPI3 change.  "Why isn't this tested?", you may
well ask.  Quite right: in fact, this was breaking the current effort to add a test for direct
upload.