### PR TITLE
Support multiple gateway domain names

### DIFF
--- a/cmd/lakefs/cmd/run.go
+++ b/cmd/lakefs/cmd/run.go
@@ -128,7 +128,7 @@ var runCmd = &cobra.Command{
 			cloudMetadataProvider,
 			actionsService,
 			logger.WithField("service", "api_gateway"),
-			cfg.GetS3GatewayDomainName(),
+			cfg.GetS3GatewayDomainNames(),
 		)
 
 		// init gateway server
@@ -146,7 +146,7 @@ var runCmd = &cobra.Command{
 			multipartsTracker,
 			blockStore,
 			authService,
-			cfg.GetS3GatewayDomainName(),
+			cfg.GetS3GatewayDomainNames(),
 			bufferedCollector,
 			s3FallbackURL,
 		)
@@ -161,8 +161,8 @@ var runCmd = &cobra.Command{
 			Handler: httputil.HostMux(
 				httputil.HostHandler(apiHandler).Default(), // api as default handler
 				httputil.HostHandler(s3gatewayHandler, // s3 gateway for its bare domain and sub-domains of that
-					httputil.Exact(cfg.GetS3GatewayDomainName()),
-					httputil.SubdomainsOf(cfg.GetS3GatewayDomainName())),
+					httputil.Exact(cfg.GetS3GatewayDomainNames()),
+					httputil.SubdomainsOf(cfg.GetS3GatewayDomainNames())),
 			),
 		}
 

