### PR TITLE
Retry DB connection on Migration

### DIFF
--- a/pkg/db/connect.go
+++ b/pkg/db/connect.go
@@ -115,9 +115,9 @@ func tryConnectConfig(ctx context.Context, config *pgxpool.Config, log logging.L
 			return nil, fmt.Errorf("error while connecting to DB: %w", err)
 		}
 		if a.More() {
-			log.WithError(err).Info("could not connect to DB: Trying again")
+			log.WithError(err).Info("Could not connect to DB: Trying again")
 		}
 	}
 
-	return nil, fmt.Errorf("could not connect to DB: %w", err)
+	return nil, fmt.Errorf("retries exhausted, could not connect to DB: %w", err)
 }

--- a/pkg/db/connect.go
+++ b/pkg/db/connect.go
@@ -111,7 +111,7 @@ func tryConnectConfig(ctx context.Context, config *pgxpool.Config, log logging.L
 		if err == nil {
 			return pool, nil
 		}
-		if !IsDialError(err) {
+		if !isDialError(err) {
 			return nil, fmt.Errorf("error while connecting to DB: %w", err)
 		}
 		if a.More() {

--- a/pkg/db/connect.go
+++ b/pkg/db/connect.go
@@ -2,7 +2,9 @@ package db
 
 import (
 	"context"
+	"errors"
 	"fmt"
+	"net"
 	"time"
 
 	"github.com/jackc/pgx/v4/pgxpool"
@@ -110,6 +112,10 @@ func tryConnectConfig(ctx context.Context, config *pgxpool.Config, log logging.L
 		pool, err = pgxpool.ConnectConfig(ctx, config)
 		if err == nil {
 			return pool, nil
+		}
+		netError := &net.OpError{}
+		if !(errors.As(err, &netError) && netError.Op == "dial") {
+			return nil, err
 		}
 		if a.More() {
 			log.WithError(err).Info("could not open DB: Trying again")

--- a/pkg/db/errors.go
+++ b/pkg/db/errors.go
@@ -3,6 +3,7 @@ package db
 import (
 	"errors"
 	"fmt"
+	"net"
 
 	"github.com/jackc/pgx/v4"
 )
@@ -12,3 +13,8 @@ var (
 	ErrAlreadyExists = errors.New("already exists")
 	ErrSerialization = errors.New("serialization error")
 )
+
+func IsDialError(err error) bool {
+	netError := &net.OpError{}
+	return errors.As(err, &netError) && netError.Op == "dial"
+}

--- a/pkg/db/errors.go
+++ b/pkg/db/errors.go
@@ -14,7 +14,7 @@ var (
 	ErrSerialization = errors.New("serialization error")
 )
 
-func IsDialError(err error) bool {
+func isDialError(err error) bool {
 	netError := &net.OpError{}
 	return errors.As(err, &netError) && netError.Op == "dial"
 }

--- a/pkg/db/migration.go
+++ b/pkg/db/migration.go
@@ -119,9 +119,10 @@ func getMigrate(params params.Database) (*migrate.Migrate, error) {
 
 func tryNewWithSourceInstance(sourceName string, sourceInstance source.Driver, databaseURL string) (*migrate.Migrate, error) {
 	strategy := params.DatabaseRetryStrategy
+	var m *migrate.Migrate
 	var err error
 	for a := retry.Start(strategy, nil); a.Next(); {
-		m, err := migrate.NewWithSourceInstance(sourceName, sourceInstance, databaseURL)
+		m, err = migrate.NewWithSourceInstance(sourceName, sourceInstance, databaseURL)
 		if err == nil {
 			return m, nil
 		}

--- a/pkg/db/migration.go
+++ b/pkg/db/migration.go
@@ -126,15 +126,15 @@ func tryNewWithSourceInstance(sourceName string, sourceInstance source.Driver, d
 		if err == nil {
 			return m, nil
 		}
-		if !IsDialError(err) {
+		if !isDialError(err) {
 			return nil, fmt.Errorf("error while connecting to DB: %w", err)
 		}
 		if a.More() {
-			logging.Default().WithError(err).Info("could not connect to DB: Trying again")
+			logging.Default().WithError(err).Info("Could not connect to DB: Trying again")
 		}
 	}
 
-	return nil, fmt.Errorf("could not connect to DB: %w", err)
+	return nil, fmt.Errorf("retries exhausted, could not connect to DB: %w", err)
 }
 
 func closeMigrate(m *migrate.Migrate) {

--- a/pkg/db/migration.go
+++ b/pkg/db/migration.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net"
 	"os"
 	"time"
 
@@ -126,16 +125,15 @@ func tryNewWithSourceInstance(sourceName string, sourceInstance source.Driver, d
 		if err == nil {
 			return m, nil
 		}
-		netError := &net.OpError{}
-		if !(errors.As(err, &netError) && netError.Op == "dial") {
-			return nil, err
+		if !IsDialError(err) {
+			return nil, fmt.Errorf("error while connecting to DB: %w", err)
 		}
 		if a.More() {
-			logging.Default().WithError(err).Error("could not open DB: Trying again")
+			logging.Default().WithError(err).Info("could not connect to DB: Trying again")
 		}
 	}
 
-	return nil, fmt.Errorf("could not open DB: %w", err)
+	return nil, fmt.Errorf("could not connect to DB: %w", err)
 }
 
 func closeMigrate(m *migrate.Migrate) {

--- a/pkg/db/params/retry.go
+++ b/pkg/db/params/retry.go
@@ -1,0 +1,21 @@
+package params
+
+import (
+	"time"
+
+	"gopkg.in/retry.v1"
+)
+
+const (
+	databaseFirstWait  = 50 * time.Millisecond
+	databaseWaitGrowth = 1.2
+	databaseMaxWait    = 3 * time.Second
+)
+
+var DatabaseRetryStrategy = retry.LimitTime(databaseMaxWait,
+	retry.Exponential{
+		Initial: databaseFirstWait,
+		Factor:  databaseWaitGrowth,
+		Jitter:  true,
+	},
+)


### PR DESCRIPTION
Fixes #2017 

Retries the database connection after encountering any error while connecting for a migration task, specifically within the `getMigrate(params params.Database)` function. Both `lakefs run` and `lakefs setup` connect to the db to perform migration tasks, and will retry the connection if they encounter an error. 