### PR TITLE
UI: "Include uncommitted" toggle on Objects view

### DIFF
--- a/webui/src/lib/api/index.js
+++ b/webui/src/lib/api/index.js
@@ -468,7 +468,10 @@ class Branches {
 class Objects {
 
     async list(repoId, ref, tree, after = "", amount = DEFAULT_LISTING_AMOUNT, readUncommitted = true, delimiter = "/") {
-        const query = qs({prefix:tree, amount, after, readUncommitted, delimiter});
+        const query = qs({prefix:tree, amount, after, delimiter});
+        if (!readUncommitted) {
+            ref+="@"
+        }
         const response = await apiRequest(`/repositories/${repoId}/refs/${ref}/objects/ls?${query}`);
         if (response.status !== 200) {
             throw new Error(await extractError(response));

--- a/webui/src/lib/components/repository/refDropdown.jsx
+++ b/webui/src/lib/components/repository/refDropdown.jsx
@@ -5,11 +5,12 @@ import Alert from "react-bootstrap/Alert";
 import Button from "react-bootstrap/Button";
 import Badge from "react-bootstrap/Badge";
 import Overlay from "react-bootstrap/Overlay";
-import {ChevronDownIcon, ChevronRightIcon, ChevronUpIcon, XIcon} from "@primer/octicons-react";
+import {ChevronDownIcon, ChevronRightIcon, ChevronUpIcon, InfoIcon, XIcon} from "@primer/octicons-react";
 import Popover from "react-bootstrap/Popover";
 
 import {branches, commits} from '../../api';
-
+import Tooltip from "react-bootstrap/Tooltip";
+import {OverlayTrigger} from "react-bootstrap";
 
 const BranchSelector = ({ repo, selected, branches, listBranches, selectRef, withCommits, withWorkspace, amount = 300 }) => {
     // used for branch pagination
@@ -147,9 +148,12 @@ const BranchEntry = ({repo, branch, selectRef, selected, logCommits, withCommits
             <div className="actions">
                 {(branch === repo.default_branch) ? (<Badge variant="info">Default</Badge>) : <span/>}
                 {(withCommits) ? (
-                    <Button onClick={logCommits} size="sm" variant="link">
+                    <OverlayTrigger placement="bottom" overlay={<Tooltip id={"tooltip-view-commits"} style={{
+                        fontSize: "0.8rem"
+                    }}>Choose commit from history</Tooltip>}>
+                        <Button onClick={logCommits} size="sm" variant="link">
                         <ChevronRightIcon/>
-                    </Button>
+                    </Button></OverlayTrigger>
                 ) : (<span/>)}
             </div>
         </li>
@@ -203,7 +207,7 @@ const RefDropdown = ({ repo, selected, selectRef, onCancel, variant="light", pre
                         withCommits={withCommits}
                         listBranches={listBranches}
                         withWorkspace={withWorkspace}
-                        selected={selected}
+                        selected={selected.id}
                         selectRef={(ref) => {
                             selectRef(ref);
                             setShow(false);

--- a/webui/src/lib/components/repository/tree.jsx
+++ b/webui/src/lib/components/repository/tree.jsx
@@ -23,6 +23,8 @@ import {linkToPath} from "../../api";
 import {ConfirmationModal} from "../modals";
 import {Paginator} from "../pagination";
 import {Link} from "../nav";
+import Form from "react-bootstrap/Form";
+import {useRouter} from "../../hooks/router";
 
 
 const humanSize = (bytes) => {
@@ -284,8 +286,8 @@ const GetStarted = ({ onUpload }) => {
     );
 };
 
-export const Tree = ({ repo, reference, results, after, onPaginate, nextPage, onUpload, onDelete, showActions = false, path = "" }) => {
-
+export const Tree = ({ repo, reference, results, after, onPaginate, nextPage, onUpload, onDelete, showActions = false, path = "", readUncommitted = true }) => {
+    const { push } = useRouter();
     let body;
     if (results.length === 0 && path === "") {
         // empty state!
@@ -317,6 +319,25 @@ export const Tree = ({ repo, reference, results, after, onPaginate, nextPage, on
             <Card>
                 <Card.Header>
                     <URINavigator path={path} repo={repo} reference={reference}/>
+                    {reference.type === 'branch' && <span className="float-right">
+                            <Form>
+                                <Form.Switch
+                                    label="Include uncommitted"
+                                    id="objects-include-uncommitted-toggle"
+                                    defaultChecked={readUncommitted}
+                                    onChange={(e) => {
+                                        push({
+                                            pathname: '/repositories/:repoId/objects',
+                                            params: {repoId: repo.id},
+                                            query: {
+                                                ref: reference.id,
+                                                withWorkspace: e.target.checked ? 1 : 0,
+                                            }
+                                        })
+                                    }}
+                                />
+                            </Form>
+                        </span>}
                 </Card.Header>
                 <Card.Body>
                     {body}

--- a/webui/src/pages/repositories/repository/objects.jsx
+++ b/webui/src/pages/repositories/repository/objects.jsx
@@ -11,7 +11,7 @@ import Row from "react-bootstrap/Row";
 import Col from "react-bootstrap/Col";
 
 import {Tree} from "../../../lib/components/repository/tree";
-import {config, objects} from "../../../lib/api";
+import {config, DEFAULT_LISTING_AMOUNT, objects} from "../../../lib/api";
 import {useAPI, useAPIWithPagination} from "../../../lib/hooks/api";
 import {RefContextProvider, useRefs} from "../../../lib/hooks/repo";
 import {useRouter} from "../../../lib/hooks/router";
@@ -120,9 +120,11 @@ const UploadButton = ({ config, repo, reference, path, onDone, variant = "succes
 }
 
 const TreeContainer = ({ repo, reference, path, after, onPaginate, onRefresh, onUpload, refreshToken }) => {
+    const router = useRouter();
+    const { withWorkspace } = router.query;
     const { results, error, loading, nextPage } = useAPIWithPagination( () => {
-        return objects.list(repo.id, reference.id, path, after)
-    },[repo.id, reference.id, path, after, refreshToken]);
+        return objects.list(repo.id, reference.id, path, after, DEFAULT_LISTING_AMOUNT, withWorkspace !== "0")
+    },[repo.id, reference.id, path, after, refreshToken, withWorkspace]);
     const initialState = {
         inProgress: false,
         error: null,
@@ -143,6 +145,7 @@ const TreeContainer = ({ repo, reference, path, after, onPaginate, onRefresh, on
                 showActions={true}
                 results={results}
                 after={after}
+                readUncommitted={withWorkspace !== "0"}
                 nextPage={nextPage}
                 onPaginate={onPaginate}
                 onUpload={onUpload}


### PR DESCRIPTION
Suggesting this change which will allow the user to select whether to show uncommitted changes on the objects view, when viewing a HEAD of a branch:

![image](https://user-images.githubusercontent.com/3149885/137099050-e9ecedea-a14b-40ec-940a-164f88f47183.png)

More than anything else, I suggest this change to make understood the point that by default, when viewing a branch it includes the uncommitted changes.