### PR TITLE
Reset after param when prefix changes

### DIFF
--- a/webui/src/lib/components/repository/changes.jsx
+++ b/webui/src/lib/components/repository/changes.jsx
@@ -60,9 +60,9 @@ const ChangeRowActions = ({ entry, onRevert }) => {
     getMore: callback to be called when more items need to be rendered
     depth: the item's depth withing the tree
  */
-export const TreeItem = ({ entry, repo, reference, internalRefresh, onRevert, onNavigate, delimiter, after, relativeTo, getMore, depth=0 }) => {
+export const TreeItem = ({ entry, repo, reference, internalRefresh, onRevert, onNavigate, delimiter, relativeTo, getMore, depth=0 }) => {
     const [expanded, setExpanded] = useState(false); // state of the item expansion
-    const [afterUpdated, setAfterUpdated] = useState(after); // state of pagination of the item's children
+    const [afterUpdated, setAfterUpdated] = useState(""); // state of pagination of the item's children
     const [resultsState, setResultsState] = useState({results:[], pagination:{}}); // current retrieved children of the item
 
     const { error, loading, nextPage } = useAPIWithPagination(async () => {
@@ -94,7 +94,7 @@ export const TreeItem = ({ entry, repo, reference, internalRefresh, onRevert, on
             {expanded && results &&
                 results.map(child =>
                     ( <TreeItem key={child.path+"-item"} entry={child} repo={repo} reference={reference} onRevert={onRevert} onNavigate={onNavigate}
-                                internalReferesh={internalRefresh} delimiter={delimiter} depth={depth+1} after={after} relativeTo={entry.path} getMore={getMore}/>))}
+                                internalReferesh={internalRefresh} delimiter={delimiter} depth={depth+1} relativeTo={entry.path} getMore={getMore}/>))}
             {(!!nextPage || loading) &&
                 <TreeEntryPaginator path={entry.path} depth={depth} loading={loading} nextPage={nextPage} setAfterUpdated={setAfterUpdated}/>
             }

--- a/webui/src/pages/repositories/repository/changes.jsx
+++ b/webui/src/pages/repositories/repository/changes.jsx
@@ -147,10 +147,11 @@ const RevertButton = ({onRevert, enabled = false}) => {
     );
 }
 
-export async function appendMoreResults(resultsState, prefix, afterUpdated, setResultsState, getMore) {
+export async function appendMoreResults(resultsState, prefix, afterUpdated, setAfterUpdated, setResultsState, getMore) {
     let resultsFiltered = resultsState.results
     if (resultsState.prefix !== prefix) {
         // prefix changed, need to delete previous results
+        setAfterUpdated("")
         resultsFiltered = []
     }
 
@@ -174,7 +175,7 @@ const ChangesBrowser = ({repo, reference, prefix, onSelectRef, }) => {
 
     const { error, loading, nextPage } = useAPIWithPagination(async () => {
         if (!repo) return
-        return await appendMoreResults(resultsState, prefix, afterUpdated, setResultsState,
+        return await appendMoreResults(resultsState, prefix, afterUpdated, setAfterUpdated, setResultsState,
             () => refs.changes(repo.id, reference.id, afterUpdated, prefix, delimiter));
     }, [repo.id, reference.id, internalRefresh, afterUpdated, delimiter, prefix])
 
@@ -272,7 +273,7 @@ const ChangesBrowser = ({repo, reference, prefix, onSelectRef, }) => {
                                 {results.map(entry => (
                                     <TreeItem key={entry.path + "-tree-item"} entry={entry} repo={repo} reference={reference}
                                               internalReferesh={internalRefresh} onNavigate={onNavigate}
-                                              onRevert={onRevert} delimiter={delimiter} after={""} relativeTo={prefix}
+                                              onRevert={onRevert} delimiter={delimiter} relativeTo={prefix}
                                               getMore={(afterUpdated, path) => {
                                                   return refs.changes(repo.id, reference.id, afterUpdated, path, delimiter)
                                               }}/>

--- a/webui/src/pages/repositories/repository/commits/commit/index.jsx
+++ b/webui/src/pages/repositories/repository/commits/commit/index.jsx
@@ -27,7 +27,7 @@ const ChangeList = ({ repo, commit, prefix, onNavigate }) => {
         if (!repo) return
         if (!commit.parents || commit.parents.length === 0) return {results: [], pagination: {has_more: false}};
 
-        return await appendMoreResults(resultsState, prefix, afterUpdated, setResultsState,
+        return await appendMoreResults(resultsState, prefix, afterUpdated, setAfterUpdated, setResultsState,
             () => refs.diff(repo.id, commit.parents[0], commit.id, afterUpdated, prefix, delimiter));
     }, [repo.id, commit.id, afterUpdated, prefix])
 
@@ -71,7 +71,7 @@ const ChangeList = ({ repo, commit, prefix, onNavigate }) => {
                                               }}/>
                                 ))}
                                 { !!nextPage &&
-                                <TreeEntryPaginator path={""} loading={loading} nextPage={nextPage} setAfterUpdated={setAfterUpdated}/>
+                                    <TreeEntryPaginator path={""} loading={loading} nextPage={nextPage} setAfterUpdated={setAfterUpdated}/>
                                 }
                                 </tbody>
                             </Table>

--- a/webui/src/pages/repositories/repository/compare.jsx
+++ b/webui/src/pages/repositories/repository/compare.jsx
@@ -36,7 +36,7 @@ const CompareList = ({ repo, reference, compareReference, prefix, onSelectRef, o
         if (compareReference.id === reference.id)
             return {pagination: {has_more: false}, results: []}; // nothing to compare here.
 
-        return await appendMoreResults(resultsState, prefix, afterUpdated, setResultsState,
+        return await appendMoreResults(resultsState, prefix, afterUpdated, setAfterUpdated, setResultsState,
             () => refs.diff(repo.id, reference.id, compareReference.id, afterUpdated, prefix, delimiter));
     }, [repo.id, reference.id, internalRefresh, afterUpdated, delimiter, prefix])
 
@@ -98,8 +98,8 @@ const CompareList = ({ repo, reference, compareReference, prefix, onSelectRef, o
                                 <tbody>
                                 {results.map(entry => (
                                     <TreeItem key={entry.path+"-item"} entry={entry} repo={repo} reference={reference} internalReferesh={internalRefresh}
-                                              delimiter={delimiter} after={afterUpdated} relativeTo={prefix} onNavigate={onNavigate}
-                                              getMore={(afterUpdated, path) => refs.diff(repo.id, reference.id, compareReference.id, afterUpdated, path, delimiter)}
+                                              delimiter={delimiter} relativeTo={prefix} onNavigate={onNavigate}
+                                              getMore={(afterUpdatedChild, path) => refs.diff(repo.id, reference.id, compareReference.id, afterUpdatedChild, path, delimiter)}
                                     />
                                 ))}
                                 { !!nextPage &&


### PR DESCRIPTION
`after` param is a state managed by React. The state indicates the last entry in a given "TreeItem" and it's being used in future paginations for continuing to read from the last entry.
Since it's a state, we need to reset it when the prefix changes since the pagination state is completely different.