### PR TITLE
Add DB schema version label to docker images

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -37,6 +37,13 @@ jobs:
         run: echo "::set-output name=tag::$(echo ${GITHUB_REF##*/} | sed s/^v//g)"
         id: version
 
+      - name: Extract schema migration version
+        run: |
+          cd ./pkg/ddl
+          echo "::set-output name=version::$(echo $(ls -dq *up.sql* | wc -l))"
+          cd ../..
+        id: schema
+
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
@@ -47,16 +54,17 @@ jobs:
           ECR_REPOSITORY_LAKEFS: lakefs
           ECR_REPOSITORY_LAKECTL: lakectl
         run: |
-          docker build --target lakectl -t $ECR_REGISTRY/$ECR_REPOSITORY_LAKECTL:${{ steps.version.outputs.tag }} --build-arg VERSION=${{ steps.version.outputs.tag }} .
+          docker build --target lakectl -t $ECR_REGISTRY/$ECR_REPOSITORY_LAKECTL:${{ steps.version.outputs.tag }} --build-arg VERSION=${{ steps.version.outputs.tag }} --label schema-version=${{ steps.schema.outputs.version }} .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY_LAKECTL:${{ steps.version.outputs.tag }}
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY_LAKEFS:${{ steps.version.outputs.tag }} --build-arg VERSION=${{ steps.version.outputs.tag }} .
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY_LAKEFS:${{ steps.version.outputs.tag }} --build-arg VERSION=${{ steps.version.outputs.tag }} --label schema-version=${{ steps.schema.outputs.version }} .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY_LAKEFS:${{ steps.version.outputs.tag }}
       - name: Build and push lakectl to Docker hub
         uses: docker/build-push-action@v1
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          build_args: VERSION=${{ steps.version.outputs.tag }}
+          build_args: VERSION=${{ steps.version.outputs.tag }}, 
+          labels: schema-version=${{ steps.schema.outputs.version }}
           target: lakectl
           repository: treeverse/lakectl
           tags: ${{ steps.version.outputs.tag }},latest
@@ -66,7 +74,8 @@ jobs:
         with:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
-          build_args: VERSION=${{ steps.version.outputs.tag }}
+          build_args: VERSION=${{ steps.version.outputs.tag }}, 
+          labels: schema-version=${{ steps.schema.outputs.version }}
           target: lakefs
           repository: treeverse/lakefs
           tags: ${{ steps.version.outputs.tag }},latest

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -38,7 +38,7 @@ jobs:
         id: version
 
       - name: Extract db schema version from ddl migration files
-        run: echo "::set-output name=version::$( (cd pkg/ddl/ && ls -d *.up.sql) | sed -nE '$s/^0*([0-9]+).*/\1/p' )"
+        run: echo "::set-output name=dbschema_version::$( (cd pkg/ddl/ && ls -d *.up.sql) | sed -nE '$s/^0*([0-9]+).*/\1/p' )"
         id: schema
 
       - name: Login to Amazon ECR
@@ -51,9 +51,9 @@ jobs:
           ECR_REPOSITORY_LAKEFS: lakefs
           ECR_REPOSITORY_LAKECTL: lakectl
         run: |
-          docker build --target lakectl -t $ECR_REGISTRY/$ECR_REPOSITORY_LAKECTL:${{ steps.version.outputs.tag }} --build-arg VERSION=${{ steps.version.outputs.tag }} --label db-schema-version=${{ steps.schema.outputs.version }} .
+          docker build --target lakectl -t $ECR_REGISTRY/$ECR_REPOSITORY_LAKECTL:${{ steps.version.outputs.tag }} --build-arg VERSION=${{ steps.version.outputs.tag }} --label db-schema-version=${{ steps.schema.outputs.dbschema_version}} .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY_LAKECTL:${{ steps.version.outputs.tag }}
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY_LAKEFS:${{ steps.version.outputs.tag }} --build-arg VERSION=${{ steps.version.outputs.tag }} --label db-schema-version=${{ steps.schema.outputs.version }} .
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY_LAKEFS:${{ steps.version.outputs.tag }} --build-arg VERSION=${{ steps.version.outputs.tag }} --label db-schema-version=${{ steps.schema.outputs.dbschema_version}} .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY_LAKEFS:${{ steps.version.outputs.tag }}
       - name: Build and push lakectl to Docker hub
         uses: docker/build-push-action@v1
