### PR TITLE
Move FileStatus in line with Spark expectations

### DIFF
--- a/clients/hadoopfs/src/main/java/io/lakefs/Constants.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/Constants.java
@@ -1,5 +1,7 @@
 package io.lakefs;
 
+import org.apache.commons.io.FileUtils;
+
 class Constants {
     public static final String URI_SCHEME = "lakefs";
     public static final String URI_SEPARATOR = "/";
@@ -7,5 +9,9 @@ class Constants {
     public static final String FS_LAKEFS_ACCESS_KEY = "fs.lakefs.access.key";
     public static final String FS_LAKEFS_SECRET_KEY = "fs.lakefs.secret.key";
     public static final String FS_LAKEFS_LIST_AMOUNT_KEY = "fs.lakefs.list.amount";
+
     public static final int DEFAULT_LIST_AMOUNT = 1000;
+    public static final String SEPARATOR = "/";
+
+    public static final long DEFAULT_BLOCK_SIZE = 32 * FileUtils.ONE_MB;
 }

--- a/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileSystem.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileSystem.java
@@ -18,6 +18,7 @@ import com.amazonaws.services.s3.AmazonS3Client;
 
 import io.lakefs.clients.api.model.ObjectStatsList;
 import io.lakefs.clients.api.model.Pagination;
+import org.apache.commons.io.FileUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.*;
 import org.apache.hadoop.fs.permission.FsPermission;
@@ -55,8 +56,6 @@ import static io.lakefs.Constants.*;
  */
 public class LakeFSFileSystem extends FileSystem {
     public static final Logger LOG = LoggerFactory.getLogger(LakeFSFileSystem.class);
-
-    public static final long DEFAULT_BLOCK_SIZE = 32 * 1024 * 1024;
 
     private static final String BASIC_AUTH = "basic_auth";
 
@@ -175,7 +174,7 @@ public class LakeFSFileSystem extends FileSystem {
         if (fsForConfig != null) {
             return fsForConfig.getDefaultBlockSize(path);
         }
-        return DEFAULT_BLOCK_SIZE;
+        return Constants.DEFAULT_BLOCK_SIZE;
     }
 
     @Override
@@ -183,7 +182,7 @@ public class LakeFSFileSystem extends FileSystem {
         if (fsForConfig != null) {
             return fsForConfig.getDefaultBlockSize();
         }
-        return DEFAULT_BLOCK_SIZE;
+        return Constants.DEFAULT_BLOCK_SIZE;
     }
 
     @Override

--- a/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileSystem.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileSystem.java
@@ -200,7 +200,7 @@ public class LakeFSFileSystem extends FileSystem {
             FileSystem physicalFs = physicalPath.getFileSystem(conf);
             return physicalFs.open(physicalPath, bufSize);
         } catch (ApiException e) {
-            throw new RuntimeException("lakeFS API exception", e);
+            throw new IOException("lakeFS API", e);
         } catch (java.net.URISyntaxException e) {
             throw new RuntimeException(e);
         }
@@ -388,7 +388,7 @@ public class LakeFSFileSystem extends FileSystem {
         try {
             objects.statObject(objectLoc.getRepository(), objectLoc.getRef(), objectLoc.getPath());
             return true;
-        } catch (io.lakefs.clients.api.ApiException e) {
+        } catch (ApiException e) {
             if (e.getCode() == HttpStatus.SC_NOT_FOUND) {
                 return false;
             }


### PR DESCRIPTION
- `exists` must return more than just `false`.  Implement a minimal exists that checks for file existence on lakeFS.  Note that it _will_ have to change if we ever do directories.
- `FileStatus` needs a block size entry.  Use value from underlying storage.  Also return some "reasonable"-ish _default_ block size (not used by readers, some writers or other code might use that).