### PR TITLE
[filesystem] directory support for delete status and exists operations

### DIFF
--- a/clients/hadoopfs/pom.xml
+++ b/clients/hadoopfs/pom.xml
@@ -46,20 +46,20 @@
                                     </excludes>
                                 </filter>
                             </filters>
-			    <relocations>
-			      <relocation>
-				  <pattern>org.apache.httpcomponents</pattern>
-				  <shadedPattern>io.lakefs.shaded.apache.httpcomponents</shadedPattern>
-			      </relocation>
-			      <relocation>
-				<pattern>okio</pattern>
-				<shadedPattern>io.lakefs.shaded.okio</shadedPattern>
-			      </relocation>
-			      <relocation>
-				<pattern>okhttp3</pattern>
-				<shadedPattern>io.lakefs.shaded.okhttp3</shadedPattern>
-			      </relocation>
-			    </relocations>
+                            <relocations>
+                                <relocation>
+                                    <pattern>org.apache.httpcomponents</pattern>
+                                    <shadedPattern>io.lakefs.shaded.apache.httpcomponents</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>okio</pattern>
+                                    <shadedPattern>io.lakefs.shaded.okio</shadedPattern>
+                                </relocation>
+                                <relocation>
+                                    <pattern>okhttp3</pattern>
+                                    <shadedPattern>io.lakefs.shaded.okhttp3</shadedPattern>
+                                </relocation>
+                            </relocations>
                         </configuration>
                     </execution>
                 </executions>
@@ -85,16 +85,16 @@
             <version>2.7.7</version>
         </dependency>
 
-	<dependency>
-	  <groupId>com.amazonaws</groupId>
-	  <artifactId>aws-java-sdk</artifactId>
-	  <version>1.7.4</version><!-- should match hadoop-aws version(!) -->
-	</dependency>
-	<dependency>		<!-- needed for aws-java-sdk in tests(!) -->
-	  <groupId>org.apache.httpcomponents</groupId>
-	  <artifactId>httpclient</artifactId>
-	  <version>4.3.6</version>
-	</dependency>
+        <dependency>
+            <groupId>com.amazonaws</groupId>
+            <artifactId>aws-java-sdk</artifactId>
+            <version>1.7.4</version><!-- should match hadoop-aws version(!) -->
+        </dependency>
+        <dependency>        <!-- needed for aws-java-sdk in tests(!) -->
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+            <version>4.3.6</version>
+        </dependency>
 
         <dependency>
             <groupId>junit</groupId>
@@ -107,7 +107,7 @@
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <version>1.10.19</version>
-	    <scope>test</scope>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 </project>

--- a/clients/hadoopfs/src/main/java/io/lakefs/Constants.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/Constants.java
@@ -2,7 +2,7 @@ package io.lakefs;
 
 import org.apache.commons.io.FileUtils;
 
