### PR TITLE
Bugfix/2400 change error message repo with new storage type

### DIFF
--- a/pkg/api/auth_middleware.go
+++ b/pkg/api/auth_middleware.go
@@ -148,7 +148,7 @@ func userByAuth(ctx context.Context, logger logging.Logger, authService auth.Ser
 	}
 	user, err := authService.GetUserByID(ctx, cred.UserID)
 	if err != nil {
-		logger.WithFields(logging.Fields{"user_id": cred.UserID}).Debug("could not find user id by credentials")
+		logger.WithError(err).WithFields(logging.Fields{"user_id": cred.UserID}).Debug("could not find user id by credentials")
 		return nil, ErrAuthenticatingRequest
 	}
 	return user, nil

--- a/pkg/api/auth_middleware.go
+++ b/pkg/api/auth_middleware.go
@@ -3,7 +3,6 @@ package api
 import (
 	"context"
 	"crypto/subtle"
-	"errors"
 	"fmt"
 	"net/http"
 	"strings"
@@ -15,11 +14,6 @@ import (
 	"github.com/treeverse/lakefs/pkg/auth/model"
 	"github.com/treeverse/lakefs/pkg/logging"
 	"gopkg.in/dgrijalva/jwt-go.v3"
-)
-
-var (
-	ErrUnexpectedSigningMethod = errors.New("unexpected signing method")
-	ErrAuthenticationFailed    = errors.New("error authenticating request")
 )
 
 // extractSecurityRequirements using Swagger returns an array of security requirements set for the request.

--- a/pkg/api/auth_middleware.go
+++ b/pkg/api/auth_middleware.go
@@ -92,7 +92,7 @@ func checkSecurityRequirements(r *http.Request, securityRequirements openapi3.Se
 			default:
 				// unknown security requirement to check
 				logger.WithField("provider", provider).Error("Authentication middleware unknown security requirement provider")
-				return nil, ErrAuthenticationFailed
+				return nil, ErrAuthenticatingRequest
 			}
 			if err != nil {
 				return nil, err
@@ -114,16 +114,16 @@ func userByToken(ctx context.Context, logger logging.Logger, authService auth.Se
 		return authService.SecretStore().SharedSecret(), nil
 	})
 	if err != nil {
-		return nil, ErrAuthenticationFailed
+		return nil, ErrAuthenticatingRequest
 	}
 	claims, ok := token.Claims.(*jwt.StandardClaims)
 	if !ok || !token.Valid {
-		return nil, ErrAuthenticationFailed
+		return nil, ErrAuthenticatingRequest
 	}
 	cred, err := authService.GetCredentials(ctx, claims.Subject)
 	if err != nil {
 		logger.WithField("subject", claims.Subject).Info("could not find credentials for token")
-		return nil, ErrAuthenticationFailed
+		return nil, ErrAuthenticatingRequest
 	}
 	userData, err := authService.GetUserByID(ctx, cred.UserID)
 	if err != nil {
@@ -131,7 +131,7 @@ func userByToken(ctx context.Context, logger logging.Logger, authService auth.Se
 			"user_id": cred.UserID,
 			"subject": claims.Subject,
 		}).Debug("could not find user id by credentials")
-		return nil, ErrAuthenticationFailed
+		return nil, ErrAuthenticatingRequest
 	}
 	return userData, nil
 }
@@ -140,16 +140,16 @@ func userByAuth(ctx context.Context, logger logging.Logger, authService auth.Ser
 	cred, err := authService.GetCredentials(ctx, accessKey)
 	if err != nil {
 		logger.WithError(err).Error("failed getting credentials for key")
-		return nil, ErrAuthenticationFailed
+		return nil, ErrAuthenticatingRequest
 	}
 	if subtle.ConstantTimeCompare([]byte(secretKey), []byte(cred.SecretAccessKey)) != 1 {
 		logger.Debug("access key secret does not match")
-		return nil, ErrAuthenticationFailed
+		return nil, ErrAuthenticatingRequest
 	}
 	user, err := authService.GetUserByID(ctx, cred.UserID)
 	if err != nil {
 		logger.WithFields(logging.Fields{"user_id": cred.UserID}).Debug("could not find user id by credentials")
-		return nil, ErrAuthenticationFailed
+		return nil, ErrAuthenticatingRequest
 	}
 	return user, nil
 }

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -1109,18 +1109,18 @@ func (c *Controller) CreateRepository(w http.ResponseWriter, r *http.Request, bo
 		return
 	}
 
