### PR TITLE
fix dump refs bug

### DIFF
--- a/cmd/lakectl/cmd/refs.go
+++ b/cmd/lakectl/cmd/refs.go
@@ -67,7 +67,7 @@ var refsDumpCmd = &cobra.Command{
 
 		Write(metadataDumpTemplate, struct {
 			Response interface{}
-		}{resp})
+		}{resp.JSON201})
 	},
 }
 


### PR DESCRIPTION
Fixes a regression where the refs-dump is not created because of the OpenAPI client, which deserilizes the response and puts it under the `JSON201` property of the response object. The output of this command is a JSON returned from the server (see RefsDump in swagger.yml).