@@ -61,7 +61,7 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           build_args: VERSION=${{ steps.version.outputs.tag }}, 
-          labels: db-schema-version=${{ steps.schema.outputs.version }}
+          labels: db-schema-version=${{ steps.schema.outputs.dbschema_version}}
           target: lakectl
           repository: treeverse/lakectl
           tags: ${{ steps.version.outputs.tag }},latest
@@ -72,7 +72,7 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           build_args: VERSION=${{ steps.version.outputs.tag }}, 
-          labels: db-schema-version=${{ steps.schema.outputs.version }}
+          labels: db-schema-version=${{ steps.schema.outputs.dbschema_version}}
           target: lakefs
           repository: treeverse/lakefs
           tags: ${{ steps.version.outputs.tag }},latest

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -37,11 +37,8 @@ jobs:
         run: echo "::set-output name=tag::$(echo ${GITHUB_REF##*/} | sed s/^v//g)"
         id: version
 
-      - name: Extract schema migration version
-        run: |
-          cd ./pkg/ddl
-          echo "::set-output name=version::$(echo $(ls -dq *up.sql* | wc -l))"
-          cd ../..
+      - name: Extract db schema version from ddl migration files
+        run: echo "::set-output name=version::$( (cd pkg/ddl/ && ls -d *.up.sql) | sed -nE '$s/^0*([0-9]+).*/\1/p' )"
         id: schema
 
       - name: Login to Amazon ECR
@@ -54,9 +51,9 @@ jobs:
           ECR_REPOSITORY_LAKEFS: lakefs
           ECR_REPOSITORY_LAKECTL: lakectl
         run: |
-          docker build --target lakectl -t $ECR_REGISTRY/$ECR_REPOSITORY_LAKECTL:${{ steps.version.outputs.tag }} --build-arg VERSION=${{ steps.version.outputs.tag }} --label schema-version=${{ steps.schema.outputs.version }} .
+          docker build --target lakectl -t $ECR_REGISTRY/$ECR_REPOSITORY_LAKECTL:${{ steps.version.outputs.tag }} --build-arg VERSION=${{ steps.version.outputs.tag }} --label db-schema-version=${{ steps.schema.outputs.version }} .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY_LAKECTL:${{ steps.version.outputs.tag }}
-          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY_LAKEFS:${{ steps.version.outputs.tag }} --build-arg VERSION=${{ steps.version.outputs.tag }} --label schema-version=${{ steps.schema.outputs.version }} .
+          docker build -t $ECR_REGISTRY/$ECR_REPOSITORY_LAKEFS:${{ steps.version.outputs.tag }} --build-arg VERSION=${{ steps.version.outputs.tag }} --label db-schema-version=${{ steps.schema.outputs.version }} .
           docker push $ECR_REGISTRY/$ECR_REPOSITORY_LAKEFS:${{ steps.version.outputs.tag }}
       - name: Build and push lakectl to Docker hub
         uses: docker/build-push-action@v1
@@ -64,7 +61,7 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           build_args: VERSION=${{ steps.version.outputs.tag }}, 
-          labels: schema-version=${{ steps.schema.outputs.version }}
+          labels: db-schema-version=${{ steps.schema.outputs.version }}
           target: lakectl
           repository: treeverse/lakectl
           tags: ${{ steps.version.outputs.tag }},latest
@@ -75,7 +72,7 @@ jobs:
           username: ${{ secrets.DOCKER_USERNAME }}
           password: ${{ secrets.DOCKER_PASSWORD }}
           build_args: VERSION=${{ steps.version.outputs.tag }}, 
-          labels: schema-version=${{ steps.schema.outputs.version }}
+          labels: db-schema-version=${{ steps.schema.outputs.version }}
           target: lakefs
           repository: treeverse/lakefs
           tags: ${{ steps.version.outputs.tag }},latest

--- a/.github/workflows/nessie.yaml
+++ b/.github/workflows/nessie.yaml
@@ -117,11 +117,8 @@ jobs:
         run: echo "::set-output name=tag::sha-$(git rev-parse --short HEAD | sed s/^v//g)"
         id: version
 
