### PR TITLE
Bug fix: pyramid store file fallback when destination already exist in cache

### DIFF
--- a/pkg/pyramid/directory.go
+++ b/pkg/pyramid/directory.go
@@ -75,7 +75,7 @@ func (d *directory) createFile(path string) (*os.File, error) {
 }
 
 // renameFile will move the src file to dst location and creates all parent dirs if missing.
-//   In we fail, we check if the destination exists, as it is content addressable, and remove the source.
+//   If we fail, we check if the destination exists, as it is content addressable, and remove the source.
 func (d *directory) renameFile(src, dst string) error {
 	d.mu.Lock()
 	defer d.mu.Unlock()


### PR DESCRIPTION
Fix #2531 

A common case when we merge changes from a branch to a destination branch is that the meta-range of the destination will be exactly as the source branch. While we read the meta-range to apply the merge and apply the changes to a new meta-range.  The last operation will try to move the generated output to a cache (at pyramid level). On Windows, this file is locked because an iterator still using it we fail to move the temporary data (new meta-range) to the cache folder.
The suggested change will skip moving the file if it already exists in the case and just removes the source. 
We assume that all files are downloaded and written to a temporary name, then moved to the cache, so if a file matches that name, it can be processed.