### PR TITLE
UI: Unifying 3 views into one in uncommitted/compare/commit components

### DIFF
--- a/webui/src/lib/components/repository/changes.jsx
+++ b/webui/src/lib/components/repository/changes.jsx
@@ -156,35 +156,6 @@ export const TreeEntryPaginator = ({ path, setAfterUpdated, nextPage, depth=0, l
     );
 };
 
-export const ChangeEntryRow = ({ entry, showActions, relativeTo="", onNavigate, onRevert }) => {
-    let rowClass = 'change-entry-row ' + diffType(entry);
-    let pathText = extractPathText(entry, relativeTo);
-    let diffIndicator = diffIndicatorIcon(entry);
-    let actions = entryActions(showActions, entry, onRevert);
-
-    return (
-        <tr className={rowClass}>
-            <td className="diff-indicator">
-                {diffIndicator}
-            </td>
-            <td className="tree-path">
-                {(entry.path_type === "common_prefix") ? (
-                    <span key={`link-${entry.path}`}>
-                        <Link href={onNavigate(entry)}>
-                            {pathText}
-                        </Link>
-                    </span>
-                ) : (
-                    <span>{pathText}</span>
-                )}
-            </td>
-            <td className={"change-entry-row-actions"}>
-                {actions}
-            </td>
-        </tr>
-    );
-};
-
 function extractPathText(entry, relativeTo) {
     let pathText = entry.path;
     if (pathText.startsWith(relativeTo)) {

--- a/webui/src/lib/components/repository/changes.jsx
+++ b/webui/src/lib/components/repository/changes.jsx
@@ -60,7 +60,7 @@ const ChangeRowActions = ({ entry, onRevert }) => {
     getMore: callback to be called when more items need to be rendered
     depth: the item's depth withing the tree
  */
-export const TreeItem = ({ entry, repo, reference, internalRefresh, onRevert, delimiter, after, relativeTo, getMore, depth=0 }) => {
+export const TreeItem = ({ entry, repo, reference, internalRefresh, onRevert, onNavigate, delimiter, after, relativeTo, getMore, depth=0 }) => {
     const [expanded, setExpanded] = useState(false); // state of the item expansion
     const [afterUpdated, setAfterUpdated] = useState(after); // state of pagination of the item's children
     const [resultsState, setResultsState] = useState({results:[], pagination:{}}); // current retrieved children of the item
@@ -84,57 +84,74 @@ export const TreeItem = ({ entry, repo, reference, internalRefresh, onRevert, de
         return <Error error={error}/>
 
     if (loading && results.length === 0)
-        return <TreeEntryRow key={entry.path+"entry-row"} entry={entry} showActions={true} loading={true} relativeTo={relativeTo} depth={depth} onRevert={onRevert} />
+        return <TreeEntryRow key={entry.path+"entry-row"} entry={entry} showActions={true} loading={true} relativeTo={relativeTo} depth={depth} onRevert={onRevert} onNavigate={onNavigate}/>
 
     if (!entry.path.endsWith(delimiter))
-        return <TreeEntryRow key={entry.path+"entry-row"} entry={entry} showActions={true} leaf={true} relativeTo={relativeTo} depth={depth === 0 ? 0 : depth + 1} onRevert={onRevert} />
+        return <TreeEntryRow key={entry.path+"entry-row"} entry={entry} showActions={true} leaf={true} relativeTo={relativeTo} depth={depth === 0 ? 0 : depth + 1} onRevert={onRevert} onNavigate={onNavigate}/>
 
     return <>
-            <TreeEntryRow key={entry.path+"entry-row"} entry={entry} showActions={true} expanded={expanded} relativeTo={relativeTo} depth={depth} onClick={() => setExpanded(!expanded)} onRevert={onRevert} />
+            <TreeEntryRow key={entry.path+"entry-row"} entry={entry} showActions={true} expanded={expanded} relativeTo={relativeTo} depth={depth} onClick={() => setExpanded(!expanded)} onRevert={onRevert} onNavigate={onNavigate} />
             {expanded && results &&
                 results.map(child =>
-                    ( <TreeItem key={child.path+"-item"} entry={child} repo={repo} reference={reference} onRevert={onRevert}
+                    ( <TreeItem key={child.path+"-item"} entry={child} repo={repo} reference={reference} onRevert={onRevert} onNavigate={onNavigate}
                                 internalReferesh={internalRefresh} delimiter={delimiter} depth={depth+1} after={after} relativeTo={entry.path} getMore={getMore}/>))}
             {(!!nextPage || loading) &&
-                <tr key={"row-" + entry.path}
-                    className={"tree-entry-row diff-more"}
-                    onClick={(_ => {
-                        setAfterUpdated(nextPage)
-                    })}
-                >
-                    <td className="diff-indicator"/>
-                    <td className="tree-path">
-                        <span style={{marginLeft: depth * 20 + "px",color:"#007bff"}}>
-                            {loading && <ClockIcon/>}
-                            {`Load more results for prefix ${entry.path} ....`}
-                        </span>
-                    </td>
-                    <td/>
-                </tr>
+                <TreeEntryPaginator path={entry.path} depth={depth} loading={loading} nextPage={nextPage} setAfterUpdated={setAfterUpdated}/>
             }
           </>
 }
 
-export const TreeEntryRow = ({ entry, showActions, relativeTo="", leaf=false, expanded, depth=0, onClick, loading=false, onRevert }) => {
+export const TreeEntryRow = ({ entry, showActions, relativeTo="", leaf=false, expanded, depth=0, onClick, loading=false, onRevert, onNavigate }) => {
     let rowClass = 'tree-entry-row ' + diffType(entry);
-    let pathText = extractPathText(entry, relativeTo);
+    let pathSection = extractPathText(entry, relativeTo);
     let diffIndicator = diffIndicatorIcon(entry);
     let actions = entryActions(showActions, entry, onRevert);
 
+    if (entry.path_type === "common_prefix"){
+        pathSection = <Link href={onNavigate(entry)}>{pathSection}</Link>
+    }
     return (
         <tr className={rowClass} >
             <td className="diff-indicator">{diffIndicator}</td>
-            <td onClick={onClick} className="tree-path">
+            <td className="tree-path">
                 <span style={{marginLeft: depth * 20 + "px"}}>
-                    {leaf ? "" : expanded ? <ChevronDownIcon/>:<ChevronRightIcon/>}
+                    {leaf ? "" :
+                        <span onClick={onClick}>
+                            {expanded ? <ChevronDownIcon/>:<ChevronRightIcon/>}
+                        </span>
+                    }
                     {loading ? <ClockIcon/> : ""}
-                    {pathText}
+                    {pathSection}
                 </span>
             </td>
             { actions === null ?
                 <td/> :
                 <td className={"change-entry-row-actions"}>{actions}</td>
             }
+        </tr>
+    );
+};
+
+export const TreeEntryPaginator = ({ path, setAfterUpdated, nextPage, depth=0, loading=false }) => {
+    let pathText = "Load more results ...";
+    if (path !== ""){
+        pathText = `Load more results for prefix ${path} ....`
+    }
+    return (
+        <tr key={"row-" + path}
+            className={"tree-entry-row diff-more"}
+            onClick={(_ => {
+                setAfterUpdated(nextPage)
+            })}
+        >
+            <td className="diff-indicator"/>
+            <td className="tree-path">
+                <span style={{marginLeft: depth * 20 + "px",color:"#007bff"}}>
+                    {loading && <ClockIcon/>}
+                    {pathText}
+                </span>
+            </td>
+            <td/>
         </tr>
     );
 };

--- a/webui/src/lib/components/repository/changes.jsx
+++ b/webui/src/lib/components/repository/changes.jsx
@@ -133,9 +133,9 @@ export const TreeEntryRow = ({ entry, showActions, relativeTo="", leaf=false, ex
 };
 
 export const TreeEntryPaginator = ({ path, setAfterUpdated, nextPage, depth=0, loading=false }) => {
-    let pathText = "Load more results ...";
+    let pathSectionText = "Load more results ...";
     if (path !== ""){
-        pathText = `Load more results for prefix ${path} ....`
+        pathSectionText = `Load more results for prefix ${path} ....`
     }
     return (
         <tr key={"row-" + path}
@@ -148,7 +148,7 @@ export const TreeEntryPaginator = ({ path, setAfterUpdated, nextPage, depth=0, l
             <td className="tree-path">
                 <span style={{marginLeft: depth * 20 + "px",color:"#007bff"}}>
                     {loading && <ClockIcon/>}
-                    {pathText}
+                    {pathSectionText}
                 </span>
             </td>
             <td/>

--- a/webui/src/pages/repositories/repository/changes.jsx
+++ b/webui/src/pages/repositories/repository/changes.jsx
@@ -24,13 +24,9 @@ import {ActionGroup, ActionsBar, Error, Loading, RefreshButton} from "../../../l
 import RefDropdown from "../../../lib/components/repository/refDropdown";
 import {RepositoryPageLayout} from "../../../lib/components/repository/layout";
 import {formatAlertText} from "../../../lib/components/repository/errors";
-import {ChangeEntryRow, TreeEntryPaginator, TreeItem} from "../../../lib/components/repository/changes";
-import {Paginator} from "../../../lib/components/pagination";
+import {TreeEntryPaginator, TreeItem} from "../../../lib/components/repository/changes";
 import {useRouter} from "../../../lib/hooks/router";
 import {URINavigator} from "../../../lib/components/repository/tree";
-import ButtonGroup from "react-bootstrap/ButtonGroup";
-import {ToggleButton} from "react-bootstrap";
-import {Link} from "../../../lib/components/nav";
 
 
 const CommitButton = ({repo, onCommit, enabled = false}) => {
@@ -325,7 +321,6 @@ const ChangesContainer = () => {
         />
     )
 }
-
 
 const RepositoryChangesPage = () => {
     return (

--- a/webui/src/pages/repositories/repository/changes.jsx
+++ b/webui/src/pages/repositories/repository/changes.jsx
@@ -180,7 +180,10 @@ const ChangesBrowser = ({repo, reference, prefix, onSelectRef, }) => {
 
     const results = resultsState.results
 
-    const refresh = () => setInternalRefresh(!internalRefresh)
+    const refresh = () => {
+        setResultsState({prefix: prefix, results:[], pagination:{}})
+        setInternalRefresh(!internalRefresh)
+    }
 
     if (!!error) return <Error error={error}/>
     if (loading) return <Loading/>
@@ -188,9 +191,7 @@ const ChangesBrowser = ({repo, reference, prefix, onSelectRef, }) => {
     let onRevert = async (entry) => {
         branches
             .revert(repo.id, reference.id, {type: entry.path_type, path: entry.path})
-            .then(() => {
-                setInternalRefresh(!internalRefresh)
-            })
+            .then(refresh)
             .catch(error => {
                 setActionError(error)
             })

--- a/webui/src/pages/repositories/repository/changes.jsx
+++ b/webui/src/pages/repositories/repository/changes.jsx
@@ -292,28 +292,16 @@ const ChangesBrowser = ({repo, reference, prefix, onSelectRef, }) => {
 const ChangesContainer = () => {
     const router = useRouter();
     const {repo, reference, loading, error} = useRefs()
-    const {after, prefix, view} = router.query
+    const {prefix} = router.query
 
     if (loading) return <Loading/>
     if (!!error) return <Error error={error}/>
 
     return (
         <ChangesBrowser
-            after={(!!after) ? after : ""}
             prefix={(!!prefix) ? prefix : ""}
-            view={(!!view) ? view : ""}
             repo={repo}
             reference={reference}
-            onPaginate={after => router.push({
-                pathname: `/repositories/:repoId/changes`,
-                params: {repoId: repo.id},
-                query: {
-                    ref: reference.id,
-                    after: (!!after) ? after : "",
-                    prefix: (!!prefix) ? prefix : "",
-                    view: (!!view) ? view : "",
-                }
-            })}
             onSelectRef={ref => router.push({
                 pathname: `/repositories/:repoId/changes`,
                 params: {repoId: repo.id},

--- a/webui/src/pages/repositories/repository/commits/commit/index.jsx
+++ b/webui/src/pages/repositories/repository/commits/commit/index.jsx
@@ -8,81 +8,44 @@ import {commits, refs} from "../../../../../lib/api";
 import moment from "moment";
 import Table from "react-bootstrap/Table";
 import Alert from "react-bootstrap/Alert";
-import {ChangeEntryRow, TreeItem} from "../../../../../lib/components/repository/changes";
-import {Paginator} from "../../../../../lib/components/pagination";
+import {TreeEntryPaginator, TreeItem} from "../../../../../lib/components/repository/changes";
 import ButtonGroup from "react-bootstrap/ButtonGroup";
 import {BrowserIcon, LinkIcon, PackageIcon, PlayIcon} from "@primer/octicons-react";
 import {Link} from "../../../../../lib/components/nav";
 import {useRouter} from "../../../../../lib/hooks/router";
 import {URINavigator} from "../../../../../lib/components/repository/tree";
-import Form from "react-bootstrap/Form";
-import {ToggleButton} from "react-bootstrap";
 
-
-const ChangeList = ({ repo, commit, after, prefix, view, onPaginate }) => {
+const ChangeList = ({ repo, commit, prefix, onNavigate }) => {
     const [actionError, setActionError] = useState(null);
+    const [afterUpdated, setAfterUpdated] = useState(""); // state of pagination of the item's children
+    const [resultsState, setResultsState] = useState({prefix: prefix, results:[], pagination:{}}); // current retrieved children of the item
 
-    const radios = [
-        {name: 'Flat', value: 'flat', selected: false},
-        {name: 'Directory', value: 'dir', selected: false},
-        {name: 'Tree', value: 'tree', selected: false},
-    ];
+    const delimiter = "/"
 
-    let delimiter = ""
-    switch (view) {
-        case "dir":
-            delimiter = "/";
-            radios[1].selected = true;
-            break;
-        case "tree":
-            delimiter = "/";
-            radios[2].selected = true;
-            break;
-        default:
-            delimiter = "";
-            radios[0].selected = true;
-            break;
-    }
-
-    const {results, loading, error, nextPage} = useAPIWithPagination(async() => {
+    const { error, loading, nextPage } = useAPIWithPagination(async () => {
+        if (!repo) return
         if (!commit.parents || commit.parents.length === 0) return {results: [], pagination: {has_more: false}};
-        return refs.diff(repo.id, commit.parents[0], commit.id, after, prefix, delimiter);
-    }, [repo.id, commit.id, after, prefix, delimiter]);
+
+        let resultsFiltered = resultsState.results
+        if (resultsState.prefix !== prefix){
+            // prefix changed, need to delete previous results
+            resultsFiltered = []
+        }
+
+        if (resultsFiltered.length > 0 && resultsFiltered.at(-1).path > afterUpdated) {
+            // results already cached
+            return {prefix:prefix, results:resultsFiltered, pagination: resultsState.pagination}
+        }
+
+        const { results, pagination } = await refs.diff(repo.id, commit.parents[0], commit.id, afterUpdated, prefix, delimiter);
+        setResultsState({prefix:prefix, results: resultsFiltered.concat(results), pagination: pagination})
+        return {results:resultsState.results, pagination: pagination}
+    }, [repo.id, commit.id, afterUpdated, prefix])
+
+    const results = resultsState.results
 
     if (!!error) return <Error error={error}/>
     if (loading) return <Loading/>
-
-    let tablebody;
-    if (view === 'tree') {
-        tablebody =
-            <tbody>
-            {results.map(entry => (
-                <TreeItem key={entry.path + "-tree-item"} entry={entry} repo={repo} reference={commit}
-                          delimiter={delimiter} after={after} relativeTo={""}
-                          getMore={(afterUpdated, path) => {
-                              return refs.diff(repo.id, commit.parents[0], commit.id, afterUpdated, path, delimiter)
-                          }}/>
-            ))}
-            </tbody>
-    } else {
-        tablebody = <tbody>
-        {results.map(entry => (
-            <ChangeEntryRow
-                key={entry.path + "-change-entry"}
-                entry={entry}
-                relativeTo={prefix}
-                showActions={false}
-                onNavigate={entry => {
-                    return {
-                        pathname: '/repositories/:repoId/commits/:commitId',
-                        params: {repoId: repo.id, commitId: commit.id},
-                        query: {delimiter: "/", prefix: entry.path, view:view}
-                    }
-                }}
-            />
-        ))}
-        </tbody>
-    }
 
     const actionErrorDisplay = (!!actionError) ?
         <Error error={actionError} onDismiss={() => setActionError(null)}/> : <></>
@@ -102,52 +65,30 @@ const ChangeList = ({ repo, commit, after, prefix, view, onPaginate }) => {
                                                   return {
                                                       pathname: '/repositories/:repoId/commits/:commitId',
                                                       params: {repoId: repo.id, commitId: commit.id},
-                                                      query: {delimiter, prefix: query.path, view:view}
+                                                      query: {prefix: query.path}
                                                   }
                                               }}/>
                             )}
                         </span>
-                            <span className="float-right">
-                            <Form>
-                              <ButtonGroup className={"view-options"}>
-                                {radios.map((radio, idx) => (
-                                    <div key={idx}>
-                                        <Link href={{
-                                            pathname: '/repositories/:repoId/commits/:commitId',
-                                            params: {
-                                                repoId: repo.id,
-                                                commitId: commit.id,
-                                            },
-                                            query: {
-                                                prefix: "",
-                                                view: radio.value,
-                                            }
-                                        }}>
-                                            <ToggleButton className={"view-options"}
-                                                id={`radio-${idx}`}
-                                                key={`radio-${idx}`}
-                                                type="radio"
-                                                variant="secondary"
-                                                name="radio"
-                                                value={radio.value}
-                                                checked={radio.selected}>
-                                                {radio.name}
-                                            </ToggleButton>
-                                        </Link>
-                                    </div>
-                                ))}
-                              </ButtonGroup>
-                            </Form>
-                        </span>
                         </Card.Header>
                         <Card.Body>
                             <Table borderless size="sm">
-                                {tablebody}
+                                <tbody>
+                                {results.map(entry => (
+                                    <TreeItem key={entry.path + "-tree-item"} entry={entry} repo={repo} reference={commit}
+                                              delimiter={delimiter} after={afterUpdated} relativeTo={prefix} onNavigate={onNavigate}
+                                              getMore={(afterUpdated, path) => {
+                                                  return refs.diff(repo.id, commit.parents[0], commit.id, afterUpdated, path, delimiter)
+                                              }}/>
+                                ))}
+                                { !!nextPage &&
+                                <TreeEntryPaginator path={""} loading={loading} nextPage={nextPage} setAfterUpdated={setAfterUpdated}/>
+                                }
+                                </tbody>
                             </Table>
                         </Card.Body>
                     </Card>
                 )}
-                <Paginator onPaginate={onPaginate} nextPage={nextPage} after={after}/>
             </div>
         </>
     )
@@ -258,8 +199,7 @@ const CommitInfo = ({ repo, commit }) => {
     );
 };
 
-const CommitView = ({ repo, commitId, onPaginate, view, after, prefix }) => {
-
+const CommitView = ({ repo, commitId, onNavigate, view, prefix }) => {
     // pull commit itself
     const {response, loading, error} = useAPI(async () => {
         return await commits.get(repo.id, commitId);
@@ -292,12 +232,11 @@ const CommitView = ({ repo, commitId, onPaginate, view, after, prefix }) => {
 
             <div className="mt-4">
                 <ChangeList
-                    after={after}
                     prefix={prefix}
                     view={(!!view) ? view : ""}
                     repo={repo}
                     commit={commit}
-                    onPaginate={onPaginate}
+                    onNavigate={onNavigate}
                 />
             </div>
         </div>
@@ -316,23 +255,21 @@ const CommitContainer = () => {
     return (
         <CommitView
             repo={repo}
-            after={(!!after) ? after : ""}
             view={(!!view) ? view : ""}
             prefix={(!!prefix) ? prefix : ""}
             commitId={commitId}
-            onPaginate={after => router.push({
-                pathname: '/repositories/:repoId/commits/:commitId',
-                params: {repoId: repo.id, commitId},
-                query: {
-                    after: (after) ? after : "",
-                    prefix: (prefix) ? prefix : "",
-                    delimiter: (delimiter) ? delimiter : "",
+            onNavigate={(entry) => {
+                return {
+                    pathname: '/repositories/:repoId/commits/:commitId',
+                    params: {repoId: repo.id, commitId: commitId},
+                    query: {
+                        prefix: entry.path,
+                    }
                 }
-            })}
+            }}
         />
     )
 }
-
 
 const RepositoryCommitPage = () => {
     return (

--- a/webui/src/pages/repositories/repository/commits/commit/index.jsx
+++ b/webui/src/pages/repositories/repository/commits/commit/index.jsx
@@ -14,6 +14,7 @@ import {BrowserIcon, LinkIcon, PackageIcon, PlayIcon} from "@primer/octicons-rea
 import {Link} from "../../../../../lib/components/nav";
 import {useRouter} from "../../../../../lib/hooks/router";
 import {URINavigator} from "../../../../../lib/components/repository/tree";
+import {appendMoreResults} from "../../changes";
 
 const ChangeList = ({ repo, commit, prefix, onNavigate }) => {
     const [actionError, setActionError] = useState(null);
@@ -26,20 +27,8 @@ const ChangeList = ({ repo, commit, prefix, onNavigate }) => {
         if (!repo) return
         if (!commit.parents || commit.parents.length === 0) return {results: [], pagination: {has_more: false}};
 
-        let resultsFiltered = resultsState.results
-        if (resultsState.prefix !== prefix){
-            // prefix changed, need to delete previous results
-            resultsFiltered = []
-        }
-
-        if (resultsFiltered.length > 0 && resultsFiltered.at(-1).path > afterUpdated) {
-            // results already cached
-            return {prefix:prefix, results:resultsFiltered, pagination: resultsState.pagination}
-        }
-
-        const { results, pagination } = await refs.diff(repo.id, commit.parents[0], commit.id, afterUpdated, prefix, delimiter);
-        setResultsState({prefix:prefix, results: resultsFiltered.concat(results), pagination: pagination})
-        return {results:resultsState.results, pagination: pagination}
+        return await appendMoreResults(resultsState, prefix, afterUpdated, setResultsState,
+            () => refs.diff(repo.id, commit.parents[0], commit.id, afterUpdated, prefix, delimiter));
     }, [repo.id, commit.id, afterUpdated, prefix])
 
     const results = resultsState.results

--- a/webui/src/pages/repositories/repository/commits/commit/index.jsx
+++ b/webui/src/pages/repositories/repository/commits/commit/index.jsx
@@ -235,7 +235,7 @@ const CommitView = ({ repo, commitId, onNavigate, view, prefix }) => {
 const CommitContainer = () => {
     const router = useRouter();
     const { repo, loading, error } = useRefs();
-    const { after, prefix, view } = router.query;
+    const { prefix } = router.query;
     const { commitId } = router.params;
 
     if (loading) return <Loading/>;
@@ -244,7 +244,6 @@ const CommitContainer = () => {
     return (
         <CommitView
             repo={repo}
-            view={(!!view) ? view : ""}
             prefix={(!!prefix) ? prefix : ""}
             commitId={commitId}
             onNavigate={(entry) => {

--- a/webui/src/pages/repositories/repository/compare.jsx
+++ b/webui/src/pages/repositories/repository/compare.jsx
@@ -14,6 +14,7 @@ import {TreeEntryPaginator, TreeItem} from "../../../lib/components/repository/c
 import {ConfirmationButton} from "../../../lib/components/modals";
 import {useRouter} from "../../../lib/hooks/router";
 import {URINavigator} from "../../../lib/components/repository/tree";
+import {appendMoreResults} from "./changes";
 
 
 const CompareList = ({ repo, reference, compareReference, prefix, onSelectRef, onSelectCompare, onNavigate }) => {
@@ -35,20 +36,8 @@ const CompareList = ({ repo, reference, compareReference, prefix, onSelectRef, o
         if (compareReference.id === reference.id)
             return {pagination: {has_more: false}, results: []}; // nothing to compare here.
 
-        let resultsFiltered = resultsState.results
-        if (resultsState.prefix !== prefix){
-            // prefix changed, need to delete previous results
-            resultsFiltered = []
-        }
-
-        if (resultsFiltered.length > 0 && resultsFiltered.at(-1).path > afterUpdated) {
-            // results already cached
-            return {prefix:prefix, results:resultsFiltered, pagination: resultsState.pagination}
-        }
-
-        const { results, pagination } = await refs.diff(repo.id, reference.id, compareReference.id, afterUpdated, prefix, delimiter);
-        setResultsState({prefix:prefix, results: resultsFiltered.concat(results), pagination: pagination})
-        return {results:resultsState.results, pagination: pagination}
+        return await appendMoreResults(resultsState, prefix, afterUpdated, setResultsState,
+            () => refs.diff(repo.id, reference.id, compareReference.id, afterUpdated, prefix, delimiter));
     }, [repo.id, reference.id, internalRefresh, afterUpdated, delimiter, prefix])
 
     let results = resultsState.results

--- a/webui/src/pages/repositories/repository/compare.jsx
+++ b/webui/src/pages/repositories/repository/compare.jsx
@@ -10,55 +10,48 @@ import {refs} from "../../../lib/api";
 import Alert from "react-bootstrap/Alert";
 import Card from "react-bootstrap/Card";
 import Table from "react-bootstrap/Table";
-import {ChangeEntryRow, TreeItem} from "../../../lib/components/repository/changes";
-import {Paginator} from "../../../lib/components/pagination";
+import {TreeEntryPaginator, TreeItem} from "../../../lib/components/repository/changes";
 import {ConfirmationButton} from "../../../lib/components/modals";
 import {useRouter} from "../../../lib/hooks/router";
 import {URINavigator} from "../../../lib/components/repository/tree";
-import Form from "react-bootstrap/Form";
-import ButtonGroup from "react-bootstrap/ButtonGroup";
-import {Link} from "../../../lib/components/nav";
-import {ToggleButton} from "react-bootstrap";
 
 
-const CompareList = ({ repo, reference, compareReference, after, view, prefix, onSelectRef, onSelectCompare, onPaginate }) => {
+const CompareList = ({ repo, reference, compareReference, prefix, onSelectRef, onSelectCompare, onNavigate }) => {
     const [internalRefresh, setInternalRefresh] = useState(true);
     const [mergeError, setMergeError] = useState(null);
     const [merging, setMerging] = useState(false);
+    const [afterUpdated, setAfterUpdated] = useState(""); // state of pagination of the item's children
+    const [resultsState, setResultsState] = useState({prefix: prefix, results:[], pagination:{}}); // current retrieved children of the item
 
     const refresh = () => {
         setInternalRefresh(!internalRefresh)
         setMergeError(null)
     }
 
-    const radios = [
-        { name: 'Flat', value: 'flat' , selected:false},
-        { name: 'Directory', value: 'dir', selected:false },
-        { name: 'Tree', value: 'tree', selected:false },
-    ];
+    const delimiter = "/"
 
-    let delimiter = ""
-    switch (view) {
-        case "dir":
-            delimiter = "/";
-            radios[1].selected = true;
-            break;
-        case "tree":
-            delimiter = "/";
-            radios[2].selected = true;
-            break;
-        default:
-            delimiter = "";
-            radios[0].selected = true;
-            break;
-    }
+    const { error, loading, nextPage } = useAPIWithPagination(async () => {
+        if (!repo) return
+        if (compareReference.id === reference.id)
+            return {pagination: {has_more: false}, results: []}; // nothing to compare here.
 
-    const { results, error, loading, nextPage } = useAPIWithPagination(async () => {
-        if (compareReference.id !== reference.id)
-            return refs.diff(repo.id, reference.id, compareReference.id, after, prefix, delimiter);
-        return {pagination: {has_more: false}, results: []}; // nothing to compare here.
-    }, [repo.id, reference.id, compareReference.id, internalRefresh, after, prefix, delimiter]);
+        let resultsFiltered = resultsState.results
+        if (resultsState.prefix !== prefix){
+            // prefix changed, need to delete previous results
+            resultsFiltered = []
+        }
 
+        if (resultsFiltered.length > 0 && resultsFiltered.at(-1).path > afterUpdated) {
+            // results already cached
+            return {prefix:prefix, results:resultsFiltered, pagination: resultsState.pagination}
+        }
+
+        const { results, pagination } = await refs.diff(repo.id, reference.id, compareReference.id, afterUpdated, prefix, delimiter);
+        setResultsState({prefix:prefix, results: resultsFiltered.concat(results), pagination: pagination})
+        return {results:resultsState.results, pagination: pagination}
+    }, [repo.id, reference.id, internalRefresh, afterUpdated, delimiter, prefix])
+
+    let results = resultsState.results
     let content;
 
     const relativeTitle = (from, to) => {
@@ -72,42 +65,6 @@ const CompareList = ({ repo, reference, compareReference, after, view, prefix, o
         }
 
         return `${fromId}...${toId}`
-    }
-
-    let tablebody;
-    if (view === 'tree'){
-        tablebody =
-            <tbody>
-            {results.map(entry => (
-                <TreeItem key={entry.path+"-item"} entry={entry} repo={repo} reference={reference} internalReferesh={internalRefresh}
-                          delimiter={delimiter} after={after} relativeTo={""}
-                          getMore={(afterUpdated, path) => refs.diff(repo.id, reference.id, compareReference.id, afterUpdated, path, delimiter)}
-                />
-            ))}
-            </tbody>
-    } else {
-        tablebody = <tbody>
-        {results.map(entry => (
-            <ChangeEntryRow
-                key={entry.path}
-                entry={entry}
-                relativeTo={prefix}
-                showActions={true}
-                onNavigate={entry => {
-                    return {
-                        pathname: '/repositories/:repoId/compare',
-                        params: {repoId: repo.id},
-                        query: {
-                            compare: compareReference === null ? "" : compareReference.id,
-                            ref: reference === null ? "" : reference.id,
-                            prefix: entry.path,
-                            view: "dir"
-                        }
-                    }
-                }}
-            />
-        ))}
-        </tbody>
     }
 
     if (loading) content = <Loading/>
@@ -146,46 +103,24 @@ const CompareList = ({ repo, reference, compareReference, after, view, prefix, o
                                 />
                             )}
                         </span>
-                        <span className="float-right">
-                            <Form>
-                              <ButtonGroup className={"view-options"}>
-                                {radios.map((radio, idx) => (
-                                    <div key={idx}>
-                                    <Link href={{
-                                            pathname: '/repositories/:repoId/compare',
-                                            params: {repoId: repo.id},
-                                            query: {
-                                                compare: compareReference === null ? "" : compareReference.id,
-                                                ref: reference === null ? "" : reference.id,
-                                                view: radio.value,
-                                            }
-                                    }}>
-                                        <ToggleButton className={"view-options"}
-                                            id={`radio-${idx}`}
-                                            key={`radio-${idx}`}
-                                            type="radio"
-                                            variant="secondary"
-                                            name="radio"
-                                            value={radio.value}
-                                            checked={radio.selected}>
-                                            {radio.name}
-                                        </ToggleButton>
-                                    </Link>
-                                    </div>
-                                ))}
-                              </ButtonGroup>
-                            </Form>
-                        </span>
                         </Card.Header>
                         <Card.Body>
                             <Table borderless size="sm">
-                                {tablebody}
+                                <tbody>
+                                {results.map(entry => (
+                                    <TreeItem key={entry.path+"-item"} entry={entry} repo={repo} reference={reference} internalReferesh={internalRefresh}
+                                              delimiter={delimiter} after={afterUpdated} relativeTo={prefix} onNavigate={onNavigate}
+                                              getMore={(afterUpdated, path) => refs.diff(repo.id, reference.id, compareReference.id, afterUpdated, path, delimiter)}
+                                    />
+                                ))}
+                                { !!nextPage &&
+                                <TreeEntryPaginator path={""} loading={loading} nextPage={nextPage} setAfterUpdated={setAfterUpdated}/>
+                                }
+                                </tbody>
                             </Table>
                         </Card.Body>
                     </Card>
                 )}
-
-                <Paginator onPaginate={onPaginate} nextPage={nextPage} after={after}/>
             </div>
     )
 
@@ -256,35 +191,33 @@ const CompareContainer = () => {
     const router = useRouter();
     const { loading, error, repo, reference, compare } = useRefs();
 
-    const { after, prefix, view } = router.query;
+    const { prefix } = router.query;
 
     if (loading) return <Loading/>;
     if (!!error) return <Error error={error}/>;
 
     const route = query => router.push({pathname: `/repositories/:repoId/compare`, params: {repoId: repo.id}, query: {
         ...query,
-        view: (view) ? view : "",
     }});
 
     return (
         <CompareList
             repo={repo}
-            after={(!!after) ? after : ""}
-            view={(!!view) ? view : ""}
             prefix={(!!prefix) ? prefix : ""}
             reference={reference}
             onSelectRef={reference => route(compare ? {ref: reference.id, compare: compare.id} : {ref: reference.id})}
             compareReference={compare}
             onSelectCompare={compare => route(reference ? {ref: reference.id, compare: compare.id} : {compare: compare.id})}
-            onPaginate={after => {
-                const query = {
-                    after: (after) ? after : "",
-                    prefix: (prefix) ? prefix : "",
-                    view: (view) ? view : ""
-                };
-                if (compare) query.compare = compare.id;
-                if (reference) query.ref = reference.id;
-                route(query);
+            onNavigate={entry => {
+                return {
+                    pathname: `/repositories/:repoId/compare`,
+                    params: {repoId: repo.id},
+                    query: {
+                        ref: reference.id,
+                        compare: compare.id,
+                        prefix: entry.path,
+                    }
+                }
             }}
         />
     );

--- a/webui/src/styles/globals.css
+++ b/webui/src/styles/globals.css
@@ -147,12 +147,14 @@
   padding: 0 10px;
 }
 
-.table .tree-entry-row {
+.table .tree-entry-row,
+.table .change-entry-row {
   border-bottom: 1px solid rgba(0, 0, 0, 0.125);
   height: 38px;
 }
 
 .table .tree-entry-row td,
+.table .change-entry-row td,
 .actions-runs-list .table td {
   padding-top: 5px;
   padding-bottom: 5px;
@@ -163,15 +165,19 @@
   margin-bottom: 20px;
 }
 
-.table .tree-entry-row td:first-child {
+.table .tree-entry-row td:first-child,
+.table .change-entry-row td:first-child,
+.table .change td:first-child {
   padding-left: 20px;
 }
 
-.table .tree-entry-row td:nth-child(4) {
+.table .tree-entry-row td:nth-child(4),
+.table .change-entry-row td:nth-child(4) {
   padding-right: 20px;
   text-align: right;
 }
 
+.table .change-entry-row td:last-child,
 .table .tree-entry-row td:last-child {
   padding-right: 10px;
   text-align: right;

--- a/webui/src/styles/globals.css
+++ b/webui/src/styles/globals.css
@@ -147,15 +147,15 @@
   padding: 0 10px;
 }
 
-.table .change-entry-row {
+.table .tree-entry-row {
   border-bottom: 1px solid rgba(0, 0, 0, 0.125);
-  height: 45px;
+  height: 38px;
 }
 
-.table .change-entry-row td,
+.table .tree-entry-row td,
 .actions-runs-list .table td {
-  padding-top: 10px;
-  padding-bottom: 10px;
+  padding-top: 5px;
+  padding-bottom: 5px;
   vertical-align: middle;
 }
 
@@ -163,16 +163,16 @@
   margin-bottom: 20px;
 }
 
-.table .change-entry-row td:first-child {
+.table .tree-entry-row td:first-child {
   padding-left: 20px;
 }
 
-.table .change-entry-row td:nth-child(4) {
+.table .tree-entry-row td:nth-child(4) {
   padding-right: 20px;
   text-align: right;
 }
 
-.table .change-entry-row td:last-child {
+.table .tree-entry-row td:last-child {
   padding-right: 10px;
   text-align: right;
 }


### PR DESCRIPTION
closes #2602 

Uncommitted, Compare and Commit views will show the changes made in a single view which can be browsed as a tree or at the prefix level. Some refactoring has been made to allow them to share the same components. 