### PR TITLE
Separate lakectl config from lakefs config

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -13,7 +13,7 @@ builds:
   env:
   - CGO_ENABLED=0
   ldflags:
-  - -s -w -X github.com/treeverse/lakefs/pkg/config.Version={{.Version}} -X github.com/treeverse/lakefs/pkg/config.Commit={{.Commit}} -X github.com/treeverse/lakefs/pkg/config.Date={{.Date}}
+  - -s -w -X github.com/treeverse/lakefs/pkg/version.Version={{.Version}}
   goarch:
   - amd64
   - arm64
@@ -27,7 +27,7 @@ builds:
   env:
   - CGO_ENABLED=0
   ldflags:
-  - -s -w -X github.com/treeverse/lakefs/pkg/config.Version={{.Version}} -X github.com/treeverse/lakefs/pkg/config.Commit={{.Commit}} -X github.com/treeverse/lakefs/pkg/config.Date={{.Date}}
+  - -s -w -X github.com/treeverse/lakefs/pkg/version.Version={{.Version}}
   goarch:
   - amd64
   - arm64

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,9 +15,9 @@ RUN go mod download
 COPY . ./
 
 # Build a binaries
-RUN go build -ldflags "-X github.com/treeverse/lakefs/pkg/config.Version=${VERSION}" -o lakefs ./cmd/lakefs
-RUN go build -ldflags "-X github.com/treeverse/lakefs/pkg/config.Version=${VERSION}" -o lakectl ./cmd/lakectl
-RUN go build -ldflags "-X github.com/treeverse/lakefs/pkg/config.Version=${VERSION}" -o benchmark-executor ./benchmarks
+RUN go build -ldflags "-X github.com/treeverse/lakefs/pkg/version.Version=${VERSION}" -o lakefs ./cmd/lakefs
+RUN go build -ldflags "-X github.com/treeverse/lakefs/pkg/version.Version=${VERSION}" -o lakectl ./cmd/lakectl
+RUN go build -ldflags "-X github.com/treeverse/lakefs/pkg/version.Version=${VERSION}" -o benchmark-executor ./benchmarks
 
 # lakectl image
 FROM alpine:3.12.0 AS lakectl

--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ gen-mockgen: go-install ## Run the generator for inline commands
 	$(GOGENERATE) ./pkg/onboard
 	$(GOGENERATE) ./pkg/actions
 
-LD_FLAGS := "-X github.com/treeverse/lakefs/pkg/config.Version=$(VERSION)-$(REVISION)"
+LD_FLAGS := "-X github.com/treeverse/lakefs/pkg/version.Version=$(VERSION)-$(REVISION)"
 build: gen docs ## Download dependencies and build the default binary
 	$(GOBUILD) -o $(LAKEFS_BINARY_NAME) -ldflags $(LD_FLAGS) -v ./cmd/$(LAKEFS_BINARY_NAME)
 	$(GOBUILD) -o $(LAKECTL_BINARY_NAME) -ldflags $(LD_FLAGS) -v ./cmd/$(LAKECTL_BINARY_NAME)

