### PR TITLE
Fix login worked on second try

### DIFF
--- a/webui/src/lib/hooks/api.jsx
+++ b/webui/src/lib/hooks/api.jsx
@@ -55,10 +55,14 @@ export const useAPI = (promise, deps = []) => {
 
     useEffect(() => {
         if (login) {
-            router.push({
-                pathname: '/auth/login',
-                query: {next: router.route}
-            });
+            const loginPathname = '/auth/login';
+            const place = {
+                pathname: loginPathname,
+            }
+            if (router.route !== loginPathname) {
+                place.next = router.route;
+            }
+            router.push(place);
             setLogin(false);
         }
     }, [login, router])

--- a/webui/src/lib/hooks/api.jsx
+++ b/webui/src/lib/hooks/api.jsx
@@ -76,19 +76,19 @@ export const useAPI = (promise, deps = []) => {
                 setRequest({
                     loading: false,
                     error: null,
-                    response
+                    response,
                 });
             } catch (error) {
                 if (error instanceof AuthenticationError) {
                     if (isMounted) {
                         setLogin(true);
                     }
-                    return 
+                    return;
                 }
                 setRequest({
                     loading: false,
                     error,
-                    response: null
+                    response: null,
                 });
             }
         };

--- a/webui/src/pages/auth/login.jsx
+++ b/webui/src/pages/auth/login.jsx
@@ -23,18 +23,19 @@ const LoginForm = () => {
                 <Card className="login-widget">
                     <Card.Header>Login</Card.Header>
                     <Card.Body>
-                        <Form onSubmit={async (e) => {
+                        <Form onSubmit={(e) => {
                             e.preventDefault()
-                            try {
-                                await auth.login(e.target.username.value, e.target.password.value);
-                                setLoginError(null);
-                                const nextOrRoot = next && next !== router.route ? next : '/';
-                                router.push(nextOrRoot);
-                            } catch(err) {
-                                setLoginError(err);
-                            }
-                        }}>
+                            auth
+                                .login(e.target.username.value, e.target.password.value)
+                                .then(user => {
+                                    setLoginError(null);
+                                    return router.push((!!next) ? next : '/');
+                                })
+                                .catch(err => {
+                                    setLoginError(err);
+                                })
 
+                        }}>
                             <Form.Group controlId="username">
                                 <Form.Control type="text" placeholder="Access Key ID" autoFocus/>
                                 <Form.Text className="text-muted">

--- a/webui/src/pages/auth/login.jsx
+++ b/webui/src/pages/auth/login.jsx
@@ -23,18 +23,16 @@ const LoginForm = () => {
                 <Card className="login-widget">
                     <Card.Header>Login</Card.Header>
                     <Card.Body>
-                        <Form onSubmit={(e) => {
+                        <Form onSubmit={async (e) => {
                             e.preventDefault()
-                            auth
-                                .login(e.target.username.value, e.target.password.value)
-                                .then(user => {
-                                    setLoginError(null);
-                                    return router.push((!!next) ? next : '/');
-                                })
-                                .catch(err => {
-                                    setLoginError(err);
-                                })
-
+                            try {
+                                await auth.login(e.target.username.value, e.target.password.value);
+                                setLoginError(null);
+                                const nextOrRoot = next && next !== router.route ? next : '/';
+                                router.push(nextOrRoot);
+                            } catch(err) {
+                                setLoginError(err);
+                            }
                         }}>
 
                             <Form.Group controlId="username">

--- a/webui/src/pages/auth/login.jsx
+++ b/webui/src/pages/auth/login.jsx
@@ -23,18 +23,15 @@ const LoginForm = () => {
                 <Card className="login-widget">
                     <Card.Header>Login</Card.Header>
                     <Card.Body>
-                        <Form onSubmit={(e) => {
+                        <Form onSubmit={async (e) => {
                             e.preventDefault()
-                            auth
-                                .login(e.target.username.value, e.target.password.value)
-                                .then(user => {
-                                    setLoginError(null);
-                                    return router.push((!!next) ? next : '/');
-                                })
-                                .catch(err => {
-                                    setLoginError(err);
-                                })
-
+                            try {
+                                await auth.login(e.target.username.value, e.target.password.value)
+                                setLoginError(null);
+                                router.push(next ? next : '/');
+                            } catch(err) {
+                                setLoginError(err);
+                            }
                         }}>
                             <Form.Group controlId="username">
                                 <Form.Control type="text" placeholder="Access Key ID" autoFocus/>


### PR DESCRIPTION
The first time the login acquired credentials but redirect to the login page.
Second time was optional, but this time there was no redirect instruction and we moved to root.

Fix include:
1. Redirect to login when route to login is skipped
2. Handle react state update on unmounted component - https://stackoverflow.com/questions/53949393/cant-perform-a-react-state-update-on-an-unmounted-component. Triggered when API call fail with authorization.

Fix #2524