### PR TITLE
Fix LakeFS startup with Azure storage type

### DIFF
--- a/cmd/lakefs/cmd/run.go
+++ b/cmd/lakefs/cmd/run.go
@@ -231,7 +231,7 @@ func checkForeignRepos(ctx context.Context, logger logging.Logger, authMetadataM
 					logger.WithError(err).Fatalf("Failed to parse to parse storage type '%s'", nsURL)
 				}
 
-				if adapterStorageType != repoStorageType.String() {
+				if (adapterStorageType != repoStorageType.String() && adapterStorageType != "azure") || ("https" != repoStorageType.String() && adapterStorageType == "azure") {
 					logger.Fatalf("Mismatched adapter detected. lakeFS started with adapter of type '%s', but repository '%s' is of type '%s'",
 						adapterStorageType, repo.Name, repoStorageType)
 				}

--- a/cmd/lakefs/cmd/run.go
+++ b/cmd/lakefs/cmd/run.go
@@ -231,7 +231,7 @@ func checkForeignRepos(ctx context.Context, logger logging.Logger, authMetadataM
 					logger.WithError(err).Fatalf("Failed to parse to parse storage type '%s'", nsURL)
 				}
 
-				if (adapterStorageType != repoStorageType.String() && adapterStorageType != "azure") || ("https" != repoStorageType.String() && adapterStorageType == "azure") {
+				if (adapterStorageType != repoStorageType.String() && adapterStorageType != "azure") || (repoStorageType.String() != "https" && adapterStorageType == "azure") {
 					logger.Fatalf("Mismatched adapter detected. lakeFS started with adapter of type '%s', but repository '%s' is of type '%s'",
 						adapterStorageType, repo.Name, repoStorageType)
 				}


### PR DESCRIPTION
LakeFS is not able to start after a restart if using Azure Blob storage as it returns `https` as storage class and lakeFS uses `azure` as storage class. This is fixed by an extended check for exactly this case by this PR.