-      - name: Extract schema migration version
-        run: |
-          cd ./pkg/ddl
-          echo "::set-output name=version::$(echo $(ls -dq *up.sql* | wc -l))"
-          cd ../..
+      - name: Extract db schema version from ddl migration files
+        run: echo "::set-output name=version::$( (cd pkg/ddl/ && ls -d *.up.sql) | sed -nE '$s/^0*([0-9]+).*/\1/p' )"
         id: schema
 
       - name: Login to Amazon ECR
@@ -158,7 +155,7 @@ jobs:
           docker build . \
               ${ghr_ref_tag} ${ghr_build_tag} ${ecr_tag} \
               --build-arg VERSION=${{ steps.version.outputs.tag }} \
-              --label schema-version=${{ steps.schema.outputs.version }} \
+              --label db-schema-version=${{ steps.schema.outputs.version }} \
               --cache-from=${ghr}
           docker push ${ghr_build_tag#-t }
           if [[ -n ${ghr_ref_tag} ]]; then docker push ${ghr_ref_tag#-t }; fi

--- a/.github/workflows/nessie.yaml
+++ b/.github/workflows/nessie.yaml
@@ -118,7 +118,7 @@ jobs:
         id: version
 
       - name: Extract db schema version from ddl migration files
-        run: echo "::set-output name=version::$( (cd pkg/ddl/ && ls -d *.up.sql) | sed -nE '$s/^0*([0-9]+).*/\1/p' )"
+        run: echo "::set-output name=dbschema_version::$( (cd pkg/ddl/ && ls -d *.up.sql) | sed -nE '$s/^0*([0-9]+).*/\1/p' )"
         id: schema
 
       - name: Login to Amazon ECR
@@ -155,7 +155,7 @@ jobs:
           docker build . \
               ${ghr_ref_tag} ${ghr_build_tag} ${ecr_tag} \
               --build-arg VERSION=${{ steps.version.outputs.tag }} \
-              --label db-schema-version=${{ steps.schema.outputs.version }} \
+              --label db-schema-version=${{ steps.schema.outputs.dbschema_version }} \
               --cache-from=${ghr}
           docker push ${ghr_build_tag#-t }
           if [[ -n ${ghr_ref_tag} ]]; then docker push ${ghr_ref_tag#-t }; fi

--- a/.github/workflows/nessie.yaml
+++ b/.github/workflows/nessie.yaml
@@ -117,6 +117,13 @@ jobs:
         run: echo "::set-output name=tag::sha-$(git rev-parse --short HEAD | sed s/^v//g)"
         id: version
 
+      - name: Extract schema migration version
+        run: |
+          cd ./pkg/ddl
+          echo "::set-output name=version::$(echo $(ls -dq *up.sql* | wc -l))"
+          cd ../..
+        id: schema
+
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
@@ -151,6 +158,7 @@ jobs:
           docker build . \
               ${ghr_ref_tag} ${ghr_build_tag} ${ecr_tag} \
               --build-arg VERSION=${{ steps.version.outputs.tag }} \
+              --label schema-version=${{ steps.schema.outputs.version }} \
               --cache-from=${ghr}
           docker push ${ghr_build_tag#-t }
           if [[ -n ${ghr_ref_tag} ]]; then docker push ${ghr_ref_tag#-t }; fi


### PR DESCRIPTION
Step 1 to fixing #2362 and #2271 

Since we’re able to migrate downwards using `migrate goto`, we need access to the schema version of the older lakeFS image. Like we talked about in the Cryptolake meeting, we can solve this issue for future versions of lakeFS by adding the schema version as a Label in the Docker image. Adding the Label can be done with the `--label` flag. This Label can be accessed by calling `docker image inspect --format='' myimage`. More info about Docker image Labels can be found [here](https://docs.docker.com/engine/reference/builder/#label).

Now getting the highest schema version for the image is another problem. The function GetLastMigrationAvailable() in pkg/db/migration.go seems like a good candidate, but we need the version whenever we build the docker image, which happens in docker-publish.yaml and nessie.yaml and we likely aren’t able to run lakeFS to  run this function within those workflows. 

~~We can solve it (quite hackily I would add) by counting the number of (upward) migration files in pkg/ddl/ and adding that number as a Label in the Docker image.~~ We can look at the highest number .up.sql file to determine the version and add that number as a Label to the Docker image. I am open to a better way of finding the schema version! 

To automate the downward migration process, you would access the image for the intended lakefs-version from the container registry, read the schema-version label, and perform `lakefs migrate goto` from the existing version.