### PR TITLE
Fix "checking repositories for mismatched adapter"

### DIFF
--- a/cmd/lakefs/cmd/run.go
+++ b/cmd/lakefs/cmd/run.go
@@ -215,7 +215,9 @@ func checkForeignRepos(ctx context.Context, logger logging.Logger, authMetadataM
 	if !initialized {
 		logger.Debug("lakeFS isn't initialized, skipping mismatched adapter checks")
 	} else {
-		logger.Debugf("lakeFS is initialized, checking repositories for mismatched adapter(%s)", blockStore.BlockstoreType())
+		logger.
+			WithField("adapter_type", blockStore.BlockstoreType()).
+			Debug("lakeFS is initialized, checking repositories for mismatched adapter")
 		hasMore := true
 		next := ""
 

--- a/cmd/lakefs/cmd/run.go
+++ b/cmd/lakefs/cmd/run.go
@@ -215,7 +215,7 @@ func checkForeignRepos(ctx context.Context, logger logging.Logger, authMetadataM
 	if !initialized {
 		logger.Debug("lakeFS isn't initialized, skipping mismatched adapter checks")
 	} else {
-		logger.Debug("lakeFS is initialized, checking repositories for mismatched adapter(%s)", blockStore.BlockstoreType())
+		logger.Debugf("lakeFS is initialized, checking repositories for mismatched adapter(%s)", blockStore.BlockstoreType())
 		hasMore := true
 		next := ""
 


### PR DESCRIPTION
Was unformatted, looking like
```
DEBUG  [2021-08-17T11:01:54+03:00]cmd/lakefs/cmd/run.go:213 cmd/lakefs/cmd.checkForeignRepos lakeFS is initialized, checking repositories for mismatched adapter(%s)s3 
```