--- a/pkg/api/serve.go
+++ b/pkg/api/serve.go
@@ -46,7 +46,7 @@ func Serve(
 	cloudMetadataProvider cloud.MetadataProvider,
 	actions actionsHandler,
 	logger logging.Logger,
-	gatewayDomain string,
+	gatewayDomains []string,
 ) http.Handler {
 	logger.Info("initialize OpenAPI server")
 	swagger, err := GetSwagger()
@@ -76,7 +76,7 @@ func Serve(
 	)
 	HandlerFromMuxWithBaseURL(controller, apiRouter, BaseURL)
 
-	uiHandler := NewUIHandler(authService, gatewayDomain)
+	uiHandler := NewUIHandler(authService, gatewayDomains)
 	r.Mount("/_health", httputil.ServeHealth())
 	r.Mount("/metrics", promhttp.Handler())
 	r.Mount("/_pprof/", httputil.ServePPROF("/_pprof/"))

--- a/pkg/api/serve_test.go
+++ b/pkg/api/serve_test.go
@@ -115,7 +115,7 @@ func setupHandler(t testing.TB, blockstoreType string, opts ...testutil.GetDBOpt
 		nil,
 		actionsService,
 		logging.Default(),
-		"",
+		nil,
 	)
 
 	return handler, &dependencies{

--- a/pkg/api/ui_handler.go
+++ b/pkg/api/ui_handler.go
@@ -15,22 +15,22 @@ import (
 	"github.com/treeverse/lakefs/pkg/webui"
 )
 
-func NewUIHandler(authService auth.Service, gatewayDomain string) http.Handler {
+func NewUIHandler(authService auth.Service, gatewayDomains []string) http.Handler {
 	mux := http.NewServeMux()
 	mux.Handle("/auth/login", NewLoginHandler(authService))
 	mux.Handle("/auth/logout", NewLogoutHandler())
 	staticFiles, _ := fs.NewWithNamespace(webui.Webui)
-	mux.Handle("/", NewHandlerWithDefault(staticFiles, http.FileServer(staticFiles), "/", gatewayDomain))
+	mux.Handle("/", NewHandlerWithDefault(staticFiles, http.FileServer(staticFiles), "/", gatewayDomains))
 	return mux
 }
 
-func NewHandlerWithDefault(root http.FileSystem, handler http.Handler, defaultPath, gatewayDomain string) http.Handler {
+func NewHandlerWithDefault(root http.FileSystem, handler http.Handler, defaultPath string, gatewayDomains []string) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if isGatewayRequest(r) {
 			// s3 signed request reaching the ui handler, return an error response instead of the default path
 			o := operations.Operation{}
 			err := errors.Codes[errors.ERRLakeFSWrongEndpoint]
-			err.Description = fmt.Sprintf("%s (%s)", err.Description, gatewayDomain)
+			err.Description = fmt.Sprintf("%s (%v)", err.Description, gatewayDomains)
 			o.EncodeError(w, r, err)
 			return
 		}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -133,8 +133,9 @@ const (
 
 	CommittedPebbleSSTableCacheSizeBytesKey = "committed.sstable.memory.cache_size_bytes"
 
-	GatewaysS3DomainNameKey = "gateways.s3.domain_name"
-	GatewaysS3RegionKey     = "gateways.s3.region"
+	GatewaysS3DomainNameKey  = "gateways.s3.domain_name"
+	GatewaysS3DomainNamesKey = "gateways.s3.domain_name"
+	GatewaysS3RegionKey      = "gateways.s3.region"
 
 	BlockstoreGSS3EndpointKey = "blockstore.gs.s3_endpoint"
 
@@ -297,8 +298,21 @@ func (c *Config) GetS3GatewayRegion() string {
 	return c.values.Gateways.S3.Region
 }
 
-func (c *Config) GetS3GatewayDomainName() string {
-	return c.values.Gateways.S3.DomainName
+func (c *Config) GetS3GatewayDomainNames() []string {
+	oneDomainName := c.values.Gateways.S3.DomainName
+	manyDomainNames := c.values.Gateways.S3.DomainNames
+	if manyDomainNames != nil {
+		if oneDomainName != "" {
+			// TODO(ozkatz): This fatal error can occur quite late during
+			//     operation.
+			logging.Default().WithFields(logging.Fields{
+				"domain_name": oneDomainName,
+				"domain_names": manyDomainNames,
+			}).Fatal("both single domain_name and multiple domain_names configured")
+		}
+		return manyDomainNames
+	}
+	return []string{oneDomainName}
 }
 
 func (c *Config) GetS3GatewayFallbackURL() string {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -67,7 +67,7 @@ var (
 	ErrBadConfiguration  = errors.New("bad configuration")
 	ErrMissingSecretKey  = fmt.Errorf("%w: auth.encrypt.secret_key cannot be empty", ErrBadConfiguration)
 	ErrInvalidProportion = fmt.Errorf("%w: total proportion isn't 1.0", ErrBadConfiguration)
-	ErrBadDomainNames = fmt.Errorf("%w: domain names are prefixes", ErrBadConfiguration)
+	ErrBadDomainNames    = fmt.Errorf("%w: domain names are prefixes", ErrBadConfiguration)
 )
 
 type LogrusAWSAdapter struct {
@@ -218,7 +218,7 @@ func (c *Config) validateDomainNames() error {
 		domainNames[i] = reverse(d)
 	}
 	for i := 0; i < len(domainNames)-1; i++ {
-		if strings.HasSuffix(domainNames[i+1], "." + domainNames[i]) {
+		if strings.HasSuffix(domainNames[i+1], "."+domainNames[i]) {
 			return fmt.Errorf("%w: %s, %s", ErrBadDomainNames, domainNames[i], domainNames[i+1])
 		}
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -133,7 +133,6 @@ const (
 
 	CommittedPebbleSSTableCacheSizeBytesKey = "committed.sstable.memory.cache_size_bytes"
 
-	GatewaysS3DomainNameKey  = "gateways.s3.domain_name"
 	GatewaysS3DomainNamesKey = "gateways.s3.domain_name"
 	GatewaysS3RegionKey      = "gateways.s3.region"
 
@@ -175,7 +174,7 @@ func setDefaults() {
 	viper.SetDefault(CommittedPermanentStorageRangeRaggednessKey, DefaultCommittedPermanentRangeRaggednessEntries)
 	viper.SetDefault(CommittedPebbleSSTableCacheSizeBytesKey, DefaultCommittedPebbleSSTableCacheSizeBytes)
 
-	viper.SetDefault(GatewaysS3DomainNameKey, DefaultS3GatewayDomainName)
+	viper.SetDefault(GatewaysS3DomainNamesKey, DefaultS3GatewayDomainName)
 	viper.SetDefault(GatewaysS3RegionKey, DefaultS3GatewayRegion)
 
 	viper.SetDefault(BlockstoreGSS3EndpointKey, DefaultBlockStoreGSS3Endpoint)
@@ -299,20 +298,7 @@ func (c *Config) GetS3GatewayRegion() string {
 }
 
 func (c *Config) GetS3GatewayDomainNames() []string {
-	oneDomainName := c.values.Gateways.S3.DomainName
-	manyDomainNames := c.values.Gateways.S3.DomainNames
-	if manyDomainNames != nil {
-		if oneDomainName != "" {
-			// TODO(ozkatz): This fatal error can occur quite late during
-			//     operation.
-			logging.Default().WithFields(logging.Fields{
-				"domain_name": oneDomainName,
-				"domain_names": manyDomainNames,
-			}).Fatal("both single domain_name and multiple domain_names configured")
-		}
-		return manyDomainNames
-	}
-	return []string{oneDomainName}
+	return c.values.Gateways.S3.DomainNames
 }
 
 func (c *Config) GetS3GatewayFallbackURL() string {

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/go-test/deep"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
 	"github.com/treeverse/lakefs/pkg/block/factory"
@@ -44,8 +45,8 @@ func TestConfig_NewFromFile(t *testing.T) {
 		if c.GetListenAddress() != "0.0.0.0:8005" {
 			t.Fatalf("expected listen addr 0.0.0.0:8005, got %s", c.GetListenAddress())
 		}
-		if c.GetS3GatewayDomainName() != "s3.example.com" {
-			t.Fatalf("expected domain name s3.example.com, got %s", c.GetS3GatewayDomainName())
+		if diffs := deep.Equal(c.GetS3GatewayDomainNames(), []string{"s3.example.com", "gcp.example.net"}); diffs != nil {
+			t.Fatalf("expected domain name s3.example.com, diffs %s", diffs)
 		}
 	})
 

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -45,7 +45,7 @@ func TestConfig_NewFromFile(t *testing.T) {
 		if c.GetListenAddress() != "0.0.0.0:8005" {
 			t.Fatalf("expected listen addr 0.0.0.0:8005, got %s", c.GetListenAddress())
 		}
-		if diffs := deep.Equal(c.GetS3GatewayDomainNames(), []string{"s3.example.com", "gcp.example.net"}); diffs != nil {
+		if diffs := deep.Equal(c.GetS3GatewayDomainNames(), []string{"s3.example.com", "gs3.example.com", "gcp.example.net"}); diffs != nil {
 			t.Fatalf("expected domain name s3.example.com, diffs %s", diffs)
 		}
 	})
@@ -87,6 +87,13 @@ func TestConfig_EnvironmentVariables(t *testing.T) {
 	testutil.Must(t, err)
 	if c.GetDatabaseParams().ConnectionString != dbString {
 		t.Errorf("got DB connection string %s, expected to override to %s", c.GetDatabaseParams().ConnectionString, dbString)
+	}
+}
+
+func TestConfig_DomainNamePrefix(t *testing.T) {
+	_, err := newConfigFromFile("testdata/domain_name_prefix.yaml")
+	if !errors.Is(err, config.ErrBadDomainNames) {
+		t.Errorf("got error %s not %s", err, config.ErrBadDomainNames)
 	}
 }
 

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -95,7 +95,8 @@ type configuration struct {
 	}
 	Gateways struct {
 		S3 struct {
-			DomainName  string `mapstructure:"domain_name"`
+			DomainName  string   `mapstructure:"domain_name"`
+			DomainNames []string `mapstructure:"domain_names"`
 			Region      string
 			FallbackURL string `mapstructure:"fallback_url"`
 		}

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -1,6 +1,32 @@
 package config
 
-import "time"
+import (
+	"reflect"
+	"time"
+)
+
+// Strings is a []string that mapstructure can deserialize from a single string or from a list
+// of strings.
+type Strings []string
+
+var ourStringsType = reflect.TypeOf(Strings{})
+var stringType = reflect.TypeOf("")
+var stringSliceType = reflect.TypeOf([]string{})
+
+// decodeStrings is a mapstructure.HookFuncType that decodes a single string value or a slice
+// of strings into Strings.
+func DecodeStrings(fromValue reflect.Value, toValue reflect.Value) (interface{}, error) {
+	if toValue.Type() != ourStringsType {
+		return fromValue.Interface(), nil
+	}
+	if fromValue.Type() == stringSliceType {
+		return Strings(fromValue.Interface().([]string)), nil
+	}
+	if fromValue.Type() == stringType {
+		return Strings{fromValue.String()}, nil
+	}
+	return fromValue.Interface(), nil
+}
 
 // S3AuthInfo holds S3-style authentication.
 type S3AuthInfo struct {
@@ -95,8 +121,7 @@ type configuration struct {
 	}
 	Gateways struct {
 		S3 struct {
-			DomainName  string   `mapstructure:"domain_name"`
-			DomainNames []string `mapstructure:"domain_names"`
+			DomainNames Strings `mapstructure:"domain_name"`
 			Region      string
 			FallbackURL string `mapstructure:"fallback_url"`
 		}

--- a/pkg/config/template_test.go
+++ b/pkg/config/template_test.go
@@ -1,0 +1,68 @@
+package config_test
+
+import (
+	"github.com/go-test/deep"
+	"github.com/mitchellh/mapstructure"
+	"github.com/treeverse/lakefs/pkg/config"
+	"github.com/treeverse/lakefs/pkg/testutil"
+
+	"testing"
+)
+
+type StringsStruct struct {
+	S config.Strings
+	I int
+}
+
+func TestStrings(t *testing.T) {
+	cases := []struct {
+		Name     string
+		Source   map[string]interface{}
+		Expected StringsStruct
+	}{
+		{
+			Name: "single string",
+			Source: map[string]interface{}{
+				"s": "value",
+			},
+			Expected: StringsStruct{
+				S: config.Strings{"value"},
+			},
+		}, {
+			Name: "multiple strings",
+			Source: map[string]interface{}{
+				"s": []string{"the", "quick", "brown"},
+			},
+			Expected: StringsStruct{
+				S: config.Strings{"the", "quick", "brown"},
+			},
+		}, {
+			Name: "other values",
+			Source: map[string]interface{}{
+				"s": []string{"yes"},
+				"i": 17,
+			},
+			Expected: StringsStruct{
+				S: config.Strings{"yes"},
+				I: 17,
+			},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.Name, func(t *testing.T) {
+			var s StringsStruct
+
+			dc := mapstructure.DecoderConfig{
+				DecodeHook: config.DecodeStrings,
+				Result:     &s,
+			}
+			decoder, err := mapstructure.NewDecoder(&dc)
+			testutil.MustDo(t, "new decoder", err)
+			err = decoder.Decode(c.Source)
+			testutil.MustDo(t, "decode", err)
+			if diffs := deep.Equal(s, c.Expected); diffs != nil {
+				t.Error(diffs)
+			}
+		})
+	}
+}

--- a/pkg/config/testdata/domain_name_prefix.yaml
+++ b/pkg/config/testdata/domain_name_prefix.yaml
@@ -1,0 +1,10 @@
+---
+gateways:
+  s3:
+    domain_name:
+      - gs.example.com
+      - s4.s3.example.com
+      - s3.example.com
+    region: us-east-1
+
+listen_address: "0.0.0.0:8005"

--- a/pkg/config/testdata/valid_config.yaml
+++ b/pkg/config/testdata/valid_config.yaml
@@ -19,6 +19,7 @@ gateways:
   s3:
     domain_name:
       - s3.example.com
+      - gs3.example.com
       - gcp.example.net
     region: us-east-1
 

--- a/pkg/config/testdata/valid_config.yaml
+++ b/pkg/config/testdata/valid_config.yaml
@@ -17,7 +17,9 @@ blockstore:
 
 gateways:
   s3:
-    domain_name: s3.example.com
+    domain_names:
+      - s3.example.com
+      - gcp.example.net
     region: us-east-1
 
 listen_address: "0.0.0.0:8005"

--- a/pkg/config/testdata/valid_config.yaml
+++ b/pkg/config/testdata/valid_config.yaml
@@ -17,7 +17,7 @@ blockstore:
 
 gateways:
   s3:
-    domain_names:
+    domain_name:
       - s3.example.com
       - gcp.example.net
     region: us-east-1

--- a/pkg/gateway/handler.go
+++ b/pkg/gateway/handler.go
@@ -42,7 +42,7 @@ var (
 )
 
 type handler struct {
-	BareDomains         []string
+	BareDomains        []string
 	sc                 *ServerContext
 	ServerErrorHandler http.Handler
 	operationHandlers  map[operations.OperationID]http.Handler
@@ -50,7 +50,7 @@ type handler struct {
 
 type ServerContext struct {
 	region            string
-	bareDomains        []string
+	bareDomains       []string
 	catalog           catalog.Interface
 	multipartsTracker multiparts.Tracker
 	blockStore        block.Adapter
@@ -86,7 +86,7 @@ func NewHandler(
 		catalog:           catalog,
 		multipartsTracker: multipartsTracker,
 		region:            region,
-		bareDomains:        bareDomains,
+		bareDomains:       bareDomains,
 		blockStore:        blockStore,
 		authService:       authService,
 		stats:             stats,
@@ -95,7 +95,7 @@ func NewHandler(
 	// setup routes
 	var h http.Handler
 	h = &handler{
-		BareDomains:         bareDomains,
+		BareDomains:        bareDomains,
 		sc:                 sc,
 		ServerErrorHandler: nil,
 		operationHandlers: map[operations.OperationID]http.Handler{

--- a/pkg/gateway/handler.go
+++ b/pkg/gateway/handler.go
@@ -42,7 +42,7 @@ var (
 )
 
 type handler struct {
-	BareDomain         string
+	BareDomains         []string
 	sc                 *ServerContext
 	ServerErrorHandler http.Handler
 	operationHandlers  map[operations.OperationID]http.Handler
@@ -50,7 +50,7 @@ type handler struct {
 
 type ServerContext struct {
 	region            string
-	bareDomain        string
+	bareDomains        []string
 	catalog           catalog.Interface
 	multipartsTracker multiparts.Tracker
 	blockStore        block.Adapter
@@ -64,7 +64,7 @@ func NewHandler(
 	multipartsTracker multiparts.Tracker,
 	blockStore block.Adapter,
 	authService simulator.GatewayAuthService,
-	bareDomain string,
+	bareDomains []string,
 	stats stats.Collector,
 	fallbackURL *url.URL,
 ) http.Handler {
@@ -72,7 +72,13 @@ func NewHandler(
 	if fallbackURL != nil {
 		fallbackProxy := gohttputil.NewSingleHostReverseProxy(fallbackURL)
 		fallbackHandler = http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
-			request.Host = strings.Replace(request.Host, bareDomain, fallbackURL.Host, 1)
+			for _, bareDomain := range bareDomains {
+				fallback := strings.Replace(request.Host, bareDomain, fallbackURL.Host, 1)
+				if fallback != request.Host {
+					request.Host = fallback
+					break
+				}
+			}
 			fallbackProxy.ServeHTTP(writer, request)
 		})
 	}
@@ -80,7 +86,7 @@ func NewHandler(
 		catalog:           catalog,
 		multipartsTracker: multipartsTracker,
 		region:            region,
-		bareDomain:        bareDomain,
+		bareDomains:        bareDomains,
 		blockStore:        blockStore,
 		authService:       authService,
 		stats:             stats,
@@ -89,7 +95,7 @@ func NewHandler(
 	// setup routes
 	var h http.Handler
 	h = &handler{
-		BareDomain:         bareDomain,
+		BareDomains:         bareDomains,
 		sc:                 sc,
 		ServerErrorHandler: nil,
 		operationHandlers: map[operations.OperationID]http.Handler{
@@ -106,16 +112,16 @@ func NewHandler(
 		},
 	}
 	loggingMiddleware := httputil.LoggingMiddleware("X-Amz-Request-Id", logging.Fields{"service_name": "s3_gateway"})
-	h = simulator.RegisterRecorder(loggingMiddleware(h), authService, region, bareDomain)
+	h = simulator.RegisterRecorder(loggingMiddleware(h), authService, region, bareDomains)
 	h = EnrichWithOperation(sc,
 		DurationHandler(
-			AuthenticationHandler(authService, bareDomain,
-				EnrichWithParts(bareDomain,
+			AuthenticationHandler(authService, bareDomains,
+				EnrichWithParts(bareDomains,
 					EnrichWithRepositoryOrFallback(catalog, authService, fallbackHandler,
 						OperationLookupHandler(
 							h))))))
 	logging.Default().WithFields(logging.Fields{
-		"s3_bare_domain": bareDomain,
+		"s3_bare_domain": bareDomains,
 		"s3_region":      region,
 	}).Info("initialized S3 Gateway handler")
 	return h

--- a/pkg/gateway/handler_test.go
+++ b/pkg/gateway/handler_test.go
@@ -13,7 +13,7 @@ import (
 
 func setupTest(t *testing.T, method, target string, body io.Reader) *http.Response {
 	h, _ := getBasicHandler(t, &simulator.PlayBackMockConf{
-		BareDomains:      []string{"example.net", "example.com"},
+		BareDomain:      "example.com",
 		AccessKeyID:     "AKIAIO5FODNN7EXAMPLE",
 		SecretAccessKey: "MockAccessSecretKey",
 		UserID:          1,

--- a/pkg/gateway/handler_test.go
+++ b/pkg/gateway/handler_test.go
@@ -13,7 +13,7 @@ import (
 
 func setupTest(t *testing.T, method, target string, body io.Reader) *http.Response {
 	h, _ := getBasicHandler(t, &simulator.PlayBackMockConf{
-		BareDomain:      "example.com",
+		BareDomains:      []string{"example.net", "example.com"},
 		AccessKeyID:     "AKIAIO5FODNN7EXAMPLE",
 		SecretAccessKey: "MockAccessSecretKey",
 		UserID:          1,

--- a/pkg/gateway/middleware.go
+++ b/pkg/gateway/middleware.go
@@ -21,7 +21,7 @@ import (
 	"github.com/treeverse/lakefs/pkg/permissions"
 )
 
-func AuthenticationHandler(authService simulator.GatewayAuthService, bareDomain string, next http.Handler) http.Handler {
+func AuthenticationHandler(authService simulator.GatewayAuthService, bareDomains []string, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()
 		o := ctx.Value(ContextKeyOperation).(*operations.Operation)
@@ -47,7 +47,7 @@ func AuthenticationHandler(authService simulator.GatewayAuthService, bareDomain 
 			}
 			return
 		}
-		err = authenticator.Verify(creds, bareDomain)
+		err = authenticator.Verify(creds, bareDomains)
 		logger = logger.WithField("authenticator", authenticator)
 		if err != nil {
 			logger.WithError(err).Warn("error verifying credentials for key")
@@ -68,10 +68,10 @@ func AuthenticationHandler(authService simulator.GatewayAuthService, bareDomain 
 	})
 }
 
-func EnrichWithParts(bareDomain string, next http.Handler) http.Handler {
+func EnrichWithParts(bareDomains []string, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()
-		repo, ref, pth := Parts(req.Host, req.URL.Path, bareDomain)
+		repo, ref, pth := Parts(req.Host, req.URL.Path, bareDomains)
 		ctx = context.WithValue(ctx, ContextKeyRepositoryID, repo)
 		ctx = context.WithValue(ctx, ContextKeyRef, ref)
 		ctx = context.WithValue(ctx, ContextKeyPath, pth)
@@ -85,7 +85,9 @@ func EnrichWithOperation(sc *ServerContext, next http.Handler) http.Handler {
 		ctx := req.Context()
 		o := &operations.Operation{
 			Region:            sc.region,
-			FQDN:              sc.bareDomain,
+			// BUG(ariels): This is wrong many times when there is >1 domain.  Can
+			//     we use req.Host?
+			FQDN:              sc.bareDomains[0],
 			Catalog:           sc.catalog,
 			MultipartsTracker: sc.multipartsTracker,
 			BlockStore:        sc.blockStore,
@@ -181,11 +183,22 @@ func OperationLookupHandler(next http.Handler) http.Handler {
 	})
 }
 
+// memberFold returns true if a is equal case-folded to a member of bs.
+func memberFold(a string, bs []string) bool {
+	for _, b := range bs {
+		if strings.EqualFold(a, b) {
+			return true
+		}
+	}
+	return false
+}
+
 // Parts returns the repo id, ref and path according to whether the request is path-style or virtual-host-style.
-func Parts(host string, urlPath string, bareDomain string) (repo string, ref string, pth string) {
+func Parts(host string, urlPath string, bareDomains []string) (repo string, ref string, pth string) {
 	urlPath = strings.TrimPrefix(urlPath, path.Separator)
 	var p []string
-	if strings.EqualFold(httputil.HostOnly(host), httputil.HostOnly(bareDomain)) {
+	ourHosts := httputil.HostsOnly(bareDomains)
+	if memberFold(httputil.HostOnly(host), ourHosts) {
 		// path style: extract repo from first part
 		p = strings.SplitN(urlPath, path.Separator, 3)
 		repo = p[0]
@@ -195,11 +208,12 @@ func Parts(host string, urlPath string, bareDomain string) (repo string, ref str
 	} else {
 		// virtual host style: extract repo from subdomain
 		host := httputil.HostOnly(host)
-		ourHost := httputil.HostOnly(bareDomain)
-		if !strings.HasSuffix(host, ourHost) {
-			repo = ""
-		} else {
-			repo = strings.TrimSuffix(host, "."+ourHost)
+		repo = ""
+		for _, ourHost := range ourHosts {
+			if strings.HasSuffix(host, ourHost) {
+				repo = strings.TrimSuffix(host, "."+ourHost)
+				break
+			}
 		}
 		p = strings.SplitN(urlPath, path.Separator, 2)
 	}

--- a/pkg/gateway/middleware.go
+++ b/pkg/gateway/middleware.go
@@ -91,6 +91,7 @@ func getBareDomain(hostname string, bareDomains []string) string {
 }
 
 var trailingPortRegexp = regexp.MustCompile(`:\d+$`)
+
 func stripPort(host string) string {
 	return trailingPortRegexp.ReplaceAllString(host, "")
 }

--- a/pkg/gateway/middleware.go
+++ b/pkg/gateway/middleware.go
@@ -84,7 +84,7 @@ func EnrichWithOperation(sc *ServerContext, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()
 		o := &operations.Operation{
-			Region:            sc.region,
+			Region: sc.region,
 			// BUG(ariels): This is wrong many times when there is >1 domain.  Can
 			//     we use req.Host?
 			FQDN:              sc.bareDomains[0],

--- a/pkg/gateway/middleware.go
+++ b/pkg/gateway/middleware.go
@@ -93,7 +93,7 @@ func EnrichWithOperation(sc *ServerContext, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()
 		o := &operations.Operation{
-			Region: sc.region,
+			Region:            sc.region,
 			FQDN:              getBareDomain(req.URL.Hostname(), sc.bareDomains),
 			Catalog:           sc.catalog,
 			MultipartsTracker: sc.multipartsTracker,

--- a/pkg/gateway/middleware.go
+++ b/pkg/gateway/middleware.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -89,12 +90,17 @@ func getBareDomain(hostname string, bareDomains []string) string {
 	return bareDomains[0]
 }
 
+var trailingPortRegexp = regexp.MustCompile(`:\d+$`)
+func stripPort(host string) string {
+	return trailingPortRegexp.ReplaceAllString(host, "")
+}
+
 func EnrichWithOperation(sc *ServerContext, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()
 		o := &operations.Operation{
 			Region:            sc.region,
-			FQDN:              getBareDomain(req.URL.Hostname(), sc.bareDomains),
+			FQDN:              getBareDomain(stripPort(req.Host), sc.bareDomains),
 			Catalog:           sc.catalog,
 			MultipartsTracker: sc.multipartsTracker,
 			BlockStore:        sc.blockStore,

--- a/pkg/gateway/middleware.go
+++ b/pkg/gateway/middleware.go
@@ -82,7 +82,7 @@ func EnrichWithParts(bareDomains []string, next http.Handler) http.Handler {
 
 func getBareDomain(hostname string, bareDomains []string) string {
 	for _, bd := range bareDomains {
-		if strings.HasSuffix(hostname, "." + bd) {
+		if hostname == bd || strings.HasSuffix(hostname, "."+bd) {
 			return bd
 		}
 	}

--- a/pkg/gateway/middleware.go
+++ b/pkg/gateway/middleware.go
@@ -47,7 +47,7 @@ func AuthenticationHandler(authService simulator.GatewayAuthService, bareDomains
 			}
 			return
 		}
-		err = authenticator.Verify(creds, bareDomains)
+		err = authenticator.Verify(creds, o.FQDN)
 		logger = logger.WithField("authenticator", authenticator)
 		if err != nil {
 			logger.WithError(err).Warn("error verifying credentials for key")

--- a/pkg/gateway/middleware.go
+++ b/pkg/gateway/middleware.go
@@ -80,14 +80,21 @@ func EnrichWithParts(bareDomains []string, next http.Handler) http.Handler {
 	})
 }
 
+func getBareDomain(hostname string, bareDomains []string) string {
+	for _, bd := range bareDomains {
+		if strings.HasSuffix(hostname, "." + bd) {
+			return bd
+		}
+	}
+	return bareDomains[0]
+}
+
 func EnrichWithOperation(sc *ServerContext, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()
 		o := &operations.Operation{
 			Region: sc.region,
-			// BUG(ariels): This is wrong many times when there is >1 domain.  Can
-			//     we use req.Host?
-			FQDN:              sc.bareDomains[0],
+			FQDN:              getBareDomain(req.URL.Hostname(), sc.bareDomains),
 			Catalog:           sc.catalog,
 			MultipartsTracker: sc.multipartsTracker,
 			BlockStore:        sc.blockStore,

--- a/pkg/gateway/parts_test.go
+++ b/pkg/gateway/parts_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestSplitParts(t *testing.T) {
-	bareDomain := "lakefs.example.com"
+	bareDomains := []string{"lakefs.example.com"}
 	cases := []struct {
 		Name           string
 		URLPath        string
@@ -126,7 +126,7 @@ func TestSplitParts(t *testing.T) {
 
 	for _, cas := range cases {
 		t.Run(cas.Name, func(t *testing.T) {
-			gotRepo, gotRef, gotPath := gateway.Parts(cas.Host, cas.URLPath, bareDomain)
+			gotRepo, gotRef, gotPath := gateway.Parts(cas.Host, cas.URLPath, bareDomains)
 			actualResult := []string{gotRepo, gotRef, gotPath}
 			if !reflect.DeepEqual(cas.ExpectedResult, actualResult) {
 				t.Fatalf("expected parts = %+v for split '%s', got %+v", cas.ExpectedResult, cas.URLPath, actualResult)

--- a/pkg/gateway/playback_test.go
+++ b/pkg/gateway/playback_test.go
@@ -145,7 +145,7 @@ func getBasicHandler(t *testing.T, authService *simulator.PlayBackMockConf) (htt
 		multipartsTracker,
 		blockAdapter,
 		authService,
-		authService.BareDomains,
+		[]string{authService.BareDomain},
 		&mockCollector{},
 		nil,
 	)
@@ -166,7 +166,7 @@ func newGatewayAuthFromFile(t *testing.T, directory string) *simulator.PlayBackM
 	}
 	err = json.Unmarshal(confStr, m)
 	if err != nil {
-		t.Fatal("Failed to unmarshal configuration\n ")
+		t.Fatalf("Failed to unmarshal configuration: %s", err.Error())
 	}
 	return m
 }

--- a/pkg/gateway/playback_test.go
+++ b/pkg/gateway/playback_test.go
@@ -145,7 +145,7 @@ func getBasicHandler(t *testing.T, authService *simulator.PlayBackMockConf) (htt
 		multipartsTracker,
 		blockAdapter,
 		authService,
-		authService.BareDomain,
+		authService.BareDomains,
 		&mockCollector{},
 		nil,
 	)

--- a/pkg/gateway/sig/sig.go
+++ b/pkg/gateway/sig/sig.go
@@ -81,7 +81,7 @@ type SigContext interface {
 
 type SigAuthenticator interface {
 	Parse() (SigContext, error)
-	Verify(*model.Credential, []string) error
+	Verify(*model.Credential, string) error
 }
 
 type chainedAuthenticator struct {
@@ -108,8 +108,8 @@ func Equal(sig1, sig2 []byte) bool {
 	return hmac.Equal(sig1, sig2)
 }
 
-func (c *chainedAuthenticator) Verify(creds *model.Credential, domains []string) error {
-	return c.chosen.Verify(creds, domains)
+func (c *chainedAuthenticator) Verify(creds *model.Credential, fqdn string) error {
+	return c.chosen.Verify(creds, fqdn)
 }
 
 func (c *chainedAuthenticator) String() string {

--- a/pkg/gateway/sig/sig.go
+++ b/pkg/gateway/sig/sig.go
@@ -81,7 +81,7 @@ type SigContext interface {
 
 type SigAuthenticator interface {
 	Parse() (SigContext, error)
-	Verify(*model.Credential, string) error
+	Verify(*model.Credential, []string) error
 }
 
 type chainedAuthenticator struct {
@@ -108,8 +108,8 @@ func Equal(sig1, sig2 []byte) bool {
 	return hmac.Equal(sig1, sig2)
 }
 
-func (c *chainedAuthenticator) Verify(creds *model.Credential, domain string) error {
-	return c.chosen.Verify(creds, domain)
+func (c *chainedAuthenticator) Verify(creds *model.Credential, domains []string) error {
+	return c.chosen.Verify(creds, domains)
 }
 
 func (c *chainedAuthenticator) String() string {

--- a/pkg/gateway/sig/v2.go
+++ b/pkg/gateway/sig/v2.go
@@ -219,7 +219,7 @@ func buildPath(host string, bareDomain string, path string) string {
 	return ""
 }
 
-func (a *V2SigAuthenticator) Verify(creds *model.Credential, bareDomain string) error {
+func (a *V2SigAuthenticator) Verify(creds *model.Credential, bareDomains []string) error {
 	/*
 		s3 sigV2 implementation:
 		the s3 signature  is somewhat different than general aws signature implementation.
@@ -247,7 +247,8 @@ func (a *V2SigAuthenticator) Verify(creds *model.Credential, bareDomain string) 
 	patchedPath = strings.ReplaceAll(patchedPath, "+", "%20")
 	patchedPath = strings.ReplaceAll(patchedPath, "*", "%2A")
 	patchedPath = strings.ReplaceAll(patchedPath, "%7E", "~")
-	path := buildPath(a.r.Host, bareDomain, patchedPath)
+	// TODO(ariels): Can we support sigV2 with multiple domains?
+	path := buildPath(a.r.Host, bareDomains[0], patchedPath)
 	stringToSigh := canonicalString(a.r.Method, a.r.URL.Query(), path, a.r.Header)
 	digest := signCanonicalString(stringToSigh, []byte(creds.SecretAccessKey))
 	if !Equal(digest, a.ctx.signature) {

--- a/pkg/gateway/sig/v2.go
+++ b/pkg/gateway/sig/v2.go
@@ -219,7 +219,7 @@ func buildPath(host string, bareDomain string, path string) string {
 	return ""
 }
 
-func (a *V2SigAuthenticator) Verify(creds *model.Credential, bareDomains []string) error {
+func (a *V2SigAuthenticator) Verify(creds *model.Credential, bareDomain string) error {
 	/*
 		s3 sigV2 implementation:
 		the s3 signature  is somewhat different than general aws signature implementation.
@@ -247,10 +247,9 @@ func (a *V2SigAuthenticator) Verify(creds *model.Credential, bareDomains []strin
 	patchedPath = strings.ReplaceAll(patchedPath, "+", "%20")
 	patchedPath = strings.ReplaceAll(patchedPath, "*", "%2A")
 	patchedPath = strings.ReplaceAll(patchedPath, "%7E", "~")
-	// TODO(ariels): Can we support sigV2 with multiple domains?
-	path := buildPath(a.r.Host, bareDomains[0], patchedPath)
-	stringToSigh := canonicalString(a.r.Method, a.r.URL.Query(), path, a.r.Header)
-	digest := signCanonicalString(stringToSigh, []byte(creds.SecretAccessKey))
+	path := buildPath(a.r.Host, bareDomain, patchedPath)
+	stringToSign := canonicalString(a.r.Method, a.r.URL.Query(), path, a.r.Header)
+	digest := signCanonicalString(stringToSign, []byte(creds.SecretAccessKey))
 	if !Equal(digest, a.ctx.signature) {
 		return errors.ErrSignatureDoesNotMatch
 	}

--- a/pkg/gateway/sig/v4.go
+++ b/pkg/gateway/sig/v4.go
@@ -394,7 +394,7 @@ func (a *V4Authenticator) String() string {
 	return "sigv4"
 }
 
-func (a *V4Authenticator) Verify(creds *model.Credential, _ []string) error {
+func (a *V4Authenticator) Verify(creds *model.Credential, _ string) error {
 	err := V4Verify(a.ctx, creds, a.request)
 	return err
 }

--- a/pkg/gateway/sig/v4.go
+++ b/pkg/gateway/sig/v4.go
@@ -394,7 +394,7 @@ func (a *V4Authenticator) String() string {
 	return "sigv4"
 }
 
-func (a *V4Authenticator) Verify(creds *model.Credential, bareDomain string) error {
+func (a *V4Authenticator) Verify(creds *model.Credential, _ []string) error {
 	err := V4Verify(a.ctx, creds, a.request)
 	return err
 }

--- a/pkg/gateway/sig/v4_test.go
+++ b/pkg/gateway/sig/v4_test.go
@@ -20,6 +20,8 @@ import (
 	"github.com/treeverse/lakefs/pkg/gateway/errors"
 )
 
+const sigV4NoDomain = ""
+
 var (
 	mockCreds = &model.Credential{
 		AccessKeyID:     "AKIAIOSFODNN7EXAMPLE",
@@ -99,7 +101,7 @@ func TestDoesPolicySignatureMatch(t *testing.T) {
 				return
 			}
 
-			err = authenticator.Verify(mockCreds, nil)
+			err = authenticator.Verify(mockCreds, sigV4NoDomain)
 			if err != nil {
 				if !tc.ExpectedError {
 					t.Fatal(err)
@@ -171,7 +173,7 @@ func TestSingleChunkPut(t *testing.T) {
 				AccessKeyID:     ID,
 				SecretAccessKey: SECRET,
 				IssuedDate:      time.Now(),
-			}, nil)
+			}, sigV4NoDomain)
 			if err != nil {
 				t.Errorf("expect not no error, got %v", err)
 			}
@@ -233,7 +235,7 @@ func TestStreaming(t *testing.T) {
 		AccessKeyID:     ID,
 		SecretAccessKey: SECRET,
 		IssuedDate:      time.Now(),
-	}, nil)
+	}, sigV4NoDomain)
 	if err != nil {
 		t.Error(err)
 	}
@@ -290,7 +292,7 @@ func TestStreamingLastByteWrong(t *testing.T) {
 		AccessKeyID:     ID,
 		SecretAccessKey: SECRET,
 		IssuedDate:      time.Now(),
-	}, nil)
+	}, sigV4NoDomain)
 	if err != nil {
 		t.Errorf("expect not no error, got %v", err)
 	}
@@ -335,7 +337,7 @@ func TestUnsignedPayload(t *testing.T) {
 		AccessKeyID:     testID,
 		SecretAccessKey: testSecret,
 		IssuedDate:      time.Now(),
-	}, nil)
+	}, sigV4NoDomain)
 	if err != nil {
 		t.Errorf("expect not no error, got %v", err)
 	}

--- a/pkg/gateway/sig/v4_test.go
+++ b/pkg/gateway/sig/v4_test.go
@@ -99,7 +99,7 @@ func TestDoesPolicySignatureMatch(t *testing.T) {
 				return
 			}
 
-			err = authenticator.Verify(mockCreds, "")
+			err = authenticator.Verify(mockCreds, nil)
 			if err != nil {
 				if !tc.ExpectedError {
 					t.Fatal(err)
@@ -171,7 +171,7 @@ func TestSingleChunkPut(t *testing.T) {
 				AccessKeyID:     ID,
 				SecretAccessKey: SECRET,
 				IssuedDate:      time.Now(),
-			}, "")
+			}, nil)
 			if err != nil {
 				t.Errorf("expect not no error, got %v", err)
 			}
@@ -233,7 +233,7 @@ func TestStreaming(t *testing.T) {
 		AccessKeyID:     ID,
 		SecretAccessKey: SECRET,
 		IssuedDate:      time.Now(),
-	}, "")
+	}, nil)
 	if err != nil {
 		t.Error(err)
 	}
@@ -290,7 +290,7 @@ func TestStreamingLastByteWrong(t *testing.T) {
 		AccessKeyID:     ID,
 		SecretAccessKey: SECRET,
 		IssuedDate:      time.Now(),
-	}, "")
+	}, nil)
 	if err != nil {
 		t.Errorf("expect not no error, got %v", err)
 	}
@@ -335,7 +335,7 @@ func TestUnsignedPayload(t *testing.T) {
 		AccessKeyID:     testID,
 		SecretAccessKey: testSecret,
 		IssuedDate:      time.Now(),
-	}, "")
+	}, nil)
 	if err != nil {
 		t.Errorf("expect not no error, got %v", err)
 	}

--- a/pkg/gateway/simulator/simulation_recorder.go
+++ b/pkg/gateway/simulator/simulation_recorder.go
@@ -147,6 +147,9 @@ func logRequest(r *http.Request, uploadID []byte, nameBase string, statusCode in
 }
 
 func createConfFile(r *http.Request, authService GatewayAuthService, region string, bareDomains []string, recordingDir string) {
+	if len(bareDomains) != 1 {
+		panic("cannot record with more than one s3 bare domain")
+	}
 	authenticator := sig.ChainedAuthenticator(
 		sig.NewV4Authenticator(r),
 		sig.NewV2SigAuthenticator(r))
@@ -164,7 +167,7 @@ func createConfFile(r *http.Request, authService GatewayAuthService, region stri
 			Fatal("failed getting credentials")
 	}
 	conf := &PlayBackMockConf{
-		BareDomains:      bareDomains,
+		BareDomain:      bareDomains[0],
 		AccessKeyID:     accessKeyID,
 		SecretAccessKey: creds.SecretAccessKey,
 		UserID:          creds.UserID,

--- a/pkg/gateway/simulator/simulation_utils.go
+++ b/pkg/gateway/simulator/simulation_utils.go
@@ -17,7 +17,7 @@ import (
 )
 
 type PlayBackMockConf struct {
-	BareDomain      string `json:"bare_domain"`
+	BareDomains      []string `json:"bare_domain"`
 	AccessKeyID     string `json:"access_key_id"`
 	SecretAccessKey string `json:"access_secret_key"`
 	UserID          int    `json:"user_id"`

--- a/pkg/gateway/simulator/simulation_utils.go
+++ b/pkg/gateway/simulator/simulation_utils.go
@@ -17,7 +17,7 @@ import (
 )
 
 type PlayBackMockConf struct {
-	BareDomains      []string `json:"bare_domain"`
+	BareDomain      string `json:"bare_domain"`
 	AccessKeyID     string `json:"access_key_id"`
 	SecretAccessKey string `json:"access_secret_key"`
 	UserID          int    `json:"user_id"`

--- a/pkg/httputil/server_test.go
+++ b/pkg/httputil/server_test.go
@@ -6,7 +6,7 @@ import (
 
 func TestSubdomainsOf(t *testing.T) {
 	type args struct {
-		v string
+		v []string
 	}
 	tests := []struct {
 		name string
@@ -14,14 +14,22 @@ func TestSubdomainsOf(t *testing.T) {
 		host string
 		want bool
 	}{
-		{name: "small", args: args{v: "s3.local.io"}, host: "s3", want: false},
-		{name: "extract", args: args{v: "s3.local.io"}, host: "s3.local.io", want: false},
-		{name: "no sub", args: args{v: "s3.local.io"}, host: ".s3.local.io", want: false},
-		{name: "dot sub", args: args{v: "s3.local.io"}, host: "..s3.local.io", want: false},
-		{name: "invalid1", args: args{v: "s3.local.io"}, host: "1.asdfsa.s3.local.io", want: false},
-		{name: "invalid2", args: args{v: "s3.local.io"}, host: ".asdfsa.s3.local.io", want: false},
-		{name: "subdomain", args: args{v: "s3.local.io"}, host: "asdfsa.s3.local.io", want: true},
-		{name: "subdomain port", args: args{v: "s3.local.io:8000"}, host: "sub.s3.local.io", want: true},
+		{name: "short", args: args{v: []string{"s3.local.io"}}, host: "s3", want: false},
+		{name: "short many", args: args{v: []string{"s3.local.io", "s3.dev.invalid"}}, host: "s3", want: false},
+		{name: "extract", args: args{v: []string{"s3.local.io"}}, host: "s3.local.io", want: false},
+		{name: "extract many", args: args{v: []string{"s3.dev.invalid", "s3.local.io"}}, host: "s3.local.io", want: false},
+		{name: "no sub", args: args{v: []string{"s3.local.io"}}, host: ".s3.local.io", want: false},
+		{name: "no sub many", args: args{v: []string{"s3.dev.invalid", "s3.local.io"}}, host: ".s3.local.io", want: false},
+		{name: "dot sub", args: args{v: []string{"s3.local.io"}}, host: "..s3.local.io", want: false},
+		{name: "dot sub many", args: args{v: []string{"s3.local.io", "s3.dev.invalid"}}, host: "..s3.local.io", want: false},
+		{name: "invalid1", args: args{v: []string{"s3.local.io"}}, host: "1.asdfsa.s3.local.io", want: false},
+		{name: "invalid1 many", args: args{v: []string{"s3.local.io", "s3.dev.invalid"}}, host: "1.asdfsa.s3.local.io", want: false},
+		{name: "invalid2", args: args{v: []string{"s3.local.io"}}, host: ".asdfsa.s3.local.io", want: false},
+		{name: "invalid2 many", args: args{v: []string{"s3.local.io", "s3.dev.invalid"}}, host: ".asdfsa.s3.local.io", want: false},
+		{name: "subdomain", args: args{v: []string{"s3.local.io"}}, host: "asdfsa.s3.local.io", want: true},
+		{name: "subdomain many", args: args{v: []string{"s3.dev.invalid", "s3.local.io", "s3.example.net"}}, host: "asdfsa.s3.local.io", want: true},
+		{name: "subdomain port", args: args{v: []string{"s3.local.io:8000"}}, host: "sub.s3.local.io", want: true},
+		{name: "subdomain port many", args: args{v: []string{"s3.dev.invalid:2000", "s3.local.io:8000", "s3.example.net:9000"}}, host: "sub.s3.local.io", want: true},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -35,7 +43,7 @@ func TestSubdomainsOf(t *testing.T) {
 
 func TestExact(t *testing.T) {
 	type args struct {
-		v string
+		v []string
 	}
 	tests := []struct {
 		name string
@@ -43,10 +51,14 @@ func TestExact(t *testing.T) {
 		host string
 		want bool
 	}{
-		{name: "small", args: args{v: "s3.local.io"}, host: "s3", want: false},
-		{name: "extract", args: args{v: "s3.local.io"}, host: "s3.local.io", want: true},
-		{name: "subdomain", args: args{v: "s3.local.io"}, host: "sub.s3.local.io", want: false},
-		{name: "empty", args: args{v: "s3.local.io"}, host: "", want: false},
+		{name: "short", args: args{v: []string{"s3.local.io"}}, host: "s3", want: false},
+		{name: "short many", args: args{v: []string{"s3.local.io", "s3.dev.invalid"}}, host: "s3", want: false},
+		{name: "extract", args: args{v: []string{"s3.local.io"}}, host: "s3.local.io", want: true},
+		{name: "extract many", args: args{v: []string{"s3.dev.invalid", "s3.local.io", "s3.example.net"}}, host: "s3.local.io", want: true},
+		{name: "subdomain", args: args{v: []string{"s3.local.io"}}, host: "sub.s3.local.io", want: false},
+		{name: "subdomain many", args: args{v: []string{"s3.dev.invalid", "s3.local.io"}}, host: "sub.s3.local.io", want: false},
+		{name: "empty", args: args{v: []string{"s3.local.io"}}, host: "", want: false},
+		{name: "empty many", args: args{v: []string{"s3.dev.invalid", "s3.local.io"}}, host: "", want: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/pkg/loadtest/local_load_test.go
+++ b/pkg/loadtest/local_load_test.go
@@ -96,7 +96,7 @@ func TestLocalLoad(t *testing.T) {
 		nil,
 		actionsService,
 		logging.Default(),
-		"",
+		nil,
 	)
 
 	ts := httptest.NewServer(handler)


### PR DESCRIPTION
Remaining issues:
1. Middleware EnrichWithOperation always takes first domain.  Can we take req.Host?  (If not, at
   make sure to allow *zero* domains)
2. sigV2 implementation uses the *configured* "bare domain" to sign.  This is sort-of quite a
   lot like using req.Host (but not entirely).

Fixes #1719.