### PR TITLE
hadoopfs assembly, handle workdir and lakefs client

### DIFF
--- a/clients/hadoopfs/.gitignore
+++ b/clients/hadoopfs/.gitignore
@@ -1,1 +1,2 @@
 /target
+dependency-reduced-pom.xml

--- a/clients/hadoopfs/examples/spark_with_lakefs.py
+++ b/clients/hadoopfs/examples/spark_with_lakefs.py
@@ -1,0 +1,27 @@
+from pyspark.sql import SparkSession
+import pyspark
+import sys
+
+spark = SparkSession.builder.appName("test_app").getOrCreate()
+spark._jsc.hadoopConfiguration().set("fs.lakefs.access.key", "AKIAIOSFODNN7EXAMPLE")
+spark._jsc.hadoopConfiguration().set("fs.lakefs.secret.key", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
+sc = spark.sparkContext
+sc.setLogLevel("DEBUG")
+log4jLogger = sc._jvm.org.apache.log4j
+log = log4jLogger.LogManager.getLogger(__name__)
+
+# Write using the lakefs file system
+samples = sc.parallelize([
+    ("abonsanto@fakemail.com", "Alberto", "Bonsanto"),
+    ("dbonsanto@fakemail.com", "Dakota", "Bonsanto")
+])
+# samples.collect()
+samples.saveAsTextFile("lakefs://example1/master/output.txt")
+
+# samples.unpersist()
+
+# Read file using the lakefs file system
+lines = sc.textFile("lakefs://example1/master/input.txt")
+lines.taks(10).foreach(log.trace)
+
+sc.stop()

--- a/clients/hadoopfs/pom.xml
+++ b/clients/hadoopfs/pom.xml
@@ -23,6 +23,38 @@
                     <target>1.8</target>
                 </configuration>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <version>3.2.4</version>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                        <configuration>
+                            <transformers>
+                                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                                    <mainClass>io.lakefs.LakeFSFileSystem</mainClass>
+                                </transformer>
+                            </transformers>
+                            <filters>
+                                <filter>
+                                    <artifact>*:*</artifact>
+                                    <excludes>
+                                        <exclude>module-info.class</exclude>
+                                        <exclude>META-INF/maven/**</exclude>
+                                        <exclude>META-INF/*.SF</exclude>
+                                        <exclude>META-INF/*.DSA</exclude>
+                                        <exclude>META-INF/*.RSA</exclude>
+                                    </excludes>
+                                </filter>
+                            </filters>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileSystem.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileSystem.java
@@ -1,9 +1,6 @@
 package io.lakefs;
 
-import io.lakefs.clients.api.ApiException;
-import io.lakefs.clients.api.RepositoriesApi;
 import io.lakefs.clients.api.auth.HttpBasicAuth;
-import io.lakefs.clients.api.model.Repository;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.*;
 import org.apache.hadoop.fs.permission.FsPermission;

--- a/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileSystem.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileSystem.java
@@ -13,13 +13,23 @@ import java.io.StringBufferInputStream;
 import java.net.URI;
 
 /**
- * A dummy implementation of the core Lakefs Filesystem.
+ * A dummy implementation of the core lakeFS Filesystem.
  * This class implements a {@link LakeFSFileSystem} that can be registered to Spark and support limited write and read actions.
+ *
+ * Configure Spark to use lakeFS filesystem by property:
+ *   spark.hadoop.fs.lakefs.impl=io.lakefs.LakeFSFileSystem.
+ *
+ * Configure the application or the filesystem application by properties:
+ *   fs.lakefs.endpoint=http://localhost:8000/api/v1
+ *   fs.lakefs.access.key=AKIAIOSFODNN7EXAMPLE
+ *   fs.lakefs.secret.key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
  */
 public class LakeFSFileSystem extends org.apache.hadoop.fs.FileSystem {
+    public static final String SCHEME = "lakefs";
     public static final String FS_LAKEFS_ENDPOINT = "fs.lakefs.endpoint";
     public static final String FS_LAKEFS_ACCESS_KEY = "fs.lakefs.access.key";
     public static final String FS_LAKEFS_SECRET_KEY = "fs.lakefs.secret.key";
+    private static final String BASIC_AUTH = "basic_auth";
 
     private URI uri;
     private Path workingDirectory = new Path("/");
@@ -53,7 +63,7 @@ public class LakeFSFileSystem extends org.apache.hadoop.fs.FileSystem {
         }
         this.apiClient = io.lakefs.clients.api.Configuration.getDefaultApiClient();
         this.apiClient.setBasePath(endpoint);
-        HttpBasicAuth basicAuth = (HttpBasicAuth)this.apiClient.getAuthentication("basic_auth");
+        HttpBasicAuth basicAuth = (HttpBasicAuth)this.apiClient.getAuthentication(BASIC_AUTH);
         basicAuth.setUsername(accessKey);
         basicAuth.setPassword(secretKey);
     }
@@ -132,11 +142,11 @@ public class LakeFSFileSystem extends org.apache.hadoop.fs.FileSystem {
     /**
      * Return the protocol scheme for the FileSystem.
      *
-     * @return "lakefs"
+     * @return lakefs scheme
      */
     @Override
     public String getScheme() {
-        return "lakefs";
+        return SCHEME;
     }
 
     @Override

--- a/clients/hadoopfs/src/test/java/io/lakefs/LakeFSFileSystemTest.java
+++ b/clients/hadoopfs/src/test/java/io/lakefs/LakeFSFileSystemTest.java
@@ -25,7 +25,7 @@ public class LakeFSFileSystemTest {
     @Test
     public void getUri() {
         URI u = fs.getUri();
-        Assert.assertEquals(u.toString(), "lakefs://main");
+        Assert.assertNull(u);
     }
 
     @Test(expected = UnsupportedOperationException.class)


### PR DESCRIPTION
Close #1852

- pyspark code for working with Hadoop fs
- keep the working directory
- build assembly with all dependencies
- initialize lakefs API client with endpoint, key and secret