### PR TITLE
Fix the double slash namespace bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 
 ## Unreleased - XXXX-XX-XX
 
+- Fix double slash bug in storage namespace (#2397)
+
 ## v0.49.0 - 2021-09-02
 
 - Add search locations to load lakeFS configuration. More information on

--- a/cmd/lakefs/cmd/run.go
+++ b/cmd/lakefs/cmd/run.go
@@ -204,7 +204,7 @@ var runCmd = &cobra.Command{
 	},
 }
 
-// checkRepos iterates on all repos and validates that their settings is correct.
+// checkRepos iterates on all repos and validates that their settings are correct.
 func checkRepos(ctx context.Context, logger logging.Logger, authMetadataManager *auth.DBMetadataManager, blockStore block.Adapter, c *catalog.Catalog) {
 	initialized, err := authMetadataManager.IsInitialized(ctx)
 	if err != nil {
@@ -263,7 +263,7 @@ func checkMetadataPrefix(ctx context.Context, repo *catalog.Repository, logger l
 			"path":              dummyFile,
 			"storage_namespace": repo.StorageNamespace,
 		}).Fatal("Can't find dummy file in storage namespace, did you run the migration? " +
-			"(http://docs.lakefs.io/reference/upgrade.html#data-migration-for-version-v0490)")
+			"(http://docs.lakefs.io/reference/upgrade.html#data-migration-for-version-v0500)")
 	}
 }
 

--- a/cmd/lakefs/cmd/run.go
+++ b/cmd/lakefs/cmd/run.go
@@ -260,7 +260,8 @@ func checkMetadataPrefix(ctx context.Context, repo *catalog.Repository, logger l
 		StorageNamespace: repo.StorageNamespace,
 		Identifier:       dummyFile,
 	}, -1); err != nil {
-		logger.Fatalf("Can't find dummy (path: %s) file in storage namespace (%s), did you run the migration? (LINK)", dummyFile, repo.StorageNamespace)
+		logger.Fatalf("Can't find dummy (path: %s) file in storage namespace (%s), did you run the migration? "+
+			"(http://docs.lakefs.io/reference/upgrade.html#data-migration-for-version-v0490)", dummyFile, repo.StorageNamespace)
 	}
 }
 

