### PR TITLE
Test sst parser

### DIFF
--- a/clients/spark/build.sbt
+++ b/clients/spark/build.sbt
@@ -60,6 +60,10 @@ def generateCoreProject(buildType: BuildType) =
 
         "org.scalactic" %% "scalactic" % "3.2.9",
         "org.scalatest" %% "scalatest" % "3.2.9" % "test",
+        "com.dimafeng" %% "testcontainers-scala-scalatest" % "0.39.5" % "test",
+        "com.dimafeng" %% "testcontainers-scala-munit" % "0.39.5" % "test",
+        "com.lihaoyi" %% "upickle" % "1.4.0",
+        "com.lihaoyi" %% "os-lib" % "0.7.8",
       ),
       Test / logBuffered := false,
       // Uncomment to get (very) full stacktraces in test:

--- a/clients/spark/build.sbt
+++ b/clients/spark/build.sbt
@@ -62,8 +62,8 @@ def generateCoreProject(buildType: BuildType) =
         "org.scalatest" %% "scalatest" % "3.2.9" % "test",
         "com.dimafeng" %% "testcontainers-scala-scalatest" % "0.39.5" % "test",
         "com.dimafeng" %% "testcontainers-scala-munit" % "0.39.5" % "test",
-        "com.lihaoyi" %% "upickle" % "1.4.0",
-        "com.lihaoyi" %% "os-lib" % "0.7.8",
+        "com.lihaoyi" %% "upickle" % "1.4.0" % "test",
+        "com.lihaoyi" %% "os-lib" % "0.7.8" % "test",
       ),
       Test / logBuffered := false,
       // Uncomment to get (very) full stacktraces in test:

--- a/clients/spark/core/src/test/resources/parser-test/generate-sst.sh
+++ b/clients/spark/core/src/test/resources/parser-test/generate-sst.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Generate sst files that will serve as an input jpebble parser tests
+export CGO_ENABLED=0
+cd /local
+go run sst_files_generator.go
+echo "done"

--- a/clients/spark/core/src/test/resources/parser-test/generate-sst.sh
+++ b/clients/spark/core/src/test/resources/parser-test/generate-sst.sh
@@ -1,7 +1,0 @@
-#!/bin/sh
-
-# Generate sst files that will serve as an input jpebble parser tests
-export CGO_ENABLED=0
-cd /local
-go run sst_files_generator.go
-echo "done"

--- a/clients/spark/core/src/test/resources/parser-test/go.mod
+++ b/clients/spark/core/src/test/resources/parser-test/go.mod
@@ -1,0 +1,9 @@
+module sst_files_generator
+
+go 1.16
+
+require (
+	github.com/cockroachdb/pebble v0.0.0-20210308135031-3c37882d2ac8
+	github.com/google/gofuzz v1.2.0
+	github.com/matoous/go-nanoid/v2 v2.0.0
+)

--- a/clients/spark/core/src/test/resources/parser-test/sst_files_generator.go
+++ b/clients/spark/core/src/test/resources/parser-test/sst_files_generator.go
@@ -3,32 +3,31 @@ package main
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"math/rand"
 	"os"
 	"sort"
 
-	fuzz "github.com/google/gofuzz"
-
 	"github.com/cockroachdb/pebble/sstable"
+	fuzz "github.com/google/gofuzz"
 	nanoid "github.com/matoous/go-nanoid/v2"
 )
 
 const (
 	DefaultKeySizeBytes   = 100
 	DefaultValueSizeBytes = 5
-	MbToBytes             = 1024 * 1024
-	KbToBytes             = 1024
+	KiBToBytes            = 1 << 10
+	MiBToBytes            = KiBToBytes << 10
 	FuzzerSeed            = 50
-	// DefaultCommittedPermanentMaxRangeSizeMb - the max file size that can be written by graveler (pkg/config/config.go)
-	DefaultCommittedPermanentMaxRangeSizeMb = 20
+	// DefaultCommittedPermanentMaxRangeSizeBytes - the max file size that can be written by graveler (pkg/config/config.go)
+	DefaultCommittedPermanentMaxRangeSizeBytes = 20 * MiBToBytes
+	DefaultSstSizeBytes                        = 50 * KiBToBytes
+	DefaultTwoLevelSstSizeBytes                = 10 * KiBToBytes
+	DefaultMaxSizeKb                           = 100
 )
 
