### PR TITLE
hadoop-lakefs without dedicated s3 client

### DIFF
--- a/clients/hadoopfs/README.md
+++ b/clients/hadoopfs/README.md
@@ -1,7 +1,0 @@
-# hadoop-lakefs file system
-
-Build assembly without signing
-
-```bash
-mvn -U install -Passembly -P'!treeverse-signing'
-```

--- a/clients/hadoopfs/README.md
+++ b/clients/hadoopfs/README.md
@@ -1,0 +1,7 @@
+# hadoop-lakefs file system
+
+Build assembly without signing
+
+```bash
+mvn -U install -Passembly -P'!treeverse-signing'
+```

--- a/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileSystem.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileSystem.java
@@ -382,22 +382,15 @@ public class LakeFSFileSystem extends FileSystem {
      * @return an IOException that corresponds to the translated API exception
      */
     private IOException translateException(String msg, ApiException e) {
-        IOException ex;
         int code = e.getCode();
         switch (code) {
             case HttpStatus.SC_NOT_FOUND:
-                ex = new FileNotFoundException(msg);
-                ex.initCause(e);
-                break;
+                return (FileNotFoundException) new FileNotFoundException(msg).initCause(e);
             case HttpStatus.SC_FORBIDDEN:
-                ex = new AccessDeniedException(msg);
-                ex.initCause(e);
-                break;
+                return (AccessDeniedException) new AccessDeniedException(msg).initCause(e);
             default:
-                ex = new IOException(msg, e);
-                break;
+                return new IOException(msg, e);
         }
-        return ex;
     }
 
     @Override

--- a/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileSystem.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileSystem.java
@@ -48,7 +48,6 @@ public class LakeFSFileSystem extends FileSystem {
     private LakeFSClient lfsClient;
     private int listAmount;
     private FileSystem fsForConfig;
-    private MetadataClient metadataClient;
 
     private URI translateUri(URI uri) throws java.net.URISyntaxException {
         switch (uri.getScheme()) {
@@ -97,8 +96,6 @@ public class LakeFSFileSystem extends FileSystem {
         } catch (ApiException | URISyntaxException e) {
             LOG.warn("get underlying filesystem for {}: {} (use default values)", path, e);
         }
-
-        this.metadataClient = new MetadataClient(fsForConfig);
     }
 
     @FunctionalInterface
@@ -177,7 +174,7 @@ public class LakeFSFileSystem extends FileSystem {
             // TODO(ariels): add fs.FileSystem.Statistics here to keep track.
             return new FSDataOutputStream(new LinkOnCloseOutputStream(staging, stagingLoc, objectLoc,
                     physicalUri,
-                    this.metadataClient,
+                    new MetadataClient(physicalFs),
                     // FSDataOutputStream is a kind of OutputStream(!)
                     physicalFs.create(physicalPath, false, bufferSize, replication, blockSize, progress)),
                     null);

--- a/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileSystem.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileSystem.java
@@ -8,6 +8,7 @@ import io.lakefs.clients.api.model.*;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.*;
 import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.fs.s3a.S3AFileSystem;
 import org.apache.hadoop.util.Progressable;
 import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
@@ -384,15 +385,22 @@ public class LakeFSFileSystem extends FileSystem {
      * @return an IOException that corresponds to the translated API exception
      */
     private IOException translateException(String msg, ApiException e) {
+        IOException ex;
         int code = e.getCode();
         switch (code) {
             case HttpStatus.SC_NOT_FOUND:
-                return (IOException) new FileNotFoundException(msg).initCause(e);
+                ex = new FileNotFoundException(msg);
+                ex.initCause(e);
+                break;
             case HttpStatus.SC_FORBIDDEN:
-                return (IOException) new AccessDeniedException(msg).initCause(e);
+                ex = new AccessDeniedException(msg);
+                ex.initCause(e);
+                break;
             default:
-                return new IOException(msg, e);
+                ex = new IOException(msg, e);
+                break;
         }
+        return ex;
     }
 
     @Override

--- a/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileSystem.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileSystem.java
@@ -1,17 +1,21 @@
 package io.lakefs;
 
-import static io.lakefs.Constants.DEFAULT_LIST_AMOUNT;
-import static io.lakefs.Constants.FS_LAKEFS_LIST_AMOUNT_KEY;
-import static io.lakefs.Constants.SEPARATOR;
+import io.lakefs.clients.api.ApiException;
+import io.lakefs.clients.api.ObjectsApi;
+import io.lakefs.clients.api.RepositoriesApi;
+import io.lakefs.clients.api.StagingApi;
+import io.lakefs.clients.api.model.*;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.*;
+import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.util.Progressable;
+import org.apache.http.HttpStatus;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
-import java.beans.IntrospectionException;
-import java.beans.Introspector;
-import java.beans.PropertyDescriptor;
+import javax.annotation.Nonnull;
 import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.io.InvalidObjectException;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.AccessDeniedException;
@@ -19,29 +23,7 @@ import java.util.*;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
-import javax.annotation.Nonnull;
-
-import com.amazonaws.services.s3.model.GetObjectMetadataRequest;
-import com.amazonaws.services.s3.model.ObjectMetadata;
-import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.*;
-import org.apache.hadoop.fs.permission.FsPermission;
-import org.apache.hadoop.fs.s3a.S3AFileSystem;
-import org.apache.hadoop.util.Progressable;
-import org.apache.http.HttpStatus;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import io.lakefs.clients.api.ApiException;
-import io.lakefs.clients.api.ObjectsApi;
-import io.lakefs.clients.api.RepositoriesApi;
-import io.lakefs.clients.api.StagingApi;
-import io.lakefs.clients.api.model.ObjectStageCreation;
-import io.lakefs.clients.api.model.ObjectStats;
-import io.lakefs.clients.api.model.ObjectStatsList;
-import io.lakefs.clients.api.model.Pagination;
-import io.lakefs.clients.api.model.Repository;
-import io.lakefs.clients.api.model.StagingLocation;
+import static io.lakefs.Constants.*;
 
 /**
  * A dummy implementation of the core lakeFS Filesystem.

--- a/clients/hadoopfs/src/main/java/io/lakefs/LinkOnCloseOutputStream.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/LinkOnCloseOutputStream.java
@@ -1,41 +1,45 @@
 package io.lakefs;
 
+import java.beans.IntrospectionException;
+import java.beans.Introspector;
+import java.beans.PropertyDescriptor;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.lang.reflect.InvocationTargetException;
 import java.net.URI;
-
-import com.amazonaws.services.s3.AmazonS3;
-import com.amazonaws.services.s3.model.ObjectMetadata;
 
 import io.lakefs.clients.api.StagingApi;
 import io.lakefs.clients.api.model.StagingLocation;
 import io.lakefs.clients.api.model.StagingMetadata;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 
 /**
  * Wraps a FSDataOutputStream to link file on staging when done writing
  */
 class LinkOnCloseOutputStream extends OutputStream {
-    private AmazonS3 s3Client;
     private StagingApi staging;
     private StagingLocation stagingLoc;
     private ObjectLocation objectLoc;
     private URI physicalUri;
+    private final FileSystem physicalFs;
     private OutputStream out;
 
     /**
-     * @param s3Client client used to access data on S3.
      * @param staging client used to access metadata on lakeFS.
      * @param stagingLoc physical location of object data on S3.
      * @param objectLoc location of object on lakeFS.
      * @param physicalUri translated physical location of object data for underlying FileSystem.
+     * @param physicalFs underlying filesystem used to query status for checksum.
      * @param out stream on underlying filesystem to wrap.
      */
-    LinkOnCloseOutputStream(AmazonS3 s3Client, StagingApi staging, StagingLocation stagingLoc, ObjectLocation objectLoc, URI physicalUri, OutputStream out) {
-        this.s3Client = s3Client;
+    LinkOnCloseOutputStream(StagingApi staging, StagingLocation stagingLoc, ObjectLocation objectLoc, URI physicalUri, FileSystem physicalFs, OutputStream out) {
         this.staging = staging;
         this.stagingLoc = stagingLoc;
         this.objectLoc = objectLoc;
         this.physicalUri = physicalUri;
+        this.physicalFs = physicalFs;
         this.out = out;
     }
 
@@ -62,21 +66,38 @@ class LinkOnCloseOutputStream extends OutputStream {
     @Override
     public void close() throws IOException {
         out.close();
+
         // Now the object is on the underlying store, find its parameters (sadly lost by
         // the underlying Hadoop FileSystem) so we can link it on lakeFS.
-        String bucket = physicalUri.getHost();
-        String key = ObjectLocation.trimLeadingSlash(physicalUri.getPath());
-        ObjectMetadata objectMetadata = s3Client.getObjectMetadata(bucket, key);
+        FileStatus fileStatus = physicalFs.getFileStatus(new Path(physicalUri.getPath()));
+        String checksum = getChecksumFromFileStatus(fileStatus);
+        long sizeBytes = fileStatus.getLen();
 
         // TODO(ariels): Can we add metadata here?
-        StagingMetadata metadata = new StagingMetadata().staging(stagingLoc)
-            .checksum(objectMetadata.getETag())
-            .sizeBytes(objectMetadata.getContentLength());
-
+        StagingMetadata metadata = new StagingMetadata()
+                .staging(stagingLoc)
+                .checksum(checksum)
+                .sizeBytes(sizeBytes);
         try {
             staging.linkPhysicalAddress(objectLoc.getRepository(), objectLoc.getRef(), objectLoc.getPath(), metadata);
         } catch (io.lakefs.clients.api.ApiException e) {
             throw new IOException("link lakeFS path to physical address", e);
         }
+    }
+
+    private String getChecksumFromFileStatus(FileStatus fileStatus) throws IOException {
+        try {
+            for (PropertyDescriptor pd : Introspector.getBeanInfo(fileStatus.getClass()).getPropertyDescriptors()) {
+                if (pd.getReadMethod() != null && pd.getName().equals("etag")) {
+                    String etag = (String) pd.getReadMethod().invoke(fileStatus);
+                    if (etag != null && !etag.isEmpty()) {
+                        return etag;
+                    }
+                }
+            }
+        } catch (IntrospectionException | IllegalAccessException | InvocationTargetException e) {
+            throw new IOException("failed to extract etag from FileStatus", e);
+        }
+        throw new IOException("FileStatus missing etag value");
     }
 }

--- a/clients/hadoopfs/src/main/java/io/lakefs/LinkOnCloseOutputStream.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/LinkOnCloseOutputStream.java
@@ -1,24 +1,13 @@
 package io.lakefs;
 
-import java.beans.IntrospectionException;
-import java.beans.Introspector;
-import java.beans.PropertyDescriptor;
-import java.io.IOException;
-import java.io.OutputStream;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.net.URI;
-
-import com.amazonaws.services.s3.AmazonS3Client;
-import com.amazonaws.services.s3.model.GetObjectMetadataRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import io.lakefs.clients.api.StagingApi;
 import io.lakefs.clients.api.model.StagingLocation;
 import io.lakefs.clients.api.model.StagingMetadata;
-import org.apache.hadoop.fs.FileStatus;
-import org.apache.hadoop.fs.FileSystem;
-import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.s3a.S3AFileSystem;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.URI;
 
 /**
  * Wraps a FSDataOutputStream to link file on staging when done writing

--- a/clients/hadoopfs/src/main/java/io/lakefs/MetadataClient.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/MetadataClient.java
@@ -2,15 +2,13 @@ package io.lakefs;
 
 import com.amazonaws.services.s3.model.GetObjectMetadataRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
+import org.apache.commons.lang.NullArgumentException;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.beans.IntrospectionException;
-import java.beans.Introspector;
-import java.beans.PropertyDescriptor;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -19,21 +17,22 @@ import java.net.URI;
 public class MetadataClient {
     public static final Logger LOG = LoggerFactory.getLogger(MetadataClient.class);
     private final FileSystem fs;
-    private Method getMetadata;
-    private Object s3client;
+    private Method getObjectMetadataMethod;
+    private Object s3Client;
 
     public MetadataClient(FileSystem fs) {
-        this.fs = fs;
-        if (this.fs == null) {
-            return;
+        if (fs == null) {
+            throw new NullArgumentException("fs");
         }
+        this.fs = fs;
         try {
+            // cache s3 client and get object metadata method
             Method amazonS3ClientGetter = fs.getClass().getDeclaredMethod("getAmazonS3Client");
             amazonS3ClientGetter.setAccessible(true);
-            this.s3client = amazonS3ClientGetter.invoke(fs);
-            this.getMetadata = s3client.getClass().getDeclaredMethod("getObjectMetadata", GetObjectMetadataRequest.class);
+            this.s3Client = amazonS3ClientGetter.invoke(fs);
+            this.getObjectMetadataMethod = s3Client.getClass().getDeclaredMethod("getObjectMetadata", GetObjectMetadataRequest.class);
         } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
-            LOG.warn("get underlying get object metadata method:", e);
+            LOG.debug("get underlying get object metadata method:", e);
         }
     }
 
@@ -41,49 +40,42 @@ public class MetadataClient {
      * get object metadata by physical address
      * @param physicalUri physical uri of object
      * @return ObjectMetadata filled with Etag and content length
-     * @throws IOException
+     * @throws IOException case etag can't be extracted by s3 or file status
      */
     ObjectMetadata getObjectMetadata(URI physicalUri) throws IOException {
         String bucket = physicalUri.getHost();
         String key = physicalUri.getPath().substring(1);
-        if (this.s3client != null && this.getMetadata != null) {
-            GetObjectMetadataRequest metadataRequest = new GetObjectMetadataRequest(bucket, key);
-            try {
-                return (ObjectMetadata) getMetadata.invoke(this.s3client, metadataRequest);
-            } catch (IllegalAccessException | InvocationTargetException e) {
-                LOG.warn("failed to get object metadata using underlying s3 client", e);
-            }
-        }
-
-        if (this.fs == null) {
-            throw new IOException("no underlying file system");
-        }
 
         // use underlying filesystem to get the file status and extract
         // content length and etag (using reflection)
         Path physicalPath = new Path(physicalUri.getPath());
         FileStatus fileStatus = this.fs.getFileStatus(physicalPath);
         try {
-            String etag = getEtagFromFileStatus(fileStatus);
+            Method getETagMethod = fileStatus.getClass().getMethod("getETag");
+            String etag = (String) getETagMethod.invoke(fileStatus);
+            // return the two properties over object metadata for easy fallback
             ObjectMetadata o = new ObjectMetadata();
             o.setContentLength(fileStatus.getLen());
             o.setHeader("ETag", etag);
             return o;
-        } catch (IntrospectionException | InvocationTargetException | IllegalAccessException e) {
-            throw new IOException("etag from file status", e);
+        } catch (InvocationTargetException | IllegalAccessException | NoSuchMethodException e) {
+            LOG.trace("failed to get etag from file status", e);
+        }
+
+        // fallback - use the underlying s3 client, get object metadata
+        if (this.s3Client == null) {
+            throw new IOException("no s3Client for object metadata");
+        }
+        if (this.getObjectMetadataMethod == null) {
+            throw new IOException("no getObjectMetadataMethod for object metadata");
+        }
+
+        try {
+            GetObjectMetadataRequest metadataRequest = new GetObjectMetadataRequest(bucket, key);
+            return (ObjectMetadata) getObjectMetadataMethod.invoke(this.s3Client, metadataRequest);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            LOG.warn("failed to get object metadata using underlying s3 client", e);
+            throw new IOException("get object metadata using underlying s3 client", e);
         }
     }
-
-    private static String getEtagFromFileStatus(FileStatus fileStatus) throws IntrospectionException, InvocationTargetException, IllegalAccessException {
-        for (PropertyDescriptor pd : Introspector.getBeanInfo(fileStatus.getClass()).getPropertyDescriptors()) {
-            if (pd.getReadMethod() != null && pd.getName().equals("etag")) {
-                String etag = (String) pd.getReadMethod().invoke(fileStatus);
-                if (etag != null && !etag.isEmpty()) {
-                    return etag;
-                }
-            }
-        }
-        return "";
-    }
-
 }

--- a/clients/hadoopfs/src/main/java/io/lakefs/MetadataClient.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/MetadataClient.java
@@ -47,8 +47,9 @@ public class MetadataClient {
             o.setContentLength(fileStatus.getLen());
             o.setHeader("ETag", etag);
             return o;
-        } catch (InvocationTargetException | IllegalAccessException | NoSuchMethodException e) {
-            LOG.trace("failed to get etag from file status", e);
+        } catch (InvocationTargetException | IllegalAccessException e) {
+            LOG.warn("failed to get etag from file status", e);
+        } catch (NoSuchMethodException ignored) {
         }
 
         // fallback - use the underlying s3 client, get object metadata

--- a/clients/hadoopfs/src/main/java/io/lakefs/MetadataClient.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/MetadataClient.java
@@ -1,0 +1,89 @@
+package io.lakefs;
+
+import com.amazonaws.services.s3.model.GetObjectMetadataRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.beans.IntrospectionException;
+import java.beans.Introspector;
+import java.beans.PropertyDescriptor;
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.net.URI;
+
+public class MetadataClient {
+    public static final Logger LOG = LoggerFactory.getLogger(MetadataClient.class);
+    private final FileSystem fs;
+    private Method getMetadata;
+    private Object s3client;
+
+    public MetadataClient(FileSystem fs) {
+        this.fs = fs;
+        if (this.fs == null) {
+            return;
+        }
+        try {
+            Method amazonS3ClientGetter = fs.getClass().getDeclaredMethod("getAmazonS3Client");
+            amazonS3ClientGetter.setAccessible(true);
+            this.s3client = amazonS3ClientGetter.invoke(fs);
+            this.getMetadata = s3client.getClass().getDeclaredMethod("getObjectMetadata", GetObjectMetadataRequest.class);
+        } catch (NoSuchMethodException | IllegalAccessException | InvocationTargetException e) {
+            LOG.warn("get underlying get object metadata method:", e);
+        }
+    }
+
+    /**
+     * get object metadata by physical address
+     * @param physicalUri physical uri of object
+     * @return ObjectMetadata filled with Etag and content length
+     * @throws IOException
+     */
+    ObjectMetadata getObjectMetadata(URI physicalUri) throws IOException {
+        String bucket = physicalUri.getHost();
+        String key = physicalUri.getPath().substring(1);
+        if (this.s3client != null && this.getMetadata != null) {
+            GetObjectMetadataRequest metadataRequest = new GetObjectMetadataRequest(bucket, key);
+            try {
+                return (ObjectMetadata) getMetadata.invoke(this.s3client, metadataRequest);
+            } catch (IllegalAccessException | InvocationTargetException e) {
+                LOG.warn("failed to get object metadata using underlying s3 client", e);
+            }
+        }
+
+        if (this.fs == null) {
+            throw new IOException("no underlying file system");
+        }
+
+        // use underlying filesystem to get the file status and extract
+        // content length and etag (using reflection)
+        Path physicalPath = new Path(physicalUri.getPath());
+        FileStatus fileStatus = this.fs.getFileStatus(physicalPath);
+        try {
+            String etag = getEtagFromFileStatus(fileStatus);
+            ObjectMetadata o = new ObjectMetadata();
+            o.setContentLength(fileStatus.getLen());
+            o.setHeader("ETag", etag);
+            return o;
+        } catch (IntrospectionException | InvocationTargetException | IllegalAccessException e) {
+            throw new IOException("etag from file status", e);
+        }
+    }
+
+    private static String getEtagFromFileStatus(FileStatus fileStatus) throws IntrospectionException, InvocationTargetException, IllegalAccessException {
+        for (PropertyDescriptor pd : Introspector.getBeanInfo(fileStatus.getClass()).getPropertyDescriptors()) {
+            if (pd.getReadMethod() != null && pd.getName().equals("etag")) {
+                String etag = (String) pd.getReadMethod().invoke(fileStatus);
+                if (etag != null && !etag.isEmpty()) {
+                    return etag;
+                }
+            }
+        }
+        return "";
+    }
+
+}


### PR DESCRIPTION
The Problem:

The `hadoop-lakefs` filesystem instantiates the s3 client in order to get a newly created object ETag.
Credentials used by the s3 client should be used to access the data the cluster created.
One of the issues was in Databricks instance profile credentials were not used by our client and we failed to access the data we just wrote using the underlying file system.

The Solution:

FileStatus in S3 is a specific type S3AFileStatus that holds the Etag, this is true for the client found in spark 3x.
We don't want to bind to a specific interface, so we use reflection to call the getter function to extract the ETag value from FileStatus.

Spark 2.x comes with an older version of the S3A file system which doesn't hold the Etag as part of the FileStatus. In order to address this version, we will have a fallback where ask the S3 client from the underlying filesystem.
The underlying file system has multiple implementations, we can't cast to a specific interface. Using reflection we accessed the underlying client and request the object metadata in order to extract the ETag.

Because we want to keep using the filesystem and not directly access the s3 client, we kept the s3 as a fallback although it will require the extra call.

Changes:

- Removed the s3 client instance
- Used reflection to access file status's ETag, and fallback to using AWS client using reflection after object creates completely.
- The above functionality is encapsulated into MetadataClient

Close #2192