### PR TITLE
python client build package fix missing build package script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -129,7 +129,8 @@ client-java: api/swagger.yml  ## Generate SDK for Java (and Scala) client
 clients: client-python client-java
 
 package-python: client-python
-	$(DOCKER) run --user $(UID_GID) --rm -v $(shell pwd):/mnt -e HOME=/tmp/ -w /mnt/clients/python $(PYTHON_IMAGE) ./build-package.sh
+	$(DOCKER) run --user $(UID_GID) --rm -v $(shell pwd):/mnt -e HOME=/tmp/ -w /mnt/clients/python $(PYTHON_IMAGE) /bin/bash -c \
+		"python -m pip install build --user && python -m build --sdist --wheel --outdir dist/"
 
 package: package-python
 


### PR DESCRIPTION
Build package script for the python client was removed (mistake) by another PR.
This PR remove the dependency in that script and keeps the build package command as part of the Makefile.