### PR TITLE
docker build ignore additional directories

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -14,3 +14,7 @@ cmd/lakectl/lakefs
 webui/
 golangci.yaml
 gateway/testdata/
+test/
+clients/
+docs/
+design/


### PR DESCRIPTION
enable faster docker build by ignore directories which are not required
for lakefs and lakectl build.