--- a/docs/reference/upgrade.md
+++ b/docs/reference/upgrade.md
@@ -74,7 +74,7 @@ It affects only repositories on Azure and GCP, and not all of these.
 [Issue #2397](https://github.com/treeverse/lakeFS/issues/2397#issuecomment-908397229) describes the repository storage namespaces patterns 
 which are affected by this bug.
 
-In order to upgrade to any version which higher (or equal) than v0.49.0, you must follow these steps:
+In order to upgrade to any version which higher (or equal) than v0.50.0, you must follow these steps:
 1. Stop lakeFS.
 1. Perform a data-migration (details below)
 1. Start lakeFS with the new version.

--- a/docs/reference/upgrade.md
+++ b/docs/reference/upgrade.md
@@ -80,6 +80,10 @@ In order to upgrade to any version which higher (or equal) than v0.50.0, you mus
 1. Start lakeFS with the new version.
 1. After a successful run of the new version, and after validating the objects are accessible, you can delete the old data prefix.
 
+Note: Migrating data is a delicate procedure. The lakeFS team is here to help, reach out to us on Slack.
+We'll be happy to walk you through the process.  
+{: .note .pb-3 }
+
 ### Data migration
 
 The following patterns have been impacted by the bug:
@@ -91,6 +95,12 @@ The following patterns have been impacted by the bug:
 | azure | https://account.blob.core.windows.net/containerid         | https://account.blob.core.windows.net/containerid//*       | https://account.blob.core.windows.net/containerid/*        |
 | azure | https://account.blob.core.windows.net/containerid/        | https://account.blob.core.windows.net/containerid//*       | https://account.blob.core.windows.net/containerid/*        |
 | azure | https://account.blob.core.windows.net/containerid/prefix/ | https://account.blob.core.windows.net/containerid/prefix// | https://account.blob.core.windows.net/containerid/prefix/* |
+
+You can find the repositories storage namespaces with:
+
+```shell
+lakectl repo list
+```
 
 #### Migrating Google Storage data with gsutil
 

--- a/docs/reference/upgrade.md
+++ b/docs/reference/upgrade.md
@@ -74,7 +74,7 @@ It affects only repositories on Azure and GCP, and not all of these.
 [Issue #2397](https://github.com/treeverse/lakeFS/issues/2397#issuecomment-908397229) describes the repository storage namespaces patterns 
 which are affected by this bug.
 
-In order to upgrade to any version which higher (or equal) than v0.50.0, you must follow these steps:
+When first upgrading to a version greater or equal to v0.50.0, you must follow these steps:
 1. Stop lakeFS.
 1. Perform a data-migration (details below)
 1. Start lakeFS with the new version.

--- a/docs/reference/upgrade.md
+++ b/docs/reference/upgrade.md
@@ -67,10 +67,10 @@ cataloger:
   type: rocks
 ```
 
-## Data Migration for Version v0.49.0
+## Data Migration for Version v0.50.0
 
 We discovered a bug in the way lakeFS is storing objects in the underlying object store.
-It affects azure and gcp repositories and only some of those. 
+It affects only repositories on Azure and GCP, and not all of these.
 [Issue #2397](https://github.com/treeverse/lakeFS/issues/2397#issuecomment-908397229) describes the repository storage namespaces patterns 
 which are affected by this bug.
 
@@ -115,7 +115,7 @@ az storage container generate-sas \
     --name <CONTAINER> \
     --permissions cdrw \
     --auth-mode key \
-    --expiry 2021-09-05
+    --expiry 2021-12-31
 ```
 
 With the resulted SAS, use AzCopy to copy the files:

--- a/docs/reference/upgrade.md
+++ b/docs/reference/upgrade.md
@@ -68,6 +68,7 @@ cataloger:
 ```
 
 ## Data Migration for Version v0.49.0
+
 We discovered a bug in the way lakeFS is storing objects in the underlying object store.
 It affects azure and gcp repositories and only some of those. 
 [Issue #2397](https://github.com/treeverse/lakeFS/issues/2397#issuecomment-908397229) describes the repository storage namespaces patterns 
@@ -80,6 +81,7 @@ In order to upgrade to any version which higher (or equal) than v0.49.0, you mus
 1. After a successful run of the new version, and after validating the objects are accessible, you can delete the old data prefix.
 
 ### Data migration
+
 The following patterns have been impacted by the bug:
 
 | Type  | Storage Namespace pattern                                 | Copy From                                                  | Copy To                                                    |
@@ -91,6 +93,7 @@ The following patterns have been impacted by the bug:
 | azure | https://account.blob.core.windows.net/containerid/prefix/ | https://account.blob.core.windows.net/containerid/prefix// | https://account.blob.core.windows.net/containerid/prefix/* |
 
 #### Migrating Google Storage data with gsutil
+
 [gsutil](https://cloud.google.com/storage/docs/gsutil) is a Python application that lets you access Cloud Storage from the command line.
 We can use it for copying the data between the prefixes in the Google bucket, and later on removing it.
 
@@ -100,6 +103,7 @@ gsutil -m cp -r gs://<BUCKET>//<PREFIX>/ gs://<BUCKET>/
 ```
 
 #### Migrating Azure Blob Storage data with AzCopy
+
 [AzCopy](https://docs.microsoft.com/en-us/azure/storage/common/storage-use-azcopy-v10) is a command-line utility that you can use to copy blobs or files to or from a storage account.
 We can use it for copying the data between the prefixes in the Azure storage account container, and later on removing it.
 

--- a/docs/reference/upgrade.md
+++ b/docs/reference/upgrade.md
@@ -132,10 +132,20 @@ az storage container generate-sas \
     --expiry 2021-12-31
 ```
 
-With the resulted SAS, use AzCopy to copy the files:
+With the resulted SAS, use AzCopy to copy the files.
+If a prefix exists after the container:
 ```shell
 azcopy copy \
 "https://<ACCOUNT>.blob.core.windows.net/<CONTAINER>/<PREFIX>//?<SAS_TOKEN>" \
 "https://<ACCOUNT>.blob.core.windows.net/<CONTAINER>?<SAS_TOKEN>" \
+--recursive=true
+```
+
+Or when using the container without a prefix:
+
+```shell
+azcopy copy \
+"https://<ACCOUNT>.blob.core.windows.net/<CONTAINER>//?<SAS_TOKEN>" \
+"https://<ACCOUNT>.blob.core.windows.net/<CONTAINER>/./?<SAS_TOKEN>" \
 --recursive=true
 ```

--- a/docs/reference/upgrade.md
+++ b/docs/reference/upgrade.md
@@ -102,15 +102,19 @@ You can find the repositories storage namespaces with:
 lakectl repo list
 ```
 
+Or the settings tab in the UI.
+
 #### Migrating Google Storage data with gsutil
 
 [gsutil](https://cloud.google.com/storage/docs/gsutil) is a Python application that lets you access Cloud Storage from the command line.
 We can use it for copying the data between the prefixes in the Google bucket, and later on removing it.
 
-Copy the data with:
+For every affected repository, copy its data with:
 ```shell
 gsutil -m cp -r gs://<BUCKET>//<PREFIX>/ gs://<BUCKET>/
 ```
+
+Note the double slash after the bucket name.
 
 #### Migrating Azure Blob Storage data with AzCopy
 

--- a/pkg/block/azure/adapter.go
+++ b/pkg/block/azure/adapter.go
@@ -72,7 +72,7 @@ func resolveBlobURLInfoFromURL(pathURL *url.URL) (BlobURLInfo, error) {
 		return qk, block.ErrInvalidNamespace
 	}
 	// In azure the first part of the path is part of the storage namespace
-	trimmedPath := strings.TrimLeft(pathURL.Path, "/")
+	trimmedPath := strings.Trim(pathURL.Path, "/")
 	parts := strings.Split(trimmedPath, "/")
 	if len(parts) == 0 {
 		return qk, block.ErrInvalidNamespace
@@ -100,10 +100,15 @@ func resolveBlobURLInfo(obj block.ObjectPointer) (BlobURLInfo, error) {
 		if err != nil {
 			return qk, err
 		}
-		return BlobURLInfo{
+		info := BlobURLInfo{
 			ContainerURL: qp.ContainerURL,
 			BlobURL:      qp.BlobURL + "/" + key,
-		}, nil
+		}
+		if qp.BlobURL == "" {
+			info.BlobURL = key
+		}
+
+		return info, nil
 	}
 	return resolveBlobURLInfoFromURL(parsedKey)
 }

--- a/pkg/block/namespace.go
+++ b/pkg/block/namespace.go
@@ -89,10 +89,9 @@ func GetStorageType(namespaceURL *url.URL) (StorageType, error) {
 }
 
 func formatPathWithNamespace(namespacePath, keyPath string) string {
-	namespacePath = strings.TrimSuffix(namespacePath, "/")
-	keyPath = strings.TrimPrefix(keyPath, "/")
+	namespacePath = strings.Trim(namespacePath, "/")
 	if len(namespacePath) == 0 {
-		return keyPath
+		return strings.TrimPrefix(keyPath, "/")
 	}
 	return namespacePath + "/" + keyPath
 }

--- a/pkg/block/namespace_test.go
+++ b/pkg/block/namespace_test.go
@@ -55,6 +55,42 @@ func TestResolveNamespace(t *testing.T) {
 			},
 		},
 		{
+			Name:             "valid_namespace_with_prefix_and_trailing_slash",
+			DefaultNamespace: "gs://foo/bla/",
+			Key:              "bar/baz",
+			Type:             block.IdentifierTypeRelative,
+			ExpectedErr:      nil,
+			Expected: block.QualifiedKey{
+				StorageType:      block.StorageTypeGS,
+				StorageNamespace: "foo",
+				Key:              "bla/bar/baz",
+			},
+		},
+		{
+			Name:             "valid_namespace_with_prefix_and_no_trailing_slash",
+			DefaultNamespace: "gs://foo/bla",
+			Key:              "bar/baz",
+			Type:             block.IdentifierTypeRelative,
+			ExpectedErr:      nil,
+			Expected: block.QualifiedKey{
+				StorageType:      block.StorageTypeGS,
+				StorageNamespace: "foo",
+				Key:              "bla/bar/baz",
+			},
+		},
+		{
+			Name:             "valid_namespace_with_prefix_and_leading_key_slash",
+			DefaultNamespace: "gs://foo/bla",
+			Key:              "/bar/baz",
+			Type:             block.IdentifierTypeRelative,
+			ExpectedErr:      nil,
+			Expected: block.QualifiedKey{
+				StorageType:      block.StorageTypeGS,
+				StorageNamespace: "foo",
+				Key:              "bla//bar/baz",
+			},
+		},
+		{
 			Name:             "valid_fq_key",
 			DefaultNamespace: "mem://foo/",
 			Key:              "s3://example/bar/baz",

--- a/pkg/block/namespace_test.go
+++ b/pkg/block/namespace_test.go
@@ -184,7 +184,7 @@ func TestFormatQualifiedKey(t *testing.T) {
 			QualifiedKey: block.QualifiedKey{
 				StorageType:      block.StorageTypeS3,
 				StorageNamespace: "some-bucket/",
-				Key:              "/path/to/file",
+				Key:              "path/to/file",
 			},
 			Expected: "s3://some-bucket/path/to/file",
 		},
@@ -193,16 +193,34 @@ func TestFormatQualifiedKey(t *testing.T) {
 			QualifiedKey: block.QualifiedKey{
 				StorageType:      block.StorageTypeS3,
 				StorageNamespace: "some-bucket/prefix/",
-				Key:              "/path/to/file",
+				Key:              "path/to/file",
 			},
 			Expected: "s3://some-bucket/prefix/path/to/file",
+		},
+		{
+			Name: "path_with_prefix_leading_slash",
+			QualifiedKey: block.QualifiedKey{
+				StorageType:      block.StorageTypeS3,
+				StorageNamespace: "some-bucket",
+				Key:              "/path/to/file",
+			},
+			Expected: "s3://some-bucket//path/to/file",
+		},
+		{
+			Name: "bucket_with_prefix_leading_slash",
+			QualifiedKey: block.QualifiedKey{
+				StorageType:      block.StorageTypeS3,
+				StorageNamespace: "some-bucket/prefix",
+				Key:              "/path/to/file",
+			},
+			Expected: "s3://some-bucket/prefix//path/to/file",
 		},
 		{
 			Name: "dont_eliminate_dots",
 			QualifiedKey: block.QualifiedKey{
 				StorageType:      block.StorageTypeS3,
 				StorageNamespace: "some-bucket/prefix/",
-				Key:              "/path/to/../file",
+				Key:              "path/to/../file",
 			},
 			Expected: "s3://some-bucket/prefix/path/to/../file",
 		},


### PR DESCRIPTION
closes #2397 

### How was this tested?
1. Added unit-tests to verify that the fix works for new paths.
2. Created all 4 types of repositories in gcp & azure with the previous version of lakeFS. For some of the ones that have this bug, I stopped lakeFS and moved the data (`gsutil` for gcp, `azcopy` for azure). Then started the lakeFS version which has the fix, and in all cases I was able to read old data.

Is there any other test you think is missing?