### PR TITLE
refactor: move from io/ioutil to io and os package

### DIFF
--- a/cmd/lakectl/cmd/action_validate.go
+++ b/cmd/lakectl/cmd/action_validate.go
@@ -1,7 +1,7 @@
 package cmd
 
 import (
-	"io/ioutil"
+	"io"
 
 	"github.com/spf13/cobra"
 	"github.com/treeverse/lakefs/pkg/actions"
@@ -23,7 +23,7 @@ var actionsValidateCmd = &cobra.Command{
 		reader := OpenByPath(file)
 		defer func() { _ = reader.Close() }()
 
-		bytes, err := ioutil.ReadAll(reader)
+		bytes, err := io.ReadAll(reader)
 		if err != nil {
 			DieErr(err)
 		}

--- a/cmd/lakectl/cmd/fs.go
+++ b/cmd/lakectl/cmd/fs.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"mime/multipart"
 	"net/http"
 	"net/textproto"
@@ -125,7 +124,7 @@ var fsCatCmd = &cobra.Command{
 				DieErr(err)
 			}
 			defer body.Close()
-			contents, err = ioutil.ReadAll(body)
+			contents, err = io.ReadAll(body)
 			if err != nil {
 				DieErr(err)
 			}

--- a/cmd/lakectl/cmd/refs.go
+++ b/cmd/lakectl/cmd/refs.go
@@ -2,7 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"io"
 
 	"github.com/spf13/cobra"
 	"github.com/treeverse/lakefs/pkg/api"
@@ -36,7 +36,7 @@ Since a bare repo is expected, in case of transient failure, delete the reposito
 		}()
 
 		// read and parse the JSON
-		data, err := ioutil.ReadAll(fp)
+		data, err := io.ReadAll(fp)
 		if err != nil {
 			DieErr(err)
 		}

--- a/cmd/lakectl/cmd/sst.go
+++ b/cmd/lakectl/cmd/sst.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"time"
 
@@ -23,7 +22,7 @@ func readStdin() (pebblesst.ReadableFile, error) {
 		return os.Stdin, nil
 	}
 	// not seekable - read it into a temp file
-	fh, err := ioutil.TempFile("", "cat-sst-*")
+	fh, err := os.CreateTemp("", "cat-sst-*")
 	if err != nil {
 		return nil, fmt.Errorf("error creating tempfile: %w", err)
 	}

--- a/nessie/webhook_server_test.go
+++ b/nessie/webhook_server_test.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -89,7 +88,7 @@ func failHandlerFunc(chan hookResponse) func(http.ResponseWriter, *http.Request)
 
 func hookHandlerFunc(respCh chan hookResponse) func(http.ResponseWriter, *http.Request) {
 	return func(writer http.ResponseWriter, request *http.Request) {
-		data, err := ioutil.ReadAll(request.Body)
+		data, err := io.ReadAll(request.Body)
 		if err != nil {
 			respCh <- hookResponse{path: request.URL.Path, err: err}
 			_, _ = io.WriteString(writer, "Failed")

--- a/pkg/actions/action_test.go
+++ b/pkg/actions/action_test.go
@@ -3,7 +3,7 @@ package actions_test
 import (
 	"context"
 	"errors"
-	"io/ioutil"
+	"os"
 	"path"
 	"testing"
 
@@ -31,7 +31,7 @@ func TestAction_ReadAction(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			data, err := ioutil.ReadFile(path.Join("testdata", tt.filename))
+			data, err := os.ReadFile(path.Join("testdata", tt.filename))
 			if err != nil {
 				t.Fatalf("Failed to load testdata %s, err=%s", tt.filename, err)
 			}

--- a/pkg/actions/service_test.go
+++ b/pkg/actions/service_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -47,7 +46,7 @@ func TestServiceRun(t *testing.T) {
 
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer func() { _ = r.Body.Close() }()
-		data, err := ioutil.ReadAll(r.Body)
+		data, err := io.ReadAll(r.Body)
 		if err != nil {
 			t.Error("Failed to read webhook post data", err)
 			return
@@ -157,7 +156,7 @@ hooks:
 		Return(nil).
 		DoAndReturn(func(ctx context.Context, storageNamespace, name string, reader io.Reader, size int64) error {
 			var err error
-			writerBytes, err = ioutil.ReadAll(reader)
+			writerBytes, err = io.ReadAll(reader)
 			return err
 		})
 	testOutputWriter.EXPECT().
@@ -165,7 +164,7 @@ hooks:
 		Return(nil).
 		DoAndReturn(func(ctx context.Context, storageNamespace, name string, reader io.Reader, size int64) error {
 			var err error
-			writerBytes, err = ioutil.ReadAll(reader)
+			writerBytes, err = io.ReadAll(reader)
 			return err
 		})
 	testOutputWriter.EXPECT().
@@ -173,13 +172,13 @@ hooks:
 		Return(nil).
 		DoAndReturn(func(ctx context.Context, storageNamespace, name string, reader io.Reader, size int64) error {
 			var err error
-			writerBytes, err = ioutil.ReadAll(reader)
+			writerBytes, err = io.ReadAll(reader)
 			return err
 		})
 	testOutputWriter.EXPECT().
 		OutputWrite(ctx, record.StorageNamespace.String(), actions.FormatRunManifestOutputPath(record.RunID), gomock.Any(), gomock.Any()).
 		DoAndReturn(func(ctx context.Context, storageNamespace, name string, reader io.Reader, size int64) error {
-			data, err := ioutil.ReadAll(reader)
+			data, err := io.ReadAll(reader)
 			if err != nil {
 				return err
 			}

--- a/pkg/block/local/adapter.go
+++ b/pkg/block/local/adapter.go
@@ -7,7 +7,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"os"
 	"path"
@@ -312,7 +311,7 @@ func (l *Adapter) GetProperties(_ context.Context, obj block.ObjectPointer) (blo
 // force" method of creating s dummy file.  Will work in any OS.  speed is not an issue, as
 // this will be activated very few times during startup.
 func isDirectoryWritable(pth string) bool {
-	f, err := ioutil.TempFile(pth, "dummy")
+	f, err := os.CreateTemp(pth, "dummy")
 	if err != nil {
 		return false
 	}

--- a/pkg/block/local/adapter_test.go
+++ b/pkg/block/local/adapter_test.go
@@ -2,7 +2,7 @@ package local_test
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -21,7 +21,7 @@ const testStorageNamespace = "local://test"
 
 func makeAdapter(t *testing.T) *local.Adapter {
 	t.Helper()
-	dir, err := ioutil.TempDir("", "testing-local-adapter-*")
+	dir, err := os.MkdirTemp("", "testing-local-adapter-*")
 	testutil.MustDo(t, "TempDir", err)
 	testutil.MustDo(t, "NewAdapter", os.MkdirAll(dir, 0700))
 	a, err := local.NewAdapter(dir)
@@ -64,7 +64,7 @@ func TestLocalPutExistsGet(t *testing.T) {
 			}
 			reader, err := a.Get(ctx, makePointer(c.path), 0)
 			testutil.MustDo(t, "Get", err)
-			got, err := ioutil.ReadAll(reader)
+			got, err := io.ReadAll(reader)
 			testutil.MustDo(t, "ReadAll", err)
 			if string(got) != contents {
 				t.Errorf("expected to read \"%s\" as written, got \"%s\"", contents, string(got))
@@ -122,7 +122,7 @@ func TestLocalMultipartUpload(t *testing.T) {
 			testutil.MustDo(t, "CompleteMultiPartUpload", err)
 			reader, err := a.Get(ctx, pointer, 0)
 			testutil.MustDo(t, "Get", err)
-			got, err := ioutil.ReadAll(reader)
+			got, err := io.ReadAll(reader)
 			testutil.MustDo(t, "ReadAll", err)
 			expected := strings.Join(c.partData, "")
 			if string(got) != expected {
@@ -143,7 +143,7 @@ func TestLocalCopy(t *testing.T) {
 	testutil.MustDo(t, "Copy", a.Copy(ctx, makePointer("src"), makePointer("export/to/dst")))
 	reader, err := a.Get(ctx, makePointer("export/to/dst"), 0)
 	testutil.MustDo(t, "Get", err)
-	got, err := ioutil.ReadAll(reader)
+	got, err := io.ReadAll(reader)
 	testutil.MustDo(t, "ReadAll", err)
 	if string(got) != contents {
 		t.Errorf("expected to read \"%s\" as written, got \"%s\"", contents, string(got))

--- a/pkg/block/mem/adapter.go
+++ b/pkg/block/mem/adapter.go
@@ -8,7 +8,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"sort"
 	"strings"
@@ -92,7 +91,7 @@ func getPrefix(lsOpts block.WalkOpts) string {
 func (a *Adapter) Put(_ context.Context, obj block.ObjectPointer, sizeBytes int64, reader io.Reader, opts block.PutOpts) error {
 	a.mutex.Lock()
 	defer a.mutex.Unlock()
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	if err != nil {
 		return err
 	}
@@ -109,7 +108,7 @@ func (a *Adapter) Get(_ context.Context, obj block.ObjectPointer, expectedSize i
 	if !ok {
 		return nil, ErrNoDataForKey
 	}
-	return ioutil.NopCloser(bytes.NewReader(data)), nil
+	return io.NopCloser(bytes.NewReader(data)), nil
 }
 
 func (a *Adapter) Exists(_ context.Context, obj block.ObjectPointer) (bool, error) {
@@ -126,7 +125,7 @@ func (a *Adapter) GetRange(_ context.Context, obj block.ObjectPointer, startPosi
 	if !ok {
 		return nil, ErrNoDataForKey
 	}
-	return ioutil.NopCloser(io.NewSectionReader(bytes.NewReader(data), startPosition, endPosition-startPosition+1)), nil
+	return io.NopCloser(io.NewSectionReader(bytes.NewReader(data), startPosition, endPosition-startPosition+1)), nil
 }
 
 func (a *Adapter) GetProperties(_ context.Context, obj block.ObjectPointer) (block.Properties, error) {
@@ -168,7 +167,7 @@ func (a *Adapter) UploadCopyPart(ctx context.Context, sourceObj, destinationObj 
 	if err != nil {
 		return "", err
 	}
-	data, err := ioutil.ReadAll(entry)
+	data, err := io.ReadAll(entry)
 	if err != nil {
 		return "", err
 	}
@@ -195,7 +194,7 @@ func (a *Adapter) UploadCopyPartRange(_ context.Context, sourceObj, _ block.Obje
 		return "", ErrNoDataForKey
 	}
 	reader := io.NewSectionReader(bytes.NewReader(data), startPosition, endPosition-startPosition+1)
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	if err != nil {
 		return "", err
 	}
@@ -226,7 +225,7 @@ func (a *Adapter) UploadPart(_ context.Context, obj block.ObjectPointer, sizeByt
 	if !ok {
 		return "", ErrMultiPartNotFound
 	}
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/block/s3/adapter.go
+++ b/pkg/block/s3/adapter.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"strings"
 	"sync"
@@ -195,7 +194,7 @@ func (a *Adapter) streamToS3(ctx context.Context, sdkRequest *request.Request, s
 		return "", err
 	}
 
-	req.Body = ioutil.NopCloser(&StreamingReader{
+	req.Body = io.NopCloser(&StreamingReader{
 		Reader: reader,
 		Size:   int(sizeBytes),
 		Time:   sigTime,
@@ -221,7 +220,7 @@ func (a *Adapter) streamToS3(ctx context.Context, sdkRequest *request.Request, s
 	}()
 
 	if resp.StatusCode != http.StatusOK {
-		body, err := ioutil.ReadAll(resp.Body)
+		body, err := io.ReadAll(resp.Body)
 		if err != nil {
 			err = fmt.Errorf("%w: %d %s (unknown)", ErrS3, resp.StatusCode, resp.Status)
 		} else {

--- a/pkg/block/s3/stream_test.go
+++ b/pkg/block/s3/stream_test.go
@@ -4,8 +4,8 @@ import (
 	"bytes"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
+	"os"
 	"testing"
 	"time"
 
@@ -96,10 +96,10 @@ func TestS3StreamingReader_Read(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			r := ioutil.NopCloser(bytes.NewBuffer(cas.Input))
+			r := io.NopCloser(bytes.NewBuffer(cas.Input))
 			timeout := time.Second * 300
 			if cas.Delay {
-				r = ioutil.NopCloser(&delayReader{
+				r = io.NopCloser(&delayReader{
 					r:    bytes.NewBuffer(cas.Input),
 					wait: 2 * time.Millisecond,
 				})
@@ -115,7 +115,7 @@ func TestS3StreamingReader_Read(t *testing.T) {
 				ChunkTimeout: timeout,
 			}
 
-			out, err := ioutil.ReadAll(data)
+			out, err := io.ReadAll(data)
 			if err != nil {
 				t.Fatal(err)
 			}
@@ -128,7 +128,7 @@ func TestS3StreamingReader_Read(t *testing.T) {
 }
 
 func mustReadFile(t *testing.T, path string) []byte {
-	data, err := ioutil.ReadFile(path)
+	data, err := os.ReadFile(path)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/block/transient/adapter.go
+++ b/pkg/block/transient/adapter.go
@@ -7,7 +7,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/google/uuid"
@@ -24,7 +23,7 @@ func New() *Adapter {
 }
 
 func (a *Adapter) Put(_ context.Context, _ block.ObjectPointer, _ int64, reader io.Reader, _ block.PutOpts) error {
-	_, err := io.Copy(ioutil.Discard, reader)
+	_, err := io.Copy(io.Discard, reader)
 	return err
 }
 
@@ -32,7 +31,7 @@ func (a *Adapter) Get(_ context.Context, obj block.ObjectPointer, expectedSize i
 	if expectedSize < 0 {
 		return nil, io.ErrUnexpectedEOF
 	}
-	return ioutil.NopCloser(&io.LimitedReader{R: rand.Reader, N: expectedSize}), nil
+	return io.NopCloser(&io.LimitedReader{R: rand.Reader, N: expectedSize}), nil
 }
 
 func (a *Adapter) Exists(_ context.Context, obj block.ObjectPointer) (bool, error) {
@@ -48,7 +47,7 @@ func (a *Adapter) GetRange(_ context.Context, obj block.ObjectPointer, startPosi
 		R: rand.Reader,
 		N: n,
 	}
-	return ioutil.NopCloser(reader), nil
+	return io.NopCloser(reader), nil
 }
 
 func (a *Adapter) GetProperties(_ context.Context, _ block.ObjectPointer) (block.Properties, error) {
@@ -90,7 +89,7 @@ func (a *Adapter) CreateMultiPartUpload(_ context.Context, obj block.ObjectPoint
 }
 
 func (a *Adapter) UploadPart(_ context.Context, obj block.ObjectPointer, sizeBytes int64, reader io.Reader, uploadID string, partNumber int64) (string, error) {
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/catalog/actions_source.go
+++ b/pkg/catalog/actions_source.go
@@ -3,7 +3,7 @@ package catalog
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 
 	"github.com/treeverse/lakefs/pkg/block"
 	"github.com/treeverse/lakefs/pkg/graveler"
@@ -66,7 +66,7 @@ func (s *ActionsSource) Load(ctx context.Context, record graveler.HookRecord, na
 	}()
 
 	// read action
-	bytes, err := ioutil.ReadAll(reader)
+	bytes, err := io.ReadAll(reader)
 	if err != nil {
 		return nil, fmt.Errorf("reading action file %s: %w", name, err)
 	}

--- a/pkg/cloud/aws/s3inventory/orc_utils.go
+++ b/pkg/cloud/aws/s3inventory/orc_utils.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"time"
@@ -56,7 +55,7 @@ func getTailLength(f *os.File) (int, error) {
 }
 
 func downloadRange(ctx context.Context, svc s3iface.S3API, logger logging.Logger, bucket string, key string, fromByte int64) (*os.File, error) {
-	f, err := ioutil.TempFile("", path.Base(key))
+	f, err := os.CreateTemp("", path.Base(key))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cloud/aws/s3inventory/reader_test.go
+++ b/pkg/cloud/aws/s3inventory/reader_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -56,7 +55,7 @@ func parquetSchema(fieldToRemove string) *schema.JSONSchemaItemType {
 }
 
 func generateParquet(t *testing.T, objs <-chan *TestObject, fieldToRemove string) *os.File {
-	f, err := ioutil.TempFile("", "parquettest")
+	f, err := os.CreateTemp("", "parquettest")
 	if err != nil {
 		t.Fatalf("failed to create temp file: %v", err)
 	}
@@ -152,7 +151,7 @@ func getOrcValues(o *TestObject, fieldToRemove string) []interface{} {
 }
 
 func generateOrc(t *testing.T, objs <-chan *TestObject, fieldToRemove string) *os.File {
-	f, err := ioutil.TempFile("", "orctest")
+	f, err := os.CreateTemp("", "orctest")
 	if err != nil {
 		t.Fatalf("failed to create temp file: %v", err)
 	}

--- a/pkg/cloud/azure/metadata.go
+++ b/pkg/cloud/azure/metadata.go
@@ -4,7 +4,7 @@ import (
 	"crypto/md5" //nolint:gosec
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"time"
@@ -48,7 +48,7 @@ func (m *MetadataProvider) GetMetadata() map[string]string {
 	defer func() {
 		_ = resp.Body.Close()
 	}()
-	responseBody, err := ioutil.ReadAll(resp.Body)
+	responseBody, err := io.ReadAll(resp.Body)
 	if err != nil {
 		m.logger.WithError(err).Warn("Failed to get Azure subscription ID from instance metadata", err)
 		return nil

--- a/pkg/fileutil/writer_reader.go
+++ b/pkg/fileutil/writer_reader.go
@@ -3,7 +3,6 @@ package fileutil
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 )
 
@@ -33,7 +32,7 @@ type RewindableReader interface {
 type fileWriterThenReader struct{ file *os.File }
 
 func NewFileWriterThenReader(basename string) (WriterThenReader, error) {
-	file, err := ioutil.TempFile("", basename)
+	file, err := os.CreateTemp("", basename)
 	if err != nil {
 		return nil, fmt.Errorf("creating temporary file: %w", err)
 	}

--- a/pkg/gateway/handler_test.go
+++ b/pkg/gateway/handler_test.go
@@ -2,7 +2,6 @@ package gateway_test
 
 import (
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -33,7 +32,7 @@ func setupTest(t *testing.T, method, target string, body io.Reader) *http.Respon
 func TestPathWithTrailingSlash(t *testing.T) {
 	result := setupTest(t, http.MethodHead, "/example/", nil)
 	assert.Equal(t, 200, result.StatusCode)
-	bytes, err := ioutil.ReadAll(result.Body)
+	bytes, err := io.ReadAll(result.Body)
 	assert.NoError(t, err)
 	assert.Len(t, bytes, 0)
 	assert.Contains(t, result.Header, "X-Amz-Request-Id")

--- a/pkg/gateway/operations/base.go
+++ b/pkg/gateway/operations/base.go
@@ -5,7 +5,6 @@ import (
 	"encoding/xml"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/treeverse/lakefs/pkg/auth"
@@ -100,7 +99,7 @@ func (o *Operation) EncodeResponse(w http.ResponseWriter, req *http.Request, ent
 
 func DecodeXMLBody(reader io.Reader, entity interface{}) error {
 	body := reader
-	content, err := ioutil.ReadAll(body)
+	content, err := io.ReadAll(body)
 	if err != nil {
 		return err
 	}

--- a/pkg/gateway/operations/mock_adapter_test.go
+++ b/pkg/gateway/operations/mock_adapter_test.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"io/ioutil"
 	"net/http"
 
 	"github.com/treeverse/lakefs/pkg/block"
@@ -28,7 +27,7 @@ func newMockAdapter() *mockAdapter {
 }
 
 func (a *mockAdapter) Put(ctx context.Context, obj block.ObjectPointer, _ int64, reader io.Reader, opts block.PutOpts) error {
-	data, err := ioutil.ReadAll(reader)
+	data, err := io.ReadAll(reader)
 	if err != nil {
 		return err
 	}

--- a/pkg/gateway/operations/postobject.go
+++ b/pkg/gateway/operations/postobject.go
@@ -5,16 +5,15 @@ import (
 	"encoding/xml"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"time"
 
-	"github.com/treeverse/lakefs/pkg/gateway/multiparts"
-
 	"github.com/google/uuid"
 	"github.com/treeverse/lakefs/pkg/block"
 	gatewayErrors "github.com/treeverse/lakefs/pkg/gateway/errors"
+	"github.com/treeverse/lakefs/pkg/gateway/multiparts"
 	"github.com/treeverse/lakefs/pkg/gateway/path"
 	"github.com/treeverse/lakefs/pkg/gateway/serde"
 	"github.com/treeverse/lakefs/pkg/graveler"
@@ -91,7 +90,7 @@ func (controller *PostObject) HandleCompleteMultipartUpload(w http.ResponseWrite
 	}
 	objName := multiPart.PhysicalAddress
 	req = req.WithContext(logging.AddFields(req.Context(), logging.Fields{logging.PhysicalAddressFieldKey: objName}))
-	xmlMultipartComplete, err := ioutil.ReadAll(req.Body)
+	xmlMultipartComplete, err := io.ReadAll(req.Body)
 	if err != nil {
 		o.Log(req).WithError(err).Error("could not read request body")
 		_ = o.EncodeError(w, req, gatewayErrors.Codes.ToAPIErr(gatewayErrors.ErrInternalError))

--- a/pkg/gateway/playback_test.go
+++ b/pkg/gateway/playback_test.go
@@ -4,9 +4,7 @@ import (
 	"archive/zip"
 	"context"
 	"encoding/json"
-	"github.com/spf13/viper"
 	"io"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"net/url"
@@ -16,6 +14,7 @@ import (
 	"testing"
 
 	"github.com/ory/dockertest/v3"
+	"github.com/spf13/viper"
 	"github.com/treeverse/lakefs/pkg/block"
 	"github.com/treeverse/lakefs/pkg/catalog"
 	"github.com/treeverse/lakefs/pkg/config"
@@ -166,7 +165,7 @@ func getBasicHandler(t *testing.T, authService *simulator.PlayBackMockConf) (htt
 func newGatewayAuthFromFile(t *testing.T, directory string) *simulator.PlayBackMockConf {
 	m := new(simulator.PlayBackMockConf)
 	fName := filepath.Join(directory, simulator.SimulationConfig)
-	confStr, err := ioutil.ReadFile(fName)
+	confStr, err := os.ReadFile(fName)
 	if err != nil {
 		t.Fatal(fName + " not found\n")
 	}

--- a/pkg/gateway/sig/v4_test.go
+++ b/pkg/gateway/sig/v4_test.go
@@ -3,7 +3,7 @@ package sig_test
 import (
 	"bytes"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"strings"
 	"testing"
@@ -160,8 +160,8 @@ func TestSingleChunkPut(t *testing.T) {
 				t.Errorf("expect not no error, got %v", err)
 			}
 
-			req.Body = ioutil.NopCloser(strings.NewReader(tc.RequestBody))
-			//verify request with our authenticator
+			req.Body = io.NopCloser(strings.NewReader(tc.RequestBody))
+			// verify request with our authenticator
 
 			authenticator := sig.NewV4Authenticator(req)
 			_, err = authenticator.Parse()
@@ -179,7 +179,7 @@ func TestSingleChunkPut(t *testing.T) {
 			}
 
 			// read all
-			_, err = ioutil.ReadAll(req.Body)
+			_, err = io.ReadAll(req.Body)
 			if err != tc.ExpectedReadError {
 				t.Errorf("expect Error %v error, got %s", tc.ExpectedReadError, err)
 			}
@@ -222,7 +222,7 @@ func TestStreaming(t *testing.T) {
 	chunk3 := []byte("0;chunk-signature=b6c6ea8a5354eaf15b3cb7646744f4275b71ea724fed81ceb9323e279d449df9\r\n\r\n")
 	body := append(chunk1, chunk2...)
 	body = append(body, chunk3...)
-	req.Body = ioutil.NopCloser(bytes.NewReader(body))
+	req.Body = io.NopCloser(bytes.NewReader(body))
 
 	// now test it
 	authenticator := sig.NewV4Authenticator(req)
@@ -242,7 +242,7 @@ func TestStreaming(t *testing.T) {
 	if req.ContentLength != int64(chunk1Size+chunk2Size) {
 		t.Fatal("expected content length to be equal to decoded content length")
 	}
-	_, err = ioutil.ReadAll(req.Body)
+	_, err = io.ReadAll(req.Body)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -279,7 +279,7 @@ func TestStreamingLastByteWrong(t *testing.T) {
 	chunk3 := []byte("0;chunk-signature=b6c6ea8a5354eaf15b3cb7646744f4275b71ea724fed81ceb9323e279d449df9\r\n\r\n")
 	body := append(chunk1, chunk2...)
 	body = append(body, chunk3...)
-	req.Body = ioutil.NopCloser(bytes.NewReader(body))
+	req.Body = io.NopCloser(bytes.NewReader(body))
 
 	// now test it
 	authenticator := sig.NewV4Authenticator(req)
@@ -297,7 +297,7 @@ func TestStreamingLastByteWrong(t *testing.T) {
 		t.Errorf("expect not no error, got %v", err)
 	}
 
-	_, err = ioutil.ReadAll(req.Body)
+	_, err = io.ReadAll(req.Body)
 	if err != errors.ErrSignatureDoesNotMatch {
 		t.Errorf("expect %v, got %v", errors.ErrSignatureDoesNotMatch, err)
 	}

--- a/pkg/gateway/simulation_playback_test.go
+++ b/pkg/gateway/simulation_playback_test.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
 	"os"
@@ -70,7 +69,7 @@ func DoTestRun(handler http.Handler, timed bool, speed float64, t *testing.T, pa
 }
 
 func regexpGlob(directory string, pattern *regexp.Regexp) []string {
-	dirList, err := ioutil.ReadDir(directory) //ReadDir returns files sorted by name. in the events time order
+	dirList, err := os.ReadDir(directory) // ReadDir returns files sorted by name. in the events time order
 	if err != nil {
 		logging.Default().WithError(err).Fatal("Directory read failed :" + directory)
 	}
@@ -97,7 +96,7 @@ func buildEventList(t *testing.T, params *PlaybackParams) []simulationEvent {
 		eventTimeStr := file[:baseNamePosition-6]               // time part of file name
 		evt.eventTime, _ = time.Parse("15-04-05", eventTimeStr) // add to function
 		fName := filepath.Join(params.RecordingDir, file)
-		event, err := ioutil.ReadFile(fName)
+		event, err := os.ReadFile(fName)
 		if err != nil {
 			t.Fatal("Recording file not found\n")
 		}
@@ -283,12 +282,12 @@ func compareFiles(t *testing.T, params *PlaybackParams, playbackFileName string,
 	playbackSize := playbackInfo.Size()
 	recordingSize := recordingInfo.Size()
 	if recordingSize < MaxTextResponse && playbackSize < MaxTextResponse {
-		playBytes, err := ioutil.ReadFile(playbackFileName)
+		playBytes, err := os.ReadFile(playbackFileName)
 		if err != nil {
 			t.Error("Couldn't read playback file", playbackFileName)
 			return false
 		}
-		recBytes, err := ioutil.ReadFile(recordingFileName)
+		recBytes, err := os.ReadFile(recordingFileName)
 		if err != nil {
 			t.Error("Couldn't read recording file", recordingFileName)
 			return false

--- a/pkg/gateway/simulator/external_recordings.go
+++ b/pkg/gateway/simulator/external_recordings.go
@@ -1,7 +1,6 @@
 package simulator
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 
@@ -39,7 +38,7 @@ func getEtagFileName(path string) string {
 func getLocalEtag(path string) (string, error) {
 	// if etag exists return
 	etagFileName := getEtagFileName(path)
-	etag, err := ioutil.ReadFile(etagFileName)
+	etag, err := os.ReadFile(etagFileName)
 	if err == nil {
 		return string(etag), nil
 	}
@@ -91,6 +90,6 @@ func (d *externalRecordDownloader) DownloadRecording(bucket, key, destination st
 
 	// write the etag file
 	etagFileName := getEtagFileName(destination)
-	err = ioutil.WriteFile(etagFileName, []byte(s3Etag), 0644) //nolint:gosec
+	err = os.WriteFile(etagFileName, []byte(s3Etag), 0644) //nolint:gosec
 	return err
 }

--- a/pkg/gateway/simulator/simulation_recorder.go
+++ b/pkg/gateway/simulator/simulation_recorder.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"net/http"
 	"net/http/httputil"
 	"os"
@@ -137,7 +136,7 @@ func logRequest(r *http.Request, uploadID []byte, nameBase string, statusCode in
 			Fatal("marshal event as json")
 	}
 	fName := filepath.Join(recordingDir, nameBase+RequestExtension)
-	err = ioutil.WriteFile(fName, jsonEvent, 0600)
+	err = os.WriteFile(fName, jsonEvent, 0600)
 	if err != nil {
 		logging.Default().
 			WithError(err).
@@ -179,7 +178,7 @@ func createConfFile(r *http.Request, authService GatewayAuthService, region stri
 			WithError(err).
 			Fatal("couldn't marshal configuration")
 	}
-	err = ioutil.WriteFile(filepath.Join(recordingDir, SimulationConfig), confByte, 0644) //nolint:gosec
+	err = os.WriteFile(filepath.Join(recordingDir, SimulationConfig), confByte, 0644) //nolint:gosec
 	if err != nil {
 		logging.Default().
 			WithError(err).
@@ -200,7 +199,7 @@ func compressRecordings(testName, recordingDir string) {
 	}()
 	// Create a new zip archive.
 	w := zip.NewWriter(zWriter)
-	dirList, err := ioutil.ReadDir(recordingDir)
+	dirList, err := os.ReadDir(recordingDir)
 	if err != nil {
 		logger.WithError(err).Error("Failed reading directory ")
 		return

--- a/pkg/gateway/simulator/simulation_utils.go
+++ b/pkg/gateway/simulator/simulation_utils.go
@@ -3,17 +3,14 @@ package simulator
 import (
 	"context"
 	"encoding/json"
-	"time"
-
-	"github.com/treeverse/lakefs/pkg/logging"
-
-	"io/ioutil"
 	"net/http"
 	"os"
 	"regexp"
+	"time"
 
 	"github.com/treeverse/lakefs/pkg/auth"
 	"github.com/treeverse/lakefs/pkg/auth/model"
+	"github.com/treeverse/lakefs/pkg/logging"
 )
 
 type PlayBackMockConf struct {
@@ -104,7 +101,7 @@ func (w *ResponseWriter) SaveHeaders(fName string) {
 		return
 	}
 	s, _ := json.Marshal(w.Headers)
-	err := ioutil.WriteFile(fName, s, 0600)
+	err := os.WriteFile(fName, s, 0600)
 	if err != nil {
 		logger.WithError(err).Fatal("failed crete file " + fName)
 	}

--- a/pkg/graveler/settings/manager_test.go
+++ b/pkg/graveler/settings/manager_test.go
@@ -2,7 +2,7 @@ package settings_test
 
 import (
 	"context"
-	"io/ioutil"
+	"io"
 	"sync"
 	"testing"
 
@@ -122,7 +122,7 @@ func TestStoredSettings(t *testing.T) {
 		IdentifierType:   block.IdentifierTypeRelative,
 	}, -1)
 	testutil.Must(t, err)
-	bytes, err := ioutil.ReadAll(reader)
+	bytes, err := io.ReadAll(reader)
 	testutil.Must(t, err)
 	gotSettings := &settings.ExampleSettings{}
 	testutil.Must(t, proto.Unmarshal(bytes, gotSettings))

--- a/pkg/graveler/sstable/iterator_test.go
+++ b/pkg/graveler/sstable/iterator_test.go
@@ -1,7 +1,6 @@
 package sstable_test
 
 import (
-	"io/ioutil"
 	"os"
 	"sort"
 	"testing"
@@ -124,7 +123,7 @@ type fakeReader struct {
 
 // createSStableReader creates the table from keys, vals passed to it
 func createSStableReader(t *testing.T, keys []string, vals []string) fakeReader {
-	f, err := ioutil.TempFile(os.TempDir(), "test file")
+	f, err := os.CreateTemp(os.TempDir(), "test file")
 	require.NoError(t, err)
 	w := pebblesst.NewWriter(f, pebblesst.WriterOptions{
 		Compression: pebblesst.SnappyCompression,

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -3,7 +3,7 @@ package logging
 import (
 	"context"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"os"
 	"os/signal"
 	"runtime"
@@ -93,7 +93,7 @@ func SetLevel(level string) {
 		defaultLogger.SetLevel(logrus.PanicLevel)
 	case "null", "none":
 		defaultLogger.SetLevel(logrus.PanicLevel)
-		defaultLogger.SetOutput(ioutil.Discard)
+		defaultLogger.SetOutput(io.Discard)
 	}
 }
 
@@ -118,7 +118,7 @@ func SetOutput(output string) {
 		for {
 			<-sigChannel
 			defaultLogger.Info("SIGHUP received, rotating log file")
-			defaultLogger.SetOutput(ioutil.Discard)
+			defaultLogger.SetOutput(io.Discard)
 			_ = handle.Close()
 			handle, err := os.OpenFile(filename, os.O_CREATE|os.O_WRONLY, 0755)
 			if err != nil {

--- a/pkg/pyramid/directory_test.go
+++ b/pkg/pyramid/directory_test.go
@@ -1,7 +1,6 @@
 package pyramid
 
 import (
-	"io/ioutil"
 	"os"
 	"path"
 	"strconv"
@@ -12,7 +11,7 @@ import (
 )
 
 func TestConcurrentCreateDeleteDir(t *testing.T) {
-	name, err := ioutil.TempDir("", "test-dir-")
+	name, err := os.MkdirTemp("", "test-dir-")
 	require.NoError(t, err)
 	defer os.RemoveAll(name) // clean up
 
@@ -47,7 +46,7 @@ func TestConcurrentCreateDeleteDir(t *testing.T) {
 }
 
 func TestConcurrentRenameDeleteDir(t *testing.T) {
-	name, err := ioutil.TempDir("", "test-dir-")
+	name, err := os.MkdirTemp("", "test-dir-")
 	require.NoError(t, err)
 	defer os.RemoveAll(name) // clean up
 
@@ -60,7 +59,7 @@ func TestConcurrentRenameDeleteDir(t *testing.T) {
 	for i := 0; i < concurrency; i++ {
 		// create and delete
 		originalPath := path.Join(name, strconv.Itoa(i))
-		require.NoError(t, ioutil.WriteFile(originalPath, []byte("some data"), os.ModePerm))
+		require.NoError(t, os.WriteFile(originalPath, []byte("some data"), os.ModePerm))
 
 		filepath := path.Join(pathDir, strconv.Itoa(i))
 		wg.Add(2)

--- a/pkg/pyramid/file_test.go
+++ b/pkg/pyramid/file_test.go
@@ -4,7 +4,6 @@ import (
 	"github.com/treeverse/lakefs/pkg/pyramid/params"
 
 	"context"
-	"io/ioutil"
 	"os"
 	"path"
 	"testing"
@@ -18,7 +17,7 @@ func TestPyramidWriteFile(t *testing.T) {
 	ctx := context.Background()
 	filename := uuid.New().String()
 
-	fh, err := ioutil.TempFile("", filename)
+	fh, err := os.CreateTemp("", filename)
 	if err != nil {
 		t.Fatal("Failed to create temp file", err)
 	}
@@ -66,7 +65,7 @@ func TestPyramidWriteFile(t *testing.T) {
 func TestWriteValidate(t *testing.T) {
 	ctx := context.Background()
 	filename := uuid.New().String()
-	fh, err := ioutil.TempFile("", filename)
+	fh, err := os.CreateTemp("", filename)
 	if err != nil {
 		t.Fatal("Failed to create temp file", err)
 	}
@@ -99,7 +98,7 @@ func TestWriteValidate(t *testing.T) {
 func TestMultipleWriteCalls(t *testing.T) {
 	ctx := context.Background()
 	filename := uuid.New().String()
-	fh, err := ioutil.TempFile("", filename)
+	fh, err := os.CreateTemp("", filename)
 	if err != nil {
 		t.Fatal("Failed to create temp file", err)
 	}
@@ -132,7 +131,7 @@ func TestMultipleWriteCalls(t *testing.T) {
 func TestAbort(t *testing.T) {
 	ctx := context.Background()
 	filename := uuid.New().String()
-	fh, err := ioutil.TempFile("", filename)
+	fh, err := os.CreateTemp("", filename)
 	if err != nil {
 		t.Fatal("Failed to create temp file", err)
 	}
@@ -175,7 +174,7 @@ func TestPyramidReadFile(t *testing.T) {
 	filename := uuid.New().String()
 	filepath := path.Join("/tmp", filename)
 	content := "some content to write to file"
-	if err := ioutil.WriteFile(filepath, []byte(content), os.ModePerm); err != nil {
+	if err := os.WriteFile(filepath, []byte(content), os.ModePerm); err != nil {
 		t.Fatalf("Failed to write file %s: %s", filepath, err)
 	}
 	defer os.Remove(filepath)

--- a/pkg/pyramid/tier_fs_test.go
+++ b/pkg/pyramid/tier_fs_test.go
@@ -3,7 +3,7 @@ package pyramid
 import (
 	"bytes"
 	"context"
-	"io/ioutil"
+	"io"
 	"math/rand"
 	"os"
 	"path"
@@ -91,11 +91,11 @@ func TestStartup(t *testing.T) {
 
 	filename := "ThisShouldStay"
 	content := []byte("This Should Stay - I'm telling You!!!!")
-	if err := ioutil.WriteFile(path.Join(namespacePath, filename), content, os.ModePerm); err != nil {
+	if err := os.WriteFile(path.Join(namespacePath, filename), content, os.ModePerm); err != nil {
 		t.Fatal("write file", filename, err)
 	}
 
-	if err := ioutil.WriteFile(path.Join(workspacePath, "ThisShouldNotStay"), []byte("ThisShouldNotStay"), os.ModePerm); err != nil {
+	if err := os.WriteFile(path.Join(workspacePath, "ThisShouldNotStay"), []byte("ThisShouldNotStay"), os.ModePerm); err != nil {
 		t.Fatal("write file", err)
 	}
 
@@ -126,7 +126,7 @@ func TestStartup(t *testing.T) {
 	defer func() { _ = f.Close() }()
 	assert.NoError(t, err)
 
-	data, err := ioutil.ReadAll(f)
+	data, err := io.ReadAll(f)
 	assert.NoError(t, err)
 	assert.Equal(t, content, data)
 }
@@ -151,7 +151,7 @@ func testEviction(t *testing.T, namespaces ...string) {
 		f, err := fs.Open(ctx, namespaces[i%len(namespaces)], filename)
 		require.NoError(t, err)
 
-		_, err = ioutil.ReadAll(f)
+		_, err = io.ReadAll(f)
 		require.NoError(t, err)
 		require.NoError(t, f.Close())
 	}
@@ -218,7 +218,7 @@ func checkContent(t *testing.T, ctx context.Context, namespace string, filename 
 	}
 	defer f.Close()
 
-	data, err := ioutil.ReadAll(f)
+	data, err := io.ReadAll(f)
 	if err != nil {
 		t.Errorf("Failed to read all namespace:%s filename:%s - %s", namespace, filename, err)
 		return


### PR DESCRIPTION
The `io/ioutil` package has been deprecated in Go 1.16 (See https://golang.org/doc/go1.16#ioutil). This PR replaces the existing `io/ioutil` functions with their new definitions in `io` and `os` packages.