### PR TITLE
Fix issue #2563: Documentation site version drop-down in reversed order

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -95,7 +95,7 @@ layout: table_wrappers
                 window.addEventListener("load",  async () => {
                     const pathFirstLevel = location.pathname.split('/')[1];
                     const selectedVersion = pathFirstLevel.startsWith('v') && pathFirstLevel || '';
-                    const selectVersionElmFirst = document.getElementById('selectversion').firstChild;
+                    const selectVersionElmFirst = document.getElementById('selectversion').firstElementChild;
                     const response = await fetch('/versions.json');
                     if (!response.ok) {
                         return


### PR DESCRIPTION
This fixes issue #2563 about the reversed order of the documentation site version drop-down.

To fix the issue, the elements are added just after the "Latest" option mark instead of being appended to the whole select.