### PR TITLE
List repository actions should not check branch existence

### DIFF
--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -1164,18 +1164,6 @@ func (c *Controller) ListRepositoryRuns(w http.ResponseWriter, r *http.Request, 
 		return
 	}
 
-	branchID := StringValue(params.Branch)
-	if branchID != "" {
-		exists, err := c.Catalog.BranchExists(ctx, repository, branchID)
-		if handleAPIError(w, err) {
-			return
-		}
-		if !exists {
-			writeError(w, http.StatusNotFound, catalog.ErrBranchNotFound)
-			return
-		}
-	}
-
 	branch := StringValue(params.Branch)
 	commitID := StringValue(params.Commit)
 	runsIter, err := c.Actions.ListRunResults(ctx, repository, branch, commitID, paginationAfter(params.After))

--- a/pkg/api/serve_test.go
+++ b/pkg/api/serve_test.go
@@ -76,7 +76,6 @@ func setupHandler(t testing.TB, blockstoreType string, opts ...testutil.GetDBOpt
 	if blockstoreType == "" {
 		blockstoreType = mem.BlockstoreType
 	}
-	blockAdapter := testutil.NewBlockAdapterByType(t, &block.NoOpTranslator{}, blockstoreType)
 	viper.Set(config.BlockstoreTypeKey, mem.BlockstoreType)
 	cfg, err := config.NewConfig()
 	testutil.MustDo(t, "config", err)
@@ -90,7 +89,7 @@ func setupHandler(t testing.TB, blockstoreType string, opts ...testutil.GetDBOpt
 	actionsService := actions.NewService(
 		conn,
 		catalog.NewActionsSource(c),
-		catalog.NewActionsOutputWriter(blockAdapter),
+		catalog.NewActionsOutputWriter(c.BlockAdapter),
 	)
 	c.SetHooksHandler(actionsService)
 
@@ -109,7 +108,7 @@ func setupHandler(t testing.TB, blockstoreType string, opts ...testutil.GetDBOpt
 	handler := api.Serve(
 		c,
 		authService,
-		blockAdapter,
+		c.BlockAdapter,
 		meta,
 		migrator,
 		collector,
@@ -120,7 +119,7 @@ func setupHandler(t testing.TB, blockstoreType string, opts ...testutil.GetDBOpt
 	)
 
 	return handler, &dependencies{
-		blocks:      blockAdapter,
+		blocks:      c.BlockAdapter,
 		authService: authService,
 		catalog:     c,
 		collector:   collector,


### PR DESCRIPTION
Fix #1727

Removed the check for branch exist for list actions runs.
To fix the test code was required to pass the same block adapter from our catalog to all of other services used by our controller test code.