### PR TITLE
Code-ql doesn't support paths-ignore for Go files

### DIFF
--- a/.github/codeql/codeql-config.yaml
+++ b/.github/codeql/codeql-config.yaml
@@ -2,4 +2,3 @@ paths-ignore:
   - 'webui/node_modules'
   - 'webui/dist'
   - 'pkg/**/testdata/*.yaml'
-  - 'pkg/metastore/hive/gen-go'


### PR DESCRIPTION
Remove unused path ignore from code-ql configuration.  Closed the specific Go related alerts manually.