### PR TITLE
Feature - present commit history for list of objects or/and prefixes

### DIFF
--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -1949,19 +1949,19 @@ paths:
       tags:
         - refs
       operationId: logCommits
-      summary: get commit log from ref
+      summary: get commit log from ref. If both objects and prefixes are empty, return all commits.
       parameters:
         - $ref: "#/components/parameters/PaginationAfter"
         - $ref: "#/components/parameters/PaginationAmount"
         - in: query
-          name: object_list
+          name: objects
           description: list of paths, each element is a path of a specific object
           schema:
             type: array
             items:
               type: string
         - in: query
-          name: prefix_list
+          name: prefixes
           description: list of paths, each element is a path of a prefix
           schema:
             type: array

--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -895,6 +895,7 @@ components:
           minLength: 1
       required:
         - pattern
+
 paths:
   /setup_lakefs:
     post:
@@ -1952,6 +1953,20 @@ paths:
       parameters:
         - $ref: "#/components/parameters/PaginationAfter"
         - $ref: "#/components/parameters/PaginationAmount"
+        - in: query
+          name: object_list
+          description: list of paths, each element is a path of a specific object
+          schema:
+            type: array
+            items:
+              type: string
+        - in: query
+          name: prefix_list
+          description: list of paths, each element is a path of a prefix
+          schema:
+            type: array
+            items:
+              type: string
       responses:
         200:
           description: commit log

