### PR TITLE
move blockstore type consts to block package

### DIFF
--- a/pkg/api/serve_test.go
+++ b/pkg/api/serve_test.go
@@ -19,7 +19,6 @@ import (
 	authmodel "github.com/treeverse/lakefs/pkg/auth/model"
 	authparams "github.com/treeverse/lakefs/pkg/auth/params"
 	"github.com/treeverse/lakefs/pkg/block"
-	"github.com/treeverse/lakefs/pkg/block/mem"
 	"github.com/treeverse/lakefs/pkg/catalog"
 	"github.com/treeverse/lakefs/pkg/config"
 	"github.com/treeverse/lakefs/pkg/db"
@@ -76,9 +75,9 @@ func setupHandler(t testing.TB, blockstoreType string, opts ...testutil.GetDBOpt
 		blockstoreType = os.Getenv(testutil.EnvKeyUseBlockAdapter)
 	}
 	if blockstoreType == "" {
-		blockstoreType = mem.BlockstoreType
+		blockstoreType = block.BlockstoreTypeMem
 	}
-	viper.Set(config.BlockstoreTypeKey, mem.BlockstoreType)
+	viper.Set(config.BlockstoreTypeKey, block.BlockstoreTypeMem)
 	cfg, err := config.NewConfig()
 	testutil.MustDo(t, "config", err)
 	c, err := catalog.New(ctx, catalog.Config{

--- a/pkg/block/adapter.go
+++ b/pkg/block/adapter.go
@@ -14,6 +14,15 @@ type MultipartUploadCompletion struct{ Part []*s3.CompletedPart }
 type IdentifierType int32
 
 const (
+	BlockstoreTypeS3        = "s3"
+	BlockstoreTypeGS        = "gs"
+	BlockstoreTypeAzure     = "azure"
+	BlockstoreTypeLocal     = "local"
+	BlockstoreTypeMem       = "mem"
+	BlockstoreTypeTransient = "transient"
+)
+
+const (
 	// Deprecated: indicates that the identifier might be relative or full.
 	IdentifierTypeUnknownDeprecated IdentifierType = 0
 

--- a/pkg/block/azure/adapter.go
+++ b/pkg/block/azure/adapter.go
@@ -23,7 +23,6 @@ var (
 )
 
 const (
-	BlockstoreType          = "azure"
 	sizeSuffix              = "_size"
 	idSuffix                = "_id"
 	_1MiB                   = 1024 * 1024
@@ -410,7 +409,7 @@ func (a *Adapter) ValidateConfiguration(ctx context.Context, _ string) error {
 }
 
 func (a *Adapter) BlockstoreType() string {
-	return BlockstoreType
+	return block.BlockstoreTypeAzure
 }
 
 func (a *Adapter) CompleteMultiPartUpload(ctx context.Context, obj block.ObjectPointer, _ string, multipartList *block.MultipartUploadCompletion) (*string, int64, error) {

--- a/pkg/block/factory/build.go
+++ b/pkg/block/factory/build.go
@@ -37,29 +37,29 @@ func BuildBlockAdapter(ctx context.Context, c params.AdapterConfig) (block.Adapt
 		WithField("type", blockstore).
 		Info("initialize blockstore adapter")
 	switch blockstore {
-	case local.BlockstoreType:
+	case block.BlockstoreTypeLocal:
 		p, err := c.GetBlockAdapterLocalParams()
 		if err != nil {
 			return nil, err
 		}
 		return buildLocalAdapter(p)
-	case s3a.BlockstoreType:
+	case block.BlockstoreTypeS3:
 		p, err := c.GetBlockAdapterS3Params()
 		if err != nil {
 			return nil, err
 		}
 		return buildS3Adapter(p)
-	case mem.BlockstoreType, "memory":
+	case block.BlockstoreTypeMem, "memory":
 		return mem.New(), nil
-	case transient.BlockstoreType:
+	case block.BlockstoreTypeTransient:
 		return transient.New(), nil
-	case gs.BlockstoreType:
+	case block.BlockstoreTypeGS:
 		p, err := c.GetBlockAdapterGSParams()
 		if err != nil {
 			return nil, err
 		}
 		return buildGSAdapter(ctx, p)
-	case azure.BlockstoreType:
+	case block.BlockstoreTypeAzure:
 		p, err := c.GetBlockAdapterAzureParams()
 		if err != nil {
 			return nil, err
@@ -67,7 +67,7 @@ func BuildBlockAdapter(ctx context.Context, c params.AdapterConfig) (block.Adapt
 		return buildAzureAdapter(p)
 	default:
 		return nil, fmt.Errorf("%w '%s' please choose one of %s",
-			ErrInvalidBlockStoreType, blockstore, []string{local.BlockstoreType, s3a.BlockstoreType, azure.BlockstoreType, mem.BlockstoreType, transient.BlockstoreType, gs.BlockstoreType})
+			ErrInvalidBlockStoreType, blockstore, []string{block.BlockstoreTypeLocal, block.BlockstoreTypeS3, block.BlockstoreTypeAzure, block.BlockstoreTypeMem, block.BlockstoreTypeTransient, block.BlockstoreTypeGS})
 	}
 }
 

--- a/pkg/block/gs/adapter.go
+++ b/pkg/block/gs/adapter.go
@@ -17,7 +17,6 @@ import (
 )
 
 const (
-	BlockstoreType      = "gs"
 	MaxMultipartObjects = 10000
 
 	delimiter    = "/"
@@ -555,11 +554,11 @@ func (a *Adapter) Close() error {
 }
 
 func (a *Adapter) BlockstoreType() string {
-	return BlockstoreType
+	return block.BlockstoreTypeGS
 }
 
 func (a *Adapter) GetStorageNamespaceInfo() block.StorageNamespaceInfo {
-	return block.DefaultStorageNamespaceInfo(BlockstoreType)
+	return block.DefaultStorageNamespaceInfo(block.BlockstoreTypeGS)
 }
 
 func (a *Adapter) RuntimeStats() map[string]string {

--- a/pkg/block/local/adapter.go
+++ b/pkg/block/local/adapter.go
@@ -23,8 +23,6 @@ import (
 	"github.com/treeverse/lakefs/pkg/logging"
 )
 
-const BlockstoreType = "local"
-
 type Adapter struct {
 	path               string
 	uploadIDTranslator block.UploadIDTranslator
@@ -473,11 +471,11 @@ func (l *Adapter) GenerateInventory(_ context.Context, _ logging.Logger, _ strin
 }
 
 func (l *Adapter) BlockstoreType() string {
-	return BlockstoreType
+	return block.BlockstoreTypeLocal
 }
 
 func (l *Adapter) GetStorageNamespaceInfo() block.StorageNamespaceInfo {
-	return block.DefaultStorageNamespaceInfo(BlockstoreType)
+	return block.DefaultStorageNamespaceInfo(block.BlockstoreTypeLocal)
 }
 
 func (l *Adapter) RuntimeStats() map[string]string {

--- a/pkg/block/mem/adapter.go
+++ b/pkg/block/mem/adapter.go
@@ -20,8 +20,6 @@ import (
 	"github.com/treeverse/lakefs/pkg/logging"
 )
 
-const BlockstoreType = "mem"
-
 var (
 	ErrNoDataForKey            = fmt.Errorf("no data for key: %w", adapter.ErrDataNotFound)
 	ErrMultiPartNotFound       = fmt.Errorf("multipart ID not found")
@@ -300,11 +298,11 @@ func (a *Adapter) GenerateInventory(_ context.Context, _ logging.Logger, _ strin
 }
 
 func (a *Adapter) BlockstoreType() string {
-	return BlockstoreType
+	return block.BlockstoreTypeMem
 }
 
 func (a *Adapter) GetStorageNamespaceInfo() block.StorageNamespaceInfo {
-	return block.DefaultStorageNamespaceInfo(BlockstoreType)
+	return block.DefaultStorageNamespaceInfo(block.BlockstoreTypeMem)
 }
 
 func (a *Adapter) RuntimeStats() map[string]string {

--- a/pkg/block/s3/adapter.go
+++ b/pkg/block/s3/adapter.go
@@ -23,8 +23,6 @@ import (
 )
 
 const (
-	BlockstoreType = "s3"
-
 	DefaultStreamingChunkSize    = 2 << 19         // 1MiB by default per chunk
 	DefaultStreamingChunkTimeout = time.Second * 1 // if we haven't read DefaultStreamingChunkSize by this duration, write whatever we have as a chunk
 
@@ -634,11 +632,11 @@ func (a *Adapter) ValidateConfiguration(ctx context.Context, storageNamespace st
 }
 
 func (a *Adapter) BlockstoreType() string {
-	return BlockstoreType
+	return block.BlockstoreTypeS3
 }
 
 func (a *Adapter) GetStorageNamespaceInfo() block.StorageNamespaceInfo {
-	return block.DefaultStorageNamespaceInfo(BlockstoreType)
+	return block.DefaultStorageNamespaceInfo(block.BlockstoreTypeS3)
 }
 
 func (a *Adapter) RuntimeStats() map[string]string {

--- a/pkg/block/transient/adapter.go
+++ b/pkg/block/transient/adapter.go
@@ -15,8 +15,6 @@ import (
 	"github.com/treeverse/lakefs/pkg/logging"
 )
 
-const BlockstoreType = "transient"
-
 var ErrInventoryNotImplemented = errors.New("inventory feature not implemented for transient storage adapter")
 
 type Adapter struct{}
@@ -135,11 +133,11 @@ func (a *Adapter) GenerateInventory(_ context.Context, _ logging.Logger, _ strin
 }
 
 func (a *Adapter) BlockstoreType() string {
-	return BlockstoreType
+	return block.BlockstoreTypeTransient
 }
 
 func (a *Adapter) GetStorageNamespaceInfo() block.StorageNamespaceInfo {
-	return block.DefaultStorageNamespaceInfo(BlockstoreType)
+	return block.DefaultStorageNamespaceInfo(block.BlockstoreTypeTransient)
 }
 
 func (a *Adapter) RuntimeStats() map[string]string {

--- a/pkg/stats/metadata.go
+++ b/pkg/stats/metadata.go
@@ -4,9 +4,7 @@ import (
 	"context"
 
 	"github.com/treeverse/lakefs/pkg/auth"
-	azurestorage "github.com/treeverse/lakefs/pkg/block/azure"
-	"github.com/treeverse/lakefs/pkg/block/gs"
-	s3a "github.com/treeverse/lakefs/pkg/block/s3"
+	"github.com/treeverse/lakefs/pkg/block"
 	"github.com/treeverse/lakefs/pkg/cloud"
 	"github.com/treeverse/lakefs/pkg/cloud/aws"
 	"github.com/treeverse/lakefs/pkg/cloud/azure"
@@ -51,11 +49,11 @@ func NewMetadata(ctx context.Context, logger logging.Logger, blockstoreType stri
 
 func BuildMetadataProvider(logger logging.Logger, c *config.Config) cloud.MetadataProvider {
 	switch c.GetBlockstoreType() {
-	case gs.BlockstoreType:
+	case block.BlockstoreTypeGS:
 		return gcp.NewMetadataProvider(logger)
-	case s3a.BlockstoreType:
+	case block.BlockstoreTypeS3:
 		return aws.NewMetadataProvider(logger, c.GetAwsConfig())
-	case azurestorage.BlockstoreType:
+	case block.BlockstoreTypeAzure:
 		return azure.NewMetadataProvider(logger)
 	default:
 		return nil

--- a/pkg/testutil/db.go
+++ b/pkg/testutil/db.go
@@ -213,7 +213,7 @@ func MustDo(t testing.TB, what string, err error) {
 
 func NewBlockAdapterByType(t testing.TB, translator block.UploadIDTranslator, blockstoreType string) block.Adapter {
 	switch blockstoreType {
-	case gs.BlockstoreType:
+	case block.BlockstoreTypeGS:
 		ctx := context.Background()
 		client, err := storage.NewClient(ctx)
 		if err != nil {
@@ -221,7 +221,7 @@ func NewBlockAdapterByType(t testing.TB, translator block.UploadIDTranslator, bl
 		}
 		return gs.NewAdapter(client, gs.WithTranslator(translator))
 
-	case lakefsS3.BlockstoreType:
+	case block.BlockstoreTypeS3:
 		awsRegion, regionOk := os.LookupEnv(envKeyAwsRegion)
 		if !regionOk {
 			awsRegion = "us-east-1"


### PR DESCRIPTION
These constants caused some packages to point at the concrete blockstore implementations (s3, gs, etc).
For example, the `stats` package pointed at all of the blockstore implementation packages.
This caused a dependency cycle when trying to use the `stats` package from the S3 blockstore.