### PR TITLE
lakefs client configuration key lookup using specific scheme with fallback

### DIFF
--- a/clients/hadoopfs/src/main/java/io/lakefs/Constants.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/Constants.java
@@ -3,7 +3,13 @@ package io.lakefs;
 import org.apache.commons.io.FileUtils;
 
 class Constants {
-    public static final String FS_LAKEFS_LIST_AMOUNT_KEY_SUFFIX = "list.amount";
+    public static final String DEFAULT_SCHEME = "lakefs";
+    public static final String DEFAULT_CLIENT_ENDPOINT = "http://localhost:8000/api/v1";
+    public static final String ACCESS_KEY_KEY_SUFFIX = "access.key";
+    public static final String SECRET_KEY_KEY_SUFFIX = "secret.key";
+    public static final String ENDPOINT_KEY_SUFFIX = "endpoint";
+    public static final String LIST_AMOUNT_KEY_SUFFIX = "list.amount";
+
 
     public static final int DEFAULT_LIST_AMOUNT = 1000;
     public static final String SEPARATOR = "/";

--- a/clients/hadoopfs/src/main/java/io/lakefs/Constants.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/Constants.java
@@ -3,7 +3,7 @@ package io.lakefs;
 import org.apache.commons.io.FileUtils;
 
 class Constants {
-    public static final String FS_LAKEFS_LIST_AMOUNT_KEY = "fs.lakefs.list.amount";
+    public static final String FS_LAKEFS_LIST_AMOUNT_KEY_SUFFIX = "list.amount";
 
     public static final int DEFAULT_LIST_AMOUNT = 1000;
     public static final String SEPARATOR = "/";

--- a/clients/hadoopfs/src/main/java/io/lakefs/Constants.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/Constants.java
@@ -3,9 +3,6 @@ package io.lakefs;
 import org.apache.commons.io.FileUtils;
 
 class Constants {
-    public static final String FS_LAKEFS_ENDPOINT_KEY = "fs.lakefs.endpoint";
-    public static final String FS_LAKEFS_ACCESS_KEY = "fs.lakefs.access.key";
-    public static final String FS_LAKEFS_SECRET_KEY = "fs.lakefs.secret.key";
     public static final String FS_LAKEFS_LIST_AMOUNT_KEY = "fs.lakefs.list.amount";
 
     public static final int DEFAULT_LIST_AMOUNT = 1000;

--- a/clients/hadoopfs/src/main/java/io/lakefs/FSConfiguration.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/FSConfiguration.java
@@ -1,0 +1,48 @@
+package io.lakefs;
+
+import org.apache.hadoop.conf.Configuration;
+
+public final class FSConfiguration {
+    public static final String DEFAULT_SCHEME = "lakefs";
+
+    private static String formatFSConfigurationKey(String scheme, String key) {
+        return "fs." + scheme + "." + key;
+    }
+
+    /**
+     * lookup value from configuration based on scheme and key suffix.
+     * first try to get "fs.\<scheme\>.\<key suffix\>", if value not found use the default scheme
+     * to build a key for lookup.
+     * @param conf configuration object to get the value from
+     * @param scheme used to format the key for lookup
+     * @param keySuffix key suffix to lookup
+     * @return key value or null in case no value found
+     */
+    public static String get(Configuration conf, String scheme, String keySuffix) {
+        String key = formatFSConfigurationKey(scheme, keySuffix);
+        String value = conf.get(key);
+        if (value == null && !scheme.equals(DEFAULT_SCHEME)) {
+            key = formatFSConfigurationKey(DEFAULT_SCHEME, keySuffix);
+            value = conf.get(key);
+        }
+        return value;
+    }
+
+    /**
+     * lookup value from configuration based on scheme and key suffix, returns default in case of null value.
+     * @param conf configuration object to get the value from
+     * @param scheme used to format key for lookup
+     * @param keySuffix key suffix to lookup
+     * @param defaultValue default value returned in case of null
+     * @return value found or default value
+     */
+    public static String get(Configuration conf, String scheme, String keySuffix, String defaultValue) {
+        String value = get(conf, scheme, keySuffix);
+        return (value == null) ? defaultValue : value;
+    }
+
+    public static int getInt(Configuration conf, String scheme, String keySuffix, int defaultValue) {
+        String valueString = get(conf, scheme, keySuffix);
+        return (valueString == null) ? defaultValue : Integer.parseInt(valueString);
+    }
+}

--- a/clients/hadoopfs/src/main/java/io/lakefs/FSConfiguration.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/FSConfiguration.java
@@ -3,7 +3,6 @@ package io.lakefs;
 import org.apache.hadoop.conf.Configuration;
 
 public final class FSConfiguration {
-    public static final String DEFAULT_SCHEME = "lakefs";
 
     private static String formatFSConfigurationKey(String scheme, String key) {
         return "fs." + scheme + "." + key;
@@ -13,16 +12,17 @@ public final class FSConfiguration {
      * lookup value from configuration based on scheme and key suffix.
      * first try to get "fs.\<scheme\>.\<key suffix\>", if value not found use the default scheme
      * to build a key for lookup.
-     * @param conf configuration object to get the value from
-     * @param scheme used to format the key for lookup
+     *
+     * @param conf      configuration object to get the value from
+     * @param scheme    used to format the key for lookup
      * @param keySuffix key suffix to lookup
      * @return key value or null in case no value found
      */
     public static String get(Configuration conf, String scheme, String keySuffix) {
         String key = formatFSConfigurationKey(scheme, keySuffix);
         String value = conf.get(key);
-        if (value == null && !scheme.equals(DEFAULT_SCHEME)) {
-            key = formatFSConfigurationKey(DEFAULT_SCHEME, keySuffix);
+        if (value == null && !scheme.equals(Constants.DEFAULT_SCHEME)) {
+            key = formatFSConfigurationKey(Constants.DEFAULT_SCHEME, keySuffix);
             value = conf.get(key);
         }
         return value;
@@ -30,9 +30,10 @@ public final class FSConfiguration {
 
     /**
      * lookup value from configuration based on scheme and key suffix, returns default in case of null value.
-     * @param conf configuration object to get the value from
-     * @param scheme used to format key for lookup
-     * @param keySuffix key suffix to lookup
+     *
+     * @param conf         configuration object to get the value from
+     * @param scheme       used to format key for lookup
+     * @param keySuffix    key suffix to lookup
      * @param defaultValue default value returned in case of null
      * @return value found or default value
      */

--- a/clients/hadoopfs/src/main/java/io/lakefs/LakeFSClient.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/LakeFSClient.java
@@ -78,7 +78,8 @@ public class LakeFSClient {
         String key = formatFSConfigurationKey(scheme, keySuffix);
         String value = conf.get(key);
         if (value == null && !scheme.equals(DEFAULT_SCHEME)) {
-            value = conf.get(fallbackKey);
+            key = formatFSConfigurationKey(DEFAULT_SCHEME, keySuffix);
+            value = conf.get(key);
         }
         return value;
     }

--- a/clients/hadoopfs/src/main/java/io/lakefs/LakeFSClient.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/LakeFSClient.java
@@ -7,7 +7,6 @@ import io.lakefs.clients.api.StagingApi;
 import io.lakefs.clients.api.auth.HttpBasicAuth;
 import org.apache.hadoop.conf.Configuration;
 
-import javax.xml.bind.annotation.XmlType;
 import java.io.IOException;
 
 /**

--- a/clients/hadoopfs/src/main/java/io/lakefs/LakeFSClient.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/LakeFSClient.java
@@ -14,29 +14,25 @@ import java.io.IOException;
  * This class uses the configuration to initialize API client and instance per API interface we expose.
  */
 public class LakeFSClient {
-    public static final String DEFAULT_ENDPOINT = "http://localhost:8000/api/v1";
     private static final String BASIC_AUTH = "basic_auth";
-    public static final String ACCESS_KEY_KEY_SUFFIX = "access.key";
-    public static final String SECRET_KEY_KEY_SUFFIX = "secret.key";
-    public static final String ENDPOINT_KEY_SUFFIX = "endpoint";
 
     private final ObjectsApi objects;
     private final StagingApi staging;
     private final RepositoriesApi repositories;
 
     public LakeFSClient(String scheme, Configuration conf) throws IOException {
-        String accessKey = FSConfiguration.get(conf, scheme, ACCESS_KEY_KEY_SUFFIX);
+        String accessKey = FSConfiguration.get(conf, scheme, Constants.ACCESS_KEY_KEY_SUFFIX);
         if (accessKey == null) {
             throw new IOException("Missing lakeFS access key");
         }
 
-        String secretKey = FSConfiguration.get(conf, scheme, SECRET_KEY_KEY_SUFFIX);
+        String secretKey = FSConfiguration.get(conf, scheme, Constants.SECRET_KEY_KEY_SUFFIX);
         if (secretKey == null) {
             throw new IOException("Missing lakeFS secret key");
         }
 
         ApiClient apiClient = io.lakefs.clients.api.Configuration.getDefaultApiClient();
-        String endpoint = FSConfiguration.get(conf, scheme, ENDPOINT_KEY_SUFFIX, DEFAULT_ENDPOINT);
+        String endpoint = FSConfiguration.get(conf, scheme, Constants.ENDPOINT_KEY_SUFFIX, Constants.DEFAULT_CLIENT_ENDPOINT);
         if (endpoint.endsWith("/")) {
             endpoint = endpoint.substring(0, endpoint.length() - 1);
         }

--- a/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileSystem.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileSystem.java
@@ -79,7 +79,7 @@ public class LakeFSFileSystem extends FileSystem {
         }
         setConf(conf);
 
-        listAmount = FSConfiguration.getInt(conf, uri.getScheme(), FS_LAKEFS_LIST_AMOUNT_KEY_SUFFIX, DEFAULT_LIST_AMOUNT);
+        listAmount = FSConfiguration.getInt(conf, uri.getScheme(), LIST_AMOUNT_KEY_SUFFIX, DEFAULT_LIST_AMOUNT);
 
         // based on path get underlying FileSystem
         Path path = new Path(name);

--- a/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileSystem.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileSystem.java
@@ -64,7 +64,7 @@ public class LakeFSFileSystem extends FileSystem {
 
     @Override
     public void initialize(URI name, Configuration conf) throws IOException {
-        initializeWithClient(name, conf, new LakeFSClient(conf));
+        initializeWithClient(name, conf, new LakeFSClient(name.getScheme(), conf));
     }
 
     void initializeWithClient(URI name, Configuration conf, LakeFSClient lfsClient) throws IOException {

--- a/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileSystem.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileSystem.java
@@ -79,7 +79,7 @@ public class LakeFSFileSystem extends FileSystem {
         }
         setConf(conf);
 
-        listAmount = conf.getInt(FS_LAKEFS_LIST_AMOUNT_KEY, DEFAULT_LIST_AMOUNT);
+        listAmount = FSConfiguration.getInt(conf, uri.getScheme(), FS_LAKEFS_LIST_AMOUNT_KEY_SUFFIX, DEFAULT_LIST_AMOUNT);
 
         // based on path get underlying FileSystem
         Path path = new Path(name);

--- a/clients/hadoopfs/src/test/java/io/lakefs/FSConfigurationTest.java
+++ b/clients/hadoopfs/src/test/java/io/lakefs/FSConfigurationTest.java
@@ -1,0 +1,47 @@
+package io.lakefs;
+
+import junit.framework.TestCase;
+import org.apache.hadoop.conf.Configuration;
+import org.junit.Assert;
+
+public class FSConfigurationTest extends TestCase {
+
+    public void testGet() {
+        Configuration conf = new Configuration(false);
+        conf.set("fs.lakefs.key1", "lakefs1");
+        conf.set("fs.scheme.key1", "scheme1");
+        conf.set("fs.lakefs.key2", "lakefs2");
+        conf.set("fs.scheme.key3", "scheme3");
+        Assert.assertEquals("lakefs1", FSConfiguration.get(conf, "lakefs", "key1"));
+        Assert.assertEquals("lakefs1", FSConfiguration.get(conf, "lakefs", "key1", "default"));
+        Assert.assertEquals("scheme1", FSConfiguration.get(conf, "scheme", "key1"));
+        Assert.assertEquals("scheme1", FSConfiguration.get(conf, "scheme", "key1", "default"));
+        Assert.assertEquals("lakefs2", FSConfiguration.get(conf, "scheme", "key2"));
+        Assert.assertEquals("lakefs2", FSConfiguration.get(conf, "scheme", "key2", "default"));
+        Assert.assertEquals("lakefs2", FSConfiguration.get(conf, "lakefs", "key2"));
+        Assert.assertEquals("lakefs2", FSConfiguration.get(conf, "lakefs", "key2", "default"));
+        Assert.assertEquals("scheme3", FSConfiguration.get(conf, "scheme", "key3"));
+        Assert.assertEquals("scheme3", FSConfiguration.get(conf, "scheme", "key3", "default"));
+        Assert.assertNull(FSConfiguration.get(conf, "lakefs", "key3"));
+        Assert.assertEquals("default", FSConfiguration.get(conf, "lakefs", "key3", "default"));
+        Assert.assertNull(FSConfiguration.get(conf, "lakefs", "missing"));
+        Assert.assertEquals("default", FSConfiguration.get(conf, "lakefs", "missing", "default"));
+    }
+
+    public void testGetInt() {
+        Configuration conf = new Configuration(false);
+        conf.setInt("fs.lakefs.key1", 1);
+        conf.setInt("fs.scheme.key1", 11);
+        conf.setInt("fs.lakefs.key2", 2);
+        conf.setInt("fs.scheme.key3", 33);
+        conf.set("fs.lakefs.bad.key", "bad");
+        Assert.assertEquals(1, FSConfiguration.getInt(conf, "lakefs", "key1", 99));
+        Assert.assertEquals(11, FSConfiguration.getInt(conf, "scheme", "key1", 99));
+        Assert.assertEquals(2, FSConfiguration.getInt(conf, "scheme", "key2", 99));
+        Assert.assertEquals(2, FSConfiguration.getInt(conf, "lakefs", "key2", 99));
+        Assert.assertEquals(33, FSConfiguration.getInt(conf, "scheme", "key3", 99));
+        Assert.assertEquals(99, FSConfiguration.getInt(conf, "lakefs", "key3", 99));
+        Assert.assertEquals(99, FSConfiguration.getInt(conf, "lakefs", "missing", 99));
+        Assert.assertThrows(NumberFormatException.class, () -> FSConfiguration.getInt(conf, "lakefs", "bad.key", 99));
+    }
+}

--- a/clients/hadoopfs/src/test/java/io/lakefs/FSConfigurationTest.java
+++ b/clients/hadoopfs/src/test/java/io/lakefs/FSConfigurationTest.java
@@ -1,11 +1,12 @@
 package io.lakefs;
 
-import junit.framework.TestCase;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.Assert;
+import org.junit.Test;
 
-public class FSConfigurationTest extends TestCase {
+public class FSConfigurationTest {
 
+    @Test
     public void testGet() {
         Configuration conf = new Configuration(false);
         conf.set("fs.lakefs.key1", "lakefs1");
@@ -28,6 +29,7 @@ public class FSConfigurationTest extends TestCase {
         Assert.assertEquals("default", FSConfiguration.get(conf, "lakefs", "missing", "default"));
     }
 
+    @Test
     public void testGetInt() {
         Configuration conf = new Configuration(false);
         conf.setInt("fs.lakefs.key1", 1);

--- a/clients/hadoopfs/src/test/java/io/lakefs/LakeFSFileSystemTest.java
+++ b/clients/hadoopfs/src/test/java/io/lakefs/LakeFSFileSystemTest.java
@@ -123,9 +123,6 @@ public class LakeFSFileSystemTest {
         Configuration conf = new Configuration(false);
 
         conf.set("fs.lakefs.impl", "io.lakefs.LakeFSFileSystem");
-        conf.set(Constants.FS_LAKEFS_ACCESS_KEY, "<lakefs key>");
-        conf.set(Constants.FS_LAKEFS_SECRET_KEY, "<lakefs secret>");
-        conf.set(Constants.FS_LAKEFS_ENDPOINT_KEY, "http://unused.invalid");
 
         conf.set("fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem");
         conf.set(org.apache.hadoop.fs.s3a.Constants.ACCESS_KEY, S3_ACCESS_KEY_ID);

--- a/clients/hadoopfs/src/test/java/io/lakefs/LakeFSFileSystemTest.java
+++ b/clients/hadoopfs/src/test/java/io/lakefs/LakeFSFileSystemTest.java
@@ -38,7 +38,6 @@ import org.testcontainers.utility.DockerImageName;
 import java.io.*;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 


### PR DESCRIPTION
As part of supporting multiple schemes working with lakeFS file system, the configuration parameters should also look up the keys based on the same scheme.
In this PR the key, secret, and endpoint will try to lookup the specific key with fallback to the default 'lakefs'.
