### PR TITLE
Support common prefix listing of diffs (uncommitted, commit view, compare view)

### DIFF
--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -2094,6 +2094,7 @@ paths:
     parameters:
       - $ref: "#/components/parameters/PaginationAfter"
       - $ref: "#/components/parameters/PaginationAmount"
+      - $ref: "#/components/parameters/PaginationPrefix"
       - in: path
         name: repository
         required: true
@@ -2104,6 +2105,11 @@ paths:
         required: true
         schema:
           type: string
+      - in: query
+        name: delimiter
+        schema:
+          type: string
+          default: "/"
     get:
       tags:
         - branches
@@ -2144,6 +2150,7 @@ paths:
         description: a reference (could be either a branch or a commit ID) to compare against
       - $ref: "#/components/parameters/PaginationAfter"
       - $ref: "#/components/parameters/PaginationAmount"
+      - $ref: "#/components/parameters/PaginationPrefix"
       - in: query
         name: type
         schema:
@@ -2154,6 +2161,11 @@ paths:
           type: string
           enum: [two_dot, three_dot]
           default: three_dot
+      - in: query
+        name: delimiter
+        schema:
+          type: string
+          default: "/"
     get:
       tags:
         - refs

--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -307,6 +307,7 @@ components:
           enum: [ common_prefix, object ]
         size_bytes:
           type: integer
+          description: represents the size of the added/changed/deleted entry
           format: int64
 
     DiffList:

--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -35,12 +35,14 @@ components:
       description: return items prefixed with this value
       schema:
         type: string
+
     PaginationAfter:
       in: query
       name: after
       description: return items after this value
       schema:
         type: string
+
     PaginationAmount:
       in: query
       name: amount
@@ -50,6 +52,13 @@ components:
         minimum: -1
         maximum: 1000
         default: 100
+
+    PaginationDelimiter:
+      in: query
+      name: delimiter
+      description: delimiter used to group common prefixes by
+      schema:
+        type: string
 
   responses:
     Unauthorized:
@@ -296,6 +305,9 @@ components:
         path_type:
           type: string
           enum: [ common_prefix, object ]
+        size_bytes:
+          type: integer
+          format: int64
 
     DiffList:
       type: object
@@ -2095,6 +2107,7 @@ paths:
       - $ref: "#/components/parameters/PaginationAfter"
       - $ref: "#/components/parameters/PaginationAmount"
       - $ref: "#/components/parameters/PaginationPrefix"
+      - $ref: "#/components/parameters/PaginationDelimiter"
       - in: path
         name: repository
         required: true
@@ -2105,11 +2118,7 @@ paths:
         required: true
         schema:
           type: string
-      - in: query
-        name: delimiter
-        schema:
-          type: string
-          default: "/"
+
     get:
       tags:
         - branches
@@ -2151,6 +2160,7 @@ paths:
       - $ref: "#/components/parameters/PaginationAfter"
       - $ref: "#/components/parameters/PaginationAmount"
       - $ref: "#/components/parameters/PaginationPrefix"
+      - $ref: "#/components/parameters/PaginationDelimiter"
       - in: query
         name: type
         schema:
@@ -2161,11 +2171,7 @@ paths:
           type: string
           enum: [two_dot, three_dot]
           default: three_dot
-      - in: query
-        name: delimiter
-        schema:
-          type: string
-          default: "/"
+
     get:
       tags:
         - refs
@@ -2544,18 +2550,11 @@ paths:
         schema:
           type: string
         description: a reference (could be either a branch or a commit ID)
-      - in: query
-        name: prefix
-        required: false
-        schema:
-          type: string
       - $ref: "#/components/parameters/PaginationAfter"
       - $ref: "#/components/parameters/PaginationAmount"
-      - in: query
-        name: delimiter
-        schema:
-          type: string
-          default: "/"
+      - $ref: "#/components/parameters/PaginationDelimiter"
+      - $ref: "#/components/parameters/PaginationPrefix"
+
     get:
       tags:
         - objects

--- a/clients/java/api/openapi.yaml
+++ b/clients/java/api/openapi.yaml
@@ -2497,6 +2497,14 @@ paths:
           minimum: -1
           type: integer
         style: form
+      - description: return items prefixed with this value
+        explode: true
+        in: query
+        name: prefix
+        required: false
+        schema:
+          type: string
+        style: form
       - explode: false
         in: path
         name: repository
@@ -2511,6 +2519,14 @@ paths:
         schema:
           type: string
         style: simple
+      - explode: true
+        in: query
+        name: delimiter
+        required: false
+        schema:
+          default: /
+          type: string
+        style: form
       responses:
         "200":
           content:
@@ -2587,6 +2603,14 @@ paths:
           minimum: -1
           type: integer
         style: form
+      - description: return items prefixed with this value
+        explode: true
+        in: query
+        name: prefix
+        required: false
+        schema:
+          type: string
+        style: form
       - explode: true
         in: query
         name: type
@@ -2603,6 +2627,14 @@ paths:
           enum:
           - two_dot
           - three_dot
+          type: string
+        style: form
+      - explode: true
+        in: query
+        name: delimiter
+        required: false
+        schema:
+          default: /
           type: string
         style: form
       responses:

--- a/clients/java/api/openapi.yaml
+++ b/clients/java/api/openapi.yaml
@@ -2505,6 +2505,14 @@ paths:
         schema:
           type: string
         style: form
+      - description: delimiter used to group common prefixes by
+        explode: true
+        in: query
+        name: delimiter
+        required: false
+        schema:
+          type: string
+        style: form
       - explode: false
         in: path
         name: repository
@@ -2519,14 +2527,6 @@ paths:
         schema:
           type: string
         style: simple
-      - explode: true
-        in: query
-        name: delimiter
-        required: false
-        schema:
-          default: /
-          type: string
-        style: form
       responses:
         "200":
           content:
@@ -2611,6 +2611,14 @@ paths:
         schema:
           type: string
         style: form
+      - description: delimiter used to group common prefixes by
+        explode: true
+        in: query
+        name: delimiter
+        required: false
+        schema:
+          type: string
+        style: form
       - explode: true
         in: query
         name: type
@@ -2627,14 +2635,6 @@ paths:
           enum:
           - two_dot
           - three_dot
-          type: string
-        style: form
-      - explode: true
-        in: query
-        name: delimiter
-        required: false
-        schema:
-          default: /
           type: string
         style: form
       responses:
@@ -3270,13 +3270,6 @@ paths:
         schema:
           type: string
         style: simple
-      - explode: true
-        in: query
-        name: prefix
-        required: false
-        schema:
-          type: string
-        style: form
       - description: return items after this value
         explode: true
         in: query
@@ -3296,12 +3289,20 @@ paths:
           minimum: -1
           type: integer
         style: form
-      - explode: true
+      - description: delimiter used to group common prefixes by
+        explode: true
         in: query
         name: delimiter
         required: false
         schema:
-          default: /
+          type: string
+        style: form
+      - description: return items prefixed with this value
+        explode: true
+        in: query
+        name: prefix
+        required: false
+        schema:
           type: string
         style: form
       responses:
@@ -3800,6 +3801,15 @@ components:
         minimum: -1
         type: integer
       style: form
+    PaginationDelimiter:
+      description: delimiter used to group common prefixes by
+      explode: true
+      in: query
+      name: delimiter
+      required: false
+      schema:
+        type: string
+      style: form
   requestBodies:
     inline_object:
       content:
@@ -4101,6 +4111,7 @@ components:
     Diff:
       example:
         path: path
+        size_bytes: 0
         path_type: common_prefix
         type: added
       properties:
@@ -4118,6 +4129,9 @@ components:
           - common_prefix
           - object
           type: string
+        size_bytes:
+          format: int64
+          type: integer
       required:
       - path
       - path_type
@@ -4132,9 +4146,11 @@ components:
           results: 0
         results:
         - path: path
+          size_bytes: 0
           path_type: common_prefix
           type: added
         - path: path
+          size_bytes: 0
           path_type: common_prefix
           type: added
       properties:

--- a/clients/java/api/openapi.yaml
+++ b/clients/java/api/openapi.yaml
@@ -4130,6 +4130,7 @@ components:
           - object
           type: string
         size_bytes:
+          description: represents the size of the added/changed/deleted entry
           format: int64
           type: integer
       required:

--- a/clients/java/docs/BranchesApi.md
+++ b/clients/java/docs/BranchesApi.md
@@ -178,7 +178,7 @@ null (empty response body)
 
 <a name="diffBranch"></a>
 # **diffBranch**
-> DiffList diffBranch(repository, branch, after, amount)
+> DiffList diffBranch(repository, branch, after, amount, prefix, delimiter)
 
 diff branch
 
