### PR TITLE
Cache Docker build image on GitHub Docker Registry

### DIFF
--- a/.github/workflows/nessie.yaml
+++ b/.github/workflows/nessie.yaml
@@ -108,19 +108,21 @@ jobs:
           true
       - name: Build Docker image with cache and push
         run: |
-          set +e
+          set -ex
           ghr=docker.pkg.github.com/${GITHUB_REPOSITORY,,}/build-cache
-          declare -a ghr_tags=(${{ steps.version.outputs.tag }})
-          if [[ -n $GITHUB_REF ]]; then ghr_tags=(${ghr_tags[@]} ${GITHUB_REF##*/}); fi
-          ghr_repo_tags=$(printf "%s " "${ghr_tags[@]/#/-t ${ghr}:}")
+          ghr_build_tag="-t ${ghr}:${{ steps.version.outputs.tag }}"
+          if [[ -n $GITHUB_REF ]]; then
+              ghr_ref_tag="-t ${ghr}:${GITHUB_REF##*/}"
+          else
+              ghr_ref_tag=''
+          fi
+          ecr_tag="-t $ECR_REGISTRY/$ECR_REPOSITORY_LAKEFS:${{ steps.version.outputs.tag }}"
           docker build . \
-              $ghr_repo_tags \
-              -t $ECR_REGISTRY/$ECR_REPOSITORY_LAKEFS:${{ steps.version.outputs.tag }} \
+              ${ghr_ref_tag} ${ghr_build_tag} ${ecr_tag} \
               --build-arg VERSION=${{ steps.version.outputs.tag }} \
               --cache-from=${ghr}
-          for ghr_tag in ${ghr_tags[0]}; do
-              docker push ${ghr}:${ghr_tag}
-          done
+          docker push ${ghr_build_tag#-t }
+          if [[ -n ${ghr_ref_tag} ]]; then docker push ${ghr_ref_tag#-t }; fi
         env:
           DOCKER_BUILDKIT: '1'
       - name: Push to Amazon ECR

--- a/.github/workflows/nessie.yaml
+++ b/.github/workflows/nessie.yaml
@@ -90,6 +90,11 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
 
+      - name: Export ECR parameters
+        run: |
+          echo "ECR_REGISTRY=${{ steps.login-ecr.outputs.registry }}" >> $GITHUB_ENV
+          echo "ECR_REPOSITORY_LAKEFS=lakefs" >> $GITHUB_ENV
+
       - name: Login to GitHub Docker Registry
         uses: docker/login-action@v1
         with:
@@ -104,16 +109,21 @@ jobs:
       - name: Build Docker image with cache and push
         run: |
           set +e
-          docker build . -t docker.pkg.github.com/${GITHUB_REPOSITORY,,}/build-cache:${{ steps.version.outputs.tag }} \
+          ghr=docker.pkg.github.com/${GITHUB_REPOSITORY,,}/build-cache
+          declare -a ghr_tags=(${{ steps.version.outputs.tag }})
+          if [[ -n $GITHUB_REF ]]; then ghr_tags=(${ghr_tags[@]} ${GITHUB_REF##*/}); fi
+          ghr_repo_tags=$(printf "%s " "${ghr_tags[@]/#/-t ${ghr}:}")
+          docker build . \
+              $ghr_repo_tags \
+              -t $ECR_REGISTRY/$ECR_REPOSITORY_LAKEFS:${{ steps.version.outputs.tag }} \
               --build-arg VERSION=${{ steps.version.outputs.tag }} \
-              --cache-from=docker.pkg.github.com/${GITHUB_REPOSITORY,,}/build-cache
-          docker push docker.pkg.github.com/${GITHUB_REPOSITORY,,}/build-cache:${{ steps.version.outputs.tag }}
+              --cache-from=${ghr}
+          for ghr_tag in ${ghr_tags[0]}; do
+              docker push ${ghr}:${ghr_tag}
+          done
         env:
           DOCKER_BUILDKIT: '1'
       - name: Push to Amazon ECR
-        env:
-          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
-          ECR_REPOSITORY_LAKEFS: lakefs
         run: |
           set +e
           describe_image="$( aws ecr describe-images --repository-name $ECR_REPOSITORY_LAKEFS --image-ids imageTag=${{ steps.version.outputs.tag }})"

--- a/.github/workflows/nessie.yaml
+++ b/.github/workflows/nessie.yaml
@@ -90,7 +90,27 @@ jobs:
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
 
-      - name: Build and push to Amazon ECR
+      - name: Login to GitHub Docker Registry
+        uses: docker/login-action@v1
+        with:
+          registry: docker.pkg.github.com
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - name: Pull last built docker image cache
+        run: |
+          docker pull docker.pkg.github.com/${GITHUB_REPOSITORY,,}/build-cache:${{ steps.version.outputs.tag }} || \
+          docker pull docker.pkg.github.com/${GITHUB_REPOSITORY,,}/build-cache || \
+          true
+      - name: Build Docker image with cache and push
+        run: |
+          set +e
+          docker build . -t docker.pkg.github.com/${GITHUB_REPOSITORY,,}/build-cache:${{ steps.version.outputs.tag }} \
+              --build-arg VERSION=${{ steps.version.outputs.tag }} \
+              --cache-from=docker.pkg.github.com/${GITHUB_REPOSITORY,,}/build-cache
+          docker push docker.pkg.github.com/${GITHUB_REPOSITORY,,}/build-cache:${{ steps.version.outputs.tag }}
+        env:
+          DOCKER_BUILDKIT: '1'
+      - name: Push to Amazon ECR
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY_LAKEFS: lakefs
@@ -101,7 +121,6 @@ jobs:
             echo "Image exists"
           else
             echo "Image doesn't exist"
-            docker build -t $ECR_REGISTRY/$ECR_REPOSITORY_LAKEFS:${{ steps.version.outputs.tag }} --build-arg VERSION=${{ steps.version.outputs.tag }} .
             docker push $ECR_REGISTRY/$ECR_REPOSITORY_LAKEFS:${{ steps.version.outputs.tag }}
           fi
 


### PR DESCRIPTION
Loosely based on [Caching Docker builds in GitHub Actions: Which approach is the fastest? 🤔 A
research](https://dev.to/dtinth/caching-docker-builds-in-github-actions-which-approach-is-the-fastest-a-research-18ei),
which indicates it should be the fastest.