### PR TITLE
Update docs/integrations/python.md to use consistent quotation marks

### DIFF
--- a/docs/integrations/python.md
+++ b/docs/integrations/python.md
@@ -59,7 +59,7 @@ Now that we have a client object, we can use it to interact with the API.
 ### Creating a repository
 
 ```python
-repo = models.RepositoryCreation(name="example-repo", storage_namespace="s3://storage-bucket/repos/example-repo", default_branch="main")
+repo = models.RepositoryCreation(name='example-repo', storage_namespace='s3://storage-bucket/repos/example-repo', default_branch='main')
 client.repositories.create_repository(repo)
 # output:
 # {'creation_date': 1617532175,


### PR DESCRIPTION
- [x]  Signed [LakeFS CLA](https://cla-assistant.io/treeverse/lakeFS)

While implementing lakeFS for a project, the git-diffed python code block in the documentation appears to have an inconsistent use of double quotes to denote strings in python. This PR simply uses the convention used in the rest of the document and updated the code block accordingly.

Let me know if this PR should designate a different branch to merge into other than `master`