### PR TITLE
Ignore dist folder for scanning the same code should be found on src

### DIFF
--- a/.github/codeql/codeql-config.yaml
+++ b/.github/codeql/codeql-config.yaml
@@ -1,5 +1,5 @@
 paths-ignore:
   - 'webui/node_modules'
+  - 'webui/dist'
   - 'pkg/**/testdata/*.yaml'
   - 'pkg/metastore/hive/gen-go'
-


### PR DESCRIPTION
Assume the we scan our code which found under the src folder.
The vendor packages are evaluated and reported by github and we can in cooperate other tools to scan dependencies.
The dist folder code is no longer available after the build and any report can't reference back the code. 