-func getDefaultUserProperties() map[string]string {
-	return map[string]string{
-		"user_prop_1": "val1",
-		"user_prop_2": "val2",
-	}
+var DefaultUserProperties = map[string]string{
+	"user_prop_1": "val1",
+	"user_prop_2": "val2",
 }
 
 type Entry struct {
@@ -37,16 +36,29 @@ type Entry struct {
 }
 
 func main() {
-	generateTwoLevelIdxSst()
-	fuzzSstContents()
-	fuzzWriterOptions()
-	sstsWithUnsupportedWriterOptions()
-	generateLargeSsts()
+	writeTwoLevelIdxSst()
+	writeMultiSizedSstsWithContentsFuzzing()
+	writeSstsWithWriterOptionsFuzzing()
+	writeSstsWithUnsupportedWriterOptions()
+	writeLargeSsts()
 }
 
-func sstsWithUnsupportedWriterOptions() {
-	sizeBytes := 10 * KbToBytes
-	keys := generateSortedSlice(sizeBytes)
+func generateNanoid() (string, error) {
+	return nanoid.New(DefaultValueSizeBytes)
+}
+
+func newGenerateFuzz() func() (string, error) {
+	f := fuzz.NewWithSeed(FuzzerSeed)
+	return func() (string, error) {
+		var val string
+		f.Fuzz(&val)
+		return val, nil
+	}
+}
+
+func writeSstsWithUnsupportedWriterOptions() {
+	sizeBytes := DefaultSstSizeBytes
+	keys := prepareSortedSliceWithNanoid(sizeBytes)
 
 	// Checksum specifies which checksum to use. lakeFS supports parsing sstables with crc checksum.
 	// ChecksumTypeXXHash and ChecksumTypeNone are unsupported and therefore not tested.
@@ -54,7 +66,7 @@ func sstsWithUnsupportedWriterOptions() {
 		Compression: sstable.SnappyCompression,
 		Checksum:    sstable.ChecksumTypeXXHash64,
 	}
-	writeTestInputFiles(keys, func() (string, error) { return nanoid.New(DefaultValueSizeBytes) }, sizeBytes,
+	createTestInputFiles(keys, generateNanoid, sizeBytes,
 		"checksum.type.xxHash64", writerOptions)
 
 	// TableFormat specifies the format version for writing sstables. The default
@@ -63,22 +75,21 @@ func sstsWithUnsupportedWriterOptions() {
 		Compression: sstable.SnappyCompression,
 		TableFormat: sstable.TableFormatLevelDB,
 	}
-	writeTestInputFiles(keys, func() (string, error) { return nanoid.New(DefaultValueSizeBytes) }, sizeBytes,
+	createTestInputFiles(keys, generateNanoid, sizeBytes,
 		"table.format.leveldb", writerOptions)
 }
 
-func fuzzWriterOptions() {
-	sizeBytes := 50 * KbToBytes
-	keys := generateSortedSlice(sizeBytes)
+func writeSstsWithWriterOptionsFuzzing() {
+	sizeBytes := DefaultSstSizeBytes
+	keys := prepareSortedSliceWithNanoid(sizeBytes)
 
 	// Use fuzzing to define sstable user properties.
-	f := fuzz.NewWithSeed(FuzzerSeed)
+	generateFuzz := newGenerateFuzz()
 	userProps := map[string]string{}
-	for i := 1; i <= 20; i++ {
-		var propKey string
-		var propVal string
-		f.Fuzz(&propKey)
-		f.Fuzz(&propVal)
+	const numOfUserDefinedProps = 20
+	for i := 1; i <= numOfUserDefinedProps; i++ {
+		propKey, _ := generateFuzz()
+		propVal, _ := generateFuzz()
 		userProps[propKey] = propVal
 		fmt.Printf("user property %d, key=%s, val=%s\n", i, propKey, propVal)
 	}
@@ -86,103 +97,86 @@ func fuzzWriterOptions() {
 		Compression:             sstable.SnappyCompression,
 		TablePropertyCollectors: []func() sstable.TablePropertyCollector{NewStaticCollector(userProps)},
 	}
-	writeTestInputFiles(keys, func() (string, error) { return nanoid.New(DefaultValueSizeBytes) }, sizeBytes,
-		"fuzz.table.properties", writerOptions)
+	createTestInputFiles(keys, generateNanoid, sizeBytes, "fuzz.table.properties", writerOptions)
 
 	// BlockRestartInterval is the number of keys between restart points
 	// for delta encoding of keys.
 	// The default value is 16.
-	blockRestartInterval := rand.Intn(100)
+	blockRestartInterval := 1 + rand.Intn(100)
 	writerOptions = sstable.WriterOptions{
 		Compression:             sstable.SnappyCompression,
-		TablePropertyCollectors: []func() sstable.TablePropertyCollector{NewStaticCollector(getDefaultUserProperties())},
+		TablePropertyCollectors: []func() sstable.TablePropertyCollector{NewStaticCollector(DefaultUserProperties)},
 		BlockRestartInterval:    blockRestartInterval,
 	}
 	fmt.Printf("BlockRestartInterval %d...\n", blockRestartInterval)
-	writeTestInputFiles(keys, func() (string, error) { return nanoid.New(DefaultValueSizeBytes) }, sizeBytes,
-		"fuzz.block.restart.interval", writerOptions)
+	createTestInputFiles(keys, generateNanoid, sizeBytes, "fuzz.block.restart.interval", writerOptions)
 
 	// BlockSize is the target uncompressed size in bytes of each table block.
 	// The default value is 4096.
-	blockSize := rand.Intn(9000)
+	blockSize := 1 + rand.Intn(9000)
 	writerOptions = sstable.WriterOptions{
 		Compression:             sstable.SnappyCompression,
-		TablePropertyCollectors: []func() sstable.TablePropertyCollector{NewStaticCollector(getDefaultUserProperties())},
+		TablePropertyCollectors: []func() sstable.TablePropertyCollector{NewStaticCollector(DefaultUserProperties)},
 		BlockSize:               blockSize,
 	}
 	fmt.Printf("BlockSize %d...\n", blockSize)
-	writeTestInputFiles(keys, func() (string, error) { return nanoid.New(DefaultValueSizeBytes) }, sizeBytes,
-		"fuzz.block.size", writerOptions)
+	createTestInputFiles(keys, generateNanoid, sizeBytes, "fuzz.block.size", writerOptions)
 
 	// BlockSizeThreshold finishes a block if the block size is larger than the
 	// specified percentage of the target block size and adding the next entry
 	// would cause the block to be larger than the target block size.
 	//
 	// The default value is 90
-	blockSizeThreshold := rand.Intn(100)
+	blockSizeThreshold := 1 + rand.Intn(100)
 	writerOptions = sstable.WriterOptions{
 		Compression:             sstable.SnappyCompression,
-		TablePropertyCollectors: []func() sstable.TablePropertyCollector{NewStaticCollector(getDefaultUserProperties())},
+		TablePropertyCollectors: getDefaultTablePropertyCollectors(DefaultUserProperties),
 		BlockSizeThreshold:      blockSizeThreshold,
 	}
 	fmt.Printf("BlockSizeThreshold %d...\n", blockSizeThreshold)
-	writeTestInputFiles(keys, func() (string, error) { return nanoid.New(DefaultValueSizeBytes) }, sizeBytes,
-		"fuzz.block.size.threshold", writerOptions)
+	createTestInputFiles(keys, generateNanoid, sizeBytes, "fuzz.block.size.threshold", writerOptions)
 }
 
-func generateLargeSsts() {
-	sizeBytes := DefaultCommittedPermanentMaxRangeSizeMb * MbToBytes
-	keys := generateSortedSlice(sizeBytes)
+func writeLargeSsts() {
+	sizeBytes := DefaultCommittedPermanentMaxRangeSizeBytes
+	keys := prepareSortedSliceWithNanoid(sizeBytes)
 	writerOptions := sstable.WriterOptions{
 		Compression:             sstable.SnappyCompression,
-		TablePropertyCollectors: []func() sstable.TablePropertyCollector{NewStaticCollector(getDefaultUserProperties())},
+		TablePropertyCollectors: getDefaultTablePropertyCollectors(DefaultUserProperties),
 	}
-	writeTestInputFiles(keys, func() (string, error) { return nanoid.New(DefaultValueSizeBytes) }, sizeBytes,
-		"max.size.lakefs.file", writerOptions)
+	createTestInputFiles(keys, generateNanoid, sizeBytes, "max.size.lakefs.file", writerOptions)
 }
 
-// Generates sstables on multiple sizes and uses a fuzzer to generate their contents.
-func fuzzSstContents() {
-	var fileSizes []int
-	for i := 0; i < 3; i++ {
-		curMb := rand.Intn(DefaultCommittedPermanentMaxRangeSizeMb)
-		curKb := rand.Intn(100)
-		if curMb == 0 || curKb == 0 {
-			continue
+func writeMultiSizedSstsWithContentsFuzzing() {
+	const numOfFilesToGenerate = 6
+	for i := 0; i < numOfFilesToGenerate; i++ {
+		var curSize int
+		if i%2 == 0 {
+			curSize = 1 + rand.Intn(DefaultCommittedPermanentMaxRangeSizeBytes/MiBToBytes)*MiBToBytes
+		} else {
+			curSize = 1 + rand.Intn(DefaultMaxSizeKb)*KiBToBytes
 		}
-		fileSizes = append(fileSizes, curMb*MbToBytes)
-		fileSizes = append(fileSizes, curKb*KbToBytes)
-	}
 
-	for i, size := range fileSizes {
-		sizeBytes := size
 		testFileName := fmt.Sprintf("fuzz.contents.%d", i)
-		keys := generateSortedSliceWithFuzzing(sizeBytes)
+		keys := prepareSortedSliceWithFuzzing(curSize)
 
 		writerOptions := sstable.WriterOptions{
 			Compression:             sstable.SnappyCompression,
-			TablePropertyCollectors: []func() sstable.TablePropertyCollector{NewStaticCollector(getDefaultUserProperties())},
+			TablePropertyCollectors: getDefaultTablePropertyCollectors(DefaultUserProperties),
 		}
-
-		f := fuzz.NewWithSeed(FuzzerSeed)
-		writeTestInputFiles(keys, func() (string, error) {
-			var val string
-			f.Fuzz(&val)
-			return val, nil
-		}, sizeBytes, testFileName, writerOptions)
+		createTestInputFiles(keys, newGenerateFuzz(), curSize, testFileName, writerOptions)
 	}
 }
 
-func generateSortedSliceWithFuzzing(size int) []string {
+func prepareSortedSliceWithFuzzing(size int) []string {
 	var keySumBytes int
 	var slice []string
-	f := fuzz.NewWithSeed(FuzzerSeed)
+	generateFuzz := newGenerateFuzz()
 	// Keep generating keys until we reach the desired slice size. This guarantees that the sstable writer will have
 	// enough data to write an sstable of the desired size.
 	for keySumBytes < size {
-		var key string
-		f.Fuzz(&key)
-		if key == "" { // TODO: (Tals) remove after resolving https://github.com/treeverse/lakeFS/issues/2419
+		key, _ := generateFuzz()
+		if key == "" { // TODO(Tals): remove after resolving https://github.com/treeverse/lakeFS/issues/2419
 			continue
 		}
 		keySumBytes += len(key)
@@ -192,20 +186,19 @@ func generateSortedSliceWithFuzzing(size int) []string {
 	return slice
 }
 
-func generateTwoLevelIdxSst() {
-	sizeBytes := 10 * KbToBytes
-	keys := generateSortedSlice(sizeBytes)
+func writeTwoLevelIdxSst() {
+	sizeBytes := DefaultTwoLevelSstSizeBytes
+	keys := prepareSortedSliceWithNanoid(sizeBytes)
 
 	writerOptions := sstable.WriterOptions{
 		Compression:             sstable.SnappyCompression,
 		IndexBlockSize:          5, // setting the index block size target to a small number to make 2-level index get enabled
-		TablePropertyCollectors: []func() sstable.TablePropertyCollector{NewStaticCollector(getDefaultUserProperties())},
+		TablePropertyCollectors: getDefaultTablePropertyCollectors(DefaultUserProperties),
 	}
-	writeTestInputFiles(keys, func() (string, error) { return nanoid.New(DefaultValueSizeBytes) }, sizeBytes,
-		"two.level.idx", writerOptions)
+	createTestInputFiles(keys, generateNanoid, sizeBytes, "two.level.idx", writerOptions)
 }
 
-func generateSortedSlice(size int) []string {
+func prepareSortedSliceWithNanoid(size int) []string {
 	numLines := size / DefaultKeySizeBytes
 	slice := make([]string, 0, numLines)
 	for i := 0; i < numLines; i++ {
@@ -219,22 +212,22 @@ func generateSortedSlice(size int) []string {
 	return slice
 }
 
-// Writes sst and json files that will be used to unit test the sst block parser (clients/spark/core/src/main/scala/io/treeverse/jpebble/BlockParser.scala)
+// create sst and json files that will be used to unit test the sst block parser (clients/spark/core/src/main/scala/io/treeverse/jpebble/BlockParser.scala)
 // The sst file is the test input, and the json file encapsulates the expected parser output.
-func writeTestInputFiles(keys []string, genValue func() (string, error), size int, name string,
+func createTestInputFiles(keys []string, genValue func() (string, error), size int, name string,
 	writerOptions sstable.WriterOptions) {
 	fmt.Printf("Generate %s of size %d bytes\n", name, size)
-	sstFile, err := os.Create(name + ".sst")
+	sstFileName := name + ".sst"
+	sstFile, err := os.Create(sstFileName)
 	if err != nil {
 		panic(err)
 	}
-
-	expectedContents := make([]Entry, 0, len(keys))
 	writer := sstable.NewWriter(sstFile, writerOptions)
 	defer func() {
 		_ = writer.Close()
 	}()
 
+	expectedContents := make([]Entry, 0, len(keys))
 	for _, k := range keys {
 		if writer.EstimatedSize() >= uint64(size) {
 			break
@@ -244,19 +237,27 @@ func writeTestInputFiles(keys []string, genValue func() (string, error), size in
 			panic(err)
 		}
 		if err := writer.Set([]byte(k), []byte(v)); err != nil {
-			panic(fmt.Errorf("setting key and value: %w", err))
+			panic(fmt.Errorf("setting key and value: %w, into %w", err, sstFileName))
 		}
 		expectedContents = append(expectedContents, Entry{Key: k, Value: v})
 	}
-	saveExpectedContentsAsJson(expectedContents, name)
+
+	// save the expected contents as json
+	jsonFileName := name + ".json"
+	jsonWriter, err := os.Create(jsonFileName)
+	if err != nil {
+		panic(err)
+	}
+	defer func() {
+		jsonWriter.Close()
+	}()
+	err = json.NewEncoder(jsonWriter).Encode(expectedContents)
+	if err != nil {
+		panic(err)
+	}
 }
 
-func saveExpectedContentsAsJson(contents []Entry, name string) {
-	j, _ := json.Marshal(contents)
-	ioutil.WriteFile(name+".json", j, os.ModePerm)
-}
-
-// Copied from pkg/graveler/sstable/collectors.go. lakeFS populates the following user properties for each sstable
+// staticCollector - Copied from pkg/graveler/sstable/collectors.go. lakeFS populates the following user properties for each sstable
 // graveler writes: type (range/metarange), min_key, max_key, count, estimated_size_bytes
 // staticCollector is an sstable.TablePropertyCollector that adds a map's values to the user
 // property map.
@@ -283,4 +284,8 @@ func (s *staticCollector) Finish(userProps map[string]string) error {
 // writing ends.
 func NewStaticCollector(m map[string]string) func() sstable.TablePropertyCollector {
 	return func() sstable.TablePropertyCollector { return &staticCollector{m} }
+}
+
+func getDefaultTablePropertyCollectors(m map[string]string) []func() sstable.TablePropertyCollector {
+	return []func() sstable.TablePropertyCollector{NewStaticCollector(m)}
 }

--- a/clients/spark/core/src/test/resources/parser-test/sst_files_generator.go
+++ b/clients/spark/core/src/test/resources/parser-test/sst_files_generator.go
@@ -22,7 +22,7 @@ const (
 	DefaultCommittedPermanentMaxRangeSizeBytes = 20 * MiBToBytes
 	DefaultSstSizeBytes                        = 50 * KiBToBytes
 	DefaultTwoLevelSstSizeBytes                = 10 * KiBToBytes
-	DefaultMaxSizeKb                           = 100
+	DefaultMaxSizeKib                          = 100
 )
 
 var DefaultUserProperties = map[string]string{
@@ -75,8 +75,8 @@ func writeSstsWithUnsupportedWriterOptions() {
 		Compression: sstable.SnappyCompression,
 		TableFormat: sstable.TableFormatLevelDB,
 	}
-	createTestInputFiles(keys, generateNanoid, sizeBytes,
-		"table.format.leveldb", writerOptions)
+	createTestInputFiles(keys, generateNanoid, sizeBytes, "table.format.leveldb",
+		writerOptions)
 }
 
 func writeSstsWithWriterOptionsFuzzing() {
@@ -102,7 +102,8 @@ func writeSstsWithWriterOptionsFuzzing() {
 	// BlockRestartInterval is the number of keys between restart points
 	// for delta encoding of keys.
 	// The default value is 16.
-	blockRestartInterval := 1 + rand.Intn(100)
+	src1 := rand.NewSource(5092021)
+	blockRestartInterval := 1 + rand.New(src1).Intn(100)
 	writerOptions = sstable.WriterOptions{
 		Compression:             sstable.SnappyCompression,
 		TablePropertyCollectors: []func() sstable.TablePropertyCollector{NewStaticCollector(DefaultUserProperties)},
@@ -113,7 +114,8 @@ func writeSstsWithWriterOptionsFuzzing() {
 
 	// BlockSize is the target uncompressed size in bytes of each table block.
 	// The default value is 4096.
-	blockSize := 1 + rand.Intn(9000)
+	src2 := rand.NewSource(881989)
+	blockSize := 1 + rand.New(src2).Intn(9000)
 	writerOptions = sstable.WriterOptions{
 		Compression:             sstable.SnappyCompression,
 		TablePropertyCollectors: []func() sstable.TablePropertyCollector{NewStaticCollector(DefaultUserProperties)},
@@ -127,7 +129,8 @@ func writeSstsWithWriterOptionsFuzzing() {
 	// would cause the block to be larger than the target block size.
 	//
 	// The default value is 90
-	blockSizeThreshold := 1 + rand.Intn(100)
+	src3 := rand.NewSource(123432)
+	blockSizeThreshold := 1 + rand.New(src3).Intn(100)
 	writerOptions = sstable.WriterOptions{
 		Compression:             sstable.SnappyCompression,
 		TablePropertyCollectors: getDefaultTablePropertyCollectors(DefaultUserProperties),
@@ -149,12 +152,14 @@ func writeLargeSsts() {
 
 func writeMultiSizedSstsWithContentsFuzzing() {
 	const numOfFilesToGenerate = 6
+	src := rand.NewSource(980433)
+	r := rand.New(src)
 	for i := 0; i < numOfFilesToGenerate; i++ {
 		var curSize int
 		if i%2 == 0 {
-			curSize = 1 + rand.Intn(DefaultCommittedPermanentMaxRangeSizeBytes/MiBToBytes)*MiBToBytes
+			curSize = 1 + r.Intn(DefaultCommittedPermanentMaxRangeSizeBytes/MiBToBytes)*MiBToBytes
 		} else {
-			curSize = 1 + rand.Intn(DefaultMaxSizeKb)*KiBToBytes
+			curSize = 1 + r.Intn(DefaultMaxSizeKib)*KiBToBytes
 		}
 
 		testFileName := fmt.Sprintf("fuzz.contents.%d", i)

--- a/clients/spark/core/src/test/resources/parser-test/sst_files_generator.go
+++ b/clients/spark/core/src/test/resources/parser-test/sst_files_generator.go
@@ -154,9 +154,9 @@ func writeMultiSizedSstsWithContentsFuzzing() {
 	for i := 0; i < numOfFilesToGenerate; i++ {
 		var curSize int
 		if i%2 == 0 {
-			curSize = 1 + r.Intn(DefaultCommittedPermanentMaxRangeSizeBytes/MiBToBytes)*MiBToBytes
+			curSize = (1 + r.Intn(DefaultCommittedPermanentMaxRangeSizeBytes/MiBToBytes)) * MiBToBytes
 		} else {
-			curSize = 1 + r.Intn(DefaultMaxSizeKiB)*KiBToBytes
+			curSize = (1 + r.Intn(DefaultMaxSizeKiB)) * KiBToBytes
 		}
 
 		testFileName := fmt.Sprintf("fuzz.contents.%d", i)

--- a/clients/spark/core/src/test/resources/parser-test/sst_files_generator.go
+++ b/clients/spark/core/src/test/resources/parser-test/sst_files_generator.go
@@ -1,0 +1,286 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"math/rand"
+	"os"
+	"sort"
+
+	fuzz "github.com/google/gofuzz"
+
+	"github.com/cockroachdb/pebble/sstable"
+	nanoid "github.com/matoous/go-nanoid/v2"
+)
+
+const (
+	DefaultKeySizeBytes   = 100
+	DefaultValueSizeBytes = 5
+	MbToBytes             = 1024 * 1024
+	KbToBytes             = 1024
+	FuzzerSeed            = 50
+	// DefaultCommittedPermanentMaxRangeSizeMb - the max file size that can be written by graveler (pkg/config/config.go)
+	DefaultCommittedPermanentMaxRangeSizeMb = 20
+)
+
+func getDefaultUserProperties() map[string]string {
+	return map[string]string{
+		"user_prop_1": "val1",
+		"user_prop_2": "val2",
+	}
+}
+
+type Entry struct {
+	Key   string
+	Value string
+}
+
+func main() {
+	generateTwoLevelIdxSst()
+	fuzzSstContents()
+	fuzzWriterOptions()
+	sstsWithUnsupportedWriterOptions()
+	generateLargeSsts()
+}
+
+func sstsWithUnsupportedWriterOptions() {
+	sizeBytes := 10 * KbToBytes
+	keys := generateSortedSlice(sizeBytes)
+
+	// Checksum specifies which checksum to use. lakeFS supports parsing sstables with crc checksum.
+	// ChecksumTypeXXHash and ChecksumTypeNone are unsupported and therefore not tested.
+	writerOptions := sstable.WriterOptions{
+		Compression: sstable.SnappyCompression,
+		Checksum:    sstable.ChecksumTypeXXHash64,
+	}
+	writeTestInputFiles(keys, func() (string, error) { return nanoid.New(DefaultValueSizeBytes) }, sizeBytes,
+		"checksum.type.xxHash64", writerOptions)
+
+	// TableFormat specifies the format version for writing sstables. The default
+	// is TableFormatRocksDBv2 which creates RocksDB compatible sstables. this is the only format supported by lakeFS.
+	writerOptions = sstable.WriterOptions{
+		Compression: sstable.SnappyCompression,
+		TableFormat: sstable.TableFormatLevelDB,
+	}
+	writeTestInputFiles(keys, func() (string, error) { return nanoid.New(DefaultValueSizeBytes) }, sizeBytes,
+		"table.format.leveldb", writerOptions)
+}
+
+func fuzzWriterOptions() {
+	sizeBytes := 50 * KbToBytes
+	keys := generateSortedSlice(sizeBytes)
+
+	// Use fuzzing to define sstable user properties.
+	f := fuzz.NewWithSeed(FuzzerSeed)
+	userProps := map[string]string{}
+	for i := 1; i <= 20; i++ {
+		var propKey string
+		var propVal string
+		f.Fuzz(&propKey)
+		f.Fuzz(&propVal)
+		userProps[propKey] = propVal
+		fmt.Printf("user property %d, key=%s, val=%s\n", i, propKey, propVal)
+	}
+	writerOptions := sstable.WriterOptions{
+		Compression:             sstable.SnappyCompression,
+		TablePropertyCollectors: []func() sstable.TablePropertyCollector{NewStaticCollector(userProps)},
+	}
+	writeTestInputFiles(keys, func() (string, error) { return nanoid.New(DefaultValueSizeBytes) }, sizeBytes,
+		"fuzz.table.properties", writerOptions)
+
+	// BlockRestartInterval is the number of keys between restart points
+	// for delta encoding of keys.
+	// The default value is 16.
+	blockRestartInterval := rand.Intn(100)
+	writerOptions = sstable.WriterOptions{
+		Compression:             sstable.SnappyCompression,
+		TablePropertyCollectors: []func() sstable.TablePropertyCollector{NewStaticCollector(getDefaultUserProperties())},
+		BlockRestartInterval:    blockRestartInterval,
+	}
+	fmt.Printf("BlockRestartInterval %d...\n", blockRestartInterval)
+	writeTestInputFiles(keys, func() (string, error) { return nanoid.New(DefaultValueSizeBytes) }, sizeBytes,
+		"fuzz.block.restart.interval", writerOptions)
+
+	// BlockSize is the target uncompressed size in bytes of each table block.
+	// The default value is 4096.
+	blockSize := rand.Intn(9000)
+	writerOptions = sstable.WriterOptions{
+		Compression:             sstable.SnappyCompression,
+		TablePropertyCollectors: []func() sstable.TablePropertyCollector{NewStaticCollector(getDefaultUserProperties())},
+		BlockSize:               blockSize,
+	}
+	fmt.Printf("BlockSize %d...\n", blockSize)
+	writeTestInputFiles(keys, func() (string, error) { return nanoid.New(DefaultValueSizeBytes) }, sizeBytes,
+		"fuzz.block.size", writerOptions)
+
+	// BlockSizeThreshold finishes a block if the block size is larger than the
+	// specified percentage of the target block size and adding the next entry
+	// would cause the block to be larger than the target block size.
+	//
+	// The default value is 90
+	blockSizeThreshold := rand.Intn(100)
+	writerOptions = sstable.WriterOptions{
+		Compression:             sstable.SnappyCompression,
+		TablePropertyCollectors: []func() sstable.TablePropertyCollector{NewStaticCollector(getDefaultUserProperties())},
+		BlockSizeThreshold:      blockSizeThreshold,
+	}
+	fmt.Printf("BlockSizeThreshold %d...\n", blockSizeThreshold)
+	writeTestInputFiles(keys, func() (string, error) { return nanoid.New(DefaultValueSizeBytes) }, sizeBytes,
+		"fuzz.block.size.threshold", writerOptions)
+}
+
+func generateLargeSsts() {
+	sizeBytes := DefaultCommittedPermanentMaxRangeSizeMb * MbToBytes
+	keys := generateSortedSlice(sizeBytes)
+	writerOptions := sstable.WriterOptions{
+		Compression:             sstable.SnappyCompression,
+		TablePropertyCollectors: []func() sstable.TablePropertyCollector{NewStaticCollector(getDefaultUserProperties())},
+	}
+	writeTestInputFiles(keys, func() (string, error) { return nanoid.New(DefaultValueSizeBytes) }, sizeBytes,
+		"max.size.lakefs.file", writerOptions)
+}
+
+// Generates sstables on multiple sizes and uses a fuzzer to generate their contents.
+func fuzzSstContents() {
+	var fileSizes []int
+	for i := 0; i < 3; i++ {
+		curMb := rand.Intn(DefaultCommittedPermanentMaxRangeSizeMb)
+		curKb := rand.Intn(100)
+		if curMb == 0 || curKb == 0 {
+			continue
+		}
+		fileSizes = append(fileSizes, curMb*MbToBytes)
+		fileSizes = append(fileSizes, curKb*KbToBytes)
+	}
+
+	for i, size := range fileSizes {
+		sizeBytes := size
+		testFileName := fmt.Sprintf("fuzz.contents.%d", i)
+		keys := generateSortedSliceWithFuzzing(sizeBytes)
+
+		writerOptions := sstable.WriterOptions{
+			Compression:             sstable.SnappyCompression,
+			TablePropertyCollectors: []func() sstable.TablePropertyCollector{NewStaticCollector(getDefaultUserProperties())},
+		}
+
+		f := fuzz.NewWithSeed(FuzzerSeed)
+		writeTestInputFiles(keys, func() (string, error) {
+			var val string
+			f.Fuzz(&val)
+			return val, nil
+		}, sizeBytes, testFileName, writerOptions)
+	}
+}
+
+func generateSortedSliceWithFuzzing(size int) []string {
+	var keySumBytes int
+	var slice []string
+	f := fuzz.NewWithSeed(FuzzerSeed)
+	// Keep generating keys until we reach the desired slice size. This guarantees that the sstable writer will have
+	// enough data to write an sstable of the desired size.
+	for keySumBytes < size {
+		var key string
+		f.Fuzz(&key)
+		if key == "" { // TODO: (Tals) remove after resolving https://github.com/treeverse/lakeFS/issues/2419
+			continue
+		}
+		keySumBytes += len(key)
+		slice = append(slice, key)
+	}
+	sort.Strings(slice)
+	return slice
+}
+
+func generateTwoLevelIdxSst() {
+	sizeBytes := 10 * KbToBytes
+	keys := generateSortedSlice(sizeBytes)
+
+	writerOptions := sstable.WriterOptions{
+		Compression:             sstable.SnappyCompression,
+		IndexBlockSize:          5, // setting the index block size target to a small number to make 2-level index get enabled
+		TablePropertyCollectors: []func() sstable.TablePropertyCollector{NewStaticCollector(getDefaultUserProperties())},
+	}
+	writeTestInputFiles(keys, func() (string, error) { return nanoid.New(DefaultValueSizeBytes) }, sizeBytes,
+		"two.level.idx", writerOptions)
+}
+
+func generateSortedSlice(size int) []string {
+	numLines := size / DefaultKeySizeBytes
+	slice := make([]string, 0, numLines)
+	for i := 0; i < numLines; i++ {
+		key, err := nanoid.New(DefaultKeySizeBytes)
+		if err != nil {
+			panic(err)
+		}
+		slice = append(slice, key)
+	}
+	sort.Strings(slice)
+	return slice
+}
+
+// Writes sst and json files that will be used to unit test the sst block parser (clients/spark/core/src/main/scala/io/treeverse/jpebble/BlockParser.scala)
+// The sst file is the test input, and the json file encapsulates the expected parser output.
+func writeTestInputFiles(keys []string, genValue func() (string, error), size int, name string,
+	writerOptions sstable.WriterOptions) {
+	fmt.Printf("Generate %s of size %d bytes\n", name, size)
+	sstFile, err := os.Create(name + ".sst")
+	if err != nil {
+		panic(err)
+	}
+
+	expectedContents := make([]Entry, 0, len(keys))
+	writer := sstable.NewWriter(sstFile, writerOptions)
+	defer func() {
+		_ = writer.Close()
+	}()
+
+	for _, k := range keys {
+		if writer.EstimatedSize() >= uint64(size) {
+			break
+		}
+		v, err := genValue()
+		if err != nil {
+			panic(err)
+		}
+		if err := writer.Set([]byte(k), []byte(v)); err != nil {
+			panic(fmt.Errorf("setting key and value: %w", err))
+		}
+		expectedContents = append(expectedContents, Entry{Key: k, Value: v})
+	}
+	saveExpectedContentsAsJson(expectedContents, name)
+}
+
+func saveExpectedContentsAsJson(contents []Entry, name string) {
+	j, _ := json.Marshal(contents)
+	ioutil.WriteFile(name+".json", j, os.ModePerm)
+}
+
+// Copied from pkg/graveler/sstable/collectors.go. lakeFS populates the following user properties for each sstable
+// graveler writes: type (range/metarange), min_key, max_key, count, estimated_size_bytes
+// staticCollector is an sstable.TablePropertyCollector that adds a map's values to the user
+// property map.
+type staticCollector struct {
+	m map[string]string
+}
+
+func (*staticCollector) Add(key sstable.InternalKey, value []byte) error {
+	return nil
+}
+
+func (*staticCollector) Name() string {
+	return "static"
+}
+
+func (s *staticCollector) Finish(userProps map[string]string) error {
+	for k, v := range s.m {
+		userProps[k] = v
+	}
+	return nil
+}
+
+// NewStaticCollector returns an SSTable collector that will add the properties in m when
+// writing ends.
+func NewStaticCollector(m map[string]string) func() sstable.TablePropertyCollector {
+	return func() sstable.TablePropertyCollector { return &staticCollector{m} }
+}

--- a/clients/spark/core/src/test/scala/io/treeverse/jpebble/BlockParserSpec.scala
+++ b/clients/spark/core/src/test/scala/io/treeverse/jpebble/BlockParserSpec.scala
@@ -14,9 +14,6 @@ import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy
 import org.scalatest.matchers.must.Matchers.contain
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 
-import java.nio.channels.FileChannel
-import java.nio.file.{StandardOpenOption}
-
 class BlockParserSpec extends AnyFunSpec with Matchers {
   val magicBytes = BlockParser.footerMagic
 

--- a/clients/spark/core/src/test/scala/io/treeverse/jpebble/BlockParserSpec.scala
+++ b/clients/spark/core/src/test/scala/io/treeverse/jpebble/BlockParserSpec.scala
@@ -14,6 +14,9 @@ import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy
 import org.scalatest.matchers.must.Matchers.contain
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 
+import java.nio.channels.FileChannel
+import java.nio.file.{StandardOpenOption}
+
 class BlockParserSpec extends AnyFunSpec with Matchers {
   val magicBytes = BlockParser.footerMagic
 

--- a/clients/spark/core/src/test/scala/io/treeverse/jpebble/BlockParserSpec.scala
+++ b/clients/spark/core/src/test/scala/io/treeverse/jpebble/BlockParserSpec.scala
@@ -3,7 +3,7 @@ package io.treeverse.jpebble
 import org.scalatest._
 import matchers.should._
 import funspec._
-import com.dimafeng.testcontainers.{DockerComposeContainer, ForAllTestContainer, GenericContainer}
+import com.dimafeng.testcontainers.{ForAllTestContainer, GenericContainer}
 
 import java.io.File
 import org.apache.commons.io.IOUtils
@@ -13,7 +13,6 @@ import org.testcontainers.containers.BindMode
 import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy
 import org.scalatest.matchers.must.Matchers.contain
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
-import org.testcontainers.containers.startupcheck.IndefiniteWaitOneShotStartupCheckStrategy
 
 class BlockParserSpec extends AnyFunSpec with Matchers {
   val magicBytes = BlockParser.footerMagic
@@ -277,7 +276,7 @@ class GolangContainerSpec extends AnyFunSpec with ForAllTestContainer {
       ("parser-test/go.mod", "/local/go.mod", BindMode.READ_WRITE),
       ("parser-test/go.sum", "/local/go.sum", BindMode.READ_WRITE)),
     command = Seq("/bin/sh", "-c", "cd /local && CGO_ENABLED=0 go run sst_files_generator.go && echo \"done\""),
-    waitStrategy = new LogMessageWaitStrategy().withRegEx("done\\n")
+    waitStrategy = new LogMessageWaitStrategy().withRegEx("done\\n") // TODO(Tals): use startupCheckStrategy instead of waitStrategy (https://github.com/treeverse/lakeFS/issues/2455)
   )
 
   describe("A block parser") {

--- a/clients/spark/core/src/test/scala/io/treeverse/jpebble/BlockParserSpec.scala
+++ b/clients/spark/core/src/test/scala/io/treeverse/jpebble/BlockParserSpec.scala
@@ -3,15 +3,17 @@ package io.treeverse.jpebble
 import org.scalatest._
 import matchers.should._
 import funspec._
-import com.dimafeng.testcontainers.{ForAllTestContainer, GenericContainer}
+import com.dimafeng.testcontainers.{DockerComposeContainer, ForAllTestContainer, GenericContainer}
 
 import java.io.File
 import org.apache.commons.io.IOUtils
+
 import scala.io.Source
 import org.testcontainers.containers.BindMode
 import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy
-import org.scalatest.matchers.must.Matchers.{contain}
+import org.scalatest.matchers.must.Matchers.contain
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
+import org.testcontainers.containers.startupcheck.IndefiniteWaitOneShotStartupCheckStrategy
 
 class BlockParserSpec extends AnyFunSpec with Matchers {
   val magicBytes = BlockParser.footerMagic
@@ -276,7 +278,7 @@ class GolangContainerSpec extends AnyFunSpec with ForAllTestContainer {
       ("parser-test/go.sum", "/local/go.sum", BindMode.READ_WRITE)),
     command = Seq("/bin/sh", "-c", "cd /local && CGO_ENABLED=0 go run sst_files_generator.go && echo \"done\""),
     waitStrategy = new LogMessageWaitStrategy().withRegEx("done\\n")
-  );
+  )
 
   describe("A block parser") {
     describe("with 2-level index sstable") {


### PR DESCRIPTION
Part of #2353 

### Change list
* Plumbing to generate customized sstables that can be consumed by the BlockPraserSpec scala tests. 
* Initial test cases for the java parser. 

The flow of the tests in this PR is as follows: 
* A docker container with a golang image is created once for all the added tests
* On startup the script generate-sst.sh runs and executes the go app that generates customized sstables, and jsond that include the output expected from the parser. 
* The Scala tests then copy the files from within the container to temp files the parser tests can operate on. 
* Scala tests use the sstable and json files copied from the container as their input. 

#### Note
The go app that generates the test input does this in a deterministic way. that is, in case a test fails it should be possible to reproduce the failure. 

