### PR TITLE
add blockstore type to compose

### DIFF
--- a/deployments/compose/docker-compose.yml
+++ b/deployments/compose/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - LAKECTL_CREDENTIALS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
       - LAKECTL_CREDENTIALS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
       - LAKECTL_SERVER_ENDPOINT_URL=http://lakefs:8000
+      - LAKEFS_BLOCKSTORE_TYPE=s3
     entrypoint: ["/app/wait-for", "postgres:5432", "--", "sh", "-c",
       "lakefs setup --user-name docker --access-key-id AKIAIOSFODNN7EXAMPLE --secret-access-key wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY && lakectl repo create lakefs://example s3://example"
       ]


### PR DESCRIPTION
The blockstore type has become a mandatory field in a recent version of lakeFS.