### PR TITLE
unbreak link

### DIFF
--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -4,4 +4,5 @@ title: Integrations
 description: You can integrate lakeFS with all modern data frameworks such as Spark, Hive, AWS Athena, Presto, etc.
 nav_order: 35
 has_children: true
+redirect_from: ../using
 ---


### PR DESCRIPTION
Add redirection from the "/using" page to the new "/integration" page.
The "/using" page appears on the first page when Googling "lakefs", and it is currently broken.
﻿
