### PR TITLE
Fix bad logging

### DIFF
--- a/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileSystem.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileSystem.java
@@ -759,8 +759,9 @@ public class LakeFSFileSystem extends FileSystem {
 
     @Override
     public FileStatus[] globStatus(Path pathPattern) throws IOException {
+        // TODO: implement this method as part of https://github.com/treeverse/lakeFS/issues/2629
         FileStatus fStatus = new FileStatus(0, false, 1, 20, 1,
-                new Path("tal-test"));
+                new Path("globStatus-test-path"));
         return new FileStatus[]{fStatus};
     }
 


### PR DESCRIPTION
Discovered during a live session with users. 

The globStatus operation was not implemented because it was not called by Spark in any of the flows we tested. This pr only mitigates a bad log message but the real issue will be addressed with https://github.com/treeverse/lakeFS/issues/2629

I'm not changing globStatus to an unsupported operation because it may cause unexpected issues and require more thorough testing that will be done as part of the work on the issue above. 