### PR TITLE
Hadoop filesystem fake empty directory object support

### DIFF
--- a/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileStatus.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileStatus.java
@@ -12,9 +12,9 @@ import org.apache.hadoop.fs.Path;
  */
 public class LakeFSFileStatus extends FileStatus {
 
-    private String checksum;
-    private String physicalAddress;
-    private boolean isEmptyDirectory;
+    private final String checksum;
+    private final String physicalAddress;
+    private final boolean isEmptyDirectory;
 
     private LakeFSFileStatus(Builder builder) {
         super(builder.length, builder.isdir, builder.blockReplication, builder.blockSize, builder.mTime, builder.path);
@@ -34,7 +34,7 @@ public class LakeFSFileStatus extends FileStatus {
     public boolean isEmptyDirectory() { return isEmptyDirectory; }
 
     public static class Builder {
-        private Path path;
+        private final Path path;
         private long length;
         private boolean isdir;
         private short blockReplication;

--- a/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileStatus.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileStatus.java
@@ -63,8 +63,8 @@ public class LakeFSFileStatus extends FileStatus {
             return this;
         }
 
-        public Builder blocksize(long blocksize) {
-            this.blockSize = blocksize;
+        public Builder blockSize(long blockSize) {
+            this.blockSize = blockSize;
             return this;
         }
 

--- a/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileStatus.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileStatus.java
@@ -14,11 +14,13 @@ public class LakeFSFileStatus extends FileStatus {
 
     private String checksum;
     private String physicalAddress;
+    private boolean isEmptyDirectory;
 
     private LakeFSFileStatus(Builder builder) {
         super(builder.length, builder.isdir, builder.blockReplication, builder.blockSize, builder.mTime, builder.path);
         this.checksum = builder.checksum;
         this.physicalAddress = builder.physicalAddress;
+        this.isEmptyDirectory = builder.isEmptyDirectory;
     }
 
     public String getChecksum() {
@@ -29,6 +31,8 @@ public class LakeFSFileStatus extends FileStatus {
         return physicalAddress;
     }
 
+    public boolean isEmptyDirectory() { return isEmptyDirectory; }
+
     public static class Builder {
         private Path path;
         private long length;
@@ -38,6 +42,7 @@ public class LakeFSFileStatus extends FileStatus {
         private long mTime;
         private String checksum;
         private String physicalAddress;
+        private boolean isEmptyDirectory;
 
         public Builder(Path path) {
             this.path = path;
@@ -78,9 +83,13 @@ public class LakeFSFileStatus extends FileStatus {
             return this;
         }
 
+        public Builder isEmptyDirectory(boolean isEmptyDirectory) {
+            this.isEmptyDirectory = isEmptyDirectory;
+            return this;
+        }
+
         public LakeFSFileStatus build() {
-            LakeFSFileStatus lakeFSFileStatus =  new LakeFSFileStatus(this);
-            return lakeFSFileStatus;
+            return new LakeFSFileStatus(this);
         }
     }
 }

--- a/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileSystem.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileSystem.java
@@ -1,5 +1,6 @@
 package io.lakefs;
 
+import com.amazonaws.services.s3.model.ObjectMetadata;
 import io.lakefs.clients.api.ApiException;
 import io.lakefs.clients.api.ObjectsApi;
 import io.lakefs.clients.api.RepositoriesApi;
@@ -160,7 +161,6 @@ public class LakeFSFileSystem extends FileSystem {
         OPERATIONS_LOG.trace("create({})", path);
         try {
             // TODO(ariels): overwrite ignored.
-
             StagingApi staging = lfsClient.getStaging();
             ObjectLocation objectLoc = pathToObjectLocation(path);
             StagingLocation stagingLoc = staging.getPhysicalAddress(objectLoc.getRepository(), objectLoc.getRef(), objectLoc.getPath());
@@ -170,10 +170,10 @@ public class LakeFSFileSystem extends FileSystem {
             FileSystem physicalFs = physicalPath.getFileSystem(conf);
 
             // TODO(ariels): add fs.FileSystem.Statistics here to keep track.
-            return new FSDataOutputStream(new LinkOnCloseOutputStream(staging, stagingLoc, objectLoc,
+            // FSDataOutputStream is a kind of OutputStream(!)
+            return new FSDataOutputStream(new LinkOnCloseOutputStream(this, staging, stagingLoc, objectLoc,
                     physicalUri,
                     new MetadataClient(physicalFs),
-                    // FSDataOutputStream is a kind of OutputStream(!)
                     physicalFs.create(physicalPath, false, bufferSize, replication, blockSize, progress)),
                     null);
         } catch (io.lakefs.clients.api.ApiException e) {
@@ -236,11 +236,19 @@ public class LakeFSFileSystem extends FileSystem {
         // https://github.com/apache/hadoop/blob/2960d83c255a00a549f8809882cd3b73a6266b6d/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java#L1505
         LakeFSFileStatus srcStatus;
         srcStatus = getFileStatus(src);
-        if (!srcStatus.isDirectory()) {
-            return renameFile(srcStatus, dst);
+        boolean result;
+        if (srcStatus.isDirectory()) {
+            result = renameDirectory(src, dst);
+        } else {
+            result = renameFile(srcStatus, dst);
         }
-        return renameDirectory(src, dst);
+        if (src.getParent() != dst.getParent()) {
+            deleteUnnecessaryFakeDirectories(dst.getParent());
+            createFakeDirectoryIfNecessary(src.getParent());
+        }
+        return result;
     }
+
 
     /**
      * Recursively rename objects under src dir.
@@ -394,24 +402,25 @@ public class LakeFSFileSystem extends FileSystem {
     @Override
     public boolean delete(Path path, boolean recursive) throws IOException {
         OPERATIONS_LOG.trace("delete({}), recursive={}", path, recursive);
-        if (recursive) {
+        boolean deleted = true;
+        if (!recursive) {
+            // TODO(barak): handle case of delete fake directory without recursive
+            deleted = deleteHelper(path);
+        } else {
             ListingIterator iterator = new ListingIterator(path, true, listAmount);
             while (iterator.hasNext()) {
                 LocatedFileStatus fileStatus = iterator.next();
                 deleteHelper(fileStatus.getPath());
             }
-        } else {
-            if (!deleteHelper(path)) {
-                return false;
-            }
         }
-        return true;
+        createFakeDirectoryIfNecessary(path.getParent());
+        return deleted;
     }
 
     private boolean deleteHelper(Path path) throws IOException {
         try {
-            ObjectsApi objectsApi = lfsClient.getObjects();
             ObjectLocation objectLoc = pathToObjectLocation(path);
+            ObjectsApi objectsApi = lfsClient.getObjects();
             objectsApi.deleteObject(objectLoc.getRepository(), objectLoc.getRef(), objectLoc.getPath());
         } catch (ApiException e) {
             // This condition mimics s3a behaviour in https://github.com/apache/hadoop/blob/7f93349ee74da5f35276b7535781714501ab2457/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java#L2741
@@ -422,6 +431,36 @@ public class LakeFSFileSystem extends FileSystem {
             throw new IOException("deleteObject", e);
         }
         return true;
+    }
+
+    private void deleteUnnecessaryFakeDirectories(Path f) {
+        while (true) {
+            try {
+                ObjectLocation objectLocation = pathToObjectLocation(f);
+                if (objectLocation.isValidObjectPath()) {
+                    break;
+                }
+
+                LakeFSFileStatus status = getFileStatus(f);
+                if (status.isDirectory() && status.isEmptyDirectory()) {
+                    delete(f, false);
+                }
+            } catch (IOException ignored) {
+            }
+
+            if (f.isRoot()) {
+                break;
+            }
+
+            f = f.getParent();
+        }
+    }
+
+    private void createFakeDirectoryIfNecessary(Path f) throws IOException {
+        ObjectLocation objectLocation = pathToObjectLocation(f);
+        if (!objectLocation.isValidObjectPath() && !exists(f)) {
+            createFakeDirectory(f);
+        }
     }
 
     @Override
@@ -459,7 +498,64 @@ public class LakeFSFileSystem extends FileSystem {
 
     @Override
     public boolean mkdirs(Path path, FsPermission fsPermission) throws IOException {
-        return true;
+        try {
+            // check path is not a directory already
+            FileStatus fileStatus = getFileStatus(path);
+            if (fileStatus.isDirectory()) {
+                return true;
+            }
+            throw new FileAlreadyExistsException("Path is a file: " + path);
+        } catch (FileNotFoundException e) {
+            // check if part of path is a file already
+            ObjectLocation objectLocation = pathToObjectLocation(path);
+            Path branchRoot = new Path(String.format("%s://%s/%s", objectLocation.getScheme(), objectLocation.getRepository(), objectLocation.getRef()));
+            Path fPart = path;
+            do {
+                try {
+                    FileStatus fileStatus = getFileStatus(fPart);
+                    if (fileStatus.isFile()) {
+                        throw new FileAlreadyExistsException(String.format(
+                                "Can't make directory for path '%s' since it is a file.",
+                                fPart));
+                    }
+                } catch (FileNotFoundException ignored) {
+                }
+                fPart = fPart.getParent();
+            } while (fPart != null && !fPart.equals(branchRoot));
+
+            createFakeDirectory(path);
+            return true;
+        }
+    }
+
+    private void createFakeDirectory(Path path) throws IOException {
+        try {
+            StagingApi staging = lfsClient.getStaging();
+            ObjectLocation objectLoc = pathToObjectLocation(path);
+            // append directory separator
+            if (!objectLoc.getPath().endsWith(SEPARATOR)) {
+                objectLoc.setPath(objectLoc.getPath() + SEPARATOR);
+            }
+
+            StagingLocation stagingLoc = staging.getPhysicalAddress(objectLoc.getRepository(), objectLoc.getRef(), objectLoc.getPath());
+            URI physicalUri = translateUri(new URI(Objects.requireNonNull(stagingLoc.getPhysicalAddress())));
+            Path physicalPath = new Path(physicalUri.toString());
+            FileSystem physicalFs = physicalPath.getFileSystem(conf);
+            FSDataOutputStream outputStream = physicalFs.create(physicalPath);
+            outputStream.flush();
+            outputStream.close();
+            MetadataClient metadataClient = new MetadataClient(physicalFs);
+            ObjectMetadata objectMetadata = metadataClient.getObjectMetadata(physicalUri);
+            StagingMetadata metadata = new StagingMetadata()
+                    .staging(stagingLoc)
+                    .checksum(objectMetadata.getETag())
+                    .sizeBytes(objectMetadata.getContentLength());
+            staging.linkPhysicalAddress(objectLoc.getRepository(), objectLoc.getRef(), objectLoc.getPath(), metadata);
+        } catch (io.lakefs.clients.api.ApiException e) {
+            throw new IOException("createFakeDirectory: " + e.getResponseBody(), e);
+        } catch (java.net.URISyntaxException e) {
+            throw new IOException("createFakeDirectory", e);
+        }
     }
 
     /**
@@ -472,6 +568,7 @@ public class LakeFSFileSystem extends FileSystem {
         OPERATIONS_LOG.trace("get_file_status({})", path);
         ObjectLocation objectLoc = pathToObjectLocation(path);
         ObjectsApi objectsApi = lfsClient.getObjects();
+        // get object status on path
         try {
             ObjectStats objectStat = objectsApi.statObject(objectLoc.getRepository(), objectLoc.getRef(), objectLoc.getPath());
             return convertObjectStatsToFileStatus(objectLoc, objectStat);
@@ -480,7 +577,16 @@ public class LakeFSFileSystem extends FileSystem {
                 throw new IOException("statObject", e);
             }
         }
-        // not found as a file; check if path is a "directory", i.e. a prefix.
+        // get object status on path + "/" for fake directory
+        try {
+            ObjectStats objectStat = objectsApi.statObject(objectLoc.getRepository(), objectLoc.getRef(), objectLoc.getPath() + SEPARATOR);
+            return convertObjectStatsToFileStatus(objectLoc, objectStat);
+        } catch (ApiException e) {
+            if (e.getCode() != HttpStatus.SC_NOT_FOUND) {
+                throw new IOException("statObject", e);
+            }
+        }
+        // not found as a file or fake; check if path is a "directory", i.e. a prefix.
         ListingIterator iterator = new ListingIterator(path, true, 1);
         if (iterator.hasNext()) {
             Path filePath = new Path(objectLoc.toString());
@@ -505,15 +611,21 @@ public class LakeFSFileSystem extends FileSystem {
             }
             Path filePath = new Path(ObjectLocation.formatPath(objectLocation.getScheme(), objectLocation.getRepository(),
                     objectLocation.getRef(), objectStat.getPath()));
+            String physicalAddress = objectStat.getPhysicalAddress();
             boolean isDir = isDirectory(objectStat);
-            long blockSize = 0;
-            if (!isDir) {
-                blockSize = withFileSystemAndTranslatedPhysicalPath(objectStat.getPhysicalAddress(), FileSystem::getDefaultBlockSize);
-            }
+            boolean isEmptyDirectory = isDir && objectStat.getPathType() == ObjectStats.PathTypeEnum.OBJECT;
+            long blockSize = isDir
+                    ? 0
+                    : withFileSystemAndTranslatedPhysicalPath(physicalAddress, FileSystem::getDefaultBlockSize);
             LakeFSFileStatus.Builder builder =
-                    new LakeFSFileStatus.Builder(filePath).length(length)
-                            .isdir(isDir).blocksize(blockSize).mTime(modificationTime)
-                            .checksum(objectStat.getChecksum()).physicalAddress(objectStat.getPhysicalAddress());
+                    new LakeFSFileStatus.Builder(filePath)
+                            .length(length)
+                            .isdir(isDir)
+                            .isEmptyDirectory(isEmptyDirectory)
+                            .blocksize(blockSize)
+                            .mTime(modificationTime)
+                            .checksum(objectStat.getChecksum())
+                            .physicalAddress(physicalAddress);
             return builder.build();
         } catch (java.net.URISyntaxException e) {
             throw new IOException("uri", e);
@@ -544,8 +656,18 @@ public class LakeFSFileSystem extends FileSystem {
         OPERATIONS_LOG.trace("exists({})", path);
         ObjectsApi objects = lfsClient.getObjects();
         ObjectLocation objectLoc = pathToObjectLocation(path);
+        // check if file exists
         try {
             objects.statObject(objectLoc.getRepository(), objectLoc.getRef(), objectLoc.getPath());
+            return true;
+        } catch (ApiException e) {
+            if (e.getCode() != HttpStatus.SC_NOT_FOUND) {
+                throw new IOException("statObject", e);
+            }
+        }
+        // check if fake directory exists
+        try {
+            objects.statObject(objectLoc.getRepository(), objectLoc.getRef(), objectLoc.getPath() + SEPARATOR);
             return true;
         } catch (ApiException e) {
             if (e.getCode() != HttpStatus.SC_NOT_FOUND) {
@@ -682,12 +804,16 @@ public class LakeFSFileSystem extends FileSystem {
     }
 
     private static boolean isDirectory(ObjectStats stat) {
-        return stat.getPathType() == ObjectStats.PathTypeEnum.COMMON_PREFIX;
+        return stat.getPath().endsWith(SEPARATOR) || stat.getPathType() == ObjectStats.PathTypeEnum.COMMON_PREFIX;
     }
 
     public static RemoteIterator<LocatedFileStatus> toLocatedFileStatusIterator(
             RemoteIterator<? extends LocatedFileStatus> iterator) {
         return (RemoteIterator<LocatedFileStatus>) iterator;
+    }
+
+    public void finishedWrite(Path f) throws IOException {
+        deleteUnnecessaryFakeDirectories(f.getParent());
     }
 }
 

--- a/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileSystem.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileSystem.java
@@ -180,7 +180,7 @@ public class LakeFSFileSystem extends FileSystem {
      * @param createStream callback function accepts the underlying filesystem and the physical path
      * @param objectLoc to write to
      * @param handleFinishedWrite when true, after stream closes it will delete unnecessary directory marker directories in parent
-     * @return
+     * @return output stream to write
      * @throws ApiException
      * @throws URISyntaxException
      * @throws IOException
@@ -263,7 +263,7 @@ public class LakeFSFileSystem extends FileSystem {
             result = renameFile(srcStatus, dst);
         }
         if (src.getParent() != dst.getParent()) {
-            deleteUnnecessaryDirectoryMarkers(dst.getParent());
+            deleteEmptyDirectoryMarkers(dst.getParent());
             createDirectoryMarkerIfNecessary(src.getParent());
         }
         return result;
@@ -458,7 +458,7 @@ public class LakeFSFileSystem extends FileSystem {
      * Assume the caller created an object under the path which will make the empty directory irrelevant.
      * @param f path to start for empty directory markers
      */
-    private void deleteUnnecessaryDirectoryMarkers(Path f) {
+    void deleteEmptyDirectoryMarkers(Path f) {
         while (true) {
             try {
                 ObjectLocation objectLocation = pathToObjectLocation(f);
@@ -842,13 +842,5 @@ public class LakeFSFileSystem extends FileSystem {
     public static RemoteIterator<LocatedFileStatus> toLocatedFileStatusIterator(
             RemoteIterator<? extends LocatedFileStatus> iterator) {
         return (RemoteIterator<LocatedFileStatus>) iterator;
-    }
-
-    /**
-     * delete unnecessary directory marker directories
-     * @param f path to new object
-     */
-    void finishedWrite(Path f) {
-        deleteUnnecessaryDirectoryMarkers(f.getParent());
     }
 }

--- a/clients/hadoopfs/src/main/java/io/lakefs/LakeFSLocatedFileStatus.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/LakeFSLocatedFileStatus.java
@@ -23,7 +23,7 @@ public class LakeFSLocatedFileStatus extends LocatedFileStatus {
                 .length(getLen())
                 .isdir(isDirectory())
                 .isEmptyDirectory(isEmptyDirectory)
-                .blocksize(getBlockSize())
+                .blockSize(getBlockSize())
                 .mTime(getModificationTime())
                 .checksum(checksum)
                 .physicalAddress(physicalAddress)

--- a/clients/hadoopfs/src/main/java/io/lakefs/LakeFSLocatedFileStatus.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/LakeFSLocatedFileStatus.java
@@ -7,18 +7,26 @@ import java.io.IOException;
 
 public class LakeFSLocatedFileStatus extends LocatedFileStatus {
 
-    private String checksum;
-    private String physicalAddress;
+    private final String checksum;
+    private final String physicalAddress;
+    private final boolean isEmptyDirectory;
 
     public LakeFSLocatedFileStatus(LakeFSFileStatus status, BlockLocation[] locations) throws IOException {
         super(status, locations);
         this.checksum = status.getChecksum();
         this.physicalAddress = status.getPhysicalAddress();
+        this.isEmptyDirectory = status.isEmptyDirectory();
     }
 
     public LakeFSFileStatus toLakeFSFileStatus() {
-        return new LakeFSFileStatus.Builder(getPath()).length(getLen())
-                        .isdir(isDirectory()).blocksize(getBlockSize()).mTime(getModificationTime())
-                        .checksum(checksum).physicalAddress(physicalAddress).build();
+        return new LakeFSFileStatus.Builder(getPath())
+                .length(getLen())
+                .isdir(isDirectory())
+                .isEmptyDirectory(isEmptyDirectory)
+                .blocksize(getBlockSize())
+                .mTime(getModificationTime())
+                .checksum(checksum)
+                .physicalAddress(physicalAddress)
+                .build();
     }
 }

--- a/clients/hadoopfs/src/main/java/io/lakefs/LinkOnCloseOutputStream.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/LinkOnCloseOutputStream.java
@@ -17,7 +17,6 @@ class LinkOnCloseOutputStream extends OutputStream {
     private final URI physicalUri;
     private final MetadataClient metadataClient;
     private final OutputStream out;
-    private final boolean deleteEmptyDirectoryMarkers;
 
     /**
      * @param lfs LakeFS file system
@@ -26,18 +25,15 @@ class LinkOnCloseOutputStream extends OutputStream {
      * @param physicalUri translated physical location of object data for underlying FileSystem.
      * @param metadataClient client used to request metadata information from the underlying FileSystem.
      * @param out stream on underlying filesystem to wrap.
-     * @param deleteEmptyDirectoryMarkers call delete empty directory markers after stream close
      */
     LinkOnCloseOutputStream(LakeFSFileSystem lfs, StagingLocation stagingLoc, ObjectLocation objectLoc,
-                            URI physicalUri, MetadataClient metadataClient, OutputStream out,
-                            boolean deleteEmptyDirectoryMarkers) {
+                            URI physicalUri, MetadataClient metadataClient, OutputStream out) {
         this.lfs = lfs;
         this.stagingLoc = stagingLoc;
         this.objectLoc = objectLoc;
         this.physicalUri = physicalUri;
         this.metadataClient = metadataClient;
         this.out = out;
-        this.deleteEmptyDirectoryMarkers = deleteEmptyDirectoryMarkers;
     }
 
     @Override
@@ -71,8 +67,6 @@ class LinkOnCloseOutputStream extends OutputStream {
         } catch (io.lakefs.clients.api.ApiException e) {
             throw new IOException("link lakeFS path to physical address", e);
         }
-        if (deleteEmptyDirectoryMarkers) {
-            lfs.deleteEmptyDirectoryMarkers(new Path(objectLoc.toString()).getParent());
-        }
+        lfs.deleteEmptyDirectoryMarkers(new Path(objectLoc.toString()).getParent());
     }
 }

--- a/clients/hadoopfs/src/main/java/io/lakefs/LinkOnCloseOutputStream.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/LinkOnCloseOutputStream.java
@@ -1,9 +1,7 @@
 package io.lakefs;
 
-import com.amazonaws.services.s3.model.ObjectMetadata;
 import io.lakefs.clients.api.StagingApi;
 import io.lakefs.clients.api.model.StagingLocation;
-import io.lakefs.clients.api.model.StagingMetadata;
 import org.apache.hadoop.fs.Path;
 
 import java.io.IOException;
@@ -14,31 +12,32 @@ import java.net.URI;
  * Wraps a FSDataOutputStream to link file on staging when done writing
  */
 class LinkOnCloseOutputStream extends OutputStream {
-    private final LakeFSFileSystem fs;
-    private StagingApi staging;
-    private StagingLocation stagingLoc;
-    private ObjectLocation objectLoc;
-    private URI physicalUri;
+    private final LakeFSFileSystem lfs;
+    private final StagingLocation stagingLoc;
+    private final ObjectLocation objectLoc;
+    private final URI physicalUri;
     private final MetadataClient metadataClient;
-    private OutputStream out;
+    private final OutputStream out;
+    private final boolean handleFinishedWrite;
 
     /**
-     * @param fs LakeFS file system
-     * @param staging client used to access metadata on lakeFS.
+     * @param lfs LakeFS file system
      * @param stagingLoc physical location of object data on S3.
      * @param objectLoc location of object on lakeFS.
      * @param physicalUri translated physical location of object data for underlying FileSystem.
      * @param metadataClient client used to request metadata information from the underlying FileSystem.
      * @param out stream on underlying filesystem to wrap.
+     * @param handleFinishedWrite calls LakeFS finishedWrite on after write completes
      */
-    LinkOnCloseOutputStream(LakeFSFileSystem fs, StagingApi staging, StagingLocation stagingLoc, ObjectLocation objectLoc, URI physicalUri, MetadataClient metadataClient, OutputStream out) {
-        this.fs = fs;
-        this.staging = staging;
+    LinkOnCloseOutputStream(LakeFSFileSystem lfs, StagingLocation stagingLoc, ObjectLocation objectLoc,
+                            URI physicalUri, MetadataClient metadataClient, OutputStream out, boolean handleFinishedWrite) {
+        this.lfs = lfs;
         this.stagingLoc = stagingLoc;
         this.objectLoc = objectLoc;
         this.physicalUri = physicalUri;
         this.metadataClient = metadataClient;
         this.out = out;
+        this.handleFinishedWrite = handleFinishedWrite;
     }
 
     @Override
@@ -67,17 +66,13 @@ class LinkOnCloseOutputStream extends OutputStream {
 
         // Now the object is on the underlying store, find its parameters (sadly lost by
         // the underlying Hadoop FileSystem) so we can link it on lakeFS.
-        ObjectMetadata objectMetadata = metadataClient.getObjectMetadata(physicalUri);
-        // TODO(ariels): Can we add metadata here?
-        StagingMetadata metadata = new StagingMetadata()
-                .staging(stagingLoc)
-                .checksum(objectMetadata.getETag())
-                .sizeBytes(objectMetadata.getContentLength());
         try {
-            staging.linkPhysicalAddress(objectLoc.getRepository(), objectLoc.getRef(), objectLoc.getPath(), metadata);
+            lfs.linkPhysicalAddress(objectLoc, stagingLoc, physicalUri, metadataClient);
         } catch (io.lakefs.clients.api.ApiException e) {
             throw new IOException("link lakeFS path to physical address", e);
         }
-        this.fs.finishedWrite(new Path(objectLoc.toString()));
+        if (handleFinishedWrite) {
+            lfs.finishedWrite(new Path(objectLoc.toString()));
+        }
     }
 }

--- a/clients/hadoopfs/src/main/java/io/lakefs/ObjectLocation.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/ObjectLocation.java
@@ -1,5 +1,7 @@
 package io.lakefs;
 
+import org.apache.hadoop.fs.Path;
+
 class ObjectLocation {
     private String scheme;
     private String repository;
@@ -10,6 +12,11 @@ class ObjectLocation {
         return String.format("%s://%s/%s/%s", scheme, repository, ref, path);
     }
 
+
+    public static String formatPath(String scheme, String repository, String ref) {
+        return String.format("%s://%s/%s", scheme, repository, ref);
+    }
+
     public String getScheme() {
         return scheme;
     }
@@ -18,8 +25,28 @@ class ObjectLocation {
         this.scheme = scheme;
     }
 
-    public static String formatPath(String repository, String ref) {
-        return String.format("%s://%s/%s", Constants.URI_SCHEME, repository, ref);
+    public ObjectLocation() {
+    }
+
+    public ObjectLocation(String scheme, String repository, String ref) {
+        this.scheme = scheme;
+        this.repository = repository;
+        this.ref = ref;
+    }
+
+    public ObjectLocation(String scheme, String repository, String ref, String path) {
+        this.scheme = scheme;
+        this.repository = repository;
+        this.ref = ref;
+        this.path = path;
+    }
+
+    public ObjectLocation getParent() {
+        Path parentPath = new Path(this.path).getParent();
+        if (parentPath == null) {
+            return null;
+        }
+        return new ObjectLocation(repository, ref, parentPath.toString());
     }
 
     public String getRepository() {
@@ -46,8 +73,10 @@ class ObjectLocation {
         this.path = path;
     }
 
-    public boolean isValidObjectPath() {
-        return this.path.isEmpty() || this.ref.isEmpty() || this.repository.isEmpty();
+    public boolean isValidPath() {
+        return !this.repository.isEmpty() &&
+                !this.ref.isEmpty() &&
+                !this.path.isEmpty();
     }
 
     static String trimLeadingSlash(String s) {
@@ -86,5 +115,7 @@ class ObjectLocation {
         return formatPath(scheme, repository, ref, path);
     }
 
-    public String toRefString() {return formatPath(repository, ref);}
+    public String toRefString() {
+        return formatPath(scheme, repository, ref);
+    }
 }

--- a/clients/hadoopfs/src/main/java/io/lakefs/ObjectLocation.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/ObjectLocation.java
@@ -42,6 +42,10 @@ class ObjectLocation {
         this.path = path;
     }
 
+    public boolean isValidObjectPath() {
+        return this.path.isEmpty() || this.ref.isEmpty() || this.repository.isEmpty();
+    }
+
     static String trimLeadingSlash(String s) {
         if (s.startsWith(Constants.SEPARATOR)) {
             return s.substring(1);

--- a/clients/hadoopfs/src/main/java/io/lakefs/ObjectLocation.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/ObjectLocation.java
@@ -114,7 +114,9 @@ class ObjectLocation {
      * @return true if the object location is on same branch, false otherwise
      */
     public boolean onSameBranch(ObjectLocation otherObjLoc) {
-        return this.repository.equals(otherObjLoc.getRepository()) && this.ref.equals(otherObjLoc.getRef());
+        return this.scheme.equals(otherObjLoc.getScheme()) &&
+                this.repository.equals(otherObjLoc.getRepository()) &&
+                this.ref.equals(otherObjLoc.getRef());
     }
 
     @Override

--- a/clients/hadoopfs/src/main/java/io/lakefs/ObjectLocation.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/ObjectLocation.java
@@ -89,6 +89,10 @@ class ObjectLocation {
         return s;
     }
 
+    static String addLeadingSlash(String s) {
+        return s.isEmpty() || s.endsWith(Constants.SEPARATOR) ? s : s + Constants.SEPARATOR;
+    }
+
     @Override
     public boolean equals(Object obj) {
         if (obj == this) {
@@ -120,5 +124,9 @@ class ObjectLocation {
 
     public String toRefString() {
         return formatPath(scheme, repository, ref);
+    }
+
+    public ObjectLocation toDirectory() {
+        return new ObjectLocation(scheme, repository, ref, addLeadingSlash(path));
     }
 }

--- a/clients/hadoopfs/src/main/java/io/lakefs/ObjectLocation.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/ObjectLocation.java
@@ -49,7 +49,7 @@ class ObjectLocation {
         if (parentPath == null) {
             return null;
         }
-        return new ObjectLocation(repository, ref, parentPath.toString());
+        return new ObjectLocation(scheme, repository, ref, parentPath.toString());
     }
 
     public String getRepository() {

--- a/clients/hadoopfs/src/main/java/io/lakefs/ObjectLocation.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/ObjectLocation.java
@@ -42,6 +42,9 @@ class ObjectLocation {
     }
 
     public ObjectLocation getParent() {
+        if (this.path == null) {
+            return null;
+        }
         Path parentPath = new Path(this.path).getParent();
         if (parentPath == null) {
             return null;

--- a/clients/hadoopfs/src/main/java/io/lakefs/ObjectLocation.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/ObjectLocation.java
@@ -18,6 +18,10 @@ class ObjectLocation {
         this.scheme = scheme;
     }
 
+    public static String formatPath(String repository, String ref) {
+        return String.format("%s://%s/%s", Constants.URI_SCHEME, repository, ref);
+    }
+
     public String getRepository() {
         return repository;
     }
@@ -81,4 +85,6 @@ class ObjectLocation {
     public String toString() {
         return formatPath(scheme, repository, ref, path);
     }
+
+    public String toRefString() {return formatPath(repository, ref);}
 }

--- a/clients/hadoopfs/src/test/java/io/lakefs/LakeFSFileSystemTest.java
+++ b/clients/hadoopfs/src/test/java/io/lakefs/LakeFSFileSystemTest.java
@@ -255,13 +255,15 @@ public class LakeFSFileSystemTest {
                         mtime(UNUSED_MTIME).
                         sizeBytes(UNUSED_FILE_SIZE));
         ApiException noSuchFile = new ApiException(HttpStatus.SC_NOT_FOUND, "no such file");
-        when(objectsApi.statObject("repo", "main", "no/place"))
-                .thenThrow(noSuchFile);
-        when(objectsApi.statObject("repo", "main", "no/place/"))
-                .thenThrow(noSuchFile);
-        when(objectsApi.listObjects(eq("repo"), eq("main"), eq("no/place/"), eq(""), any(), eq("")))
-                .thenReturn(new ObjectStatsList().results(Collections.emptyList()).pagination(new Pagination().hasMore(false)));
-
+        String[] arrDirs = {"no/place", "no"};
+        for (String dir: arrDirs) {
+            when(objectsApi.statObject("repo", "main", dir))
+                    .thenThrow(noSuchFile);
+            when(objectsApi.statObject("repo", "main", dir + Constants.SEPARATOR))
+                    .thenThrow(noSuchFile);
+            when(objectsApi.listObjects(eq("repo"), eq("main"), eq(dir + Constants.SEPARATOR), eq(""), any(), eq("")))
+                    .thenReturn(new ObjectStatsList().results(Collections.emptyList()).pagination(new Pagination().hasMore(false)));
+        }
         StagingLocation stagingLocation = new StagingLocation().token("foo").physicalAddress(s3Url("/repo-base/dir-marker"));
         when(stagingApi.getPhysicalAddress("repo", "main", "no/place/"))
                 .thenReturn(stagingLocation);

--- a/clients/hadoopfs/src/test/java/io/lakefs/LakeFSFileSystemTest.java
+++ b/clients/hadoopfs/src/test/java/io/lakefs/LakeFSFileSystemTest.java
@@ -170,8 +170,7 @@ public class LakeFSFileSystemTest {
     }
 
     @Test
-    public void testGetFileStatus() throws ApiException, IOException {
-        // existing file
+    public void testGetFileStatus_ExistingFile() throws ApiException, IOException {
         Path p = new Path("lakefs://repo/main/exists");
         ObjectStats os = new ObjectStats();
         os.setPath("exists");
@@ -185,8 +184,10 @@ public class LakeFSFileSystemTest {
         LakeFSFileStatus fileStatus = fs.getFileStatus(p);
         Assert.assertTrue(fileStatus.isFile());
         Assert.assertEquals(p, fileStatus.getPath());
+    }
 
-        // no file
+    @Test
+    public void testGetFileStatus_NoFile() throws ApiException, IOException {
         Path noFilePath = new Path("lakefs://repo/main/no.file");
         ApiException noSuchFileException = new ApiException(HttpStatus.SC_NOT_FOUND, "no such file");
         when(objectsApi.statObject("repo", "main", "no.file"))
@@ -196,9 +197,12 @@ public class LakeFSFileSystemTest {
         when(objectsApi.listObjects(any(), any(), any(), any(), any(), any()))
                 .thenReturn(new ObjectStatsList().results(Collections.emptyList()).pagination(new Pagination().hasMore(false)));
         Assert.assertThrows(FileNotFoundException.class, () -> fs.getFileStatus(noFilePath));
+    }
 
-        // fake directory
+    @Test
+    public void testGetFileStatus_FakeDirectory() throws ApiException, IOException {
         Path dirPath = new Path("lakefs://repo/main/dir1/dir2");
+        ApiException noSuchFileException = new ApiException(HttpStatus.SC_NOT_FOUND, "no such file");
         when(objectsApi.statObject("repo", "main", "dir1/dir2"))
                 .thenThrow(noSuchFileException);
         ObjectStats dirObjectStats = new ObjectStats();

--- a/clients/hadoopfs/src/test/java/io/lakefs/LakeFSFileSystemTest.java
+++ b/clients/hadoopfs/src/test/java/io/lakefs/LakeFSFileSystemTest.java
@@ -321,7 +321,7 @@ public class LakeFSFileSystemTest {
                 .thenReturn(stagingLocation);
 
         // mock sub1/sub2 was an empty directory
-        ObjectLocation sub2Loc = new ObjectLocation("repo", "main", "sub1/sub2");
+        ObjectLocation sub2Loc = new ObjectLocation("lakefs", "repo", "main", "sub1/sub2");
         mockEmptyDirectoryMarker(sub2Loc);
 
         OutputStream out = fs.create(p);


### PR DESCRIPTION
Using lakeFS FS with Databricks delta format failed to read data from lakeFS.
The root cause was that lakeFS didn't support empty folders as a filesystem.
In order to enable it, we fake directory like s3a does.

The implementation will modify the behavior for the following:

1. delete
   - handle delete of empty directory (marker)
   - handle the case of delete non-recursive of a non-empty directory
   - create directory marker on parent after delete, to keep an empty directory after removing the last file/directory
1. rename
   - if src != dst make sure that src parent is holding marker for empty directory and delete all markers from destination parents
   - delete dst directory marker if found
1. create
   - on complete - clear empty directory marker from parent
1. listStatus
   - show dir marker object as a directory
1. getFileStatus
   - check if the path points to an empty directory and return file status for a directory