### PR TITLE
Tell GH not to expand generated Python client files by default

### DIFF
--- a/clients/.gitattributes
+++ b/clients/.gitattributes
@@ -1,1 +1,2 @@
 java/**		linguist-generated
+python/**	linguist-generated


### PR DESCRIPTION
This is controlled by telling "linguist" that they are generated.