### PR TITLE
Reduce verbosity of lakectl config file location

### DIFF
--- a/cmd/lakectl/cmd/config/config.go
+++ b/cmd/lakectl/cmd/config/config.go
@@ -69,7 +69,7 @@ func ReadConfig() (c *Config) {
 	logger := logging.Default().WithField("file", viper.ConfigFileUsed())
 
 	if c.err == nil {
-		logger.Info("loaded configuration from file")
+		logger.Debug("loaded configuration from file")
 	} else if _, ok := c.err.(viper.ConfigFileNotFoundError); !ok {
 		logger.WithError(c.err).Fatal("failed to read config file")
 	}

--- a/cmd/lakectl/cmd/config/config.go
+++ b/cmd/lakectl/cmd/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"errors"
 	"reflect"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -68,11 +69,10 @@ func ReadConfig() (c *Config) {
 	c.err = viper.ReadInConfig()
 	logger := logging.Default().WithField("file", viper.ConfigFileUsed())
 
-	if c.err == nil {
-		logger.Debug("loaded configuration from file")
-	} else if _, ok := c.err.(viper.ConfigFileNotFoundError); !ok {
+	if errors.Is(c.err, viper.ConfigFileNotFoundError{}) {
 		logger.WithError(c.err).Fatal("failed to read config file")
 	}
+
 	return
 }
 

--- a/cmd/lakectl/cmd/root.go
+++ b/cmd/lakectl/cmd/root.go
@@ -61,6 +61,12 @@ lakectl is a CLI tool allowing exploration and manipulation of a lakeFS environm
 			return
 		}
 
+		if cfg.Err() == nil {
+			logging.Default().
+				WithField("file", viper.ConfigFileUsed()).
+				Info("loaded configuration from file")
+		}
+
 		if errors.As(cfg.Err(), &viper.ConfigFileNotFoundError{}) {
 			if cfgFile != "" {
 				// specific message in case the file isn't found

--- a/cmd/lakectl/cmd/root.go
+++ b/cmd/lakectl/cmd/root.go
@@ -64,7 +64,7 @@ lakectl is a CLI tool allowing exploration and manipulation of a lakeFS environm
 		if cfg.Err() == nil {
 			logging.Default().
 				WithField("file", viper.ConfigFileUsed()).
-				Info("loaded configuration from file")
+				Debug("loaded configuration from file")
 		}
 
 		if errors.As(cfg.Err(), &viper.ConfigFileNotFoundError{}) {


### PR DESCRIPTION
This line appears on every use of lakectl which is redundant when you're probably always using the same file after you first configured it.