### PR TITLE
update lakectl branch create output to include branch name

### DIFF
--- a/cmd/lakectl/cmd/branch.go
+++ b/cmd/lakectl/cmd/branch.go
@@ -8,10 +8,10 @@ import (
 	"github.com/treeverse/lakefs/pkg/uri"
 )
 
-const branchRevertCmdArgs = 2
-
 const (
 	ParentNumberFlagName = "parent-number"
+
+	branchRevertCmdArgs = 2
 )
 
 // branchCmd represents the branch command
@@ -70,7 +70,7 @@ var branchCreateCmd = &cobra.Command{
 			Source: sourceURI.Ref,
 		})
 		DieOnResponseError(resp, err)
-		Fmt("created branch '%s'\n", string(resp.Body))
+		Fmt("created branch '%s' %s\n", u.Ref, string(resp.Body))
 	},
 }
 


### PR DESCRIPTION
lakectl create output will include the name of the branch and the reference:
```
created branch 'more' 6887b1ae240962efb52ef74d801d3dc17a982a6ab6906fbed6487aa651c9e952
```