### PR TITLE
Fix lakectl (client) crash when reporting (some?) server errors

### DIFF
--- a/cmd/lakectl/cmd/common_helpers.go
+++ b/cmd/lakectl/cmd/common_helpers.go
@@ -186,7 +186,7 @@ func RetrieveError(response interface{}, err error) error {
 func DieOnResponseError(response interface{}, err error) {
 	retrievedErr := RetrieveError(response, err)
 	if retrievedErr != nil {
-		DieErr(err)
+		DieErr(retrievedErr)
 	}
 }
 


### PR DESCRIPTION
Was misreporting the actual error and ended up trying to report a `nil`
error.

Probably introduced in #2529; should have been caught as an unused variable.