### PR TITLE
validate client on publish using the same version

### DIFF
--- a/.github/workflows/java-api-client.yaml
+++ b/.github/workflows/java-api-client.yaml
@@ -30,9 +30,6 @@ jobs:
       - name: Java generate package
         run: make client-java PACKAGE_VERSION=${{ steps.version.outputs.tag }}
 
-      - name: Java client validate
-        run: make validate-client-java PACKAGE_VERSION=${{ steps.version.outputs.tag }}
-
       - name: Install secret key for signing
         run: |
           cat <(echo -e '${{ secrets.OSSRH_GPG_SECRET_KEY }}') | gpg --batch --import

--- a/.github/workflows/python-api-client.yaml
+++ b/.github/workflows/python-api-client.yaml
@@ -28,9 +28,6 @@ jobs:
     - name: Python build and make package
       run: make package-python PACKAGE_VERSION=${{ steps.version.outputs.tag }}
 
-    - name: Python validate client
-      run: make validate-client-python PACKAGE_VERSION=${{ steps.version.outputs.tag }}
-
     - name: Python publish package
       uses: pypa/gh-action-pypi-publish@release/v1
       with:

--- a/Makefile
+++ b/Makefile
@@ -126,6 +126,7 @@ client-java: api/swagger.yml  ## Generate SDK for Java (and Scala) client
 		--additional-properties=hideGenerationTimestamp=true,artifactVersion=$(PACKAGE_VERSION),parentArtifactId=lakefs-parent,parentGroupId=io.lakefs,parentVersion=0,groupId=io.lakefs,artifactId='api-client',artifactDescription='lakeFS OpenAPI Java client',artifactUrl=https://github.com/treeverse/lakeFS/tree/master/clients,apiPackage=io.lakefs.clients.api,modelPackage=io.lakefs.clients.api.model,mainPackage=io.lakefs.clients.api,developerEmail=services@treeverse.io,developerName='Treeverse lakeFS dev',developerOrganization='lakefs.io',developerOrganizationUrl='https://lakefs.io',licenseName=apache2,licenseUrl=http://www.apache.org/licenses/,scmConnection=scm:git:git@github.com:treeverse/lakeFS.git,scmDeveloperConnection=scm:git:git@github.com:treeverse/lakeFS.git,scmUrl=https://github.com/treeverse/lakeFS \
 		-o /mnt/clients/java
 
+.PHONY: clients client-python client-java
 clients: client-python client-java
 
 package-python: client-python


### PR DESCRIPTION
Removed the release verification from the release workflow - the generated code there holds the new version so the code is modified.
The verification step as part of 'test' workflow checks that the generated clients code is checked in.

We can build the client twice - once without the new version information to verify that everything is checked in case we think that we will run just a release process without test workflow.