### PR TITLE
bugfix/blank screen in ui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 # Changelog
 
 ## Unreleased - XXXX-XX-XX
-
+ - Fix blank screen bug in UI (#1908)
 
 ## v0.47.0 - 2021-07-28
 

--- a/webui/src/lib/components/repository/tabs.jsx
+++ b/webui/src/lib/components/repository/tabs.jsx
@@ -10,12 +10,9 @@ import {useRouter} from "../../hooks/router";
 
 
 export const RepositoryNavTabs = ({ active }) => {
-
-    const { repo, reference, loading, error } = useRefs();
-
+    const { reference } = useRefs();
     const router = useRouter();
-
-    const repoId = (loading && !error) ? '' : repo.id;
+    const { repoId } = router.params;
 
     const withRefContext = (url) => {
         const params = new URLSearchParams();


### PR DESCRIPTION
Solves #1908.

This fixes a bug in the repository page, in which rapidly switching between tabs would cause a blank screen. 
Cause: repoId variable wasn't populated when the page was in loading state.
Solution: take repoId from router params.