### PR TITLE
preserve scheme for hadoop fs filesystem

### DIFF
--- a/clients/hadoopfs/src/main/java/io/lakefs/Constants.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/Constants.java
@@ -3,7 +3,6 @@ package io.lakefs;
 import org.apache.commons.io.FileUtils;
 
 class Constants {
-    public static final String URI_SCHEME = "lakefs";
     public static final String FS_LAKEFS_ENDPOINT_KEY = "fs.lakefs.endpoint";
     public static final String FS_LAKEFS_ACCESS_KEY = "fs.lakefs.access.key";
     public static final String FS_LAKEFS_SECRET_KEY = "fs.lakefs.secret.key";

--- a/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileSystem.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileSystem.java
@@ -8,7 +8,6 @@ import io.lakefs.clients.api.model.*;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.*;
 import org.apache.hadoop.fs.permission.FsPermission;
-import org.apache.hadoop.fs.s3a.S3AFileSystem;
 import org.apache.hadoop.util.Progressable;
 import org.apache.http.HttpStatus;
 import org.slf4j.Logger;
@@ -48,6 +47,7 @@ public class LakeFSFileSystem extends FileSystem {
     private LakeFSClient lfsClient;
     private int listAmount;
     private FileSystem fsForConfig;
+    private String scheme;
 
     private URI translateUri(URI uri) throws java.net.URISyntaxException {
         switch (uri.getScheme()) {
@@ -70,6 +70,7 @@ public class LakeFSFileSystem extends FileSystem {
 
     void initializeWithClient(URI name, Configuration conf, LakeFSClient lfsClient) throws IOException {
         super.initialize(name, conf);
+        this.scheme = name.getScheme();
         this.conf = conf;
 
         String host = name.getHost();
@@ -433,7 +434,7 @@ public class LakeFSFileSystem extends FileSystem {
         try {
             ObjectsApi objectsApi = lfsClient.getObjects();
             ObjectStats objectStat = objectsApi.statObject(objectLoc.getRepository(), objectLoc.getRef(), objectLoc.getPath());
-            LakeFSFileStatus fileStatus = convertObjectStatsToFileStatus(objectLoc.getRepository(), objectLoc.getRef(), objectStat);
+            LakeFSFileStatus fileStatus = convertObjectStatsToFileStatus(objectLoc, objectStat);
             return new FileStatus[]{fileStatus};
         } catch (ApiException e) {
             if (e.getCode() != HttpStatus.SC_NOT_FOUND) {
@@ -476,7 +477,7 @@ public class LakeFSFileSystem extends FileSystem {
         ObjectsApi objectsApi = lfsClient.getObjects();
         try {
             ObjectStats objectStat = objectsApi.statObject(objectLoc.getRepository(), objectLoc.getRef(), objectLoc.getPath());
-            return convertObjectStatsToFileStatus(objectLoc.getRepository(), objectLoc.getRef(), objectStat);
+            return convertObjectStatsToFileStatus(objectLoc, objectStat);
         } catch (ApiException e) {
             if (e.getCode() != HttpStatus.SC_NOT_FOUND) {
                 throw new IOException("statObject", e);
@@ -493,7 +494,7 @@ public class LakeFSFileSystem extends FileSystem {
     }
 
     @Nonnull
-    private LakeFSFileStatus convertObjectStatsToFileStatus(String repository, String ref, ObjectStats objectStat) throws IOException {
+    private LakeFSFileStatus convertObjectStatsToFileStatus(ObjectLocation objectLocation, ObjectStats objectStat) throws IOException {
         try {
             long length = 0;
             Long sizeBytes = objectStat.getSizeBytes();
@@ -505,7 +506,8 @@ public class LakeFSFileSystem extends FileSystem {
             if (mtime != null) {
                 modificationTime = TimeUnit.SECONDS.toMillis(mtime);
             }
-            Path filePath = new Path(ObjectLocation.formatPath(repository, ref, objectStat.getPath()));
+            Path filePath = new Path(ObjectLocation.formatPath(objectLocation.getScheme(), objectLocation.getRepository(),
+                    objectLocation.getRef(), objectStat.getPath()));
             boolean isDir = isDirectory(objectStat);
             long blockSize = 0;
             if (!isDir) {
@@ -528,7 +530,7 @@ public class LakeFSFileSystem extends FileSystem {
      */
     @Override
     public String getScheme() {
-        return Constants.URI_SCHEME;
+        return scheme;
     }
 
     @Override
@@ -572,6 +574,7 @@ public class LakeFSFileSystem extends FileSystem {
 
         URI uri = path.toUri();
         ObjectLocation loc = new ObjectLocation();
+        loc.setScheme(uri.getScheme());
         loc.setRepository(uri.getHost());
         // extract ref and rest of the path after removing the '/' prefix
         String s = ObjectLocation.trimLeadingSlash(uri.getPath());
@@ -661,8 +664,7 @@ public class LakeFSFileSystem extends FileSystem {
             }
             ObjectStats objectStats = chunk.get(pos++);
             LakeFSFileStatus fileStatus = convertObjectStatsToFileStatus(
-                    objectLocation.getRepository(),
-                    objectLocation.getRef(),
+                    objectLocation,
                     objectStats);
             return toLakeFSLocatedFileStatus(fileStatus);
         }

--- a/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileSystem.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileSystem.java
@@ -47,7 +47,6 @@ public class LakeFSFileSystem extends FileSystem {
     private LakeFSClient lfsClient;
     private int listAmount;
     private FileSystem fsForConfig;
-    private String scheme;
 
     private URI translateUri(URI uri) throws java.net.URISyntaxException {
         switch (uri.getScheme()) {
@@ -70,17 +69,15 @@ public class LakeFSFileSystem extends FileSystem {
 
     void initializeWithClient(URI name, Configuration conf, LakeFSClient lfsClient) throws IOException {
         super.initialize(name, conf);
-        this.scheme = name.getScheme();
+        this.uri = name;
         this.conf = conf;
+        this.lfsClient = lfsClient;
 
         String host = name.getHost();
         if (host == null) {
             throw new IOException("Invalid repository specified");
         }
         setConf(conf);
-        this.uri = name;
-
-        this.lfsClient = lfsClient;
 
         listAmount = conf.getInt(FS_LAKEFS_LIST_AMOUNT_KEY, DEFAULT_LIST_AMOUNT);
 
@@ -530,7 +527,7 @@ public class LakeFSFileSystem extends FileSystem {
      */
     @Override
     public String getScheme() {
-        return scheme;
+        return this.uri.getScheme();
     }
 
     @Override

--- a/clients/hadoopfs/src/main/java/io/lakefs/ObjectLocation.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/ObjectLocation.java
@@ -1,12 +1,21 @@
 package io.lakefs;
 
 class ObjectLocation {
+    private String scheme;
     private String repository;
     private String ref;
     private String path;
 
-    public static String formatPath(String repository, String ref, String path) {
-        return String.format("%s://%s/%s/%s", Constants.URI_SCHEME,repository, ref, path);
+    public static String formatPath(String scheme, String repository, String ref, String path) {
+        return String.format("%s://%s/%s/%s", scheme, repository, ref, path);
+    }
+
+    public String getScheme() {
+        return scheme;
+    }
+
+    public void setScheme(String scheme) {
+        this.scheme = scheme;
     }
 
     public String getRepository() {
@@ -66,6 +75,6 @@ class ObjectLocation {
 
     @Override
     public String toString() {
-        return formatPath(repository, ref, path);
+        return formatPath(scheme, repository, ref, path);
     }
 }


### PR DESCRIPTION
@arielshaqed found the following issue and a way to improve the use of lakeFS hadoop filesystem - Thanks!

### Problem

The lakefs filesystem uses the constant 'lakefs' as a scheme when formatting objects locations. 
This prevents instantiate multiple lakeFS implementations based on different schemes.

### Solution

Using the scheme passed to the implementation we will enable initiate multiple/different lakefs fs implementations. Each instance will use the scheme to format the object locations.
