### PR TITLE
Fix hadoopfs-lakefs move file to a file without existing target directory

### DIFF
--- a/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileSystem.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileSystem.java
@@ -377,6 +377,19 @@ public class LakeFSFileSystem extends FileSystem {
         } catch (FileNotFoundException e) {
             LOG.debug("renameFile: dst does not exist, renaming src {} to a file called dst {}",
                     srcStatus.getPath(), dst);
+            // Parent must exist
+            Path dstPath = dst.getParent();
+            ObjectLocation dstParent = pathToObjectLocation(dstPath);
+            if (dstParent.isValidPath()) {
+                try {
+                    LakeFSFileStatus dstParentStatus = getFileStatus(dstPath);
+                    if (!dstParentStatus.isDirectory()) {
+                        return false;
+                    }
+                } catch (FileNotFoundException e2) {
+                    return false;
+                }
+            }
         }
         return renameObject(srcStatus, dst);
     }

--- a/clients/hadoopfs/src/test/java/io/lakefs/contract/TestLakeFSFileSystemContract.java
+++ b/clients/hadoopfs/src/test/java/io/lakefs/contract/TestLakeFSFileSystemContract.java
@@ -117,8 +117,4 @@ public class TestLakeFSFileSystemContract extends FileSystemContractBaseTest {
     // TODO make this test green and remove override
   }
 
-  @Override
-  public void testRenameFileMoveToNonExistentDirectory() throws Exception {
-    // TODO make this test green and remove override
-  }
 }


### PR DESCRIPTION
Align behavior of fs rename - when moving file to a target file, the parent directory of the parent should exist. (testRenameFileMoveToNonExistentDirectory contract test)

Reference implementation: https://github.com/apache/hadoop/blob/branch-2.7/hadoop-tools/hadoop-aws/src/main/java/org/apache/hadoop/fs/s3a/S3AFileSystem.java#L493

Part of #2309 