### PR TITLE
Fix/api unknown path return error 2190

### DIFF
--- a/pkg/api/serve_test.go
+++ b/pkg/api/serve_test.go
@@ -178,3 +178,34 @@ func setupClientWithAdmin(t testing.TB, blockstoreType string, opts ...testutil.
 	clt = setupClientByEndpoint(t, server.URL, cred.AccessKeyID, cred.SecretAccessKey)
 	return clt, deps
 }
+
+func TestInvalidRoute(t *testing.T) {
+	handler, _ := setupHandler(t, "")
+	server := setupServer(t, handler)
+	clt := setupClientByEndpoint(t, server.URL, "", "")
+	cred := createDefaultAdminUser(t, clt)
+
+	// setup client with invalid endpoint base url
+	basicAuthProvider, err := securityprovider.NewSecurityProviderBasicAuth(cred.AccessKeyID, cred.SecretAccessKey)
+	if err != nil {
+		t.Fatal("basic auth security provider", err)
+	}
+	clt, err = api.NewClientWithResponses(server.URL+api.BaseURL+"//", api.WithRequestEditorFn(basicAuthProvider.Intercept))
+	if err != nil {
+		t.Fatal("failed to create api client:", err)
+	}
+
+	ctx := context.Background()
+	resp, err := clt.ListRepositoriesWithResponse(ctx, &api.ListRepositoriesParams{})
+	if err != nil {
+		t.Fatalf("failed to get lakefs server version")
+	}
+	if resp.JSONDefault == nil {
+		t.Fatalf("client api call expected default error, got nil")
+	}
+	expectedErrMsg := api.ErrInvalidAPIEndpoint.Error()
+	errMsg := resp.JSONDefault.Message
+	if errMsg != expectedErrMsg {
+		t.Fatalf("client response error message: %s, expected: %s", errMsg, expectedErrMsg)
+	}
+}


### PR DESCRIPTION
This PR fixes Issue #2190 by creating a handler to return invalid error for routes downstream of the `BaseURL`.

This PR fixes the issue by creating a handler that ensures that only routes on the mounted route (i.e. `/api/v1`) will be successful. Other routes are returned with `ErrInvalidAPIEndpoint` with the error string being `invalid API endpoint`.

This handler can be used with future/other routes by chi Mount'ing the handler to the specific route you want so that users are returned with the invalid endpoint error when trying to access any downstream route from the route/pattern the handler is chi Mount'ed to. 

Tests were successful for the tested for this fix (test created by @nopcoder - thank you!), but I still had issues with getting `TestLocalLoad` to pass successfully. I wanted to put this PR up for review and then we can talk about any issues it has AND how to resolve the testing issue for `TestLocalLoad`. 

Thank you.