### PR TITLE
Add api endpoint to retrieve user-defined metadata

### DIFF
--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -216,13 +216,13 @@ components:
           type: string
         checksum:
           type: string
+        size_bytes:
+          type: integer
+          format: int64
         mtime:
           type: integer
           format: int64
           description: Unix Epoch in seconds
-        size_bytes:
-          type: integer
-          format: int64
 
     ObjectStatsList:
       type: object
@@ -256,9 +256,12 @@ components:
           format: int64
           description: Unix Epoch in seconds
         metadata:
-          type: object
-          additionalProperties:
-            type: string
+          $ref: "#/components/schemas/ObjectUserMetadata"
+
+    ObjectUserMetadata:
+      type: object
+      additionalProperties:
+        type: string
 
     UnderlyingObjectProperties:
       type: object
@@ -2439,7 +2442,7 @@ paths:
       tags:
         - objects
       operationId: stageObject
-      summary: stage an object"s metadata for the given branch
+      summary: stage an object's metadata for the given branch
       requestBody:
         required: true
         content:
@@ -2553,6 +2556,45 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ObjectStats"
+        401:
+          $ref: "#/components/responses/Unauthorized"
+        404:
+          $ref: "#/components/responses/NotFound"
+        default:
+          $ref: "#/components/responses/ServerError"
+        410:
+          description: object gone (but partial metadata may be available)
+
+  /repositories/{repository}/refs/{ref}/objects/metadata:
+    parameters:
+      - in: path
+        name: repository
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: ref
+        required: true
+        schema:
+          type: string
+        description: a reference (could be either a branch or a commit ID)
+      - in: query
+        name: path
+        required: true
+        schema:
+          type: string
+    get:
+      tags:
+        - objects
+      operationId: getObjectUserMetadata
+      summary: get user-defined object metadata
+      responses:
+        200:
+          description: user-defined object metadata
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ObjectUserMetadata"
         401:
           $ref: "#/components/responses/Unauthorized"
         404:

--- a/cmd/lakectl/cmd/fs.go
+++ b/cmd/lakectl/cmd/fs.go
@@ -256,7 +256,7 @@ var fsStageCmd = &cobra.Command{
 			SizeBytes:       size,
 		}
 		if metaErr == nil {
-			metadata := api.ObjectStageCreation_Metadata{
+			metadata := api.ObjectUserMetadata{
 				AdditionalProperties: meta,
 			}
 			obj.Metadata = &metadata


### PR DESCRIPTION
Adds the endpoint `/repositories/{repository}/refs/{ref}/objects/metadata` to retrieve user-defined metadata