### PR TITLE
[lakectl] Show "fs" command, start all command descriptions with capital letter

### DIFF
--- a/cmd/lakectl/cmd/abuse.go
+++ b/cmd/lakectl/cmd/abuse.go
@@ -18,7 +18,7 @@ import (
 
 var abuseCmd = &cobra.Command{
 	Use:    "abuse <sub command>",
-	Short:  "abuse a running lakeFS instance. See sub commands for more info.",
+	Short:  "Abuse a running lakeFS instance. See sub commands for more info.",
 	Hidden: true,
 }
 

--- a/cmd/lakectl/cmd/auth.go
+++ b/cmd/lakectl/cmd/auth.go
@@ -41,18 +41,18 @@ var policyCreatedTemplate = `{{ "Policy created successfully." | green }}
 
 var authCmd = &cobra.Command{
 	Use:   "auth [sub-command]",
-	Short: "manage authentication and authorization",
+	Short: "Manage authentication and authorization",
 	Long:  "manage authentication and authorization including users, groups and policies",
 }
 
 var authUsers = &cobra.Command{
 	Use:   "users",
-	Short: "manage users",
+	Short: "Manage users",
 }
 
 var authUsersList = &cobra.Command{
 	Use:   "list",
-	Short: "list users",
+	Short: "List users",
 	Run: func(cmd *cobra.Command, args []string) {
 		amount, _ := cmd.Flags().GetInt("amount")
 		after, _ := cmd.Flags().GetString("after")
@@ -79,7 +79,7 @@ var authUsersList = &cobra.Command{
 
 var authUsersCreate = &cobra.Command{
 	Use:   "create",
-	Short: "create a user",
+	Short: "Create a user",
 	Run: func(cmd *cobra.Command, args []string) {
 		id, _ := cmd.Flags().GetString("id")
 		clt := getClient()
@@ -95,7 +95,7 @@ var authUsersCreate = &cobra.Command{
 
 var authUsersDelete = &cobra.Command{
 	Use:   "delete",
-	Short: "delete a user",
+	Short: "Delete a user",
 	Run: func(cmd *cobra.Command, args []string) {
 		id, _ := cmd.Flags().GetString("id")
 		clt := getClient()
@@ -108,12 +108,12 @@ var authUsersDelete = &cobra.Command{
 
 var authUsersGroups = &cobra.Command{
 	Use:   "groups",
-	Short: "manage user groups",
+	Short: "Manage user groups",
 }
 
 var authUsersGroupsList = &cobra.Command{
 	Use:   "list",
-	Short: "list groups for the given user",
+	Short: "List groups for the given user",
 	Run: func(cmd *cobra.Command, args []string) {
 		id, _ := cmd.Flags().GetString("id")
 		amount, _ := cmd.Flags().GetInt("amount")
@@ -141,12 +141,12 @@ var authUsersGroupsList = &cobra.Command{
 
 var authUsersPolicies = &cobra.Command{
 	Use:   "policies",
-	Short: "manage user policies",
+	Short: "Manage user policies",
 }
 
 var authUsersPoliciesList = &cobra.Command{
 	Use:   "list",
-	Short: "list policies for the given user",
+	Short: "List policies for the given user",
 	Run: func(cmd *cobra.Command, args []string) {
 		id, _ := cmd.Flags().GetString("id")
 		amount, _ := cmd.Flags().GetInt("amount")
@@ -179,7 +179,7 @@ var authUsersPoliciesList = &cobra.Command{
 
 var authUsersPoliciesAttach = &cobra.Command{
 	Use:   "attach",
-	Short: "attach a policy to a user",
+	Short: "Attach a policy to a user",
 	Run: func(cmd *cobra.Command, args []string) {
 		id, _ := cmd.Flags().GetString("id")
 		policy, _ := cmd.Flags().GetString("policy")
@@ -192,7 +192,7 @@ var authUsersPoliciesAttach = &cobra.Command{
 
 var authUsersPoliciesDetach = &cobra.Command{
 	Use:   "detach",
-	Short: "detach a policy from a user",
+	Short: "Detach a policy from a user",
 	Run: func(cmd *cobra.Command, args []string) {
 		id, _ := cmd.Flags().GetString("id")
 		policy, _ := cmd.Flags().GetString("policy")
@@ -207,12 +207,12 @@ var authUsersPoliciesDetach = &cobra.Command{
 
 var authUsersCredentials = &cobra.Command{
 	Use:   "credentials",
-	Short: "manage user credentials",
+	Short: "Manage user credentials",
 }
 
 var authUsersCredentialsCreate = &cobra.Command{
 	Use:   "create",
-	Short: "create user credentials",
+	Short: "Create user credentials",
 	Run: func(cmd *cobra.Command, args []string) {
 		id, _ := cmd.Flags().GetString("id")
 		clt := getClient()
@@ -233,7 +233,7 @@ var authUsersCredentialsCreate = &cobra.Command{
 
 var authUsersCredentialsDelete = &cobra.Command{
 	Use:   "delete",
-	Short: "delete user credentials",
+	Short: "Delete user credentials",
 	Run: func(cmd *cobra.Command, args []string) {
 		id, _ := cmd.Flags().GetString("id")
 		accessKeyID, _ := cmd.Flags().GetString("access-key-id")
@@ -253,7 +253,7 @@ var authUsersCredentialsDelete = &cobra.Command{
 
 var authUsersCredentialsList = &cobra.Command{
 	Use:   "list",
-	Short: "list user credentials",
+	Short: "List user credentials",
 	Run: func(cmd *cobra.Command, args []string) {
 		amount, _ := cmd.Flags().GetInt("amount")
 		after, _ := cmd.Flags().GetString("after")
@@ -286,12 +286,12 @@ var authUsersCredentialsList = &cobra.Command{
 // groups
 var authGroups = &cobra.Command{
 	Use:   "groups",
-	Short: "manage groups",
+	Short: "Manage groups",
 }
 
 var authGroupsList = &cobra.Command{
 	Use:   "list",
-	Short: "list groups",
+	Short: "List groups",
 	Run: func(cmd *cobra.Command, args []string) {
 		amount, _ := cmd.Flags().GetInt("amount")
 		after, _ := cmd.Flags().GetString("after")
@@ -318,7 +318,7 @@ var authGroupsList = &cobra.Command{
 
 var authGroupsCreate = &cobra.Command{
 	Use:   "create",
-	Short: "create a group",
+	Short: "Create a group",
 	Run: func(cmd *cobra.Command, args []string) {
 		id, _ := cmd.Flags().GetString("id")
 		clt := getClient()
@@ -334,7 +334,7 @@ var authGroupsCreate = &cobra.Command{
 
 var authGroupsDelete = &cobra.Command{
 	Use:   "delete",
-	Short: "delete a group",
+	Short: "Delete a group",
 	Run: func(cmd *cobra.Command, args []string) {
 		id, _ := cmd.Flags().GetString("id")
 		clt := getClient()
@@ -347,12 +347,12 @@ var authGroupsDelete = &cobra.Command{
 
 var authGroupsMembers = &cobra.Command{
 	Use:   "members",
-	Short: "manage group user memberships",
+	Short: "Manage group user memberships",
 }
 
 var authGroupsListMembers = &cobra.Command{
 	Use:   "list",
-	Short: "list users in a group",
+	Short: "List users in a group",
 	Run: func(cmd *cobra.Command, args []string) {
 		id, _ := cmd.Flags().GetString("id")
 		amount, _ := cmd.Flags().GetInt("amount")
@@ -379,7 +379,7 @@ var authGroupsListMembers = &cobra.Command{
 
 var authGroupsAddMember = &cobra.Command{
 	Use:   "add",
-	Short: "add a user to a group",
+	Short: "Add a user to a group",
 	Run: func(cmd *cobra.Command, args []string) {
 		id, _ := cmd.Flags().GetString("id")
 		user, _ := cmd.Flags().GetString("user")
@@ -393,7 +393,7 @@ var authGroupsAddMember = &cobra.Command{
 
 var authGroupsRemoveMember = &cobra.Command{
 	Use:   "remove",
-	Short: "remove a user from a group",
+	Short: "Remove a user from a group",
 	Run: func(cmd *cobra.Command, args []string) {
 		id, _ := cmd.Flags().GetString("id")
 		user, _ := cmd.Flags().GetString("user")
@@ -407,12 +407,12 @@ var authGroupsRemoveMember = &cobra.Command{
 
 var authGroupsPolicies = &cobra.Command{
 	Use:   "policies",
-	Short: "manage group policies",
+	Short: "Manage group policies",
 }
 
 var authGroupsPoliciesList = &cobra.Command{
 	Use:   "list",
-	Short: "list policies for the given group",
+	Short: "List policies for the given group",
 	Run: func(cmd *cobra.Command, args []string) {
 		id, _ := cmd.Flags().GetString("id")
 		amount, _ := cmd.Flags().GetInt("amount")
@@ -443,7 +443,7 @@ var authGroupsPoliciesList = &cobra.Command{
 
 var authGroupsPoliciesAttach = &cobra.Command{
 	Use:   "attach",
-	Short: "attach a policy to a group",
+	Short: "Attach a policy to a group",
 	Run: func(cmd *cobra.Command, args []string) {
 		id, _ := cmd.Flags().GetString("id")
 		policy, _ := cmd.Flags().GetString("policy")
@@ -458,7 +458,7 @@ var authGroupsPoliciesAttach = &cobra.Command{
 
 var authGroupsPoliciesDetach = &cobra.Command{
 	Use:   "detach",
-	Short: "detach a policy from a group",
+	Short: "Detach a policy from a group",
 	Run: func(cmd *cobra.Command, args []string) {
 		id, _ := cmd.Flags().GetString("id")
 		policy, _ := cmd.Flags().GetString("policy")
@@ -474,12 +474,12 @@ var authGroupsPoliciesDetach = &cobra.Command{
 // policies
 var authPolicies = &cobra.Command{
 	Use:   "policies",
-	Short: "manage policies",
+	Short: "Manage policies",
 }
 
 var authPoliciesList = &cobra.Command{
 	Use:   "list",
-	Short: "list policies",
+	Short: "List policies",
 	Run: func(cmd *cobra.Command, args []string) {
 		amount, _ := cmd.Flags().GetInt("amount")
 		after, _ := cmd.Flags().GetString("after")
@@ -505,7 +505,7 @@ var authPoliciesList = &cobra.Command{
 
 var authPoliciesCreate = &cobra.Command{
 	Use:   "create",
-	Short: "create a policy",
+	Short: "Create a policy",
 	Run: func(cmd *cobra.Command, args []string) {
 		id, _ := cmd.Flags().GetString("id")
 		document, _ := cmd.Flags().GetString("statement-document")
@@ -555,7 +555,7 @@ type StatementDoc struct {
 
 var authPoliciesShow = &cobra.Command{
 	Use:   "show",
-	Short: "show a policy",
+	Short: "Show a policy",
 	Run: func(cmd *cobra.Command, args []string) {
 		id, _ := cmd.Flags().GetString("id")
 		clt := getClient()
@@ -578,7 +578,7 @@ var authPoliciesShow = &cobra.Command{
 
 var authPoliciesDelete = &cobra.Command{
 	Use:   "delete",
-	Short: "delete a policy",
+	Short: "Delete a policy",
 	Run: func(cmd *cobra.Command, args []string) {
 		id, _ := cmd.Flags().GetString("id")
 		clt := getClient()

--- a/cmd/lakectl/cmd/branch.go
+++ b/cmd/lakectl/cmd/branch.go
@@ -17,13 +17,13 @@ const (
 // branchCmd represents the branch command
 var branchCmd = &cobra.Command{
 	Use:   "branch",
-	Short: "create and manage branches within a repository",
+	Short: "Create and manage branches within a repository",
 	Long:  `Create delete and list branches within a lakeFS repository`,
 }
 
 var branchListCmd = &cobra.Command{
 	Use:     "list <repository uri>",
-	Short:   "list branches in a repository",
+	Short:   "List branches in a repository",
 	Example: "lakectl branch list lakefs://<repository>",
 	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
@@ -50,7 +50,7 @@ var branchListCmd = &cobra.Command{
 
 var branchCreateCmd = &cobra.Command{
 	Use:   "create <ref uri>",
-	Short: "create a new branch in a repository",
+	Short: "Create a new branch in a repository",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		u := MustParseRefURI("branch", args[0])
@@ -76,7 +76,7 @@ var branchCreateCmd = &cobra.Command{
 
 var branchDeleteCmd = &cobra.Command{
 	Use:   "delete <branch uri>",
-	Short: "delete a branch in a repository, along with its uncommitted changes (CAREFUL)",
+	Short: "Delete a branch in a repository, along with its uncommitted changes (CAREFUL)",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		confirmation, err := Confirm(cmd.Flags(), "Are you sure you want to delete branch")
@@ -94,7 +94,7 @@ var branchDeleteCmd = &cobra.Command{
 // lakectl branch revert lakefs://myrepo/main commitId
 var branchRevertCmd = &cobra.Command{
 	Use:   "revert <branch uri> <commit ref to revert>",
-	Short: "given a commit, record a new commit to reverse the effect of this commit",
+	Short: "Given a commit, record a new commit to reverse the effect of this commit",
 	Args:  cobra.ExactArgs(branchRevertCmdArgs),
 	Run: func(cmd *cobra.Command, args []string) {
 		u := MustParseRefURI("branch", args[0])
@@ -121,7 +121,7 @@ var branchRevertCmd = &cobra.Command{
 // lakectl branch reset lakefs://myrepo/main --commit commitId --prefix path --object path
 var branchResetCmd = &cobra.Command{
 	Use:   "reset <branch uri> [flags]",
-	Short: "reset changes to specified commit, or reset uncommitted changes - all changes, or by path",
+	Short: "Reset changes to specified commit, or reset uncommitted changes - all changes, or by path",
 	Long: `reset changes.  There are four different ways to reset changes:
   1. reset all uncommitted changes - reset lakefs://myrepo/main 
   2. reset uncommitted changes under specific path -	reset lakefs://myrepo/main --prefix path
@@ -174,7 +174,7 @@ var branchResetCmd = &cobra.Command{
 
 var branchShowCmd = &cobra.Command{
 	Use:   "show <branch uri>",
-	Short: "show branch latest commit reference",
+	Short: "Show branch latest commit reference",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getClient()

--- a/cmd/lakectl/cmd/commit.go
+++ b/cmd/lakectl/cmd/commit.go
@@ -22,7 +22,7 @@ var errInvalidKeyValueFormat = fmt.Errorf("invalid key/value pair - should be se
 
 var commitCmd = &cobra.Command{
 	Use:   "commit <branch uri>",
-	Short: "commit changes on a given branch",
+	Short: "Commit changes on a given branch",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		// validate message

--- a/cmd/lakectl/cmd/config.go
+++ b/cmd/lakectl/cmd/config.go
@@ -15,7 +15,7 @@ import (
 // configCmd represents the config command
 var configCmd = &cobra.Command{
 	Use:   "config",
-	Short: "create/update local lakeFS configuration",
+	Short: "Create/update local lakeFS configuration",
 	Run: func(cmd *cobra.Command, args []string) {
 		if viper.ConfigFileUsed() == "" {
 			// Find home directory.

--- a/cmd/lakectl/cmd/fs.go
+++ b/cmd/lakectl/cmd/fs.go
@@ -33,7 +33,7 @@ Human Total Size: {{.Bytes|human_bytes}}
 
 var fsStatCmd = &cobra.Command{
 	Use:   "stat <path uri>",
-	Short: "view object metadata",
+	Short: "View object metadata",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		pathURI := MustParsePathURI("path", args[0])
@@ -55,7 +55,7 @@ const fsLsTemplate = `{{ range $val := . -}}
 
 var fsListCmd = &cobra.Command{
 	Use:   "ls <path uri>",
-	Short: "list entries under a given tree",
+	Short: "List entries under a given tree",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getClient()
@@ -108,7 +108,7 @@ var fsListCmd = &cobra.Command{
 
 var fsCatCmd = &cobra.Command{
 	Use:   "cat <path uri>",
-	Short: "dump content of object to stdout",
+	Short: "Dump content of object to stdout",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getClient()
@@ -181,7 +181,7 @@ func uploadObject(ctx context.Context, client api.ClientWithResponsesInterface, 
 
 var fsUploadCmd = &cobra.Command{
 	Use:   "upload <path uri>",
-	Short: "upload a local file to the specified URI",
+	Short: "Upload a local file to the specified URI",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getClient()
@@ -232,7 +232,7 @@ var fsUploadCmd = &cobra.Command{
 
 var fsStageCmd = &cobra.Command{
 	Use:    "stage <path uri>",
-	Short:  "stages a reference to an existing object, to be managed in lakeFS",
+	Short:  "Stage a reference to an existing object, to be managed in lakeFS",
 	Hidden: true,
 	Args:   cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
@@ -273,7 +273,7 @@ var fsStageCmd = &cobra.Command{
 
 var fsRmCmd = &cobra.Command{
 	Use:   "rm <path uri>",
-	Short: "delete object",
+	Short: "Delete object",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		pathURI := MustParsePathURI("path", args[0])
@@ -288,7 +288,7 @@ var fsRmCmd = &cobra.Command{
 // fsCmd represents the fs command
 var fsCmd = &cobra.Command{
 	Use:    "fs",
-	Short:  "view and manipulate objects",
+	Short:  "View and manipulate objects",
 	Hidden: true,
 }
 

--- a/cmd/lakectl/cmd/fs.go
+++ b/cmd/lakectl/cmd/fs.go
@@ -287,8 +287,8 @@ var fsRmCmd = &cobra.Command{
 
 // fsCmd represents the fs command
 var fsCmd = &cobra.Command{
-	Use:    "fs",
-	Short:  "View and manipulate objects",
+	Use:   "fs",
+	Short: "View and manipulate objects",
 }
 
 //nolint:gochecknoinits

--- a/cmd/lakectl/cmd/fs.go
+++ b/cmd/lakectl/cmd/fs.go
@@ -289,7 +289,6 @@ var fsRmCmd = &cobra.Command{
 var fsCmd = &cobra.Command{
 	Use:    "fs",
 	Short:  "View and manipulate objects",
-	Hidden: true,
 }
 
 //nolint:gochecknoinits

--- a/cmd/lakectl/cmd/gc.go
+++ b/cmd/lakectl/cmd/gc.go
@@ -24,12 +24,12 @@ Branch Rules: {{ range $branch := .Branches }}
 
 var gcCmd = &cobra.Command{
 	Use:   "gc",
-	Short: "manage garbage collection configuration",
+	Short: "Manage garbage collection configuration",
 }
 
 var gcSetConfigCmd = &cobra.Command{
 	Use:   "set-config",
-	Short: "set the garbage collection configuration JSON",
+	Short: "Set garbage collection configuration JSON",
 	Long: `Sets the garbage collection configuration JSON.
 Example configuration file:
 {
@@ -79,7 +79,7 @@ Example configuration file:
 
 var gcGetConfigCmd = &cobra.Command{
 	Use:     "get-config",
-	Short:   "show the garbage collection configuration JSON",
+	Short:   "Show garbage collection configuration JSON",
 	Example: "lakectl gc get-config <repository uri>",
 	Args:    cobra.ExactArgs(gcSetConfigCmdArgs),
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/lakectl/cmd/log.go
+++ b/cmd/lakectl/cmd/log.go
@@ -25,7 +25,8 @@ Merge:         {{ $val.Parents|join ", "|bold }}
 // logCmd represents the log command
 var logCmd = &cobra.Command{
 	Use:   "log <branch uri>",
-	Short: "show log of commits for the given branch",
+	Short: "Show log of commits",
+	Long:  "Show log of commits for a given branch",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		amount := MustInt(cmd.Flags().GetInt("amount"))

--- a/cmd/lakectl/cmd/merge.go
+++ b/cmd/lakectl/cmd/merge.go
@@ -27,8 +27,8 @@ type FromTo struct {
 // mergeCmd represents the merge command
 var mergeCmd = &cobra.Command{
 	Use:   "merge <source ref> <destination ref>",
-	Short: "merge",
-	Long:  "merge & commit changes from source branch into destination branch",
+	Short: "Merge & commit changes from source branch into destination branch",
+	Long:  "Merge & commit changes from source branch into destination branch",
 	Args:  cobra.RangeArgs(mergeCmdMinArgs, mergeCmdMaxArgs),
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getClient()

--- a/cmd/lakectl/cmd/metastore.go
+++ b/cmd/lakectl/cmd/metastore.go
@@ -14,12 +14,12 @@ import (
 
 var metastoreCmd = &cobra.Command{
 	Use:   "metastore",
-	Short: "manage metastore commands",
+	Short: "Manage metastore commands",
 }
 
 var metastoreCopyCmd = &cobra.Command{
 	Use:   "copy",
-	Short: "copy or merge table",
+	Short: "Copy or merge table",
 	Long:  "copy or merge table. the destination table will point to the selected branch",
 	Run: func(cmd *cobra.Command, args []string) {
 		fromClientType, _ := cmd.Flags().GetString("from-client-type")
@@ -100,7 +100,7 @@ func getMetastoreClient(msType, hiveAddress string) (metastore.Client, func()) {
 
 var metastoreCopyAllCmd = &cobra.Command{
 	Use:   "copy-all",
-	Short: "copy from one metastore to another",
+	Short: "Copy from one metastore to another",
 	Long:  "copy or merge requested tables between hive metastores. the destination tables will point to the selected branch",
 	Run: func(cmd *cobra.Command, args []string) {
 		fromClientType, _ := cmd.Flags().GetString("from-client-type")
@@ -131,7 +131,7 @@ var metastoreCopyAllCmd = &cobra.Command{
 
 var metastoreImportAllCmd = &cobra.Command{
 	Use:   "import-all",
-	Short: "import from one metastore to another",
+	Short: "Import from one metastore to another",
 	Long: `
 import requested tables between hive metastores. the destination tables will point to the selected repository and branch
 table with location s3://my-s3-bucket/path/to/table 
@@ -167,7 +167,7 @@ will be transformed to location s3://repo-param/bucket-param/path/to/table
 
 var metastoreDiffCmd = &cobra.Command{
 	Use:   "diff",
-	Short: "show column and partition differences between two tables",
+	Short: "Show column and partition differences between two tables",
 	Run: func(cmd *cobra.Command, args []string) {
 		fromClientType, _ := cmd.Flags().GetString("from-client-type")
 		toAddress, _ := cmd.Flags().GetString("to-address")
@@ -222,7 +222,7 @@ var metastoreDiffCmd = &cobra.Command{
 
 var glueSymlinkCmd = &cobra.Command{
 	Use:   "create-symlink",
-	Short: "create symlink table and data",
+	Short: "Create symlink table and data",
 	Long:  "create table with symlinks, and create the symlinks in s3 in order to access from external services that could only access s3 directly (e.g athena)",
 	Run: func(cmd *cobra.Command, args []string) {
 		repo, _ := cmd.Flags().GetString("repo")

--- a/cmd/lakectl/cmd/refs.go
+++ b/cmd/lakectl/cmd/refs.go
@@ -18,7 +18,7 @@ var refsRestoreSuccess = `
 
 var refsRestoreCmd = &cobra.Command{
 	Use:   "refs-restore <repository uri>",
-	Short: "restores refs (branches, commits, tags) from the underlying object store to a bare repository",
+	Short: "Restores refs (branches, commits, tags) from the underlying object store to a bare repository",
 	Long: `restores refs (branches, commits, tags) from the underlying object store to a bare repository.
 
 This command is expected to run on a bare repository (i.e. one created with 'lakectl repo create-bare').
@@ -55,7 +55,7 @@ Since a bare repo is expected, in case of transient failure, delete the reposito
 
 var refsDumpCmd = &cobra.Command{
 	Use:    "refs-dump <repository uri>",
-	Short:  "dumps refs (branches, commits, tags) to the underlying object store",
+	Short:  "Dumps refs (branches, commits, tags) to the underlying object store",
 	Hidden: true,
 	Args:   cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/lakectl/cmd/repo.go
+++ b/cmd/lakectl/cmd/repo.go
@@ -15,12 +15,12 @@ const (
 // repoCmd represents the repo command
 var repoCmd = &cobra.Command{
 	Use:   "repo",
-	Short: "manage and explore repos",
+	Short: "Manage and explore repos",
 }
 
 var repoListCmd = &cobra.Command{
 	Use:   "list",
-	Short: "list repositories",
+	Short: "List repositories",
 	Run: func(cmd *cobra.Command, args []string) {
 		amount := MustInt(cmd.Flags().GetInt("amount"))
 		after := MustString(cmd.Flags().GetString("after"))
@@ -46,7 +46,7 @@ var repoListCmd = &cobra.Command{
 // lakectl create lakefs://myrepo s3://my-bucket/
 var repoCreateCmd = &cobra.Command{
 	Use:   "create <repository uri> <storage namespace>",
-	Short: "create a new repository ",
+	Short: "Create a new repository ",
 	Args:  cobra.ExactArgs(repoCreateCmdArgs),
 	Run: func(cmd *cobra.Command, args []string) {
 		clt := getClient()
@@ -78,7 +78,7 @@ var repoCreateCmd = &cobra.Command{
 // lakectl create-bare lakefs://myrepo s3://my-bucket/
 var repoCreateBareCmd = &cobra.Command{
 	Use:    "create-bare <repository uri> <storage namespace>",
-	Short:  "create a new repository with no initial branch or commit",
+	Short:  "Create a new repository with no initial branch or commit",
 	Hidden: true,
 	Args:   cobra.ExactArgs(repoCreateCmdArgs),
 	Run: func(cmd *cobra.Command, args []string) {
@@ -112,7 +112,7 @@ var repoCreateBareCmd = &cobra.Command{
 // lakectl delete lakefs://myrepo
 var repoDeleteCmd = &cobra.Command{
 	Use:   "delete <repository uri>",
-	Short: "delete existing repository",
+	Short: "Delete existing repository",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		clt := getClient()

--- a/cmd/lakectl/cmd/tag.go
+++ b/cmd/lakectl/cmd/tag.go
@@ -10,13 +10,13 @@ const tagCreateRequiredArgs = 2
 // tagCmd represents the tag command
 var tagCmd = &cobra.Command{
 	Use:   "tag",
-	Short: "create and manage tags within a repository",
+	Short: "Create and manage tags within a repository",
 	Long:  `Create delete and list tags within a lakeFS repository`,
 }
 
 var tagListCmd = &cobra.Command{
 	Use:     "list <repository uri>",
-	Short:   "list tags in a repository",
+	Short:   "List tags in a repository",
 	Example: "lakectl tag list lakefs://<repository>",
 	Args:    cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
@@ -62,7 +62,7 @@ var tagListCmd = &cobra.Command{
 
 var tagCreateCmd = &cobra.Command{
 	Use:   "create <tag uri> <commit ref>",
-	Short: "create a new tag in a repository",
+	Short: "Create a new tag in a repository",
 	Args:  cobra.ExactArgs(tagCreateRequiredArgs),
 	Run: func(cmd *cobra.Command, args []string) {
 		tagURI := MustParseRefURI("tag", args[0])
@@ -96,7 +96,7 @@ var tagCreateCmd = &cobra.Command{
 
 var tagDeleteCmd = &cobra.Command{
 	Use:   "delete <tag uri>",
-	Short: "delete a tag from a repository",
+	Short: "Delete a tag from a repository",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		confirmation, err := Confirm(cmd.Flags(), "Are you sure you want to delete tag")
@@ -115,7 +115,7 @@ var tagDeleteCmd = &cobra.Command{
 
 var tagShowCmd = &cobra.Command{
 	Use:   "show <tag uri>",
-	Short: "show tag's commit reference",
+	Short: "Show tag's commit reference",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getClient()

--- a/cmd/lakefs/cmd/migrate.go
+++ b/cmd/lakefs/cmd/migrate.go
@@ -11,7 +11,7 @@ import (
 // migrateCmd represents the migrate command
 var migrateCmd = &cobra.Command{
 	Use:   "migrate",
-	Short: "manage migrations",
+	Short: "Manage migrations",
 }
 
 var versionCmd = &cobra.Command{


### PR DESCRIPTION
Fixes #2204.

Some descriptions still start with a lowercase letter, e.g. when saying "lakeFS"... which is never capitalized.