### PR TITLE
Add a forwarding ClassLoader to help load 2 copies of rocksdbjni

### DIFF
--- a/clients/spark/build.sbt
+++ b/clients/spark/build.sbt
@@ -51,6 +51,11 @@ def generateCoreProject(buildType: BuildType) =
         "com.google.guava" % "failureaccess" % "1.0.1",
         "org.rogach" %% "scallop" % "4.0.3",
         "software.amazon.awssdk" % "s3" % "2.15.15",
+        "org.ow2.asm" % "asm" % "9.2",
+        "org.ow2.asm" % "asm-util" % "9.2",
+
+        "org.scalactic" %% "scalactic" % "3.2.9",
+        "org.scalatest" %% "scalatest" % "3.2.9" % "test",
       ),
       target := file(s"target/core-${buildType.name}/")
     ).enablePlugins(S3Plugin)
@@ -110,6 +115,8 @@ lazy val s3UploadSettings = Seq(
 
 // Don't publish root project
 root / publish / skip := true
+
+root / Test / logBuffered := false
 
 lazy val commonSettings = Seq(
   version := projectVersion,

--- a/clients/spark/build.sbt
+++ b/clients/spark/build.sbt
@@ -57,6 +57,8 @@ def generateCoreProject(buildType: BuildType) =
         "org.scalactic" %% "scalactic" % "3.2.9",
         "org.scalatest" %% "scalatest" % "3.2.9" % "test",
       ),
+      Test / logBuffered := false,
+      Test / testOptions += Tests.Argument("-oF"),
       target := file(s"target/core-${buildType.name}/")
     ).enablePlugins(S3Plugin)
 
@@ -115,8 +117,6 @@ lazy val s3UploadSettings = Seq(
 
 // Don't publish root project
 root / publish / skip := true
-
-root / Test / logBuffered := false
 
 lazy val commonSettings = Seq(
   version := projectVersion,

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/SSTableReader.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/SSTableReader.scala
@@ -5,7 +5,7 @@ import io.treeverse.lakefs.catalog.Entry
 import io.treeverse.lakefs.graveler.committed.RangeData
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs.Path
-import org.rocksdb.{SstFileReader, _}
+import org.rocksdb.{Options, ReadOptions, RocksDB, SstFileReader, SstFileReaderIterator}
 import scalapb.{GeneratedMessage, GeneratedMessageCompanion}
 
 import java.io.{ByteArrayInputStream, Closeable, DataInputStream, File}

--- a/clients/spark/core/src/main/scala/io/treeverse/utils/AsInterface.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/utils/AsInterface.scala
@@ -1,10 +1,52 @@
 package io.treeverse.utils
 
 import org.objectweb.asm.{ClassVisitor, MethodVisitor}
-import org.objectweb.asm.Opcodes.ASM8
+import org.objectweb.asm.Opcodes._
 import org.objectweb.asm.Type
 
+private object AsInterface {
+  def getName(typ: Type): String =
+    typ.getSort match {
+      case Type.OBJECT => typ.getInternalName
+      case Type.ARRAY => s"Array[${typ.getInternalName}]"
+      case _ => typ.getClassName
+    }
+
+  def loadFor(sort: Int) = {
+    import Type._
+    sort match {
+      case BOOLEAN | CHAR | SHORT | INT => ILOAD
+      case LONG => LLOAD
+      case FLOAT => FLOAD
+      case DOUBLE => DLOAD
+      case ARRAY | OBJECT => ALOAD
+      case _ => throw new IllegalArgumentException(s"cannot load type of sort ${sort}")
+    }
+  }
+
+  def returnFor(sort: Int) = {
+    import Type._
+    sort match {
+      case BOOLEAN | CHAR | SHORT | INT => IRETURN
+      case LONG => LRETURN
+      case FLOAT => FRETURN
+      case DOUBLE => DRETURN
+      case ARRAY | OBJECT => ARETURN
+      case VOID => RETURN
+      case _ => throw new IllegalArgumentException(s"cannot load type of sort ${sort}")
+    }
+  }
+
+  // Scala array equality is too hard: the best (only-ish) way is to use
+  // java.util.Arrays.equals, but that doesn't work because the variance
+  // between Array[A] and Array[Object] is not defined there.
+  def equals[T](a: Array[T], b: Array[T]): Boolean =
+    (a zip b).foldLeft(true){ case (e, (x, y)) => e && x == y }
+}
+
 private class AsInterface(cv: ClassVisitor, val ifaces: Map[String, Class[_]]) extends ClassVisitor(ASM8, cv) {
+  var className: String = ""
+
   override def visit(
     version: Int,
     access: Int,
@@ -16,26 +58,75 @@ private class AsInterface(cv: ClassVisitor, val ifaces: Map[String, Class[_]]) e
     val newInterfaces = ifaces get name match {
         case Some(iface) => interfaces :+ Type.getType(iface).getInternalName
         case None => interfaces
-      }
+    }
+    className = name
     cv.visit(version, access, name, signature, superName, newInterfaces)
   }
 
-  val descReturnType = """\)L([a-zA-Z_0-9/]+);""".r
-  def translateDesc(desc: String) =
-    descReturnType.replaceAllIn(desc, _ match {
-      case scala.util.matching.Regex.Groups(name) => /* BUG */ s")L${translateName(name)};"
-    })
-
-  def translateName(name: String) =
-    ifaces get name match {
-      case Some(iface) => iface.getName.replaceAll("\\.", "/")
-      case None => name
+  def translateType(typ: Type) =
+    ifaces get typ.getInternalName.replaceAll("\\.", "/") match {
+      case Some(iface) => Type.getType(iface)
+      case None => typ
     }
 
   override def visitMethod(access: Int, name: String, desc: String, signature: String, exceptions: Array[String]): MethodVisitor = {
-    Console.out.println(s"[DEBUG] name ${name} desc ${desc} signature ${signature}")
-    val newDesc = translateDesc(desc)
-    val mv = cv.visitMethod(access, name, newDesc, signature, exceptions)
-    return mv
+    // BUG(ariels): Does not support generic methods (ignores signature).
+    //     At least throw an exception...
+    Console.out.println(s"[DEBUG] name ${className}.${name} desc ${desc} signature ${signature}")
+
+    // BUG(ariels): Test exceptions.
+    generateForwardingMethod(access, name, desc, exceptions)
+
+    val mv = cv.visitMethod(access, name, desc, null, exceptions)
+    return mv;
+  }
+
+  def generateForwardingMethod(access: Int, name: String, desc: String, exceptions: Array[String]): Unit = {
+    val argTypes = Type.getArgumentTypes(desc)
+    if (argTypes == null) throw new IllegalArgumentException(s"Bad method descriptor ${desc}")
+    argTypes.foreach((typ) => Console.out.println(s"[DEBUG] arg " + AsInterface.getName(typ)))
+    val translatedArgTypes = argTypes.map(translateType)
+
+    val retType = Type.getReturnType(desc)
+
+    val translatedRetType = translateType(retType)
+    Console.out.println(s"[DEBUG] return type ${retType.getInternalName} => ${translatedRetType.getInternalName}")
+
+    val translatedExceptions = if (exceptions != null)
+      exceptions.map((name: String) => translateType(Type.getObjectType(name)).getInternalName)
+    else
+      exceptions
+
+    val translatedDesc = Type.getMethodDescriptor(translatedRetType, translatedArgTypes: _*)
+
+    if (retType.equals(translatedRetType) &&
+      (exceptions == null || AsInterface.equals(exceptions, translatedExceptions)) &&
+      AsInterface.equals(argTypes, translatedArgTypes)) {
+      Console.out.println("[DEBUG] nothing to do")
+      return
+    }
+
+    Console.out.println(s"[DEBUG] create casting overload for ${name}${translatedDesc}")
+    val mv = cv.visitMethod(access, name, translatedDesc, null /* no support for generics */, translatedExceptions)
+
+    mv.visitCode()
+    // BUG(ariels): assumes non-static.
+    mv.visitVarInsn(ALOAD, 0) // load "this"
+
+    for (((argType, translatedArgType), index) <- (argTypes zip translatedArgTypes).zipWithIndex) {
+      // BUG(ariels): Maybe *LOAD.
+      mv.visitVarInsn(AsInterface.loadFor(argType.getSort), index+1) // load arg
+      if (!argType.equals(translatedRetType)) {
+        mv.visitTypeInsn(CHECKCAST, argType.getInternalName)
+      }
+    }
+
+    mv.visitMethodInsn(INVOKESPECIAL, className, name, desc)
+    // TODO(ariels): Do we have to upcast here?
+    mv.visitInsn(AsInterface.returnFor(translatedRetType.getSort))
+
+    mv.visitMaxs(argTypes.length + 1, argTypes.length + 1)
+
+    mv.visitEnd()
   }
 }

--- a/clients/spark/core/src/main/scala/io/treeverse/utils/AsInterface.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/utils/AsInterface.scala
@@ -60,7 +60,7 @@ private class AsInterface(cv: ClassVisitor, val ifaces: Map[String, Class[_]])
   ) = {
     val newInterfaces = ifaces get name match {
       case Some(iface) => interfaces :+ Type.getType(iface).getInternalName
-      case None => interfaces
+      case None        => interfaces
     }
     className = name
     cv.visit(version, access, name, signature, superName, newInterfaces)

--- a/clients/spark/core/src/main/scala/io/treeverse/utils/AsInterface.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/utils/AsInterface.scala
@@ -1,6 +1,6 @@
 package io.treeverse.utils
 
-import org.objectweb.asm.{ClassVisitor, MethodVisitor}
+import org.objectweb.asm.ClassVisitor
 import org.objectweb.asm.Opcodes._
 import org.objectweb.asm.Type
 
@@ -71,14 +71,20 @@ private class AsInterface(cv: ClassVisitor, val ifaces: Map[String, Class[_]])
       case Some(iface) => {
         // Generate wrappers for all methods of iface in the class.
         iface.getMethods.foreach(method =>
-          generateForwardingMethod(
-            ACC_PUBLIC | ACC_SYNTHETIC, method.getName, Type.getMethodDescriptor(method),
-            method.getExceptionTypes.map(e => Type.getType(e).getDescriptor)))
+          generateForwardingMethod(ACC_PUBLIC | ACC_SYNTHETIC,
+                                   method.getName,
+                                   Type.getMethodDescriptor(method),
+                                   method.getExceptionTypes.map(e => Type.getType(e).getDescriptor)
+                                  )
+        )
         // Generate wrapper for all constructors for the class.
         iface.getConstructors.foreach(ctor =>
-          generateForwardingMethod(
-            ACC_PUBLIC | ACC_SYNTHETIC, "<init>", Type.getConstructorDescriptor(ctor),
-            ctor.getExceptionTypes.map(e => Type.getType(e).getDescriptor)))
+          generateForwardingMethod(ACC_PUBLIC | ACC_SYNTHETIC,
+                                   "<init>",
+                                   Type.getConstructorDescriptor(ctor),
+                                   ctor.getExceptionTypes.map(e => Type.getType(e).getDescriptor)
+                                  )
+        )
       }
       case _ => Unit
     }
