### PR TITLE
lakefs config.yaml align name and search order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 
 ## Unreleased - XXXX-XX-XX
 
- - lakeFS starts configuration load non-hidden config files first (#2355)
+ - Add search locations to load lakeFS configuration. More information on https://docs.lakefs.io/reference/configuration (#2355)
 
 ## v0.48.0 - 2021-08-22
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 ## Unreleased - XXXX-XX-XX
 
+ - lakeFS starts configuration load non-hidden config files first (#2355)
 
 ## v0.48.0 - 2021-08-22
 

--- a/cmd/lakefs/cmd/root.go
+++ b/cmd/lakefs/cmd/root.go
@@ -83,7 +83,7 @@ func initConfig() {
 			viper.SetConfigFile(fallbackCfgFile)
 			logger = logger.WithField("file", viper.ConfigFileUsed()) // should be called after SetConfigFile
 			err = viper.ReadInConfig()
-			if err != nil && !errors.As(err, &errFileNotFound) {
+			if err != nil && os.IsNotExist(err) {
 				logger.WithError(err).Fatal("Failed to read config file")
 			}
 		}

--- a/cmd/lakefs/cmd/root.go
+++ b/cmd/lakefs/cmd/root.go
@@ -58,9 +58,9 @@ func initConfig() {
 	} else {
 		viper.SetConfigType("yaml")
 		viper.SetConfigName("config")
-		viper.AddConfigPath("/etc/lakefs")
-		viper.AddConfigPath(path.Join(getHomeDir(), ".lakefs"))
 		viper.AddConfigPath(".")
+		viper.AddConfigPath(path.Join(getHomeDir(), ".lakefs"))
+		viper.AddConfigPath("/etc/lakefs")
 	}
 
 	viper.SetEnvPrefix("LAKEFS")

--- a/cmd/lakefs/cmd/root.go
+++ b/cmd/lakefs/cmd/root.go
@@ -73,7 +73,7 @@ func initConfig() {
 	logger = logger.WithField("file", viper.ConfigFileUsed()) // should be called after SetConfigFile
 	var errFileNotFound viper.ConfigFileNotFoundError
 	if err != nil && !errors.As(err, &errFileNotFound) {
-		logger.WithError(err).Fatal("Failed to read config file")
+		logger.WithError(err).Fatal("Failed to find a config file")
 	}
 	// fallback - try to load the previous supported $HOME/.lakefs.yaml
 	//   if err is set it will be file-not-found based on previous check
@@ -83,7 +83,7 @@ func initConfig() {
 			viper.SetConfigFile(fallbackCfgFile)
 			logger = logger.WithField("file", viper.ConfigFileUsed()) // should be called after SetConfigFile
 			err = viper.ReadInConfig()
-			if err != nil && os.IsNotExist(err) {
+			if err != nil && !os.IsNotExist(err) {
 				logger.WithError(err).Fatal("Failed to read config file")
 			}
 		}

--- a/docs/deploy/docker.md
+++ b/docs/deploy/docker.md
@@ -28,7 +28,7 @@ Here is a minimal example, but you can see the [reference](../reference/configur
   <li><a href="#docker-tabs-2">Google Cloud</a></li>
   <li><a href="#docker-tabs-3">Microsoft Azure</a></li>
 </ul>
-<div markdown="1" id="docker-tabs-1">      
+<div markdown="1" id="docker-tabs-1">
 {% include_relative includes/aws-docker-config.md %}
 </div>
 <div markdown="1" id="docker-tabs-2">
@@ -45,8 +45,8 @@ Save the configuration file locally as `lakefs-config.yaml` and run the followin
 docker run \
   --name lakefs \
   -p 8000:8000 \
-  -v $(pwd)/lakefs-config.yaml:/home/lakefs/.lakefs.yaml \
-  treeverse/lakefs:latest run
+  -v $(pwd)/lakefs-config.yaml:/etc/lakefs/config.yaml \
+  treeverse/lakefs:latest run --config /etc/lakefs/config.yaml
 ```
 
 ## Load balancing

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -13,11 +13,11 @@ has_children: false
 {% include toc.html %}
 
 Configuring lakeFS is done using a yaml configuration file and/or environment variable.
-The configuration file location can be set with the '--config' flag. It will lookup, load, and use the first file found in the following order:
+The configuration file location can be set with the '--config' flag. If not specified, the the first file found in the following order will be used:
 1. ./config.yaml
-1. `<home directory>`/lakefs/config.yaml
+1. `$HOME`/lakefs/config.yaml
 1. /etc/lakefs/config.yaml
-1. `<home directory>`/.lakefs.yaml
+1. `$HOME`/.lakefs.yaml
 
 Configuration items can each be controlled by an environment variable. The variable name will have a prefix of *LAKEFS_*, followed by the name of the configuration, replacing every '.' with a '_'.
 Example: `LAKEFS_LOGGING_LEVEL` controls `logging.format`.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -12,7 +12,16 @@ has_children: false
 
 {% include toc.html %}
 
-Configuring lakeFS is done using a yaml configuration file.
+Configuring lakeFS is done using a yaml configuration file and/or environment variable.
+The configuration file location can be set with the '--config' flag. It will lookup, load, and use the first file found in the following order:
+1. ./config.yaml
+1. `<home directory>`/lakefs/config.yaml
+1. /etc/lakefs/config.yaml
+1. `<home directory>`/.lakefs.yaml
+
+Configuration items can each be controlled by an environment variable. The variable name will have a prefix of *LAKEFS_*, followed by the name of the configuration, replacing every '.' with a '_'.
+Example: `LAKEFS_LOGGING_LEVEL` controls `logging.format`.
+
 This reference uses `.` to denote the nesting of values.
 
 ## Reference


### PR DESCRIPTION
lakefs service configuration - align the filename and search locations to other services, with fallback support:

- configuration file named lakefs.yaml
- search for /etc/lakefs/config.yaml
- search for $HOME/.lakefs/config.yaml
- search for ./config.yaml
- (fallback) search for $HOME/.lakefs.yaml

Close #2355