### PR TITLE
Increase4 Nessie Spark jobs timeout

### DIFF
--- a/.github/workflows/nessie.yaml
+++ b/.github/workflows/nessie.yaml
@@ -230,7 +230,7 @@ jobs:
         run: mvn -Passembly -Djar.finalName=client --batch-mode --update-snapshots package
 
       - name: Test lakeFS S3 with Spark 2.x thick client
-        timeout-minutes: 2
+        timeout-minutes: 4
         env:
           JARS: clients/hadoopfs/
           STORAGE_NAMESPACE: s3://nessie-system-testing/${{ github.run_number }}-spark2-client
@@ -311,7 +311,7 @@ jobs:
         run: mvn -Passembly -Djar.finalName=client --batch-mode --update-snapshots package
 
       - name: Test lakeFS S3 with Spark 3.x thick client
-        timeout-minutes: 2
+        timeout-minutes: 4
         env:
           JARS: clients/hadoopfs/
           STORAGE_NAMESPACE: s3://nessie-system-testing/${{ github.run_number }}-spark3-client


### PR DESCRIPTION
2 minutes is not enough time :-(

AFAICT we originally set it because the client could block indefinitely on
the lakeFS server and trying to resolve there.  But this no longer happens
so there is little point in failing fast when this does happen.

Fixes #2288.