@@ -217,8 +217,10 @@ public class Example {
     String branch = "branch_example"; // String | 
     String after = "after_example"; // String | return items after this value
     Integer amount = 100; // Integer | how many items to return
+    String prefix = "prefix_example"; // String | return items prefixed with this value
+    String delimiter = "/"; // String | 
     try {
-      DiffList result = apiInstance.diffBranch(repository, branch, after, amount);
+      DiffList result = apiInstance.diffBranch(repository, branch, after, amount, prefix, delimiter);
       System.out.println(result);
     } catch (ApiException e) {
       System.err.println("Exception when calling BranchesApi#diffBranch");
@@ -239,6 +241,8 @@ Name | Type | Description  | Notes
  **branch** | **String**|  |
  **after** | **String**| return items after this value | [optional]
  **amount** | **Integer**| how many items to return | [optional] [default to 100]
+ **prefix** | **String**| return items prefixed with this value | [optional]
+ **delimiter** | **String**|  | [optional] [default to /]
 
 ### Return type
 

--- a/clients/java/docs/BranchesApi.md
+++ b/clients/java/docs/BranchesApi.md
@@ -218,7 +218,7 @@ public class Example {
     String after = "after_example"; // String | return items after this value
     Integer amount = 100; // Integer | how many items to return
     String prefix = "prefix_example"; // String | return items prefixed with this value
-    String delimiter = "/"; // String | 
+    String delimiter = "delimiter_example"; // String | delimiter used to group common prefixes by
     try {
       DiffList result = apiInstance.diffBranch(repository, branch, after, amount, prefix, delimiter);
       System.out.println(result);
@@ -242,7 +242,7 @@ Name | Type | Description  | Notes
  **after** | **String**| return items after this value | [optional]
  **amount** | **Integer**| how many items to return | [optional] [default to 100]
  **prefix** | **String**| return items prefixed with this value | [optional]
- **delimiter** | **String**|  | [optional] [default to /]
+ **delimiter** | **String**| delimiter used to group common prefixes by | [optional]
 
 ### Return type
 

--- a/clients/java/docs/Diff.md
+++ b/clients/java/docs/Diff.md
@@ -10,6 +10,7 @@ Name | Type | Description | Notes
 **type** | [**TypeEnum**](#TypeEnum) |  | 
 **path** | **String** |  | 
 **pathType** | [**PathTypeEnum**](#PathTypeEnum) |  | 
+**sizeBytes** | **Long** |  |  [optional]
 
 
 

--- a/clients/java/docs/Diff.md
+++ b/clients/java/docs/Diff.md
@@ -10,7 +10,7 @@ Name | Type | Description | Notes
 **type** | [**TypeEnum**](#TypeEnum) |  | 
 **path** | **String** |  | 
 **pathType** | [**PathTypeEnum**](#PathTypeEnum) |  | 
-**sizeBytes** | **Long** |  |  [optional]
+**sizeBytes** | **Long** | represents the size of the added/changed/deleted entry |  [optional]
 
 
 

--- a/clients/java/docs/ObjectsApi.md
+++ b/clients/java/docs/ObjectsApi.md
@@ -264,7 +264,7 @@ Name | Type | Description  | Notes
 
 <a name="listObjects"></a>
 # **listObjects**
-> ObjectStatsList listObjects(repository, ref, prefix, after, amount, delimiter)
+> ObjectStatsList listObjects(repository, ref, after, amount, delimiter, prefix)
 
 list objects under a given prefix
 
@@ -301,12 +301,12 @@ public class Example {
     ObjectsApi apiInstance = new ObjectsApi(defaultClient);
     String repository = "repository_example"; // String | 
     String ref = "ref_example"; // String | a reference (could be either a branch or a commit ID)
-    String prefix = "prefix_example"; // String | 
     String after = "after_example"; // String | return items after this value
     Integer amount = 100; // Integer | how many items to return
-    String delimiter = "/"; // String | 
+    String delimiter = "delimiter_example"; // String | delimiter used to group common prefixes by
+    String prefix = "prefix_example"; // String | return items prefixed with this value
     try {
-      ObjectStatsList result = apiInstance.listObjects(repository, ref, prefix, after, amount, delimiter);
+      ObjectStatsList result = apiInstance.listObjects(repository, ref, after, amount, delimiter, prefix);
       System.out.println(result);
     } catch (ApiException e) {
       System.err.println("Exception when calling ObjectsApi#listObjects");
@@ -325,10 +325,10 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **repository** | **String**|  |
  **ref** | **String**| a reference (could be either a branch or a commit ID) |
- **prefix** | **String**|  | [optional]
  **after** | **String**| return items after this value | [optional]
  **amount** | **Integer**| how many items to return | [optional] [default to 100]
- **delimiter** | **String**|  | [optional] [default to /]
+ **delimiter** | **String**| delimiter used to group common prefixes by | [optional]
+ **prefix** | **String**| return items prefixed with this value | [optional]
 
 ### Return type
 

--- a/clients/java/docs/RefsApi.md
+++ b/clients/java/docs/RefsApi.md
@@ -13,7 +13,7 @@ Method | HTTP request | Description
 
 <a name="diffRefs"></a>
 # **diffRefs**
-> DiffList diffRefs(repository, leftRef, rightRef, after, amount, type, diffType)
+> DiffList diffRefs(repository, leftRef, rightRef, after, amount, prefix, type, diffType, delimiter)
 
 diff references
 
@@ -53,10 +53,12 @@ public class Example {
     String rightRef = "rightRef_example"; // String | a reference (could be either a branch or a commit ID) to compare against
     String after = "after_example"; // String | return items after this value
     Integer amount = 100; // Integer | how many items to return
+    String prefix = "prefix_example"; // String | return items prefixed with this value
     String type = "type_example"; // String | 
     String diffType = "three_dot"; // String | 
+    String delimiter = "/"; // String | 
     try {
-      DiffList result = apiInstance.diffRefs(repository, leftRef, rightRef, after, amount, type, diffType);
+      DiffList result = apiInstance.diffRefs(repository, leftRef, rightRef, after, amount, prefix, type, diffType, delimiter);
       System.out.println(result);
     } catch (ApiException e) {
       System.err.println("Exception when calling RefsApi#diffRefs");
@@ -78,8 +80,10 @@ Name | Type | Description  | Notes
  **rightRef** | **String**| a reference (could be either a branch or a commit ID) to compare against |
  **after** | **String**| return items after this value | [optional]
  **amount** | **Integer**| how many items to return | [optional] [default to 100]
+ **prefix** | **String**| return items prefixed with this value | [optional]
  **type** | **String**|  | [optional]
  **diffType** | **String**|  | [optional] [default to three_dot] [enum: two_dot, three_dot]
+ **delimiter** | **String**|  | [optional] [default to /]
 
 ### Return type
 

--- a/clients/java/docs/RefsApi.md
+++ b/clients/java/docs/RefsApi.md
@@ -13,7 +13,7 @@ Method | HTTP request | Description
 
 <a name="diffRefs"></a>
 # **diffRefs**
-> DiffList diffRefs(repository, leftRef, rightRef, after, amount, prefix, type, diffType, delimiter)
+> DiffList diffRefs(repository, leftRef, rightRef, after, amount, prefix, delimiter, type, diffType)
 
 diff references
 
@@ -54,11 +54,11 @@ public class Example {
     String after = "after_example"; // String | return items after this value
     Integer amount = 100; // Integer | how many items to return
     String prefix = "prefix_example"; // String | return items prefixed with this value
+    String delimiter = "delimiter_example"; // String | delimiter used to group common prefixes by
     String type = "type_example"; // String | 
     String diffType = "three_dot"; // String | 
-    String delimiter = "/"; // String | 
     try {
-      DiffList result = apiInstance.diffRefs(repository, leftRef, rightRef, after, amount, prefix, type, diffType, delimiter);
+      DiffList result = apiInstance.diffRefs(repository, leftRef, rightRef, after, amount, prefix, delimiter, type, diffType);
       System.out.println(result);
     } catch (ApiException e) {
       System.err.println("Exception when calling RefsApi#diffRefs");
@@ -81,9 +81,9 @@ Name | Type | Description  | Notes
  **after** | **String**| return items after this value | [optional]
  **amount** | **Integer**| how many items to return | [optional] [default to 100]
  **prefix** | **String**| return items prefixed with this value | [optional]
+ **delimiter** | **String**| delimiter used to group common prefixes by | [optional]
  **type** | **String**|  | [optional]
  **diffType** | **String**|  | [optional] [default to three_dot] [enum: two_dot, three_dot]
- **delimiter** | **String**|  | [optional] [default to /]
 
 ### Return type
 

--- a/clients/java/src/main/java/io/lakefs/clients/api/BranchesApi.java
+++ b/clients/java/src/main/java/io/lakefs/clients/api/BranchesApi.java
@@ -337,6 +337,8 @@ public class BranchesApi {
      * @param branch  (required)
      * @param after return items after this value (optional)
      * @param amount how many items to return (optional, default to 100)
+     * @param prefix return items prefixed with this value (optional)
+     * @param delimiter  (optional, default to /)
      * @param _callback Callback for upload/download progress
      * @return Call to execute
      * @throws ApiException If fail to serialize the request body object
@@ -349,7 +351,7 @@ public class BranchesApi {
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call diffBranchCall(String repository, String branch, String after, Integer amount, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call diffBranchCall(String repository, String branch, String after, Integer amount, String prefix, String delimiter, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -371,6 +373,14 @@ public class BranchesApi {
             localVarQueryParams.addAll(localVarApiClient.parameterToPair("amount", amount));
         }
 
+        if (prefix != null) {
+            localVarQueryParams.addAll(localVarApiClient.parameterToPair("prefix", prefix));
+        }
+
+        if (delimiter != null) {
+            localVarQueryParams.addAll(localVarApiClient.parameterToPair("delimiter", delimiter));
+        }
+
         final String[] localVarAccepts = {
             "application/json"
         };
@@ -390,7 +400,7 @@ public class BranchesApi {
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call diffBranchValidateBeforeCall(String repository, String branch, String after, Integer amount, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call diffBranchValidateBeforeCall(String repository, String branch, String after, Integer amount, String prefix, String delimiter, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'repository' is set
         if (repository == null) {
@@ -403,7 +413,7 @@ public class BranchesApi {
         }
         
 
-        okhttp3.Call localVarCall = diffBranchCall(repository, branch, after, amount, _callback);
+        okhttp3.Call localVarCall = diffBranchCall(repository, branch, after, amount, prefix, delimiter, _callback);
         return localVarCall;
 
     }
@@ -415,6 +425,8 @@ public class BranchesApi {
      * @param branch  (required)
      * @param after return items after this value (optional)
      * @param amount how many items to return (optional, default to 100)
+     * @param prefix return items prefixed with this value (optional)
+     * @param delimiter  (optional, default to /)
      * @return DiffList
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -426,8 +438,8 @@ public class BranchesApi {
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
      */
-    public DiffList diffBranch(String repository, String branch, String after, Integer amount) throws ApiException {
-        ApiResponse<DiffList> localVarResp = diffBranchWithHttpInfo(repository, branch, after, amount);
+    public DiffList diffBranch(String repository, String branch, String after, Integer amount, String prefix, String delimiter) throws ApiException {
+        ApiResponse<DiffList> localVarResp = diffBranchWithHttpInfo(repository, branch, after, amount, prefix, delimiter);
         return localVarResp.getData();
     }
 
@@ -438,6 +450,8 @@ public class BranchesApi {
      * @param branch  (required)
      * @param after return items after this value (optional)
      * @param amount how many items to return (optional, default to 100)
+     * @param prefix return items prefixed with this value (optional)
+     * @param delimiter  (optional, default to /)
      * @return ApiResponse&lt;DiffList&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -449,8 +463,8 @@ public class BranchesApi {
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<DiffList> diffBranchWithHttpInfo(String repository, String branch, String after, Integer amount) throws ApiException {
-        okhttp3.Call localVarCall = diffBranchValidateBeforeCall(repository, branch, after, amount, null);
+    public ApiResponse<DiffList> diffBranchWithHttpInfo(String repository, String branch, String after, Integer amount, String prefix, String delimiter) throws ApiException {
+        okhttp3.Call localVarCall = diffBranchValidateBeforeCall(repository, branch, after, amount, prefix, delimiter, null);
         Type localVarReturnType = new TypeToken<DiffList>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
@@ -462,6 +476,8 @@ public class BranchesApi {
      * @param branch  (required)
      * @param after return items after this value (optional)
      * @param amount how many items to return (optional, default to 100)
+     * @param prefix return items prefixed with this value (optional)
+     * @param delimiter  (optional, default to /)
      * @param _callback The callback to be executed when the API call finishes
      * @return The request call
      * @throws ApiException If fail to process the API call, e.g. serializing the request body object
@@ -474,9 +490,9 @@ public class BranchesApi {
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call diffBranchAsync(String repository, String branch, String after, Integer amount, final ApiCallback<DiffList> _callback) throws ApiException {
+    public okhttp3.Call diffBranchAsync(String repository, String branch, String after, Integer amount, String prefix, String delimiter, final ApiCallback<DiffList> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = diffBranchValidateBeforeCall(repository, branch, after, amount, _callback);
+        okhttp3.Call localVarCall = diffBranchValidateBeforeCall(repository, branch, after, amount, prefix, delimiter, _callback);
         Type localVarReturnType = new TypeToken<DiffList>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;

--- a/clients/java/src/main/java/io/lakefs/clients/api/BranchesApi.java
+++ b/clients/java/src/main/java/io/lakefs/clients/api/BranchesApi.java
@@ -338,7 +338,7 @@ public class BranchesApi {
      * @param after return items after this value (optional)
      * @param amount how many items to return (optional, default to 100)
      * @param prefix return items prefixed with this value (optional)
-     * @param delimiter  (optional, default to /)
+     * @param delimiter delimiter used to group common prefixes by (optional)
      * @param _callback Callback for upload/download progress
      * @return Call to execute
      * @throws ApiException If fail to serialize the request body object
@@ -426,7 +426,7 @@ public class BranchesApi {
      * @param after return items after this value (optional)
      * @param amount how many items to return (optional, default to 100)
      * @param prefix return items prefixed with this value (optional)
-     * @param delimiter  (optional, default to /)
+     * @param delimiter delimiter used to group common prefixes by (optional)
      * @return DiffList
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -451,7 +451,7 @@ public class BranchesApi {
      * @param after return items after this value (optional)
      * @param amount how many items to return (optional, default to 100)
      * @param prefix return items prefixed with this value (optional)
-     * @param delimiter  (optional, default to /)
+     * @param delimiter delimiter used to group common prefixes by (optional)
      * @return ApiResponse&lt;DiffList&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -477,7 +477,7 @@ public class BranchesApi {
      * @param after return items after this value (optional)
      * @param amount how many items to return (optional, default to 100)
      * @param prefix return items prefixed with this value (optional)
-     * @param delimiter  (optional, default to /)
+     * @param delimiter delimiter used to group common prefixes by (optional)
      * @param _callback The callback to be executed when the API call finishes
      * @return The request call
      * @throws ApiException If fail to process the API call, e.g. serializing the request body object

--- a/clients/java/src/main/java/io/lakefs/clients/api/ObjectsApi.java
+++ b/clients/java/src/main/java/io/lakefs/clients/api/ObjectsApi.java
@@ -504,10 +504,10 @@ public class ObjectsApi {
      * Build call for listObjects
      * @param repository  (required)
      * @param ref a reference (could be either a branch or a commit ID) (required)
-     * @param prefix  (optional)
      * @param after return items after this value (optional)
      * @param amount how many items to return (optional, default to 100)
-     * @param delimiter  (optional, default to /)
+     * @param delimiter delimiter used to group common prefixes by (optional)
+     * @param prefix return items prefixed with this value (optional)
      * @param _callback Callback for upload/download progress
      * @return Call to execute
      * @throws ApiException If fail to serialize the request body object
@@ -520,7 +520,7 @@ public class ObjectsApi {
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call listObjectsCall(String repository, String ref, String prefix, String after, Integer amount, String delimiter, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call listObjectsCall(String repository, String ref, String after, Integer amount, String delimiter, String prefix, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -534,10 +534,6 @@ public class ObjectsApi {
         Map<String, String> localVarCookieParams = new HashMap<String, String>();
         Map<String, Object> localVarFormParams = new HashMap<String, Object>();
 
-        if (prefix != null) {
-            localVarQueryParams.addAll(localVarApiClient.parameterToPair("prefix", prefix));
-        }
-
         if (after != null) {
             localVarQueryParams.addAll(localVarApiClient.parameterToPair("after", after));
         }
@@ -548,6 +544,10 @@ public class ObjectsApi {
 
         if (delimiter != null) {
             localVarQueryParams.addAll(localVarApiClient.parameterToPair("delimiter", delimiter));
+        }
+
+        if (prefix != null) {
+            localVarQueryParams.addAll(localVarApiClient.parameterToPair("prefix", prefix));
         }
 
         final String[] localVarAccepts = {
@@ -569,7 +569,7 @@ public class ObjectsApi {
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call listObjectsValidateBeforeCall(String repository, String ref, String prefix, String after, Integer amount, String delimiter, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call listObjectsValidateBeforeCall(String repository, String ref, String after, Integer amount, String delimiter, String prefix, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'repository' is set
         if (repository == null) {
@@ -582,7 +582,7 @@ public class ObjectsApi {
         }
         
 
-        okhttp3.Call localVarCall = listObjectsCall(repository, ref, prefix, after, amount, delimiter, _callback);
+        okhttp3.Call localVarCall = listObjectsCall(repository, ref, after, amount, delimiter, prefix, _callback);
         return localVarCall;
 
     }
@@ -592,10 +592,10 @@ public class ObjectsApi {
      * 
      * @param repository  (required)
      * @param ref a reference (could be either a branch or a commit ID) (required)
-     * @param prefix  (optional)
      * @param after return items after this value (optional)
      * @param amount how many items to return (optional, default to 100)
-     * @param delimiter  (optional, default to /)
+     * @param delimiter delimiter used to group common prefixes by (optional)
+     * @param prefix return items prefixed with this value (optional)
      * @return ObjectStatsList
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -607,8 +607,8 @@ public class ObjectsApi {
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
      */
-    public ObjectStatsList listObjects(String repository, String ref, String prefix, String after, Integer amount, String delimiter) throws ApiException {
-        ApiResponse<ObjectStatsList> localVarResp = listObjectsWithHttpInfo(repository, ref, prefix, after, amount, delimiter);
+    public ObjectStatsList listObjects(String repository, String ref, String after, Integer amount, String delimiter, String prefix) throws ApiException {
+        ApiResponse<ObjectStatsList> localVarResp = listObjectsWithHttpInfo(repository, ref, after, amount, delimiter, prefix);
         return localVarResp.getData();
     }
 
@@ -617,10 +617,10 @@ public class ObjectsApi {
      * 
      * @param repository  (required)
      * @param ref a reference (could be either a branch or a commit ID) (required)
-     * @param prefix  (optional)
      * @param after return items after this value (optional)
      * @param amount how many items to return (optional, default to 100)
-     * @param delimiter  (optional, default to /)
+     * @param delimiter delimiter used to group common prefixes by (optional)
+     * @param prefix return items prefixed with this value (optional)
      * @return ApiResponse&lt;ObjectStatsList&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -632,8 +632,8 @@ public class ObjectsApi {
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<ObjectStatsList> listObjectsWithHttpInfo(String repository, String ref, String prefix, String after, Integer amount, String delimiter) throws ApiException {
-        okhttp3.Call localVarCall = listObjectsValidateBeforeCall(repository, ref, prefix, after, amount, delimiter, null);
+    public ApiResponse<ObjectStatsList> listObjectsWithHttpInfo(String repository, String ref, String after, Integer amount, String delimiter, String prefix) throws ApiException {
+        okhttp3.Call localVarCall = listObjectsValidateBeforeCall(repository, ref, after, amount, delimiter, prefix, null);
         Type localVarReturnType = new TypeToken<ObjectStatsList>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
@@ -643,10 +643,10 @@ public class ObjectsApi {
      * 
      * @param repository  (required)
      * @param ref a reference (could be either a branch or a commit ID) (required)
-     * @param prefix  (optional)
      * @param after return items after this value (optional)
      * @param amount how many items to return (optional, default to 100)
-     * @param delimiter  (optional, default to /)
+     * @param delimiter delimiter used to group common prefixes by (optional)
+     * @param prefix return items prefixed with this value (optional)
      * @param _callback The callback to be executed when the API call finishes
      * @return The request call
      * @throws ApiException If fail to process the API call, e.g. serializing the request body object
@@ -659,9 +659,9 @@ public class ObjectsApi {
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call listObjectsAsync(String repository, String ref, String prefix, String after, Integer amount, String delimiter, final ApiCallback<ObjectStatsList> _callback) throws ApiException {
+    public okhttp3.Call listObjectsAsync(String repository, String ref, String after, Integer amount, String delimiter, String prefix, final ApiCallback<ObjectStatsList> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = listObjectsValidateBeforeCall(repository, ref, prefix, after, amount, delimiter, _callback);
+        okhttp3.Call localVarCall = listObjectsValidateBeforeCall(repository, ref, after, amount, delimiter, prefix, _callback);
         Type localVarReturnType = new TypeToken<ObjectStatsList>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;

--- a/clients/java/src/main/java/io/lakefs/clients/api/RefsApi.java
+++ b/clients/java/src/main/java/io/lakefs/clients/api/RefsApi.java
@@ -66,8 +66,10 @@ public class RefsApi {
      * @param rightRef a reference (could be either a branch or a commit ID) to compare against (required)
      * @param after return items after this value (optional)
      * @param amount how many items to return (optional, default to 100)
+     * @param prefix return items prefixed with this value (optional)
      * @param type  (optional)
      * @param diffType  (optional, default to three_dot)
+     * @param delimiter  (optional, default to /)
      * @param _callback Callback for upload/download progress
      * @return Call to execute
      * @throws ApiException If fail to serialize the request body object
@@ -80,7 +82,7 @@ public class RefsApi {
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call diffRefsCall(String repository, String leftRef, String rightRef, String after, Integer amount, String type, String diffType, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call diffRefsCall(String repository, String leftRef, String rightRef, String after, Integer amount, String prefix, String type, String diffType, String delimiter, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -103,12 +105,20 @@ public class RefsApi {
             localVarQueryParams.addAll(localVarApiClient.parameterToPair("amount", amount));
         }
 
+        if (prefix != null) {
+            localVarQueryParams.addAll(localVarApiClient.parameterToPair("prefix", prefix));
+        }
+
         if (type != null) {
             localVarQueryParams.addAll(localVarApiClient.parameterToPair("type", type));
         }
 
         if (diffType != null) {
             localVarQueryParams.addAll(localVarApiClient.parameterToPair("diff_type", diffType));
+        }
+
+        if (delimiter != null) {
+            localVarQueryParams.addAll(localVarApiClient.parameterToPair("delimiter", delimiter));
         }
 
         final String[] localVarAccepts = {
@@ -130,7 +140,7 @@ public class RefsApi {
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call diffRefsValidateBeforeCall(String repository, String leftRef, String rightRef, String after, Integer amount, String type, String diffType, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call diffRefsValidateBeforeCall(String repository, String leftRef, String rightRef, String after, Integer amount, String prefix, String type, String diffType, String delimiter, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'repository' is set
         if (repository == null) {
@@ -148,7 +158,7 @@ public class RefsApi {
         }
         
 
-        okhttp3.Call localVarCall = diffRefsCall(repository, leftRef, rightRef, after, amount, type, diffType, _callback);
+        okhttp3.Call localVarCall = diffRefsCall(repository, leftRef, rightRef, after, amount, prefix, type, diffType, delimiter, _callback);
         return localVarCall;
 
     }
@@ -161,8 +171,10 @@ public class RefsApi {
      * @param rightRef a reference (could be either a branch or a commit ID) to compare against (required)
      * @param after return items after this value (optional)
      * @param amount how many items to return (optional, default to 100)
+     * @param prefix return items prefixed with this value (optional)
      * @param type  (optional)
      * @param diffType  (optional, default to three_dot)
+     * @param delimiter  (optional, default to /)
      * @return DiffList
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -174,8 +186,8 @@ public class RefsApi {
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
      */
-    public DiffList diffRefs(String repository, String leftRef, String rightRef, String after, Integer amount, String type, String diffType) throws ApiException {
-        ApiResponse<DiffList> localVarResp = diffRefsWithHttpInfo(repository, leftRef, rightRef, after, amount, type, diffType);
+    public DiffList diffRefs(String repository, String leftRef, String rightRef, String after, Integer amount, String prefix, String type, String diffType, String delimiter) throws ApiException {
+        ApiResponse<DiffList> localVarResp = diffRefsWithHttpInfo(repository, leftRef, rightRef, after, amount, prefix, type, diffType, delimiter);
         return localVarResp.getData();
     }
 
@@ -187,8 +199,10 @@ public class RefsApi {
      * @param rightRef a reference (could be either a branch or a commit ID) to compare against (required)
      * @param after return items after this value (optional)
      * @param amount how many items to return (optional, default to 100)
+     * @param prefix return items prefixed with this value (optional)
      * @param type  (optional)
      * @param diffType  (optional, default to three_dot)
+     * @param delimiter  (optional, default to /)
      * @return ApiResponse&lt;DiffList&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -200,8 +214,8 @@ public class RefsApi {
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<DiffList> diffRefsWithHttpInfo(String repository, String leftRef, String rightRef, String after, Integer amount, String type, String diffType) throws ApiException {
-        okhttp3.Call localVarCall = diffRefsValidateBeforeCall(repository, leftRef, rightRef, after, amount, type, diffType, null);
+    public ApiResponse<DiffList> diffRefsWithHttpInfo(String repository, String leftRef, String rightRef, String after, Integer amount, String prefix, String type, String diffType, String delimiter) throws ApiException {
+        okhttp3.Call localVarCall = diffRefsValidateBeforeCall(repository, leftRef, rightRef, after, amount, prefix, type, diffType, delimiter, null);
         Type localVarReturnType = new TypeToken<DiffList>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
@@ -214,8 +228,10 @@ public class RefsApi {
      * @param rightRef a reference (could be either a branch or a commit ID) to compare against (required)
      * @param after return items after this value (optional)
      * @param amount how many items to return (optional, default to 100)
+     * @param prefix return items prefixed with this value (optional)
      * @param type  (optional)
      * @param diffType  (optional, default to three_dot)
+     * @param delimiter  (optional, default to /)
      * @param _callback The callback to be executed when the API call finishes
      * @return The request call
      * @throws ApiException If fail to process the API call, e.g. serializing the request body object
@@ -228,9 +244,9 @@ public class RefsApi {
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call diffRefsAsync(String repository, String leftRef, String rightRef, String after, Integer amount, String type, String diffType, final ApiCallback<DiffList> _callback) throws ApiException {
+    public okhttp3.Call diffRefsAsync(String repository, String leftRef, String rightRef, String after, Integer amount, String prefix, String type, String diffType, String delimiter, final ApiCallback<DiffList> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = diffRefsValidateBeforeCall(repository, leftRef, rightRef, after, amount, type, diffType, _callback);
+        okhttp3.Call localVarCall = diffRefsValidateBeforeCall(repository, leftRef, rightRef, after, amount, prefix, type, diffType, delimiter, _callback);
         Type localVarReturnType = new TypeToken<DiffList>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;

--- a/clients/java/src/main/java/io/lakefs/clients/api/RefsApi.java
+++ b/clients/java/src/main/java/io/lakefs/clients/api/RefsApi.java
@@ -67,9 +67,9 @@ public class RefsApi {
      * @param after return items after this value (optional)
      * @param amount how many items to return (optional, default to 100)
      * @param prefix return items prefixed with this value (optional)
+     * @param delimiter delimiter used to group common prefixes by (optional)
      * @param type  (optional)
      * @param diffType  (optional, default to three_dot)
-     * @param delimiter  (optional, default to /)
      * @param _callback Callback for upload/download progress
      * @return Call to execute
      * @throws ApiException If fail to serialize the request body object
@@ -82,7 +82,7 @@ public class RefsApi {
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call diffRefsCall(String repository, String leftRef, String rightRef, String after, Integer amount, String prefix, String type, String diffType, String delimiter, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call diffRefsCall(String repository, String leftRef, String rightRef, String after, Integer amount, String prefix, String delimiter, String type, String diffType, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -109,16 +109,16 @@ public class RefsApi {
             localVarQueryParams.addAll(localVarApiClient.parameterToPair("prefix", prefix));
         }
 
+        if (delimiter != null) {
+            localVarQueryParams.addAll(localVarApiClient.parameterToPair("delimiter", delimiter));
+        }
+
         if (type != null) {
             localVarQueryParams.addAll(localVarApiClient.parameterToPair("type", type));
         }
 
         if (diffType != null) {
             localVarQueryParams.addAll(localVarApiClient.parameterToPair("diff_type", diffType));
-        }
-
-        if (delimiter != null) {
-            localVarQueryParams.addAll(localVarApiClient.parameterToPair("delimiter", delimiter));
         }
 
         final String[] localVarAccepts = {
@@ -140,7 +140,7 @@ public class RefsApi {
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call diffRefsValidateBeforeCall(String repository, String leftRef, String rightRef, String after, Integer amount, String prefix, String type, String diffType, String delimiter, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call diffRefsValidateBeforeCall(String repository, String leftRef, String rightRef, String after, Integer amount, String prefix, String delimiter, String type, String diffType, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'repository' is set
         if (repository == null) {
@@ -158,7 +158,7 @@ public class RefsApi {
         }
         
 
-        okhttp3.Call localVarCall = diffRefsCall(repository, leftRef, rightRef, after, amount, prefix, type, diffType, delimiter, _callback);
+        okhttp3.Call localVarCall = diffRefsCall(repository, leftRef, rightRef, after, amount, prefix, delimiter, type, diffType, _callback);
         return localVarCall;
 
     }
@@ -172,9 +172,9 @@ public class RefsApi {
      * @param after return items after this value (optional)
      * @param amount how many items to return (optional, default to 100)
      * @param prefix return items prefixed with this value (optional)
+     * @param delimiter delimiter used to group common prefixes by (optional)
      * @param type  (optional)
      * @param diffType  (optional, default to three_dot)
-     * @param delimiter  (optional, default to /)
      * @return DiffList
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -186,8 +186,8 @@ public class RefsApi {
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
      */
-    public DiffList diffRefs(String repository, String leftRef, String rightRef, String after, Integer amount, String prefix, String type, String diffType, String delimiter) throws ApiException {
-        ApiResponse<DiffList> localVarResp = diffRefsWithHttpInfo(repository, leftRef, rightRef, after, amount, prefix, type, diffType, delimiter);
+    public DiffList diffRefs(String repository, String leftRef, String rightRef, String after, Integer amount, String prefix, String delimiter, String type, String diffType) throws ApiException {
+        ApiResponse<DiffList> localVarResp = diffRefsWithHttpInfo(repository, leftRef, rightRef, after, amount, prefix, delimiter, type, diffType);
         return localVarResp.getData();
     }
 
@@ -200,9 +200,9 @@ public class RefsApi {
      * @param after return items after this value (optional)
      * @param amount how many items to return (optional, default to 100)
      * @param prefix return items prefixed with this value (optional)
+     * @param delimiter delimiter used to group common prefixes by (optional)
      * @param type  (optional)
      * @param diffType  (optional, default to three_dot)
-     * @param delimiter  (optional, default to /)
      * @return ApiResponse&lt;DiffList&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -214,8 +214,8 @@ public class RefsApi {
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<DiffList> diffRefsWithHttpInfo(String repository, String leftRef, String rightRef, String after, Integer amount, String prefix, String type, String diffType, String delimiter) throws ApiException {
-        okhttp3.Call localVarCall = diffRefsValidateBeforeCall(repository, leftRef, rightRef, after, amount, prefix, type, diffType, delimiter, null);
+    public ApiResponse<DiffList> diffRefsWithHttpInfo(String repository, String leftRef, String rightRef, String after, Integer amount, String prefix, String delimiter, String type, String diffType) throws ApiException {
+        okhttp3.Call localVarCall = diffRefsValidateBeforeCall(repository, leftRef, rightRef, after, amount, prefix, delimiter, type, diffType, null);
         Type localVarReturnType = new TypeToken<DiffList>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
@@ -229,9 +229,9 @@ public class RefsApi {
      * @param after return items after this value (optional)
      * @param amount how many items to return (optional, default to 100)
      * @param prefix return items prefixed with this value (optional)
+     * @param delimiter delimiter used to group common prefixes by (optional)
      * @param type  (optional)
      * @param diffType  (optional, default to three_dot)
-     * @param delimiter  (optional, default to /)
      * @param _callback The callback to be executed when the API call finishes
      * @return The request call
      * @throws ApiException If fail to process the API call, e.g. serializing the request body object
@@ -244,9 +244,9 @@ public class RefsApi {
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call diffRefsAsync(String repository, String leftRef, String rightRef, String after, Integer amount, String prefix, String type, String diffType, String delimiter, final ApiCallback<DiffList> _callback) throws ApiException {
+    public okhttp3.Call diffRefsAsync(String repository, String leftRef, String rightRef, String after, Integer amount, String prefix, String delimiter, String type, String diffType, final ApiCallback<DiffList> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = diffRefsValidateBeforeCall(repository, leftRef, rightRef, after, amount, prefix, type, diffType, delimiter, _callback);
+        okhttp3.Call localVarCall = diffRefsValidateBeforeCall(repository, leftRef, rightRef, after, amount, prefix, delimiter, type, diffType, _callback);
         Type localVarReturnType = new TypeToken<DiffList>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;

--- a/clients/java/src/main/java/io/lakefs/clients/api/model/Diff.java
+++ b/clients/java/src/main/java/io/lakefs/clients/api/model/Diff.java
@@ -217,11 +217,11 @@ public class Diff {
   }
 
    /**
-   * Get sizeBytes
+   * represents the size of the added/changed/deleted entry
    * @return sizeBytes
   **/
   @javax.annotation.Nullable
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(value = "represents the size of the added/changed/deleted entry")
 
   public Long getSizeBytes() {
     return sizeBytes;

--- a/clients/java/src/main/java/io/lakefs/clients/api/model/Diff.java
+++ b/clients/java/src/main/java/io/lakefs/clients/api/model/Diff.java
@@ -139,6 +139,10 @@ public class Diff {
   @SerializedName(SERIALIZED_NAME_PATH_TYPE)
   private PathTypeEnum pathType;
 
+  public static final String SERIALIZED_NAME_SIZE_BYTES = "size_bytes";
+  @SerializedName(SERIALIZED_NAME_SIZE_BYTES)
+  private Long sizeBytes;
+
 
   public Diff type(TypeEnum type) {
     
@@ -206,6 +210,29 @@ public class Diff {
   }
 
 
+  public Diff sizeBytes(Long sizeBytes) {
+    
+    this.sizeBytes = sizeBytes;
+    return this;
+  }
+
+   /**
+   * Get sizeBytes
+   * @return sizeBytes
+  **/
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "")
+
+  public Long getSizeBytes() {
+    return sizeBytes;
+  }
+
+
+  public void setSizeBytes(Long sizeBytes) {
+    this.sizeBytes = sizeBytes;
+  }
+
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -217,12 +244,13 @@ public class Diff {
     Diff diff = (Diff) o;
     return Objects.equals(this.type, diff.type) &&
         Objects.equals(this.path, diff.path) &&
-        Objects.equals(this.pathType, diff.pathType);
+        Objects.equals(this.pathType, diff.pathType) &&
+        Objects.equals(this.sizeBytes, diff.sizeBytes);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(type, path, pathType);
+    return Objects.hash(type, path, pathType, sizeBytes);
   }
 
   @Override
@@ -232,6 +260,7 @@ public class Diff {
     sb.append("    type: ").append(toIndentedString(type)).append("\n");
     sb.append("    path: ").append(toIndentedString(path)).append("\n");
     sb.append("    pathType: ").append(toIndentedString(pathType)).append("\n");
+    sb.append("    sizeBytes: ").append(toIndentedString(sizeBytes)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/clients/python/docs/BranchesApi.md
+++ b/clients/python/docs/BranchesApi.md
@@ -256,7 +256,7 @@ with lakefs_client.ApiClient(configuration) as api_client:
     after = "after_example" # str | return items after this value (optional)
     amount = 100 # int | how many items to return (optional) if omitted the server will use the default value of 100
     prefix = "prefix_example" # str | return items prefixed with this value (optional)
-    delimiter = "/" # str |  (optional) if omitted the server will use the default value of "/"
+    delimiter = "delimiter_example" # str | delimiter used to group common prefixes by (optional)
 
     # example passing only required values which don't have defaults set
     try:
@@ -286,7 +286,7 @@ Name | Type | Description  | Notes
  **after** | **str**| return items after this value | [optional]
  **amount** | **int**| how many items to return | [optional] if omitted the server will use the default value of 100
  **prefix** | **str**| return items prefixed with this value | [optional]
- **delimiter** | **str**|  | [optional] if omitted the server will use the default value of "/"
+ **delimiter** | **str**| delimiter used to group common prefixes by | [optional]
 
 ### Return type
 

--- a/clients/python/docs/BranchesApi.md
+++ b/clients/python/docs/BranchesApi.md
@@ -255,6 +255,8 @@ with lakefs_client.ApiClient(configuration) as api_client:
     branch = "branch_example" # str | 
     after = "after_example" # str | return items after this value (optional)
     amount = 100 # int | how many items to return (optional) if omitted the server will use the default value of 100
+    prefix = "prefix_example" # str | return items prefixed with this value (optional)
+    delimiter = "/" # str |  (optional) if omitted the server will use the default value of "/"
 
     # example passing only required values which don't have defaults set
     try:
@@ -268,7 +270,7 @@ with lakefs_client.ApiClient(configuration) as api_client:
     # and optional values
     try:
         # diff branch
-        api_response = api_instance.diff_branch(repository, branch, after=after, amount=amount)
+        api_response = api_instance.diff_branch(repository, branch, after=after, amount=amount, prefix=prefix, delimiter=delimiter)
         pprint(api_response)
     except lakefs_client.ApiException as e:
         print("Exception when calling BranchesApi->diff_branch: %s\n" % e)
@@ -283,6 +285,8 @@ Name | Type | Description  | Notes
  **branch** | **str**|  |
  **after** | **str**| return items after this value | [optional]
  **amount** | **int**| how many items to return | [optional] if omitted the server will use the default value of 100
+ **prefix** | **str**| return items prefixed with this value | [optional]
+ **delimiter** | **str**|  | [optional] if omitted the server will use the default value of "/"
 
 ### Return type
 

--- a/clients/python/docs/Diff.md
+++ b/clients/python/docs/Diff.md
@@ -7,7 +7,7 @@ Name | Type | Description | Notes
 **type** | **str** |  | 
 **path** | **str** |  | 
 **path_type** | **str** |  | 
-**size_bytes** | **int** |  | [optional] 
+**size_bytes** | **int** | represents the size of the added/changed/deleted entry | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/clients/python/docs/Diff.md
+++ b/clients/python/docs/Diff.md
@@ -7,6 +7,7 @@ Name | Type | Description | Notes
 **type** | **str** |  | 
 **path** | **str** |  | 
 **path_type** | **str** |  | 
+**size_bytes** | **int** |  | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/clients/python/docs/ObjectsApi.md
+++ b/clients/python/docs/ObjectsApi.md
@@ -347,10 +347,10 @@ with lakefs_client.ApiClient(configuration) as api_client:
     api_instance = objects_api.ObjectsApi(api_client)
     repository = "repository_example" # str | 
     ref = "ref_example" # str | a reference (could be either a branch or a commit ID)
-    prefix = "prefix_example" # str |  (optional)
     after = "after_example" # str | return items after this value (optional)
     amount = 100 # int | how many items to return (optional) if omitted the server will use the default value of 100
-    delimiter = "/" # str |  (optional) if omitted the server will use the default value of "/"
+    delimiter = "delimiter_example" # str | delimiter used to group common prefixes by (optional)
+    prefix = "prefix_example" # str | return items prefixed with this value (optional)
 
     # example passing only required values which don't have defaults set
     try:
@@ -364,7 +364,7 @@ with lakefs_client.ApiClient(configuration) as api_client:
     # and optional values
     try:
         # list objects under a given prefix
-        api_response = api_instance.list_objects(repository, ref, prefix=prefix, after=after, amount=amount, delimiter=delimiter)
+        api_response = api_instance.list_objects(repository, ref, after=after, amount=amount, delimiter=delimiter, prefix=prefix)
         pprint(api_response)
     except lakefs_client.ApiException as e:
         print("Exception when calling ObjectsApi->list_objects: %s\n" % e)
@@ -377,10 +377,10 @@ Name | Type | Description  | Notes
 ------------- | ------------- | ------------- | -------------
  **repository** | **str**|  |
  **ref** | **str**| a reference (could be either a branch or a commit ID) |
- **prefix** | **str**|  | [optional]
  **after** | **str**| return items after this value | [optional]
  **amount** | **int**| how many items to return | [optional] if omitted the server will use the default value of 100
- **delimiter** | **str**|  | [optional] if omitted the server will use the default value of "/"
+ **delimiter** | **str**| delimiter used to group common prefixes by | [optional]
+ **prefix** | **str**| return items prefixed with this value | [optional]
 
 ### Return type
 

--- a/clients/python/docs/RefsApi.md
+++ b/clients/python/docs/RefsApi.md
@@ -65,8 +65,10 @@ with lakefs_client.ApiClient(configuration) as api_client:
     right_ref = "rightRef_example" # str | a reference (could be either a branch or a commit ID) to compare against
     after = "after_example" # str | return items after this value (optional)
     amount = 100 # int | how many items to return (optional) if omitted the server will use the default value of 100
+    prefix = "prefix_example" # str | return items prefixed with this value (optional)
     type = "type_example" # str |  (optional)
     diff_type = "three_dot" # str |  (optional) if omitted the server will use the default value of "three_dot"
+    delimiter = "/" # str |  (optional) if omitted the server will use the default value of "/"
 
     # example passing only required values which don't have defaults set
     try:
@@ -80,7 +82,7 @@ with lakefs_client.ApiClient(configuration) as api_client:
     # and optional values
     try:
         # diff references
-        api_response = api_instance.diff_refs(repository, left_ref, right_ref, after=after, amount=amount, type=type, diff_type=diff_type)
+        api_response = api_instance.diff_refs(repository, left_ref, right_ref, after=after, amount=amount, prefix=prefix, type=type, diff_type=diff_type, delimiter=delimiter)
         pprint(api_response)
     except lakefs_client.ApiException as e:
         print("Exception when calling RefsApi->diff_refs: %s\n" % e)
@@ -96,8 +98,10 @@ Name | Type | Description  | Notes
  **right_ref** | **str**| a reference (could be either a branch or a commit ID) to compare against |
  **after** | **str**| return items after this value | [optional]
  **amount** | **int**| how many items to return | [optional] if omitted the server will use the default value of 100
+ **prefix** | **str**| return items prefixed with this value | [optional]
  **type** | **str**|  | [optional]
  **diff_type** | **str**|  | [optional] if omitted the server will use the default value of "three_dot"
+ **delimiter** | **str**|  | [optional] if omitted the server will use the default value of "/"
 
 ### Return type
 

--- a/clients/python/docs/RefsApi.md
+++ b/clients/python/docs/RefsApi.md
@@ -66,9 +66,9 @@ with lakefs_client.ApiClient(configuration) as api_client:
     after = "after_example" # str | return items after this value (optional)
     amount = 100 # int | how many items to return (optional) if omitted the server will use the default value of 100
     prefix = "prefix_example" # str | return items prefixed with this value (optional)
+    delimiter = "delimiter_example" # str | delimiter used to group common prefixes by (optional)
     type = "type_example" # str |  (optional)
     diff_type = "three_dot" # str |  (optional) if omitted the server will use the default value of "three_dot"
-    delimiter = "/" # str |  (optional) if omitted the server will use the default value of "/"
 
     # example passing only required values which don't have defaults set
     try:
@@ -82,7 +82,7 @@ with lakefs_client.ApiClient(configuration) as api_client:
     # and optional values
     try:
         # diff references
-        api_response = api_instance.diff_refs(repository, left_ref, right_ref, after=after, amount=amount, prefix=prefix, type=type, diff_type=diff_type, delimiter=delimiter)
+        api_response = api_instance.diff_refs(repository, left_ref, right_ref, after=after, amount=amount, prefix=prefix, delimiter=delimiter, type=type, diff_type=diff_type)
         pprint(api_response)
     except lakefs_client.ApiException as e:
         print("Exception when calling RefsApi->diff_refs: %s\n" % e)
@@ -99,9 +99,9 @@ Name | Type | Description  | Notes
  **after** | **str**| return items after this value | [optional]
  **amount** | **int**| how many items to return | [optional] if omitted the server will use the default value of 100
  **prefix** | **str**| return items prefixed with this value | [optional]
+ **delimiter** | **str**| delimiter used to group common prefixes by | [optional]
  **type** | **str**|  | [optional]
  **diff_type** | **str**|  | [optional] if omitted the server will use the default value of "three_dot"
- **delimiter** | **str**|  | [optional] if omitted the server will use the default value of "/"
 
 ### Return type
 

--- a/clients/python/lakefs_client/api/branches_api.py
+++ b/clients/python/lakefs_client/api/branches_api.py
@@ -327,7 +327,7 @@ class BranchesApi(object):
                 after (str): return items after this value. [optional]
                 amount (int): how many items to return. [optional] if omitted the server will use the default value of 100
                 prefix (str): return items prefixed with this value. [optional]
-                delimiter (str): [optional] if omitted the server will use the default value of "/"
+                delimiter (str): delimiter used to group common prefixes by. [optional]
                 _return_http_data_only (bool): response data without head status
                     code and headers. Default is True.
                 _preload_content (bool): if False, the urllib3.HTTPResponse object

--- a/clients/python/lakefs_client/api/branches_api.py
+++ b/clients/python/lakefs_client/api/branches_api.py
@@ -326,6 +326,8 @@ class BranchesApi(object):
             Keyword Args:
                 after (str): return items after this value. [optional]
                 amount (int): how many items to return. [optional] if omitted the server will use the default value of 100
+                prefix (str): return items prefixed with this value. [optional]
+                delimiter (str): [optional] if omitted the server will use the default value of "/"
                 _return_http_data_only (bool): response data without head status
                     code and headers. Default is True.
                 _preload_content (bool): if False, the urllib3.HTTPResponse object
@@ -395,6 +397,8 @@ class BranchesApi(object):
                     'branch',
                     'after',
                     'amount',
+                    'prefix',
+                    'delimiter',
                 ],
                 'required': [
                     'repository',
@@ -427,18 +431,26 @@ class BranchesApi(object):
                         (str,),
                     'amount':
                         (int,),
+                    'prefix':
+                        (str,),
+                    'delimiter':
+                        (str,),
                 },
                 'attribute_map': {
                     'repository': 'repository',
                     'branch': 'branch',
                     'after': 'after',
                     'amount': 'amount',
+                    'prefix': 'prefix',
+                    'delimiter': 'delimiter',
                 },
                 'location_map': {
                     'repository': 'path',
                     'branch': 'path',
                     'after': 'query',
                     'amount': 'query',
+                    'prefix': 'query',
+                    'delimiter': 'query',
                 },
                 'collection_format_map': {
                 }

--- a/clients/python/lakefs_client/api/objects_api.py
+++ b/clients/python/lakefs_client/api/objects_api.py
@@ -481,10 +481,10 @@ class ObjectsApi(object):
                 ref (str): a reference (could be either a branch or a commit ID)
 
             Keyword Args:
-                prefix (str): [optional]
                 after (str): return items after this value. [optional]
                 amount (int): how many items to return. [optional] if omitted the server will use the default value of 100
-                delimiter (str): [optional] if omitted the server will use the default value of "/"
+                delimiter (str): delimiter used to group common prefixes by. [optional]
+                prefix (str): return items prefixed with this value. [optional]
                 _return_http_data_only (bool): response data without head status
                     code and headers. Default is True.
                 _preload_content (bool): if False, the urllib3.HTTPResponse object
@@ -552,10 +552,10 @@ class ObjectsApi(object):
                 'all': [
                     'repository',
                     'ref',
-                    'prefix',
                     'after',
                     'amount',
                     'delimiter',
+                    'prefix',
                 ],
                 'required': [
                     'repository',
@@ -584,30 +584,30 @@ class ObjectsApi(object):
                         (str,),
                     'ref':
                         (str,),
-                    'prefix':
-                        (str,),
                     'after':
                         (str,),
                     'amount':
                         (int,),
                     'delimiter':
                         (str,),
+                    'prefix':
+                        (str,),
                 },
                 'attribute_map': {
                     'repository': 'repository',
                     'ref': 'ref',
-                    'prefix': 'prefix',
                     'after': 'after',
                     'amount': 'amount',
                     'delimiter': 'delimiter',
+                    'prefix': 'prefix',
                 },
                 'location_map': {
                     'repository': 'path',
                     'ref': 'path',
-                    'prefix': 'query',
                     'after': 'query',
                     'amount': 'query',
                     'delimiter': 'query',
+                    'prefix': 'query',
                 },
                 'collection_format_map': {
                 }

--- a/clients/python/lakefs_client/api/refs_api.py
+++ b/clients/python/lakefs_client/api/refs_api.py
@@ -66,9 +66,9 @@ class RefsApi(object):
                 after (str): return items after this value. [optional]
                 amount (int): how many items to return. [optional] if omitted the server will use the default value of 100
                 prefix (str): return items prefixed with this value. [optional]
+                delimiter (str): delimiter used to group common prefixes by. [optional]
                 type (str): [optional]
                 diff_type (str): [optional] if omitted the server will use the default value of "three_dot"
-                delimiter (str): [optional] if omitted the server will use the default value of "/"
                 _return_http_data_only (bool): response data without head status
                     code and headers. Default is True.
                 _preload_content (bool): if False, the urllib3.HTTPResponse object
@@ -142,9 +142,9 @@ class RefsApi(object):
                     'after',
                     'amount',
                     'prefix',
+                    'delimiter',
                     'type',
                     'diff_type',
-                    'delimiter',
                 ],
                 'required': [
                     'repository',
@@ -188,11 +188,11 @@ class RefsApi(object):
                         (int,),
                     'prefix':
                         (str,),
+                    'delimiter':
+                        (str,),
                     'type':
                         (str,),
                     'diff_type':
-                        (str,),
-                    'delimiter':
                         (str,),
                 },
                 'attribute_map': {
@@ -202,9 +202,9 @@ class RefsApi(object):
                     'after': 'after',
                     'amount': 'amount',
                     'prefix': 'prefix',
+                    'delimiter': 'delimiter',
                     'type': 'type',
                     'diff_type': 'diff_type',
-                    'delimiter': 'delimiter',
                 },
                 'location_map': {
                     'repository': 'path',
@@ -213,9 +213,9 @@ class RefsApi(object):
                     'after': 'query',
                     'amount': 'query',
                     'prefix': 'query',
+                    'delimiter': 'query',
                     'type': 'query',
                     'diff_type': 'query',
-                    'delimiter': 'query',
                 },
                 'collection_format_map': {
                 }

--- a/clients/python/lakefs_client/api/refs_api.py
+++ b/clients/python/lakefs_client/api/refs_api.py
@@ -65,8 +65,10 @@ class RefsApi(object):
             Keyword Args:
                 after (str): return items after this value. [optional]
                 amount (int): how many items to return. [optional] if omitted the server will use the default value of 100
+                prefix (str): return items prefixed with this value. [optional]
                 type (str): [optional]
                 diff_type (str): [optional] if omitted the server will use the default value of "three_dot"
+                delimiter (str): [optional] if omitted the server will use the default value of "/"
                 _return_http_data_only (bool): response data without head status
                     code and headers. Default is True.
                 _preload_content (bool): if False, the urllib3.HTTPResponse object
@@ -139,8 +141,10 @@ class RefsApi(object):
                     'right_ref',
                     'after',
                     'amount',
+                    'prefix',
                     'type',
                     'diff_type',
+                    'delimiter',
                 ],
                 'required': [
                     'repository',
@@ -182,9 +186,13 @@ class RefsApi(object):
                         (str,),
                     'amount':
                         (int,),
+                    'prefix':
+                        (str,),
                     'type':
                         (str,),
                     'diff_type':
+                        (str,),
+                    'delimiter':
                         (str,),
                 },
                 'attribute_map': {
@@ -193,8 +201,10 @@ class RefsApi(object):
                     'right_ref': 'rightRef',
                     'after': 'after',
                     'amount': 'amount',
+                    'prefix': 'prefix',
                     'type': 'type',
                     'diff_type': 'diff_type',
+                    'delimiter': 'delimiter',
                 },
                 'location_map': {
                     'repository': 'path',
@@ -202,8 +212,10 @@ class RefsApi(object):
                     'right_ref': 'path',
                     'after': 'query',
                     'amount': 'query',
+                    'prefix': 'query',
                     'type': 'query',
                     'diff_type': 'query',
+                    'delimiter': 'query',
                 },
                 'collection_format_map': {
                 }

--- a/clients/python/lakefs_client/model/diff.py
+++ b/clients/python/lakefs_client/model/diff.py
@@ -152,7 +152,7 @@ class Diff(ModelNormal):
                                 Animal class but this time we won't travel
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
-            size_bytes (int): [optional]  # noqa: E501
+            size_bytes (int): represents the size of the added/changed/deleted entry. [optional]  # noqa: E501
         """
 
         _check_type = kwargs.pop('_check_type', True)

--- a/clients/python/lakefs_client/model/diff.py
+++ b/clients/python/lakefs_client/model/diff.py
@@ -86,6 +86,7 @@ class Diff(ModelNormal):
             'type': (str,),  # noqa: E501
             'path': (str,),  # noqa: E501
             'path_type': (str,),  # noqa: E501
+            'size_bytes': (int,),  # noqa: E501
         }
 
     @cached_property
@@ -97,6 +98,7 @@ class Diff(ModelNormal):
         'type': 'type',  # noqa: E501
         'path': 'path',  # noqa: E501
         'path_type': 'path_type',  # noqa: E501
+        'size_bytes': 'size_bytes',  # noqa: E501
     }
 
     _composed_schemas = {}
@@ -150,6 +152,7 @@ class Diff(ModelNormal):
                                 Animal class but this time we won't travel
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
+            size_bytes (int): [optional]  # noqa: E501
         """
 
         _check_type = kwargs.pop('_check_type', True)

--- a/cmd/lakectl/cmd/fs.go
+++ b/cmd/lakectl/cmd/fs.go
@@ -70,18 +70,19 @@ var fsListCmd = &cobra.Command{
 			trimPrefix = prefix[:idx+1]
 		}
 		// delimiter used for listing
-		var paramsDelimiter *string
+		var paramsDelimiter api.PaginationDelimiter
 		if recursive {
-			paramsDelimiter = api.StringPtr("")
+			paramsDelimiter = ""
 		} else {
-			paramsDelimiter = api.StringPtr(delimiter)
+			paramsDelimiter = delimiter
 		}
 		var from string
 		for {
+			pfx := api.PaginationPrefix(prefix)
 			params := &api.ListObjectsParams{
-				Prefix:    &prefix,
+				Prefix:    &pfx,
 				After:     api.PaginationAfterPtr(from),
-				Delimiter: paramsDelimiter,
+				Delimiter: &paramsDelimiter,
 			}
 			resp, err := client.ListObjectsWithResponse(cmd.Context(), pathURI.Repository, pathURI.Ref, params)
 			DieOnResponseError(resp, err)

--- a/nessie/sanity_api_test.go
+++ b/nessie/sanity_api_test.go
@@ -125,10 +125,11 @@ func TestSanityAPI(t *testing.T) {
 	})
 	require.NoError(t, err, "diff between branch1 and main")
 	require.Equal(t, http.StatusOK, diffResp.StatusCode())
+	size := int64(randomDataContentLength)
 	require.ElementsMatch(t, diffResp.JSON200.Results, []api.Diff{
-		{Path: "file0", PathType: "object", Type: "changed"},
-		{Path: "file1", PathType: "object", Type: "removed"},
-		{Path: "fileX", PathType: "object", Type: "added"},
+		{Path: "file0", PathType: "object", Type: "changed", SizeBytes: &size},
+		{Path: "file1", PathType: "object", Type: "removed", SizeBytes: &size},
+		{Path: "fileX", PathType: "object", Type: "added", SizeBytes: &size},
 	})
 
 	log.Debug("branch1 - merge changes to main")

--- a/nessie/system_test.go
+++ b/nessie/system_test.go
@@ -91,10 +91,10 @@ func createRepository(ctx context.Context, t *testing.T, name string, repoStorag
 		"create repository '%s', storage '%s'", name, repoStorage)
 }
 
-func uploadFileRandomDataAndReport(ctx context.Context, repo, branch, objPath string, direct bool) (checksum, content string, err error) {
-	const contentLength = 16
-	objContent := randstr.Hex(contentLength)
+const randomDataContentLength = 16
 
+func uploadFileRandomDataAndReport(ctx context.Context, repo, branch, objPath string, direct bool) (checksum, content string, err error) {
+	objContent := randstr.Hex(randomDataContentLength)
 	checksum, err = uploadFileAndReport(ctx, repo, branch, objPath, objContent, direct)
 	if err != nil {
 		return "", "", err

--- a/nessie/system_test.go
+++ b/nessie/system_test.go
@@ -94,7 +94,7 @@ func createRepository(ctx context.Context, t *testing.T, name string, repoStorag
 const randomDataContentLength = 16
 
 func uploadFileRandomDataAndReport(ctx context.Context, repo, branch, objPath string, direct bool) (checksum, content string, err error) {
-	objContent := randstr.Hex(randomDataContentLength)
+	objContent := randstr.String(randomDataContentLength)
 	checksum, err = uploadFileAndReport(ctx, repo, branch, objPath, objContent, direct)
 	if err != nil {
 		return "", "", err

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -42,6 +42,9 @@ const (
 
 	actionStatusCompleted = "completed"
 	actionStatusFailed    = "failed"
+
+	entryTypeObject       = "object"
+	entryTypeCommonPrefix = "common_prefix"
 )
 
 type actionsHandler interface {
@@ -1536,11 +1539,11 @@ func (c *Controller) ResetBranch(w http.ResponseWriter, r *http.Request, body Re
 
 	var err error
 	switch body.Type {
-	case "common_prefix":
+	case entryTypeCommonPrefix:
 		err = c.Catalog.ResetEntries(ctx, repository, branch, StringValue(body.Path))
 	case "reset":
 		err = c.Catalog.ResetBranch(ctx, repository, branch)
-	case "object":
+	case entryTypeObject:
 		err = c.Catalog.ResetEntry(ctx, repository, branch, StringValue(body.Path))
 	default:
 		writeError(w, http.StatusNotFound, "reset type not found")
@@ -1629,9 +1632,9 @@ func (c *Controller) DiffBranch(w http.ResponseWriter, r *http.Request, reposito
 
 	results := make([]Diff, 0, len(diff))
 	for _, d := range diff {
-		pathType := "object"
+		pathType := entryTypeObject
 		if d.Type == catalog.DifferenceTypeCommonPrefix {
-			pathType = "common_prefix"
+			pathType = entryTypeCommonPrefix
 		}
 		results = append(results, Diff{
 			Path:     d.Path,
@@ -1767,7 +1770,7 @@ func (c *Controller) UploadObject(w http.ResponseWriter, r *http.Request, reposi
 		Checksum:        blob.Checksum,
 		Mtime:           writeTime.Unix(),
 		Path:            params.Path,
-		PathType:        "object",
+		PathType:        entryTypeObject,
 		PhysicalAddress: qk.Format(),
 		SizeBytes:       Int64Ptr(blob.Size),
 	}
@@ -1833,7 +1836,7 @@ func (c *Controller) StageObject(w http.ResponseWriter, r *http.Request, body St
 		Checksum:        entry.Checksum,
 		Mtime:           entry.CreationDate.Unix(),
 		Path:            entry.Path,
-		PathType:        "object",
+		PathType:        entryTypeObject,
 		PhysicalAddress: qk.Format(),
 		SizeBytes:       Int64Ptr(entry.Size),
 	}
@@ -2196,9 +2199,9 @@ func (c *Controller) DiffRefs(w http.ResponseWriter, r *http.Request, repository
 	}
 	results := make([]Diff, 0, len(diff))
 	for _, d := range diff {
-		pathType := "object"
+		pathType := entryTypeObject
 		if d.Type == catalog.DifferenceTypeCommonPrefix {
-			pathType = "common_prefix"
+			pathType = entryTypeCommonPrefix
 		}
 		results = append(results, Diff{
 			Path:     d.Path,
@@ -2371,7 +2374,7 @@ func (c *Controller) ListObjects(w http.ResponseWriter, r *http.Request, reposit
 		if entry.CommonLevel {
 			objList = append(objList, ObjectStats{
 				Path:     entry.Path,
-				PathType: "common_prefix",
+				PathType: entryTypeCommonPrefix,
 			})
 		} else {
 			var mtime int64
@@ -2383,7 +2386,7 @@ func (c *Controller) ListObjects(w http.ResponseWriter, r *http.Request, reposit
 				Mtime:           mtime,
 				Path:            entry.Path,
 				PhysicalAddress: qk.Format(),
-				PathType:        "object",
+				PathType:        entryTypeObject,
 				SizeBytes:       Int64Ptr(entry.Size),
 			})
 		}
@@ -2434,7 +2437,7 @@ func (c *Controller) StatObject(w http.ResponseWriter, r *http.Request, reposito
 		Checksum:        entry.Checksum,
 		Mtime:           entry.CreationDate.Unix(),
 		Path:            params.Path,
-		PathType:        "object",
+		PathType:        entryTypeObject,
 		PhysicalAddress: qk.Format(),
 		SizeBytes:       Int64Ptr(entry.Size),
 	}

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -935,9 +935,9 @@ func TestController_ObjectsListObjectsHandler(t *testing.T) {
 	}
 
 	t.Run("get object list", func(t *testing.T) {
-		pfx := api.PaginationPrefix("foo/")
+		prefix := api.PaginationPrefix("foo/")
 		resp, err := clt.ListObjectsWithResponse(ctx, "repo1", "main", &api.ListObjectsParams{
-			Prefix: &pfx,
+			Prefix: &prefix,
 		})
 		verifyResponseOK(t, resp, err)
 		results := resp.JSON200.Results
@@ -947,9 +947,9 @@ func TestController_ObjectsListObjectsHandler(t *testing.T) {
 	})
 
 	t.Run("get object list paginated", func(t *testing.T) {
-		pfx := api.PaginationPrefix("foo/")
+		prefix := api.PaginationPrefix("foo/")
 		resp, err := clt.ListObjectsWithResponse(ctx, "repo1", "main", &api.ListObjectsParams{
-			Prefix: &pfx,
+			Prefix: &prefix,
 			Amount: api.PaginationAmountPtr(2),
 		})
 		verifyResponseOK(t, resp, err)

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -935,8 +935,9 @@ func TestController_ObjectsListObjectsHandler(t *testing.T) {
 	}
 
 	t.Run("get object list", func(t *testing.T) {
+		pfx := api.PaginationPrefix("foo/")
 		resp, err := clt.ListObjectsWithResponse(ctx, "repo1", "main", &api.ListObjectsParams{
-			Prefix: api.StringPtr("foo/"),
+			Prefix: &pfx,
 		})
 		verifyResponseOK(t, resp, err)
 		results := resp.JSON200.Results
@@ -946,8 +947,9 @@ func TestController_ObjectsListObjectsHandler(t *testing.T) {
 	})
 
 	t.Run("get object list paginated", func(t *testing.T) {
+		pfx := api.PaginationPrefix("foo/")
 		resp, err := clt.ListObjectsWithResponse(ctx, "repo1", "main", &api.ListObjectsParams{
-			Prefix: api.StringPtr("foo/"),
+			Prefix: &pfx,
 			Amount: api.PaginationAmountPtr(2),
 		})
 		verifyResponseOK(t, resp, err)
@@ -1539,8 +1541,9 @@ func TestController_MergeDiffWithParent(t *testing.T) {
 
 	diffResp, err := clt.DiffRefsWithResponse(ctx, repoName, "main", "main~1", &api.DiffRefsParams{})
 	verifyResponseOK(t, diffResp, err)
+	var expectedSize = int64(len(content))
 	expectedResults := []api.Diff{
-		{Path: "file1", PathType: "object", Type: "added"},
+		{Path: "file1", PathType: "object", Type: "added", SizeBytes: &expectedSize},
 	}
 	if diff := deep.Equal(diffResp.JSON200.Results, expectedResults); diff != nil {
 		t.Fatal("Diff results not as expected:", diff)

--- a/pkg/api/transform.go
+++ b/pkg/api/transform.go
@@ -10,7 +10,7 @@ func transformDifferenceTypeToString(d catalog.DifferenceType) string {
 		return "added"
 	case catalog.DifferenceTypeRemoved:
 		return "removed"
-	case catalog.DifferenceTypeChanged:
+	case catalog.DifferenceTypeChanged, catalog.DifferenceTypeCommonPrefix:
 		return "changed"
 	case catalog.DifferenceTypeConflict:
 		return "conflict"

--- a/pkg/api/transform.go
+++ b/pkg/api/transform.go
@@ -11,6 +11,9 @@ func transformDifferenceTypeToString(d catalog.DifferenceType) string {
 	case catalog.DifferenceTypeRemoved:
 		return "removed"
 	case catalog.DifferenceTypeChanged, catalog.DifferenceTypeCommonPrefix:
+		// note that common prefixes are always considered "changed".
+		// while technically possible to check if the underlying diff would result in the prefix being deleted,
+		// this would turn the diff to be O(N) where N is the amount of entries starting with that prefix
 		return "changed"
 	case catalog.DifferenceTypeConflict:
 		return "conflict"

--- a/pkg/api/transform.go
+++ b/pkg/api/transform.go
@@ -10,10 +10,7 @@ func transformDifferenceTypeToString(d catalog.DifferenceType) string {
 		return "added"
 	case catalog.DifferenceTypeRemoved:
 		return "removed"
-	case catalog.DifferenceTypeChanged, catalog.DifferenceTypeCommonPrefix:
-		// note that common prefixes are always considered "changed".
-		// while technically possible to check if the underlying diff would result in the prefix being deleted,
-		// this would turn the diff to be O(N) where N is the amount of entries starting with that prefix
+	case catalog.DifferenceTypeChanged:
 		return "changed"
 	case catalog.DifferenceTypeConflict:
 		return "conflict"

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -1050,7 +1050,8 @@ func listDiffHelper(it EntryDiffIterator, prefix, delimiter string, limit int, a
 						CommonLevel: true,
 						Path:        commonPrefix,
 					},
-					Type: DifferenceTypeCommonPrefix,
+					// We always return "changed" for common prefixes. Seeing if a common prefix is e.g. deleted is O(N)
+					Type: DifferenceTypeChanged,
 				})
 				if len(diffs) >= limit+1 {
 					break // collected enough results

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -993,22 +993,23 @@ func (c *Catalog) DiffUncommitted(ctx context.Context, repository, branch, prefi
 	return listDiffHelper(it, prefix, delimiter, limit, after)
 }
 
-// GetStartPos finds the correct place to start iterating from based on delimiter, prefix & after
+// GetStartPos returns a key that SeekGE will transform to a place start iterating on all elements in
+//    the keys that start with `prefix' after `after' and taking `delimiter' into account
 func GetStartPos(prefix, after, delimiter string) string {
-	switch {
-	case prefix == "" && after == "":
-		// if no prefix given and no after given, start at the beginning
-		return ""
-	case delimiter != "" && after != "":
-		// if we have a delimiter and after is not empty, start at the next common prefix after "after"
-		return string(graveler.UpperBoundForPrefix([]byte(after)))
-	case after != "":
-		// otherwise if after is set and no delimiter, continue from after
-		return after
-	default:
+	if after == "" {
 		// whether we have a delimiter or not, if after is not set, start at prefix
 		return prefix
 	}
+	if after < prefix {
+		// if after is before prefix, no point in starting there, start with prefix instead
+		return prefix
+	}
+	if delimiter == "" {
+		// no delimiter, continue from after
+		return after
+	}
+	// there is a delimiter and after is not empty, start at the next common prefix after "after"
+	return string(graveler.UpperBoundForPrefix([]byte(after)))
 }
 
 const commonPrefixSplitParts = 2

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -993,16 +993,20 @@ func (c *Catalog) DiffUncommitted(ctx context.Context, repository, branch, prefi
 	return listDiffHelper(it, prefix, delimiter, limit, after)
 }
 
+// GetStartPos finds the correct place to start iterating from based on delimiter, prefix & after
 func GetStartPos(prefix, after, delimiter string) string {
-	// find the correct place to start iterating from based on delimiter, prefix, after
 	switch {
 	case prefix == "" && after == "":
+		// if no prefix given and no after given, start at the beginning
 		return ""
 	case delimiter != "" && after != "":
+		// if we have a delimiter and after is not empty, start at the next common prefix after "after"
 		return string(graveler.UpperBoundForPrefix([]byte(after)))
 	case after != "":
+		// otherwise if after is set and no delimiter, continue from after
 		return after
 	default:
+		// whether we have a delimiter or not, if after is not set, start at prefix
 		return prefix
 	}
 }

--- a/pkg/catalog/catalog_test.go
+++ b/pkg/catalog/catalog_test.go
@@ -38,6 +38,9 @@ func TestGetStartPos(t *testing.T) {
 		{"delimiter_and_after", "/", "", "a/b/", string(graveler.UpperBoundForPrefix([]byte("a/b/")))},
 		{"delimiter_and_prefix", "/", "a/", "", "a/"},
 		{"delimiter_prefix_and_after", "/", "a/", "a/b/", string(graveler.UpperBoundForPrefix([]byte("a/b/")))},
+		{"empty_directory", "/", "", "a/b//", string(graveler.UpperBoundForPrefix([]byte("a/b//")))},
+		{"after_before_prefix", "", "c", "a", "c"},
+		{"after_before_prefix_with_delim", "/", "c/", "a", "c/"},
 	}
 
 	for _, cas := range cases {

--- a/pkg/catalog/diff.go
+++ b/pkg/catalog/diff.go
@@ -7,7 +7,6 @@ const (
 	DifferenceTypeRemoved
 	DifferenceTypeChanged
 	DifferenceTypeConflict
-	DifferenceTypeCommonPrefix
 	DifferenceTypeNone
 )
 

--- a/pkg/catalog/diff.go
+++ b/pkg/catalog/diff.go
@@ -7,6 +7,7 @@ const (
 	DifferenceTypeRemoved
 	DifferenceTypeChanged
 	DifferenceTypeConflict
+	DifferenceTypeCommonPrefix
 	DifferenceTypeNone
 )
 

--- a/pkg/catalog/interface.go
+++ b/pkg/catalog/interface.go
@@ -14,6 +14,8 @@ const (
 type DiffParams struct {
 	Limit            int
 	After            string
+	Prefix           string
+	Delimiter        string
 	AdditionalFields []string // db fields names that will be load in additional to Path on Difference's Entry
 }
 
@@ -98,7 +100,7 @@ type Interface interface {
 
 	Diff(ctx context.Context, repository, leftReference string, rightReference string, params DiffParams) (Differences, bool, error)
 	Compare(ctx context.Context, repository, leftReference string, rightReference string, params DiffParams) (Differences, bool, error)
-	DiffUncommitted(ctx context.Context, repository, branch string, limit int, after string) (Differences, bool, error)
+	DiffUncommitted(ctx context.Context, repository, branch, prefix, delimiter string, limit int, after string) (Differences, bool, error)
 
 	Merge(ctx context.Context, repository, destinationBranch, sourceRef, committer, message string, metadata Metadata) (*MergeResult, error)
 

--- a/webui/src/lib/api/index.js
+++ b/webui/src/lib/api/index.js
@@ -529,8 +529,8 @@ class Commits {
 
 class Refs {
 
-    async changes(repoId, branchId, after, amount = DEFAULT_LISTING_AMOUNT) {
-        const query = qs({after, amount});
+    async changes(repoId, branchId, after, prefix, delimiter, amount = DEFAULT_LISTING_AMOUNT) {
+        const query = qs({after, prefix, delimiter, amount});
         const response = await apiRequest(`/repositories/${repoId}/branches/${branchId}/diff?${query}`);
         if (response.status !== 200) {
             throw new Error(await extractError(response));

--- a/webui/src/lib/api/index.js
+++ b/webui/src/lib/api/index.js
@@ -459,8 +459,8 @@ class Branches {
 
 class Objects {
 
-    async list(repoId, ref, tree, after = "", amount = DEFAULT_LISTING_AMOUNT, readUncommitted = true) {
-        const query = qs({prefix:tree, amount, after, readUncommitted});
+    async list(repoId, ref, tree, after = "", amount = DEFAULT_LISTING_AMOUNT, readUncommitted = true, delimiter = "/") {
+        const query = qs({prefix:tree, amount, after, readUncommitted, delimiter});
         const response = await apiRequest(`/repositories/${repoId}/refs/${ref}/objects/ls?${query}`);
         if (response.status !== 200) {
             throw new Error(await extractError(response));

--- a/webui/src/lib/api/index.js
+++ b/webui/src/lib/api/index.js
@@ -538,8 +538,8 @@ class Refs {
         return response.json();
     }
 
-    async diff(repoId, leftRef, rightRef, after, amount = DEFAULT_LISTING_AMOUNT) {
-        const query = qs({after, amount});
+    async diff(repoId, leftRef, rightRef, after, prefix = "", delimiter = "", amount = DEFAULT_LISTING_AMOUNT) {
+        const query = qs({after, amount, delimiter, prefix});
         const response = await apiRequest(`/repositories/${repoId}/refs/${leftRef}/diff/${rightRef}?${query}`);
         if (response.status !== 200) {
             throw new Error(await extractError(response));

--- a/webui/src/lib/components/auth/forms.jsx
+++ b/webui/src/lib/components/auth/forms.jsx
@@ -58,7 +58,7 @@ export const AttachModal = ({ show, searchFn, onAttach, onHide, addText = "Add",
                     }
                 </div>
             </>
-        )
+        );
 
     return (
         <Modal show={show} onHide={onHide}>

--- a/webui/src/lib/components/controls.jsx
+++ b/webui/src/lib/components/controls.jsx
@@ -322,3 +322,16 @@ export const Checkbox = ({ name, onAdd, onRemove, disabled = false, defaultCheck
         </Form.Group>
     );
 };
+
+export const ToggleSwitch = ({  label, id, defaultChecked, onChange }) => {
+    return (
+        <Form>
+            <Form.Switch
+                label={label}
+                id={id}
+                defaultChecked={defaultChecked}
+                onChange={onChange}
+            />
+        </Form>
+    )
+}

--- a/webui/src/lib/components/repository/changes.jsx
+++ b/webui/src/lib/components/repository/changes.jsx
@@ -123,8 +123,7 @@ export const ChangeEntryRow = ({ entry, showActions, relativeTo="", onNavigate, 
                         </span>
                     ) : (
                         <span>{pathText}</span>
-                    )
-                    }
+                    )}
                 </td>
                 <td className={"tree-row-actions"}>
                     {entryActions}

--- a/webui/src/lib/components/repository/changes.jsx
+++ b/webui/src/lib/components/repository/changes.jsx
@@ -53,7 +53,7 @@ export const ChangeEntryRow = ({ entry, showActions, relativeTo="", onNavigate, 
     }
 
     let pathText = entry.path;
-    if (pathText.indexOf(relativeTo) === 0) {
+    if (pathText.startsWith(relativeTo)) {
         pathText = pathText.substr(relativeTo.length, pathText.length);
     }
 

--- a/webui/src/lib/components/repository/changes.jsx
+++ b/webui/src/lib/components/repository/changes.jsx
@@ -33,7 +33,7 @@ const ChangeRowActions = ({ entry, onRevert }) => {
     );
 };
 
-export const ChangeEntryRow = ({ repo, reference, entry, showActions, onRevert, relativeTo="" }) => {
+export const ChangeEntryRow = ({ entry, showActions, relativeTo="", onNavigate, onRevert }) => {
     let rowClass = 'tree-row ';
     switch (entry.type) {
         case 'changed':
@@ -116,11 +116,7 @@ export const ChangeEntryRow = ({ repo, reference, entry, showActions, onRevert, 
                 <td className="tree-path">
                     {(entry.path_type === "common_prefix") ? (
                         <span>
-                            <Link href={{
-                                pathname: '/repositories/:repoId/changes',
-                                params: {repoId: repo.id},
-                                query: {ref: reference.id, delimiter: "/", prefix: entry.path}
-                            }}>
+                            <Link href={onNavigate(entry)}>
                                 <FileDirectoryIcon/>
                                 {pathText}
                             </Link>

--- a/webui/src/lib/components/repository/changes.jsx
+++ b/webui/src/lib/components/repository/changes.jsx
@@ -3,9 +3,10 @@ import React, {useState} from "react";
 import {OverlayTrigger} from "react-bootstrap";
 import Tooltip from "react-bootstrap/Tooltip";
 import Button from "react-bootstrap/Button";
-import {CircleSlashIcon, HistoryIcon, PencilIcon, PlusIcon, TrashIcon} from "@primer/octicons-react";
+import {CircleSlashIcon, FileDirectoryIcon, HistoryIcon, PencilIcon, PlusIcon, TrashIcon} from "@primer/octicons-react";
 
 import {ConfirmationModal} from "../modals";
+import {Link} from "../nav";
 
 
 const ChangeRowActions = ({ entry, onRevert }) => {
@@ -26,12 +27,13 @@ const ChangeRowActions = ({ entry, onRevert }) => {
                     <HistoryIcon/>
                 </Button>
             </OverlayTrigger>
+
             <ConfirmationModal show={show} onHide={() => setShow(false)} msg={revertConfirmMsg} onConfirm={onSubmit}/>
         </>
     );
 };
 
-export const ChangeEntryRow = ({ entry, showActions, onRevert }) => {
+export const ChangeEntryRow = ({ repo, reference, entry, showActions, onRevert, relativeTo="" }) => {
     let rowClass = 'tree-row ';
     switch (entry.type) {
         case 'changed':
@@ -50,7 +52,10 @@ export const ChangeEntryRow = ({ entry, showActions, onRevert }) => {
             break;
     }
 
-    const pathText = entry.path;
+    let pathText = entry.path;
+    if (pathText.indexOf(relativeTo) === 0) {
+        pathText = pathText.substr(relativeTo.length, pathText.length);
+    }
 
     let diffIndicator;
     switch (entry.type) {
@@ -109,7 +114,21 @@ export const ChangeEntryRow = ({ entry, showActions, onRevert }) => {
                     {diffIndicator}
                 </td>
                 <td className="tree-path">
-                    <span>{pathText}</span>
+                    {(entry.path_type === "common_prefix") ? (
+                        <span>
+                            <Link href={{
+                                pathname: '/repositories/:repoId/changes',
+                                params: {repoId: repo.id},
+                                query: {ref: reference.id, delimiter: "/", prefix: entry.path}
+                            }}>
+                                <FileDirectoryIcon/>
+                                {pathText}
+                            </Link>
+                        </span>
+                    ) : (
+                        <span>{pathText}</span>
+                    )
+                    }
                 </td>
                 <td className={"tree-row-actions"}>
                     {entryActions}

--- a/webui/src/lib/components/repository/tabs.jsx
+++ b/webui/src/lib/components/repository/tabs.jsx
@@ -49,7 +49,7 @@ export const RepositoryNavTabs = ({ active }) => {
                 <DatabaseIcon/> Objects
             </Link>
             <Link active={active === 'changes'} href={withBranchContext(`/repositories/${repoId}/changes`)} component={NavItem}>
-                <FileDiffIcon/> Changes
+                <FileDiffIcon/> Uncommitted Changes
             </Link>
             <Link active={active === 'commits'} href={withRefContext(`/repositories/${repoId}/commits`)} component={NavItem}>
                 <GitCommitIcon/> Commits

--- a/webui/src/lib/components/repository/tree.jsx
+++ b/webui/src/lib/components/repository/tree.jsx
@@ -220,23 +220,38 @@ function pathParts(path, rootName = "root") {
     return resolved;
 }
 
-const URINavigator = ({ repo, reference, path }) => {
+const buildPathURL = (params, query) => {
+    return {pathname: '/repositories/:repoId/objects', params, query};
+};
+
+export const URINavigator = ({ repo, reference, path, relativeTo = "", pathURLBuilder = buildPathURL }) => {
     const parts = pathParts(path);
     const params = {repoId: repo.id};
 
     return (
         <span className="lakefs-uri">
-            <strong>{'lakefs://'}</strong>
-            <Link href={{pathname: '/repositories/:repoId/objects', params}}>{repo.id}</Link>
-            <strong>{'/'}</strong>
-            <Link href={{pathname: '/repositories/:repoId/objects',params, query: {ref: reference.id}}}>{(reference.type === 'commit') ? reference.id.substr(0, 12) : reference.id}</Link>
-            <strong>{'/'}</strong>
+            {(relativeTo === "") ? (
+                <>
+                    <strong>{'lakefs://'}</strong>
+                    <Link href={{pathname: '/repositories/:repoId/objects', params}}>{repo.id}</Link>
+                    <strong>{'/'}</strong>
+                    <Link href={{pathname: '/repositories/:repoId/objects',params, query: {ref: reference.id}}}>{(reference.type === 'commit') ? reference.id.substr(0, 12) : reference.id}</Link>
+                    <strong>{'/'}</strong>
+                </>
+            ): (
+
+                <>
+                    <Link href={pathURLBuilder(params, {path: ""})}>{relativeTo}</Link>
+                    <strong>{'/'}</strong>
+                </>
+            )}
+
             {parts.map((part, i) => {
                 const path = parts.slice(0, i+1).map(p => p.name).join('/') + '/';
                 const query = {path, ref: reference.id};
                 return (
                     <span key={i}>
-                        <Link href={{pathname: '/repositories/:repoId/objects', params, query}}>{part.name}</Link>
+                        <Link href={pathURLBuilder(params, query)}>{part.name}</Link>
                         <strong>{'/'}</strong>
                     </span>
                 );

--- a/webui/src/pages/auth/groups/group/members.jsx
+++ b/webui/src/pages/auth/groups/group/members.jsx
@@ -33,7 +33,7 @@ const GroupMemberList = ({ groupId, after, onPaginate }) => {
 
     useEffect(() => {
         setAttachError(null);
-    }, [refresh])
+    }, [refresh]);
 
     let content;
     if (loading) content = <Loading/>;

--- a/webui/src/pages/auth/groups/group/policies.jsx
+++ b/webui/src/pages/auth/groups/group/policies.jsx
@@ -31,7 +31,7 @@ const GroupPoliciesList = ({ groupId, after, onPaginate }) => {
         return auth.listGroupPolicies(groupId, after);
     }, [groupId, after, refresh]);
 
-    useEffect(() => { setAttachError(null); }, [refresh, after])
+    useEffect(() => { setAttachError(null); }, [refresh, after]);
 
     let content;
     if (loading) content = <Loading/>;

--- a/webui/src/pages/repositories/repository/actions/run/index.jsx
+++ b/webui/src/pages/repositories/repository/actions/run/index.jsx
@@ -125,7 +125,7 @@ const HookLog = ({ repo, run, execution }) => {
                     {content}
                 </div>
             </div>
-    )
+    );
 }
 
 const ExecutionsExplorer = ({ repo, run, executions }) => {

--- a/webui/src/pages/repositories/repository/changes.jsx
+++ b/webui/src/pages/repositories/repository/changes.jsx
@@ -241,16 +241,33 @@ const ChangesBrowser = ({ repo, reference, after, prefix, delimiter, onSelectRef
                             <Table borderless size="sm">
                                 <tbody>
                                 {results.map(entry => (
-                                    <ChangeEntryRow key={entry.path} entry={entry} relativeTo={prefix} repo={repo} reference={reference} showActions={true} onRevert={(entry) => {
-                                        branches
-                                            .revert(repo.id, reference.id, {type: entry.path_type, path: entry.path})
-                                            .then(() => {
-                                                setInternalRefresh(!internalRefresh)
-                                            })
-                                            .catch(error => {
-                                                setActionError(error)
-                                            })
-                                    }}/>
+                                    <ChangeEntryRow
+                                        key={entry.path}
+                                        entry={entry}
+                                        relativeTo={prefix}
+                                        showActions={true}
+                                        onRevert={(entry) => {
+                                            branches
+                                                .revert(repo.id, reference.id, {type: entry.path_type, path: entry.path})
+                                                .then(() => {
+                                                    setInternalRefresh(!internalRefresh)
+                                                })
+                                                .catch(error => {
+                                                    setActionError(error)
+                                                })
+                                        }}
+                                        onNavigate={entry => {
+                                            return {
+                                                pathname: '/repositories/:repoId/changes',
+                                                params: {repoId: repo.id},
+                                                query: {
+                                                    delimiter: "/",
+                                                    prefix: entry.path,
+                                                    ref: reference.id
+                                                }
+                                            }
+                                        }}
+                                    />
                                 ))}
                                 </tbody>
                             </Table>

--- a/webui/src/pages/repositories/repository/changes.jsx
+++ b/webui/src/pages/repositories/repository/changes.jsx
@@ -1,4 +1,4 @@
-import React, {useEffect, useRef, useState} from "react";
+import React, {useRef, useState} from "react";
 
 import {
     GitCommitIcon,

--- a/webui/src/pages/repositories/repository/changes.jsx
+++ b/webui/src/pages/repositories/repository/changes.jsx
@@ -241,9 +241,9 @@ const ChangesBrowser = ({ repo, reference, after, prefix, delimiter, onSelectRef
                             <Table borderless size="sm">
                                 <tbody>
                                 {results.map(entry => (
-                                    <ChangeEntryRow key={entry.path} entry={entry} relativeTo={prefix} repo={repo} reference={reference} showActions={entry.path_type === "object"} onRevert={(entry) => {
+                                    <ChangeEntryRow key={entry.path} entry={entry} relativeTo={prefix} repo={repo} reference={reference} showActions={true} onRevert={(entry) => {
                                         branches
-                                            .revert(repo.id, reference.id, {type: 'object', path: entry.path})
+                                            .revert(repo.id, reference.id, {type: entry.path_type, path: entry.path})
                                             .then(() => {
                                                 setInternalRefresh(!internalRefresh)
                                             })

--- a/webui/src/pages/repositories/repository/commits/commit/index.jsx
+++ b/webui/src/pages/repositories/repository/commits/commit/index.jsx
@@ -3,7 +3,7 @@ import {RepositoryPageLayout} from "../../../../../lib/components/repository/lay
 import {
     ClipboardButton,
     Error, LinkButton,
-    Loading
+    Loading, ToggleSwitch
 } from "../../../../../lib/components/controls";
 import {RefContextProvider, useRefs} from "../../../../../lib/hooks/repo";
 import Card from "react-bootstrap/Card";
@@ -49,27 +49,25 @@ const ChangeList = ({ repo, commit, after, prefix, delimiter, onPaginate }) => {
                                         return {
                                             pathname: '/repositories/:repoId/commits/:commitId',
                                             params: {repoId: repo.id, commitId: commit.id},
-                                            query: {delimiter: "/", prefix: query.path}
+                                            query: {delimiter, prefix: query.path}
                                         }
                                     }}
                                 />
                             )}
                         </span>
                         <span className="float-right">
-                            <Form>
-                                <Form.Switch
-                                    label="Directory View"
-                                    id="changes-directory-view-toggle"
-                                    defaultChecked={(delimiter !== "")}
-                                    onChange={(e) => {
-                                        push({
-                                            pathname: '/repositories/:repoId/commits/:commitId',
-                                            params: {repoId: repo.id, commitId: commit.id},
-                                            query: {delimiter: (e.target.checked) ? "/" : ""},
-                                        })
-                                    }}
-                                />
-                                </Form>
+                            <ToggleSwitch
+                                label="Directory View"
+                                id="changes-directory-view-toggle"
+                                defaultChecked={(delimiter !== "")}
+                                onChange={(e) => {
+                                    push({
+                                        pathname: '/repositories/:repoId/commits/:commitId',
+                                        params: {repoId: repo.id, commitId: commit.id},
+                                        query: {delimiter: (e.target.checked) ? "/" : ""},
+                                    })
+                                }}
+                            />
                         </span>
                     </Card.Header>
                     <Card.Body>

--- a/webui/src/pages/repositories/repository/commits/commit/index.jsx
+++ b/webui/src/pages/repositories/repository/commits/commit/index.jsx
@@ -19,7 +19,6 @@ import {BrowserIcon, LinkIcon, PackageIcon, PlayIcon} from "@primer/octicons-rea
 import {Link} from "../../../../../lib/components/nav";
 import {useRouter} from "../../../../../lib/hooks/router";
 import {URINavigator} from "../../../../../lib/components/repository/tree";
-import Form from "react-bootstrap/Form";
 
 
 const ChangeList = ({ repo, commit, after, prefix, delimiter, onPaginate }) => {

--- a/webui/src/pages/repositories/repository/compare.jsx
+++ b/webui/src/pages/repositories/repository/compare.jsx
@@ -32,7 +32,7 @@ const CompareList = ({ repo, reference, compareReference, after, delimiter, pref
 
     const { results, error, loading, nextPage } = useAPIWithPagination(async () => {
         if (compareReference.id !== reference.id)
-            return refs.diff(repo.id, compareReference.id, reference.id, after, prefix, delimiter, 3);
+            return refs.diff(repo.id, compareReference.id, reference.id, after, prefix, delimiter);
         return {pagination: {has_more: false}, results: []}; // nothing to compare here.
     }, [repo.id, reference.id, compareReference.id, internalRefresh, after, prefix, delimiter]);
 

--- a/webui/src/pages/repositories/repository/compare.jsx
+++ b/webui/src/pages/repositories/repository/compare.jsx
@@ -14,14 +14,16 @@ import {ChangeEntryRow} from "../../../lib/components/repository/changes";
 import {Paginator} from "../../../lib/components/pagination";
 import {ConfirmationButton} from "../../../lib/components/modals";
 import {useRouter} from "../../../lib/hooks/router";
+import {URINavigator} from "../../../lib/components/repository/tree";
+import Form from "react-bootstrap/Form";
 
 
-const CompareList = ({ repo, reference, compareReference, after, onSelectRef, onSelectCompare, onPaginate }) => {
+const CompareList = ({ repo, reference, compareReference, after, delimiter, prefix, onSelectRef, onSelectCompare, onPaginate }) => {
     if (compareReference === null) compareReference = reference
-
-    const [internalRefresh, setInternalRefresh] = useState(true)
-    const [mergeError, setMergeError] = useState(null)
-    const [merging, setMerging] = useState(false)
+    const [internalRefresh, setInternalRefresh] = useState(true);
+    const [mergeError, setMergeError] = useState(null);
+    const [merging, setMerging] = useState(false);
+    const { push } = useRouter();
 
     const refresh = () => {
         setInternalRefresh(!internalRefresh)
@@ -30,11 +32,12 @@ const CompareList = ({ repo, reference, compareReference, after, onSelectRef, on
 
     const { results, error, loading, nextPage } = useAPIWithPagination(async () => {
         if (compareReference.id !== reference.id)
-            return refs.diff(repo.id, compareReference.id, reference.id, after)
-        return {pagination: {has_more: false}, results: []} // nothing to compare here.
-    }, [repo.id, reference.id, compareReference.id, internalRefresh, after])
+            return refs.diff(repo.id, compareReference.id, reference.id, after, prefix, delimiter, 3);
+        return {pagination: {has_more: false}, results: []}; // nothing to compare here.
+    }, [repo.id, reference.id, compareReference.id, internalRefresh, after, prefix, delimiter]);
 
     let content;
+
     if (loading) content = <Loading/>
     else if (!!error) content = <Error error={error}/>
     else if (compareReference.id === reference.id) content = (
@@ -47,13 +50,80 @@ const CompareList = ({ repo, reference, compareReference, after, onSelectRef, on
             <div className="tree-container">
                 {(results.length === 0) ? <Alert variant="info">No changes</Alert> : (
                     <Card>
-                        <Table borderless size="sm">
-                            <tbody>
-                            {results.map(entry => (
-                                <ChangeEntryRow key={entry.path} entry={entry} showActions={false}/>
-                            ))}
-                            </tbody>
-                        </Table>
+                        <Card.Header>
+                        <span className="float-left">
+                            {(delimiter !== "") && (
+                                <URINavigator
+                                    path={prefix}
+                                    reference={reference}
+                                    relativeTo={`${reference.id}...${compareReference.id}`}
+                                    repo={repo}
+                                    pathURLBuilder={(params, query) => {
+                                        const q = {
+                                            delimiter: "/",
+                                            prefix: query.path,
+                                        };
+                                        if (compareReference) q.compare = compareReference.id;
+                                        if (reference) q.ref = reference.id;
+                                        return {
+                                            pathname: '/repositories/:repoId/compare',
+                                            params: {repoId: repo.id},
+                                            query: q
+                                        }
+                                    }}
+                                />
+                            )}
+                        </span>
+                            <span className="float-right">
+                            <Form>
+                                <Form.Switch
+                                    label="Directory View"
+                                    id="changes-directory-view-toggle"
+                                    defaultChecked={(delimiter !== "")}
+                                    onChange={(e) => {
+                                        const query = {
+                                            delimiter: (e.target.checked) ? "/" : ""
+                                        };
+                                        if (compareReference) query.compare = compareReference.id;
+                                        if (reference) query.ref = reference.id;
+                                        push({
+                                            pathname: '/repositories/:repoId/compare',
+                                            params: {repoId: repo.id},
+                                            query,
+                                        });
+                                    }}
+                                />
+                                </Form>
+                        </span>
+                        </Card.Header>
+                        <Card.Body>
+                            <Table borderless size="sm">
+                                <tbody>
+                                {results.map(entry => (
+                                    <ChangeEntryRow
+                                        key={entry.path}
+                                        entry={entry}
+                                        showActions={false}
+                                        relativeTo={prefix}
+                                        onNavigate={entry => {
+                                            const query = {
+                                                prefix: entry.path,
+                                                delimiter: (delimiter) ? delimiter : "",
+
+                                            };
+                                            if (compareReference) query.compare = compareReference.id;
+                                            if (reference) query.ref = reference.id;
+                                            return {
+                                                pathname: '/repositories/:repoId/compare',
+                                                params: {repoId: repo.id},
+                                                query,
+                                            }
+                                        }}
+                                    />
+                                ))}
+                                </tbody>
+                            </Table>
+                        </Card.Body>
                     </Card>
                 )}
 
@@ -128,23 +198,32 @@ const CompareContainer = () => {
     const router = useRouter();
     const { loading, error, repo, reference, compare } = useRefs();
 
-    const { after } = router.query;
+    const { after, prefix, delimiter } = router.query;
 
     if (loading) return <Loading/>;
     if (!!error) return <Error error={error}/>;
 
-    const route = query => router.push({pathname: `/repositories/:repoId/compare`, params: {repoId: repo.id}, query});
+    const route = query => router.push({pathname: `/repositories/:repoId/compare`, params: {repoId: repo.id}, query: {
+        ...query,
+        delimiter: (delimiter) ? delimiter : "",
+    }});
 
     return (
         <CompareList
             repo={repo}
             after={(!!after) ? after : ""}
+            delimiter={(!!delimiter) ? delimiter : ""}
+            prefix={(!!prefix) ? prefix : ""}
             reference={reference}
             onSelectRef={reference => route(compare ? {ref: reference.id, compare: compare.id} : {ref: reference.id})}
             compareReference={compare}
             onSelectCompare={compare => route(reference ? {ref: reference.id, compare: compare.id} : {compare: compare.id})}
             onPaginate={after => {
-                const query = {after};
+                const query = {
+                    after: (after) ? after : "",
+                    prefix: (prefix) ? prefix : "",
+                    delimiter: (delimiter) ? delimiter : ""
+                };
                 if (compare) query.compare = compare.id;
                 if (reference) query.ref = reference.id;
                 route(query);

--- a/webui/src/pages/repositories/repository/compare.jsx
+++ b/webui/src/pages/repositories/repository/compare.jsx
@@ -38,6 +38,19 @@ const CompareList = ({ repo, reference, compareReference, after, delimiter, pref
 
     let content;
 
+    const relativeTitle = (from, to) => {
+        let fromId = from.id;
+        let toId = to.id;
+        if (from.type === 'commit') {
+            fromId = fromId.substr(0, 12);
+        }
+        if (to.type === 'commit') {
+            toId = toId.substr(0, 12);
+        }
+
+        return `${fromId}...${toId}`
+    }
+
     if (loading) content = <Loading/>
     else if (!!error) content = <Error error={error}/>
     else if (compareReference.id === reference.id) content = (
@@ -56,7 +69,7 @@ const CompareList = ({ repo, reference, compareReference, after, delimiter, pref
                                 <URINavigator
                                     path={prefix}
                                     reference={reference}
-                                    relativeTo={`${reference.id}...${compareReference.id}`}
+                                    relativeTo={relativeTitle(reference, compareReference)}
                                     repo={repo}
                                     pathURLBuilder={(params, query) => {
                                         const q = {

--- a/webui/src/styles/globals.css
+++ b/webui/src/styles/globals.css
@@ -188,7 +188,7 @@
 }
 
 .diff-changed {
-  background-color: #d1ecf1;
+  background-color: #ffeaa7;
 }
 
 .diff-added {


### PR DESCRIPTION
Addressing some of #2029 - When working with large diffs, paging across multiple data objects is not optimal.
This PR adds the ability (a toggle in the UI) to view diffs with a directory structure. Should make answering "which tables/partitions were modifed" much easier.
 