### PR TITLE
Add example for Specific Repository ReadWriteAccess

### DIFF
--- a/docs/reference/authorization.md
+++ b/docs/reference/authorization.md
@@ -396,8 +396,8 @@ Policy:
         }
     ]
 }
-
 ```
+
 ### Preconfigured Groups
 
 ##### Admins

--- a/docs/reference/authorization.md
+++ b/docs/reference/authorization.md
@@ -340,7 +340,7 @@ Policy:
 
 ### Additional Policies
 
-The following examples can be used to create additional policies to further limit user accesses:
+The following examples can be used to create additional policies to further limit user access. Use the web UI or the [lakectl auth](./commands.md#lakectl-auth-policies-create) command to create policies.
 
 ##### ReadWriteAccessForSpecificRepository
 

--- a/docs/reference/authorization.md
+++ b/docs/reference/authorization.md
@@ -338,6 +338,66 @@ Policy:
 }
 ```
 
+### Additional Policies
+
+The following examples can be used to create additional policies to further limit user accesses:
+
+##### ReadWriteAccessForSpecificRepository
+
+Policy: 
+```json
+{
+    "statement": [
+        {
+            "action": [
+                "fs:ReadRepository",
+                "fs:ReadCommit",
+                "fs:ListBranches",
+                "fs:ListTags",
+                "fs:ListObjects"
+            ],
+            "effect": "allow",
+            "resource": "arn:lakefs:fs:::repository/<repository-name>"
+        },
+        {
+            "action": [
+                "fs:RevertBranch",
+                "fs:ReadBranch",
+                "fs:CreateBranch",
+                "fs:DeleteBranch",
+                "fs:CreateCommit"
+            ],
+            "effect": "allow",
+            "resource": "arn:lakefs:fs:::repository/<repository-name>/branch/*"
+        },
+                {
+            "action": [
+                "fs:ListObjects",
+                "fs:ReadObject",
+                "fs:WriteObject",
+                "fs:DeleteObject",
+            ],
+            "effect": "allow",
+            "resource": "arn:lakefs:fs:::repository/<repository-name>/object/*"
+        },
+                {
+            "action": [
+                "fs:ReadTag",
+                "fs:CreateTag",
+                "fs:DeleteTag"
+            ],
+            "effect": "allow",
+            "resource": "arn:lakefs:fs:::repository/<repository-name>/tag/*"
+        },
+        {
+        	"action": ["fs:ReadConfig"],
+        	"effect": "allow",
+        	"resource": "*"
+        }
+    ]
+}
+
+```
 ### Preconfigured Groups
 
 ##### Admins

--- a/docs/reference/authorization.md
+++ b/docs/reference/authorization.md
@@ -342,7 +342,7 @@ Policy:
 
 The following examples can be used to create additional policies to further limit user access. Use the web UI or the [lakectl auth](./commands.md#lakectl-auth-policies-create) command to create policies.
 
-##### ReadWriteAccessForSpecificRepository
+#### Read/write access for a specific repository
 
 Policy: 
 ```json


### PR DESCRIPTION
#### Realed Issue
Closes #2413 

#### Changes
Add example policy to docs for specific repository read-write access. 

#### Other Comments
ReadConfig and List Repositories access for all repositories is required as of now for specific repositories. https://github.com/treeverse/lakeFS/issues/2414