### PR TITLE
python client set http scheme if missing and use urllib3 parse_url

### DIFF
--- a/clients/python/lakefs_client/client.py
+++ b/clients/python/lakefs_client/client.py
@@ -25,10 +25,13 @@ class LakeFSClient:
 
     @staticmethod
     def _ensure_endpoint(configuration):
+        """Normalize lakefs connection endpoint found in configuration's host"""
         if configuration.host:
             try:
+                # prefix http scheme if missing
                 if not configuration.host.startswith('http://') and not configuration.host.startswith('https://'):
                     configuration.host = 'http://' + configuration.host
+                # if 'host' not set any 'path', format the endpoint url with default 'path' based on the generated code
                 o = parse_url(configuration.host)
                 if not o.path or o.path == '/':
                     settings = configuration.get_host_settings()


### PR DESCRIPTION
- Configuration add `http://` prefix to host if missing 
- Configuration host parse_url (urllib3) used to parse and construct final URL as the generated code