### PR TITLE
Remove MatchSimple entirely

### DIFF
--- a/pkg/auth/arn_test.go
+++ b/pkg/auth/arn_test.go
@@ -81,6 +81,10 @@ func TestArnMatch(t *testing.T) {
 	}{
 		{"arn:lakefs:repos::b:myrepo", "arn:lakefs:repos::b:myrepo", true},
 		{"arn:lakefs:repos::b:*", "arn:lakefs:repos::b:myrepo", true},
+		{"arn:lakefs:repos::b:my*", "arn:lakefs:repos::b:myrepo", true},
+		{"arn:lakefs:repos::b:my*po", "arn:lakefs:repos::b:myrepo", true},
+		{"arn:lakefs:repos::b:our*", "arn:lakefs:repos::b:myrepo", false},
+		{"arn:lakefs:repos::b:my*own", "arn:lakefs:repos::b:myrepo", false},
 		{"arn:lakefs:repos::b:myrepo", "arn:lakefs:repos::b:*", false},
 		{"arn:lakefs:repo:::*", "arn:lakefs:repo:::*", true},
 		{"arn:lakefs:repo", "arn:lakefs:repo", false},

--- a/pkg/auth/wildcard/match.go
+++ b/pkg/auth/wildcard/match.go
@@ -16,20 +16,6 @@
 
 package wildcard
 
-// MatchSimple - finds whether the text matches/satisfies the pattern string.
-// supports only '*' wildcard in the pattern.
-// considers a file system path as a flat name space.
-func MatchSimple(pattern, name string) bool {
-	if pattern == "" {
-		return name == pattern
-	}
-	if pattern == "*" {
-		return true
-	}
-	// Does only wildcard '*' match.
-	return deepMatchRune([]rune(name), []rune(pattern), true)
-}
-
 // Match -  finds whether the text matches/satisfies the pattern string.
 // supports  '*' and '?' wildcards in the pattern string.
 // unlike path.Match(), considers a path as a flat name space while matching the pattern.
@@ -42,10 +28,10 @@ func Match(pattern, name string) (matched bool) {
 		return true
 	}
 	// Does extended wildcard '*' and '?' match.
-	return deepMatchRune([]rune(name), []rune(pattern), false)
+	return deepMatchRune([]rune(name), []rune(pattern))
 }
 
-func deepMatchRune(str, pattern []rune, simple bool) bool {
+func deepMatchRune(str, pattern []rune) bool {
 	for len(pattern) > 0 {
 		switch pattern[0] {
 		default:
@@ -53,12 +39,12 @@ func deepMatchRune(str, pattern []rune, simple bool) bool {
 				return false
 			}
 		case '?':
-			if len(str) == 0 && !simple {
+			if len(str) == 0 {
 				return false
 			}
 		case '*':
-			return deepMatchRune(str, pattern[1:], simple) ||
-				(len(str) > 0 && deepMatchRune(str[1:], pattern, simple))
+			return deepMatchRune(str, pattern[1:]) ||
+				(len(str) > 0 && deepMatchRune(str[1:], pattern))
 		}
 		str = str[1:]
 		pattern = pattern[1:]


### PR DESCRIPTION
Apparently inherited as ASL-2 code from minio.  The behaviour of `?` in
`MatchSimple` is not documented, and unclear.  Luckily for us we do not
use it anywhere.

Just remove it.