--- a/cmd/lakectl/cmd/config/config.go
+++ b/cmd/lakectl/cmd/config/config.go
@@ -8,7 +8,7 @@ import (
 
 type configuration struct {
 	Credentials struct {
-		AccessKeyID    string `mapstructure:"access_key_id"`
+		AccessKeyID     string `mapstructure:"access_key_id"`
 		SecretAccessKey string `mapstructure:"secret_access_key"`
 	}
 	Server struct {

--- a/cmd/lakectl/cmd/config/config.go
+++ b/cmd/lakectl/cmd/config/config.go
@@ -51,9 +51,6 @@ func ReadConfig() (c *Config) {
 		return
 	}
 	c.err = viper.UnmarshalExact(&c.configuration)
-	if c.err != nil {
-		return
-	}
 	return
 }
 

--- a/cmd/lakectl/cmd/config/config.go
+++ b/cmd/lakectl/cmd/config/config.go
@@ -6,6 +6,8 @@ import (
 	"github.com/spf13/viper"
 )
 
+// configuration is the user-visible configuration structure in Golang form.  When editing
+// make sure *all* fields have a `mapstructure:"..."` tag, to simplify future refactoring.
 type configuration struct {
 	Credentials struct {
 		AccessKeyID     string `mapstructure:"access_key_id"`
@@ -15,21 +17,21 @@ type configuration struct {
 		EndpointURL string `mapstructure:"endpoint_url"`
 	}
 	Metastore struct {
-		Type string
+		Type string `mapstructure:"type"`
 		Hive struct {
-			URI string
-		}
+			URI string `mapstructure:"uri"`
+		} `mapstructure:"hive"`
 		Glue struct {
 			// TODO(ariels): Refactor credentials to share with server side.
-			Profile         string
+			Profile         string `mapstructure:"profile"`
 			CredentialsFile string `mapstructure:"credentials_file"`
 			Credentials     *struct {
 				AccessKeyID     string `mapstructure:"access_key_id"`
 				AccessSecretKey string `mapstructure:"access_secret_key"`
 				SessionToken    string `mapstructure:"session_token"`
-			}
+			} `mapstructure:"credentials"`
 
-			Region    string
+			Region    string `mapstructure:"region"`
 			CatalogID string `mapstructure:"catalog_id"`
 		}
 	}

--- a/cmd/lakectl/cmd/config/config.go
+++ b/cmd/lakectl/cmd/config/config.go
@@ -1,0 +1,93 @@
+package config
+
+import (
+	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
+	"github.com/spf13/viper"
+)
+
+type configuration struct {
+	Credentials struct {
+		AccessKeyID    string `mapstructure:"access_key_id"`
+		SecretAccessKey string `mapstructure:"secret_access_key"`
+	}
+	Server struct {
+		EndpointURL string `mapstructure:"endpoint_url"`
+	}
+	Metastore struct {
+		Type string
+		Hive struct {
+			URI string
+		}
+		Glue struct {
+			// TODO(ariels): Refactor credentials to share with server side.
+			Profile         string
+			CredentialsFile string `mapstructure:"credentials_file"`
+			Credentials     *struct {
+				AccessKeyID     string `mapstructure:"access_key_id"`
+				AccessSecretKey string `mapstructure:"access_secret_key"`
+				SessionToken    string `mapstructure:"session_token"`
+			}
+
+			Region    string
+			CatalogID string `mapstructure:"catalog_id"`
+		}
+	}
+}
+
+// Config is the currently-loaded configuration.  Its error state supports being able to run
+// `lakectl config' without a valid configuration.
+type Config struct {
+	configuration
+	err error
+}
+
+// ReadConfig loads according to the current viper configuration into a Config, which will
+// have non-nil Err() if loading fails.
+func ReadConfig() (c *Config) {
+	c = &Config{}
+	c.err = viper.ReadInConfig()
+	if c.err != nil {
+		return
+	}
+	c.err = viper.UnmarshalExact(&c.configuration)
+	if c.err != nil {
+		return
+	}
+	return
+}
+
+func (c *Config) Err() error {
+	return c.err
+}
+
+func (c *Config) GetMetastoreAwsConfig() *aws.Config {
+	cfg := &aws.Config{
+		Region: aws.String(c.configuration.Metastore.Glue.Region),
+	}
+	if c.Metastore.Glue.Profile != "" || c.Metastore.Glue.CredentialsFile != "" {
+		cfg.Credentials = credentials.NewSharedCredentials(
+			c.Metastore.Glue.CredentialsFile,
+			c.Metastore.Glue.Profile,
+		)
+	}
+	if c.Metastore.Glue.Credentials != nil {
+		cfg.Credentials = credentials.NewStaticCredentials(
+			c.Metastore.Glue.Credentials.AccessKeyID,
+			c.Metastore.Glue.Credentials.AccessSecretKey,
+			c.Metastore.Glue.Credentials.SessionToken,
+		)
+	}
+	return cfg
+}
+
+func (c *Config) GetMetastoreHiveURI() string {
+	return c.Metastore.Hive.URI
+}
+
+func (c *Config) GetMetastoreGlueCatalogID() string {
+	return c.Metastore.Glue.CatalogID
+}
+func (c *Config) GetMetastoreType() string {
+	return c.Metastore.Type
+}

--- a/cmd/lakectl/cmd/metastore.go
+++ b/cmd/lakectl/cmd/metastore.go
@@ -6,7 +6,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/treeverse/lakefs/pkg/api"
-	"github.com/treeverse/lakefs/pkg/config"
 	"github.com/treeverse/lakefs/pkg/metastore"
 	"github.com/treeverse/lakefs/pkg/metastore/glue"
 	"github.com/treeverse/lakefs/pkg/metastore/hive"
@@ -37,10 +36,10 @@ var metastoreCopyCmd = &cobra.Command{
 
 		var client metastoreClient
 		var err error
-		msType := config.GetMetastoreType()
+		msType := cfg.GetMetastoreType()
 		switch msType {
 		case "hive":
-			hiveClient, err := hive.NewMSClient(cmd.Context(), config.GetMetastoreHiveURI(), false)
+			hiveClient, err := hive.NewMSClient(cmd.Context(), cfg.GetMetastoreHiveURI(), false)
 			if err != nil {
 				DieErr(err)
 			}
@@ -53,7 +52,7 @@ var metastoreCopyCmd = &cobra.Command{
 			client = hiveClient
 
 		case "glue":
-			client, err = glue.NewMSClient(cmd.Context(), config.GetMetastoreAwsConfig(), config.GetMetastoreGlueCatalogID())
+			client, err = glue.NewMSClient(cmd.Context(), cfg.GetMetastoreAwsConfig(), cfg.GetMetastoreGlueCatalogID())
 			if err != nil {
 				DieErr(err)
 			}
@@ -130,11 +129,11 @@ var metastoreDiffCmd = &cobra.Command{
 		var diff *metastore.MetaDiff
 		var client metastoreClient
 		var err error
-		msType := config.GetMetastoreType()
+		msType := cfg.GetMetastoreType()
 		switch msType {
 		case "hive":
 			var hiveClient *hive.MSClient
-			hiveClient, err = hive.NewMSClient(cmd.Context(), config.GetMetastoreHiveURI(), false)
+			hiveClient, err = hive.NewMSClient(cmd.Context(), cfg.GetMetastoreHiveURI(), false)
 			if err != nil {
 				DieErr(err)
 			}
@@ -147,7 +146,7 @@ var metastoreDiffCmd = &cobra.Command{
 			client = hiveClient
 
 		case "glue":
-			client, err = glue.NewMSClient(cmd.Context(), config.GetMetastoreAwsConfig(), config.GetMetastoreGlueCatalogID())
+			client, err = glue.NewMSClient(cmd.Context(), cfg.GetMetastoreAwsConfig(), cfg.GetMetastoreGlueCatalogID())
 			if err != nil {
 				DieErr(err)
 			}
@@ -205,7 +204,7 @@ var glueSymlinkCmd = &cobra.Command{
 		}
 		location := res.JSON201.Location
 
-		msClient, err := glue.NewMSClient(cmd.Context(), config.GetMetastoreAwsConfig(), config.GetMetastoreGlueCatalogID())
+		msClient, err := glue.NewMSClient(cmd.Context(), cfg.GetMetastoreAwsConfig(), cfg.GetMetastoreGlueCatalogID())
 		if err != nil {
 			DieErr(err)
 		}
@@ -222,11 +221,11 @@ func init() {
 	rootCmd.AddCommand(metastoreCmd)
 	metastoreCmd.AddCommand(metastoreCopyCmd)
 	_ = metastoreCopyCmd.Flags().String("type", "", "metastore type [hive, glue]")
-	_ = viper.BindPFlag(config.MetaStoreType, metastoreCopyCmd.Flag("type"))
+	_ = viper.BindPFlag("metastore.type", metastoreCopyCmd.Flag("type"))
 	_ = metastoreCopyCmd.Flags().String("metastore-uri", "", "Hive metastore URI")
-	_ = viper.BindPFlag(config.MetaStoreHiveURI, metastoreCopyCmd.Flag("metastore-uri"))
+	_ = viper.BindPFlag("metastore.hive.uri", metastoreCopyCmd.Flag("metastore-uri"))
 	_ = metastoreCopyCmd.Flags().String("catalog-id", "", "Glue catalog ID")
-	_ = viper.BindPFlag(config.MetastoreGlueCatalogID, metastoreCopyCmd.Flag("catalog-id"))
+	_ = viper.BindPFlag("metastore.glue.catalog_id", metastoreCopyCmd.Flag("catalog-id"))
 	_ = metastoreCopyCmd.Flags().String("from-schema", "", "source schema name")
 	_ = metastoreCopyCmd.MarkFlagRequired("from-schema")
 	_ = metastoreCopyCmd.Flags().String("from-table", "", "source table name")
@@ -240,11 +239,11 @@ func init() {
 
 	metastoreCmd.AddCommand(metastoreDiffCmd)
 	_ = metastoreDiffCmd.Flags().String("type", "", "metastore type [hive, glue]")
-	_ = viper.BindPFlag(config.MetaStoreType, metastoreDiffCmd.Flag("type"))
+	_ = viper.BindPFlag("metastore.type", metastoreDiffCmd.Flag("type"))
 	_ = metastoreDiffCmd.Flags().String("metastore-uri", "", "Hive metastore URI")
-	_ = viper.BindPFlag(config.MetaStoreHiveURI, metastoreDiffCmd.Flag("metastore-uri"))
+	_ = viper.BindPFlag("metastore.hive.URI", metastoreDiffCmd.Flag("metastore-uri"))
 	_ = metastoreDiffCmd.Flags().String("catalog-id", "", "Glue catalog ID")
-	_ = viper.BindPFlag(config.MetastoreGlueCatalogID, metastoreDiffCmd.Flag("catalog-id"))
+	_ = viper.BindPFlag("metastore.glue.catalog_id", metastoreDiffCmd.Flag("catalog-id"))
 	_ = metastoreDiffCmd.Flags().String("from-schema", "", "source schema name")
 	_ = metastoreDiffCmd.MarkFlagRequired("from-schema")
 	_ = metastoreDiffCmd.Flags().String("from-table", "", "source table name")
@@ -271,7 +270,7 @@ func init() {
 	_ = glueSymlinkCmd.Flags().String("path", "", "path to table on lakeFS")
 	_ = glueSymlinkCmd.MarkFlagRequired("path")
 	_ = glueSymlinkCmd.Flags().String("catalog-id", "", "Glue catalog ID")
-	_ = viper.BindPFlag(config.MetastoreGlueCatalogID, glueSymlinkCmd.Flag("catalog-id"))
+	_ = viper.BindPFlag("metastore.glue.catalog_id", glueSymlinkCmd.Flag("catalog-id"))
 	_ = glueSymlinkCmd.Flags().String("from-schema", "", "source schema name")
 	_ = glueSymlinkCmd.MarkFlagRequired("from-schema")
 	_ = glueSymlinkCmd.Flags().String("from-table", "", "source table name")

--- a/cmd/lakectl/cmd/root.go
+++ b/cmd/lakectl/cmd/root.go
@@ -14,9 +14,9 @@ import (
 	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"github.com/treeverse/lakefs/cmd/lakectl/cmd/config"
 	"github.com/treeverse/lakefs/pkg/api"
 	"github.com/treeverse/lakefs/pkg/version"
-	"github.com/treeverse/lakefs/cmd/lakectl/cmd/config"
 )
 
 const (
@@ -30,7 +30,7 @@ const (
 
 var (
 	cfgFile string
-	cfg *config.Config
+	cfg     *config.Config
 )
 
 // rootCmd represents the base command when called without any sub-commands

--- a/cmd/lakefs-loadtest/cmd/root.go
+++ b/cmd/lakefs-loadtest/cmd/root.go
@@ -1,6 +1,5 @@
 package cmd
 
-
 import (
 	"fmt"
 	"os"

--- a/cmd/lakefs-loadtest/cmd/root.go
+++ b/cmd/lakefs-loadtest/cmd/root.go
@@ -1,5 +1,6 @@
 package cmd
 
+
 import (
 	"fmt"
 	"os"
@@ -8,7 +9,7 @@ import (
 	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"github.com/treeverse/lakefs/pkg/config"
+	"github.com/treeverse/lakefs/pkg/version"
 )
 
 const (
@@ -27,7 +28,7 @@ var (
 var rootCmd = &cobra.Command{
 	Use:     "lakefs-loadtest",
 	Short:   "Run a loadtest on a lakeFS instance.",
-	Version: config.Version,
+	Version: version.Version,
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/cmd/lakefs/cmd/root.go
+++ b/cmd/lakefs/cmd/root.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/treeverse/lakefs/pkg/config"
+	"github.com/treeverse/lakefs/pkg/version"
 )
 
 var (
@@ -20,7 +21,7 @@ var (
 var rootCmd = &cobra.Command{
 	Use:     "lakefs",
 	Short:   "lakeFS is a data lake management platform",
-	Version: config.Version,
+	Version: version.Version,
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/cmd/lakefs/cmd/run.go
+++ b/cmd/lakefs/cmd/run.go
@@ -22,7 +22,6 @@ import (
 	"github.com/treeverse/lakefs/pkg/auth/crypt"
 	"github.com/treeverse/lakefs/pkg/block/factory"
 	"github.com/treeverse/lakefs/pkg/catalog"
-	"github.com/treeverse/lakefs/pkg/config"
 	"github.com/treeverse/lakefs/pkg/db"
 	"github.com/treeverse/lakefs/pkg/gateway"
 	"github.com/treeverse/lakefs/pkg/gateway/multiparts"
@@ -30,6 +29,7 @@ import (
 	"github.com/treeverse/lakefs/pkg/httputil"
 	"github.com/treeverse/lakefs/pkg/logging"
 	"github.com/treeverse/lakefs/pkg/stats"
+	"github.com/treeverse/lakefs/pkg/version"
 )
 
 const (
@@ -50,7 +50,7 @@ var runCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		logger := logging.Default()
 		ctx := cmd.Context()
-		logger.WithField("version", config.Version).Infof("lakeFS run")
+		logger.WithField("version", version.Version).Infof("lakeFS run")
 
 		// validate service names and turn on the right flags
 		dbParams := cfg.GetDatabaseParams()
@@ -102,7 +102,7 @@ var runCmd = &cobra.Command{
 			dbPool,
 			crypt.NewSecretStore(cfg.GetAuthEncryptionSecret()),
 			cfg.GetAuthCacheConfig())
-		authMetadataManager := auth.NewDBMetadataManager(config.Version, dbPool)
+		authMetadataManager := auth.NewDBMetadataManager(version.Version, dbPool)
 		cloudMetadataProvider := stats.BuildMetadataProvider(logger, cfg)
 		metadata := stats.NewMetadata(ctx, logger, cfg.GetBlockstoreType(), authMetadataManager, cloudMetadataProvider)
 		bufferedCollector := stats.NewBufferedCollector(metadata.InstallationID, cfg)
@@ -209,7 +209,7 @@ const runBanner = `
 
 func printWelcome(w io.Writer) {
 	_, _ = fmt.Fprint(w, runBanner)
-	_, _ = fmt.Fprintf(w, "Version %s\n\n", config.Version)
+	_, _ = fmt.Fprintf(w, "Version %s\n\n", version.Version)
 }
 
 func registerPrometheusCollector(db sqlstats.StatsGetter) {
@@ -222,7 +222,7 @@ func registerPrometheusCollector(db sqlstats.StatsGetter) {
 
 func gracefulShutdown(ctx context.Context, quit <-chan os.Signal, done chan<- bool, servers ...Shutter) {
 	logger := logging.Default()
-	logger.WithField("version", config.Version).Info("Up and running (^C to shutdown)...")
+	logger.WithField("version", version.Version).Info("Up and running (^C to shutdown)...")
 
 	printWelcome(os.Stderr)
 

--- a/cmd/lakefs/cmd/setup.go
+++ b/cmd/lakefs/cmd/setup.go
@@ -8,10 +8,10 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/treeverse/lakefs/pkg/auth"
 	"github.com/treeverse/lakefs/pkg/auth/crypt"
-	"github.com/treeverse/lakefs/pkg/config"
 	"github.com/treeverse/lakefs/pkg/db"
 	"github.com/treeverse/lakefs/pkg/logging"
 	"github.com/treeverse/lakefs/pkg/stats"
+	"github.com/treeverse/lakefs/pkg/version"
 )
 
 // setupCmd initial lakeFS system setup - build database, load initial data and create first superuser
@@ -52,7 +52,7 @@ var setupCmd = &cobra.Command{
 			dbPool,
 			crypt.NewSecretStore(cfg.GetAuthEncryptionSecret()),
 			cfg.GetAuthCacheConfig())
-		metadataManager := auth.NewDBMetadataManager(config.Version, dbPool)
+		metadataManager := auth.NewDBMetadataManager(version.Version, dbPool)
 		cloudMetadataProvider := stats.BuildMetadataProvider(logging.Default(), cfg)
 		metadata := stats.NewMetadata(ctx, logging.Default(), cfg.GetBlockstoreType(), metadataManager, cloudMetadataProvider)
 

--- a/cmd/lakefs/cmd/superuser.go
+++ b/cmd/lakefs/cmd/superuser.go
@@ -10,10 +10,10 @@ import (
 	"github.com/treeverse/lakefs/pkg/auth"
 	"github.com/treeverse/lakefs/pkg/auth/crypt"
 	"github.com/treeverse/lakefs/pkg/auth/model"
-	"github.com/treeverse/lakefs/pkg/config"
 	"github.com/treeverse/lakefs/pkg/db"
 	"github.com/treeverse/lakefs/pkg/logging"
 	"github.com/treeverse/lakefs/pkg/stats"
+	"github.com/treeverse/lakefs/pkg/version"
 )
 
 // superuserCmd represents the init command
@@ -45,7 +45,7 @@ var superuserCmd = &cobra.Command{
 			dbPool,
 			crypt.NewSecretStore(cfg.GetAuthEncryptionSecret()),
 			cfg.GetAuthCacheConfig())
-		authMetadataManager := auth.NewDBMetadataManager(config.Version, dbPool)
+		authMetadataManager := auth.NewDBMetadataManager(version.Version, dbPool)
 		metadataProvider := stats.BuildMetadataProvider(logging.Default(), cfg)
 		metadata := stats.NewMetadata(ctx, logging.Default(), cfg.GetBlockstoreType(), authMetadataManager, metadataProvider)
 		credentials, err := auth.AddAdminUser(ctx, authService, &model.SuperuserConfiguration{

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -57,10 +57,6 @@ const (
 	DefaultStatsAddr          = "https://stats.treeverse.io"
 	DefaultStatsFlushInterval = time.Second * 30
 
-	MetaStoreType          = "metastore.type"
-	MetaStoreHiveURI       = "metastore.hive.uri"
-	MetastoreGlueCatalogID = "metastore.glue.catalog_id"
-
 	DefaultAzureTryTimeout = 10 * time.Minute
 	DefaultAzureAuthMethod = "access-key"
 )
@@ -367,36 +363,6 @@ func (c *Config) GetCommittedParams() *committed.Params {
 		RangeSizeEntriesRaggedness: viper.GetFloat64(CommittedPermanentStorageRangeRaggednessKey),
 		MaxUploaders:               viper.GetInt(CommittedLocalCacheNumUploadersKey),
 	}
-}
-
-func GetMetastoreAwsConfig() *aws.Config {
-	cfg := &aws.Config{
-		Region: aws.String(viper.GetString("metastore.glue.region")),
-		Logger: &LogrusAWSAdapter{},
-	}
-	if viper.IsSet("metastore.glue.profile") || viper.IsSet("metastore.glue.credentials_file") {
-		cfg.Credentials = credentials.NewSharedCredentials(
-			viper.GetString("metastore.glue.credentials_file"),
-			viper.GetString("metastore.glue.profile"))
-	}
-	if viper.IsSet("metastore.glue.credentials.access_key_id") {
-		cfg.Credentials = credentials.NewStaticCredentials(
-			viper.GetString("metastore.glue.credentials.access_key_id"),
-			viper.GetString("metastore.glue.credentials.secret_access_key"),
-			viper.GetString("metastore.glue.credentials.session_token"))
-	}
-	return cfg
-}
-
-func GetMetastoreHiveURI() string {
-	return viper.GetString(MetaStoreHiveURI)
-}
-
-func GetMetastoreGlueCatalogID() string {
-	return viper.GetString(MetastoreGlueCatalogID)
-}
-func GetMetastoreType() string {
-	return viper.GetString(MetaStoreType)
 }
 
 func GetFixedInstallationID() string {

--- a/pkg/config/version.go
+++ b/pkg/config/version.go
@@ -1,6 +1,0 @@
-package config
-
-var (
-	UnreleasedVersion = "dev"
-	Version           = "dev"
-)

--- a/pkg/stats/collector.go
+++ b/pkg/stats/collector.go
@@ -9,6 +9,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/treeverse/lakefs/pkg/config"
 	"github.com/treeverse/lakefs/pkg/logging"
+	"github.com/treeverse/lakefs/pkg/version"
 )
 
 const (
@@ -228,7 +229,7 @@ func getBufferedCollectorArgs(c *config.Config) (processID string, opts []Buffer
 		return "", nil
 	}
 	var sender Sender
-	if c.GetStatsEnabled() && !strings.HasPrefix(config.Version, config.UnreleasedVersion) {
+	if c.GetStatsEnabled() && !strings.HasPrefix(version.Version, version.UnreleasedVersion) {
 		sender = NewHTTPSender(c.GetStatsAddress(), time.Now)
 	} else {
 		sender = NewDummySender()

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,8 @@
+package version
+
+var (
+	UnreleasedVersion = "dev"
+	// Version is the current git version of the code.  It is filled in by "make build".
+	// Make sure to change that target in Makefile if you change its name or package.
+	Version = "dev"
+)


### PR DESCRIPTION
Otherwise metastore config -- for lakectl -- mixes up with the rest of lakefs config.

Unsure how to test `lakectl metastore`.

Fixes #1735, part of #1732.
