### PR TITLE
docs: fix reference swagger for open api

### DIFF
--- a/docs/assets/js/swagger-ui-lakefs.js
+++ b/docs/assets/js/swagger-ui-lakefs.js
@@ -2,7 +2,7 @@
 window.onload = function() {
     // Begin Swagger UI call region
     const ui = SwaggerUIBundle({
-        url: "{{ site.baseurl }}/assets/js/swagger.yml",
+        url: "../assets/js/swagger.yml",
         dom_id: '#swagger-ui',
         deepLinking: true,
         validatorUrl: null,


### PR DESCRIPTION
Fix the use of site.baseurl in js assert - the variable is not processed by Jekyll and we should use a relative path to the document that renders the reference.