-public class Constants {
+class Constants {
     public static final String URI_SCHEME = "lakefs";
     public static final String FS_LAKEFS_ENDPOINT_KEY = "fs.lakefs.endpoint";
     public static final String FS_LAKEFS_ACCESS_KEY = "fs.lakefs.access.key";

--- a/clients/hadoopfs/src/main/java/io/lakefs/Constants.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/Constants.java
@@ -2,9 +2,8 @@ package io.lakefs;
 
 import org.apache.commons.io.FileUtils;
 
-class Constants {
+public class Constants {
     public static final String URI_SCHEME = "lakefs";
-    public static final String URI_SEPARATOR = "/";
     public static final String FS_LAKEFS_ENDPOINT_KEY = "fs.lakefs.endpoint";
     public static final String FS_LAKEFS_ACCESS_KEY = "fs.lakefs.access.key";
     public static final String FS_LAKEFS_SECRET_KEY = "fs.lakefs.secret.key";

--- a/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileSystem.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileSystem.java
@@ -321,7 +321,7 @@ public class LakeFSFileSystem extends FileSystem {
 
         ObjectsApi objectsApi = lfsClient.getObjects();
         if (recursive) {
-            ListingIterator iterator = new ListingIterator(path, recursive, listAmount);
+            ListingIterator iterator = new ListingIterator(path, true, listAmount);
             while (iterator.hasNext()) {
                 LocatedFileStatus fileStatus = iterator.next();
                 try {

--- a/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileSystem.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileSystem.java
@@ -407,12 +407,12 @@ public class LakeFSFileSystem extends FileSystem {
                 modificationTime = TimeUnit.SECONDS.toMillis(mtime);
             }
             Path filePath = new Path(ObjectLocation.formatPath(repository, ref, objectStat.getPath()));
-            boolean isdir = objectStat.getPathType() == ObjectStats.PathTypeEnum.COMMON_PREFIX;
+            boolean isDir = objectStat.getPathType() == ObjectStats.PathTypeEnum.COMMON_PREFIX;
             long blockSize = 0;
-            if (!isdir) {
+            if (!isDir) {
                 blockSize = withFileSystemAndTranslatedPhysicalPath(objectStat.getPhysicalAddress(), FileSystem::getDefaultBlockSize);
             }
-            return new FileStatus(length, isdir, 0, blockSize, modificationTime, filePath);
+            return new FileStatus(length, isDir, 0, blockSize, modificationTime, filePath);
         } catch (java.net.URISyntaxException e) {
             throw new IOException("uri", e);
         }

--- a/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileSystem.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileSystem.java
@@ -407,7 +407,7 @@ public class LakeFSFileSystem extends FileSystem {
                 modificationTime = TimeUnit.SECONDS.toMillis(mtime);
             }
             Path filePath = new Path(ObjectLocation.formatPath(repository, ref, objectStat.getPath()));
-            boolean isDir = objectStat.getPathType() == ObjectStats.PathTypeEnum.COMMON_PREFIX;
+            boolean isDir = isDirectory(objectStat);
             long blockSize = 0;
             if (!isDir) {
                 blockSize = withFileSystemAndTranslatedPhysicalPath(objectStat.getPhysicalAddress(), FileSystem::getDefaultBlockSize);
@@ -545,7 +545,7 @@ public class LakeFSFileSystem extends FileSystem {
                     throw new IOException("listObjects", e);
                 }
                 // filter objects
-                chunk = chunk.stream().filter(stat -> stat.getPathType() != ObjectStats.PathTypeEnum.COMMON_PREFIX).collect(Collectors.toList());
+                chunk = chunk.stream().filter(LakeFSFileSystem::isDirectory).collect(Collectors.toList());
                 // loop until we have something or last chunk
             } while (!chunk.isEmpty() && !last);
         }
@@ -560,5 +560,9 @@ public class LakeFSFileSystem extends FileSystem {
             // currently do not pass locations of the file blocks - until we understand if it is required in order to work
             return new LocatedFileStatus(fileStatus, null);
         }
+    }
+
+    private static boolean isDirectory(ObjectStats stat) {
+        return stat.getPathType() != ObjectStats.PathTypeEnum.COMMON_PREFIX;
     }
 }

--- a/clients/hadoopfs/src/main/java/io/lakefs/ObjectLocation.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/ObjectLocation.java
@@ -5,6 +5,10 @@ class ObjectLocation {
     private String ref;
     private String path;
 
+    public static String formatPath(String repository, String ref, String path) {
+        return Constants.URI_SCHEME + "://" + repository + "/" + ref + "/" + path;
+    }
+
     public String getRepository() {
         return repository;
     }
@@ -58,5 +62,10 @@ class ObjectLocation {
      */
     public boolean onSameBranch(ObjectLocation otherObjLoc) {
         return this.repository.equals(otherObjLoc.getRepository()) && this.ref.equals(otherObjLoc.getRef());
+    }
+
+    @Override
+    public String toString() {
+        return formatPath(repository, ref, path);
     }
 }

--- a/clients/hadoopfs/src/main/java/io/lakefs/ObjectLocation.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/ObjectLocation.java
@@ -30,7 +30,7 @@ class ObjectLocation {
     }
 
     static String trimLeadingSlash(String s) {
-        if (s.startsWith(Constants.URI_SEPARATOR)) {
+        if (s.startsWith(Constants.SEPARATOR)) {
             return s.substring(1);
         }
         return s;

--- a/clients/hadoopfs/src/main/java/io/lakefs/ObjectLocation.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/ObjectLocation.java
@@ -6,7 +6,7 @@ class ObjectLocation {
     private String path;
 
     public static String formatPath(String repository, String ref, String path) {
-        return Constants.URI_SCHEME + "://" + repository + "/" + ref + "/" + path;
+        return String.format("%s://%s/%s/%s", Constants.URI_SCHEME,repository, ref, path);
     }
 
     public String getRepository() {


### PR DESCRIPTION
- delete API - recursive use listing and delete each file. non-recursive performs object delete.
- exists API - fallback to listing one element to identify a path
- file status API - fallback to listing one element to return directory file status
Fix listing should return the full path to lakeFS object URI

Close #1855