@@ -97,10 +103,10 @@ private class AsInterface(cv: ClassVisitor, val ifaces: Map[String, Class[_]])
     }
 
   def generateForwardingMethod(
-    access: Int,
-    name: String,
-    translatedDesc: String,
-    translatedExceptions: Seq[String]
+      access: Int,
+      name: String,
+      translatedDesc: String,
+      translatedExceptions: Seq[String]
   ): Unit = {
     val translatedArgTypes = Type.getArgumentTypes(translatedDesc)
     if (translatedArgTypes == null) {
@@ -117,13 +123,15 @@ private class AsInterface(cv: ClassVisitor, val ifaces: Map[String, Class[_]])
     val exceptions =
       if (translatedExceptions != null)
         translatedExceptions.map((name: String) =>
-          revTranslateType(Type.getObjectType(name)).getInternalName)
+          revTranslateType(Type.getObjectType(name)).getInternalName
+        )
       else
         null
 
     val desc = Type.getMethodDescriptor(retType, argTypes: _*)
 
-    if (retType.equals(translatedRetType) &&
+    if (
+      retType.equals(translatedRetType) &&
       (exceptions == null || AsInterface.equals(exceptions, translatedExceptions)) &&
       AsInterface.equals(argTypes, translatedArgTypes)
     ) {

--- a/clients/spark/core/src/main/scala/io/treeverse/utils/AsInterface.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/utils/AsInterface.scala
@@ -15,42 +15,41 @@ private object AsInterface {
   def undot(dotted: String) = dotted.replaceAll("\\.", "/")
 }
 
-/**
- * ASM ClassVisitor that translates the visited class from the loaded
- * library into a parallel class that uses `interface` types instead of
- * exporting its own classes.  When visited, writes a similar class, except
- * that any type named as a key in ifaces is translated to the corresponding
- * interface.
+/** ASM ClassVisitor that translates the visited class from the loaded
+ *  library into a parallel class that uses `interface` types instead of
+ *  exporting its own classes.  When visited, writes a similar class, except
+ *  that any type named as a key in ifaces is translated to the corresponding
+ *  interface.
  *
- * This is not always possible and does not even always make sense; here is
- * what it <em>does</em> do:
+ *  This is not always possible and does not even always make sense; here is
+ *  what it <em>does</em> do:
  *
- * 1. A class whose name is a key in ifaces is exported from the loaded
+ *  1. A class whose name is a key in ifaces is exported from the loaded
  *    library to the client side.  So its matching interface is added to the
  *    list of implements that it implements.
- * 1. Any return type appearing in ifaces is automatically translated to
+ *  1. Any return type appearing in ifaces is automatically translated to
  *    return as an interface.  While this is not required to compile regular
  *    uses, it _will_ matter when client code tries to select a desired
  *    method.
- * 1. For any interface appearing in ifaces, an overload is generated into
+ *  1. For any interface appearing in ifaces, an overload is generated into
  *    the class.  The overload accepts the interface type(s) and downcasts
  *    them to the required parameter types, then calls the original method
  *    (which might be defined in this class or in a superclass).  This cast
  *    is safe ''as long as the client does not implement the interface on
  *    its own and tries to pass it in''.
- * 1. In particular, any types parametric in ifaces are '''not'''
+ *  1. In particular, any types parametric in ifaces are '''not'''
  *    translated, as there is no way to ensure type safety.  So even if you
  *    define a mapping from a type named `Concrete` to an interface `Iface`
  *    in ifaces, the generated class '''cannot''' handle types such as
  *    `Concrete[]` or `Set<Concrete>`.
  *
- * Many errors cannot be detected during translation (without reading and
- * loading the entire class), so will only be detected when the method is
- * used.  This *is* part of a ClassLoader, and ClassLoaders can have trouble
- * when translation fails.
+ *  Many errors cannot be detected during translation (without reading and
+ *  loading the entire class), so will only be detected when the method is
+ *  used.  This *is* part of a ClassLoader, and ClassLoaders can have trouble
+ *  when translation fails.
  *
- * @param cv ClassVisitor to use to generate code.
- * @param ifaces Map of concrete class names in the loaded library to
+ *  @param cv ClassVisitor to use to generate code.
+ *  @param ifaces Map of concrete class names in the loaded library to
  *     interface types that will be exposed on the client side.
  */
 private class AsInterface(cv: ClassVisitor, val ifaces: Map[String, Class[_]])

--- a/clients/spark/core/src/main/scala/io/treeverse/utils/AsInterface.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/utils/AsInterface.scala
@@ -10,18 +10,18 @@ private object AsInterface {
   def getName(typ: Type): String =
     typ.getSort match {
       case Type.OBJECT => typ.getInternalName
-      case Type.ARRAY => s"Array[${typ.getInternalName}]"
-      case _ => typ.getClassName
+      case Type.ARRAY  => s"Array[${typ.getInternalName}]"
+      case _           => typ.getClassName
     }
 
   def loadFor(sort: Int) = {
     import Type._
     sort match {
       case BOOLEAN | CHAR | SHORT | INT => ILOAD
-      case LONG => LLOAD
-      case FLOAT => FLOAD
-      case DOUBLE => DLOAD
-      case ARRAY | OBJECT => ALOAD
+      case LONG                         => LLOAD
+      case FLOAT                        => FLOAD
+      case DOUBLE                       => DLOAD
+      case ARRAY | OBJECT               => ALOAD
       case _ => throw new IllegalArgumentException(s"cannot load type of sort ${sort}")
     }
   }
@@ -30,11 +30,11 @@ private object AsInterface {
     import Type._
     sort match {
       case BOOLEAN | CHAR | SHORT | INT => IRETURN
-      case LONG => LRETURN
-      case FLOAT => FRETURN
-      case DOUBLE => DRETURN
-      case ARRAY | OBJECT => ARETURN
-      case VOID => RETURN
+      case LONG                         => LRETURN
+      case FLOAT                        => FRETURN
+      case DOUBLE                       => DRETURN
+      case ARRAY | OBJECT               => ARETURN
+      case VOID                         => RETURN
       case _ => throw new IllegalArgumentException(s"cannot load type of sort ${sort}")
     }
   }
@@ -43,22 +43,23 @@ private object AsInterface {
   // java.util.Arrays.equals, but that doesn't work because the variance
   // between Array[A] and Array[Object] is not defined there.
   def equals[T](a: Array[T], b: Array[T]): Boolean =
-    (a zip b).foldLeft(true){ case (e, (x, y)) => e && x == y }
+    (a zip b).foldLeft(true) { case (e, (x, y)) => e && x == y }
 }
 
-private class AsInterface(cv: ClassVisitor, val ifaces: Map[String, Class[_]]) extends ClassVisitor(ASM8, cv) {
+private class AsInterface(cv: ClassVisitor, val ifaces: Map[String, Class[_]])
+    extends ClassVisitor(ASM8, cv) {
   var className: String = ""
   // If set, the interface to be translated.
-  var toIface : Class[_] = null
+  var toIface: Class[_] = null
   var translatedMethodDescs = Set[String]()
 
   override def visit(
-    version: Int,
-    access: Int,
-    name: String,
-    signature: String,
-    superName: String,
-    interfaces: Array[String]
+      version: Int,
+      access: Int,
+      name: String,
+      signature: String,
+      superName: String,
+      interfaces: Array[String]
   ) = {
     val newInterfaces = ifaces get name match {
       case Some(iface) => {
@@ -74,7 +75,7 @@ private class AsInterface(cv: ClassVisitor, val ifaces: Map[String, Class[_]]) e
   def translateType(typ: Type) =
     ifaces get typ.getInternalName.replaceAll("\\.", "/") match {
       case Some(iface) => Type.getType(iface)
-      case None => typ
+      case None        => typ
     }
 
   // Verify that any interface methods were translated, i.e. implemented.
@@ -83,16 +84,22 @@ private class AsInterface(cv: ClassVisitor, val ifaces: Map[String, Class[_]]) e
       // No translation, nothing to verify.
       return
     }
-    val interfaceMethodDescs = toIface.getDeclaredMethods.map((m: Method) =>
-      m.getName + ": " + Type.getMethodDescriptor(m)
-    ).toSet
+    val interfaceMethodDescs = toIface.getDeclaredMethods
+      .map((m: Method) => m.getName + ": " + Type.getMethodDescriptor(m))
+      .toSet
     val unimplemented = interfaceMethodDescs -- translatedMethodDescs
     if (!unimplemented.isEmpty) {
       throw new UnimplementedMethodsException("Unimplemented methods", unimplemented)
     }
   }
 
-  override def visitMethod(access: Int, name: String, desc: String, signature: String, exceptions: Array[String]): MethodVisitor = {
+  override def visitMethod(
+      access: Int,
+      name: String,
+      desc: String,
+      signature: String,
+      exceptions: Array[String]
+  ): MethodVisitor = {
     // BUG(ariels): Does not support generic methods (ignores signature).
     //     At least throw an exception...
 
@@ -103,7 +110,12 @@ private class AsInterface(cv: ClassVisitor, val ifaces: Map[String, Class[_]]) e
     return mv;
   }
 
-  def generateForwardingMethod(access: Int, name: String, desc: String, exceptions: Array[String]): Unit = {
+  def generateForwardingMethod(
+      access: Int,
+      name: String,
+      desc: String,
+      exceptions: Array[String]
+  ): Unit = {
     val argTypes = Type.getArgumentTypes(desc)
     if (argTypes == null) throw new IllegalArgumentException(s"Bad method descriptor ${desc}")
     val translatedArgTypes = argTypes.map(translateType)
@@ -112,29 +124,37 @@ private class AsInterface(cv: ClassVisitor, val ifaces: Map[String, Class[_]]) e
 
     val translatedRetType = translateType(retType)
 
-    val translatedExceptions = if (exceptions != null)
-      exceptions.map((name: String) => translateType(Type.getObjectType(name)).getInternalName)
-    else
-      exceptions
+    val translatedExceptions =
+      if (exceptions != null)
+        exceptions.map((name: String) => translateType(Type.getObjectType(name)).getInternalName)
+      else
+        exceptions
 
     val translatedDesc = Type.getMethodDescriptor(translatedRetType, translatedArgTypes: _*)
 
     translatedMethodDescs = translatedMethodDescs + (name + ": " + translatedDesc)
 
-    if (retType.equals(translatedRetType) &&
+    if (
+      retType.equals(translatedRetType) &&
       (exceptions == null || AsInterface.equals(exceptions, translatedExceptions)) &&
-      AsInterface.equals(argTypes, translatedArgTypes)) {
+      AsInterface.equals(argTypes, translatedArgTypes)
+    ) {
       return
     }
 
-    val mv = cv.visitMethod(access, name, translatedDesc, null /* no support for generics */, translatedExceptions)
+    val mv = cv.visitMethod(access,
+                            name,
+                            translatedDesc,
+                            null /* no support for generics */,
+                            translatedExceptions
+                           )
 
     mv.visitCode()
     // BUG(ariels): assumes non-static.
     mv.visitVarInsn(ALOAD, 0) // load "this"
 
     for (((argType, translatedArgType), index) <- (argTypes zip translatedArgTypes).zipWithIndex) {
-      mv.visitVarInsn(AsInterface.loadFor(argType.getSort), index+1) // load arg
+      mv.visitVarInsn(AsInterface.loadFor(argType.getSort), index + 1) // load arg
       if (!argType.equals(translatedRetType)) {
         mv.visitTypeInsn(CHECKCAST, argType.getInternalName)
       }

--- a/clients/spark/core/src/main/scala/io/treeverse/utils/AsInterface.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/utils/AsInterface.scala
@@ -4,8 +4,6 @@ import org.objectweb.asm.{ClassVisitor, MethodVisitor}
 import org.objectweb.asm.Opcodes._
 import org.objectweb.asm.Type
 
-import java.lang.reflect.Method
-
 private object AsInterface {
   def getName(typ: Type): String =
     typ.getSort match {

--- a/clients/spark/core/src/main/scala/io/treeverse/utils/AsInterface.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/utils/AsInterface.scala
@@ -1,0 +1,41 @@
+package io.treeverse.utils
+
+import org.objectweb.asm.{ClassVisitor, MethodVisitor}
+import org.objectweb.asm.Opcodes.ASM8
+import org.objectweb.asm.Type
+
+private class AsInterface(cv: ClassVisitor, val ifaces: Map[String, Class[_]]) extends ClassVisitor(ASM8, cv) {
+  override def visit(
+    version: Int,
+    access: Int,
+    name: String,
+    signature: String,
+    superName: String,
+    interfaces: Array[String]
+  ) = {
+    val newInterfaces = ifaces get name match {
+        case Some(iface) => interfaces :+ Type.getType(iface).getInternalName
+        case None => interfaces
+      }
+    cv.visit(version, access, name, signature, superName, newInterfaces)
+  }
+
+  val descReturnType = """\)L([a-zA-Z_0-9/]+);""".r
+  def translateDesc(desc: String) =
+    descReturnType.replaceAllIn(desc, _ match {
+      case scala.util.matching.Regex.Groups(name) => /* BUG */ s")L${translateName(name)};"
+    })
+
+  def translateName(name: String) =
+    ifaces get name match {
+      case Some(iface) => iface.getName.replaceAll("\\.", "/")
+      case None => name
+    }
+
+  override def visitMethod(access: Int, name: String, desc: String, signature: String, exceptions: Array[String]): MethodVisitor = {
+    Console.out.println(s"[DEBUG] name ${name} desc ${desc} signature ${signature}")
+    val newDesc = translateDesc(desc)
+    val mv = cv.visitMethod(access, name, newDesc, signature, exceptions)
+    return mv
+  }
+}

--- a/clients/spark/core/src/main/scala/io/treeverse/utils/AsInterfaceClassLoader.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/utils/AsInterfaceClassLoader.scala
@@ -1,0 +1,62 @@
+package io.treeverse.utils
+
+import org.objectweb.asm.{ClassReader, ClassWriter}
+import org.objectweb.asm.util.{CheckClassAdapter}
+import java.io.ByteArrayOutputStream
+import com.google.common.io.ByteStreams
+
+class AsInterfaceClassLoader(
+  parent: ClassLoader, ifaces: Map[String, Class[_]]) extends ClassLoader(parent) {
+
+  val skip = ifaces.values.map(_.getName).toSet
+
+  private def asInterfaceClass(bytes: Array[Byte]): Array[Byte] = {
+    val cr = new ClassReader(bytes)
+    val cw = new ClassWriter(cr, 0)
+    val cc = new CheckClassAdapter(cw)
+    val ai = new AsInterface(cc, ifaces)
+
+    cr.accept(ai, 0)
+    cw.toByteArray
+  }
+
+  override protected def loadClass(name: String, resolve: Boolean): Class[_] = {
+    if (name.startsWith("java.") || (skip contains name)) {
+      // Unsafe to define these classes, no point in trying.
+      return getParent.loadClass(name)
+    }
+
+    val cls = {
+      {
+        val loaded = findLoadedClass(name)
+        if (loaded != null) {
+          return loaded
+        }
+      }
+      {
+        val found = findClass(name)
+        if (found != null) {
+          return found
+        }
+      }
+      return getParent.loadClass(name)
+    }
+    if (resolve) {
+      resolveClass(cls)
+    }
+    cls
+  }
+
+  override protected def findClass(name: String): Class[_] = {
+    val internalName = name.replaceAll("\\.", "/") + ".class"
+    val classStream = parent.getResourceAsStream(internalName)
+    if (classStream == null) {
+      throw new ClassNotFoundException(name)
+    }
+    val rawBytesStream = new ByteArrayOutputStream
+    ByteStreams.copy(classStream, rawBytesStream)
+    val rawBytes = rawBytesStream.toByteArray
+    val bytes = asInterfaceClass(rawBytes)
+    defineClass(name, bytes, 0, bytes.length)
+  }
+}

--- a/clients/spark/core/src/main/scala/io/treeverse/utils/AsInterfaceClassLoader.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/utils/AsInterfaceClassLoader.scala
@@ -13,12 +13,12 @@ class AsInterfaceClassLoader(
 
   val skip = ifaces.values.map(_.getName).toSet
 
-  def newInstance(name: String, args: Any*): Any = {
+  def newInstance[C](name: String, args: Any*): C = {
     val argsTypes = args.map(_.getClass).toArray
     val ctor = loadClass(name).getConstructor(argsTypes: _*)
     // Box any primitives so they become Objects for the newInstance call.
     val boxedArgs = args.map(_.asInstanceOf[AnyRef])
-    ctor.newInstance(boxedArgs: _*)
+    ctor.newInstance(boxedArgs: _*).asInstanceOf[C]
   }
 
   private def asInterfaceClass(bytes: Array[Byte]): Array[Byte] = {

--- a/clients/spark/core/src/main/scala/io/treeverse/utils/AsInterfaceClassLoader.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/utils/AsInterfaceClassLoader.scala
@@ -1,8 +1,8 @@
 package io.treeverse.utils
 
 import org.objectweb.asm.{ClassReader, ClassWriter}
-import org.objectweb.asm.util.{CheckClassAdapter}
-import java.io.ByteArrayOutputStream
+import org.objectweb.asm.util.{CheckClassAdapter, TraceClassVisitor}
+import java.io.{ByteArrayOutputStream, PrintWriter}
 import com.google.common.io.ByteStreams
 
 class AsInterfaceClassLoader(

--- a/clients/spark/core/src/main/scala/io/treeverse/utils/AsInterfaceClassLoader.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/utils/AsInterfaceClassLoader.scala
@@ -6,8 +6,10 @@ import java.io.{ByteArrayOutputStream, PrintWriter}
 import com.google.common.io.ByteStreams
 
 class AsInterfaceClassLoader(
-  parent: ClassLoader, ifaces: Map[String, Class[_]], val pw: PrintWriter = null)
-    extends ClassLoader(parent) {
+    parent: ClassLoader,
+    ifaces: Map[String, Class[_]],
+    val pw: PrintWriter = null
+) extends ClassLoader(parent) {
 
   val skip = ifaces.values.map(_.getName).toSet
 

--- a/clients/spark/core/src/main/scala/io/treeverse/utils/AsInterfaceClassLoader.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/utils/AsInterfaceClassLoader.scala
@@ -11,6 +11,11 @@ class AsInterfaceClassLoader(
     val pw: PrintWriter = null
 ) extends ClassLoader(parent) {
 
+  // Some additional classes never to attempt to translate.  If an interface
+  // is supplied that is *also* defined on the library side, cannot
+  // translate it -- so don't even try.  The interfaces in particular are
+  // used by the classloader, so need to be loaded -- transfer them directly
+  // to the parent classloader.
   val skip = ifaces.values.map(_.getName).toSet
 
   def newInstance[C](name: String, args: Any*): C = {

--- a/clients/spark/core/src/main/scala/io/treeverse/utils/AsInterfaceClassLoader.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/utils/AsInterfaceClassLoader.scala
@@ -11,6 +11,14 @@ class AsInterfaceClassLoader(
 
   val skip = ifaces.values.map(_.getName).toSet
 
+  def newInstance(name: String, args: Any*): Any = {
+    val argsTypes = args.map(_.getClass).toArray
+    val ctor = loadClass(name).getConstructor(argsTypes: _*)
+    // Box any primitives so they become Objects for the newInstance call.
+    val boxedArgs = args.map(_.asInstanceOf[AnyRef])
+    ctor.newInstance(boxedArgs: _*)
+  }
+
   private def asInterfaceClass(bytes: Array[Byte]): Array[Byte] = {
     val cr = new ClassReader(bytes)
     val cw = new ClassWriter(cr, 0)

--- a/clients/spark/core/src/test/scala/io/treeverse/utils/AsInterfaceTest.scala
+++ b/clients/spark/core/src/test/scala/io/treeverse/utils/AsInterfaceTest.scala
@@ -1,0 +1,70 @@
+package io.treeverse.utils
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import org.objectweb.asm.{ClassReader, ClassWriter}
+import org.objectweb.asm.util.CheckClassAdapter
+
+import java.io.ByteArrayOutputStream
+import com.google.common.io.ByteStreams
+
+class AsInterfaceTest extends AnyFunSuite {
+  test("[internal] Boo does not implement Foo") {
+    assertThrows[ClassCastException] {
+      (new Boo).asInstanceOf[Foo]
+    }
+  }
+
+  test("AsInterface: Boo as Foo") {
+    val booStream = this.getClass.getClassLoader.getResourceAsStream("io/treeverse/utils/Boo.class")
+    val booBytes = new ByteArrayOutputStream
+    ByteStreams.copy(booStream, booBytes)
+
+    val cr = new ClassReader(booBytes.toByteArray)
+    val cw = new ClassWriter(cr, 0)
+    val cc = new CheckClassAdapter(cw);
+    val ai = new AsInterface(cc, Map(("Foo", classOf[Foo])))
+    cr.accept(ai, 0)
+  }
+
+  test("Boo as Foo") {
+    val aicl = new AsInterfaceClassLoader(
+      getClass.getClassLoader,
+      Map(("io/treeverse/utils/Boo", classOf[Foo])))
+    val f: Foo = aicl.loadClass("io.treeverse.utils.Boo").newInstance.asInstanceOf[Foo]
+    assert(f.foo(4) === 16)
+  }
+
+  test("Boo as Foo can use method returning a Boo") {
+    val aicl = new AsInterfaceClassLoader(
+      getClass.getClassLoader,
+      Map(("io/treeverse/utils/Boo", classOf[Foo])))
+    val f: Foo = aicl.loadClass("io.treeverse.utils.Boo").newInstance.asInstanceOf[Foo]
+    assert(f.another.foo(4) === 16)
+  }
+
+  test("Goo as Foo fails") {
+    val aicl = new AsInterfaceClassLoader(
+      getClass.getClassLoader,
+      Map(("io/treeverse/utils/Goo", classOf[Foo])))
+    val f: Foo = aicl.loadClass("io.treeverse.utils.Goo").newInstance.asInstanceOf[Foo]
+    assertThrows[AbstractMethodError](f.foo(4))
+  }
+
+  test("Boo as Foo is not a Moo") {
+    val aicl = new AsInterfaceClassLoader(
+      getClass.getClassLoader,
+      Map(("io/treeverse/utils/Boo", classOf[Foo])))
+    assertThrows[ClassCastException](
+      aicl.loadClass("io.treeverse.utils.Boo").newInstance.asInstanceOf[Moo]
+    )
+  }
+
+  test("Boo as a Moo fails at runtime") {
+    val aicl = new AsInterfaceClassLoader(
+      getClass.getClassLoader,
+      Map(("io/treeverse/utils/Boo", classOf[Moo])))
+    assertThrows[InstantiationException](
+      aicl.loadClass("io.treeverse.utils.Moo").newInstance.asInstanceOf[Moo])
+  }
+}

--- a/clients/spark/core/src/test/scala/io/treeverse/utils/AsInterfaceTest.scala
+++ b/clients/spark/core/src/test/scala/io/treeverse/utils/AsInterfaceTest.scala
@@ -48,8 +48,10 @@ class AsInterfaceTest extends AnyFunSuite {
     val aicl = new AsInterfaceClassLoader(
       getClass.getClassLoader,
       Map(("io/treeverse/utils/Goo", classOf[Foo])))
-    val f: Foo = aicl.loadClass("io.treeverse.utils.Goo").getConstructor().newInstance().asInstanceOf[Foo]
-    assertThrows[AbstractMethodError](f.foo(4))
+    val cce = intercept[UnimplementedMethodsException](aicl.loadClass("io.treeverse.utils.Goo"))
+    assert(cce.methods == Set(
+      "foo: (I)I",
+      "addFoo: (Lio/treeverse/utils/Foo;)Lio/treeverse/utils/Foo;"))
   }
 
   test("Boo as Foo is not a Moo") {
@@ -61,11 +63,13 @@ class AsInterfaceTest extends AnyFunSuite {
     )
   }
 
-  test("Boo as a Moo fails at runtime") {
+  test("Boo as a Moo fails to load") {
     val aicl = new AsInterfaceClassLoader(
       getClass.getClassLoader,
       Map(("io/treeverse/utils/Boo", classOf[Moo])))
-    // BUG(ariels): It works because it's lazy :-(
-    aicl.loadClass("io.treeverse.utils.Boo").getConstructor(classOf[Integer]).newInstance(9.asInstanceOf[Integer]).asInstanceOf[Moo]
+    assertThrows[ClassCastException](aicl.loadClass("io.treeverse.utils.Boo")
+        .getConstructor(classOf[Integer])
+        .newInstance(9.asInstanceOf[Integer])
+        .asInstanceOf[Moo])
   }
 }

--- a/clients/spark/core/src/test/scala/io/treeverse/utils/AsInterfaceTest.scala
+++ b/clients/spark/core/src/test/scala/io/treeverse/utils/AsInterfaceTest.scala
@@ -31,7 +31,7 @@ class AsInterfaceTest extends AnyFunSuite {
     val aicl = new AsInterfaceClassLoader(
       getClass.getClassLoader,
       Map(("io/treeverse/utils/Boo", classOf[Foo])))
-    val f = aicl.newInstance("io.treeverse.utils.Boo", 9).asInstanceOf[Foo]
+    val f = aicl.newInstance[Foo]("io.treeverse.utils.Boo", 9)
     assert(f.foo(4) === 36)
   }
 
@@ -39,8 +39,8 @@ class AsInterfaceTest extends AnyFunSuite {
     val aicl = new AsInterfaceClassLoader(
       getClass.getClassLoader,
       Map(("io/treeverse/utils/Boo", classOf[Foo])))
-    val f: Foo = aicl.newInstance("io.treeverse.utils.Boo", 9).asInstanceOf[Foo]
-    val f2: Foo = aicl.newInstance("io.treeverse.utils.Boo", 3).asInstanceOf[Foo]
+    val f: Foo = aicl.newInstance[Foo]("io.treeverse.utils.Boo", 9)
+    val f2: Foo = aicl.newInstance[Foo]("io.treeverse.utils.Boo", 3)
     assert(f.addFoo(f2).foo(4) === (9 + 3) * 4)
   }
 
@@ -48,7 +48,7 @@ class AsInterfaceTest extends AnyFunSuite {
     val aicl = new AsInterfaceClassLoader(
       getClass.getClassLoader,
       Map(("io/treeverse/utils/Goo", classOf[Foo])))
-    val notF: Foo = aicl.newInstance("io.treeverse.utils.Goo").asInstanceOf[Foo]
+    val notF: Foo = aicl.newInstance[Foo]("io.treeverse.utils.Goo")
     assertThrows[AbstractMethodError](notF.foo(0))
   }
 
@@ -57,7 +57,7 @@ class AsInterfaceTest extends AnyFunSuite {
       getClass.getClassLoader,
       Map(("io/treeverse/utils/Boo", classOf[Foo])))
     assertThrows[ClassCastException](
-      aicl.newInstance("io.treeverse.utils.Boo", 9).asInstanceOf[Moo]
+      aicl.newInstance[Moo]("io.treeverse.utils.Boo", 9)
     )
   }
 
@@ -65,7 +65,7 @@ class AsInterfaceTest extends AnyFunSuite {
     val aicl = new AsInterfaceClassLoader(
       getClass.getClassLoader,
       Map(("io/treeverse/utils/Boo", classOf[Moo])))
-    val notM: Moo = aicl.newInstance("io.treeverse.utils.Boo", 9).asInstanceOf[Moo]
+    val notM: Moo = aicl.newInstance[Moo]("io.treeverse.utils.Boo", 9)
     assertThrows[AbstractMethodError](notM.bar(0))
   }
 }

--- a/clients/spark/core/src/test/scala/io/treeverse/utils/AsInterfaceTest.scala
+++ b/clients/spark/core/src/test/scala/io/treeverse/utils/AsInterfaceTest.scala
@@ -31,7 +31,7 @@ class AsInterfaceTest extends AnyFunSuite {
     val aicl = new AsInterfaceClassLoader(
       getClass.getClassLoader,
       Map(("io/treeverse/utils/Boo", classOf[Foo])))
-    val f: Foo = aicl.loadClass("io.treeverse.utils.Boo").getConstructor(classOf[Integer]).newInstance(9.asInstanceOf[Integer]).asInstanceOf[Foo]
+    val f = aicl.newInstance("io.treeverse.utils.Boo", 9).asInstanceOf[Foo]
     assert(f.foo(4) === 36)
   }
 
@@ -39,8 +39,8 @@ class AsInterfaceTest extends AnyFunSuite {
     val aicl = new AsInterfaceClassLoader(
       getClass.getClassLoader,
       Map(("io/treeverse/utils/Boo", classOf[Foo])))
-    val f: Foo = aicl.loadClass("io.treeverse.utils.Boo").getConstructor(classOf[Integer]).newInstance(9.asInstanceOf[Integer]).asInstanceOf[Foo]
-    val f2: Foo = aicl.loadClass("io.treeverse.utils.Boo").getConstructor(classOf[Integer]).newInstance(3.asInstanceOf[Integer]).asInstanceOf[Foo]
+    val f: Foo = aicl.newInstance("io.treeverse.utils.Boo", 9).asInstanceOf[Foo]
+    val f2: Foo = aicl.newInstance("io.treeverse.utils.Boo", 3).asInstanceOf[Foo]
     assert(f.addFoo(f2).foo(4) === (9 + 3) * 4)
   }
 
@@ -59,7 +59,7 @@ class AsInterfaceTest extends AnyFunSuite {
       getClass.getClassLoader,
       Map(("io/treeverse/utils/Boo", classOf[Foo])))
     assertThrows[ClassCastException](
-      aicl.loadClass("io.treeverse.utils.Boo").getConstructor(classOf[Integer]).newInstance(9.asInstanceOf[Integer]).asInstanceOf[Moo]
+      aicl.newInstance("io.treeverse.utils.Boo", 9).asInstanceOf[Moo]
     )
   }
 
@@ -67,9 +67,7 @@ class AsInterfaceTest extends AnyFunSuite {
     val aicl = new AsInterfaceClassLoader(
       getClass.getClassLoader,
       Map(("io/treeverse/utils/Boo", classOf[Moo])))
-    assertThrows[ClassCastException](aicl.loadClass("io.treeverse.utils.Boo")
-        .getConstructor(classOf[Integer])
-        .newInstance(9.asInstanceOf[Integer])
-        .asInstanceOf[Moo])
+    assertThrows[ClassCastException](
+      aicl.newInstance("io.treeverse.utils.Boo", 9).asInstanceOf[Moo])
   }
 }

--- a/clients/spark/core/src/test/scala/io/treeverse/utils/AsInterfaceTest.scala
+++ b/clients/spark/core/src/test/scala/io/treeverse/utils/AsInterfaceTest.scala
@@ -11,7 +11,7 @@ import com.google.common.io.ByteStreams
 class AsInterfaceTest extends AnyFunSuite {
   test("[internal] Boo does not implement Foo") {
     assertThrows[ClassCastException] {
-      (new Boo).asInstanceOf[Foo]
+      (new Boo(9)).asInstanceOf[Foo]
     }
   }
 
@@ -31,23 +31,24 @@ class AsInterfaceTest extends AnyFunSuite {
     val aicl = new AsInterfaceClassLoader(
       getClass.getClassLoader,
       Map(("io/treeverse/utils/Boo", classOf[Foo])))
-    val f: Foo = aicl.loadClass("io.treeverse.utils.Boo").newInstance.asInstanceOf[Foo]
-    assert(f.foo(4) === 16)
+    val f: Foo = aicl.loadClass("io.treeverse.utils.Boo").getConstructor(classOf[Integer]).newInstance(9.asInstanceOf[Integer]).asInstanceOf[Foo]
+    assert(f.foo(4) === 36)
   }
 
-  test("Boo as Foo can use method returning a Boo") {
+  test("Boo as Foo can use method taking and returning a Boo") {
     val aicl = new AsInterfaceClassLoader(
       getClass.getClassLoader,
       Map(("io/treeverse/utils/Boo", classOf[Foo])))
-    val f: Foo = aicl.loadClass("io.treeverse.utils.Boo").newInstance.asInstanceOf[Foo]
-    assert(f.another.foo(4) === 16)
+    val f: Foo = aicl.loadClass("io.treeverse.utils.Boo").getConstructor(classOf[Integer]).newInstance(9.asInstanceOf[Integer]).asInstanceOf[Foo]
+    val f2: Foo = aicl.loadClass("io.treeverse.utils.Boo").getConstructor(classOf[Integer]).newInstance(3.asInstanceOf[Integer]).asInstanceOf[Foo]
+    assert(f.addFoo(f2).foo(4) === (9 + 3) * 4)
   }
 
   test("Goo as Foo fails") {
     val aicl = new AsInterfaceClassLoader(
       getClass.getClassLoader,
       Map(("io/treeverse/utils/Goo", classOf[Foo])))
-    val f: Foo = aicl.loadClass("io.treeverse.utils.Goo").newInstance.asInstanceOf[Foo]
+    val f: Foo = aicl.loadClass("io.treeverse.utils.Goo").getConstructor().newInstance().asInstanceOf[Foo]
     assertThrows[AbstractMethodError](f.foo(4))
   }
 
@@ -56,7 +57,7 @@ class AsInterfaceTest extends AnyFunSuite {
       getClass.getClassLoader,
       Map(("io/treeverse/utils/Boo", classOf[Foo])))
     assertThrows[ClassCastException](
-      aicl.loadClass("io.treeverse.utils.Boo").newInstance.asInstanceOf[Moo]
+      aicl.loadClass("io.treeverse.utils.Boo").getConstructor(classOf[Integer]).newInstance(9.asInstanceOf[Integer]).asInstanceOf[Moo]
     )
   }
 
@@ -64,7 +65,7 @@ class AsInterfaceTest extends AnyFunSuite {
     val aicl = new AsInterfaceClassLoader(
       getClass.getClassLoader,
       Map(("io/treeverse/utils/Boo", classOf[Moo])))
-    assertThrows[InstantiationException](
-      aicl.loadClass("io.treeverse.utils.Moo").newInstance.asInstanceOf[Moo])
+    // BUG(ariels): It works because it's lazy :-(
+    aicl.loadClass("io.treeverse.utils.Boo").getConstructor(classOf[Integer]).newInstance(9.asInstanceOf[Integer]).asInstanceOf[Moo]
   }
 }

--- a/clients/spark/core/src/test/scala/io/treeverse/utils/AsInterfaceTest.scala
+++ b/clients/spark/core/src/test/scala/io/treeverse/utils/AsInterfaceTest.scala
@@ -44,14 +44,12 @@ class AsInterfaceTest extends AnyFunSuite {
     assert(f.addFoo(f2).foo(4) === (9 + 3) * 4)
   }
 
-  test("Goo as Foo fails") {
+  test("Goo as Foo fails to call missing method at call time :-(") {
     val aicl = new AsInterfaceClassLoader(
       getClass.getClassLoader,
       Map(("io/treeverse/utils/Goo", classOf[Foo])))
-    val cce = intercept[UnimplementedMethodsException](aicl.loadClass("io.treeverse.utils.Goo"))
-    assert(cce.methods == Set(
-      "foo: (I)I",
-      "addFoo: (Lio/treeverse/utils/Foo;)Lio/treeverse/utils/Foo;"))
+    val notF: Foo = aicl.newInstance("io.treeverse.utils.Goo").asInstanceOf[Foo]
+    assertThrows[AbstractMethodError](notF.foo(0))
   }
 
   test("Boo as Foo is not a Moo") {
@@ -63,11 +61,11 @@ class AsInterfaceTest extends AnyFunSuite {
     )
   }
 
-  test("Boo as a Moo fails to load") {
+  test("Boo as a Moo fails to call missing method at call time :-(") {
     val aicl = new AsInterfaceClassLoader(
       getClass.getClassLoader,
       Map(("io/treeverse/utils/Boo", classOf[Moo])))
-    assertThrows[ClassCastException](
-      aicl.newInstance("io.treeverse.utils.Boo", 9).asInstanceOf[Moo])
+    val notM: Moo = aicl.newInstance("io.treeverse.utils.Boo", 9).asInstanceOf[Moo]
+    assertThrows[AbstractMethodError](notM.bar(0))
   }
 }

--- a/clients/spark/core/src/test/scala/io/treeverse/utils/Boo.scala
+++ b/clients/spark/core/src/test/scala/io/treeverse/utils/Boo.scala
@@ -1,8 +1,8 @@
 package io.treeverse.utils
 
-// Boo could implement Foo, but doesn't...
-class Boo {
-  def foo(x: Int): Int = x * x
+// Boo could implement Foo, but doesn't...  
+class Boo(val s: Integer) {
+  def foo(x: Int): Int = s * x
 
-  def another(): Boo = new Boo
+  def addFoo(b: Boo): Boo = new Boo(s + b.s)
 }

--- a/clients/spark/core/src/test/scala/io/treeverse/utils/Boo.scala
+++ b/clients/spark/core/src/test/scala/io/treeverse/utils/Boo.scala
@@ -5,4 +5,6 @@ class Boo(val s: Integer) {
   def foo(x: Int): Int = s * x
 
   def addFoo(b: Boo): Boo = new Boo(s + b.s)
+
+  def another(): Boo = return new Boo(s)
 }

--- a/clients/spark/core/src/test/scala/io/treeverse/utils/Boo.scala
+++ b/clients/spark/core/src/test/scala/io/treeverse/utils/Boo.scala
@@ -1,0 +1,8 @@
+package io.treeverse.utils
+
+// Boo could implement Foo, but doesn't...
+class Boo {
+  def foo(x: Int): Int = x * x
+
+  def another(): Boo = new Boo
+}

--- a/clients/spark/core/src/test/scala/io/treeverse/utils/Foo.scala
+++ b/clients/spark/core/src/test/scala/io/treeverse/utils/Foo.scala
@@ -1,0 +1,7 @@
+package io.treeverse.utils
+
+trait Foo {
+  def foo(x: Int): Int
+
+  def another(): Foo
+}

--- a/clients/spark/core/src/test/scala/io/treeverse/utils/Foo.scala
+++ b/clients/spark/core/src/test/scala/io/treeverse/utils/Foo.scala
@@ -4,4 +4,6 @@ trait Foo {
   def foo(x: Int): Int
 
   def another(): Foo
+
+  def addFoo(f: Foo): Foo
 }

--- a/clients/spark/core/src/test/scala/io/treeverse/utils/Goo.scala
+++ b/clients/spark/core/src/test/scala/io/treeverse/utils/Goo.scala
@@ -1,0 +1,6 @@
+package io.treeverse.utils
+
+// Goo almost implements Foo, but uses the wrong types....
+class Goo {
+  def foo(x: Double): Double = x * x
+}

--- a/clients/spark/core/src/test/scala/io/treeverse/utils/Goo.scala
+++ b/clients/spark/core/src/test/scala/io/treeverse/utils/Goo.scala
@@ -3,4 +3,6 @@ package io.treeverse.utils
 // Goo almost implements Foo, but uses the wrong types....
 class Goo {
   def foo(x: Double): Double = x * x
+
+  def another(): Goo = null
 }

--- a/clients/spark/core/src/test/scala/io/treeverse/utils/Moo.scala
+++ b/clients/spark/core/src/test/scala/io/treeverse/utils/Moo.scala
@@ -1,0 +1,6 @@
+package io.treeverse.utils
+
+// Moo does not define a method "foo".
+trait Moo {
+  def bar(x: Int): Int
+}


### PR DESCRIPTION
Part of fixing #1847.

This implements most of the ClassLoader described in [design/double-rocksdbjni](https://github.com/treeverse/lakeFS/blob/master/design/double-rocksdbjni.md).  But it does not hook anything up yet, so does not affect anything (except a slight increase in client size).