### PR TITLE
UI policy editor: Reflect error and body status in UI

### DIFF
--- a/webui/src/lib/components/policy.jsx
+++ b/webui/src/lib/components/policy.jsx
@@ -23,24 +23,40 @@ export const PolicyEditor = ({ show, onHide, onSubmit, policy = null, noID = fal
     const [body, setBody] = useState('')
     useEffect(() => {
         if (policy !== null) {
-            setBody(JSON.stringify(policy, null, 4));
+	    const newBody = JSON.stringify(policy, null, 4);
+            setBody(newBody);
+	    setSavedBody(newBody);
         }
     }, [policy]);
+
+    const [savedBody, setSavedBody] = useState(null);
 
     const submit = () => {
         const statement = bodyField.current.value;
         try {
             JSON.parse(statement);
         } catch (error) {
-            setError(error)
-            return false
+            setError(error);
+	    return false;
         }
         const promise = (policy === null) ? onSubmit(idField.current.value, statement) : onSubmit(statement)
-        return promise.catch(err => setError(err));
+        return promise
+	    .then((res) => {
+		setSavedBody(statement);
+		setError(null);
+		return res;
+	    })
+	    .catch((err) => {
+		setError(err);
+		return null;
+	    });
     };
 
     const hide = () => {
         setError(null);
+	if (savedBody !== null) {
+	    setBody(savedBody);
+	}
         onHide();
     };
     const actionName = policy === null || isCreate ? 'Create' : 'Edit'


### PR DESCRIPTION
1. Restore last (successfully) saved body when cancelling an edit.
2. Cancel last error when successfully saving the body.

These issues affected *only* the GUI state.  State in the DB was always correct.

Fixes #2474.