### PR TITLE
api authorization jwt check the standard way

### DIFF
--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -20,9 +20,9 @@ components:
       type: http
       scheme: basic
     jwt_token:
-      type: apiKey
-      in: header
-      name: X-JWT-Authorization
+      type: http
+      scheme: bearer
+      bearerFormat: JWT
     cookie_auth:
       type: apiKey
       in: cookie

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -77,11 +77,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 
 # Enter a context with an instance of the API client
@@ -249,9 +248,7 @@ Class | Method | HTTP request | Description
 
 ## jwt_token
 
-- **Type**: API key
-- **API key parameter name**: X-JWT-Authorization
-- **Location**: HTTP header
+- **Type**: Bearer authentication (JWT)
 
 
 ## Author

--- a/clients/python/docs/ActionsApi.md
+++ b/clients/python/docs/ActionsApi.md
@@ -19,7 +19,7 @@ get a run
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -50,11 +50,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:
@@ -113,7 +112,7 @@ get run hook output
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -143,11 +142,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:
@@ -208,7 +206,7 @@ list runs
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -239,11 +237,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:
@@ -317,7 +314,7 @@ list run hooks
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -348,11 +345,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:

--- a/clients/python/docs/AuthApi.md
+++ b/clients/python/docs/AuthApi.md
@@ -45,7 +45,7 @@ add group membership
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -75,11 +75,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:
@@ -137,7 +136,7 @@ attach policy to group
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -167,11 +166,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:
@@ -229,7 +227,7 @@ attach policy to user
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -259,11 +257,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:
@@ -321,7 +318,7 @@ create credentials
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -352,11 +349,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:
@@ -413,7 +409,7 @@ create group
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -445,11 +441,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:
@@ -509,7 +504,7 @@ create policy
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -540,11 +535,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:
@@ -613,7 +607,7 @@ create user
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -645,11 +639,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:
@@ -709,7 +702,7 @@ delete credentials
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -739,11 +732,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:
@@ -801,7 +793,7 @@ delete group
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -831,11 +823,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:
@@ -891,7 +882,7 @@ delete group membership
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -921,11 +912,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:
@@ -983,7 +973,7 @@ delete policy
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -1013,11 +1003,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:
@@ -1073,7 +1062,7 @@ delete user
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -1103,11 +1092,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:
@@ -1163,7 +1151,7 @@ detach policy from group
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -1193,11 +1181,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:
@@ -1255,7 +1242,7 @@ detach policy from user
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -1285,11 +1272,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:
@@ -1347,7 +1333,7 @@ get credentials
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -1378,11 +1364,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:
@@ -1441,7 +1426,7 @@ get current user
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -1471,11 +1456,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:
@@ -1525,7 +1509,7 @@ get group
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -1556,11 +1540,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:
@@ -1617,7 +1600,7 @@ get policy
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -1648,11 +1631,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:
@@ -1709,7 +1691,7 @@ get user
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -1740,11 +1722,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:
@@ -1801,7 +1782,7 @@ list group members
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -1832,11 +1813,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:
@@ -1907,7 +1887,7 @@ list group policies
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -1938,11 +1918,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:
@@ -2014,7 +1993,7 @@ list groups
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -2045,11 +2024,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:
@@ -2110,7 +2088,7 @@ list policies
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -2141,11 +2119,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:
@@ -2206,7 +2183,7 @@ list user credentials
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -2237,11 +2214,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:
@@ -2313,7 +2289,7 @@ list user groups
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -2344,11 +2320,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:
@@ -2420,7 +2395,7 @@ list user policies
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -2451,11 +2426,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:
@@ -2529,7 +2503,7 @@ list users
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -2560,11 +2534,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:
@@ -2767,7 +2740,7 @@ update policy
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -2798,11 +2771,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:

