### PR TITLE
test: fix hadoop fs 'rename' contract test

### DIFF
--- a/clients/hadoopfs/src/test/java/io/lakefs/contract/TestLakeFSContractRename.java
+++ b/clients/hadoopfs/src/test/java/io/lakefs/contract/TestLakeFSContractRename.java
@@ -1,12 +1,10 @@
 package io.lakefs.contract;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.contract.AbstractContractRenameTest;
-import org.apache.hadoop.fs.contract.AbstractFSContract;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.contract.ContractTestUtils;
-import org.junit.Test;
+import org.apache.hadoop.fs.contract.AbstractContractRenameTest;
+import org.apache.hadoop.fs.contract.AbstractFSContract;
 
 import static org.apache.hadoop.fs.contract.ContractTestUtils.dataset;
 import static org.apache.hadoop.fs.contract.ContractTestUtils.writeDataset;
@@ -41,15 +39,4 @@ public class TestLakeFSContractRename extends AbstractContractRenameTest {
     assertFalse("s3a doesn't support rename to non-empty directory", rename);
   }
 
-  @Override
-  public void testRenameFileNonexistentDir() throws Throwable {
-    ContractTestUtils.skip("test needs to be fixed");
-    // TODO make this test green and remove override
-  }
-
-  @Override
-  public void testRenameNonexistentFile() throws Throwable {
-    ContractTestUtils.skip("test needs to be fixed");
-    // TODO make this test green and remove override
-  }
 }

--- a/clients/hadoopfs/src/test/resources/contract/lakefs.xml
+++ b/clients/hadoopfs/src/test/resources/contract/lakefs.xml
@@ -44,7 +44,7 @@
 
     <property>
         <name>fs.contract.rename-returns-false-if-source-missing</name>
-        <value>true</value>
+        <value>false</value>
     </property>
 
     <property>
@@ -107,4 +107,8 @@
         <value>true</value>
     </property>
 
+    <property>
+        <name>fs.contract.rename-creates-dest-dirs</name>
+        <value>true</value>
+    </property>
 </configuration>


### PR DESCRIPTION
Part of #2309 

Fix hadoop-lakefs contracts for TestLakeFSContractRename:
 - testRenameNonexistentFile
 - testRenameFileNonexistentDir

The contract was aligned to s3a on the following:
```
fs.contract.rename-returns-false-if-source-missing=false
fs.contract.rename-creates-dest-dirs=true
```

Based on s3a contract: https://github.com/apache/hadoop/blob/rel/release-3.3.1/hadoop-tools/hadoop-aws/src/test/resources/contract/s3a.xml