### PR TITLE
Use the right bind flag name for minio

### DIFF
--- a/deployments/compose/docker-compose.yml
+++ b/deployments/compose/docker-compose.yml
@@ -38,7 +38,7 @@ services:
     ports:
       - 9000:9000
       - 9001:9001
-    entrypoint: ["minio", "server", "/data", "--console-address", ":9001"]
+    entrypoint: ["minio", "server", "/data", "--address", ":9001"]
 
   lakefs:
     image: treeverse/lakefs:latest


### PR DESCRIPTION
Otherwise `cd deployments/compose; docker-compose up` never brings up minio.