### PR TITLE
log lakefs configuration on startup

### DIFF
--- a/cmd/lakefs/cmd/root.go
+++ b/cmd/lakefs/cmd/root.go
@@ -100,6 +100,8 @@ func initConfig() {
 	if err != nil {
 		logger.WithError(err).Fatal("Invalid config")
 	}
+
+	logger.WithFields(cfg.ToLoggerFields()).Info("Config")
 }
 
 // getHomeDir find and return the home directory

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -20,6 +20,14 @@ We are extremely responsive on our slack channel, and we make sure to prioritize
 ### 4. Do you collect data from your active installations?
 We collect anonymous usage statistics in order to understand the patterns of use and to detect product gaps we may have so we can fix them. This is completely optional and may be turned off by setting `stats.enabled` to `false`. See the [configuration reference](reference/configuration.md#reference) for more details.
 
+
+The data we gather is limited to the following:
+1. A UUID which is generated when setting up lakeFS for the first time and contains no personal or otherwise identifiable information
+1. The lakeFS version currently running
+1. The OS and architecture lakeFS is running on
+1. Metadata regarding the database used (version, installed extensions and parameters such as DB Timezone and work memory)
+1. Periodic aggregated action counters (e.g. how many "get_object" operations occurred).
+
 ### 5. How is lakeFS different from Delta Lake / Hudi / Iceberg?
 Delta Lake, Hudi and Iceberg all define dedicated, structured data formats that allow deletes and upserts. lakeFS is format-agnostic and enables consistent cross-collection versioning of your data using git-like operations. Read our [blog](https://lakefs.io/hudi-iceberg-and-delta-lake-data-lake-table-formats-compared/) for a more detailed comparison. 
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -76,7 +76,7 @@ type Config struct {
 func NewConfig() (*Config, error) {
 	c := &Config{}
 
-	// Inform viper of all expected fields.  Otherwise it fails to deserialize from the
+	// Inform viper of all expected fields.  Otherwise, it fails to deserialize from the
 	// environment.
 	keys := GetStructKeys(reflect.TypeOf(c.values), "mapstructure", "squash")
 	for _, key := range keys {
@@ -411,4 +411,8 @@ func (c *Config) GetFixedInstallationID() string {
 
 func (c *Config) GetCommittedBlockStoragePrefix() string {
 	return c.values.Committed.BlockStoragePrefix
+}
+
+func (c *Config) ToLoggerFields() logging.Fields {
+	return MapLoggingFields(c.values)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -229,7 +229,7 @@ func (c *Config) Validate() error {
 
 func (c *Config) GetDatabaseParams() dbparams.Database {
 	return dbparams.Database{
-		ConnectionString:      c.values.Database.ConnectionString,
+		ConnectionString:      c.values.Database.ConnectionString.String(),
 		MaxOpenConnections:    c.values.Database.MaxOpenConnections,
 		MaxIdleConnections:    c.values.Database.MaxIdleConnections,
 		ConnectionMaxLifetime: c.values.Database.ConnectionMaxLifetime,
@@ -259,9 +259,9 @@ func (c *Config) GetAwsConfig() *aws.Config {
 			secretAccessKey = c.values.Blockstore.S3.Credentials.AccessSecretKey
 		}
 		cfg.Credentials = credentials.NewStaticCredentials(
-			c.values.Blockstore.S3.Credentials.AccessKeyID,
-			secretAccessKey,
-			c.values.Blockstore.S3.Credentials.SessionToken,
+			c.values.Blockstore.S3.Credentials.AccessKeyID.String(),
+			secretAccessKey.String(),
+			c.values.Blockstore.S3.Credentials.SessionToken.String(),
 		)
 	}
 

--- a/pkg/config/struct_fields_test.go
+++ b/pkg/config/struct_fields_test.go
@@ -46,15 +46,8 @@ func TestMapLoggingFields(t *testing.T) {
 				E bool
 			} `mapstructure:"squash"`
 		}
-		EE1 string `validate:"secret"`
-		EE2 string `validate:"secret"`
-		FF  struct {
-			A int
-			B string
-			C *float64
-			D []rune
-			E bool
-		} `validate:"secret"`
+		EE1 config.SecureString
+		EE2 config.SecureString
 	}{
 		A: 1,
 		B: "2",
@@ -113,19 +106,6 @@ func TestMapLoggingFields(t *testing.T) {
 		},
 		EE1: "ee1ee1ee1",
 		EE2: "",
-		FF: struct {
-			A int
-			B string
-			C *float64
-			D []rune
-			E bool
-		}{
-			A: 1,
-			B: "2",
-			C: &f,
-			D: []rune{1, 2},
-			E: true,
-		},
 	}
 	expected := logging.Fields{
 		"a":           "1",
@@ -150,7 +130,6 @@ func TestMapLoggingFields(t *testing.T) {
 		"e":           "true",
 		"ee1":         config.FieldMaskedValue,
 		"ee2":         config.FieldMaskedNoValue,
-		"ff":          config.FieldMaskedValue,
 	}
 
 	fields := config.MapLoggingFields(value)

--- a/pkg/config/struct_fields_test.go
+++ b/pkg/config/struct_fields_test.go
@@ -1,0 +1,167 @@
+package config_test
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/treeverse/lakefs/pkg/config"
+	"github.com/treeverse/lakefs/pkg/logging"
+)
+
+func TestMapLoggingFields(t *testing.T) {
+	f := 64.0
+	value := struct {
+		A  int
+		B  string
+		C  *float64
+		D  []rune
+		E  bool
+		AA struct {
+			A int
+			B string
+			C *float64
+			D []rune
+			E bool
+		}
+		BB *struct {
+			A int
+			B string
+			C *float64
+			D []rune
+			E bool
+		}
+		CC struct {
+			A int      `mapstructure:"a1"`
+			B string   `mapstructure:"b1"`
+			C *float64 `mapstructure:"c1"`
+			D []rune   `mapstructure:"d1"`
+			E bool     `mapstructure:"e1"`
+		} `mapstructure:"c_c"`
+		DD struct {
+			Squash struct {
+				A int
+				B string
+				C *float64
+				D []rune
+				E bool
+			} `mapstructure:"squash"`
+		}
+		EE1 string `validate:"secret"`
+		EE2 string `validate:"secret"`
+		FF  struct {
+			A int
+			B string
+			C *float64
+			D []rune
+			E bool
+		} `validate:"secret"`
+	}{
+		A: 1,
+		B: "2",
+		C: &f,
+		D: []rune{1, 2, 3},
+		E: true,
+		AA: struct {
+			A int
+			B string
+			C *float64
+			D []rune
+			E bool
+		}{
+			A: 1,
+			B: "2",
+			C: &f,
+			D: []rune{1, 2, 3},
+			E: true,
+		},
+		BB: nil,
+		CC: struct {
+			A int      `mapstructure:"a1"`
+			B string   `mapstructure:"b1"`
+			C *float64 `mapstructure:"c1"`
+			D []rune   `mapstructure:"d1"`
+			E bool     `mapstructure:"e1"`
+		}{
+			A: 1,
+			B: "2",
+			C: &f,
+			D: []rune{1, 2, 3, 4},
+			E: true,
+		},
+		DD: struct {
+			Squash struct {
+				A int
+				B string
+				C *float64
+				D []rune
+				E bool
+			} `mapstructure:"squash"`
+		}{
+			Squash: struct {
+				A int
+				B string
+				C *float64
+				D []rune
+				E bool
+			}{
+				A: 1,
+				B: "2",
+				C: &f,
+				D: []rune{1, 2, 3},
+				E: true,
+			},
+		},
+		EE1: "ee1ee1ee1",
+		EE2: "",
+		FF: struct {
+			A int
+			B string
+			C *float64
+			D []rune
+			E bool
+		}{
+			A: 1,
+			B: "2",
+			C: &f,
+			D: []rune{1, 2},
+			E: true,
+		},
+	}
+	expected := logging.Fields{
+		"a":           "1",
+		"aa.a":        "1",
+		"aa.b":        "2",
+		"aa.c":        "64",
+		"aa.d":        "[1 2 3]",
+		"aa.e":        "true",
+		"b":           "2",
+		"c":           "64",
+		"c_c.a1":      "1",
+		"c_c.b1":      "2",
+		"c_c.c1":      "64",
+		"c_c.d1":      "[1 2 3 4]",
+		"c_c.e1":      "true",
+		"d":           "[1 2 3]",
+		"dd.squash.a": "1",
+		"dd.squash.b": "2",
+		"dd.squash.c": "64",
+		"dd.squash.d": "[1 2 3]",
+		"dd.squash.e": "true",
+		"e":           "true",
+		"ee1":         config.FieldMaskedValue,
+		"ee2":         config.FieldMaskedNoValue,
+		"ff":          config.FieldMaskedValue,
+	}
+
+	fields := config.MapLoggingFields(value)
+	if len(expected) != len(fields) {
+		t.Fatalf("Expected %d fields, got %d", len(expected), len(fields))
+	}
+	for k, v := range fields {
+		expectedString := expected[k]
+		vString := fmt.Sprint(v)
+		if vString != expectedString {
+			t.Errorf("Value for '%s' is '%s', expected '%s'", k, vString, expectedString)
+		}
+	}
+}

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -28,18 +28,24 @@ func DecodeStrings(fromValue reflect.Value, toValue reflect.Value) (interface{},
 	return fromValue.Interface(), nil
 }
 
+type SecureString string
+
+func (s *SecureString) String() string {
+	return string(*s)
+}
+
 // S3AuthInfo holds S3-style authentication.
 type S3AuthInfo struct {
 	CredentialsFile string `mapstructure:"credentials_file"`
 	Profile         string
 	Credentials     *struct {
-		AccessKeyID string `mapstructure:"access_key_id" validate:"secret"`
+		AccessKeyID SecureString `mapstructure:"access_key_id"`
 		// AccessSecretKey is the old name for SecretAccessKey.
 		//
 		// Deprecated: use SecretAccessKey instead.
-		AccessSecretKey string `mapstructure:"access_secret_key" validate:"secret"`
-		SecretAccessKey string `mapstructure:"secret_access_key" validate:"secret"`
-		SessionToken    string `mapstructure:"session_token" validate:"secret"`
+		AccessSecretKey SecureString `mapstructure:"access_secret_key"`
+		SecretAccessKey SecureString `mapstructure:"secret_access_key"`
+		SessionToken    SecureString `mapstructure:"session_token"`
 	}
 }
 
@@ -56,7 +62,7 @@ type configuration struct {
 	}
 
 	Database struct {
-		ConnectionString      string        `mapstructure:"connection_string" validate:"secret"`
+		ConnectionString      SecureString  `mapstructure:"connection_string"`
 		MaxOpenConnections    int32         `mapstructure:"max_open_connections"`
 		MaxIdleConnections    int32         `mapstructure:"max_idle_connections"`
 		ConnectionMaxLifetime time.Duration `mapstructure:"connection_max_lifetime"`
@@ -70,7 +76,7 @@ type configuration struct {
 			Jitter  time.Duration
 		}
 		Encrypt struct {
-			SecretKey string `mapstructure:"secret_key" validate:"required,secret"`
+			SecretKey SecureString `mapstructure:"secret_key" validate:"required"`
 		}
 	}
 	Blockstore struct {

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -33,13 +33,13 @@ type S3AuthInfo struct {
 	CredentialsFile string `mapstructure:"credentials_file"`
 	Profile         string
 	Credentials     *struct {
-		AccessKeyID string `mapstructure:"access_key_id"`
+		AccessKeyID string `mapstructure:"access_key_id" validate:"secret"`
 		// AccessSecretKey is the old name for SecretAccessKey.
 		//
 		// Deprecated: use SecretAccessKey instead.
-		AccessSecretKey string `mapstructure:"access_secret_key"`
-		SecretAccessKey string `mapstructure:"secret_access_key"`
-		SessionToken    string `mapstructure:"session_token"`
+		AccessSecretKey string `mapstructure:"access_secret_key" validate:"secret"`
+		SecretAccessKey string `mapstructure:"secret_access_key" validate:"secret"`
+		SessionToken    string `mapstructure:"session_token" validate:"secret"`
 	}
 }
 
@@ -56,7 +56,7 @@ type configuration struct {
 	}
 
 	Database struct {
-		ConnectionString      string        `mapstructure:"connection_string"`
+		ConnectionString      string        `mapstructure:"connection_string" validate:"secret"`
 		MaxOpenConnections    int32         `mapstructure:"max_open_connections"`
 		MaxIdleConnections    int32         `mapstructure:"max_idle_connections"`
 		ConnectionMaxLifetime time.Duration `mapstructure:"connection_max_lifetime"`
@@ -70,7 +70,7 @@ type configuration struct {
 			Jitter  time.Duration
 		}
 		Encrypt struct {
-			SecretKey string `mapstructure:"secret_key" validate:"required"`
+			SecretKey string `mapstructure:"secret_key" validate:"required,secret"`
 		}
 	}
 	Blockstore struct {


### PR DESCRIPTION
Close #2416

Traverse and log our configuration on startup.

- Do not print out values for secrets
- Support the same field conventions that we used while loading. The dotted field name and squash levels

Issues to discuss:

- [x] which level do we like to use when we dump the information
- [x] implementation - can we reuse the same functionality found inside struct_keys