### PR TITLE
Fix cryptolake workflow input name

### DIFF
--- a/.github/workflows/cryptolake.yaml
+++ b/.github/workflows/cryptolake.yaml
@@ -38,4 +38,4 @@ jobs:
           -X POST \
           -H "Accept: application/vnd.github.v3+json" \
           https://api.github.com/repos/treeverse/terraform/actions/workflows/deploy-lakefs-on-ecs.yaml/dispatches \
-          -d '{"ref":"master", "inputs": {"lakefs-version": "${{ steps.version.outputs.tag }}", "environment": "cryptolake-prod" }}'
+          -d '{"ref":"master", "inputs": {"lakefs_version": "${{ steps.version.outputs.tag }}", "environment": "cryptolake-prod" }}'


### PR DESCRIPTION
`lakefs-version` was updated to `lakefs_version` in the Terraform repository