### PR TITLE
lakeFS endpoint as URI with support of base URI by flag and env var

### DIFF
--- a/cmd/lakectl/cmd/abuse.go
+++ b/cmd/lakectl/cmd/abuse.go
@@ -13,9 +13,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/treeverse/lakefs/pkg/api"
 	"github.com/treeverse/lakefs/pkg/api/helpers"
-	"github.com/treeverse/lakefs/pkg/cmdutils"
 	"github.com/treeverse/lakefs/pkg/testutil/stress"
-	"github.com/treeverse/lakefs/pkg/uri"
 )
 
 var abuseCmd = &cobra.Command{
@@ -50,13 +48,9 @@ var abuseRandomReadsCmd = &cobra.Command{
 	Use:    "random-read <source ref uri>",
 	Short:  "Read keys from a file and generate random reads from the source ref for those keys.",
 	Hidden: false,
-	Args: cmdutils.ValidationChain(
-		cobra.ExactArgs(1),
-		cmdutils.FuncValidator(0, uri.ValidateRefURI),
-	),
+	Args:   cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		u := MustParseURI(args[0])
-
+		u := MustParseRefURI("source ref", args[0])
 		amount := MustInt(cmd.Flags().GetInt("amount"))
 		parallelism := MustInt(cmd.Flags().GetInt("parallelism"))
 		fromFile := MustString(cmd.Flags().GetString("from-file"))
@@ -104,13 +98,9 @@ var abuseRandomWritesCmd = &cobra.Command{
 	Use:    "random-write <source branch uri>",
 	Short:  "Generate random writes to the source branch",
 	Hidden: false,
-	Args: cmdutils.ValidationChain(
-		cobra.ExactArgs(1),
-		cmdutils.FuncValidator(0, uri.ValidateRefURI),
-	),
+	Args:   cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		u := MustParseURI(args[0])
-
+		u := MustParseRefURI("source branch", args[0])
 		amount := MustInt(cmd.Flags().GetInt("amount"))
 		parallelism := MustInt(cmd.Flags().GetInt("parallelism"))
 		prefix := MustString(cmd.Flags().GetString("prefix"))
@@ -164,13 +154,9 @@ var abuseCreateBranchesCmd = &cobra.Command{
 	Use:    "create-branches <source ref uri>",
 	Short:  "Create a lot of branches very quickly.",
 	Hidden: false,
-	Args: cmdutils.ValidationChain(
-		cobra.ExactArgs(1),
-		cmdutils.FuncValidator(0, uri.ValidateRefURI),
-	),
+	Args:   cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		u := MustParseURI(args[0])
-
+		u := MustParseRefURI("source ref", args[0])
 		cleanOnly := MustBool(cmd.Flags().GetBool("clean-only"))
 		branchPrefix := MustString(cmd.Flags().GetString("branch-prefix"))
 		amount := MustInt(cmd.Flags().GetInt("amount"))

--- a/cmd/lakectl/cmd/abuse.go
+++ b/cmd/lakectl/cmd/abuse.go
@@ -55,7 +55,7 @@ var abuseRandomReadsCmd = &cobra.Command{
 		cmdutils.FuncValidator(0, uri.ValidateRefURI),
 	),
 	Run: func(cmd *cobra.Command, args []string) {
-		u := uri.Must(uri.Parse(args[0]))
+		u := MustParseURI(args[0])
 
 		amount := MustInt(cmd.Flags().GetInt("amount"))
 		parallelism := MustInt(cmd.Flags().GetInt("parallelism"))
@@ -109,7 +109,7 @@ var abuseRandomWritesCmd = &cobra.Command{
 		cmdutils.FuncValidator(0, uri.ValidateRefURI),
 	),
 	Run: func(cmd *cobra.Command, args []string) {
-		u := uri.Must(uri.Parse(args[0]))
+		u := MustParseURI(args[0])
 
 		amount := MustInt(cmd.Flags().GetInt("amount"))
 		parallelism := MustInt(cmd.Flags().GetInt("parallelism"))
@@ -169,7 +169,7 @@ var abuseCreateBranchesCmd = &cobra.Command{
 		cmdutils.FuncValidator(0, uri.ValidateRefURI),
 	),
 	Run: func(cmd *cobra.Command, args []string) {
-		u := uri.Must(uri.Parse(args[0]))
+		u := MustParseURI(args[0])
 
 		cleanOnly := MustBool(cmd.Flags().GetBool("clean-only"))
 		branchPrefix := MustString(cmd.Flags().GetString("branch-prefix"))

--- a/cmd/lakectl/cmd/abuse.go
+++ b/cmd/lakectl/cmd/abuse.go
@@ -55,6 +55,7 @@ var abuseRandomReadsCmd = &cobra.Command{
 		parallelism := MustInt(cmd.Flags().GetInt("parallelism"))
 		fromFile := MustString(cmd.Flags().GetString("from-file"))
 
+		Fmt("Source ref: %s\n", u.String())
 		// read the input file
 		keys, err := readLines(fromFile)
 		if err != nil {
@@ -105,6 +106,7 @@ var abuseRandomWritesCmd = &cobra.Command{
 		parallelism := MustInt(cmd.Flags().GetInt("parallelism"))
 		prefix := MustString(cmd.Flags().GetString("prefix"))
 
+		Fmt("Source branch: %s\n", u.String())
 		generator := stress.NewGenerator(parallelism, stress.WithSignalHandlersFor(os.Interrupt, syscall.SIGTERM))
 
 		// generate randomly selected keys as input
@@ -162,6 +164,7 @@ var abuseCreateBranchesCmd = &cobra.Command{
 		amount := MustInt(cmd.Flags().GetInt("amount"))
 		parallelism := MustInt(cmd.Flags().GetInt("parallelism"))
 
+		Fmt("Source ref: %s\n", u.String())
 		deleteGen := stress.NewGenerator(parallelism)
 
 		const paginationAmount = 1000

--- a/cmd/lakectl/cmd/branch.go
+++ b/cmd/lakectl/cmd/branch.go
@@ -81,6 +81,7 @@ var branchCreateCmd = &cobra.Command{
 		if err != nil {
 			DieFmt("failed to parse source URI: %s", err)
 		}
+		Fmt("Source ref: %s\n", sourceURI.String())
 		if sourceURI.Repository != u.Repository {
 			Die("source branch must be in the same repository", 1)
 		}
@@ -105,6 +106,7 @@ var branchDeleteCmd = &cobra.Command{
 		}
 		client := getClient()
 		u := MustParseRefURI("branch", args[0])
+		Fmt("Branch: %s\n", u.String())
 		resp, err := client.DeleteBranchWithResponse(cmd.Context(), u.Repository, u.Ref)
 		DieOnResponseError(resp, err)
 	},
@@ -117,6 +119,7 @@ var branchRevertCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(branchRevertCmdArgs),
 	Run: func(cmd *cobra.Command, args []string) {
 		u := MustParseRefURI("branch", args[0])
+		Fmt("Branch: %s\n", u.String())
 		commitRef := args[1]
 		clt := getClient()
 		hasParentNumber := cmd.Flags().Changed(ParentNumberFlagName)
@@ -149,6 +152,7 @@ var branchResetCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		clt := getClient()
 		u := MustParseRefURI("branch", args[0])
+		Fmt("Branch: %s\n", u.String())
 		commitID, err := cmd.Flags().GetString("commit")
 		if err != nil {
 			DieErr(err)
@@ -207,6 +211,7 @@ var branchShowCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getClient()
 		u := MustParseRefURI("branch", args[0])
+		Fmt("Branch: %s\n", u.String())
 		resp, err := client.GetBranchWithResponse(cmd.Context(), u.Repository, u.Ref)
 		DieOnResponseError(resp, err)
 		branch := resp.JSON200

--- a/cmd/lakectl/cmd/cat_hook_output.go
+++ b/cmd/lakectl/cmd/cat_hook_output.go
@@ -18,7 +18,7 @@ var catHookOutputCmd = &cobra.Command{
 		cmdutils.FuncValidator(0, uri.ValidateRepoURI),
 	),
 	Run: func(cmd *cobra.Command, args []string) {
-		u := uri.Must(uri.Parse(args[0]))
+		u := MustParseURI(args[0])
 		runID := args[1]
 		hookRunID := args[2]
 		client := getClient()

--- a/cmd/lakectl/cmd/cat_hook_output.go
+++ b/cmd/lakectl/cmd/cat_hook_output.go
@@ -2,8 +2,6 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
-	"github.com/treeverse/lakefs/pkg/cmdutils"
-	"github.com/treeverse/lakefs/pkg/uri"
 )
 
 const catHookOutputRequiredArgs = 3
@@ -13,12 +11,9 @@ var catHookOutputCmd = &cobra.Command{
 	Short:   "Cat actions hook output",
 	Hidden:  true,
 	Example: "lakectl cat-hook-output lakefs://<repository> <run_id> <run_hook_id>",
-	Args: cmdutils.ValidationChain(
-		cobra.ExactArgs(catHookOutputRequiredArgs),
-		cmdutils.FuncValidator(0, uri.ValidateRepoURI),
-	),
+	Args:    cobra.ExactArgs(catHookOutputRequiredArgs),
 	Run: func(cmd *cobra.Command, args []string) {
-		u := MustParseURI(args[0])
+		u := MustParseRepoURI("repository", args[0])
 		runID := args[1]
 		hookRunID := args[2]
 		client := getClient()

--- a/cmd/lakectl/cmd/cat_hook_output.go
+++ b/cmd/lakectl/cmd/cat_hook_output.go
@@ -14,6 +14,7 @@ var catHookOutputCmd = &cobra.Command{
 	Args:    cobra.ExactArgs(catHookOutputRequiredArgs),
 	Run: func(cmd *cobra.Command, args []string) {
 		u := MustParseRepoURI("repository", args[0])
+		Fmt("Repository: %s\n", u.String())
 		runID := args[1]
 		hookRunID := args[2]
 		client := getClient()

--- a/cmd/lakectl/cmd/commit.go
+++ b/cmd/lakectl/cmd/commit.go
@@ -35,6 +35,7 @@ var commitCmd = &cobra.Command{
 			DieErr(err)
 		}
 		branchURI := MustParseRefURI("branch", args[0])
+		Fmt("Branch: %s\n", branchURI.String())
 
 		// do commit
 		metadata := api.CommitCreation_Metadata{

--- a/cmd/lakectl/cmd/commit.go
+++ b/cmd/lakectl/cmd/commit.go
@@ -6,7 +6,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/treeverse/lakefs/pkg/api"
-	"github.com/treeverse/lakefs/pkg/cmdutils"
 	"github.com/treeverse/lakefs/pkg/uri"
 )
 
@@ -24,10 +23,7 @@ var errInvalidKeyValueFormat = fmt.Errorf("invalid key/value pair - should be se
 var commitCmd = &cobra.Command{
 	Use:   "commit <branch uri>",
 	Short: "commit changes on a given branch",
-	Args: cmdutils.ValidationChain(
-		cobra.ExactArgs(1),
-		cmdutils.FuncValidator(0, uri.ValidateRefURI),
-	),
+	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		// validate message
 		kvPairs, err := getKV(cmd, "meta")
@@ -38,7 +34,7 @@ var commitCmd = &cobra.Command{
 		if err != nil {
 			DieErr(err)
 		}
-		branchURI := MustParseURI(args[0])
+		branchURI := MustParseRefURI("branch", args[0])
 
 		// do commit
 		metadata := api.CommitCreation_Metadata{

--- a/cmd/lakectl/cmd/commit.go
+++ b/cmd/lakectl/cmd/commit.go
@@ -38,7 +38,7 @@ var commitCmd = &cobra.Command{
 		if err != nil {
 			DieErr(err)
 		}
-		branchURI := uri.Must(uri.Parse(args[0]))
+		branchURI := MustParseURI(args[0])
 
 		// do commit
 		metadata := api.CommitCreation_Metadata{

--- a/cmd/lakectl/cmd/common_helpers.go
+++ b/cmd/lakectl/cmd/common_helpers.go
@@ -208,10 +208,35 @@ func PrintTable(rows [][]interface{}, headers []interface{}, paginator *api.Pagi
 	Write(resourceListTemplate, ctx)
 }
 
-func MustParseURI(s string) *uri.URI {
+func MustParseRepoURI(name, s string) *uri.URI {
 	u, err := uri.ParseWithBaseURI(s, baseURI)
 	if err != nil {
-		DieErr(err)
+		DieFmt("Invalid '%s': %s", name, err)
+	}
+	if !u.IsRepository() {
+		DieFmt("Invalid '%s': %s", name, uri.ErrInvalidRepoURI)
+	}
+	return u
+}
+
+func MustParseRefURI(name, s string) *uri.URI {
+	u, err := uri.ParseWithBaseURI(s, baseURI)
+	if err != nil {
+		DieFmt("Invalid '%s': %s", name, err)
+	}
+	if !u.IsRef() {
+		DieFmt("Invalid %s: %s", name, uri.ErrInvalidRefURI)
+	}
+	return u
+}
+
+func MustParsePathURI(name, s string) *uri.URI {
+	u, err := uri.ParseWithBaseURI(s, baseURI)
+	if err != nil {
+		DieFmt("Invalid '%s': %s", name, err)
+	}
+	if !u.IsFullyQualified() {
+		DieFmt("Invalid '%s': %s", name, uri.ErrInvalidPathURI)
 	}
 	return u
 }

--- a/cmd/lakectl/cmd/common_helpers.go
+++ b/cmd/lakectl/cmd/common_helpers.go
@@ -10,6 +10,8 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/treeverse/lakefs/pkg/uri"
+
 	"github.com/jedib0t/go-pretty/table"
 	"github.com/jedib0t/go-pretty/text"
 	"github.com/treeverse/lakefs/pkg/api"
@@ -204,4 +206,12 @@ func PrintTable(rows [][]interface{}, headers []interface{}, paginator *api.Pagi
 	}
 
 	Write(resourceListTemplate, ctx)
+}
+
+func MustParseURI(s string) *uri.URI {
+	u, err := uri.ParseWithBaseURI(s, baseURI)
+	if err != nil {
+		DieErr(err)
+	}
+	return u
 }

--- a/cmd/lakectl/cmd/diff.go
+++ b/cmd/lakectl/cmd/diff.go
@@ -7,13 +7,12 @@ import (
 	"github.com/jedib0t/go-pretty/text"
 	"github.com/spf13/cobra"
 	"github.com/treeverse/lakefs/pkg/api"
-	"github.com/treeverse/lakefs/pkg/cmdutils"
-	"github.com/treeverse/lakefs/pkg/uri"
 )
 
 const (
-	diffCmdMinArgs  = 1
-	diffCmdMaxArgs  = 2
+	diffCmdMinArgs = 1
+	diffCmdMaxArgs = 2
+
 	minDiffPageSize = 50
 	maxDiffPageSize = 100000
 )
@@ -22,26 +21,18 @@ var diffCmd = &cobra.Command{
 	Use:   "diff <ref uri> [other ref uri]",
 	Short: "diff between commits/hashes",
 	Long:  "see the list of paths added/changed/removed in a branch or between two references (could be either commit hash or branch name)",
-	Args: cmdutils.ValidationChain(
-		cobra.RangeArgs(diffCmdMinArgs, diffCmdMaxArgs),
-		cmdutils.FuncValidator(0, uri.ValidateRefURI),
-	),
+	Args:  cobra.RangeArgs(diffCmdMinArgs, diffCmdMaxArgs),
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getClient()
-
-		const diffWithOtherArgsCount = 2
-		if len(args) == diffWithOtherArgsCount {
-			if err := uri.ValidateRefURI(args[1]); err != nil {
-				DieErr(err)
-			}
-			leftRefURI := MustParseURI(args[0])
-			rightRefURI := MustParseURI(args[1])
+		if len(args) == diffCmdMaxArgs {
+			leftRefURI := MustParseRefURI("left ref", args[0])
+			rightRefURI := MustParseRefURI("right ref", args[1])
 			if leftRefURI.Repository != rightRefURI.Repository {
 				Die("both references must belong to the same repository", 1)
 			}
 			printDiffRefs(cmd.Context(), client, leftRefURI.Repository, leftRefURI.Ref, rightRefURI.Ref)
 		} else {
-			branchURI := MustParseURI(args[0])
+			branchURI := MustParseRefURI("ref", args[0])
 			printDiffBranch(cmd.Context(), client, branchURI.Repository, branchURI.Ref)
 		}
 	},

--- a/cmd/lakectl/cmd/diff.go
+++ b/cmd/lakectl/cmd/diff.go
@@ -27,12 +27,15 @@ var diffCmd = &cobra.Command{
 		if len(args) == diffCmdMaxArgs {
 			leftRefURI := MustParseRefURI("left ref", args[0])
 			rightRefURI := MustParseRefURI("right ref", args[1])
+			Fmt("Left ref: %s\nRight ref: %s\n", leftRefURI.String(), rightRefURI.String())
+
 			if leftRefURI.Repository != rightRefURI.Repository {
 				Die("both references must belong to the same repository", 1)
 			}
 			printDiffRefs(cmd.Context(), client, leftRefURI.Repository, leftRefURI.Ref, rightRefURI.Ref)
 		} else {
 			branchURI := MustParseRefURI("ref", args[0])
+			Fmt("Ref: %s\n", branchURI.String())
 			printDiffBranch(cmd.Context(), client, branchURI.Repository, branchURI.Ref)
 		}
 	},

--- a/cmd/lakectl/cmd/diff.go
+++ b/cmd/lakectl/cmd/diff.go
@@ -34,14 +34,14 @@ var diffCmd = &cobra.Command{
 			if err := uri.ValidateRefURI(args[1]); err != nil {
 				DieErr(err)
 			}
-			leftRefURI := uri.Must(uri.Parse(args[0]))
-			rightRefURI := uri.Must(uri.Parse(args[1]))
+			leftRefURI := MustParseURI(args[0])
+			rightRefURI := MustParseURI(args[1])
 			if leftRefURI.Repository != rightRefURI.Repository {
 				Die("both references must belong to the same repository", 1)
 			}
 			printDiffRefs(cmd.Context(), client, leftRefURI.Repository, leftRefURI.Ref, rightRefURI.Ref)
 		} else {
-			branchURI := uri.Must(uri.Parse(args[0]))
+			branchURI := MustParseURI(args[0])
 			printDiffBranch(cmd.Context(), client, branchURI.Repository, branchURI.Ref)
 		}
 	},

--- a/cmd/lakectl/cmd/fs.go
+++ b/cmd/lakectl/cmd/fs.go
@@ -15,7 +15,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/treeverse/lakefs/pkg/api"
 	"github.com/treeverse/lakefs/pkg/api/helpers"
-	"github.com/treeverse/lakefs/pkg/cmdutils"
 	"github.com/treeverse/lakefs/pkg/uri"
 )
 
@@ -35,12 +34,9 @@ Human Total Size: {{.Bytes|human_bytes}}
 var fsStatCmd = &cobra.Command{
 	Use:   "stat <path uri>",
 	Short: "view object metadata",
-	Args: cmdutils.ValidationChain(
-		cobra.ExactArgs(1),
-		cmdutils.FuncValidator(0, uri.ValidatePathURI),
-	),
+	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		pathURI := MustParseURI(args[0])
+		pathURI := MustParsePathURI("path", args[0])
 		client := getClient()
 		res, err := client.StatObjectWithResponse(cmd.Context(), pathURI.Repository, pathURI.Ref, &api.StatObjectParams{
 			Path: *pathURI.Path,
@@ -63,14 +59,8 @@ var fsListCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getClient()
-		pathURI := MustParseURI(args[0])
+		pathURI := MustParsePathURI("path", args[0])
 		recursive, _ := cmd.Flags().GetBool("recursive")
-
-		fmt.Println("Path", pathURI.String())
-		if !pathURI.IsFullyQualified() {
-			Die("Invalid path", 1)
-		}
-
 		prefix := *pathURI.Path
 
 		// prefix we need to trim in ls output (non recursive)
@@ -118,13 +108,10 @@ var fsListCmd = &cobra.Command{
 var fsCatCmd = &cobra.Command{
 	Use:   "cat <path uri>",
 	Short: "dump content of object to stdout",
-	Args: cmdutils.ValidationChain(
-		cobra.ExactArgs(1),
-		cmdutils.FuncValidator(0, uri.ValidatePathURI),
-	),
+	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getClient()
-		pathURI := MustParseURI(args[0]))
+		pathURI := MustParsePathURI(args[0])
 		direct, _ := cmd.Flags().GetBool("direct")
 		var contents []byte
 		if direct {
@@ -194,13 +181,10 @@ func uploadObject(ctx context.Context, client api.ClientWithResponsesInterface, 
 var fsUploadCmd = &cobra.Command{
 	Use:   "upload <path uri>",
 	Short: "upload a local file to the specified URI",
-	Args: cmdutils.ValidationChain(
-		cobra.ExactArgs(1),
-		cmdutils.FuncValidator(0, uri.ValidatePathURI),
-	),
+	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getClient()
-		pathURI := MustParseURI(args[0])
+		pathURI := MustParsePathURI("path", args[0])
 		source, _ := cmd.Flags().GetString("source")
 		recursive, _ := cmd.Flags().GetBool("recursive")
 		direct, _ := cmd.Flags().GetBool("direct")
@@ -249,13 +233,10 @@ var fsStageCmd = &cobra.Command{
 	Use:    "stage <path uri>",
 	Short:  "stages a reference to an existing object, to be managed in lakeFS",
 	Hidden: true,
-	Args: cmdutils.ValidationChain(
-		cobra.ExactArgs(1),
-		cmdutils.FuncValidator(0, uri.ValidatePathURI),
-	),
+	Args:   cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getClient()
-		pathURI := MustParseURI(args[0])
+		pathURI := MustParsePathURI("path", args[0])
 		size, _ := cmd.Flags().GetInt64("size")
 		location, _ := cmd.Flags().GetString("location")
 		checksum, _ := cmd.Flags().GetString("checksum")
@@ -285,12 +266,9 @@ var fsStageCmd = &cobra.Command{
 var fsRmCmd = &cobra.Command{
 	Use:   "rm <path uri>",
 	Short: "delete object",
-	Args: cmdutils.ValidationChain(
-		cobra.ExactArgs(1),
-		cmdutils.FuncValidator(0, uri.ValidatePathURI),
-	),
+	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		pathURI := MustParseURI(args[0])
+		pathURI := MustParsePathURI("path", args[0])
 		client := getClient()
 		resp, err := client.DeleteObjectWithResponse(cmd.Context(), pathURI.Repository, pathURI.Ref, &api.DeleteObjectParams{
 			Path: *pathURI.Path,

--- a/cmd/lakectl/cmd/fs.go
+++ b/cmd/lakectl/cmd/fs.go
@@ -111,7 +111,7 @@ var fsCatCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getClient()
-		pathURI := MustParsePathURI(args[0])
+		pathURI := MustParsePathURI("path", args[0])
 		direct, _ := cmd.Flags().GetBool("direct")
 		var contents []byte
 		if direct {

--- a/cmd/lakectl/cmd/input.go
+++ b/cmd/lakectl/cmd/input.go
@@ -55,7 +55,7 @@ type deleteOnClose struct {
 
 func (d *deleteOnClose) Close() error {
 	if err := os.Remove(d.Name()); err != nil {
-		d.File.Close() // "Only" file descriptor leak if close fails (but data might stay).
+		_ = d.File.Close() // "Only" file descriptor leak if close fails (but data might stay).
 		return fmt.Errorf("delete on close: %w", err)
 	}
 	return d.File.Close()

--- a/cmd/lakectl/cmd/log.go
+++ b/cmd/lakectl/cmd/log.go
@@ -45,7 +45,7 @@ var logCmd = &cobra.Command{
 		}
 		showMetaRangeID, _ := cmd.Flags().GetBool("show-meta-range-id")
 		client := getClient()
-		branchURI := uri.Must(uri.Parse(args[0]))
+		branchURI := MustParseURI(args[0])
 		res, err := client.LogCommitsWithResponse(cmd.Context(), branchURI.Repository, branchURI.Ref, &api.LogCommitsParams{
 			After:  api.PaginationAfterPtr(after),
 			Amount: api.PaginationAmountPtr(amount),

--- a/cmd/lakectl/cmd/log.go
+++ b/cmd/lakectl/cmd/log.go
@@ -3,8 +3,6 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 	"github.com/treeverse/lakefs/pkg/api"
-	"github.com/treeverse/lakefs/pkg/cmdutils"
-	"github.com/treeverse/lakefs/pkg/uri"
 )
 
 const commitsTemplate = `
@@ -30,10 +28,7 @@ Merge:         {{ $val.Parents|join ", "|bold }}
 var logCmd = &cobra.Command{
 	Use:   "log <branch uri>",
 	Short: "show log of commits for the given branch",
-	Args: cmdutils.ValidationChain(
-		cobra.ExactArgs(1),
-		cmdutils.FuncValidator(0, uri.ValidateRefURI),
-	),
+	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		amount, err := cmd.Flags().GetInt("amount")
 		if err != nil {
@@ -45,7 +40,7 @@ var logCmd = &cobra.Command{
 		}
 		showMetaRangeID, _ := cmd.Flags().GetBool("show-meta-range-id")
 		client := getClient()
-		branchURI := MustParseURI(args[0])
+		branchURI := MustParseRefURI("branch", args[0])
 		res, err := client.LogCommitsWithResponse(cmd.Context(), branchURI.Repository, branchURI.Ref, &api.LogCommitsParams{
 			After:  api.PaginationAfterPtr(after),
 			Amount: api.PaginationAmountPtr(amount),

--- a/cmd/lakectl/cmd/merge.go
+++ b/cmd/lakectl/cmd/merge.go
@@ -34,6 +34,7 @@ var mergeCmd = &cobra.Command{
 		client := getClient()
 		sourceRef := MustParseRefURI("source ref", args[0])
 		destinationRef := MustParseRefURI("destination ref", args[1])
+		Fmt("Source: %s\n, Destination: %s\n", sourceRef.String(), destinationRef)
 		if destinationRef.Repository != sourceRef.Repository {
 			Die("both references must belong to the same repository", 1)
 		}

--- a/cmd/lakectl/cmd/merge.go
+++ b/cmd/lakectl/cmd/merge.go
@@ -34,7 +34,7 @@ var mergeCmd = &cobra.Command{
 		client := getClient()
 		sourceRef := MustParseRefURI("source ref", args[0])
 		destinationRef := MustParseRefURI("destination ref", args[1])
-		Fmt("Source: %s\n, Destination: %s\n", sourceRef.String(), destinationRef)
+		Fmt("Source: %s\nDestination: %s\n", sourceRef.String(), destinationRef)
 		if destinationRef.Repository != sourceRef.Repository {
 			Die("both references must belong to the same repository", 1)
 		}

--- a/cmd/lakectl/cmd/merge.go
+++ b/cmd/lakectl/cmd/merge.go
@@ -5,8 +5,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/treeverse/lakefs/pkg/api"
-	"github.com/treeverse/lakefs/pkg/cmdutils"
-	"github.com/treeverse/lakefs/pkg/uri"
 )
 
 const (
@@ -31,16 +29,11 @@ var mergeCmd = &cobra.Command{
 	Use:   "merge <source ref> <destination ref>",
 	Short: "merge",
 	Long:  "merge & commit changes from source branch into destination branch",
-	Args: cmdutils.ValidationChain(
-		cobra.RangeArgs(mergeCmdMinArgs, mergeCmdMaxArgs),
-		cmdutils.FuncValidator(0, uri.ValidateRefURI),
-		cmdutils.FuncValidator(1, uri.ValidateRefURI),
-	),
+	Args:  cobra.RangeArgs(mergeCmdMinArgs, mergeCmdMaxArgs),
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getClient()
-		sourceRef := MustParseURI(args[0])
-		destinationRef := MustParseURI(args[1])
-
+		sourceRef := MustParseRefURI("source ref", args[0])
+		destinationRef := MustParseRefURI("destination ref", args[1])
 		if destinationRef.Repository != sourceRef.Repository {
 			Die("both references must belong to the same repository", 1)
 		}

--- a/cmd/lakectl/cmd/merge.go
+++ b/cmd/lakectl/cmd/merge.go
@@ -38,8 +38,8 @@ var mergeCmd = &cobra.Command{
 	),
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getClient()
-		sourceRef := uri.Must(uri.Parse(args[0]))
-		destinationRef := uri.Must(uri.Parse(args[1]))
+		sourceRef := MustParseURI(args[0])
+		destinationRef := MustParseURI(args[1])
 
 		if destinationRef.Repository != sourceRef.Repository {
 			Die("both references must belong to the same repository", 1)

--- a/cmd/lakectl/cmd/refs.go
+++ b/cmd/lakectl/cmd/refs.go
@@ -32,7 +32,7 @@ Since a bare repo is expected, in case of transient failure, delete the reposito
 		cmdutils.FuncValidator(0, uri.ValidateRepoURI),
 	),
 	Run: func(cmd *cobra.Command, args []string) {
-		repoURI := uri.Must(uri.Parse(args[0]))
+		repoURI := MustParseURI(args[0])
 		manifestFileName, _ := cmd.Flags().GetString("manifest")
 		fp := OpenByPath(manifestFileName)
 		defer func() {
@@ -66,7 +66,7 @@ var refsDumpCmd = &cobra.Command{
 		cmdutils.FuncValidator(0, uri.ValidateRepoURI),
 	),
 	Run: func(cmd *cobra.Command, args []string) {
-		repoURI := uri.Must(uri.Parse(args[0]))
+		repoURI := MustParseURI(args[0])
 
 		client := getClient()
 		resp, err := client.DumpRefsWithResponse(cmd.Context(), repoURI.Repository)

--- a/cmd/lakectl/cmd/refs.go
+++ b/cmd/lakectl/cmd/refs.go
@@ -6,8 +6,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/treeverse/lakefs/pkg/api"
-	"github.com/treeverse/lakefs/pkg/cmdutils"
-	"github.com/treeverse/lakefs/pkg/uri"
 )
 
 var metadataDumpTemplate = `
@@ -27,12 +25,9 @@ This command is expected to run on a bare repository (i.e. one created with 'lak
 Since a bare repo is expected, in case of transient failure, delete the repository and recreate it as bare and retry.`,
 	Example: "aws s3 cp s3://bucket/_lakefs/refs_manifest.json - | lakectl refs-load lakefs://my-bare-repository --manifest -",
 	Hidden:  true,
-	Args: cmdutils.ValidationChain(
-		cobra.ExactArgs(1),
-		cmdutils.FuncValidator(0, uri.ValidateRepoURI),
-	),
+	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		repoURI := MustParseURI(args[0])
+		repoURI := MustParseRepoURI("repository", args[0])
 		manifestFileName, _ := cmd.Flags().GetString("manifest")
 		fp := OpenByPath(manifestFileName)
 		defer func() {
@@ -61,13 +56,9 @@ var refsDumpCmd = &cobra.Command{
 	Use:    "refs-dump <repository uri>",
 	Short:  "dumps refs (branches, commits, tags) to the underlying object store",
 	Hidden: true,
-	Args: cmdutils.ValidationChain(
-		cobra.ExactArgs(1),
-		cmdutils.FuncValidator(0, uri.ValidateRepoURI),
-	),
+	Args:   cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		repoURI := MustParseURI(args[0])
-
+		repoURI := MustParseRepoURI("repository", args[0])
 		client := getClient()
 		resp, err := client.DumpRefsWithResponse(cmd.Context(), repoURI.Repository)
 		DieOnResponseError(resp, err)

--- a/cmd/lakectl/cmd/refs.go
+++ b/cmd/lakectl/cmd/refs.go
@@ -28,6 +28,7 @@ Since a bare repo is expected, in case of transient failure, delete the reposito
 	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		repoURI := MustParseRepoURI("repository", args[0])
+		Fmt("Repository: %s\n", repoURI.String())
 		manifestFileName, _ := cmd.Flags().GetString("manifest")
 		fp := OpenByPath(manifestFileName)
 		defer func() {
@@ -59,6 +60,7 @@ var refsDumpCmd = &cobra.Command{
 	Args:   cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		repoURI := MustParseRepoURI("repository", args[0])
+		Fmt("Repository: %s\n", repoURI.String())
 		client := getClient()
 		resp, err := client.DumpRefsWithResponse(cmd.Context(), repoURI.Repository)
 		DieOnResponseError(resp, err)

--- a/cmd/lakectl/cmd/repo.go
+++ b/cmd/lakectl/cmd/repo.go
@@ -80,7 +80,7 @@ var repoCreateCmd = &cobra.Command{
 
 	Run: func(cmd *cobra.Command, args []string) {
 		clt := getClient()
-		u := uri.Must(uri.Parse(args[0]))
+		u := MustParseURI(args[0])
 		defaultBranch, err := cmd.Flags().GetString("default-branch")
 		if err != nil {
 			DieErr(err)
@@ -116,7 +116,7 @@ var repoCreateBareCmd = &cobra.Command{
 
 	Run: func(cmd *cobra.Command, args []string) {
 		clt := getClient()
-		u := uri.Must(uri.Parse(args[0]))
+		u := MustParseURI(args[0])
 		defaultBranch, err := cmd.Flags().GetString("default-branch")
 		if err != nil {
 			DieErr(err)
@@ -151,7 +151,7 @@ var repoDeleteCmd = &cobra.Command{
 	),
 	Run: func(cmd *cobra.Command, args []string) {
 		clt := getClient()
-		u := uri.Must(uri.Parse(args[0]))
+		u := MustParseURI(args[0])
 		confirmation, err := Confirm(cmd.Flags(), "Are you sure you want to delete repository: "+u.Repository)
 		if err != nil || !confirmation {
 			DieFmt("Delete Repository '%s' aborted\n", u.Repository)

--- a/cmd/lakectl/cmd/repo.go
+++ b/cmd/lakectl/cmd/repo.go
@@ -5,8 +5,6 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/treeverse/lakefs/pkg/api"
-	"github.com/treeverse/lakefs/pkg/cmdutils"
-	"github.com/treeverse/lakefs/pkg/uri"
 )
 
 const (
@@ -73,14 +71,10 @@ var repoListCmd = &cobra.Command{
 var repoCreateCmd = &cobra.Command{
 	Use:   "create <repository uri> <storage namespace>",
 	Short: "create a new repository ",
-	Args: cmdutils.ValidationChain(
-		cobra.ExactArgs(repoCreateCmdArgs),
-		cmdutils.FuncValidator(0, uri.ValidateRepoURI),
-	),
-
+	Args:  cobra.ExactArgs(repoCreateCmdArgs),
 	Run: func(cmd *cobra.Command, args []string) {
 		clt := getClient()
-		u := MustParseURI(args[0])
+		u := MustParseRepoURI("repository", args[0])
 		defaultBranch, err := cmd.Flags().GetString("default-branch")
 		if err != nil {
 			DieErr(err)
@@ -109,14 +103,10 @@ var repoCreateBareCmd = &cobra.Command{
 	Use:    "create-bare <repository uri> <storage namespace>",
 	Short:  "create a new repository with no initial branch or commit",
 	Hidden: true,
-	Args: cmdutils.ValidationChain(
-		cobra.ExactArgs(repoCreateCmdArgs),
-		cmdutils.FuncValidator(0, uri.ValidateRepoURI),
-	),
-
+	Args:   cobra.ExactArgs(repoCreateCmdArgs),
 	Run: func(cmd *cobra.Command, args []string) {
 		clt := getClient()
-		u := MustParseURI(args[0])
+		u := MustParseRepoURI("repository", args[0])
 		defaultBranch, err := cmd.Flags().GetString("default-branch")
 		if err != nil {
 			DieErr(err)
@@ -145,13 +135,10 @@ var repoCreateBareCmd = &cobra.Command{
 var repoDeleteCmd = &cobra.Command{
 	Use:   "delete <repository uri>",
 	Short: "delete existing repository",
-	Args: cmdutils.ValidationChain(
-		cobra.ExactArgs(1),
-		cmdutils.FuncValidator(0, uri.ValidateRepoURI),
-	),
+	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		clt := getClient()
-		u := MustParseURI(args[0])
+		u := MustParseRepoURI("repository", args[0])
 		confirmation, err := Confirm(cmd.Flags(), "Are you sure you want to delete repository: "+u.Repository)
 		if err != nil || !confirmation {
 			DieFmt("Delete Repository '%s' aborted\n", u.Repository)

--- a/cmd/lakectl/cmd/repo.go
+++ b/cmd/lakectl/cmd/repo.go
@@ -75,6 +75,7 @@ var repoCreateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		clt := getClient()
 		u := MustParseRepoURI("repository", args[0])
+		Fmt("Repository: %s\n", u.String())
 		defaultBranch, err := cmd.Flags().GetString("default-branch")
 		if err != nil {
 			DieErr(err)
@@ -107,6 +108,7 @@ var repoCreateBareCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		clt := getClient()
 		u := MustParseRepoURI("repository", args[0])
+		Fmt("Repository: %s\n", u.String())
 		defaultBranch, err := cmd.Flags().GetString("default-branch")
 		if err != nil {
 			DieErr(err)
@@ -139,6 +141,7 @@ var repoDeleteCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		clt := getClient()
 		u := MustParseRepoURI("repository", args[0])
+		Fmt("Repository: %s\n", u.String())
 		confirmation, err := Confirm(cmd.Flags(), "Are you sure you want to delete repository: "+u.Repository)
 		if err != nil || !confirmation {
 			DieFmt("Delete Repository '%s' aborted\n", u.Repository)

--- a/cmd/lakectl/cmd/root.go
+++ b/cmd/lakectl/cmd/root.go
@@ -124,8 +124,7 @@ func init() {
 	cobra.OnInitialize(initConfig)
 	rootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", "config file (default is $HOME/.lakectl.yaml)")
 	rootCmd.PersistentFlags().BoolVar(&noColorRequested, "no-color", false, "don't use fancy output colors (default when not attached to an interactive terminal)")
-	baseURIDefault := os.Getenv("LAKECTL_BASE_URI")
-	rootCmd.PersistentFlags().StringVarP(&baseURI, "base-uri", "", baseURIDefault, "base URI used for lakeFS address parse")
+	rootCmd.PersistentFlags().StringVarP(&baseURI, "base-uri", "", os.Getenv("LAKECTL_BASE_URI"), "base URI used for lakeFS address parse")
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/lakectl/cmd/root.go
+++ b/cmd/lakectl/cmd/root.go
@@ -31,6 +31,7 @@ const (
 var (
 	cfgFile string
 	cfg     *config.Config
+	baseURI string
 )
 
 // rootCmd represents the base command when called without any sub-commands
@@ -148,6 +149,8 @@ func init() {
 	cobra.OnInitialize(initConfig)
 	rootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", "config file (default is $HOME/.lakectl.yaml)")
 	rootCmd.PersistentFlags().BoolVar(&noColorRequested, "no-color", false, "don't use fancy output colors (default when not attached to an interactive terminal)")
+	baseURIDefault := os.Getenv("LAKECTL_BASE_URI")
+	rootCmd.PersistentFlags().StringVarP(&baseURI, "base-uri", "", baseURIDefault, "base URI used for lakeFS address parse")
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/lakectl/cmd/root.go
+++ b/cmd/lakectl/cmd/root.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
@@ -114,30 +113,6 @@ func Execute() {
 	err := rootCmd.Execute()
 	if err != nil {
 		DieErr(err)
-	}
-}
-
-// ParseDocument parses the contents of filename into dest, which
-// should be a JSON-deserializable struct.  If filename is "-" it
-// reads standard input.  If any errors occur it dies with an error
-// message containing fileTitle.
-func ParseDocument(dest interface{}, filename string, fileTitle string) {
-	var (
-		fp  io.ReadCloser
-		err error
-	)
-	if filename == "-" {
-		fp = os.Stdin
-	} else {
-		if fp, err = os.Open(filename); err != nil {
-			DieFmt("open %s %s for read: %v", fileTitle, filename, err)
-		}
-		defer func() {
-			_ = fp.Close()
-		}()
-	}
-	if err := json.NewDecoder(fp).Decode(dest); err != nil {
-		DieFmt("could not parse %s document: %v", fileTitle, err)
 	}
 }
 

--- a/cmd/lakectl/cmd/root.go
+++ b/cmd/lakectl/cmd/root.go
@@ -30,6 +30,13 @@ const (
 var (
 	cfgFile string
 	cfg     *config.Config
+
+	// baseURI default value is set by the environment variable LAKECTL_BASE_URI and
+	// override by flag 'base-url'. The baseURI is used as a prefix when we parse lakefs address (repo, ref or path).
+	// The prefix is used only when the address we parse is not a full address (starts with 'lakefs://' scheme).
+	// Examples:
+	//   `--base-uri lakefs:// repo1` will resolve to repository `lakefs://repo1`
+	//   `--base-uri lakefs://repo1 /master/file.md` will resolve to path `lakefs://repo1/master/file.md`
 	baseURI string
 )
 

--- a/cmd/lakectl/cmd/runs_describe.go
+++ b/cmd/lakectl/cmd/runs_describe.go
@@ -8,8 +8,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/treeverse/lakefs/pkg/api"
 	"github.com/treeverse/lakefs/pkg/api/helpers"
-	"github.com/treeverse/lakefs/pkg/cmdutils"
-	"github.com/treeverse/lakefs/pkg/uri"
 )
 
 const actionRunResultTemplate = `
@@ -30,14 +28,11 @@ var runsDescribeCmd = &cobra.Command{
 	Short:   "Describe run results",
 	Long:    `Show information about the run and all the hooks that were executed as part of the run`,
 	Example: "lakectl actions runs describe lakefs://<repository> <run_id>",
-	Args: cmdutils.ValidationChain(
-		cobra.ExactArgs(runsShowRequiredArgs),
-		cmdutils.FuncValidator(0, uri.ValidateRepoURI),
-	),
+	Args:    cobra.ExactArgs(runsShowRequiredArgs),
 	Run: func(cmd *cobra.Command, args []string) {
 		amount, _ := cmd.Flags().GetInt("amount")
 		after, _ := cmd.Flags().GetString("after")
-		u := MustParseURI(args[0])
+		u := MustParseRepoURI("repository", args[0])
 		runID := args[1]
 
 		client := getClient()

--- a/cmd/lakectl/cmd/runs_describe.go
+++ b/cmd/lakectl/cmd/runs_describe.go
@@ -33,6 +33,7 @@ var runsDescribeCmd = &cobra.Command{
 		amount, _ := cmd.Flags().GetInt("amount")
 		after, _ := cmd.Flags().GetString("after")
 		u := MustParseRepoURI("repository", args[0])
+		Fmt("Repository: %s\n", u.String())
 		runID := args[1]
 
 		client := getClient()

--- a/cmd/lakectl/cmd/runs_describe.go
+++ b/cmd/lakectl/cmd/runs_describe.go
@@ -37,7 +37,7 @@ var runsDescribeCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		amount, _ := cmd.Flags().GetInt("amount")
 		after, _ := cmd.Flags().GetString("after")
-		u := uri.Must(uri.Parse(args[0]))
+		u := MustParseURI(args[0])
 		runID := args[1]
 
 		client := getClient()

--- a/cmd/lakectl/cmd/runs_list.go
+++ b/cmd/lakectl/cmd/runs_list.go
@@ -26,7 +26,7 @@ var runsListCmd = &cobra.Command{
 		commit, _ := cmd.Flags().GetString("commit")
 		branch, _ := cmd.Flags().GetString("branch")
 
-		u := uri.Must(uri.Parse(args[0]))
+		u := MustParseURI(args[0])
 		if commit != "" && branch != "" {
 			Die("Can't specify 'commit' and 'branch'", 1)
 		}

--- a/cmd/lakectl/cmd/runs_list.go
+++ b/cmd/lakectl/cmd/runs_list.go
@@ -3,8 +3,6 @@ package cmd
 import (
 	"github.com/spf13/cobra"
 	"github.com/treeverse/lakefs/pkg/api"
-	"github.com/treeverse/lakefs/pkg/cmdutils"
-	"github.com/treeverse/lakefs/pkg/uri"
 )
 
 const actionsRunsListTemplate = `{{.ActionsRunsTable | table -}}
@@ -16,17 +14,13 @@ var runsListCmd = &cobra.Command{
 	Short:   "List runs",
 	Long:    `List all runs on a repository optional filter by branch or commit`,
 	Example: "lakectl actions runs list lakefs://<repository> [--branch <branch>] [--commit <commit_id>]",
-	Args: cmdutils.ValidationChain(
-		cobra.ExactArgs(1),
-		cmdutils.FuncValidator(0, uri.ValidateRepoURI),
-	),
+	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		amount, _ := cmd.Flags().GetInt("amount")
 		after, _ := cmd.Flags().GetString("after")
 		commit, _ := cmd.Flags().GetString("commit")
 		branch, _ := cmd.Flags().GetString("branch")
-
-		u := MustParseURI(args[0])
+		u := MustParseRepoURI("repository", args[0])
 		if commit != "" && branch != "" {
 			Die("Can't specify 'commit' and 'branch'", 1)
 		}

--- a/cmd/lakectl/cmd/show.go
+++ b/cmd/lakectl/cmd/show.go
@@ -14,6 +14,8 @@ var showCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		u := MustParseRepoURI("repository", args[0])
+		Fmt("Repository: %s\n", u.String())
+
 		oneOf := []string{"commit"}
 		var found bool
 		var showType, identifier string

--- a/cmd/lakectl/cmd/show.go
+++ b/cmd/lakectl/cmd/show.go
@@ -18,7 +18,7 @@ var showCmd = &cobra.Command{
 		cmdutils.FuncValidator(0, uri.ValidateRepoURI),
 	),
 	Run: func(cmd *cobra.Command, args []string) {
-		u := uri.Must(uri.Parse(args[0]))
+		u := MustParseURI(args[0])
 		oneOf := []string{"commit"}
 		var found bool
 		var showType, identifier string

--- a/cmd/lakectl/cmd/show.go
+++ b/cmd/lakectl/cmd/show.go
@@ -5,20 +5,15 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/treeverse/lakefs/pkg/api"
-	"github.com/treeverse/lakefs/pkg/cmdutils"
-	"github.com/treeverse/lakefs/pkg/uri"
 )
 
 // showCmd represents the show command
 var showCmd = &cobra.Command{
 	Use:   "show <repository uri>",
 	Short: "See detailed information about an entity by ID (commit, user, etc)",
-	Args: cmdutils.ValidationChain(
-		cobra.ExactArgs(1),
-		cmdutils.FuncValidator(0, uri.ValidateRepoURI),
-	),
+	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		u := MustParseURI(args[0])
+		u := MustParseRepoURI("repository", args[0])
 		oneOf := []string{"commit"}
 		var found bool
 		var showType, identifier string

--- a/cmd/lakectl/cmd/tag.go
+++ b/cmd/lakectl/cmd/tag.go
@@ -28,6 +28,7 @@ var tagListCmd = &cobra.Command{
 		after, _ := cmd.Flags().GetString("after")
 
 		u := MustParseRepoURI("repository", args[0])
+
 		ctx := cmd.Context()
 		client := getClient()
 		resp, err := client.ListTagsWithResponse(ctx, u.Repository, &api.ListTagsParams{
@@ -70,6 +71,8 @@ var tagCreateCmd = &cobra.Command{
 	Args:  cobra.ExactArgs(tagCreateRequiredArgs),
 	Run: func(cmd *cobra.Command, args []string) {
 		tagURI := MustParseRefURI("tag", args[0])
+		Fmt("Tag ref: %s\n", tagURI.String())
+
 		client := getClient()
 		commitRef := args[1]
 		ctx := cmd.Context()
@@ -95,6 +98,8 @@ var tagDeleteCmd = &cobra.Command{
 		}
 		client := getClient()
 		u := MustParseRefURI("tag", args[0])
+		Fmt("Tag ref: %s\n", u.String())
+
 		ctx := cmd.Context()
 		resp, err := client.DeleteTagWithResponse(ctx, u.Repository, u.Ref)
 		DieOnResponseError(resp, err)
@@ -108,6 +113,8 @@ var tagShowCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getClient()
 		u := MustParseRefURI("tag", args[0])
+		Fmt("Tag ref: %s\n", u.String())
+
 		ctx := cmd.Context()
 		resp, err := client.GetTagWithResponse(ctx, u.Repository, u.Ref)
 		DieOnResponseError(resp, err)

--- a/cmd/lakectl/cmd/tag.go
+++ b/cmd/lakectl/cmd/tag.go
@@ -32,7 +32,7 @@ var tagListCmd = &cobra.Command{
 		amount, _ := cmd.Flags().GetInt("amount")
 		after, _ := cmd.Flags().GetString("after")
 
-		u := uri.Must(uri.Parse(args[0]))
+		u := MustParseURI(args[0])
 		ctx := cmd.Context()
 		client := getClient()
 		resp, err := client.ListTagsWithResponse(ctx, u.Repository, &api.ListTagsParams{
@@ -77,7 +77,7 @@ var tagCreateCmd = &cobra.Command{
 		cmdutils.FuncValidator(0, uri.ValidateRefURI),
 	),
 	Run: func(cmd *cobra.Command, args []string) {
-		tagURI := uri.Must(uri.Parse(args[0]))
+		tagURI := MustParseURI(args[0])
 		client := getClient()
 		commitRef := args[1]
 		ctx := cmd.Context()
@@ -105,7 +105,7 @@ var tagDeleteCmd = &cobra.Command{
 			Die("Delete tag aborted", 1)
 		}
 		client := getClient()
-		u := uri.Must(uri.Parse(args[0]))
+		u := MustParseURI(args[0])
 		ctx := cmd.Context()
 		resp, err := client.DeleteTagWithResponse(ctx, u.Repository, u.Ref)
 		DieOnResponseError(resp, err)
@@ -121,7 +121,7 @@ var tagShowCmd = &cobra.Command{
 	),
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getClient()
-		u := uri.Must(uri.Parse(args[0]))
+		u := MustParseURI(args[0])
 		ctx := cmd.Context()
 		resp, err := client.GetTagWithResponse(ctx, u.Repository, u.Ref)
 		DieOnResponseError(resp, err)

--- a/cmd/lakefs-loadtest/cmd/entry.go
+++ b/cmd/lakefs-loadtest/cmd/entry.go
@@ -15,7 +15,6 @@ import (
 	"github.com/schollz/progressbar/v3"
 	"github.com/spf13/cobra"
 	"github.com/treeverse/lakefs/pkg/catalog"
-	"github.com/treeverse/lakefs/pkg/cmdutils"
 	"github.com/treeverse/lakefs/pkg/config"
 	"github.com/treeverse/lakefs/pkg/uri"
 )
@@ -26,12 +25,13 @@ const createEntryPathLength = 110
 var entryCmd = &cobra.Command{
 	Use:   "entry <ref uri>",
 	Short: "Load test database with create entry calls",
-	Args: cmdutils.ValidationChain(
-		cobra.ExactArgs(1),
-		cmdutils.FuncValidator(0, uri.ValidateRefURI),
-	),
+	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		u := uri.Must(uri.Parse(args[0]))
+		if !u.IsRef() {
+			fmt.Printf("Invalid 'ref': %s", uri.ErrInvalidRefURI)
+			os.Exit(1)
+		}
 		connectionString, _ := cmd.Flags().GetString("db")
 		requests, _ := cmd.Flags().GetInt("requests")
 		concurrency, _ := cmd.Flags().GetInt("concurrency")

--- a/cmd/lakefs/cmd/import.go
+++ b/cmd/lakefs/cmd/import.go
@@ -39,12 +39,10 @@ var importCmd = &cobra.Command{
 	Use:   "import <repository uri> --manifest <s3 uri to manifest.json>",
 	Short: "Import data from S3 to a lakeFS repository",
 	Long:  fmt.Sprintf("Import from an S3 inventory to lakeFS without copying the data. It will be added as a new commit in branch %s", onboard.DefaultImportBranchName),
-	Args: cmdutils.ValidationChain(
-		cobra.ExactArgs(ImportCmdNumArgs),
-		cmdutils.FuncValidator(0, uri.ValidateRepoURI),
-	),
+	Args:  cobra.ExactArgs(ImportCmdNumArgs),
 	Run: func(cmd *cobra.Command, args []string) {
-		os.Exit(runImport(cmd, args))
+		rc := runImport(cmd, args)
+		os.Exit(rc)
 	},
 }
 
@@ -53,12 +51,10 @@ var importBaseCmd = &cobra.Command{
 	Short:  "Import data from S3 to a lakeFS repository on top of existing commit",
 	Long:   "Creates a new commit with the imported data, on top of the given commit. Does not affect any branch",
 	Hidden: true,
-	Args: cmdutils.ValidationChain(
-		cobra.ExactArgs(ImportCmdNumArgs),
-		cmdutils.FuncValidator(0, uri.ValidateRepoURI),
-	),
+	Args:   cobra.ExactArgs(ImportCmdNumArgs),
 	Run: func(cmd *cobra.Command, args []string) {
-		os.Exit(runImport(cmd, args))
+		rc := runImport(cmd, args)
+		os.Exit(rc)
 	},
 }
 
@@ -106,6 +102,11 @@ func runImport(cmd *cobra.Command, args []string) (statusCode int) {
 	c.SetHooksHandler(actionsService)
 
 	u := uri.Must(uri.Parse(args[0]))
+	if !u.IsRepository() {
+		fmt.Printf("Invalid 'repository': %s\n", uri.ErrInvalidRefURI)
+		return 1
+	}
+
 	blockStore, err := factory.BuildBlockAdapter(ctx, cfg)
 	if err != nil {
 		fmt.Printf("Failed to create block adapter: %s\n", err)

--- a/pkg/uri/parser.go
+++ b/pkg/uri/parser.go
@@ -78,7 +78,7 @@ func ParseWithBaseURI(s string, baseURI string) (*URI, error) {
 	}
 	u, err := Parse(s)
 	if err != nil {
-		return nil, fmt.Errorf("%w: %s", err, s)
+		return nil, fmt.Errorf("parsing %s: %w", s, err)
 	}
 	return u, nil
 }

--- a/pkg/uri/parser.go
+++ b/pkg/uri/parser.go
@@ -127,39 +127,6 @@ func Equals(a, b *URI) bool {
 			(a.Path != nil && b.Path != nil && *a.Path == *b.Path))
 }
 
-func ValidateRepoURI(str string) error {
-	u, err := Parse(str)
-	if err != nil {
-		return err
-	}
-	if !u.IsRepository() {
-		return ErrInvalidRepoURI
-	}
-	return nil
-}
-
-func ValidatePathURI(str string) error {
-	u, err := Parse(str)
-	if err != nil {
-		return err
-	}
-	if !u.IsFullyQualified() {
-		return ErrInvalidPathURI
-	}
-	return nil
-}
-
-func ValidateRefURI(str string) error {
-	u, err := Parse(str)
-	if err != nil {
-		return err
-	}
-	if !u.IsRef() {
-		return ErrInvalidRefURI
-	}
-	return nil
-}
-
 func IsValid(str string) bool {
 	_, err := Parse(str)
 	return err == nil

--- a/pkg/uri/parser_test.go
+++ b/pkg/uri/parser_test.go
@@ -18,48 +18,93 @@ func TestParse(t *testing.T) {
 		Err      error
 		Expected *uri.URI
 	}{
-		{"lakefs://foo/bar/baz", nil, &uri.URI{
-			Protocol:   "lakefs",
-			Repository: "foo",
-			Ref:        "bar",
-			Path:       strp("baz"),
-		}},
-		{"lakefs://foo/bar/baz/path", nil, &uri.URI{
-			Protocol:   "lakefs",
-			Repository: "foo",
-			Ref:        "bar",
-			Path:       strp("baz/path"),
-		}},
-		{"lakefs://foo/bar/baz/path@withappendix.foo", nil, &uri.URI{
-			Protocol:   "lakefs",
-			Repository: "foo",
-			Ref:        "bar",
-			Path:       strp("baz/path@withappendix.foo"),
-		}},
-		{"lakefs://fo-o/bar/baz/path@withappendix.foo", nil, &uri.URI{
-			Protocol:   "lakefs",
-			Repository: "fo-o",
-			Ref:        "bar",
-			Path:       strp("baz/path@withappendix.foo"),
-		}},
-		{"lakefs://foo", nil, &uri.URI{
-			Protocol:   "lakefs",
-			Repository: "foo",
-		}},
-		{"lakefs://foo/bar/", nil, &uri.URI{
-			Protocol:   "lakefs",
-			Repository: "foo",
-			Ref:        "bar",
-			Path:       strp(""),
-		}},
-		{"lakefs://foo/bar", nil, &uri.URI{
-			Protocol:   "lakefs",
-			Repository: "foo",
-			Ref:        "bar",
-		}},
-		{"lakefssss://foo/bar/baz", uri.ErrMalformedURI, nil},
-		{"lakefs:/foo/bar/baz", uri.ErrMalformedURI, nil},
-		{"lakefs//foo/bar/baz", uri.ErrMalformedURI, nil},
+		{
+			Input: "lakefs://foo/bar/baz",
+			Expected: &uri.URI{
+				Repository: "foo",
+				Ref:        "bar",
+				Path:       strp("baz"),
+			},
+		},
+		{
+			Input: "lakefs://foo",
+			Expected: &uri.URI{
+				Repository: "foo",
+			},
+		},
+		{
+			Input: "lakefs://foo/bar/baz/path",
+			Expected: &uri.URI{
+				Repository: "foo",
+				Ref:        "bar",
+				Path:       strp("baz/path"),
+			},
+		},
+		{
+			Input: "lakefs://foo/bar/baz/path@withappendix.foo",
+			Expected: &uri.URI{
+				Repository: "foo",
+				Ref:        "bar",
+				Path:       strp("baz/path@withappendix.foo"),
+			},
+		},
+		{
+			Input: "lakefs://fo-o/bar/baz/path@withappendix.foo",
+			Expected: &uri.URI{
+				Repository: "fo-o",
+				Ref:        "bar",
+				Path:       strp("baz/path@withappendix.foo"),
+			},
+		},
+		{
+			Input: "lakefs://foo",
+			Expected: &uri.URI{
+				Repository: "foo",
+			},
+		},
+		{
+			Input: "lakefs://foo/bar/",
+			Expected: &uri.URI{
+				Repository: "foo",
+				Ref:        "bar",
+				Path:       strp(""),
+			},
+		},
+		{
+			Input: "lakefs://foo/bar//",
+			Expected: &uri.URI{
+				Repository: "foo",
+				Ref:        "bar",
+				Path:       strp("/"),
+			},
+		},
+		{
+			Input: "lakefs://foo/bar",
+			Expected: &uri.URI{
+				Repository: "foo",
+				Ref:        "bar",
+			},
+		},
+		{
+			Input: "lakefs://foo@bar",
+			Err:   uri.ErrMalformedURI,
+		},
+		{
+			Input: "lakefs://foo@bar/baz",
+			Err:   uri.ErrMalformedURI,
+		},
+		{
+			Input: "lakefssss://foo/bar/baz",
+			Err:   uri.ErrMalformedURI,
+		},
+		{
+			Input: "lakefs:/foo/bar/baz",
+			Err:   uri.ErrMalformedURI,
+		},
+		{
+			Input: "lakefs//foo/bar/baz",
+			Err:   uri.ErrMalformedURI,
+		},
 	}
 
 	for i, test := range cases {
@@ -82,24 +127,20 @@ func TestURI_String(t *testing.T) {
 		Expected string
 	}{
 		{&uri.URI{
-			Protocol:   "lakefs",
 			Repository: "foo",
 			Ref:        "bar",
 			Path:       strp("baz/file.csv"),
 		}, "lakefs://foo/bar/baz/file.csv"},
 		{&uri.URI{
-			Protocol:   "lakefs",
 			Repository: "foo",
 			Ref:        "bar",
 			Path:       strp(""),
 		}, "lakefs://foo/bar/"},
 		{&uri.URI{
-			Protocol:   "lakefs",
 			Repository: "foo",
 			Ref:        "bar",
 		}, "lakefs://foo/bar"},
 		{&uri.URI{
-			Protocol:   "lakefs",
 			Repository: "foo",
 		}, "lakefs://foo"},
 	}
@@ -131,7 +172,6 @@ func TestMust(t *testing.T) {
 	// should not panic
 	u := uri.Must(uri.Parse("lakefs://foo/bar/baz"))
 	if !uri.Equals(u, &uri.URI{
-		Protocol:   "lakefs",
 		Repository: "foo",
 		Ref:        "bar",
 		Path:       strp("baz"),

--- a/pkg/uri/parser_test.go
+++ b/pkg/uri/parser_test.go
@@ -18,27 +18,27 @@ func TestParse(t *testing.T) {
 		Err      error
 		Expected *uri.URI
 	}{
-		{"lakefs://foo@bar/baz", nil, &uri.URI{
+		{"lakefs://foo/bar/baz", nil, &uri.URI{
 			Protocol:   "lakefs",
 			Repository: "foo",
 			Ref:        "bar",
 			Path:       strp("baz"),
 		}},
-		{"lakefs://foo@bar/baz/path", nil, &uri.URI{
+		{"lakefs://foo/bar/baz/path", nil, &uri.URI{
 			Protocol:   "lakefs",
 			Repository: "foo",
 			Ref:        "bar",
 			Path:       strp("baz/path"),
 		}},
-		{"lakefs://foo@bar/baz/path@withappendix.foo", nil, &uri.URI{
+		{"lakefs://foo/bar/baz/path@withappendix.foo", nil, &uri.URI{
 			Protocol:   "lakefs",
 			Repository: "foo",
 			Ref:        "bar",
 			Path:       strp("baz/path@withappendix.foo"),
 		}},
-		{"lakefs://fo/o@bar/baz/path@withappendix.foo", nil, &uri.URI{
+		{"lakefs://fo-o/bar/baz/path@withappendix.foo", nil, &uri.URI{
 			Protocol:   "lakefs",
-			Repository: "fo/o",
+			Repository: "fo-o",
 			Ref:        "bar",
 			Path:       strp("baz/path@withappendix.foo"),
 		}},
@@ -46,20 +46,20 @@ func TestParse(t *testing.T) {
 			Protocol:   "lakefs",
 			Repository: "foo",
 		}},
-		{"lakefs://foo@bar/", nil, &uri.URI{
+		{"lakefs://foo/bar/", nil, &uri.URI{
 			Protocol:   "lakefs",
 			Repository: "foo",
 			Ref:        "bar",
 			Path:       strp(""),
 		}},
-		{"lakefs://foo@bar", nil, &uri.URI{
+		{"lakefs://foo/bar", nil, &uri.URI{
 			Protocol:   "lakefs",
 			Repository: "foo",
 			Ref:        "bar",
 		}},
-		{"lakefssss://foo@bar/baz", uri.ErrMalformedURI, nil},
-		{"lakefs:/foo@bar/baz", uri.ErrMalformedURI, nil},
-		{"lakefs//foo@bar/baz", uri.ErrMalformedURI, nil},
+		{"lakefssss://foo/bar/baz", uri.ErrMalformedURI, nil},
+		{"lakefs:/foo/bar/baz", uri.ErrMalformedURI, nil},
+		{"lakefs//foo/bar/baz", uri.ErrMalformedURI, nil},
 	}
 
 	for i, test := range cases {
@@ -67,12 +67,11 @@ func TestParse(t *testing.T) {
 		if test.Err != nil {
 			if !errors.Is(err, test.Err) {
 				t.Fatalf("case (%d) - expected error %v for input %s, got error: %v", i, test.Err, test.Input, err)
-			} else {
-				continue
 			}
+			continue
 		}
 		if !uri.Equals(u, test.Expected) {
-			t.Fatalf("case (%d) - expected uri %s for input %s, got uri: %v", i, test.Expected, test.Input, u)
+			t.Fatalf("case (%d) - expected uri '%s' for input '%s', got uri: '%v'", i, test.Expected, test.Input, u)
 		}
 	}
 }
@@ -87,18 +86,18 @@ func TestURI_String(t *testing.T) {
 			Repository: "foo",
 			Ref:        "bar",
 			Path:       strp("baz/file.csv"),
-		}, "lakefs://foo@bar/baz/file.csv"},
+		}, "lakefs://foo/bar/baz/file.csv"},
 		{&uri.URI{
 			Protocol:   "lakefs",
 			Repository: "foo",
 			Ref:        "bar",
 			Path:       strp(""),
-		}, "lakefs://foo@bar/"},
+		}, "lakefs://foo/bar/"},
 		{&uri.URI{
 			Protocol:   "lakefs",
 			Repository: "foo",
 			Ref:        "bar",
-		}, "lakefs://foo@bar"},
+		}, "lakefs://foo/bar"},
 		{&uri.URI{
 			Protocol:   "lakefs",
 			Repository: "foo",
@@ -117,8 +116,8 @@ func TestIsValid(t *testing.T) {
 		Input    string
 		Expected bool
 	}{
-		{"lakefs://foo@bar/baz", true},
-		{"lekefs://foo@bar/baz", false},
+		{"lakefs://foo/bar/baz", true},
+		{"lekefs://foo/bar/baz", false},
 	}
 
 	for i, test := range cases {
@@ -130,7 +129,7 @@ func TestIsValid(t *testing.T) {
 
 func TestMust(t *testing.T) {
 	// should not panic
-	u := uri.Must(uri.Parse("lakefs://foo@bar/baz"))
+	u := uri.Must(uri.Parse("lakefs://foo/bar/baz"))
 	if !uri.Equals(u, &uri.URI{
 		Protocol:   "lakefs",
 		Repository: "foo",
@@ -146,7 +145,7 @@ func TestMust(t *testing.T) {
 				recovered = true
 			}
 		}()
-		uri.Must(uri.Parse("lakefsssss://foo@bar"))
+		uri.Must(uri.Parse("lakefsssss://foo/bar"))
 	}()
 
 	if !recovered {


### PR DESCRIPTION
Close #1489
Close #1488
Close #1487

1. Use '/' as a separator between repository and branch
2. Parse endpoint as URI
3. In case the endpoint doesn't start with lakefs:// and LAKECTL_BASE_URI or flag --base-uri is set. Use the base URI as a prefix for the parsed URI
