### PR TITLE
lakectl: make lakectl read environment variables 

### DIFF
--- a/cmd/lakectl/cmd/config.go
+++ b/cmd/lakectl/cmd/config.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"github.com/treeverse/lakefs/cmd/lakectl/cmd/config"
 	"net/url"
 	"path/filepath"
 
@@ -10,6 +9,7 @@ import (
 	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	"github.com/treeverse/lakefs/cmd/lakectl/cmd/config"
 )
 
 // configCmd represents the config command

--- a/cmd/lakectl/cmd/config.go
+++ b/cmd/lakectl/cmd/config.go
@@ -33,9 +33,9 @@ var configCmd = &cobra.Command{
 			Key    string
 			Prompt *promptui.Prompt
 		}{
-			{Key: config.ConfigAccessKeyID, Prompt: &promptui.Prompt{Label: "Access key ID"}},
+			{Key: config.ConfigAccessKeyIDKey, Prompt: &promptui.Prompt{Label: "Access key ID"}},
 			{Key: config.ConfigSecretAccessKey, Prompt: &promptui.Prompt{Label: "Secret access key"}},
-			{Key: config.ConfigServerEndpointURL, Prompt: &promptui.Prompt{Label: "Server endpoint URL", Validate: func(rawurl string) error {
+			{Key: config.ConfigServerEndpointURLKey, Prompt: &promptui.Prompt{Label: "Server endpoint URL", Validate: func(rawurl string) error {
 				_, err := url.ParseRequestURI(rawurl)
 				return err
 			}}},

--- a/cmd/lakectl/cmd/config.go
+++ b/cmd/lakectl/cmd/config.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"fmt"
+	"github.com/treeverse/lakefs/cmd/lakectl/cmd/config"
 	"net/url"
 	"path/filepath"
 
@@ -32,9 +33,9 @@ var configCmd = &cobra.Command{
 			Key    string
 			Prompt *promptui.Prompt
 		}{
-			{Key: ConfigAccessKeyID, Prompt: &promptui.Prompt{Label: "Access key ID"}},
-			{Key: ConfigSecretAccessKey, Prompt: &promptui.Prompt{Label: "Secret access key"}},
-			{Key: ConfigServerEndpointURL, Prompt: &promptui.Prompt{Label: "Server endpoint URL", Validate: func(rawurl string) error {
+			{Key: config.ConfigAccessKeyID, Prompt: &promptui.Prompt{Label: "Access key ID"}},
+			{Key: config.ConfigSecretAccessKey, Prompt: &promptui.Prompt{Label: "Secret access key"}},
+			{Key: config.ConfigServerEndpointURL, Prompt: &promptui.Prompt{Label: "Server endpoint URL", Validate: func(rawurl string) error {
 				_, err := url.ParseRequestURI(rawurl)
 				return err
 			}}},

--- a/cmd/lakectl/cmd/config/config.go
+++ b/cmd/lakectl/cmd/config/config.go
@@ -4,11 +4,12 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/spf13/viper"
-	"github.com/treeverse/lakefs/cmd/lakectl/cmd"
 	"github.com/treeverse/lakefs/pkg/config"
 	"github.com/treeverse/lakefs/pkg/logging"
 	"reflect"
 )
+
+
 
 // configuration is the user-visible configuration structure in Golang form.  When editing
 // make sure *all* fields have a `mapstructure:"..."` tag, to simplify future refactoring.
@@ -85,11 +86,15 @@ const (
 
 	// Defaults
 	HiveDBLocationURI = "file:/user/hive/warehouse/"
+	ConfigServerEndpointURL = "server.endpoint_url"
+	DefaultServerEndpointURL = "http://127.0.0.1:8000"
+	ConfigAccessKeyID = "credentials.access_key_id"
+	ConfigSecretAccessKey = "credentials.secret_access_key"
 )
 
 func setDefaults() {
 	viper.SetDefault(HiveDBLocationURIKey, HiveDBLocationURI)
-	viper.SetDefault(cmd.ConfigServerEndpointURL, cmd.DefaultServerEndpointURL)
+	viper.SetDefault(ConfigServerEndpointURL, DefaultServerEndpointURL)
 }
 
 func (c *Config) Err() error {

--- a/cmd/lakectl/cmd/config/config.go
+++ b/cmd/lakectl/cmd/config/config.go
@@ -4,6 +4,9 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/spf13/viper"
+	"github.com/treeverse/lakefs/pkg/config"
+	"github.com/treeverse/lakefs/pkg/logging"
+	"reflect"
 )
 
 // configuration is the user-visible configuration structure in Golang form.  When editing
@@ -42,20 +45,36 @@ type configuration struct {
 // Config is the currently-loaded configuration.  Its error state supports being able to run
 // `lakectl config' without a valid configuration.
 type Config struct {
-	configuration
-	err error
+	Values configuration
+	err    error
 }
 
 // ReadConfig loads according to the current viper configuration into a Config, which will
 // have non-nil Err() if loading fails.
 func ReadConfig() (c *Config) {
 	c = &Config{}
+
+	// Inform viper of all expected fields.  Otherwise it fails to deserialize from the
+	// environment.
+	keys := config.GetStructKeys(reflect.TypeOf(c.Values), "mapstructure", "squash")
+	for _, key := range keys {
+		viper.SetDefault(key, nil)
+	}
+
 	setDefaults()
 	c.err = viper.ReadInConfig()
+	logger := logging.Default().WithField("file", viper.ConfigFileUsed())
+
+	if c.err == nil {
+		logger.Info("loaded configuration from file")
+	} else if _, ok := c.err.(viper.ConfigFileNotFoundError); !ok {
+		logger.WithError(c.err).Fatal("failed to read config file")
+	}
+
+	c.err = viper.UnmarshalExact(&c.Values)
 	if c.err != nil {
 		return
 	}
-	c.err = viper.UnmarshalExact(&c.configuration)
 	return
 }
 
@@ -77,39 +96,39 @@ func (c *Config) Err() error {
 
 func (c *Config) GetMetastoreAwsConfig() *aws.Config {
 	cfg := &aws.Config{
-		Region: aws.String(c.configuration.Metastore.Glue.Region),
+		Region: aws.String(c.Values.Metastore.Glue.Region),
 	}
-	if c.Metastore.Glue.Profile != "" || c.Metastore.Glue.CredentialsFile != "" {
+	if c.Values.Metastore.Glue.Profile != "" || c.Values.Metastore.Glue.CredentialsFile != "" {
 		cfg.Credentials = credentials.NewSharedCredentials(
-			c.Metastore.Glue.CredentialsFile,
-			c.Metastore.Glue.Profile,
+			c.Values.Metastore.Glue.CredentialsFile,
+			c.Values.Metastore.Glue.Profile,
 		)
 	}
-	if c.Metastore.Glue.Credentials != nil {
+	if c.Values.Metastore.Glue.Credentials != nil {
 		cfg.Credentials = credentials.NewStaticCredentials(
-			c.Metastore.Glue.Credentials.AccessKeyID,
-			c.Metastore.Glue.Credentials.AccessSecretKey,
-			c.Metastore.Glue.Credentials.SessionToken,
+			c.Values.Metastore.Glue.Credentials.AccessKeyID,
+			c.Values.Metastore.Glue.Credentials.AccessSecretKey,
+			c.Values.Metastore.Glue.Credentials.SessionToken,
 		)
 	}
 	return cfg
 }
 
 func (c *Config) GetMetastoreHiveURI() string {
-	return c.Metastore.Hive.URI
+	return c.Values.Metastore.Hive.URI
 }
 
 func (c *Config) GetMetastoreGlueCatalogID() string {
-	return c.Metastore.Glue.CatalogID
+	return c.Values.Metastore.Glue.CatalogID
 }
 func (c *Config) GetMetastoreType() string {
-	return c.Metastore.Type
+	return c.Values.Metastore.Type
 }
 
 func (c *Config) GetHiveDBLocationURI() string {
-	return c.Metastore.Hive.DBLocationtURI
+	return c.Values.Metastore.Hive.DBLocationtURI
 }
 
 func (c *Config) GetGlueDBLocationURI() string {
-	return c.Metastore.Glue.DBLocationtURI
+	return c.Values.Metastore.Glue.DBLocationtURI
 }

--- a/cmd/lakectl/cmd/config/config.go
+++ b/cmd/lakectl/cmd/config/config.go
@@ -71,11 +71,6 @@ func ReadConfig() (c *Config) {
 	} else if _, ok := c.err.(viper.ConfigFileNotFoundError); !ok {
 		logger.WithError(c.err).Fatal("failed to read config file")
 	}
-
-	c.err = viper.UnmarshalExact(&c.Values)
-	if c.err != nil {
-		return
-	}
 	return
 }
 

--- a/cmd/lakectl/cmd/config/config.go
+++ b/cmd/lakectl/cmd/config/config.go
@@ -76,19 +76,19 @@ func ReadConfig() (c *Config) {
 
 const (
 	// Default flag keys
-	HiveDBLocationURIKey = "metastore.hive.db_location_uri"
+	HiveDBLocationURIKey       = "metastore.hive.db_location_uri"
+	ConfigServerEndpointURLKey = "server.endpoint_url"
+	ConfigAccessKeyIDKey       = "credentials.access_key_id"
+	ConfigSecretAccessKey      = "credentials.secret_access_key"
 
 	// Defaults
-	HiveDBLocationURI        = "file:/user/hive/warehouse/"
-	ConfigServerEndpointURL  = "server.endpoint_url"
+	DefaultHiveDBLocationURI = "file:/user/hive/warehouse/"
 	DefaultServerEndpointURL = "http://127.0.0.1:8000"
-	ConfigAccessKeyID        = "credentials.access_key_id"
-	ConfigSecretAccessKey    = "credentials.secret_access_key"
 )
 
 func setDefaults() {
-	viper.SetDefault(HiveDBLocationURIKey, HiveDBLocationURI)
-	viper.SetDefault(ConfigServerEndpointURL, DefaultServerEndpointURL)
+	viper.SetDefault(HiveDBLocationURIKey, DefaultHiveDBLocationURI)
+	viper.SetDefault(ConfigServerEndpointURLKey, DefaultServerEndpointURL)
 }
 
 func (c *Config) Err() error {

--- a/cmd/lakectl/cmd/config/config.go
+++ b/cmd/lakectl/cmd/config/config.go
@@ -1,15 +1,14 @@
 package config
 
 import (
+	"reflect"
+
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/spf13/viper"
 	"github.com/treeverse/lakefs/pkg/config"
 	"github.com/treeverse/lakefs/pkg/logging"
-	"reflect"
 )
-
-
 
 // configuration is the user-visible configuration structure in Golang form.  When editing
 // make sure *all* fields have a `mapstructure:"..."` tag, to simplify future refactoring.
@@ -85,11 +84,11 @@ const (
 	HiveDBLocationURIKey = "metastore.hive.db_location_uri"
 
 	// Defaults
-	HiveDBLocationURI = "file:/user/hive/warehouse/"
-	ConfigServerEndpointURL = "server.endpoint_url"
+	HiveDBLocationURI        = "file:/user/hive/warehouse/"
+	ConfigServerEndpointURL  = "server.endpoint_url"
 	DefaultServerEndpointURL = "http://127.0.0.1:8000"
-	ConfigAccessKeyID = "credentials.access_key_id"
-	ConfigSecretAccessKey = "credentials.secret_access_key"
+	ConfigAccessKeyID        = "credentials.access_key_id"
+	ConfigSecretAccessKey    = "credentials.secret_access_key"
 )
 
 func setDefaults() {

--- a/cmd/lakectl/cmd/config/config.go
+++ b/cmd/lakectl/cmd/config/config.go
@@ -4,6 +4,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/spf13/viper"
+	"github.com/treeverse/lakefs/cmd/lakectl/cmd"
 	"github.com/treeverse/lakefs/pkg/config"
 	"github.com/treeverse/lakefs/pkg/logging"
 	"reflect"
@@ -88,6 +89,7 @@ const (
 
 func setDefaults() {
 	viper.SetDefault(HiveDBLocationURIKey, HiveDBLocationURI)
+	viper.SetDefault(cmd.ConfigServerEndpointURL, cmd.DefaultServerEndpointURL)
 }
 
 func (c *Config) Err() error {

--- a/cmd/lakectl/cmd/root.go
+++ b/cmd/lakectl/cmd/root.go
@@ -20,11 +20,6 @@ import (
 )
 
 const (
-	ConfigAccessKeyID        = "credentials.access_key_id"
-	ConfigSecretAccessKey    = "credentials.secret_access_key"
-	ConfigServerEndpointURL  = "server.endpoint_url"
-	DefaultServerEndpointURL = "http://127.0.0.1:8000"
-
 	DefaultMaxIdleConnsPerHost = 1000
 )
 

--- a/cmd/lakectl/cmd/root.go
+++ b/cmd/lakectl/cmd/root.go
@@ -170,8 +170,5 @@ func initConfig() {
 	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_")) // support nested config
 	viper.AutomaticEnv()                                   // read in environment variables that match
 
-	// Configuration defaults
-	viper.SetDefault(ConfigServerEndpointURL, DefaultServerEndpointURL)
-
 	cfg = config.ReadConfig()
 }

--- a/cmd/lakectl/cmd/root.go
+++ b/cmd/lakectl/cmd/root.go
@@ -62,15 +62,18 @@ lakectl is a CLI tool allowing exploration and manipulation of a lakeFS environm
 		}
 
 		if errors.As(cfg.Err(), &viper.ConfigFileNotFoundError{}) {
-			if cfgFile == "" {
-				// if the config file wasn't provided, try to run using the default values + env vars
-				return
+			if cfgFile != "" {
+				// specific message in case the file isn't found
+				DieFmt("config file not found, please run \"lakectl config\" to create one\n%s\n", cfg.Err())
 			}
-			// specific message in case the file isn't found
-			DieFmt("config file not found, please run \"lakectl config\" to create one\n%s\n", cfg.Err())
+			// if the config file wasn't provided, try to run using the default values + env vars
 		} else if cfg.Err() != nil {
 			// other errors while reading the config file
 			DieFmt("error reading configuration file: %v", cfg.Err())
+		}
+
+		if err := viper.UnmarshalExact(&cfg.Values); err != nil {
+			DieFmt("error unmarshal configuration: %v", err)
 		}
 	},
 	Version: version.Version,

--- a/cmd/lakectl/cmd/root.go
+++ b/cmd/lakectl/cmd/root.go
@@ -89,14 +89,14 @@ func getClient() api.ClientWithResponsesInterface {
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	transport.MaxIdleConnsPerHost = DefaultMaxIdleConnsPerHost
 
-	accessKeyID := cfg.Credentials.AccessKeyID
-	secretAccessKey := cfg.Credentials.SecretAccessKey
+	accessKeyID := cfg.Values.Credentials.AccessKeyID
+	secretAccessKey := cfg.Values.Credentials.SecretAccessKey
 	basicAuthProvider, err := securityprovider.NewSecurityProviderBasicAuth(accessKeyID, secretAccessKey)
 	if err != nil {
 		DieErr(err)
 	}
 
-	serverEndpoint := cfg.Server.EndpointURL
+	serverEndpoint := cfg.Values.Server.EndpointURL
 	u, err := url.Parse(serverEndpoint)
 	if err != nil {
 		DieErr(err)


### PR DESCRIPTION
fixes #2097 

### Background 
lakectl uses Viper as its configuration solution. While unmarshaling configurations with Viper, the following process holds:  
1. Viper checks if each configuration key has an entry in its defaults.
2. For configurations included in the defaults, Viper searches for environment variables with that key and fetches their value if they exist. 
3. If environment variables with that key don't exist in the map, Viper takes the key's default value from defaults. 

### Problem & Root cause 
Viper never searches for environment variables for configurations that are not in the default configurations map. Therefore, lakectl does not consider environment variables.  

### Solution
For each potential configuration, add an entry to Viper's defaults with a nil value, forcing Viper to search environment variables for these configurations. 