### PR TITLE
Bugfix/2307 change error message in lakefs setup

### DIFF
--- a/cmd/lakefs/cmd/setup.go
+++ b/cmd/lakefs/cmd/setup.go
@@ -63,7 +63,7 @@ var setupCmd = &cobra.Command{
 			os.Exit(1)
 		}
 		if initialized {
-			fmt.Printf("lakeFS already initialized.")
+			fmt.Printf("Setup is already complete.")
 			os.Exit(1)
 		}
 

--- a/cmd/lakefs/cmd/setup.go
+++ b/cmd/lakefs/cmd/setup.go
@@ -63,7 +63,7 @@ var setupCmd = &cobra.Command{
 			os.Exit(1)
 		}
 		if initialized {
-			fmt.Printf("Setup is already complete.")
+			fmt.Printf("Setup is already complete.\n")
 			os.Exit(1)
 		}
 

--- a/cmd/lakefs/cmd/setup.go
+++ b/cmd/lakefs/cmd/setup.go
@@ -57,6 +57,16 @@ var setupCmd = &cobra.Command{
 		cloudMetadataProvider := stats.BuildMetadataProvider(logging.Default(), cfg)
 		metadata := stats.NewMetadata(ctx, logging.Default(), cfg.GetBlockstoreType(), metadataManager, cloudMetadataProvider)
 
+		initialized, err := metadataManager.IsInitialized(ctx)
+		if err != nil {
+			fmt.Printf("Setup failed: %s\n", err)
+			os.Exit(1)
+		}
+		if initialized {
+			fmt.Printf("lakeFS already initialized.")
+			os.Exit(1)
+		}
+
 		credentials, err := auth.CreateInitialAdminUserWithKeys(ctx, authService, metadataManager, userName, &accessKeyID, &secretAccessKey)
 		if err != nil {
 			fmt.Printf("Failed to setup admin user: %s\n", err)

--- a/webui/src/lib/api/index.js
+++ b/webui/src/lib/api/index.js
@@ -651,7 +651,7 @@ class Setup {
             case 200:
                 return response.json();
             case 409:
-                throw new Error('lakeFs already initialized.');
+                throw new Error('Setup is already complete.');
             default:
                 throw new Error('Unknown');
         }

--- a/webui/src/lib/api/index.js
+++ b/webui/src/lib/api/index.js
@@ -651,7 +651,7 @@ class Setup {
             case 200:
                 return response.json();
             case 409:
-                throw new Error('Conflict');
+                throw new Error('lakeFs already initialized.');
             default:
                 throw new Error('Unknown');
         }


### PR DESCRIPTION
Close: #2307

When trying to set up lakeFS more than once, the error message was not descriptive.
I made two changes:
1. In the setup phase I added a verification of whether the setup already happened. In this case, a descriptive error message will be printed.
2. I changed the error message in the UI to be descriptive.  