### PR TITLE
Require Spark thick client Nessie test to pass

### DIFF
--- a/.github/workflows/nessie.yaml
+++ b/.github/workflows/nessie.yaml
@@ -166,7 +166,6 @@ jobs:
         run: mvn -Djar.finalName=client --batch-mode --update-snapshots package
 
       - name: Test lakeFS S3 with Spark thick client
-        continue-on-error: true # Still working on this client!
         timeout-minutes: 2
         env:
           JARS: clients/hadoopfs/


### PR DESCRIPTION
Working since @nopcoder's #2019 (see [post merge
test](https://github.com/treeverse/lakeFS/runs/2708293022?check_suite_focus=true)), let's not slide back!