--- a/clients/python/docs/BranchesApi.md
+++ b/clients/python/docs/BranchesApi.md
@@ -22,7 +22,7 @@ create branch
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -53,11 +53,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:
@@ -120,7 +119,7 @@ delete branch
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -150,11 +149,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:
@@ -212,7 +210,7 @@ diff branch
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -243,11 +241,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:
@@ -319,7 +316,7 @@ get branch
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -350,11 +347,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:
@@ -413,7 +409,7 @@ list branches
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -444,11 +440,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:
@@ -520,7 +515,7 @@ reset branch
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -551,11 +546,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:
@@ -619,7 +613,7 @@ revert
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -650,11 +644,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:

--- a/clients/python/docs/CommitsApi.md
+++ b/clients/python/docs/CommitsApi.md
@@ -18,7 +18,7 @@ create commit
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -50,11 +50,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:
@@ -122,7 +121,7 @@ get commit
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -153,11 +152,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:
@@ -216,7 +214,7 @@ get commit log from branch. Deprecated: replaced by logCommits by passing branch
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -247,11 +245,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:

--- a/clients/python/docs/ConfigApi.md
+++ b/clients/python/docs/ConfigApi.md
@@ -19,7 +19,7 @@ retrieve the lakefs config
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -50,11 +50,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:

--- a/clients/python/docs/MetadataApi.md
+++ b/clients/python/docs/MetadataApi.md
@@ -18,7 +18,7 @@ creates symlink files corresponding to the given directory
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -49,11 +49,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:
@@ -123,7 +122,7 @@ return URI to a meta-range file
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -154,11 +153,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:
@@ -201,7 +199,7 @@ Name | Type | Description  | Notes
 ### HTTP response details
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
-**200** | meta-range URI |  -  |
+**200** | meta-range URI |  * Location - redirect to S3 <br>  |
 **401** | Unauthorized |  -  |
 **404** | Resource Not Found |  -  |
 **0** | Internal Server Error |  -  |
@@ -217,7 +215,7 @@ return URI to a range file
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -248,11 +246,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:

--- a/clients/python/docs/ObjectsApi.md
+++ b/clients/python/docs/ObjectsApi.md
@@ -22,7 +22,7 @@ delete object
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -52,11 +52,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:
@@ -116,7 +115,7 @@ get object content
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -146,11 +145,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:
@@ -212,7 +210,7 @@ get object properties on underlying storage
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -243,11 +241,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:
@@ -308,7 +305,7 @@ list objects under a given prefix
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -339,11 +336,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:
@@ -419,7 +415,7 @@ stage an object\"s metadata for the given branch
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -451,11 +447,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:
@@ -526,7 +521,7 @@ get object metadata
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -557,11 +552,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:
@@ -623,7 +617,7 @@ Name | Type | Description  | Notes
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -654,11 +648,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:

--- a/clients/python/docs/RefsApi.md
+++ b/clients/python/docs/RefsApi.md
@@ -20,7 +20,7 @@ diff references
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -51,11 +51,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:
@@ -133,7 +132,7 @@ Dump repository refs (tags, commits, branches) to object store
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -164,11 +163,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:
@@ -226,7 +224,7 @@ get commit log from ref
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -257,11 +255,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:
@@ -333,7 +330,7 @@ merge references
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -365,11 +362,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:
@@ -449,7 +445,7 @@ Restore repository refs (tags, commits, branches) from object store
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -480,11 +476,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:

--- a/clients/python/docs/RepositoriesApi.md
+++ b/clients/python/docs/RepositoriesApi.md
@@ -19,7 +19,7 @@ create repository
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -51,11 +51,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:
@@ -127,7 +126,7 @@ delete repository
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -157,11 +156,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:
@@ -217,7 +215,7 @@ get repository
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -248,11 +246,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:
@@ -309,7 +306,7 @@ list repositories
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -340,11 +337,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:

--- a/clients/python/docs/StagingApi.md
+++ b/clients/python/docs/StagingApi.md
@@ -17,7 +17,7 @@ get a physical address and a return token to write object to underlying storage
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -48,11 +48,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:
@@ -115,7 +114,7 @@ If the supplied token matches the current staging token, associate the object as
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -147,11 +146,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:

