### PR TITLE
Rename Nessie cache to make docker push succeed

### DIFF
--- a/.github/workflows/nessie.yaml
+++ b/.github/workflows/nessie.yaml
@@ -138,13 +138,13 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Pull last built docker image cache
         run: |
-          docker pull ghcr.io/${GITHUB_REPOSITORY,,}/build-cache:${{ steps.version.outputs.tag }} || \
-          docker pull ghcr.io/${GITHUB_REPOSITORY,,}/build-cache || \
+          docker pull ghcr.io/${GITHUB_REPOSITORY,,}/build-cache-2:${{ steps.version.outputs.tag }} || \
+          docker pull ghcr.io/${GITHUB_REPOSITORY,,}/build-cache-2 || \
           true
       - name: Build Docker image with cache and push
         run: |
           set -ex
-          ghr=ghcr.io/${GITHUB_REPOSITORY,,}/build-cache
+          ghr=ghcr.io/${GITHUB_REPOSITORY,,}/build-cache-2
           ghr_build_tag="-t ${ghr}:${{ steps.version.outputs.tag }}"
           if [[ -n $GITHUB_REF ]]; then
               ghr_ref_tag="-t ${ghr}:${GITHUB_REF##*/}"


### PR DESCRIPTION
Nessie is failing with the following error: 
```
+ docker push ghcr.io/treeverse/lakefs/build-cache:sha-8a0240c
The push refers to repository [ghcr.io/treeverse/lakefs/build-cache]
5f70bf18a086: Preparing
6de7035aacdd: Preparing
5fb26e64c1ef: Preparing
7ca4d7123b42: Preparing
075d83c5c640: Preparing
63831648b236: Preparing
50644c29ef5a: Preparing
63831648b236: Waiting
50644c29ef5a: Waiting
denied: permission_denied: write_package
Error: Process completed with exit code 1.
```

This change is in order to workaround this problem. 
https://github.community/t/github-token-no-longer-authenticates-for-container-registry/201666?u