-	parsedNs, err := url.ParseRequestURI(body.StorageNamespace)
+	parsedNamespace, err := url.ParseRequestURI(body.StorageNamespace)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "error parsing storage namespace. Please enter valid repository url.")
+		writeError(w, http.StatusBadRequest, "error parsing storage namespace. Please enter a valid repository url.")
 		return
 	}
-	storageType, err := block.GetStorageType(parsedNs)
+	namespaceStorageType, err := block.GetStorageType(parsedNamespace)
 	if err != nil {
-		writeError(w, http.StatusBadRequest, "error creating repository: storage type is not valid.")
+		writeError(w, http.StatusBadRequest, "error creating repository: invalid storage type.")
 		return
 	}
-	if relStorageType := c.BlockAdapter.BlockstoreType(); relStorageType != storageType.BlockstoreType() {
-		writeError(w, http.StatusBadRequest, "error creating repository: can only create repository with storage type: "+relStorageType)
+	if adapterStorageType := c.BlockAdapter.BlockstoreType(); adapterStorageType != namespaceStorageType.BlockstoreType() {
+		writeError(w, http.StatusBadRequest, "error creating repository: can only create repository with storage type: "+adapterStorageType)
 		return
 	}
 

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -1119,8 +1119,8 @@ func (c *Controller) CreateRepository(w http.ResponseWriter, r *http.Request, bo
 		writeError(w, http.StatusBadRequest, "error creating repository: storage type is not valid.")
 		return
 	}
-	if relStorageType:= c.BlockAdapter.BlockstoreType(); relStorageType != storageType.BlockstoreType(){
-		writeError(w, http.StatusBadRequest, "error creating repository: can only create repository with storage type: " + relStorageType)
+	if relStorageType := c.BlockAdapter.BlockstoreType(); relStorageType != storageType.BlockstoreType() {
+		writeError(w, http.StatusBadRequest, "error creating repository: can only create repository with storage type: "+relStorageType)
 		return
 	}
 

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -1140,8 +1140,6 @@ func ensureStorageNamespace(ctx context.Context, adapter block.Adapter, storageN
 		dummyData = "this is dummy data - created by lakeFS in order to check accessibility"
 	)
 
-	var ErrEnsureStorageNamespace = errors.New("failed to ensure access to the storage")
-
 	obj := block.ObjectPointer{StorageNamespace: storageNamespace, Identifier: dummyKey}
 	objLen := int64(len(dummyData))
 	err := adapter.Put(ctx, obj, objLen, strings.NewReader(dummyData), block.PutOpts{})

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -1147,18 +1147,18 @@ func ensureStorageNamespace(ctx context.Context, adapter block.Adapter, storageN
 	err := adapter.Put(ctx, obj, objLen, strings.NewReader(dummyData), block.PutOpts{})
 	if err != nil {
 		if errors.Is(err, block.ErrInvalidNamespace) {
-			return fmt.Errorf("error creating repository: %w. Can only create repository with storage type: %v \n", ErrEnsureStorageNamespace, adapter.BlockstoreType())
+			return fmt.Errorf("error creating repository: %w. Can only create repository with storage type: %v", ErrEnsureStorageNamespace, adapter.BlockstoreType())
 		}
 		var e *url.Error
 		if errors.As(err, &e) && e.Op == "parse" {
-			return fmt.Errorf("error creating repository: %w \n", err)
+			return fmt.Errorf("error creating repository: %w", err)
 		}
-		return fmt.Errorf("error creating repository: %w \n", ErrEnsureStorageNamespace)
+		return fmt.Errorf("error creating repository: %w", ErrEnsureStorageNamespace)
 	}
 
 	_, err = adapter.Get(ctx, obj, objLen)
 	if err != nil {
-		return fmt.Errorf("error creating repository: %w \n", ErrEnsureStorageNamespace)
+		return fmt.Errorf("error creating repository: %w", ErrEnsureStorageNamespace)
 	}
 	return err
 }

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -1145,18 +1145,18 @@ func ensureStorageNamespace(ctx context.Context, adapter block.Adapter, storageN
 	err := adapter.Put(ctx, obj, objLen, strings.NewReader(dummyData), block.PutOpts{})
 	if err != nil {
 		if errors.Is(err, block.ErrInvalidNamespace) {
-			return fmt.Errorf("error creating repository: can only create repository with storage type: %v \n", adapter.BlockstoreType())
+			return errors.New("error creating repository: can only create repository with storage type: " + adapter.BlockstoreType() + "\n")
 		}
 		var e *url.Error
 		if errors.As(err, &e) && e.Op == "parse" {
-			return fmt.Errorf("error creating repository: %v \n", err.Error())
+			return fmt.Errorf("error creating repository: %w \n", err)
 		}
-		return fmt.Errorf("error creating repository: failed to ensure access to the storage. \n ")
+		return errors.New("error creating repository: failed to ensure access to the storage. \n ")
 	}
 
 	_, err = adapter.Get(ctx, obj, objLen)
 	if err != nil {
-		return fmt.Errorf("error creating repository: failed to ensure access to the storage. \n ")
+		return errors.New("error creating repository: failed to ensure access to the storage. \n ")
 	}
 	return err
 }

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -322,11 +322,11 @@ func TestController_CreateRepositoryHandler(t *testing.T) {
 	})
 
 	t.Run("create repo with conflicting storage type", func(t *testing.T) {
-		_, err := deps.catalog.CreateRepository(ctx, "repo3", onBlock(deps, "foo1"), "main")
-		if err != nil {
-			t.Fatal(err)
-		}
-		resp, err := clt.CreateRepositoryWithResponse(ctx, &api.CreateRepositoryParams{}, api.CreateRepositoryJSONRequestBody{
+		//_, err := deps.catalog.CreateRepository(ctx, "repo3", onBlock(deps, "foo1"), "main")
+		//if err != nil {
+		//	t.Fatal(err)
+		//}
+		resp, _ := clt.CreateRepositoryWithResponse(ctx, &api.CreateRepositoryParams{}, api.CreateRepositoryJSONRequestBody{
 			DefaultBranch:    api.StringPtr("main"),
 			Name:             "repo2",
 			StorageNamespace: "s3://foo-bucket",
@@ -336,7 +336,7 @@ func TestController_CreateRepositoryHandler(t *testing.T) {
 		}
 		validationErrResp := resp.JSON409
 		if validationErrResp == nil {
-			t.Fatalf("expected error creating repo with wrong storage type")
+			t.Fatal("expected error creating repo with conflicting storage type")
 		}
 	})
 }

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -320,6 +320,25 @@ func TestController_CreateRepositoryHandler(t *testing.T) {
 			t.Fatalf("expected error creating duplicate repo")
 		}
 	})
+
+	t.Run("create repo with wrong storage type", func(t *testing.T) {
+		_, err := deps.catalog.CreateRepository(ctx, "repo3", onBlock(deps, "foo1"), "main")
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp, err := clt.CreateRepositoryWithResponse(ctx, &api.CreateRepositoryParams{}, api.CreateRepositoryJSONRequestBody{
+			DefaultBranch:    api.StringPtr("main"),
+			Name:             "repo2",
+			StorageNamespace: "s3://foo-bucket",
+		})
+		if resp == nil {
+			t.Fatal("CreateRepository missing response")
+		}
+		validationErrResp := resp.JSON409
+		if validationErrResp == nil {
+			t.Fatalf("expected error creating repo with wrong storage type")
+		}
+	})
 }
 
 func TestController_DeleteRepositoryHandler(t *testing.T) {

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -322,10 +322,6 @@ func TestController_CreateRepositoryHandler(t *testing.T) {
 	})
 
 	t.Run("create repo with conflicting storage type", func(t *testing.T) {
-		//_, err := deps.catalog.CreateRepository(ctx, "repo3", onBlock(deps, "foo1"), "main")
-		//if err != nil {
-		//	t.Fatal(err)
-		//}
 		resp, _ := clt.CreateRepositoryWithResponse(ctx, &api.CreateRepositoryParams{}, api.CreateRepositoryJSONRequestBody{
 			DefaultBranch:    api.StringPtr("main"),
 			Name:             "repo2",

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -321,7 +321,7 @@ func TestController_CreateRepositoryHandler(t *testing.T) {
 		}
 	})
 
-	t.Run("create repo with wrong storage type", func(t *testing.T) {
+	t.Run("create repo with conflicting storage type", func(t *testing.T) {
 		_, err := deps.catalog.CreateRepository(ctx, "repo3", onBlock(deps, "foo1"), "main")
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/api/errors.go
+++ b/pkg/api/errors.go
@@ -8,4 +8,10 @@ var (
 	// ErrEnsureStorageNamespace is an error returned when trying to create a new repository
 	// and the try to access the storage fails
 	ErrEnsureStorageNamespace = errors.New("failed to ensure access to the storage")
+
+	ErrUnexpectedSigningMethod = errors.New("unexpected signing method")
+
+	ErrAuthenticationFailed = errors.New("error authenticating request")
+
+	ErrInvalidAPIEndpoint = errors.New("invalid API endpoint")
 )

--- a/pkg/api/errors.go
+++ b/pkg/api/errors.go
@@ -1,0 +1,11 @@
+package api
+
+import (
+	"errors"
+)
+
+var (
+	// ErrEnsureStorageNamespace is an error returned when trying to create a new repository
+	// and the try to access the storage fails
+	ErrEnsureStorageNamespace = errors.New("failed to ensure access to the storage")
+)

--- a/pkg/api/errors.go
+++ b/pkg/api/errors.go
@@ -11,7 +11,7 @@ var (
 
 	ErrUnexpectedSigningMethod = errors.New("unexpected signing method")
 
-	ErrAuthenticationFailed = errors.New("error authenticating request")
+	ErrAuthenticatingRequest = errors.New("error authenticating request")
 
 	ErrInvalidAPIEndpoint = errors.New("invalid API endpoint")
 )

--- a/pkg/api/errors.go
+++ b/pkg/api/errors.go
@@ -6,7 +6,7 @@ import (
 
 var (
 	// ErrEnsureStorageNamespace is an error returned when trying to create a new repository
-	// and the try to access the storage fails
+	// and the attempt to access the storage fails
 	ErrEnsureStorageNamespace = errors.New("failed to ensure access to the storage")
 
 	ErrUnexpectedSigningMethod = errors.New("unexpected signing method")

--- a/pkg/api/errors.go
+++ b/pkg/api/errors.go
@@ -5,7 +5,7 @@ import (
 )
 
 var (
-	ErrFailedToAccessStorage = errors.New(" failed to access storage")
+	ErrFailedToAccessStorage = errors.New("failed to access storage")
 
 	ErrUnexpectedSigningMethod = errors.New("unexpected signing method")
 

--- a/pkg/api/errors.go
+++ b/pkg/api/errors.go
@@ -5,9 +5,7 @@ import (
 )
 
 var (
-	// ErrEnsureStorageNamespace is an error returned when trying to create a new repository
-	// and the attempt to access the storage fails
-	ErrEnsureStorageNamespace = errors.New("failed to ensure access to the storage")
+	ErrFailedToAccessStorage = errors.New(" failed to access storage")
 
 	ErrUnexpectedSigningMethod = errors.New("unexpected signing method")
 

--- a/pkg/api/serve.go
+++ b/pkg/api/serve.go
@@ -33,8 +33,6 @@ const (
 	extensionValidationExcludeBody = "x-validation-exclude-body"
 )
 
-var ErrInvalidAPIEndpoint = errors.New("invalid API endpoint")
-
 type responseError struct {
 	Message string `json:"message"`
 }

--- a/pkg/block/namespace.go
+++ b/pkg/block/namespace.go
@@ -126,7 +126,7 @@ func ResolveNamespace(defaultNamespace, key string, identifierType IdentifierTyp
 func resolveFull(key string) (QualifiedKey, error) {
 	parsedKey, err := url.ParseRequestURI(key)
 	if err != nil {
-		return QualifiedKey{}, fmt.Errorf("key isn't a valid address: %w", err)
+		return QualifiedKey{}, fmt.Errorf("Could not parse URI: %w", err)
 	}
 	// extract its scheme
 	storageType, err := GetStorageType(parsedKey)

--- a/pkg/block/namespace.go
+++ b/pkg/block/namespace.go
@@ -126,7 +126,7 @@ func ResolveNamespace(defaultNamespace, key string, identifierType IdentifierTyp
 func resolveFull(key string) (QualifiedKey, error) {
 	parsedKey, err := url.ParseRequestURI(key)
 	if err != nil {
-		return QualifiedKey{}, fmt.Errorf("Could not parse URI: %w", err)
+		return QualifiedKey{}, fmt.Errorf("could not parse URI: %w", err)
 	}
 	// extract its scheme
 	storageType, err := GetStorageType(parsedKey)

--- a/pkg/loadtest/local_load_test.go
+++ b/pkg/loadtest/local_load_test.go
@@ -123,7 +123,7 @@ func TestLocalLoad(t *testing.T) {
 		KeepRepo:         false,
 		Credentials:      *credentials,
 		ServerAddress:    ts.URL,
-		StorageNamespace: "s3://local/test/",
+		StorageNamespace: "mem://local/test/",
 	}
 	loader := NewLoader(testConfig)
 	err = loader.Run()

--- a/webui/src/lib/components/repositoryCreateForm.jsx
+++ b/webui/src/lib/components/repositoryCreateForm.jsx
@@ -42,6 +42,7 @@ export const RepositoryCreateForm = ({ config, onSubmit, onCancel, error = null,
         setFormValid(isBranchValid && storageNamespaceValid && repoValid);
     };
 
+    const storageType = config.blockstore_type
     const storageNamespaceValidityRegexStr = config ? config.blockstore_namespace_ValidityRegex : DEFAULT_BLOCKSTORE_VALIDITY_REGEX;
     const storageNamespaceValidityRegex = RegExp(storageNamespaceValidityRegexStr);
     const storageNamespaceExample = config ? config.blockstore_namespace_example : DEFAULT_BLOCKSTORE_EXAMPLE;
@@ -77,7 +78,7 @@ export const RepositoryCreateForm = ({ config, onSubmit, onCancel, error = null,
                     <Form.Control type="text" ref={storageNamespaceField} placeholder={storageNamespaceExample} onChange={checkStorageNamespaceValidity}/>
                     {!storageNamespaceValid &&
                     <Form.Text className="text-danger">
-                        Invalid Storage Namespace.
+                        {"Can only create repository with storage type: " + storageType}
                     </Form.Text>
                     }
                 </Col>


### PR DESCRIPTION
Close: #2400 

When trying to create a repository with a different storage type than the one defined in the configuration, the error message was not descriptive.
I made two changes:

1. In create repo I added a verification of whether the storage type is the same as the one defined in the configuration. In this case, a descriptive error message will be printed.
2. I changed the error message in the UI to be descriptive.