### PR TITLE
Change config file references in docs from config.yaml to .lakefs.yaml

### DIFF
--- a/docs/deploy/aws.md
+++ b/docs/deploy/aws.md
@@ -40,7 +40,7 @@ If you already have a database, take note of the connection string and skip to t
 ## Installation Options
 
 ### On EC2
-1. Save the following configuration file as `config.yaml`:
+1. Save the following configuration file as `.lakefs.yaml`:
 
    ```yaml
    ---
@@ -63,7 +63,7 @@ If you already have a database, take note of the connection string and skip to t
 1. [Download the binary](../index.md#downloads) to the EC2 instance.
 1. Run the `lakefs` binary on the EC2 instance:
    ```bash
-   lakefs --config config.yaml run
+   lakefs --config /path/to/.lakefs.yaml run
    ```
    **Note:** it is preferable to run the binary as a service using systemd or your operating system's facilities.
 

--- a/docs/deploy/azure.md
+++ b/docs/deploy/azure.md
@@ -33,7 +33,7 @@ If you already have a database, take note of the connection string and skip to t
 ## Installation Options
 
 ### On Azure VM
-1. Save the following configuration file as `config.yaml`:
+1. Save the following configuration file as `.lakefs.yaml`:
 
    ```yaml
    ---
@@ -59,7 +59,7 @@ If you already have a database, take note of the connection string and skip to t
 1. [Download the binary](../index.md#downloads) to the Azure Virtual Machine.
 1. Run the `lakefs` binary on the machine:
    ```bash
-   lakefs --config config.yaml run
+   lakefs --config /path/to/.lakefs.yaml run
    ```
    **Note:** it is preferable to run the binary as a service using systemd or your operating system's facilities.
 1. To support Azure AD authentication go to `Identity` tab and switch `Status` toggle to on, then add the `Storage Blob Data Contributor' role on the container you created.

--- a/docs/deploy/gcp.md
+++ b/docs/deploy/gcp.md
@@ -36,7 +36,7 @@ For example, if you install lakeFS on GKE, you need to deploy the SQL Auth Proxy
 ## Installation Options
 
 ### On Google Compute Engine
-1. Save the following configuration file as `config.yaml`:
+1. Save the following configuration file as `.lakefs.yaml`:
 
    ```yaml
    ---
@@ -60,7 +60,7 @@ For example, if you install lakeFS on GKE, you need to deploy the SQL Auth Proxy
 1. [Download the binary](../index.md#downloads) to the GCE instance.
 1. Run the `lakefs` binary on the GCE machine:
    ```bash
-   lakefs --config config.yaml run
+   lakefs --config /path/to/.lakefs.yaml run
    ```
    **Note:** it is preferable to run the binary as a service using systemd or your operating system's facilities.
 

--- a/docs/quickstart/more_quickstart_options.md
+++ b/docs/quickstart/more_quickstart_options.md
@@ -53,7 +53,7 @@ Alternatively, you may opt to run the lakefs binary directly on your computer.
 
 1. Install and configure [PostgreSQL](https://www.postgresql.org/download/){:target="_blank"}
 
-1. Create a configuration file:
+1. Create a configuration file and save it as `.lakefs.yaml`:
     
    ```yaml
    ---
@@ -82,5 +82,5 @@ Alternatively, you may opt to run the lakefs binary directly on your computer.
 1. Run the server:
     
    ```bash
-   ./lakefs --config /path/to/config.yaml run
+   ./lakefs --config /path/to/.lakefs.yaml run
    ```

--- a/docs/setup/import.md
+++ b/docs/setup/import.md
@@ -114,10 +114,10 @@ when accessing it through other branches. In a sense, your original bucket becom
 
 Import is performed by `lakefs`'s `import` command.
 
-Assuming your manifest.json is at `s3://example-bucket/path/to/inventory/YYYY-MM-DDT00-00Z/manifest.json`, and your lakeFS configuration yaml is at `config.yaml` (see notes below), run the following command to start the import:
+Assuming your manifest.json is at `s3://example-bucket/path/to/inventory/YYYY-MM-DDT00-00Z/manifest.json`, and your lakeFS configuration yaml is at `.lakefs.yaml` (see notes below), run the following command to start the import:
 
 ```bash
-lakefs import lakefs://example-repo -m s3://example-bucket/path/to/inventory/YYYY-MM-DDT00-00Z/manifest.json --config config.yaml
+lakefs import lakefs://example-repo -m s3://example-bucket/path/to/inventory/YYYY-MM-DDT00-00Z/manifest.json --config .lakefs.yaml
 ```
 
 You will see the progress of your import as it is performed.
@@ -141,7 +141,7 @@ As previously mentioned, the above command imports data to the dedicated `import
 By adding the `--with-merge` flag to the import command, this branch will be automatically merged to your main branch immediately after the import.
 
 ```bash
-lakefs import --with-merge lakefs://example-repo -m s3://example-bucket/path/to/inventory/YYYY-MM-DDT00-00Z/manifest.json --config config.yaml
+lakefs import --with-merge lakefs://example-repo -m s3://example-bucket/path/to/inventory/YYYY-MM-DDT00-00Z/manifest.json --config .lakefs.yaml
 ```
 
 #### Notes


### PR DESCRIPTION
Following a question in the help channel, it is best if we use the same terminology everywhere when referencing the configuration file.