### PR TITLE
reduce db connect calls by reduce calls from migrate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
  - Fix blank screen bug in UI (#1908)
  - Support multiple AWS regions for underlying buckets (#2245, #2325, #2326)
  - Actions secrets support with env vars (#2333)
+ - Reduce the number of database connections used on startup
 
 ## v0.47.0 - 2021-07-28
 

--- a/cmd/lakefs/cmd/migrate.go
+++ b/cmd/lakefs/cmd/migrate.go
@@ -19,7 +19,10 @@ var versionCmd = &cobra.Command{
 	Short: "Print current migration version and available version",
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := cmd.Context()
-		version, _, err := db.MigrateVersion(ctx, cfg.GetDatabaseParams())
+		dbParams := cfg.GetDatabaseParams()
+		dbPool := db.BuildDatabaseConnection(ctx, dbParams)
+		defer dbPool.Close()
+		version, _, err := db.MigrateVersion(ctx, dbPool, dbParams)
 		if err != nil {
 			fmt.Printf("Failed to get info for schema: %s\n", err)
 			return

--- a/cmd/lakefs/cmd/setup.go
+++ b/cmd/lakefs/cmd/setup.go
@@ -22,15 +22,16 @@ var setupCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := cmd.Context()
 
-		migrator := db.NewDatabaseMigrator(cfg.GetDatabaseParams())
+		dbParams := cfg.GetDatabaseParams()
+		dbPool := db.BuildDatabaseConnection(ctx, dbParams)
+		defer dbPool.Close()
+
+		migrator := db.NewDatabaseMigrator(dbParams)
 		err := migrator.Migrate(ctx)
 		if err != nil {
 			fmt.Printf("Failed to setup DB: %s\n", err)
 			os.Exit(1)
 		}
-
-		dbPool := db.BuildDatabaseConnection(ctx, cfg.GetDatabaseParams())
-		defer dbPool.Close()
 
 		userName, err := cmd.Flags().GetString("user-name")
 		if err != nil {

--- a/pkg/db/connect.go
+++ b/pkg/db/connect.go
@@ -51,7 +51,7 @@ func ConnectDBPool(ctx context.Context, p params.Database) (*pgxpool.Pool, error
 		"max_idle_conns":    p.MaxIdleConnections,
 		"conn_max_lifetime": p.ConnectionMaxLifetime,
 	})
-	log.Info("connecting to the DB")
+	log.Info("Connecting to the DB")
 	config, err := pgxpool.ParseConfig(p.ConnectionString)
 	if err != nil {
 		return nil, fmt.Errorf("parse connection string: %w", err)
@@ -71,7 +71,7 @@ func ConnectDBPool(ctx context.Context, p params.Database) (*pgxpool.Pool, error
 		return nil, err
 	}
 
-	log.Info("initialized DB connection")
+	log.Info("DB connection established")
 	return pool, err
 }
 

--- a/pkg/db/migration.go
+++ b/pkg/db/migration.go
@@ -59,8 +59,8 @@ func getStatikSrc() (source.Driver, error) {
 	return httpfs.New(migrationFs, "/")
 }
 
-func ValidateSchemaUpToDate(ctx context.Context, params params.Database) error {
-	version, _, err := MigrateVersion(ctx, params)
+func ValidateSchemaUpToDate(ctx context.Context, dbPool Database, params params.Database) error {
+	version, _, err := MigrateVersion(ctx, dbPool, params)
 	if err != nil {
 		return err
 	}
@@ -196,11 +196,9 @@ func MigrateTo(ctx context.Context, p params.Database, version uint, force bool)
 	return nil
 }
 
-func MigrateVersion(ctx context.Context, params params.Database) (uint, bool, error) {
+func MigrateVersion(ctx context.Context, dbPool Database, params params.Database) (uint, bool, error) {
 	// validate that default migrations table exists with information - a workaround
 	// so we will not create the migration table as the package will ensure the table exists
-	dbPool := BuildDatabaseConnection(ctx, params)
-	defer dbPool.Close()
 	var rows int
 	err := dbPool.Get(ctx, &rows, `SELECT COUNT(*) FROM `+postgres.DefaultMigrationsTable)
 	if err != nil || rows == 0 {


### PR DESCRIPTION
In order to reduce the number of times, we create connections pools on startup, connect to the database first and reuse the pool for migrating version functionality.
