### PR TITLE
Fix generated Java API client

### DIFF
--- a/clients/java/.project
+++ b/clients/java/.project
@@ -22,7 +22,7 @@
 	</natures>
 	<filteredResources>
 		<filter>
-			<id>1626737428619</id>
+			<id>0</id>
 			<name></name>
 			<type>30</type>
 			<matcher>

--- a/clients/java/src/test/java/io/lakefs/clients/api/ObjectsApiTest.java
+++ b/clients/java/src/test/java/io/lakefs/clients/api/ObjectsApiTest.java
@@ -103,17 +103,18 @@ public class ObjectsApiTest {
     public void listObjectsTest() throws ApiException {
         String repository = null;
         String ref = null;
+        Boolean userMetadata = null;
         String after = null;
         Integer amount = null;
         String delimiter = null;
         String prefix = null;
-        ObjectStatsList response = api.listObjects(repository, ref, after, amount, delimiter, prefix);
+        ObjectStatsList response = api.listObjects(repository, ref, userMetadata, after, amount, delimiter, prefix);
 
         // TODO: test validations
     }
     
     /**
-     * stage an object\&quot;s metadata for the given branch
+     * stage an object&#39;s metadata for the given branch
      *
      * 
      *
@@ -144,7 +145,8 @@ public class ObjectsApiTest {
         String repository = null;
         String ref = null;
         String path = null;
-        ObjectStats response = api.statObject(repository, ref, path);
+        Boolean userMetadata = null;
+        ObjectStats response = api.statObject(repository, ref, path, userMetadata);
 
         // TODO: test validations
     }

--- a/clients/java/src/test/java/io/lakefs/clients/api/model/ObjectStatsTest.java
+++ b/clients/java/src/test/java/io/lakefs/clients/api/model/ObjectStatsTest.java
@@ -21,6 +21,9 @@ import com.google.gson.stream.JsonWriter;
 import io.swagger.annotations.ApiModel;
 import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
@@ -73,6 +76,14 @@ public class ObjectStatsTest {
     }
 
     /**
+     * Test the property 'sizeBytes'
+     */
+    @Test
+    public void sizeBytesTest() {
+        // TODO: test sizeBytes
+    }
+
+    /**
      * Test the property 'mtime'
      */
     @Test
@@ -81,11 +92,11 @@ public class ObjectStatsTest {
     }
 
     /**
-     * Test the property 'sizeBytes'
+     * Test the property 'metadata'
      */
     @Test
-    public void sizeBytesTest() {
-        // TODO: test sizeBytes
+    public void metadataTest() {
+        // TODO: test metadata
     }
 
 }


### PR DESCRIPTION
Had to delete the old one and re(de?)generate a new one: a new
_incompatible_ API was generated to support the added _optional_ argument
`user_metadata`, but our Makefile failed to update the matching test.