### PR TITLE
python client class ensure server endpoint incldue default path api/v1

### DIFF
--- a/clients/python/lakefs_client/client.py
+++ b/clients/python/lakefs_client/client.py
@@ -4,13 +4,10 @@ import lakefs_client
 from lakefs_client.apis import ActionsApi, AuthApi, BranchesApi, CommitsApi, ConfigApi, HealthCheckApi, MetadataApi, \
     ObjectsApi, RefsApi, RepositoriesApi, StagingApi, TagsApi
 
-DEFAULT_BASE_URL_PATH = "/api/v1"
-
-
 class LakeFSClient:
     def __init__(self, configuration=None, header_name=None, header_value=None, cookie=None, pool_threads=1):
         if configuration:
-            configuration.host = LakeFSClient._ensure_endpoint(configuration.host)
+            configuration = LakeFSClient._ensure_endpoint(configuration)
         self._api = lakefs_client.ApiClient(configuration=configuration, header_name=header_name,
                                             header_value=header_value, cookie=cookie, pool_threads=pool_threads)
         self.actions = ActionsApi(self._api)
@@ -27,11 +24,15 @@ class LakeFSClient:
         self.tags = TagsApi(self._api)
 
     @staticmethod
-    def _ensure_endpoint(endpoint):
-        try:
-            o = urlparse(endpoint)
-            if not o.path or o.path == '/':
-                return urlunparse((o.scheme, o.netloc, DEFAULT_BASE_URL_PATH, o.params, o.query, o.fragment))
-        except ValueError:
-            pass
-        return endpoint
+    def _ensure_endpoint(configuration):
+        if configuration.host:
+            try:
+                o = urlparse(configuration.host)
+                if not o.path or o.path == '/':
+                    settings = configuration.get_host_settings()
+                    if settings:
+                        base_path = urlparse(settings[0].get('url')).path
+                        configuration.host = urlunparse((o.scheme, o.netloc, base_path, o.params, o.query, o.fragment))
+            except ValueError:
+                pass
+        return configuration

--- a/clients/python/lakefs_client/client.py
+++ b/clients/python/lakefs_client/client.py
@@ -1,9 +1,18 @@
+from urllib.parse import urlparse, urlunparse
+
 import lakefs_client
-from lakefs_client.apis import ActionsApi, AuthApi, BranchesApi, CommitsApi, ConfigApi, HealthCheckApi, MetadataApi, ObjectsApi, RefsApi, RepositoriesApi, StagingApi, TagsApi
+from lakefs_client.apis import ActionsApi, AuthApi, BranchesApi, CommitsApi, ConfigApi, HealthCheckApi, MetadataApi, \
+    ObjectsApi, RefsApi, RepositoriesApi, StagingApi, TagsApi
+
+DEFAULT_BASE_URL_PATH = "/api/v1"
+
 
 class LakeFSClient:
     def __init__(self, configuration=None, header_name=None, header_value=None, cookie=None, pool_threads=1):
-        self._api = lakefs_client.ApiClient(configuration=configuration, header_name=header_name, header_value=header_value, cookie=cookie, pool_threads=pool_threads)
+        if configuration:
+            configuration.host = LakeFSClient._ensure_endpoint(configuration.host)
+        self._api = lakefs_client.ApiClient(configuration=configuration, header_name=header_name,
+                                            header_value=header_value, cookie=cookie, pool_threads=pool_threads)
         self.actions = ActionsApi(self._api)
         self.auth = AuthApi(self._api)
         self.branches = BranchesApi(self._api)
@@ -16,3 +25,13 @@ class LakeFSClient:
         self.repositories = RepositoriesApi(self._api)
         self.staging = StagingApi(self._api)
         self.tags = TagsApi(self._api)
+
+    @staticmethod
+    def _ensure_endpoint(endpoint):
+        try:
+            o = urlparse(endpoint)
+            if not o.path or o.path == '/':
+                return urlunparse((o.scheme, o.netloc, DEFAULT_BASE_URL_PATH, o.params, o.query, o.fragment))
+        except ValueError:
+            pass
+        return endpoint


### PR DESCRIPTION
LakeFSClient client class should ensure that configuration's host property will include the API base path.
Example:
```py
import lakefs_client
from lakefs_client.client import LakefsClient
configuration = lakefs_client.Configuration(
  host = "http://localhost:8000",
  username = "key",
  password = "secret"
)
client = LakeFSClient(configuration=configuration)
```
The LakeFSClient will ensure that the API base URL will include "/api/v1" (DEFAULT_BASE_URL_PATH constant) in the endpoint so the end-user will not be required to align the API endpoint with the package version.