### PR TITLE
Split StorageType.String

### DIFF
--- a/cmd/lakefs/cmd/run.go
+++ b/cmd/lakefs/cmd/run.go
@@ -233,9 +233,9 @@ func checkForeignRepos(ctx context.Context, logger logging.Logger, authMetadataM
 					logger.WithError(err).Fatalf("Failed to parse to parse storage type '%s'", nsURL)
 				}
 
-				if adapterStorageType != repoStorageType.MatchingAdapterPrefix() {
+				if adapterStorageType != repoStorageType.BlockstoreType() {
 					logger.Fatalf("Mismatched adapter detected. lakeFS started with adapter of type '%s', but repository '%s' is of type '%s'",
-						adapterStorageType, repo.Name, repoStorageType.MatchingAdapterPrefix())
+						adapterStorageType, repo.Name, repoStorageType.BlockstoreType())
 				}
 
 				next = repo.Name

--- a/cmd/lakefs/cmd/run.go
+++ b/cmd/lakefs/cmd/run.go
@@ -233,9 +233,9 @@ func checkForeignRepos(ctx context.Context, logger logging.Logger, authMetadataM
 					logger.WithError(err).Fatalf("Failed to parse to parse storage type '%s'", nsURL)
 				}
 
-				if (adapterStorageType != repoStorageType.String() && adapterStorageType != "azure") || (repoStorageType.String() != "https" && adapterStorageType == "azure") {
+				if adapterStorageType != repoStorageType.MatchingAdapterPrefix() {
 					logger.Fatalf("Mismatched adapter detected. lakeFS started with adapter of type '%s', but repository '%s' is of type '%s'",
-						adapterStorageType, repo.Name, repoStorageType)
+						adapterStorageType, repo.Name, repoStorageType.MatchingAdapterPrefix())
 				}
 
 				next = repo.Name

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -201,9 +201,9 @@ func (c *Controller) LinkPhysicalAddress(w http.ResponseWriter, r *http.Request,
 	}
 
 	blockStoreType := c.BlockAdapter.BlockstoreType()
-	if qk.StorageType.String() != blockStoreType {
+	if qk.StorageType.MatchingAdapterPrefix() != blockStoreType {
 		writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid storage type: %s: current block adapter is %s",
-			qk.StorageType.String(),
+			qk.StorageType.MatchingAdapterPrefix(),
 			blockStoreType,
 		))
 		return

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -201,9 +201,9 @@ func (c *Controller) LinkPhysicalAddress(w http.ResponseWriter, r *http.Request,
 	}
 
 	blockStoreType := c.BlockAdapter.BlockstoreType()
-	if qk.StorageType.MatchingAdapterPrefix() != blockStoreType {
+	if qk.StorageType.BlockstoreType() != blockStoreType {
 		writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid storage type: %s: current block adapter is %s",
-			qk.StorageType.MatchingAdapterPrefix(),
+			qk.StorageType.BlockstoreType(),
 			blockStoreType,
 		))
 		return

--- a/pkg/block/namespace.go
+++ b/pkg/block/namespace.go
@@ -21,7 +21,7 @@ var (
 	ErrInvalidNamespace = errors.New("invalid namespace")
 )
 
-func (s StorageType) MatchingAdapterPrefix() string {
+func (s StorageType) BlockstoreType() string {
 	switch s {
 	case StorageTypeAzure:
 		return "azure"

--- a/pkg/block/namespace.go
+++ b/pkg/block/namespace.go
@@ -21,7 +21,16 @@ var (
 	ErrInvalidNamespace = errors.New("invalid namespace")
 )
 
-func (s StorageType) String() string {
+func (s StorageType) MatchingAdapterPrefix() string {
+	switch s {
+	case StorageTypeAzure:
+		return "azure"
+	default:
+		return s.Scheme()
+	}
+}
+
+func (s StorageType) Scheme() string {
 	scheme := ""
 	switch s {
 	case StorageTypeMem:
@@ -58,7 +67,7 @@ type QualifiedPrefix struct {
 }
 
 func (qk QualifiedKey) Format() string {
-	return qk.StorageType.String() + "://" + formatPathWithNamespace(qk.StorageNamespace, qk.Key)
+	return qk.StorageType.Scheme() + "://" + formatPathWithNamespace(qk.StorageNamespace, qk.Key)
 }
 
 func GetStorageType(namespaceURL *url.URL) (StorageType, error) {


### PR DESCRIPTION
closes #2253 

Azure has a unique behaviour where the storage type (`azure`) doesn't match the scheme (`https` and `http`). Up until now the StorageType struct simply returned the Scheme as the String, which caused a mismatch with the adapter when checking for foreign repos (check #2253). 
This PR removes the `String` function which was used for both logic of `Scheme` and `MatchingAdapterType`, and creates those functions instead.