### PR TITLE
New Spark Metadata Client version 0.1.6

### DIFF
--- a/clients/spark/build.sbt
+++ b/clients/spark/build.sbt
@@ -2,7 +2,7 @@ import build.BuildType
 
 lazy val baseName = "lakefs-spark"
 
-lazy val projectVersion = "0.1.5"
+lazy val projectVersion = "0.1.6"
 ThisBuild / isSnapshot := false
 
 // Spark versions 2.4.7 and 3.0.1 use different Scala versions.  Changing this is a deep


### PR DESCRIPTION
Changes:

- Easier to use on GCS
- Now runs on DataBricks (read RocksDB SSTables without rocksdbjni)