### PR TITLE
Short timeout on fetch AWS account ID

### DIFF
--- a/pkg/cloud/aws/metadata.go
+++ b/pkg/cloud/aws/metadata.go
@@ -3,6 +3,8 @@ package aws
 import (
 	"crypto/md5" //nolint:gosec
 	"fmt"
+	"net/http"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -22,16 +24,27 @@ func NewMetadataProvider(logger logging.Logger, awsConfig *aws.Config) *Metadata
 }
 
 func (m *MetadataProvider) GetMetadata() map[string]string {
-	sess, err := session.NewSession(m.awsConfig)
+	// max number of retries on the client operation
+	const sessionMaxRetries = 0
+	// use a shorter timeout than default because the service can be inaccessible from networks which don't have internet connection
+	const sessionTimeout = 5 * time.Second
+	metaConfig := &aws.Config{
+		HTTPClient: &http.Client{
+			Timeout: sessionTimeout,
+		},
+		MaxRetries: aws.Int(sessionMaxRetries),
+	}
+	sess, err := session.NewSession(m.awsConfig.Copy(metaConfig))
 	if err != nil {
-		m.logger.Warnf("%v: failed to create AWS session for BI", err)
+		m.logger.WithError(err).Warn("Failed to create AWS session for BI")
 		return nil
 	}
 	sess.ClientConfig(s3.ServiceName)
+
 	stsClient := sts.New(sess)
 	identity, err := stsClient.GetCallerIdentity(&sts.GetCallerIdentityInput{})
 	if err != nil {
-		m.logger.Warnf("%v: failed to get AWS account ID for BI", err)
+		m.logger.WithError(err).Warn("%v: failed to get AWS account ID for BI")
 		return nil
 	}
 	return map[string]string{


### PR DESCRIPTION
Fix #1788

The AWS session used to fetch the AWS account ID will timeout after 5sec without retries.