--- a/clients/java/README.md
+++ b/clients/java/README.md
@@ -183,7 +183,7 @@ Class | Method | HTTP request | Description
 *ObjectsApi* | [**uploadObject**](docs/ObjectsApi.md#uploadObject) | **POST** /repositories/{repository}/branches/{branch}/objects | 
 *RefsApi* | [**diffRefs**](docs/RefsApi.md#diffRefs) | **GET** /repositories/{repository}/refs/{leftRef}/diff/{rightRef} | diff references
 *RefsApi* | [**dumpRefs**](docs/RefsApi.md#dumpRefs) | **PUT** /repositories/{repository}/refs/dump | Dump repository refs (tags, commits, branches) to object store
-*RefsApi* | [**logCommits**](docs/RefsApi.md#logCommits) | **GET** /repositories/{repository}/refs/{ref}/commits | get commit log from ref
+*RefsApi* | [**logCommits**](docs/RefsApi.md#logCommits) | **GET** /repositories/{repository}/refs/{ref}/commits | get commit log from ref. If both objects and prefixes are empty, return all commits.
 *RefsApi* | [**mergeIntoBranch**](docs/RefsApi.md#mergeIntoBranch) | **POST** /repositories/{repository}/refs/{sourceRef}/merge/{destinationBranch} | merge references
 *RefsApi* | [**restoreRefs**](docs/RefsApi.md#restoreRefs) | **PUT** /repositories/{repository}/refs/restore | Restore repository refs (tags, commits, branches) from object store
 *RepositoriesApi* | [**createBranchProtectionRule**](docs/RepositoriesApi.md#createBranchProtectionRule) | **POST** /repositories/{repository}/branch_protection | 

--- a/clients/java/api/openapi.yaml
+++ b/clients/java/api/openapi.yaml
@@ -2046,7 +2046,7 @@ paths:
       - description: list of paths, each element is a path of a specific object
         explode: true
         in: query
-        name: object_list
+        name: objects
         required: false
         schema:
           items:
@@ -2056,7 +2056,7 @@ paths:
       - description: list of paths, each element is a path of a prefix
         explode: true
         in: query
-        name: prefix_list
+        name: prefixes
         required: false
         schema:
           items:
@@ -2088,7 +2088,8 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: Internal Server Error
-      summary: get commit log from ref
+      summary: get commit log from ref. If both objects and prefixes are empty, return
+        all commits.
       tags:
       - refs
       x-accepts: application/json

--- a/clients/java/api/openapi.yaml
+++ b/clients/java/api/openapi.yaml
@@ -2043,6 +2043,26 @@ paths:
           minimum: -1
           type: integer
         style: form
+      - description: list of paths, each element is a path of a specific object
+        explode: true
+        in: query
+        name: object_list
+        required: false
+        schema:
+          items:
+            type: string
+          type: array
+        style: form
+      - description: list of paths, each element is a path of a prefix
+        explode: true
+        in: query
+        name: prefix_list
+        required: false
+        schema:
+          items:
+            type: string
+          type: array
+        style: form
       responses:
         "200":
           content:

--- a/clients/java/docs/RefsApi.md
+++ b/clients/java/docs/RefsApi.md
@@ -188,7 +188,7 @@ Name | Type | Description  | Notes
 
 <a name="logCommits"></a>
 # **logCommits**
-> CommitList logCommits(repository, ref, after, amount)
+> CommitList logCommits(repository, ref, after, amount, objectList, prefixList)
 
 get commit log from ref
 
@@ -227,8 +227,10 @@ public class Example {
     String ref = "ref_example"; // String | 
     String after = "after_example"; // String | return items after this value
     Integer amount = 100; // Integer | how many items to return
+    List<String> objectList = Arrays.asList(); // List<String> | list of paths, each element is a path of a specific object
+    List<String> prefixList = Arrays.asList(); // List<String> | list of paths, each element is a path of a prefix
     try {
-      CommitList result = apiInstance.logCommits(repository, ref, after, amount);
+      CommitList result = apiInstance.logCommits(repository, ref, after, amount, objectList, prefixList);
       System.out.println(result);
     } catch (ApiException e) {
       System.err.println("Exception when calling RefsApi#logCommits");
@@ -249,6 +251,8 @@ Name | Type | Description  | Notes
  **ref** | **String**|  |
  **after** | **String**| return items after this value | [optional]
  **amount** | **Integer**| how many items to return | [optional] [default to 100]
+ **objectList** | [**List&lt;String&gt;**](String.md)| list of paths, each element is a path of a specific object | [optional]
+ **prefixList** | [**List&lt;String&gt;**](String.md)| list of paths, each element is a path of a prefix | [optional]
 
 ### Return type
 

--- a/clients/java/docs/RefsApi.md
+++ b/clients/java/docs/RefsApi.md
@@ -6,7 +6,7 @@ Method | HTTP request | Description
 ------------- | ------------- | -------------
 [**diffRefs**](RefsApi.md#diffRefs) | **GET** /repositories/{repository}/refs/{leftRef}/diff/{rightRef} | diff references
 [**dumpRefs**](RefsApi.md#dumpRefs) | **PUT** /repositories/{repository}/refs/dump | Dump repository refs (tags, commits, branches) to object store
-[**logCommits**](RefsApi.md#logCommits) | **GET** /repositories/{repository}/refs/{ref}/commits | get commit log from ref
+[**logCommits**](RefsApi.md#logCommits) | **GET** /repositories/{repository}/refs/{ref}/commits | get commit log from ref. If both objects and prefixes are empty, return all commits.
 [**mergeIntoBranch**](RefsApi.md#mergeIntoBranch) | **POST** /repositories/{repository}/refs/{sourceRef}/merge/{destinationBranch} | merge references
 [**restoreRefs**](RefsApi.md#restoreRefs) | **PUT** /repositories/{repository}/refs/restore | Restore repository refs (tags, commits, branches) from object store
 
@@ -188,9 +188,9 @@ Name | Type | Description  | Notes
 
 <a name="logCommits"></a>
 # **logCommits**
-> CommitList logCommits(repository, ref, after, amount, objectList, prefixList)
+> CommitList logCommits(repository, ref, after, amount, objects, prefixes)
 
-get commit log from ref
+get commit log from ref. If both objects and prefixes are empty, return all commits.
 
 ### Example
 ```java
@@ -227,10 +227,10 @@ public class Example {
     String ref = "ref_example"; // String | 
     String after = "after_example"; // String | return items after this value
     Integer amount = 100; // Integer | how many items to return
-    List<String> objectList = Arrays.asList(); // List<String> | list of paths, each element is a path of a specific object
-    List<String> prefixList = Arrays.asList(); // List<String> | list of paths, each element is a path of a prefix
+    List<String> objects = Arrays.asList(); // List<String> | list of paths, each element is a path of a specific object
+    List<String> prefixes = Arrays.asList(); // List<String> | list of paths, each element is a path of a prefix
     try {
-      CommitList result = apiInstance.logCommits(repository, ref, after, amount, objectList, prefixList);
+      CommitList result = apiInstance.logCommits(repository, ref, after, amount, objects, prefixes);
       System.out.println(result);
     } catch (ApiException e) {
       System.err.println("Exception when calling RefsApi#logCommits");
@@ -251,8 +251,8 @@ Name | Type | Description  | Notes
  **ref** | **String**|  |
  **after** | **String**| return items after this value | [optional]
  **amount** | **Integer**| how many items to return | [optional] [default to 100]
- **objectList** | [**List&lt;String&gt;**](String.md)| list of paths, each element is a path of a specific object | [optional]
- **prefixList** | [**List&lt;String&gt;**](String.md)| list of paths, each element is a path of a prefix | [optional]
+ **objects** | [**List&lt;String&gt;**](String.md)| list of paths, each element is a path of a specific object | [optional]
+ **prefixes** | [**List&lt;String&gt;**](String.md)| list of paths, each element is a path of a prefix | [optional]
 
 ### Return type
 

--- a/clients/java/src/main/java/io/lakefs/clients/api/RefsApi.java
+++ b/clients/java/src/main/java/io/lakefs/clients/api/RefsApi.java
@@ -385,8 +385,8 @@ public class RefsApi {
      * @param ref  (required)
      * @param after return items after this value (optional)
      * @param amount how many items to return (optional, default to 100)
-     * @param objectList list of paths, each element is a path of a specific object (optional)
-     * @param prefixList list of paths, each element is a path of a prefix (optional)
+     * @param objects list of paths, each element is a path of a specific object (optional)
+     * @param prefixes list of paths, each element is a path of a prefix (optional)
      * @param _callback Callback for upload/download progress
      * @return Call to execute
      * @throws ApiException If fail to serialize the request body object
@@ -399,7 +399,7 @@ public class RefsApi {
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call logCommitsCall(String repository, String ref, String after, Integer amount, List<String> objectList, List<String> prefixList, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call logCommitsCall(String repository, String ref, String after, Integer amount, List<String> objects, List<String> prefixes, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -421,12 +421,12 @@ public class RefsApi {
             localVarQueryParams.addAll(localVarApiClient.parameterToPair("amount", amount));
         }
 
-        if (objectList != null) {
-            localVarCollectionQueryParams.addAll(localVarApiClient.parameterToPairs("multi", "object_list", objectList));
+        if (objects != null) {
+            localVarCollectionQueryParams.addAll(localVarApiClient.parameterToPairs("multi", "objects", objects));
         }
 
-        if (prefixList != null) {
-            localVarCollectionQueryParams.addAll(localVarApiClient.parameterToPairs("multi", "prefix_list", prefixList));
+        if (prefixes != null) {
+            localVarCollectionQueryParams.addAll(localVarApiClient.parameterToPairs("multi", "prefixes", prefixes));
         }
 
         final String[] localVarAccepts = {
@@ -448,7 +448,7 @@ public class RefsApi {
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call logCommitsValidateBeforeCall(String repository, String ref, String after, Integer amount, List<String> objectList, List<String> prefixList, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call logCommitsValidateBeforeCall(String repository, String ref, String after, Integer amount, List<String> objects, List<String> prefixes, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'repository' is set
         if (repository == null) {
@@ -461,20 +461,20 @@ public class RefsApi {
         }
         
 
-        okhttp3.Call localVarCall = logCommitsCall(repository, ref, after, amount, objectList, prefixList, _callback);
+        okhttp3.Call localVarCall = logCommitsCall(repository, ref, after, amount, objects, prefixes, _callback);
         return localVarCall;
 
     }
 
     /**
-     * get commit log from ref
+     * get commit log from ref. If both objects and prefixes are empty, return all commits.
      * 
      * @param repository  (required)
      * @param ref  (required)
      * @param after return items after this value (optional)
      * @param amount how many items to return (optional, default to 100)
-     * @param objectList list of paths, each element is a path of a specific object (optional)
-     * @param prefixList list of paths, each element is a path of a prefix (optional)
+     * @param objects list of paths, each element is a path of a specific object (optional)
+     * @param prefixes list of paths, each element is a path of a prefix (optional)
      * @return CommitList
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -486,20 +486,20 @@ public class RefsApi {
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
      */
-    public CommitList logCommits(String repository, String ref, String after, Integer amount, List<String> objectList, List<String> prefixList) throws ApiException {
-        ApiResponse<CommitList> localVarResp = logCommitsWithHttpInfo(repository, ref, after, amount, objectList, prefixList);
+    public CommitList logCommits(String repository, String ref, String after, Integer amount, List<String> objects, List<String> prefixes) throws ApiException {
+        ApiResponse<CommitList> localVarResp = logCommitsWithHttpInfo(repository, ref, after, amount, objects, prefixes);
         return localVarResp.getData();
     }
 
     /**
-     * get commit log from ref
+     * get commit log from ref. If both objects and prefixes are empty, return all commits.
      * 
      * @param repository  (required)
      * @param ref  (required)
      * @param after return items after this value (optional)
      * @param amount how many items to return (optional, default to 100)
-     * @param objectList list of paths, each element is a path of a specific object (optional)
-     * @param prefixList list of paths, each element is a path of a prefix (optional)
+     * @param objects list of paths, each element is a path of a specific object (optional)
+     * @param prefixes list of paths, each element is a path of a prefix (optional)
      * @return ApiResponse&lt;CommitList&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -511,21 +511,21 @@ public class RefsApi {
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<CommitList> logCommitsWithHttpInfo(String repository, String ref, String after, Integer amount, List<String> objectList, List<String> prefixList) throws ApiException {
-        okhttp3.Call localVarCall = logCommitsValidateBeforeCall(repository, ref, after, amount, objectList, prefixList, null);
+    public ApiResponse<CommitList> logCommitsWithHttpInfo(String repository, String ref, String after, Integer amount, List<String> objects, List<String> prefixes) throws ApiException {
+        okhttp3.Call localVarCall = logCommitsValidateBeforeCall(repository, ref, after, amount, objects, prefixes, null);
         Type localVarReturnType = new TypeToken<CommitList>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
     /**
-     * get commit log from ref (asynchronously)
+     * get commit log from ref. If both objects and prefixes are empty, return all commits. (asynchronously)
      * 
      * @param repository  (required)
      * @param ref  (required)
      * @param after return items after this value (optional)
      * @param amount how many items to return (optional, default to 100)
-     * @param objectList list of paths, each element is a path of a specific object (optional)
-     * @param prefixList list of paths, each element is a path of a prefix (optional)
+     * @param objects list of paths, each element is a path of a specific object (optional)
+     * @param prefixes list of paths, each element is a path of a prefix (optional)
      * @param _callback The callback to be executed when the API call finishes
      * @return The request call
      * @throws ApiException If fail to process the API call, e.g. serializing the request body object
@@ -538,9 +538,9 @@ public class RefsApi {
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call logCommitsAsync(String repository, String ref, String after, Integer amount, List<String> objectList, List<String> prefixList, final ApiCallback<CommitList> _callback) throws ApiException {
+    public okhttp3.Call logCommitsAsync(String repository, String ref, String after, Integer amount, List<String> objects, List<String> prefixes, final ApiCallback<CommitList> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = logCommitsValidateBeforeCall(repository, ref, after, amount, objectList, prefixList, _callback);
+        okhttp3.Call localVarCall = logCommitsValidateBeforeCall(repository, ref, after, amount, objects, prefixes, _callback);
         Type localVarReturnType = new TypeToken<CommitList>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;

--- a/clients/java/src/main/java/io/lakefs/clients/api/RefsApi.java
+++ b/clients/java/src/main/java/io/lakefs/clients/api/RefsApi.java
@@ -385,6 +385,8 @@ public class RefsApi {
      * @param ref  (required)
      * @param after return items after this value (optional)
      * @param amount how many items to return (optional, default to 100)
+     * @param objectList list of paths, each element is a path of a specific object (optional)
+     * @param prefixList list of paths, each element is a path of a prefix (optional)
      * @param _callback Callback for upload/download progress
      * @return Call to execute
      * @throws ApiException If fail to serialize the request body object
@@ -397,7 +399,7 @@ public class RefsApi {
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call logCommitsCall(String repository, String ref, String after, Integer amount, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call logCommitsCall(String repository, String ref, String after, Integer amount, List<String> objectList, List<String> prefixList, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -419,6 +421,14 @@ public class RefsApi {
             localVarQueryParams.addAll(localVarApiClient.parameterToPair("amount", amount));
         }
 
+        if (objectList != null) {
+            localVarCollectionQueryParams.addAll(localVarApiClient.parameterToPairs("multi", "object_list", objectList));
+        }
+
+        if (prefixList != null) {
+            localVarCollectionQueryParams.addAll(localVarApiClient.parameterToPairs("multi", "prefix_list", prefixList));
+        }
+
         final String[] localVarAccepts = {
             "application/json"
         };
@@ -438,7 +448,7 @@ public class RefsApi {
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call logCommitsValidateBeforeCall(String repository, String ref, String after, Integer amount, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call logCommitsValidateBeforeCall(String repository, String ref, String after, Integer amount, List<String> objectList, List<String> prefixList, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'repository' is set
         if (repository == null) {
@@ -451,7 +461,7 @@ public class RefsApi {
         }
         
 
-        okhttp3.Call localVarCall = logCommitsCall(repository, ref, after, amount, _callback);
+        okhttp3.Call localVarCall = logCommitsCall(repository, ref, after, amount, objectList, prefixList, _callback);
         return localVarCall;
 
     }
@@ -463,6 +473,8 @@ public class RefsApi {
      * @param ref  (required)
      * @param after return items after this value (optional)
      * @param amount how many items to return (optional, default to 100)
+     * @param objectList list of paths, each element is a path of a specific object (optional)
+     * @param prefixList list of paths, each element is a path of a prefix (optional)
      * @return CommitList
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -474,8 +486,8 @@ public class RefsApi {
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
      */
-    public CommitList logCommits(String repository, String ref, String after, Integer amount) throws ApiException {
-        ApiResponse<CommitList> localVarResp = logCommitsWithHttpInfo(repository, ref, after, amount);
+    public CommitList logCommits(String repository, String ref, String after, Integer amount, List<String> objectList, List<String> prefixList) throws ApiException {
+        ApiResponse<CommitList> localVarResp = logCommitsWithHttpInfo(repository, ref, after, amount, objectList, prefixList);
         return localVarResp.getData();
     }
 
@@ -486,6 +498,8 @@ public class RefsApi {
      * @param ref  (required)
      * @param after return items after this value (optional)
      * @param amount how many items to return (optional, default to 100)
+     * @param objectList list of paths, each element is a path of a specific object (optional)
+     * @param prefixList list of paths, each element is a path of a prefix (optional)
      * @return ApiResponse&lt;CommitList&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -497,8 +511,8 @@ public class RefsApi {
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<CommitList> logCommitsWithHttpInfo(String repository, String ref, String after, Integer amount) throws ApiException {
-        okhttp3.Call localVarCall = logCommitsValidateBeforeCall(repository, ref, after, amount, null);
+    public ApiResponse<CommitList> logCommitsWithHttpInfo(String repository, String ref, String after, Integer amount, List<String> objectList, List<String> prefixList) throws ApiException {
+        okhttp3.Call localVarCall = logCommitsValidateBeforeCall(repository, ref, after, amount, objectList, prefixList, null);
         Type localVarReturnType = new TypeToken<CommitList>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
@@ -510,6 +524,8 @@ public class RefsApi {
      * @param ref  (required)
      * @param after return items after this value (optional)
      * @param amount how many items to return (optional, default to 100)
+     * @param objectList list of paths, each element is a path of a specific object (optional)
+     * @param prefixList list of paths, each element is a path of a prefix (optional)
      * @param _callback The callback to be executed when the API call finishes
      * @return The request call
      * @throws ApiException If fail to process the API call, e.g. serializing the request body object
@@ -522,9 +538,9 @@ public class RefsApi {
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call logCommitsAsync(String repository, String ref, String after, Integer amount, final ApiCallback<CommitList> _callback) throws ApiException {
+    public okhttp3.Call logCommitsAsync(String repository, String ref, String after, Integer amount, List<String> objectList, List<String> prefixList, final ApiCallback<CommitList> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = logCommitsValidateBeforeCall(repository, ref, after, amount, _callback);
+        okhttp3.Call localVarCall = logCommitsValidateBeforeCall(repository, ref, after, amount, objectList, prefixList, _callback);
         Type localVarReturnType = new TypeToken<CommitList>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -164,7 +164,7 @@ Class | Method | HTTP request | Description
 *ObjectsApi* | [**upload_object**](docs/ObjectsApi.md#upload_object) | **POST** /repositories/{repository}/branches/{branch}/objects | 
 *RefsApi* | [**diff_refs**](docs/RefsApi.md#diff_refs) | **GET** /repositories/{repository}/refs/{leftRef}/diff/{rightRef} | diff references
 *RefsApi* | [**dump_refs**](docs/RefsApi.md#dump_refs) | **PUT** /repositories/{repository}/refs/dump | Dump repository refs (tags, commits, branches) to object store
-*RefsApi* | [**log_commits**](docs/RefsApi.md#log_commits) | **GET** /repositories/{repository}/refs/{ref}/commits | get commit log from ref
+*RefsApi* | [**log_commits**](docs/RefsApi.md#log_commits) | **GET** /repositories/{repository}/refs/{ref}/commits | get commit log from ref. If both objects and prefixes are empty, return all commits.
 *RefsApi* | [**merge_into_branch**](docs/RefsApi.md#merge_into_branch) | **POST** /repositories/{repository}/refs/{sourceRef}/merge/{destinationBranch} | merge references
 *RefsApi* | [**restore_refs**](docs/RefsApi.md#restore_refs) | **PUT** /repositories/{repository}/refs/restore | Restore repository refs (tags, commits, branches) from object store
 *RepositoriesApi* | [**create_branch_protection_rule**](docs/RepositoriesApi.md#create_branch_protection_rule) | **POST** /repositories/{repository}/branch_protection | 

--- a/clients/python/docs/RefsApi.md
+++ b/clients/python/docs/RefsApi.md
@@ -277,6 +277,12 @@ with lakefs_client.ApiClient(configuration) as api_client:
     ref = "ref_example" # str | 
     after = "after_example" # str | return items after this value (optional)
     amount = 100 # int | how many items to return (optional) if omitted the server will use the default value of 100
+    object_list = [
+        "object_list_example",
+    ] # [str] | list of paths, each element is a path of a specific object (optional)
+    prefix_list = [
+        "prefix_list_example",
+    ] # [str] | list of paths, each element is a path of a prefix (optional)
 
     # example passing only required values which don't have defaults set
     try:
@@ -290,7 +296,7 @@ with lakefs_client.ApiClient(configuration) as api_client:
     # and optional values
     try:
         # get commit log from ref
-        api_response = api_instance.log_commits(repository, ref, after=after, amount=amount)
+        api_response = api_instance.log_commits(repository, ref, after=after, amount=amount, object_list=object_list, prefix_list=prefix_list)
         pprint(api_response)
     except lakefs_client.ApiException as e:
         print("Exception when calling RefsApi->log_commits: %s\n" % e)
@@ -305,6 +311,8 @@ Name | Type | Description  | Notes
  **ref** | **str**|  |
  **after** | **str**| return items after this value | [optional]
  **amount** | **int**| how many items to return | [optional] if omitted the server will use the default value of 100
+ **object_list** | **[str]**| list of paths, each element is a path of a specific object | [optional]
+ **prefix_list** | **[str]**| list of paths, each element is a path of a prefix | [optional]
 
 ### Return type
 

--- a/clients/python/docs/RefsApi.md
+++ b/clients/python/docs/RefsApi.md
@@ -6,7 +6,7 @@ Method | HTTP request | Description
 ------------- | ------------- | -------------
 [**diff_refs**](RefsApi.md#diff_refs) | **GET** /repositories/{repository}/refs/{leftRef}/diff/{rightRef} | diff references
 [**dump_refs**](RefsApi.md#dump_refs) | **PUT** /repositories/{repository}/refs/dump | Dump repository refs (tags, commits, branches) to object store
-[**log_commits**](RefsApi.md#log_commits) | **GET** /repositories/{repository}/refs/{ref}/commits | get commit log from ref
+[**log_commits**](RefsApi.md#log_commits) | **GET** /repositories/{repository}/refs/{ref}/commits | get commit log from ref. If both objects and prefixes are empty, return all commits.
 [**merge_into_branch**](RefsApi.md#merge_into_branch) | **POST** /repositories/{repository}/refs/{sourceRef}/merge/{destinationBranch} | merge references
 [**restore_refs**](RefsApi.md#restore_refs) | **PUT** /repositories/{repository}/refs/restore | Restore repository refs (tags, commits, branches) from object store
 
@@ -226,7 +226,7 @@ Name | Type | Description  | Notes
 # **log_commits**
 > CommitList log_commits(repository, ref)
 
-get commit log from ref
+get commit log from ref. If both objects and prefixes are empty, return all commits.
 
 ### Example
 
@@ -277,16 +277,16 @@ with lakefs_client.ApiClient(configuration) as api_client:
     ref = "ref_example" # str | 
     after = "after_example" # str | return items after this value (optional)
     amount = 100 # int | how many items to return (optional) if omitted the server will use the default value of 100
-    object_list = [
-        "object_list_example",
+    objects = [
+        "objects_example",
     ] # [str] | list of paths, each element is a path of a specific object (optional)
-    prefix_list = [
-        "prefix_list_example",
+    prefixes = [
+        "prefixes_example",
     ] # [str] | list of paths, each element is a path of a prefix (optional)
 
     # example passing only required values which don't have defaults set
     try:
-        # get commit log from ref
+        # get commit log from ref. If both objects and prefixes are empty, return all commits.
         api_response = api_instance.log_commits(repository, ref)
         pprint(api_response)
     except lakefs_client.ApiException as e:
@@ -295,8 +295,8 @@ with lakefs_client.ApiClient(configuration) as api_client:
     # example passing only required values which don't have defaults set
     # and optional values
     try:
-        # get commit log from ref
-        api_response = api_instance.log_commits(repository, ref, after=after, amount=amount, object_list=object_list, prefix_list=prefix_list)
+        # get commit log from ref. If both objects and prefixes are empty, return all commits.
+        api_response = api_instance.log_commits(repository, ref, after=after, amount=amount, objects=objects, prefixes=prefixes)
         pprint(api_response)
     except lakefs_client.ApiException as e:
         print("Exception when calling RefsApi->log_commits: %s\n" % e)
@@ -311,8 +311,8 @@ Name | Type | Description  | Notes
  **ref** | **str**|  |
  **after** | **str**| return items after this value | [optional]
  **amount** | **int**| how many items to return | [optional] if omitted the server will use the default value of 100
- **object_list** | **[str]**| list of paths, each element is a path of a specific object | [optional]
- **prefix_list** | **[str]**| list of paths, each element is a path of a prefix | [optional]
+ **objects** | **[str]**| list of paths, each element is a path of a specific object | [optional]
+ **prefixes** | **[str]**| list of paths, each element is a path of a prefix | [optional]
 
 ### Return type
 

--- a/clients/python/lakefs_client/api/refs_api.py
+++ b/clients/python/lakefs_client/api/refs_api.py
@@ -356,7 +356,7 @@ class RefsApi(object):
             ref,
             **kwargs
         ):
-            """get commit log from ref  # noqa: E501
+            """get commit log from ref. If both objects and prefixes are empty, return all commits.  # noqa: E501
 
             This method makes a synchronous HTTP request by default. To make an
             asynchronous HTTP request, please pass async_req=True
@@ -371,8 +371,8 @@ class RefsApi(object):
             Keyword Args:
                 after (str): return items after this value. [optional]
                 amount (int): how many items to return. [optional] if omitted the server will use the default value of 100
-                object_list ([str]): list of paths, each element is a path of a specific object. [optional]
-                prefix_list ([str]): list of paths, each element is a path of a prefix. [optional]
+                objects ([str]): list of paths, each element is a path of a specific object. [optional]
+                prefixes ([str]): list of paths, each element is a path of a prefix. [optional]
                 _return_http_data_only (bool): response data without head status
                     code and headers. Default is True.
                 _preload_content (bool): if False, the urllib3.HTTPResponse object
@@ -442,8 +442,8 @@ class RefsApi(object):
                     'ref',
                     'after',
                     'amount',
-                    'object_list',
-                    'prefix_list',
+                    'objects',
+                    'prefixes',
                 ],
                 'required': [
                     'repository',
@@ -476,9 +476,9 @@ class RefsApi(object):
                         (str,),
                     'amount':
                         (int,),
-                    'object_list':
+                    'objects':
                         ([str],),
-                    'prefix_list':
+                    'prefixes':
                         ([str],),
                 },
                 'attribute_map': {
@@ -486,20 +486,20 @@ class RefsApi(object):
                     'ref': 'ref',
                     'after': 'after',
                     'amount': 'amount',
-                    'object_list': 'object_list',
-                    'prefix_list': 'prefix_list',
+                    'objects': 'objects',
+                    'prefixes': 'prefixes',
                 },
                 'location_map': {
                     'repository': 'path',
                     'ref': 'path',
                     'after': 'query',
                     'amount': 'query',
-                    'object_list': 'query',
-                    'prefix_list': 'query',
+                    'objects': 'query',
+                    'prefixes': 'query',
                 },
                 'collection_format_map': {
-                    'object_list': 'multi',
-                    'prefix_list': 'multi',
+                    'objects': 'multi',
+                    'prefixes': 'multi',
                 }
             },
             headers_map={

--- a/clients/python/lakefs_client/api/refs_api.py
+++ b/clients/python/lakefs_client/api/refs_api.py
@@ -371,6 +371,8 @@ class RefsApi(object):
             Keyword Args:
                 after (str): return items after this value. [optional]
                 amount (int): how many items to return. [optional] if omitted the server will use the default value of 100
+                object_list ([str]): list of paths, each element is a path of a specific object. [optional]
+                prefix_list ([str]): list of paths, each element is a path of a prefix. [optional]
                 _return_http_data_only (bool): response data without head status
                     code and headers. Default is True.
                 _preload_content (bool): if False, the urllib3.HTTPResponse object
@@ -440,6 +442,8 @@ class RefsApi(object):
                     'ref',
                     'after',
                     'amount',
+                    'object_list',
+                    'prefix_list',
                 ],
                 'required': [
                     'repository',
@@ -472,20 +476,30 @@ class RefsApi(object):
                         (str,),
                     'amount':
                         (int,),
+                    'object_list':
+                        ([str],),
+                    'prefix_list':
+                        ([str],),
                 },
                 'attribute_map': {
                     'repository': 'repository',
                     'ref': 'ref',
                     'after': 'after',
                     'amount': 'amount',
+                    'object_list': 'object_list',
+                    'prefix_list': 'prefix_list',
                 },
                 'location_map': {
                     'repository': 'path',
                     'ref': 'path',
                     'after': 'query',
                     'amount': 'query',
+                    'object_list': 'query',
+                    'prefix_list': 'query',
                 },
                 'collection_format_map': {
+                    'object_list': 'multi',
+                    'prefix_list': 'multi',
                 }
             },
             headers_map={

--- a/clients/python/test/test_refs_api.py
+++ b/clients/python/test/test_refs_api.py
@@ -41,7 +41,7 @@ class TestRefsApi(unittest.TestCase):
     def test_log_commits(self):
         """Test case for log_commits
 
-        get commit log from ref  # noqa: E501
+        get commit log from ref. If both objects and prefixes are empty, return all commits.  # noqa: E501
         """
         pass
 

--- a/cmd/lakectl/cmd/common_helpers.go
+++ b/cmd/lakectl/cmd/common_helpers.go
@@ -24,7 +24,7 @@ var isTerminal = true
 var noColorRequested = false
 
 // ErrInvalidValueInList is an error returned when a parameter of type list contains an empty string
-var ErrInvalidValueInList = errors.New("invalid value in list. All values in list should be non-empty string")
+var ErrInvalidValueInList = errors.New("empty string in list")
 
 const (
 	LakectlInteractive        = "LAKECTL_INTERACTIVE"

--- a/cmd/lakectl/cmd/common_helpers.go
+++ b/cmd/lakectl/cmd/common_helpers.go
@@ -23,6 +23,9 @@ import (
 var isTerminal = true
 var noColorRequested = false
 
+// ErrInvalidValueInList is an error returned when a parameter of type list contains an empty string
+var ErrInvalidValueInList = errors.New("invalid value in list. All values in list should be non-empty string")
+
 const (
 	LakectlInteractive        = "LAKECTL_INTERACTIVE"
 	LakectlInteractiveDisable = "no"

--- a/cmd/lakectl/cmd/input.go
+++ b/cmd/lakectl/cmd/input.go
@@ -100,6 +100,22 @@ func MustString(v string, err error) string {
 	return v
 }
 
+func MustStringSlice(v []string, err error) []string {
+	if err != nil {
+		DieErr(err)
+	}
+	return v
+}
+
+func MustSliceNonEmptyString(list string, v []string) []string {
+	for _, s := range v {
+		if s == "" {
+			DieErr(fmt.Errorf("error in %s list: %w", list, ErrInvalidValueInList))
+		}
+	}
+	return v
+}
+
 func MustInt(v int, err error) int {
 	if err != nil {
 		DieErr(err)

--- a/cmd/lakectl/cmd/log.go
+++ b/cmd/lakectl/cmd/log.go
@@ -26,11 +26,14 @@ Merge:         {{ $val.Parents|join ", "|bold }}
 var logCmd = &cobra.Command{
 	Use:   "log <branch uri>",
 	Short: "Show log of commits",
-	Long:  "Show log of commits for a given branch",
+	Long:  "Show log of commits for a given branch. \nWith objects or prefixes, show log of commits containing changes to at least one of the paths.",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		amount := MustInt(cmd.Flags().GetInt("amount"))
 		after := MustString(cmd.Flags().GetString("after"))
+		objectsList := MustSliceNonEmptyString("objects", MustStringSlice(cmd.Flags().GetStringSlice("objects")))
+		prefixesList := MustSliceNonEmptyString("prefixes", MustStringSlice(cmd.Flags().GetStringSlice("prefixes")))
+
 		pagination := api.Pagination{HasMore: true}
 		showMetaRangeID, _ := cmd.Flags().GetBool("show-meta-range-id")
 		client := getClient()
@@ -39,14 +42,21 @@ var logCmd = &cobra.Command{
 		if amountForPagination <= 0 {
 			amountForPagination = internalPageSize
 		}
+		logCommitsParams := &api.LogCommitsParams{
+			After:  api.PaginationAfterPtr(after),
+			Amount: api.PaginationAmountPtr(amountForPagination),
+		}
+		if len(objectsList) > 0 {
+			logCommitsParams.ObjectList = &objectsList
+		}
+		if len(prefixesList) > 0 {
+			logCommitsParams.PrefixList = &prefixesList
+		}
 		for pagination.HasMore {
-			res, err := client.LogCommitsWithResponse(cmd.Context(), branchURI.Repository, branchURI.Ref, &api.LogCommitsParams{
-				After:  api.PaginationAfterPtr(after),
-				Amount: api.PaginationAmountPtr(amountForPagination),
-			})
+			res, err := client.LogCommitsWithResponse(cmd.Context(), branchURI.Repository, branchURI.Ref, logCommitsParams)
 			DieOnResponseError(res, err)
 			pagination = res.JSON200.Pagination
-			after = pagination.NextOffset
+			logCommitsParams.After = api.PaginationAfterPtr(pagination.NextOffset)
 			data := struct {
 				Commits         []api.Commit
 				Pagination      *Pagination
@@ -72,7 +82,9 @@ var logCmd = &cobra.Command{
 //nolint:gochecknoinits
 func init() {
 	rootCmd.AddCommand(logCmd)
-	logCmd.Flags().Int("amount", 0, "number of results to return. By default, all results are returned.")
+	logCmd.Flags().Int("amount", 0, "number of results to return. By default, all results are returned")
 	logCmd.Flags().String("after", "", "show results after this value (used for pagination)")
 	logCmd.Flags().Bool("show-meta-range-id", false, "also show meta range ID")
+	logCmd.Flags().StringSlice("objects", nil, "show results that contains changes to that list of objects. Use comma separator to pass all objects together")
+	logCmd.Flags().StringSlice("prefixes", nil, "show results that contains changes to that list of prefixes. Use comma separator to pass all prefixes together")
 }

--- a/cmd/lakectl/cmd/log.go
+++ b/cmd/lakectl/cmd/log.go
@@ -47,10 +47,10 @@ var logCmd = &cobra.Command{
 			Amount: api.PaginationAmountPtr(amountForPagination),
 		}
 		if len(objectsList) > 0 {
-			logCommitsParams.ObjectList = &objectsList
+			logCommitsParams.Objects = &objectsList
 		}
 		if len(prefixesList) > 0 {
-			logCommitsParams.PrefixList = &prefixesList
+			logCommitsParams.Prefixes = &prefixesList
 		}
 		for pagination.HasMore {
 			res, err := client.LogCommitsWithResponse(cmd.Context(), branchURI.Repository, branchURI.Ref, logCommitsParams)

--- a/cmd/lakectl/cmd/log.go
+++ b/cmd/lakectl/cmd/log.go
@@ -26,7 +26,7 @@ Merge:         {{ $val.Parents|join ", "|bold }}
 var logCmd = &cobra.Command{
 	Use:   "log <branch uri>",
 	Short: "Show log of commits",
-	Long:  "Show log of commits for a given branch. \nWith objects or prefixes, show log of commits containing changes to at least one of the paths.",
+	Long:  "Show log of commits for a given branch",
 	Args:  cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		amount := MustInt(cmd.Flags().GetInt("amount"))
@@ -85,6 +85,6 @@ func init() {
 	logCmd.Flags().Int("amount", 0, "number of results to return. By default, all results are returned")
 	logCmd.Flags().String("after", "", "show results after this value (used for pagination)")
 	logCmd.Flags().Bool("show-meta-range-id", false, "also show meta range ID")
-	logCmd.Flags().StringSlice("objects", nil, "show results that contains changes to that list of objects. Use comma separator to pass all objects together")
-	logCmd.Flags().StringSlice("prefixes", nil, "show results that contains changes to that list of prefixes. Use comma separator to pass all prefixes together")
+	logCmd.Flags().StringSlice("objects", nil, "show results that contains changes to at least one path in that list of objects. Use comma separator to pass all objects together")
+	logCmd.Flags().StringSlice("prefixes", nil, "show results that contains changes to at least one path in that list of prefixes. Use comma separator to pass all prefixes together")
 }

--- a/docs/assets/js/swagger.yml
+++ b/docs/assets/js/swagger.yml
@@ -1949,19 +1949,19 @@ paths:
       tags:
         - refs
       operationId: logCommits
-      summary: get commit log from ref
+      summary: get commit log from ref. If both objects and prefixes are empty, return all commits.
       parameters:
         - $ref: "#/components/parameters/PaginationAfter"
         - $ref: "#/components/parameters/PaginationAmount"
         - in: query
-          name: object_list
+          name: objects
           description: list of paths, each element is a path of a specific object
           schema:
             type: array
             items:
               type: string
         - in: query
-          name: prefix_list
+          name: prefixes
           description: list of paths, each element is a path of a prefix
           schema:
             type: array

--- a/docs/assets/js/swagger.yml
+++ b/docs/assets/js/swagger.yml
@@ -225,6 +225,9 @@ components:
           description: Unix Epoch in seconds
         metadata:
           $ref: "#/components/schemas/ObjectUserMetadata"
+        content_type:
+          type: string
+          description: Object media type
 
     ObjectStatsList:
       type: object
@@ -259,6 +262,9 @@ components:
           description: Unix Epoch in seconds
         metadata:
           $ref: "#/components/schemas/ObjectUserMetadata"
+        content_type:
+          type: string
+          description: Object media type
 
     ObjectUserMetadata:
       type: object
@@ -819,6 +825,9 @@ components:
           type: object
           additionalProperties:
             type: string
+        content_type:
+          type: string
+          description: Object media type
       required:
         - staging
         - checksum
@@ -886,6 +895,7 @@ components:
           minLength: 1
       required:
         - pattern
+
 paths:
   /setup_lakefs:
     post:
@@ -1943,6 +1953,20 @@ paths:
       parameters:
         - $ref: "#/components/parameters/PaginationAfter"
         - $ref: "#/components/parameters/PaginationAmount"
+        - in: query
+          name: object_list
+          description: list of paths, each element is a path of a specific object
+          schema:
+            type: array
+            items:
+              type: string
+        - in: query
+          name: prefix_list
+          description: list of paths, each element is a path of a prefix
+          schema:
+            type: array
+            items:
+              type: string
       responses:
         200:
           description: commit log
@@ -2419,7 +2443,11 @@ paths:
           # This actually violates HTTP, which requires returning 201 if a new object was
           # created or 200 if an existing object was modified,
           # https://tools.ietf.org/html/rfc7231#section-4.3.4
-          description: successfully linked
+          description: object metadata
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ObjectStats"
         400:
           $ref: "#/components/responses/ValidationError"
         401:

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1925,7 +1925,8 @@ Show log of commits
 #### Synopsis
 {:.no_toc}
 
-Show log of commits for a given branch
+Show log of commits for a given branch. 
+With objects or prefixes, show log of commits containing changes to at least one of the paths.
 
 ```
 lakectl log <branch uri> [flags]
@@ -1936,8 +1937,10 @@ lakectl log <branch uri> [flags]
 
 ```
       --after string         show results after this value (used for pagination)
-      --amount int           number of results to return. By default, all results are returned.
+      --amount int           number of results to return. By default, all results are returned
   -h, --help                 help for log
+      --objects strings      show results that contains changes to that list of objects. Use comma separator to pass all objects together
+      --prefixes strings     show results that contains changes to that list of prefixes. Use comma separator to pass all prefixes together
       --show-meta-range-id   also show meta range ID
 ```
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -1925,8 +1925,7 @@ Show log of commits
 #### Synopsis
 {:.no_toc}
 
-Show log of commits for a given branch. 
-With objects or prefixes, show log of commits containing changes to at least one of the paths.
+Show log of commits for a given branch
 
 ```
 lakectl log <branch uri> [flags]
@@ -1939,8 +1938,8 @@ lakectl log <branch uri> [flags]
       --after string         show results after this value (used for pagination)
       --amount int           number of results to return. By default, all results are returned
   -h, --help                 help for log
-      --objects strings      show results that contains changes to that list of objects. Use comma separator to pass all objects together
-      --prefixes strings     show results that contains changes to that list of prefixes. Use comma separator to pass all prefixes together
+      --objects strings      show results that contains changes to at least one path in that list of objects. Use comma separator to pass all objects together
+      --prefixes strings     show results that contains changes to at least one path in that list of prefixes. Use comma separator to pass all prefixes together
       --show-meta-range-id   also show meta range ID
 ```
 
@@ -1988,7 +1987,7 @@ Copy or merge table
 #### Synopsis
 {:.no_toc}
 
-copy or merge table. the destination table will point to the selected branch
+Copy or merge table. the destination table will point to the selected branch
 
 ```
 lakectl metastore copy [flags]
@@ -2042,6 +2041,36 @@ lakectl metastore copy-all [flags]
       --table-filter string       filter for tables to copy in metastore pattern (default ".*")
       --to-address string         destination metastore address
       --to-client-type string     metastore type [hive, glue]
+```
+
+
+
+### lakectl metastore copy-schema
+
+Copy schema
+
+#### Synopsis
+{:.no_toc}
+
+Copy schema (without tables). the destination schema will point to the selected branch
+
+```
+lakectl metastore copy-schema [flags]
+```
+
+#### Options
+{:.no_toc}
+
+```
+      --catalog-id string         Glue catalog ID
+      --dbfs-root dbfs:/          dbfs location root will replace dbfs:/ in the location before transforming
+      --from-client-type string   metastore type [hive, glue]
+      --from-schema string        source schema name
+  -h, --help                      help for copy-schema
+      --metastore-uri string      Hive metastore URI
+      --to-branch string          lakeFS branch name
+      --to-client-type string     metastore type [hive, glue]
+      --to-schema string          destination schema name [default is from-branch]
 ```
 
 

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -2242,7 +2242,11 @@ func (c *Controller) RestoreRefs(w http.ResponseWriter, r *http.Request, body Re
 	}
 
 	// ensure no refs currently found
-	_, _, err = c.Catalog.ListCommits(ctx, repo.Name, repo.DefaultBranch, "", 1)
+	_, _, err = c.Catalog.ListCommits(ctx, repo.Name, repo.DefaultBranch, catalog.LogParams{
+		PathList:      make([]catalog.PathRecord, 0),
+		FromReference: "",
+		Limit:         1,
+	})
 	if !errors.Is(err, graveler.ErrNotFound) {
 		writeError(w, http.StatusBadRequest, "can only restore into a bare repository")
 		return
@@ -2404,14 +2408,17 @@ func (c *Controller) DiffRefs(w http.ResponseWriter, r *http.Request, repository
 
 // LogBranchCommits deprecated replaced by LogCommits
 func (c *Controller) LogBranchCommits(w http.ResponseWriter, r *http.Request, repository string, branch string, params LogBranchCommitsParams) {
-	c.logCommitsHelper(w, r, repository, branch, params.After, params.Amount)
+	c.logCommitsHelper(w, r, repository, branch, LogCommitsParams{
+		After:  params.After,
+		Amount: params.Amount,
+	})
 }
 
 func (c *Controller) LogCommits(w http.ResponseWriter, r *http.Request, repository string, ref string, params LogCommitsParams) {
-	c.logCommitsHelper(w, r, repository, ref, params.After, params.Amount)
+	c.logCommitsHelper(w, r, repository, ref, params)
 }
 
-func (c *Controller) logCommitsHelper(w http.ResponseWriter, r *http.Request, repository string, ref string, after *PaginationAfter, amount *PaginationAmount) {
+func (c *Controller) logCommitsHelper(w http.ResponseWriter, r *http.Request, repository string, ref string, params LogCommitsParams) {
 	if !c.authorize(w, r, permissions.Node{
 		Permission: permissions.Permission{
 			Action:   permissions.ReadBranchAction,
@@ -2424,7 +2431,11 @@ func (c *Controller) logCommitsHelper(w http.ResponseWriter, r *http.Request, re
 	c.LogAction(ctx, "get_branch_commit_log")
 
 	// get commit log
-	commitLog, hasMore, err := c.Catalog.ListCommits(ctx, repository, ref, paginationAfter(after), paginationAmount(amount))
+	commitLog, hasMore, err := c.Catalog.ListCommits(ctx, repository, ref, catalog.LogParams{
+		PathList:      resolvePathList(params.ObjectList, params.PrefixList),
+		FromReference: paginationAfter(params.After),
+		Limit:         paginationAmount(params.Amount),
+	})
 	if handleAPIError(w, err) {
 		return
 	}
@@ -2920,6 +2931,13 @@ func StringValue(s *string) string {
 	return *s
 }
 
+func BoolValue(v *bool) bool {
+	if v == nil {
+		return false
+	}
+	return *v
+}
+
 func Int64Value(p *int64) int64 {
 	if p == nil {
 		return 0
@@ -2994,6 +3012,36 @@ func paginationAmount(v *PaginationAmount) int {
 		return DefaultMaxPerPage
 	}
 	return i
+}
+
+func resolvePathList(objectList *[]string, prefixList *[]string) []catalog.PathRecord {
+	var pathList []catalog.PathRecord
+	if objectList == nil && prefixList == nil {
+		return make([]catalog.PathRecord, 0)
+	}
+	if objectList != nil {
+		for _, path := range *objectList {
+			if path != "" {
+				path := path
+				pathList = append(pathList, catalog.PathRecord{
+					Path:     catalog.Path(StringValue(&path)),
+					IsPrefix: false,
+				})
+			}
+		}
+	}
+	if prefixList != nil {
+		for _, path := range *prefixList {
+			if path != "" {
+				path := path
+				pathList = append(pathList, catalog.PathRecord{
+					Path:     catalog.Path(StringValue(&path)),
+					IsPrefix: true,
+				})
+			}
+		}
+	}
+	return pathList
 }
 
 func NewController(

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -2432,7 +2432,7 @@ func (c *Controller) logCommitsHelper(w http.ResponseWriter, r *http.Request, re
 
 	// get commit log
 	commitLog, hasMore, err := c.Catalog.ListCommits(ctx, repository, ref, catalog.LogParams{
-		PathList:      resolvePathList(params.ObjectList, params.PrefixList),
+		PathList:      resolvePathList(params.Objects, params.Prefixes),
 		FromReference: paginationAfter(params.After),
 		Limit:         paginationAmount(params.Amount),
 	})

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -3014,34 +3014,34 @@ func paginationAmount(v *PaginationAmount) int {
 	return i
 }
 
-func resolvePathList(objectList *[]string, prefixList *[]string) []catalog.PathRecord {
-	var pathList []catalog.PathRecord
-	if objectList == nil && prefixList == nil {
+func resolvePathList(objects *[]string, prefixes *[]string) []catalog.PathRecord {
+	var pathRecords []catalog.PathRecord
+	if objects == nil && prefixes == nil {
 		return make([]catalog.PathRecord, 0)
 	}
-	if objectList != nil {
-		for _, path := range *objectList {
+	if objects != nil {
+		for _, path := range *objects {
 			if path != "" {
 				path := path
-				pathList = append(pathList, catalog.PathRecord{
+				pathRecords = append(pathRecords, catalog.PathRecord{
 					Path:     catalog.Path(StringValue(&path)),
 					IsPrefix: false,
 				})
 			}
 		}
 	}
-	if prefixList != nil {
-		for _, path := range *prefixList {
+	if prefixes != nil {
+		for _, path := range *prefixes {
 			if path != "" {
 				path := path
-				pathList = append(pathList, catalog.PathRecord{
+				pathRecords = append(pathRecords, catalog.PathRecord{
 					Path:     catalog.Path(StringValue(&path)),
 					IsPrefix: true,
 				})
 			}
 		}
 	}
-	return pathList
+	return pathRecords
 }
 
 func NewController(

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 	"testing"
@@ -35,6 +36,15 @@ const (
 
 type Statuser interface {
 	StatusCode() int
+}
+
+type commitEntriesParams struct {
+	repo       string
+	branch     string
+	seed       int
+	paths      []string
+	user       string
+	commitName string
 }
 
 func verifyResponseOK(t testing.TB, resp Statuser, err error) {
@@ -176,6 +186,25 @@ func TestController_GetRepoHandler(t *testing.T) {
 	})
 }
 
+func testCommitEntries(t *testing.T, ctx context.Context, cat catalog.Interface, deps *dependencies, params commitEntriesParams) string {
+	t.Helper()
+	s := strconv.Itoa(params.seed)
+	for _, p := range params.paths {
+		err := cat.CreateEntry(ctx, params.repo, params.branch,
+			catalog.DBEntry{
+				Path:            p,
+				PhysicalAddress: onBlock(deps, "add"+s+"of:"+p),
+				CreationDate:    time.Now(),
+				Size:            int64(params.seed),
+				Checksum:        "cksum" + s,
+			})
+		testutil.MustDo(t, "create entry "+p, err)
+	}
+	commit, err := cat.Commit(ctx, params.repo, params.branch, "commit"+params.commitName, params.user, nil)
+	testutil.MustDo(t, "commit", err)
+	return commit.Reference
+}
+
 func TestController_CommitsGetBranchCommitLogHandler(t *testing.T) {
 	clt, deps := setupClientWithAdmin(t, "")
 	ctx := context.Background()
@@ -214,6 +243,189 @@ func TestController_CommitsGetBranchCommitLogHandler(t *testing.T) {
 			t.Fatalf("Log %d commits, expected %d", len(commitsLog), expectedCommits)
 		}
 	})
+}
+
+func TestController_CommitsGetBranchCommitLogByPath(t *testing.T) {
+	clt, deps := setupClientWithAdmin(t, "")
+	ctx := context.Background()
+	/*
+			This is the tree we test on:
+
+		                      P              branch "branch-b"
+		                     / \
+		                   	/   \
+		 .---A---B---C-----D-----R---N---X-  branch "main"
+		              \             /
+		               \           /
+		                ---L---M---          branch "branch-a"
+
+				Commits content:
+				•	commit A
+					⁃	added data/a/a.txt
+					⁃	added data/a/b.txt
+					⁃	added data/a/c.txt
+					⁃	added data/b/b.txt
+				•	commit B
+					⁃	added data/a/foo.txt
+					⁃	added data/b/bar.txt
+				•	commit C
+					⁃	changed data/a/a.txt
+				•	commit D
+					⁃	changed data/b/b.txt
+				•	commit P
+					⁃	added data/c/banana.txt
+				•	commit R
+					⁃	merged branch-a to main
+				•	commit L
+					⁃	changed data/a/foo.txt
+					⁃	changed data/b/bar.txt
+				•	commit M
+					⁃	added data/a/d.txt
+				•	commit N
+					⁃	merged branch-b to main
+				•	commit x
+					⁃	changed data/a/a.txt
+					⁃	added data/c/zebra.txt
+	*/
+
+	_, err := deps.catalog.CreateRepository(ctx, "repo3", onBlock(deps, "ns1"), "main")
+	testutil.Must(t, err)
+
+	commitsMap := make(map[string]string)
+	commitsMap["commitA"] = testCommitEntries(t, ctx, deps.catalog, deps, commitEntriesParams{
+		repo:       "repo3",
+		branch:     "main",
+		seed:       1,
+		paths:      []string{"data/a/a.txt", "data/a/b.txt", "data/a/c.txt", "data/b/b.txt"},
+		user:       "user1",
+		commitName: "A",
+	})
+	commitsMap["commitB"] = testCommitEntries(t, ctx, deps.catalog, deps, commitEntriesParams{
+		repo:       "repo3",
+		branch:     "main",
+		seed:       1,
+		paths:      []string{"data/a/foo.txt", "data/b/bar.txt"},
+		user:       "user1",
+		commitName: "B",
+	})
+	commitsMap["commitC"] = testCommitEntries(t, ctx, deps.catalog, deps, commitEntriesParams{
+		repo:       "repo3",
+		branch:     "main",
+		seed:       2,
+		paths:      []string{"data/a/a.txt"},
+		user:       "user1",
+		commitName: "C",
+	})
+	deps.catalog.CreateBranch(ctx, "repo3", "branch-a", "main")
+	commitsMap["commitL"] = testCommitEntries(t, ctx, deps.catalog, deps, commitEntriesParams{
+		repo:       "repo3",
+		branch:     "branch-a",
+		seed:       2,
+		paths:      []string{"data/a/foo.txt", "data/b/bar.txt"},
+		user:       "user2",
+		commitName: "L",
+	})
+	commitsMap["commitD"] = testCommitEntries(t, ctx, deps.catalog, deps, commitEntriesParams{
+		repo:       "repo3",
+		branch:     "main",
+		seed:       2,
+		paths:      []string{"data/b/b.txt"},
+		user:       "user1",
+		commitName: "D",
+	})
+	deps.catalog.CreateBranch(ctx, "repo3", "branch-b", "main")
+	commitsMap["commitP"] = testCommitEntries(t, ctx, deps.catalog, deps, commitEntriesParams{
+		repo:       "repo3",
+		branch:     "branch-b",
+		seed:       1,
+		paths:      []string{"data/c/banana.txt"},
+		user:       "user3",
+		commitName: "P",
+	})
+	mergeCommit, _ := deps.catalog.Merge(ctx, "repo3", "main", "branch-b", "user3", "commitR", nil)
+	commitsMap["commitR"] = mergeCommit.Reference
+	commitsMap["commitM"] = testCommitEntries(t, ctx, deps.catalog, deps, commitEntriesParams{
+		repo:       "repo3",
+		branch:     "branch-a",
+		seed:       1,
+		paths:      []string{"data/a/d.txt"},
+		user:       "user2",
+		commitName: "M",
+	})
+	mergeCommit, _ = deps.catalog.Merge(ctx, "repo3", "main", "branch-a", "user2", "commitN", nil)
+	commitsMap["commitN"] = mergeCommit.Reference
+	commitsMap["commitX"] = testCommitEntries(t, ctx, deps.catalog, deps, commitEntriesParams{
+		repo:       "repo3",
+		branch:     "main",
+		seed:       3,
+		paths:      []string{"data/a/a.txt", "data/c/zebra.txt"},
+		user:       "user1",
+		commitName: "X",
+	})
+
+	cases := []struct {
+		name            string
+		objectList      *[]string
+		prefixList      *[]string
+		expectedCommits []string
+	}{
+		{
+			name:            "simpleObjectWithOneCommit",
+			objectList:      &[]string{"data/a/d.txt"},
+			expectedCommits: []string{commitsMap["commitM"]},
+		},
+		{
+			name:            "simpleObjectWithMultipleCommits",
+			objectList:      &[]string{"data/a/a.txt"},
+			expectedCommits: []string{commitsMap["commitX"], commitsMap["commitC"], commitsMap["commitA"]},
+		},
+		{
+			name:            "simpleObjectLastFile",
+			objectList:      &[]string{"data/c/zebra.txt"},
+			expectedCommits: []string{commitsMap["commitX"]},
+		},
+		{
+			name:            "multipleObjects",
+			objectList:      &[]string{"data/a/foo.txt", "data/b/bar.txt", "data/b/b.txt", "data/c/banana.txt"},
+			expectedCommits: []string{commitsMap["commitP"], commitsMap["commitD"], commitsMap["commitL"], commitsMap["commitB"], commitsMap["commitA"]},
+		},
+		{
+			name:            "oneObjectOnePrefix",
+			objectList:      &[]string{"data/a/c.txt"},
+			prefixList:      &[]string{"data/b/"},
+			expectedCommits: []string{commitsMap["commitD"], commitsMap["commitL"], commitsMap["commitB"], commitsMap["commitA"]},
+		},
+		{
+			name:            "simplePrefix",
+			prefixList:      &[]string{"data/b/"},
+			expectedCommits: []string{commitsMap["commitD"], commitsMap["commitL"], commitsMap["commitB"], commitsMap["commitA"]},
+		},
+		{
+			name:            "twoPrefixs",
+			prefixList:      &[]string{"data/a/", "data/c/"},
+			expectedCommits: []string{commitsMap["commitX"], commitsMap["commitM"], commitsMap["commitP"], commitsMap["commitL"], commitsMap["commitC"], commitsMap["commitB"], commitsMap["commitA"]},
+		},
+		{
+			name:            "mainPrefix",
+			prefixList:      &[]string{"data/"},
+			expectedCommits: []string{commitsMap["commitX"], commitsMap["commitM"], commitsMap["commitP"], commitsMap["commitD"], commitsMap["commitL"], commitsMap["commitC"], commitsMap["commitB"], commitsMap["commitA"]},
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			resp, err := clt.LogCommitsWithResponse(ctx, "repo3", "main", &api.LogCommitsParams{ObjectList: c.objectList, PrefixList: c.prefixList})
+			verifyResponseOK(t, resp, err)
+
+			commitsLog := resp.JSON200.Results
+			commitsIds := make([]string, 0, len(commitsLog))
+			for _, commit := range commitsLog {
+				commitsIds = append(commitsIds, commit.Id)
+			}
+			if !reflect.DeepEqual(c.expectedCommits, commitsIds) {
+				t.Fatalf("Log commits is: %v, expected %v", commitsIds, c.expectedCommits)
+			}
+		})
+	}
 }
 
 func TestController_GetCommitHandler(t *testing.T) {
@@ -1724,6 +1936,7 @@ func TestController_CreateTag(t *testing.T) {
 		}
 	})
 }
+
 func testUniqueRepoName() string {
 	return "repo-" + nanoid.MustGenerate("abcdef1234567890", 8)
 }

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -413,7 +413,7 @@ func TestController_CommitsGetBranchCommitLogByPath(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			resp, err := clt.LogCommitsWithResponse(ctx, "repo3", "main", &api.LogCommitsParams{ObjectList: c.objectList, PrefixList: c.prefixList})
+			resp, err := clt.LogCommitsWithResponse(ctx, "repo3", "main", &api.LogCommitsParams{Objects: c.objectList, Prefixes: c.prefixList})
 			verifyResponseOK(t, resp, err)
 
 			commitsLog := resp.JSON200.Results

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -274,14 +274,14 @@ func TestController_CommitsGetBranchCommitLogByPath(t *testing.T) {
 				•	commit P
 					⁃	added data/c/banana.txt
 				•	commit R
-					⁃	merged branch-a to main
+					⁃	merged branch-b to main
 				•	commit L
 					⁃	changed data/a/foo.txt
 					⁃	changed data/b/bar.txt
 				•	commit M
 					⁃	added data/a/d.txt
 				•	commit N
-					⁃	merged branch-b to main
+					⁃	merged branch-a to main
 				•	commit x
 					⁃	changed data/a/a.txt
 					⁃	added data/c/zebra.txt
@@ -369,7 +369,7 @@ func TestController_CommitsGetBranchCommitLogByPath(t *testing.T) {
 		expectedCommits []string
 	}{
 		{
-			name:            "simpleObjectWithOneCommit",
+			name:            "singleObjectWithOneCommit",
 			objectList:      &[]string{"data/a/d.txt"},
 			expectedCommits: []string{commitsMap["commitM"]},
 		},

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -1,6 +1,7 @@
 package catalog
 
 import (
+	"bytes"
 	"context"
 	"crypto"
 	_ "crypto/sha256"
@@ -841,7 +842,7 @@ func (c *Catalog) GetCommit(ctx context.Context, repository string, reference st
 	return catalogCommitLog, nil
 }
 
-func (c *Catalog) ListCommits(ctx context.Context, repository string, branch string, fromReference string, limit int) ([]*CommitLog, bool, error) {
+func (c *Catalog) ListCommits(ctx context.Context, repository string, branch string, params LogParams) ([]*CommitLog, bool, error) {
 	repositoryID := graveler.RepositoryID(repository)
 	branchRef := graveler.BranchID(branch)
 	if err := Validate([]ValidateArg{
@@ -860,8 +861,8 @@ func (c *Catalog) ListCommits(ctx context.Context, repository string, branch str
 	}
 	defer it.Close()
 	// skip until 'fromReference' if needed
-	if fromReference != "" {
-		fromCommitID, err := c.dereferenceCommitID(ctx, repositoryID, graveler.Ref(fromReference))
+	if params.FromReference != "" {
+		fromCommitID, err := c.dereferenceCommitID(ctx, repositoryID, graveler.Ref(params.FromReference))
 		if err != nil {
 			return nil, false, fmt.Errorf("from ref: %w", err)
 		}
@@ -877,6 +878,7 @@ func (c *Catalog) ListCommits(ctx context.Context, repository string, branch str
 
 	// collect commits
 	var commits []*CommitLog
+
 	for it.Next() {
 		v := it.Value()
 		commit := &CommitLog{
@@ -891,8 +893,22 @@ func (c *Catalog) ListCommits(ctx context.Context, repository string, branch str
 		for _, parent := range v.Parents {
 			commit.Parents = append(commit.Parents, parent.String())
 		}
-		commits = append(commits, commit)
-		if len(commits) >= limit+1 {
+
+		if len(params.PathList) != 0 && len(v.Parents) == 1 {
+			// if we need to log only commits associated to the path, and also the current commit
+			// is not a merge commit, then we check if the current commit contains changes to the path
+			pathInCommit, err := c.pathInCommit(ctx, repositoryID, v, params)
+			if err != nil {
+				return nil, false, err
+			}
+			if pathInCommit {
+				commits = append(commits, commit)
+			}
+		} else if len(params.PathList) == 0 {
+			// if there is no specification of path - we will output all commits
+			commits = append(commits, commit)
+		}
+		if len(commits) >= params.Limit+1 {
 			break
 		}
 	}
@@ -900,11 +916,41 @@ func (c *Catalog) ListCommits(ctx context.Context, repository string, branch str
 		return nil, false, err
 	}
 	hasMore := false
-	if len(commits) > limit {
+	if len(commits) > params.Limit {
 		hasMore = true
-		commits = commits[:limit]
+		commits = commits[:params.Limit]
 	}
 	return commits, hasMore, nil
+}
+
+func (c *Catalog) pathInCommit(ctx context.Context, repositoryID graveler.RepositoryID, commit *graveler.CommitRecord, params LogParams) (bool, error) {
+	left := graveler.Ref(commit.Parents[0])
+	right := graveler.Ref(commit.CommitID)
+	diffIter, err := c.Store.Diff(ctx, repositoryID, left, right)
+	if err != nil {
+		return false, err
+	}
+
+	for _, path := range params.PathList {
+		key := graveler.Key(path.Path)
+		diffIter.SeekGE(key)
+		if diffIter.Next() {
+			diffKey := diffIter.Value().Key
+			var result bool
+			if path.IsPrefix {
+				result = bytes.HasPrefix(diffKey, key)
+			} else {
+				result = bytes.Equal(diffKey, key)
+			}
+			if result {
+				return true, nil
+			}
+		}
+		if err := diffIter.Err(); err != nil {
+			return false, err
+		}
+	}
+	return false, nil
 }
 
 func (c *Catalog) Revert(ctx context.Context, repository string, branch string, params RevertParams) error {

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -897,7 +897,7 @@ func (c *Catalog) ListCommits(ctx context.Context, repository string, branch str
 		}
 
 		if len(params.PathList) != 0 && len(v.Parents) == NumberOfParentsOfNonMergeCommit {
-			// if path list ins't empty, and also the current commit isn't a merge commit -
+			// if path list isn't empty, and also the current commit isn't a merge commit -
 			// we check if the current commit contains changes to the paths
 			pathInCommit, err := c.pathInCommit(ctx, repositoryID, v, params)
 			if err != nil {

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -37,6 +37,8 @@ import (
 // function they will be unable to re-use any existing objects.
 const hashAlg = crypto.SHA256
 
+const NumberOfParentsOfNonMergeCommit = 1
+
 type Path string
 
 type EntryRecord struct {
@@ -894,9 +896,9 @@ func (c *Catalog) ListCommits(ctx context.Context, repository string, branch str
 			commit.Parents = append(commit.Parents, parent.String())
 		}
 
-		if len(params.PathList) != 0 && len(v.Parents) == 1 {
-			// if we need to log only commits associated to the path, and also the current commit
-			// is not a merge commit, then we check if the current commit contains changes to the path
+		if len(params.PathList) != 0 && len(v.Parents) == NumberOfParentsOfNonMergeCommit {
+			// if path list ins't empty, and also the current commit isn't a merge commit -
+			// we check if the current commit contains changes to the paths
 			pathInCommit, err := c.pathInCommit(ctx, repositoryID, v, params)
 			if err != nil {
 				return nil, false, err

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -924,12 +924,16 @@ func (c *Catalog) ListCommits(ctx context.Context, repository string, branch str
 }
 
 func (c *Catalog) pathInCommit(ctx context.Context, repositoryID graveler.RepositoryID, commit *graveler.CommitRecord, params LogParams) (bool, error) {
+	// this function checks whether the given commmit contains changes to a list of paths.
+	// it searches the path in the diff between the commit and it's parent, but do so only to commits
+	// that have single parent (not merge commits)
 	left := graveler.Ref(commit.Parents[0])
 	right := graveler.Ref(commit.CommitID)
 	diffIter, err := c.Store.Diff(ctx, repositoryID, left, right)
 	if err != nil {
 		return false, err
 	}
+	defer diffIter.Close()
 
 	for _, path := range params.PathList {
 		key := graveler.Key(path.Path)

--- a/pkg/catalog/interface.go
+++ b/pkg/catalog/interface.go
@@ -25,6 +25,17 @@ type RevertParams struct {
 	Committer    string
 }
 
+type PathRecord struct {
+	Path     Path
+	IsPrefix bool
+}
+
+type LogParams struct {
+	PathList      []PathRecord
+	FromReference string
+	Limit         int
+}
+
 type ExpireResult struct {
 	Repository        string
 	Branch            string
@@ -92,7 +103,7 @@ type Interface interface {
 
 	Commit(ctx context.Context, repository, branch string, message string, committer string, metadata Metadata) (*CommitLog, error)
 	GetCommit(ctx context.Context, repository, reference string) (*CommitLog, error)
-	ListCommits(ctx context.Context, repository, branch string, fromReference string, limit int) ([]*CommitLog, bool, error)
+	ListCommits(ctx context.Context, repository, branch string, params LogParams) ([]*CommitLog, bool, error)
 
 	// Revert creates a reverse patch to the given commit, and applies it as a new commit on the given branch.
 	Revert(ctx context.Context, repository, branch string, params RevertParams) error

--- a/pkg/graveler/committed/diff.go
+++ b/pkg/graveler/committed/diff.go
@@ -273,6 +273,7 @@ func (d *diffIterator) SeekGE(id graveler.Key) {
 	d.rightValue = iteratorValue{}
 	d.err = nil
 	d.state = diffIteratorStatePreInit
+	d.currentRange = currentRangeData{}
 }
 
 func (d *diffIterator) Value() (*graveler.Diff, *RangeDiff) {


### PR DESCRIPTION
Closes #2251 

This feature gives the ability to get the log of all commits that contains changes to list of paths.
Log api now can get a list of prefixes and/or a list of objects, and returns all commits containing changes to one or more of the paths mentioned. 
I added the functionality under the log commits function. 
Also, I changed the api and lakectl log file to work with the new feature. 

Usage example:
`lakectl log lakefs://example1/main --objects "a/a.txt,a/b.txt" --prefixes b/`
will show all commits that relevant to either `a/a.txt`, `a/b.txt` or `b/`