### PR TITLE
Use apache httpcomponents httpclient v4.5.13

### DIFF
--- a/clients/hadoopfs/pom.xml
+++ b/clients/hadoopfs/pom.xml
@@ -237,7 +237,7 @@ To export to S3:
         <dependency>        <!-- needed for aws-java-sdk in tests(!) -->
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>4.3.6</version>
+            <version>4.5.13</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This bypasses a dependabot alert on using a bad httpclient version, https://github.com/treeverse/lakeFS/security/dependabot/clients/hadoopfs/pom.xml/org.apache.httpcomponents:httpclient/open

Before merging:

* [x] Verify client works on DataBricks