### PR TITLE
Support post-merge and post-commit events

### DIFF
--- a/cmd/lakefs/cmd/import.go
+++ b/cmd/lakefs/cmd/import.go
@@ -99,11 +99,13 @@ func runImport(cmd *cobra.Command, args []string) (statusCode int) {
 
 	// wire actions into entry catalog
 	actionsService := actions.NewService(
+		ctx,
 		dbPool,
 		catalog.NewActionsSource(c),
 		catalog.NewActionsOutputWriter(c.BlockAdapter),
 	)
 	c.SetHooksHandler(actionsService)
+	defer actionsService.Stop()
 
 	u := uri.Must(uri.Parse(args[0]))
 	if !u.IsRepository() {

--- a/cmd/lakefs/cmd/run.go
+++ b/cmd/lakefs/cmd/run.go
@@ -83,11 +83,13 @@ var runCmd = &cobra.Command{
 
 		// wire actions
 		actionsService := actions.NewService(
+			ctx,
 			dbPool,
 			catalog.NewActionsSource(c),
 			catalog.NewActionsOutputWriter(c.BlockAdapter),
 		)
 		c.SetHooksHandler(actionsService)
+		defer actionsService.Stop()
 
 		multipartsTracker := multiparts.NewTracker(dbPool)
 

--- a/nessie/hooks_test.go
+++ b/nessie/hooks_test.go
@@ -127,7 +127,7 @@ func TestHooksSuccess(t *testing.T) {
 
 	commitRecord := commitResp.JSON201
 	require.Equal(t, "pre-commit", preCommitEvent.EventType)
-	require.Equal(t, "Test Commit", preCommitEvent.ActionName)
+	require.Equal(t, "Test Pre Commit", preCommitEvent.ActionName)
 	require.Equal(t, "test_webhook", preCommitEvent.HookID)
 	require.Equal(t, repo, preCommitEvent.RepositoryID)
 	require.Equal(t, branch, preCommitEvent.BranchID)
@@ -144,7 +144,7 @@ func TestHooksSuccess(t *testing.T) {
 	require.NoError(t, decoder.Decode(&postCommitEvent), "reading post-commit data")
 
 	require.Equal(t, "post-commit", postCommitEvent.EventType)
-	require.Equal(t, "Test Commit", postCommitEvent.ActionName)
+	require.Equal(t, "Test Post Commit", postCommitEvent.ActionName)
 	require.Equal(t, "test_webhook", postCommitEvent.HookID)
 	require.Equal(t, repo, postCommitEvent.RepositoryID)
 	require.Equal(t, branch, postCommitEvent.BranchID)

--- a/nessie/hooks_test.go
+++ b/nessie/hooks_test.go
@@ -169,7 +169,7 @@ func TestHooksSuccess(t *testing.T) {
 	require.Equal(t, "test_webhook", postMergeEvent.HookID)
 	require.Equal(t, repo, postMergeEvent.RepositoryID)
 	require.Equal(t, mainBranch, postMergeEvent.BranchID)
-	require.Equal(t, commitRecord.Id, postMergeEvent.SourceRef)
+	require.Equal(t, branch, postMergeEvent.SourceRef)
 
 	t.Log("List repository runs", mergeRef)
 	runsResp, err := client.ListRepositoryRunsWithResponse(ctx, repo, &api.ListRepositoryRunsParams{

--- a/nessie/hooks_test.go
+++ b/nessie/hooks_test.go
@@ -187,6 +187,8 @@ func TestHooksSuccess(t *testing.T) {
 }
 
 func parseAndUpload(t *testing.T, ctx context.Context, repo, branch, yaml, templateName, actionPath string) {
+	t.Helper()
+
 	// render actions based on templates
 	docData := struct {
 		URL string

--- a/nessie/hooks_test.go
+++ b/nessie/hooks_test.go
@@ -62,13 +62,13 @@ const actionPostMergeYaml = `
 name: Test Post Merge
 description: set of checks to verify that branch is good
 on:
-  pre-merge:
+  post-merge:
     branches:
       - main
 hooks:
   - id: test_webhook
     type: webhook
-    description: Check webhooks for pre-merge works
+    description: Check webhooks for post-merge works
     properties:
       url: "{{.URL}}/post-merge"
 `
@@ -90,8 +90,8 @@ func TestHooksSuccess(t *testing.T) {
 
 	parseAndUpload(t, ctx, repo, branch, actionPreMergeYaml, "action-pre-merge", "testing_pre_merge")
 	parseAndUpload(t, ctx, repo, branch, actionPreCommitYaml, "action-pre-commit", "testing_pre_commit")
-	parseAndUpload(t, ctx, repo, branch, actionPostMergeYaml, "action-post-merge", "testing_post_merge")
 	parseAndUpload(t, ctx, repo, branch, actionPostCommitYaml, "action-post-commit", "testing_post_commit")
+	parseAndUpload(t, ctx, repo, branch, actionPostMergeYaml, "action-post-merge", "testing_post_merge")
 
 	logger.WithField("branch", branch).Info("Commit initial content")
 

--- a/nessie/webhook_server_test.go
+++ b/nessie/webhook_server_test.go
@@ -34,6 +34,7 @@ func startWebhookServer() (*webhookServer, error) {
 	respCh := make(chan hookResponse, 10)
 	mux := http.NewServeMux()
 	mux.HandleFunc("/pre-commit", hookHandlerFunc(respCh))
+	mux.HandleFunc("/post-commit", hookHandlerFunc(respCh))
 	mux.HandleFunc("/pre-merge", hookHandlerFunc(respCh))
 	mux.HandleFunc("/timeout", timeoutHandlerFunc(respCh))
 	mux.HandleFunc("/fail", failHandlerFunc(respCh))

--- a/nessie/webhook_server_test.go
+++ b/nessie/webhook_server_test.go
@@ -36,6 +36,7 @@ func startWebhookServer() (*webhookServer, error) {
 	mux.HandleFunc("/pre-commit", hookHandlerFunc(respCh))
 	mux.HandleFunc("/post-commit", hookHandlerFunc(respCh))
 	mux.HandleFunc("/pre-merge", hookHandlerFunc(respCh))
+	mux.HandleFunc("/post-merge", hookHandlerFunc(respCh))
 	mux.HandleFunc("/timeout", timeoutHandlerFunc(respCh))
 	mux.HandleFunc("/fail", failHandlerFunc(respCh))
 	listener, err := net.Listen("tcp", ":0")

--- a/pkg/actions/action.go
+++ b/pkg/actions/action.go
@@ -20,8 +20,10 @@ type Action struct {
 }
 
 type OnEvents struct {
-	PreMerge  *ActionOn `yaml:"pre-merge"`
-	PreCommit *ActionOn `yaml:"pre-commit"`
+	PreMerge   *ActionOn `yaml:"pre-merge"`
+	PostMerge  *ActionOn `yaml:"post-merge"`
+	PreCommit  *ActionOn `yaml:"pre-commit"`
+	PostCommit *ActionOn `yaml:"post-commit"`
 }
 
 type ActionOn struct {
@@ -55,7 +57,10 @@ func (a *Action) Validate() error {
 	if !reName.MatchString(a.Name) {
 		return fmt.Errorf("'name' is invalid: %w", ErrInvalidAction)
 	}
-	if a.On.PreMerge == nil && a.On.PreCommit == nil {
+	if a.On.PreMerge == nil &&
+		a.On.PostMerge == nil &&
+		a.On.PreCommit == nil &&
+		a.On.PostCommit == nil {
 		return fmt.Errorf("'on' is required: %w", ErrInvalidAction)
 	}
 	ids := make(map[string]struct{})
@@ -82,6 +87,10 @@ func (a *Action) Match(spec MatchSpec) (bool, error) {
 		actionOn = a.On.PreCommit
 	case graveler.EventTypePreMerge:
 		actionOn = a.On.PreMerge
+	case graveler.EventTypePostCommit:
+		actionOn = a.On.PostCommit
+	case graveler.EventTypePostMerge:
+		actionOn = a.On.PostMerge
 	default:
 		return false, ErrInvalidEventType
 	}

--- a/pkg/actions/service.go
+++ b/pkg/actions/service.go
@@ -102,7 +102,7 @@ func (s *Service) Stop() {
 	s.wg.Wait()
 }
 
-func (s *Service) AsyncRun(record graveler.HookRecord) error {
+func (s *Service) AsyncRun(record graveler.HookRecord) {
 	s.wg.Add(1)
 	go func() {
 		defer s.wg.Done()
@@ -113,8 +113,6 @@ func (s *Service) AsyncRun(record graveler.HookRecord) error {
 				Info("Async run of hook failed")
 		}
 	}()
-
-	return nil
 }
 
 // Run load and run actions based on the event information
@@ -424,7 +422,8 @@ func (s *Service) PostCommitHook(ctx context.Context, record graveler.HookRecord
 		return err
 	}
 
-	return s.Run(ctx, record)
+	s.AsyncRun(record)
+	return nil
 }
 
 func (s *Service) PreMergeHook(ctx context.Context, record graveler.HookRecord) error {
@@ -438,7 +437,8 @@ func (s *Service) PostMergeHook(ctx context.Context, record graveler.HookRecord)
 		return err
 	}
 
-	return s.Run(ctx, record)
+	s.AsyncRun(record)
+	return nil
 }
 
 func NewHookRunID(actionIdx, hookIdx int) string {

--- a/pkg/actions/service.go
+++ b/pkg/actions/service.go
@@ -299,7 +299,7 @@ func buildRunManifestFromTasks(record graveler.HookRecord, tasks [][]*Task) RunM
 				manifest.Run.EndTime = task.EndTime
 			}
 			// did we failed
-			manifest.Run.Passed = manifest.Run.Passed && task.Err != nil
+			manifest.Run.Passed = manifest.Run.Passed && task.Err == nil
 		}
 	}
 

--- a/pkg/actions/service.go
+++ b/pkg/actions/service.go
@@ -102,7 +102,7 @@ func (s *Service) Stop() {
 	s.wg.Wait()
 }
 
-func (s *Service) AsyncRun(record graveler.HookRecord) {
+func (s *Service) asyncRun(record graveler.HookRecord) {
 	s.wg.Add(1)
 	go func() {
 		defer s.wg.Done()
@@ -422,7 +422,7 @@ func (s *Service) PostCommitHook(ctx context.Context, record graveler.HookRecord
 		return err
 	}
 
-	s.AsyncRun(record)
+	s.asyncRun(record)
 	return nil
 }
 
@@ -437,7 +437,7 @@ func (s *Service) PostMergeHook(ctx context.Context, record graveler.HookRecord)
 		return err
 	}
 
-	s.AsyncRun(record)
+	s.asyncRun(record)
 	return nil
 }
 

--- a/pkg/actions/service.go
+++ b/pkg/actions/service.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"sync"
 	"time"
 
 	"github.com/hashicorp/go-multierror"
@@ -20,6 +21,9 @@ type Service struct {
 	DB     db.Database
 	Source Source
 	Writer OutputWriter
+	ctx    context.Context
+	cancel context.CancelFunc
+	wg     sync.WaitGroup
 }
 
 type Task struct {
@@ -81,12 +85,36 @@ const defaultFetchSize = 1024
 
 var ErrNotFound = errors.New("not found")
 
-func NewService(db db.Database, source Source, writer OutputWriter) *Service {
+func NewService(ctx context.Context, db db.Database, source Source, writer OutputWriter) *Service {
+	ctx, cancel := context.WithCancel(ctx)
 	return &Service{
 		DB:     db,
 		Source: source,
 		Writer: writer,
+		ctx:    ctx,
+		cancel: cancel,
+		wg:     sync.WaitGroup{},
 	}
+}
+
+func (s *Service) Stop() {
+	s.cancel()
+	s.wg.Wait()
+}
+
+func (s *Service) AsyncRun(record graveler.HookRecord) error {
+	s.wg.Add(1)
+	go func() {
+		defer s.wg.Done()
+
+		// passing the global context for cancelling all runs when lakeFS shuts down
+		if err := s.Run(s.ctx, record); err != nil {
+			logging.Default().WithField("record", record).
+				Info("Async run of hook failed")
+		}
+	}()
+
+	return nil
 }
 
 // Run load and run actions based on the event information
@@ -271,9 +299,7 @@ func buildRunManifestFromTasks(record graveler.HookRecord, tasks [][]*Task) RunM
 				manifest.Run.EndTime = task.EndTime
 			}
 			// did we failed
-			if manifest.Run.Passed && task.Err != nil {
-				manifest.Run.Passed = false
-			}
+			manifest.Run.Passed = manifest.Run.Passed && task.Err != nil
 		}
 	}
 
@@ -397,8 +423,8 @@ func (s *Service) PostCommitHook(ctx context.Context, record graveler.HookRecord
 	if err != nil {
 		return err
 	}
-	// post commit actions will be enabled here
-	return nil
+
+	return s.Run(ctx, record)
 }
 
 func (s *Service) PreMergeHook(ctx context.Context, record graveler.HookRecord) error {
@@ -411,8 +437,8 @@ func (s *Service) PostMergeHook(ctx context.Context, record graveler.HookRecord)
 	if err != nil {
 		return err
 	}
-	// post merge actions will be enabled here
-	return nil
+
+	return s.Run(ctx, record)
 }
 
 func NewHookRunID(actionIdx, hookIdx int) string {

--- a/pkg/actions/service_test.go
+++ b/pkg/actions/service_test.go
@@ -150,7 +150,8 @@ hooks:
 
 	// run actions
 	now := time.Now()
-	actionsService := actions.NewService(conn, testSource, testOutputWriter)
+	actionsService := actions.NewService(ctx, conn, testSource, testOutputWriter)
+	defer actionsService.Stop()
 
 	err := actionsService.Run(ctx, record)
 	if err != nil {

--- a/pkg/api/serve_test.go
+++ b/pkg/api/serve_test.go
@@ -89,6 +89,7 @@ func setupHandler(t testing.TB, blockstoreType string, opts ...testutil.GetDBOpt
 
 	// wire actions
 	actionsService := actions.NewService(
+		ctx,
 		conn,
 		catalog.NewActionsSource(c),
 		catalog.NewActionsOutputWriter(c.BlockAdapter),

--- a/pkg/loadtest/local_load_test.go
+++ b/pkg/loadtest/local_load_test.go
@@ -73,6 +73,7 @@ func TestLocalLoad(t *testing.T) {
 
 	// wire actions
 	actionsService := actions.NewService(
+		ctx,
 		conn,
 		catalog.NewActionsSource(c),
 		catalog.NewActionsOutputWriter(c.BlockAdapter),


### PR DESCRIPTION
closes #2182 
Adds 2 more hooks triggering events: `post-commit` and `post-merge`. Both of them are non-blocking. For example, if a commit succeeded, the appropriate action will be triggered and the commit action will return without waiting for the `post-commit` run. To support it, the `ActionService` now has a draining mechanism for any ongoing running hook when the system shuts down.