### PR TITLE
Revert "Fix IsTracing method"

### DIFF
--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -235,8 +235,8 @@ func (l *logrusEntryWrapper) Panicf(format string, args ...interface{}) {
 	l.e.Panicf(format, args...)
 }
 
-func (l *logrusEntryWrapper) IsTracing() bool {
-	return l.e.Logger.Level >= logrus.TraceLevel
+func (*logrusEntryWrapper) IsTracing() bool {
+	return logrus.IsLevelEnabled(logrus.TraceLevel)
 }
 
 type logrusCallerFormatter struct {


### PR DESCRIPTION
Reverts treeverse/lakeFS#2470

This breaks the gateway playback test on GH actions due to creating a data race (during the initial download?!) -- see e.g. https://github.com/treeverse/lakeFS/runs/3597721059?check_suite_focus=true.  I'm rolling this back, because I've no idea how this could possibly break something like that... yet it does.

Quite possibly the bug is in the playback test, which tries to call `IsTracing` before it sets up a config, which is what sets up the logger, which is what changed.