### PR TITLE
Align graveler ref explict branch cases

### DIFF
--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -1510,7 +1510,8 @@ func handleAPIError(w http.ResponseWriter, err error) bool {
 		errors.Is(err, graveler.ErrNoChanges),
 		errors.Is(err, permissions.ErrInvalidServiceName),
 		errors.Is(err, permissions.ErrInvalidAction),
-		errors.Is(err, model.ErrValidationError):
+		errors.Is(err, model.ErrValidationError),
+		errors.Is(err, graveler.ErrInvalidRef):
 		writeError(w, http.StatusBadRequest, err)
 
 	case errors.Is(err, graveler.ErrNotUnique):

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -1198,7 +1198,7 @@ func (c *Catalog) Close() error {
 	return errs
 }
 
-// dereferenceCommitID dereference 'ref' and make sure it doesn't point to staging
+// dereferenceCommitID dereference 'ref' to a commit ID, this helper makes sure we do not point to explicit branch staging
 func (c *Catalog) dereferenceCommitID(ctx context.Context, repositoryID graveler.RepositoryID, ref graveler.Ref) (graveler.CommitID, error) {
 	resolvedRef, err := c.Store.Dereference(ctx, repositoryID, ref)
 	if err != nil {

--- a/pkg/catalog/validate.go
+++ b/pkg/catalog/validate.go
@@ -94,7 +94,8 @@ func ValidateBranchID(v interface{}) error {
 	if len(s) == 0 {
 		return ErrRequiredValue
 	}
-	if !reValidBranchID.MatchString(s.String()) {
+	branchName := s.String()
+	if !reValidBranchID.MatchString(branchName) {
 		return ErrInvalidValue
 	}
 	return nil

--- a/pkg/graveler/testutil/fakes.go
+++ b/pkg/graveler/testutil/fakes.go
@@ -198,6 +198,7 @@ type RefsFake struct {
 	AddedCommit         AddedCommitData
 	CommitID            graveler.CommitID
 	Commits             map[graveler.CommitID]*graveler.Commit
+	StagingToken        graveler.StagingToken
 }
 
 func (m *RefsFake) FillGenerations(ctx context.Context, repositoryID graveler.RepositoryID) error {
@@ -228,14 +229,17 @@ func (m *RefsFake) ResolveRawRef(ctx context.Context, repoID graveler.Repository
 	}
 
 	var branch graveler.BranchID
+	var stagingToken graveler.StagingToken
 	if m.RefType == graveler.ReferenceTypeBranch {
 		branch = DefaultBranchID
+		stagingToken = m.StagingToken
 	}
 
 	return &graveler.ResolvedRef{
-		Type:     m.RefType,
-		BranchID: branch,
-		CommitID: m.CommitID,
+		Type:         m.RefType,
+		BranchID:     branch,
+		CommitID:     m.CommitID,
+		StagingToken: stagingToken,
 	}, nil
 }
 


### PR DESCRIPTION
Passing explicit branch name with latest commit or staging modifier should return an error in cases the operation works only on committed data.
In this PR extracting commit/commit_id for from ref in these calls will return invalid ref in case staging ref was passed.
Testing the above is done through the API controller test - passing the values all the way from the controller, catalog into graveler.