### PR TITLE
Re-use generated code in deploy-image

### DIFF
--- a/.github/workflows/nessie.yaml
+++ b/.github/workflows/nessie.yaml
@@ -27,9 +27,55 @@ jobs:
           echo "Enable next jobs based on secrets existence: ${{ env.ENABLE_NEXT_JOBS != '' }}"
           echo "::set-output name=secretsavailable::${{ env.ENABLE_NEXT_JOBS != '' }}"
 
+  gen-code:
+    name: Generate code from latest lakeFS app
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check-out code
+        uses: actions/checkout@v2
+
+      # No way to share code between workflows :-( If you change this, find and change the
+      # same code wherever "Find Go module and build caches" appears!
+      - name: Find Go module and build caches
+        run: |
+          echo GOMODCACHE=`go env GOMODCACHE` >> $GITHUB_ENV
+          echo GOCACHE=`go env GOCACHE` >> $GITHUB_ENV
+          cat $GITHUB_ENV
+
+      - name: Setup Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: 1.16.2
+        id: go
+
+      - name: Cache Go modules and builds
+        uses: actions/cache@v2
+        env:
+          cache-name: cache-go-modules
+        with:
+          path: |
+            ${{ env.GOMODCACHE }}
+            ${{ env.GOCACHE }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('go.mod', 'go.sum') }}
+          restore-keys:
+            ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      - name: Generate code
+        run: |
+          make gen
+          tar -cf /tmp/generated.tar.gz .
+
+      - name: Store generated code
+        uses: actions/upload-artifact@v2
+        with:
+          name: generated-code
+          path: /tmp/generated.tar.gz
+
   deploy-image:
     name: Build and push Docker image
-    needs: check-secrets
+    needs: [check-secrets, gen-code]
     if: needs.check-secrets.outputs.secretsavailable == 'true'
     runs-on: ubuntu-20.04
     outputs:
@@ -49,30 +95,14 @@ jobs:
           go-version: 1.16.2
         id: go
 
-      # No way to share code between workflows :-( If you change this, find and change the
-      # same code wherever "Find Go module and build caches" appears!
-      - name: Find Go module and build caches
-        run: |
-          echo GOMODCACHE=`go env GOMODCACHE` >> $GITHUB_ENV
-          echo GOCACHE=`go env GOCACHE` >> $GITHUB_ENV
-          cat $GITHUB_ENV
-      - name: Cache Go modules and builds
-        uses: actions/cache@v2
-        env:
-          cache-name: cache-go-modules
+      - name: Retrieve generated code
+        uses: actions/download-artifact@v2
         with:
-          path: |
-            ${{ env.GOMODCACHE }}
-            ${{ env.GOCACHE }}
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('go.mod', 'go.sum') }}
-          restore-keys:
-            ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
+          name: generated-code
+          path: /tmp/
 
-      - name: Generate code
-        run: |
-          make gen
+      - name: Unpack generated code
+        run: tar -xf /tmp/generated.tar.gz
 
       - name: Configure AWS Credentials
         uses: aws-actions/configure-aws-credentials@v1
@@ -213,28 +243,6 @@ jobs:
         continue-on-error: true
         working-directory: test/spark
         run: docker-compose logs --tail=1000 lakefs
-
-  gen-code:
-    name: Generate code from latest lakeFS app
-    needs: deploy-image
-    runs-on: ubuntu-20.04
-    steps:
-      - name: Check-out code
-        uses: actions/checkout@v2
-      - name: Setup Go
-        uses: actions/setup-go@v2
-        with:
-          go-version: 1.16.2
-        id: go
-      - name: Generate code
-        run: |
-          make gen
-          tar -cf /tmp/generated.tar.gz .
-      - name: Store generated code
-        uses: actions/upload-artifact@v2
-        with:
-          name: generated-code
-          path: /tmp/generated.tar.gz
 
   run-system-aws-s3:
     name: Run latest lakeFS app on AWS S3


### PR DESCRIPTION
Also place caching around it, which might reduce time to `go get` those
dependencies.