### PR TITLE
filesystem listStatus implementation

### DIFF
--- a/clients/hadoopfs/pom.xml
+++ b/clients/hadoopfs/pom.xml
@@ -59,6 +59,10 @@
                                     <pattern>okhttp3</pattern>
                                     <shadedPattern>io.lakefs.shaded.okhttp3</shadedPattern>
                                 </relocation>
+                                <relocation>
+                                    <pattern>com.google.gson</pattern>
+                                    <shadedPattern>io.lakefs.shaded.gson</shadedPattern>
+                                </relocation>
                             </relocations>
                         </configuration>
                     </execution>

--- a/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileSystem.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileSystem.java
@@ -629,7 +629,7 @@ public class LakeFSFileSystem extends FileSystem {
     }
 
     class ListingIterator implements RemoteIterator<LakeFSLocatedFileStatus> {
-        private final boolean recursive;
+        private final boolean removeDirectory;
         private final ObjectLocation objectLocation;
         private final String delimiter;
         private final int amount;
@@ -648,7 +648,7 @@ public class LakeFSFileSystem extends FileSystem {
          * @param amount    buffer size to fetch listing
          */
         public ListingIterator(Path path, boolean recursive, int amount) {
-            this.recursive = recursive;
+            this.removeDirectory = recursive;
             this.chunk = Collections.emptyList();
             this.objectLocation = pathToObjectLocation(path);
             String locationPath = this.objectLocation.getPath();
@@ -693,7 +693,7 @@ public class LakeFSFileSystem extends FileSystem {
                     throw new IOException("listObjects", e);
                 }
                 // filter objects in recursive mode
-                if (recursive) {
+                if (this.removeDirectory) {
                     chunk = chunk.stream().filter(item -> !isDirectory(item)).collect(Collectors.toList());
                 }
                 // loop until we have something or last chunk


### PR DESCRIPTION
- listStatus api for file/directory uses get file status and listing api
- share gson package: the lakefs java client generated code uses gson to deserialize the response from the server. the version found with spark use different version that failed to work with string as enum type (path_type in this case)