--- a/clients/python/docs/TagsApi.md
+++ b/clients/python/docs/TagsApi.md
@@ -19,7 +19,7 @@ create tag
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -51,11 +51,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:
@@ -118,7 +117,7 @@ delete tag
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -148,11 +147,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:
@@ -210,7 +208,7 @@ get tag
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -241,11 +239,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:
@@ -304,7 +301,7 @@ list tags
 
 * Basic Authentication (basic_auth):
 * Api Key Authentication (cookie_auth):
-* Api Key Authentication (jwt_token):
+* Bearer (JWT) Authentication (jwt_token):
 ```python
 import time
 import lakefs_client
@@ -335,11 +332,10 @@ configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
 # Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
 # configuration.api_key_prefix['cookie_auth'] = 'Bearer'
 
-# Configure API key authorization: jwt_token
-configuration.api_key['jwt_token'] = 'YOUR_API_KEY'
-
-# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
-# configuration.api_key_prefix['jwt_token'] = 'Bearer'
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
 
 # Enter a context with an instance of the API client
 with lakefs_client.ApiClient(configuration) as api_client:

--- a/clients/python/lakefs_client/configuration.py
+++ b/clients/python/lakefs_client/configuration.py
@@ -419,14 +419,13 @@ conf = lakefs_client.Configuration(
                     'cookie_auth',
                 ),
             }
-        if 'jwt_token' in self.api_key:
+        if self.access_token is not None:
             auth['jwt_token'] = {
-                'type': 'api_key',
+                'type': 'bearer',
                 'in': 'header',
-                'key': 'X-JWT-Authorization',
-                'value': self.get_api_key_with_prefix(
-                    'jwt_token',
-                ),
+                'format': 'JWT',
+                'key': 'Authorization',
+                'value': 'Bearer ' + self.access_token
             }
         return auth
 

--- a/pkg/api/auth_middleware.go
+++ b/pkg/api/auth_middleware.go
@@ -75,7 +75,7 @@ func checkSecurityRequirements(r *http.Request, securityRequirements openapi3.Se
 				if authHeaderValue == "" {
 					continue
 				}
-				parts := strings.SplitN(authHeaderValue, " ", 2)
+				parts := strings.Fields(authHeaderValue)
 				if len(parts) != 2 || !strings.EqualFold(parts[0], "Bearer") {
 					continue
 				}

--- a/pkg/api/auth_middleware_test.go
+++ b/pkg/api/auth_middleware_test.go
@@ -48,7 +48,7 @@ func TestAuthMiddleware(t *testing.T) {
 	t.Run("valid jwt header", func(t *testing.T) {
 		ctx := context.Background()
 		apiToken := testGenerateApiToken(t, deps.authService, cred.AccessKeyID)
-		authProvider, err := securityprovider.NewSecurityProviderApiKey("header", api.JWTAuthorizationHeaderName, apiToken)
+		authProvider, err := securityprovider.NewSecurityProviderApiKey("header", "Authorization", "Bearer "+apiToken)
 		if err != nil {
 			t.Fatal("basic auth security provider", err)
 		}
@@ -68,7 +68,7 @@ func TestAuthMiddleware(t *testing.T) {
 	t.Run("invalid jwt header", func(t *testing.T) {
 		ctx := context.Background()
 		apiToken := testGenerateApiToken(t, deps.authService, "AKIAIOSFODNN7EXAMPLE")
-		authProvider, err := securityprovider.NewSecurityProviderApiKey("header", api.JWTAuthorizationHeaderName, apiToken)
+		authProvider, err := securityprovider.NewSecurityProviderApiKey("header", "Authorization", "Bearer "+apiToken)
 		if err != nil {
 			t.Fatal("basic auth security provider", err)
 		}


### PR DESCRIPTION
Closes #1362

NOTE this change break backward compatibility for clients that used `X-JWT-Authorization` header