### PR TITLE
Fix NPE while reading partitioned parquet on Databricks

### DIFF
--- a/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileSystem.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileSystem.java
@@ -444,7 +444,7 @@ public class LakeFSFileSystem extends FileSystem {
         ListingIterator iterator = new ListingIterator(path, false, listAmount);
         while (iterator.hasNext()) {
             LocatedFileStatus fileStatus = iterator.next();
-            fileStatuses.add(fileStatus);
+            fileStatuses.add(((LakeFSLocatedFileStatus)fileStatus).toLakeFSFileStatus());
         }
         return fileStatuses.toArray(new FileStatus[0]);
     }


### PR DESCRIPTION
Fixes #2111

### Problem 
Partition parquet reads with LakeFSFileSystem on Databricks fail due to a NullPointerException. 

### Diagnosis
- The NPE occurred when a `LakeFSFileSystem.listStatus` operation is invoked on a directory that has directories in it. and therefore, fail partitioned parquet reads (partitions are represented as directories for each partition value). 
- For directories, `LakeFSFileSystem.listStatus` returns an array of LocatedFileStatus objects, as opposed to an array of FileStatus objects returned by `S3AFileSystem.listStatus`. 
- When a LocatedFileStatus is returned, spark tries to get its BlockLocation, but the LakeFSFileSystem sets it to be null for directories, causing the NPE. 

### Solution 
Make `LakeFSFileSystem.listStatus` return an array of FileStatus objects instead of LocatedFileStatus. This solution brings the LakeFSFileSystem implementation closer to the S3AFileSystem implementation.

