### PR TITLE
Fix s3 adapter multipart upload working with encrypted bucket

### DIFF
--- a/pkg/block/adapter.go
+++ b/pkg/block/adapter.go
@@ -64,7 +64,28 @@ type WalkOpts struct {
 	Prefix           string
 }
 
-// CreateMultiPartOpts contains optional arguments for
+// CreateMultiPartUploadResponse multipart upload ID and additional headers (implementation specific) currently it targets s3
+// capabilities to enable encryption properties
+type CreateMultiPartUploadResponse struct {
+	UploadID string
+	Header   http.Header
+}
+
+// CompleteMultiPartUploadResponse complete multipart etag, content length and additional headers (implementation specific) currently it targets s3
+type CompleteMultiPartUploadResponse struct {
+	ETag          string
+	ContentLength int64
+	Header        http.Header
+}
+
+// UploadPartResponse upload part ETag and additional headers (implementation specific) currently it targets s3
+// capabilities to enable encryption properties
+type UploadPartResponse struct {
+	ETag   string
+	Header http.Header
+}
+
+// CreateMultiPartUploadOpts contains optional arguments for
 // CreateMultiPartUpload.  These should be analogous to options on
 // some underlying storage layer.  Missing arguments are mapped to the
 // default if a storage layer implements the option.
@@ -101,12 +122,12 @@ type Adapter interface {
 	GetProperties(ctx context.Context, obj ObjectPointer) (Properties, error)
 	Remove(ctx context.Context, obj ObjectPointer) error
 	Copy(ctx context.Context, sourceObj, destinationObj ObjectPointer) error
-	CreateMultiPartUpload(ctx context.Context, obj ObjectPointer, r *http.Request, opts CreateMultiPartUploadOpts) (string, error)
-	UploadPart(ctx context.Context, obj ObjectPointer, sizeBytes int64, reader io.Reader, uploadID string, partNumber int64) (string, error)
-	UploadCopyPart(ctx context.Context, sourceObj, destinationObj ObjectPointer, uploadID string, partNumber int64) (string, error)
-	UploadCopyPartRange(ctx context.Context, sourceObj, destinationObj ObjectPointer, uploadID string, partNumber, startPosition, endPosition int64) (string, error)
+	CreateMultiPartUpload(ctx context.Context, obj ObjectPointer, r *http.Request, opts CreateMultiPartUploadOpts) (*CreateMultiPartUploadResponse, error)
+	UploadPart(ctx context.Context, obj ObjectPointer, sizeBytes int64, reader io.Reader, uploadID string, partNumber int64) (*UploadPartResponse, error)
+	UploadCopyPart(ctx context.Context, sourceObj, destinationObj ObjectPointer, uploadID string, partNumber int64) (*UploadPartResponse, error)
+	UploadCopyPartRange(ctx context.Context, sourceObj, destinationObj ObjectPointer, uploadID string, partNumber, startPosition, endPosition int64) (*UploadPartResponse, error)
 	AbortMultiPartUpload(ctx context.Context, obj ObjectPointer, uploadID string) error
-	CompleteMultiPartUpload(ctx context.Context, obj ObjectPointer, uploadID string, multipartList *MultipartUploadCompletion) (*string, int64, error)
+	CompleteMultiPartUpload(ctx context.Context, obj ObjectPointer, uploadID string, multipartList *MultipartUploadCompletion) (*CompleteMultiPartUploadResponse, error)
 	// ValidateConfiguration validates an appropriate bucket
 	// configuration and returns a validation error or nil.
 	ValidateConfiguration(ctx context.Context, storageNamespace string) error

--- a/pkg/block/adapter.go
+++ b/pkg/block/adapter.go
@@ -8,6 +8,10 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 )
 
+// MultipartUploadCompletion parts described as part of complete multipart upload. Each part holds the part number and ETag received while calling part upload.
+// NOTE that S3 implementation and our S3 gateway accept and returns ETag value surrounded with double-quotes ("), while
+// the adapter implementations supply the raw value of the etag (without double quotes) and let the gateway manage the s3
+// protocol specifications.
 type MultipartUploadCompletion struct{ Part []*s3.CompletedPart }
 
 // IdentifierType is the type the ObjectPointer Identifier
@@ -71,7 +75,8 @@ type CreateMultiPartUploadResponse struct {
 	ServerSideHeader http.Header
 }
 
-// CompleteMultiPartUploadResponse complete multipart etag, content length and additional headers (implementation specific) currently it targets s3
+// CompleteMultiPartUploadResponse complete multipart etag, content length and additional headers (implementation specific) currently it targets s3.
+// The ETag is a hex string value of the content checksum
 type CompleteMultiPartUploadResponse struct {
 	ETag             string
 	ContentLength    int64
@@ -80,6 +85,7 @@ type CompleteMultiPartUploadResponse struct {
 
 // UploadPartResponse upload part ETag and additional headers (implementation specific) currently it targets s3
 // capabilities to enable encryption properties
+// The ETag is a hex string value of the content checksum
 type UploadPartResponse struct {
 	ETag             string
 	ServerSideHeader http.Header

--- a/pkg/block/adapter.go
+++ b/pkg/block/adapter.go
@@ -67,22 +67,22 @@ type WalkOpts struct {
 // CreateMultiPartUploadResponse multipart upload ID and additional headers (implementation specific) currently it targets s3
 // capabilities to enable encryption properties
 type CreateMultiPartUploadResponse struct {
-	UploadID string
-	Header   http.Header
+	UploadID         string
+	ServerSideHeader http.Header
 }
 
 // CompleteMultiPartUploadResponse complete multipart etag, content length and additional headers (implementation specific) currently it targets s3
 type CompleteMultiPartUploadResponse struct {
-	ETag          string
-	ContentLength int64
-	Header        http.Header
+	ETag             string
+	ContentLength    int64
+	ServerSideHeader http.Header
 }
 
 // UploadPartResponse upload part ETag and additional headers (implementation specific) currently it targets s3
 // capabilities to enable encryption properties
 type UploadPartResponse struct {
-	ETag   string
-	Header http.Header
+	ETag             string
+	ServerSideHeader http.Header
 }
 
 // CreateMultiPartUploadOpts contains optional arguments for
@@ -149,7 +149,9 @@ type NoOpTranslator struct{}
 func (d *NoOpTranslator) SetUploadID(uploadID string) string {
 	return uploadID
 }
+
 func (d *NoOpTranslator) TranslateUploadID(uploadID string) string {
 	return uploadID
 }
+
 func (d *NoOpTranslator) RemoveUploadID(_ string) {}

--- a/pkg/block/azure/adapter.go
+++ b/pkg/block/azure/adapter.go
@@ -332,26 +332,28 @@ func (a *Adapter) Copy(ctx context.Context, sourceObj, destinationObj block.Obje
 	return nil
 }
 
-func (a *Adapter) CreateMultiPartUpload(ctx context.Context, obj block.ObjectPointer, _ *http.Request, _ block.CreateMultiPartUploadOpts) (string, error) {
+func (a *Adapter) CreateMultiPartUpload(_ context.Context, obj block.ObjectPointer, _ *http.Request, _ block.CreateMultiPartUploadOpts) (*block.CreateMultiPartUploadResponse, error) {
 	// Azure has no create multipart upload
 	var err error
 	defer reportMetrics("CreateMultiPartUpload", time.Now(), nil, &err)
 
 	qualifiedKey, err := resolveBlobURLInfo(obj)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
-	return qualifiedKey.BlobURL, nil
+	return &block.CreateMultiPartUploadResponse{
+		UploadID: qualifiedKey.BlobURL,
+	}, nil
 }
 
-func (a *Adapter) UploadPart(ctx context.Context, obj block.ObjectPointer, _ int64, reader io.Reader, _ string, _ int64) (string, error) {
+func (a *Adapter) UploadPart(ctx context.Context, obj block.ObjectPointer, _ int64, reader io.Reader, _ string, _ int64) (*block.UploadPartResponse, error) {
 	var err error
 	defer reportMetrics("UploadPart", time.Now(), nil, &err)
 
 	qualifiedKey, err := resolveBlobURLInfo(obj)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	container := a.getContainerURL(qualifiedKey.ContainerURL)
@@ -359,7 +361,7 @@ func (a *Adapter) UploadPart(ctx context.Context, obj block.ObjectPointer, _ int
 
 	transferManager, err := azblob.NewStaticBuffer(_1MiB, MaxBuffers)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	defer transferManager.Close()
 	multipartBlockWriter := NewMultipartBlockWriter(hashReader, container, qualifiedKey.BlobURL)
@@ -367,34 +369,35 @@ func (a *Adapter) UploadPart(ctx context.Context, obj block.ObjectPointer, _ int
 		TransferManager: transferManager,
 	})
 	if err != nil {
-		return "", err
+		return nil, err
 	}
-	return multipartBlockWriter.etag, nil
+	return &block.UploadPartResponse{
+		ETag: multipartBlockWriter.etag,
+	}, nil
 }
 
-func (a *Adapter) UploadCopyPart(ctx context.Context, sourceObj, destinationObj block.ObjectPointer, _ string, _ int64) (string, error) {
+func (a *Adapter) UploadCopyPart(ctx context.Context, sourceObj, destinationObj block.ObjectPointer, _ string, _ int64) (*block.UploadPartResponse, error) {
 	var err error
 	defer reportMetrics("UploadPart", time.Now(), nil, &err)
 
 	return a.copyPartRange(ctx, sourceObj, destinationObj, 0, azblob.CountToEnd)
 }
 
-func (a *Adapter) UploadCopyPartRange(ctx context.Context, sourceObj, destinationObj block.ObjectPointer, _ string, _, startPosition, endPosition int64) (string, error) {
+func (a *Adapter) UploadCopyPartRange(ctx context.Context, sourceObj, destinationObj block.ObjectPointer, _ string, _, startPosition, endPosition int64) (*block.UploadPartResponse, error) {
 	var err error
 	defer reportMetrics("UploadPart", time.Now(), nil, &err)
-
 	return a.copyPartRange(ctx, sourceObj, destinationObj, startPosition, endPosition-startPosition+1)
 }
 
-func (a *Adapter) copyPartRange(ctx context.Context, sourceObj, destinationObj block.ObjectPointer, startPosition, count int64) (string, error) {
+func (a *Adapter) copyPartRange(ctx context.Context, sourceObj, destinationObj block.ObjectPointer, startPosition, count int64) (*block.UploadPartResponse, error) {
 	qualifiedSourceKey, err := resolveBlobURLInfo(sourceObj)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	qualifiedDestinationKey, err := resolveBlobURLInfo(destinationObj)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	destinationContainer := a.getContainerURL(qualifiedDestinationKey.ContainerURL)
@@ -404,12 +407,12 @@ func (a *Adapter) copyPartRange(ctx context.Context, sourceObj, destinationObj b
 	return copyPartRange(ctx, destinationContainer, qualifiedDestinationKey.BlobURL, sourceBlobURL, startPosition, count)
 }
 
-func (a *Adapter) AbortMultiPartUpload(ctx context.Context, _ block.ObjectPointer, _ string) error {
+func (a *Adapter) AbortMultiPartUpload(_ context.Context, _ block.ObjectPointer, _ string) error {
 	// Azure has no abort, in case of commit, uncommitted parts are erased, otherwise staged data is erased after 7 days
 	return nil
 }
 
-func (a *Adapter) ValidateConfiguration(ctx context.Context, _ string) error {
+func (a *Adapter) ValidateConfiguration(_ context.Context, _ string) error {
 	return nil
 }
 
@@ -417,15 +420,14 @@ func (a *Adapter) BlockstoreType() string {
 	return block.BlockstoreTypeAzure
 }
 
-func (a *Adapter) CompleteMultiPartUpload(ctx context.Context, obj block.ObjectPointer, _ string, multipartList *block.MultipartUploadCompletion) (*string, int64, error) {
+func (a *Adapter) CompleteMultiPartUpload(ctx context.Context, obj block.ObjectPointer, _ string, multipartList *block.MultipartUploadCompletion) (*block.CompleteMultiPartUploadResponse, error) {
 	var err error
 	defer reportMetrics("CompleteMultiPartUpload", time.Now(), nil, &err)
 	qualifiedKey, err := resolveBlobURLInfo(obj)
 	if err != nil {
-		return nil, 0, err
+		return nil, err
 	}
 	containerURL := a.getContainerURL(qualifiedKey.ContainerURL)
-
 	return CompleteMultipart(ctx, multipartList.Part, containerURL, qualifiedKey.BlobURL, a.configurations.retryReaderOptions)
 }
 

--- a/pkg/block/azure/adapter.go
+++ b/pkg/block/azure/adapter.go
@@ -372,7 +372,7 @@ func (a *Adapter) UploadPart(ctx context.Context, obj block.ObjectPointer, _ int
 		return nil, err
 	}
 	return &block.UploadPartResponse{
-		ETag: multipartBlockWriter.etag,
+		ETag: strings.Trim(multipartBlockWriter.etag, `"`),
 	}, nil
 }
 
@@ -428,7 +428,7 @@ func (a *Adapter) CompleteMultiPartUpload(ctx context.Context, obj block.ObjectP
 		return nil, err
 	}
 	containerURL := a.getContainerURL(qualifiedKey.ContainerURL)
-	return CompleteMultipart(ctx, multipartList.Part, containerURL, qualifiedKey.BlobURL, a.configurations.retryReaderOptions)
+	return completeMultipart(ctx, multipartList.Part, containerURL, qualifiedKey.BlobURL, a.configurations.retryReaderOptions)
 }
 
 func (a *Adapter) GetStorageNamespaceInfo() block.StorageNamespaceInfo {

--- a/pkg/block/azure/multipart_block_writer.go
+++ b/pkg/block/azure/multipart_block_writer.go
@@ -60,7 +60,7 @@ func (m *MultipartBlockWriter) CommitBlockList(ctx context.Context, ids []string
 	return &azblob.BlockBlobCommitBlockListResponse{}, err
 }
 
-func CompleteMultipart(ctx context.Context, parts []*s3.CompletedPart, container azblob.ContainerURL, objName string, retryOptions azblob.RetryReaderOptions) (*string, int64, error) {
+func CompleteMultipart(ctx context.Context, parts []*s3.CompletedPart, container azblob.ContainerURL, objName string, retryOptions azblob.RetryReaderOptions) (*block.CompleteMultiPartUploadResponse, error) {
 	sort.Slice(parts, func(i, j int) bool {
 		return *parts[i].PartNumber < *parts[j].PartNumber
 	})
@@ -76,20 +76,23 @@ func CompleteMultipart(ctx context.Context, parts []*s3.CompletedPart, container
 
 	stageBlockIDs, err := getMultipartIDs(ctx, container, objName, metaBlockIDs, retryOptions)
 	if err != nil {
-		return nil, 0, err
+		return nil, err
 	}
 	size, err := getMultipartSize(ctx, container, objName, metaBlockIDs, retryOptions)
 	if err != nil {
-		return nil, 0, err
+		return nil, err
 	}
 	blobURL := container.NewBlockBlobURL(objName)
 
 	res, err := blobURL.CommitBlockList(ctx, stageBlockIDs, azblob.BlobHTTPHeaders{}, azblob.Metadata{}, azblob.BlobAccessConditions{}, azblob.AccessTierNone, azblob.BlobTagsMap{}, azblob.ClientProvidedKeyOptions{})
 	if err != nil {
-		return nil, 0, err
+		return nil, err
 	}
 	etag := string(res.ETag())
-	return &etag, int64(size), nil
+	return &block.CompleteMultiPartUploadResponse{
+		ETag:          etag,
+		ContentLength: int64(size),
+	}, nil
 }
 
 func getMultipartIDs(ctx context.Context, container azblob.ContainerURL, objName string, base64BlockIDs []string, retryOptions azblob.RetryReaderOptions) ([]string, error) {
@@ -156,17 +159,17 @@ func getMultipartSize(ctx context.Context, container azblob.ContainerURL, objNam
 	return size, nil
 }
 
-func copyPartRange(ctx context.Context, destinationContainer azblob.ContainerURL, destinationObjName string, sourceBlobURL azblob.BlockBlobURL, startPosition, count int64) (string, error) {
+func copyPartRange(ctx context.Context, destinationContainer azblob.ContainerURL, destinationObjName string, sourceBlobURL azblob.BlockBlobURL, startPosition, count int64) (*block.UploadPartResponse, error) {
 	base64BlockID := generateRandomBlockID()
 	_, err := sourceBlobURL.StageBlockFromURL(ctx, base64BlockID, sourceBlobURL.URL(), startPosition, count, azblob.LeaseAccessConditions{}, azblob.ModifiedAccessConditions{}, azblob.ClientProvidedKeyOptions{})
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	// add size and id to etag
 	response, err := sourceBlobURL.GetProperties(ctx, azblob.BlobAccessConditions{}, azblob.ClientProvidedKeyOptions{})
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	etag := "\"" + hex.EncodeToString(response.ContentMD5()) + "\""
 	size := response.ContentLength()
@@ -175,7 +178,7 @@ func copyPartRange(ctx context.Context, destinationContainer azblob.ContainerURL
 	blobIDsURL := destinationContainer.NewBlockBlobURL(destinationObjName + idSuffix)
 	_, err = blobIDsURL.StageBlock(ctx, base64Etag, strings.NewReader(base64BlockID+"\n"), azblob.LeaseAccessConditions{}, nil, azblob.ClientProvidedKeyOptions{})
 	if err != nil {
-		return "", fmt.Errorf("failed staging part data: %w", err)
+		return nil, fmt.Errorf("failed staging part data: %w", err)
 	}
 
 	// stage size data
@@ -183,10 +186,12 @@ func copyPartRange(ctx context.Context, destinationContainer azblob.ContainerURL
 	blobSizesURL := destinationContainer.NewBlockBlobURL(destinationObjName + sizeSuffix)
 	_, err = blobSizesURL.StageBlock(ctx, base64Etag, strings.NewReader(sizeData), azblob.LeaseAccessConditions{}, nil, azblob.ClientProvidedKeyOptions{})
 	if err != nil {
-		return "", fmt.Errorf("failed staging part data: %w", err)
+		return nil, fmt.Errorf("failed staging part data: %w", err)
 	}
 
-	return etag, nil
+	return &block.UploadPartResponse{
+		ETag: etag,
+	}, nil
 }
 
 func generateRandomBlockID() string {

--- a/pkg/block/azure/multipart_block_writer.go
+++ b/pkg/block/azure/multipart_block_writer.go
@@ -60,7 +60,7 @@ func (m *MultipartBlockWriter) CommitBlockList(ctx context.Context, ids []string
 	return &azblob.BlockBlobCommitBlockListResponse{}, err
 }
 
-func CompleteMultipart(ctx context.Context, parts []*s3.CompletedPart, container azblob.ContainerURL, objName string, retryOptions azblob.RetryReaderOptions) (*block.CompleteMultiPartUploadResponse, error) {
+func completeMultipart(ctx context.Context, parts []*s3.CompletedPart, container azblob.ContainerURL, objName string, retryOptions azblob.RetryReaderOptions) (*block.CompleteMultiPartUploadResponse, error) {
 	sort.Slice(parts, func(i, j int) bool {
 		return *parts[i].PartNumber < *parts[j].PartNumber
 	})
@@ -182,7 +182,7 @@ func copyPartRange(ctx context.Context, destinationContainer azblob.ContainerURL
 	}
 
 	// stage size data
-	sizeData := strconv.Itoa(int(size)) + "\n"
+	sizeData := fmt.Sprintf("%d\n", size)
 	blobSizesURL := destinationContainer.NewBlockBlobURL(destinationObjName + sizeSuffix)
 	_, err = blobSizesURL.StageBlock(ctx, base64Etag, strings.NewReader(sizeData), azblob.LeaseAccessConditions{}, nil, azblob.ClientProvidedKeyOptions{})
 	if err != nil {
@@ -190,7 +190,7 @@ func copyPartRange(ctx context.Context, destinationContainer azblob.ContainerURL
 	}
 
 	return &block.UploadPartResponse{
-		ETag: etag,
+		ETag: strings.Trim(etag, `"`),
 	}, nil
 }
 

--- a/pkg/block/gs/adapter.go
+++ b/pkg/block/gs/adapter.go
@@ -248,12 +248,12 @@ func (a *Adapter) Copy(ctx context.Context, sourceObj, destinationObj block.Obje
 	}
 	return nil
 }
-func (a *Adapter) CreateMultiPartUpload(ctx context.Context, obj block.ObjectPointer, r *http.Request, opts block.CreateMultiPartUploadOpts) (string, error) {
+func (a *Adapter) CreateMultiPartUpload(ctx context.Context, obj block.ObjectPointer, r *http.Request, opts block.CreateMultiPartUploadOpts) (*block.CreateMultiPartUploadResponse, error) {
 	var err error
 	defer reportMetrics("CreateMultiPartUpload", time.Now(), nil, &err)
 	qualifiedKey, err := resolveNamespace(obj)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	// we use the qualified key as the upload id
 	uploadID := a.uploadIDTranslator.SetUploadID(qualifiedKey.Key)
@@ -265,11 +265,11 @@ func (a *Adapter) CreateMultiPartUpload(ctx context.Context, obj block.ObjectPoi
 	w := o.NewWriter(ctx)
 	_, err = io.WriteString(w, qualifiedKey.Key)
 	if err != nil {
-		return "", fmt.Errorf("io.WriteString: %w", err)
+		return nil, fmt.Errorf("io.WriteString: %w", err)
 	}
 	err = w.Close()
 	if err != nil {
-		return "", fmt.Errorf("writer.Close: %w", err)
+		return nil, fmt.Errorf("writer.Close: %w", err)
 	}
 	// log information
 	a.log(ctx).WithFields(logging.Fields{
@@ -278,15 +278,17 @@ func (a *Adapter) CreateMultiPartUpload(ctx context.Context, obj block.ObjectPoi
 		"qualified_key": qualifiedKey.Key,
 		"key":           obj.Identifier,
 	}).Debug("created multipart upload")
-	return uploadID, nil
+	return &block.CreateMultiPartUploadResponse{
+		UploadID: uploadID,
+	}, nil
 }
 
-func (a *Adapter) UploadPart(ctx context.Context, obj block.ObjectPointer, sizeBytes int64, reader io.Reader, uploadID string, partNumber int64) (string, error) {
+func (a *Adapter) UploadPart(ctx context.Context, obj block.ObjectPointer, sizeBytes int64, reader io.Reader, uploadID string, partNumber int64) (*block.UploadPartResponse, error) {
 	var err error
 	defer reportMetrics("UploadPart", time.Now(), &sizeBytes, &err)
 	qualifiedKey, err := resolveNamespace(obj)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	uploadID = a.uploadIDTranslator.SetUploadID(uploadID)
 	objName := formatMultipartFilename(uploadID, partNumber)
@@ -296,25 +298,27 @@ func (a *Adapter) UploadPart(ctx context.Context, obj block.ObjectPointer, sizeB
 	w := o.NewWriter(ctx)
 	_, err = io.Copy(w, reader)
 	if err != nil {
-		return "", fmt.Errorf("io.Copy: %w", err)
+		return nil, fmt.Errorf("io.Copy: %w", err)
 	}
 	err = w.Close()
 	if err != nil {
-		return "", fmt.Errorf("writer.Close: %w", err)
+		return nil, fmt.Errorf("writer.Close: %w", err)
 	}
 	attrs, err := o.Attrs(ctx)
 	if err != nil {
-		return "", fmt.Errorf("object.Attrs: %w", err)
+		return nil, fmt.Errorf("object.Attrs: %w", err)
 	}
-	return attrs.Etag, nil
+	return &block.UploadPartResponse{
+		ETag: attrs.Etag,
+	}, nil
 }
 
-func (a *Adapter) UploadCopyPart(ctx context.Context, sourceObj, destinationObj block.ObjectPointer, uploadID string, partNumber int64) (string, error) {
+func (a *Adapter) UploadCopyPart(ctx context.Context, sourceObj, destinationObj block.ObjectPointer, uploadID string, partNumber int64) (*block.UploadPartResponse, error) {
 	var err error
 	defer reportMetrics("UploadCopyPart", time.Now(), nil, &err)
 	qualifiedKey, err := resolveNamespace(destinationObj)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	uploadID = a.uploadIDTranslator.SetUploadID(uploadID)
 	objName := formatMultipartFilename(uploadID, partNumber)
@@ -324,23 +328,25 @@ func (a *Adapter) UploadCopyPart(ctx context.Context, sourceObj, destinationObj 
 
 	qualifiedSourceKey, err := resolveNamespace(sourceObj)
 	if err != nil {
-		return "", fmt.Errorf("resolve source: %w", err)
+		return nil, fmt.Errorf("resolve source: %w", err)
 	}
 	sourceObjectHandle := a.client.Bucket(qualifiedSourceKey.StorageNamespace).Object(qualifiedSourceKey.Key)
 
 	attrs, err := o.CopierFrom(sourceObjectHandle).Run(ctx)
 	if err != nil {
-		return "", fmt.Errorf("CopierFrom: %w", err)
+		return nil, fmt.Errorf("CopierFrom: %w", err)
 	}
-	return attrs.Etag, nil
+	return &block.UploadPartResponse{
+		ETag: attrs.Etag,
+	}, nil
 }
 
-func (a *Adapter) UploadCopyPartRange(ctx context.Context, sourceObj, destinationObj block.ObjectPointer, uploadID string, partNumber, startPosition, endPosition int64) (string, error) {
+func (a *Adapter) UploadCopyPartRange(ctx context.Context, sourceObj, destinationObj block.ObjectPointer, uploadID string, partNumber, startPosition, endPosition int64) (*block.UploadPartResponse, error) {
 	var err error
 	defer reportMetrics("UploadCopyPartRange", time.Now(), nil, &err)
 	qualifiedKey, err := resolveNamespace(destinationObj)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	uploadID = a.uploadIDTranslator.SetUploadID(uploadID)
 	objName := formatMultipartFilename(uploadID, partNumber)
@@ -350,28 +356,30 @@ func (a *Adapter) UploadCopyPartRange(ctx context.Context, sourceObj, destinatio
 
 	reader, err := a.GetRange(ctx, sourceObj, startPosition, endPosition)
 	if err != nil {
-		return "", fmt.Errorf("GetRange: %w", err)
+		return nil, fmt.Errorf("GetRange: %w", err)
 	}
 	w := o.NewWriter(ctx)
 	_, err = io.Copy(w, reader)
 	if err != nil {
-		return "", fmt.Errorf("Copy: %w", err)
+		return nil, fmt.Errorf("Copy: %w", err)
 	}
 	err = w.Close()
 	if err != nil {
 		_ = reader.Close()
-		return "", fmt.Errorf("WriterClose: %w", err)
+		return nil, fmt.Errorf("WriterClose: %w", err)
 	}
 	err = reader.Close()
 	if err != nil {
-		return "", fmt.Errorf("ReaderClose: %w", err)
+		return nil, fmt.Errorf("ReaderClose: %w", err)
 	}
 
 	attrs, err := o.Attrs(ctx)
 	if err != nil {
-		return "", fmt.Errorf("object.Attrs: %w", err)
+		return nil, fmt.Errorf("object.Attrs: %w", err)
 	}
-	return attrs.Etag, nil
+	return &block.UploadPartResponse{
+		ETag: attrs.Etag,
+	}, nil
 }
 
 func (a *Adapter) AbortMultiPartUpload(ctx context.Context, obj block.ObjectPointer, uploadID string) error {
@@ -405,12 +413,12 @@ func (a *Adapter) AbortMultiPartUpload(ctx context.Context, obj block.ObjectPoin
 	return nil
 }
 
-func (a *Adapter) CompleteMultiPartUpload(ctx context.Context, obj block.ObjectPointer, uploadID string, multipartList *block.MultipartUploadCompletion) (*string, int64, error) {
+func (a *Adapter) CompleteMultiPartUpload(ctx context.Context, obj block.ObjectPointer, uploadID string, multipartList *block.MultipartUploadCompletion) (*block.CompleteMultiPartUploadResponse, error) {
 	var err error
 	defer reportMetrics("CompleteMultiPartUpload", time.Now(), nil, &err)
 	qualifiedKey, err := resolveNamespace(obj)
 	if err != nil {
-		return nil, 0, err
+		return nil, err
 	}
 	uploadID = a.uploadIDTranslator.TranslateUploadID(uploadID)
 	lg := a.log(ctx).WithFields(logging.Fields{
@@ -423,12 +431,12 @@ func (a *Adapter) CompleteMultiPartUpload(ctx context.Context, obj block.ObjectP
 	// list bucket parts and validate request match
 	bucketParts, err := a.listMultipartUploadParts(ctx, qualifiedKey.StorageNamespace, uploadID)
 	if err != nil {
-		return nil, 0, err
+		return nil, err
 	}
 	// validate bucketParts match the request multipartList
 	err = a.validateMultipartUploadParts(uploadID, multipartList, bucketParts)
 	if err != nil {
-		return nil, 0, err
+		return nil, err
 	}
 
 	// prepare names
@@ -441,7 +449,7 @@ func (a *Adapter) CompleteMultiPartUpload(ctx context.Context, obj block.ObjectP
 	targetAttrs, err := a.composeMultipartUploadParts(ctx, qualifiedKey.StorageNamespace, uploadID, parts)
 	if err != nil {
 		lg.WithError(err).Error("CompleteMultipartUpload failed")
-		return nil, 0, err
+		return nil, err
 	}
 
 	// delete marker
@@ -452,7 +460,10 @@ func (a *Adapter) CompleteMultiPartUpload(ctx context.Context, obj block.ObjectP
 	}
 	a.uploadIDTranslator.RemoveUploadID(uploadID)
 	lg.Debug("completed multipart upload")
-	return &targetAttrs.Etag, targetAttrs.Size, nil
+	return &block.CompleteMultiPartUploadResponse{
+		ETag:          targetAttrs.Etag,
+		ContentLength: targetAttrs.Size,
+	}, nil
 }
 
 func (a *Adapter) validateMultipartUploadParts(uploadID string, multipartList *block.MultipartUploadCompletion, bucketParts []*storage.ObjectAttrs) error {
@@ -541,7 +552,7 @@ func (a *Adapter) composeMultipartUploadParts(ctx context.Context, bucketName st
 	return targetAttrs, nil
 }
 
-func (a *Adapter) ValidateConfiguration(ctx context.Context, _ string) error {
+func (a *Adapter) ValidateConfiguration(_ context.Context, _ string) error {
 	return nil
 }
 

--- a/pkg/block/gs/adapter.go
+++ b/pkg/block/gs/adapter.go
@@ -248,6 +248,7 @@ func (a *Adapter) Copy(ctx context.Context, sourceObj, destinationObj block.Obje
 	}
 	return nil
 }
+
 func (a *Adapter) CreateMultiPartUpload(ctx context.Context, obj block.ObjectPointer, r *http.Request, opts block.CreateMultiPartUploadOpts) (*block.CreateMultiPartUploadResponse, error) {
 	var err error
 	defer reportMetrics("CreateMultiPartUpload", time.Now(), nil, &err)

--- a/pkg/block/local/adapter.go
+++ b/pkg/block/local/adapter.go
@@ -402,10 +402,7 @@ func (l *Adapter) CompleteMultiPartUpload(_ context.Context, obj block.ObjectPoi
 func computeETag(parts []*s3.CompletedPart) string {
 	var etagHex []string
 	for _, p := range parts {
-		e := *p.ETag
-		if strings.HasPrefix(e, "\"") && strings.HasSuffix(e, "\"") {
-			e = e[1 : len(e)-1]
-		}
+		e := strings.Trim(*p.ETag, `"`)
 		etagHex = append(etagHex, e)
 	}
 	s := strings.Join(etagHex, "")

--- a/pkg/block/local/adapter.go
+++ b/pkg/block/local/adapter.go
@@ -201,34 +201,44 @@ func (l *Adapter) Copy(_ context.Context, sourceObj, destinationObj block.Object
 	return err
 }
 
-func (l *Adapter) UploadCopyPart(ctx context.Context, sourceObj, destinationObj block.ObjectPointer, uploadID string, partNumber int64) (string, error) {
+func (l *Adapter) UploadCopyPart(ctx context.Context, sourceObj, destinationObj block.ObjectPointer, uploadID string, partNumber int64) (*block.UploadPartResponse, error) {
 	if err := isValidUploadID(uploadID); err != nil {
-		return "", err
+		return nil, err
 	}
 	r, err := l.Get(ctx, sourceObj, 0)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	md5Read := block.NewHashingReader(r, block.HashFunctionMD5)
 	fName := uploadID + fmt.Sprintf("-%05d", partNumber)
 	err = l.Put(ctx, block.ObjectPointer{StorageNamespace: destinationObj.StorageNamespace, Identifier: fName}, -1, md5Read, block.PutOpts{})
-	etag := "\"" + hex.EncodeToString(md5Read.Md5.Sum(nil)) + "\""
-	return etag, err
+	if err != nil {
+		return nil, err
+	}
+	etag := hex.EncodeToString(md5Read.Md5.Sum(nil))
+	return &block.UploadPartResponse{
+		ETag: etag,
+	}, nil
 }
 
-func (l *Adapter) UploadCopyPartRange(ctx context.Context, sourceObj, destinationObj block.ObjectPointer, uploadID string, partNumber, startPosition, endPosition int64) (string, error) {
+func (l *Adapter) UploadCopyPartRange(ctx context.Context, sourceObj, destinationObj block.ObjectPointer, uploadID string, partNumber, startPosition, endPosition int64) (*block.UploadPartResponse, error) {
 	if err := isValidUploadID(uploadID); err != nil {
-		return "", err
+		return nil, err
 	}
 	r, err := l.GetRange(ctx, sourceObj, startPosition, endPosition)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	md5Read := block.NewHashingReader(r, block.HashFunctionMD5)
 	fName := uploadID + fmt.Sprintf("-%05d", partNumber)
 	err = l.Put(ctx, block.ObjectPointer{StorageNamespace: destinationObj.StorageNamespace, Identifier: fName}, -1, md5Read, block.PutOpts{})
-	etag := "\"" + hex.EncodeToString(md5Read.Md5.Sum(nil)) + "\""
-	return etag, err
+	if err != nil {
+		return nil, err
+	}
+	etag := hex.EncodeToString(md5Read.Md5.Sum(nil))
+	return &block.UploadPartResponse{
+		ETag: etag,
+	}, err
 }
 
 func (l *Adapter) Get(_ context.Context, obj block.ObjectPointer, _ int64) (reader io.ReadCloser, err error) {
@@ -320,33 +330,37 @@ func isDirectoryWritable(pth string) bool {
 	return true
 }
 
-func (l *Adapter) CreateMultiPartUpload(_ context.Context, obj block.ObjectPointer, _ *http.Request, _ block.CreateMultiPartUploadOpts) (string, error) {
+func (l *Adapter) CreateMultiPartUpload(_ context.Context, obj block.ObjectPointer, _ *http.Request, _ block.CreateMultiPartUploadOpts) (*block.CreateMultiPartUploadResponse, error) {
 	if strings.Contains(obj.Identifier, "/") {
 		fullPath, err := l.getPath(obj)
 		if err != nil {
-			return "", err
+			return nil, err
 		}
 		fullDir := path.Dir(fullPath)
 		err = os.MkdirAll(fullDir, 0750)
 		if err != nil {
-			return "", err
+			return nil, err
 		}
 	}
 	uidBytes := uuid.New()
 	uploadID := hex.EncodeToString(uidBytes[:])
 	uploadID = l.uploadIDTranslator.SetUploadID(uploadID)
-	return uploadID, nil
+	return &block.CreateMultiPartUploadResponse{
+		UploadID: uploadID,
+	}, nil
 }
 
-func (l *Adapter) UploadPart(ctx context.Context, obj block.ObjectPointer, _ int64, reader io.Reader, uploadID string, partNumber int64) (string, error) {
+func (l *Adapter) UploadPart(ctx context.Context, obj block.ObjectPointer, _ int64, reader io.Reader, uploadID string, partNumber int64) (*block.UploadPartResponse, error) {
 	if err := isValidUploadID(uploadID); err != nil {
-		return "", err
+		return nil, err
 	}
 	md5Read := block.NewHashingReader(reader, block.HashFunctionMD5)
 	fName := uploadID + fmt.Sprintf("-%05d", partNumber)
 	err := l.Put(ctx, block.ObjectPointer{StorageNamespace: obj.StorageNamespace, Identifier: fName}, -1, md5Read, block.PutOpts{})
-	etag := "\"" + hex.EncodeToString(md5Read.Md5.Sum(nil)) + "\""
-	return etag, err
+	etag := hex.EncodeToString(md5Read.Md5.Sum(nil))
+	return &block.UploadPartResponse{
+		ETag: etag,
+	}, err
 }
 
 func (l *Adapter) AbortMultiPartUpload(_ context.Context, obj block.ObjectPointer, uploadID string) error {
@@ -363,23 +377,26 @@ func (l *Adapter) AbortMultiPartUpload(_ context.Context, obj block.ObjectPointe
 	return nil
 }
 
-func (l *Adapter) CompleteMultiPartUpload(_ context.Context, obj block.ObjectPointer, uploadID string, multipartList *block.MultipartUploadCompletion) (*string, int64, error) {
+func (l *Adapter) CompleteMultiPartUpload(_ context.Context, obj block.ObjectPointer, uploadID string, multipartList *block.MultipartUploadCompletion) (*block.CompleteMultiPartUploadResponse, error) {
 	if err := isValidUploadID(uploadID); err != nil {
-		return nil, -1, err
+		return nil, err
 	}
 	etag := computeETag(multipartList.Part) + "-" + strconv.Itoa(len(multipartList.Part))
 	partFiles, err := l.getPartFiles(uploadID, obj)
 	if err != nil {
-		return nil, -1, fmt.Errorf("part files not found for %s: %w", uploadID, err)
+		return nil, fmt.Errorf("part files not found for %s: %w", uploadID, err)
 	}
 	size, err := l.unitePartFiles(obj, partFiles)
 	if err != nil {
-		return nil, -1, fmt.Errorf("multipart upload unite for %s: %w", uploadID, err)
+		return nil, fmt.Errorf("multipart upload unite for %s: %w", uploadID, err)
 	}
 	if err = l.removePartFiles(partFiles); err != nil {
-		return nil, -1, err
+		return nil, err
 	}
-	return &etag, size, nil
+	return &block.CompleteMultiPartUploadResponse{
+		ETag:          etag,
+		ContentLength: size,
+	}, nil
 }
 
 func computeETag(parts []*s3.CompletedPart) string {

--- a/pkg/block/local/adapter_test.go
+++ b/pkg/block/local/adapter_test.go
@@ -105,18 +105,18 @@ func TestLocalMultipartUpload(t *testing.T) {
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
 			pointer := makePointer(c.path)
-			uploadID, err := a.CreateMultiPartUpload(ctx, pointer, nil, block.CreateMultiPartUploadOpts{})
+			resp, err := a.CreateMultiPartUpload(ctx, pointer, nil, block.CreateMultiPartUploadOpts{})
 			testutil.MustDo(t, "CreateMultiPartUpload", err)
 			parts := make([]*s3.CompletedPart, 0)
 			for partNumber, content := range c.partData {
-				cs, err := a.UploadPart(ctx, pointer, 0, strings.NewReader(content), uploadID, int64(partNumber))
+				partResp, err := a.UploadPart(ctx, pointer, 0, strings.NewReader(content), resp.UploadID, int64(partNumber))
 				testutil.MustDo(t, "UploadPart", err)
 				parts = append(parts, &s3.CompletedPart{
-					ETag:       aws.String(cs),
+					ETag:       aws.String(partResp.ETag),
 					PartNumber: aws.Int64(int64(partNumber)),
 				})
 			}
-			_, _, err = a.CompleteMultiPartUpload(ctx, pointer, uploadID, &block.MultipartUploadCompletion{
+			_, err = a.CompleteMultiPartUpload(ctx, pointer, resp.UploadID, &block.MultipartUploadCompletion{
 				Part: parts,
 			})
 			testutil.MustDo(t, "CompleteMultiPartUpload", err)

--- a/pkg/block/s3/adapter.go
+++ b/pkg/block/s3/adapter.go
@@ -168,8 +168,8 @@ func (a *Adapter) UploadPart(ctx context.Context, obj block.ObjectPointer, sizeB
 		return nil, ErrMissingETag
 	}
 	return &block.UploadPartResponse{
-		ETag:   etag,
-		Header: extractAmzServerSideHeader(headers),
+		ETag:             etag,
+		ServerSideHeader: extractAmzServerSideHeader(headers),
 	}, nil
 }
 
@@ -460,8 +460,8 @@ func (a *Adapter) copyPart(ctx context.Context, sourceObj, destinationObj block.
 		}
 	}
 	return &block.UploadPartResponse{
-		ETag:   etag,
-		Header: headers,
+		ETag:             etag,
+		ServerSideHeader: headers,
 	}, nil
 }
 
@@ -533,8 +533,8 @@ func (a *Adapter) CreateMultiPartUpload(ctx context.Context, obj block.ObjectPoi
 		"key":                  obj.Identifier,
 	}).Debug("created multipart upload")
 	return &block.CreateMultiPartUploadResponse{
-		UploadID: uploadID,
-		Header:   extractAmzServerSideHeader(req.HTTPResponse.Header),
+		UploadID:         uploadID,
+		ServerSideHeader: extractAmzServerSideHeader(req.HTTPResponse.Header),
 	}, err
 }
 
@@ -604,9 +604,9 @@ func (a *Adapter) CompleteMultiPartUpload(ctx context.Context, obj block.ObjectP
 	etag := strings.Trim(aws.StringValue(resp.ETag), `"`)
 	contentLength := aws.Int64Value(headResp.ContentLength)
 	return &block.CompleteMultiPartUploadResponse{
-		ETag:          etag,
-		ContentLength: contentLength,
-		Header:        extractAmzServerSideHeader(req.HTTPResponse.Header),
+		ETag:             etag,
+		ContentLength:    contentLength,
+		ServerSideHeader: extractAmzServerSideHeader(req.HTTPResponse.Header),
 	}, nil
 }
 

--- a/pkg/block/s3/adapter.go
+++ b/pkg/block/s3/adapter.go
@@ -168,7 +168,7 @@ func (a *Adapter) UploadPart(ctx context.Context, obj block.ObjectPointer, sizeB
 		return nil, ErrMissingETag
 	}
 	return &block.UploadPartResponse{
-		ETag:             etag,
+		ETag:             strings.Trim(etag, `"`),
 		ServerSideHeader: extractAmzServerSideHeader(headers),
 	}, nil
 }
@@ -451,7 +451,7 @@ func (a *Adapter) copyPart(ctx context.Context, sourceObj, destinationObj block.
 	if resp == nil || resp.CopyPartResult == nil || resp.CopyPartResult.ETag == nil {
 		return nil, ErrMissingETag
 	}
-	etag := strings.Trim(*resp.CopyPartResult.ETag, "\"")
+	etag := strings.Trim(*resp.CopyPartResult.ETag, `"`)
 	// x-amz-server-side-* headers
 	headers := make(http.Header)
 	for k, v := range req.HTTPResponse.Header {

--- a/pkg/block/s3/adapter.go
+++ b/pkg/block/s3/adapter.go
@@ -130,17 +130,25 @@ func (a *Adapter) Put(ctx context.Context, obj block.ObjectPointer, sizeBytes in
 		Key:          aws.String(qualifiedKey.Key),
 		StorageClass: opts.StorageClass,
 	}
-	sdkRequest, _ := a.clients.Get(ctx, qualifiedKey.StorageNamespace).PutObjectRequest(&putObject)
-	_, err = a.streamToS3(ctx, sdkRequest, sizeBytes, reader)
+	client := a.clients.Get(ctx, qualifiedKey.StorageNamespace)
+	sdkRequest, _ := client.PutObjectRequest(&putObject)
+	headers, err := a.streamToS3(ctx, sdkRequest, sizeBytes, reader)
+	if err != nil {
+		return err
+	}
+	etag := headers.Get("ETag")
+	if etag == "" {
+		return ErrMissingETag
+	}
 	return err
 }
 
-func (a *Adapter) UploadPart(ctx context.Context, obj block.ObjectPointer, sizeBytes int64, reader io.Reader, uploadID string, partNumber int64) (string, error) {
+func (a *Adapter) UploadPart(ctx context.Context, obj block.ObjectPointer, sizeBytes int64, reader io.Reader, uploadID string, partNumber int64) (*block.UploadPartResponse, error) {
 	var err error
 	defer reportMetrics("UploadPart", time.Now(), &sizeBytes, &err)
 	qualifiedKey, err := resolveNamespace(obj)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	uploadID = a.uploadIDTranslator.TranslateUploadID(uploadID)
 	uploadPartObject := s3.UploadPartInput{
@@ -149,29 +157,33 @@ func (a *Adapter) UploadPart(ctx context.Context, obj block.ObjectPointer, sizeB
 		PartNumber: aws.Int64(partNumber),
 		UploadId:   aws.String(uploadID),
 	}
-	sdkRequest, _ := a.clients.Get(ctx, qualifiedKey.StorageNamespace).UploadPartRequest(&uploadPartObject)
-	etag, err := a.streamToS3(ctx, sdkRequest, sizeBytes, reader)
-
+	client := a.clients.Get(ctx, qualifiedKey.StorageNamespace)
+	sdkRequest, _ := client.UploadPartRequest(&uploadPartObject)
+	headers, err := a.streamToS3(ctx, sdkRequest, sizeBytes, reader)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
+	etag := headers.Get("ETag")
 	if etag == "" {
-		return "", ErrMissingETag
+		return nil, ErrMissingETag
 	}
-	return etag, nil
+	return &block.UploadPartResponse{
+		ETag:   etag,
+		Header: extractAmzServerSideHeader(headers),
+	}, nil
 }
 
-func (a *Adapter) streamToS3(ctx context.Context, sdkRequest *request.Request, sizeBytes int64, reader io.Reader) (string, error) {
+func (a *Adapter) streamToS3(ctx context.Context, sdkRequest *request.Request, sizeBytes int64, reader io.Reader) (http.Header, error) {
 	sigTime := time.Now()
 	log := a.log(ctx).WithField("operation", "PutObject")
 
 	if err := sdkRequest.Build(); err != nil {
-		return "", err
+		return nil, err
 	}
 
 	req, err := http.NewRequest(sdkRequest.HTTPRequest.Method, sdkRequest.HTTPRequest.URL.String(), nil)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	req.Header.Set("Content-Encoding", StreamingContentEncoding)
 	req.Header.Set("Transfer-Encoding", "chunked")
@@ -184,14 +196,14 @@ func (a *Adapter) streamToS3(ctx context.Context, sdkRequest *request.Request, s
 	_, err = baseSigner.Sign(req, nil, s3.ServiceName, aws.StringValue(sdkRequest.Config.Region), sigTime)
 	if err != nil {
 		log.WithError(err).Error("failed to sign request")
-		return "", err
+		return nil, err
 	}
 	req.Header.Set("Expect", "100-Continue")
 
 	sigSeed, err := v4.GetSignedRequestSignature(req)
 	if err != nil {
 		log.WithError(err).Error("failed to get seed signature")
-		return "", err
+		return nil, err
 	}
 
 	req.Body = io.NopCloser(&StreamingReader{
@@ -212,7 +224,7 @@ func (a *Adapter) streamToS3(ctx context.Context, sdkRequest *request.Request, s
 		log.WithError(err).
 			WithField("url", sdkRequest.HTTPRequest.URL.String()).
 			Error("error making request request")
-		return "", err
+		return nil, err
 	}
 
 	defer func() {
@@ -230,17 +242,11 @@ func (a *Adapter) streamToS3(ctx context.Context, sdkRequest *request.Request, s
 			WithField("url", sdkRequest.HTTPRequest.URL.String()).
 			WithField("status_code", resp.StatusCode).
 			Error("bad S3 PutObject response")
-		return "", err
+		return nil, err
 	}
 
 	a.extractS3Server(resp)
-
-	etag := resp.Header.Get("Etag")
-	// error in case etag is missing - note that empty header value will cause the same error
-	if len(etag) == 0 {
-		return "", ErrMissingETag
-	}
-	return etag, nil
+	return resp.Header, nil
 }
 
 func isErrNotFound(err error) bool {
@@ -261,7 +267,8 @@ func (a *Adapter) Get(ctx context.Context, obj block.ObjectPointer, _ int64) (io
 		Bucket: aws.String(qualifiedKey.StorageNamespace),
 		Key:    aws.String(qualifiedKey.Key),
 	}
-	objectOutput, err := a.clients.Get(ctx, qualifiedKey.StorageNamespace).GetObjectWithContext(ctx, &getObjectInput)
+	client := a.clients.Get(ctx, qualifiedKey.StorageNamespace)
+	objectOutput, err := client.GetObjectWithContext(ctx, &getObjectInput)
 	if isErrNotFound(err) {
 		return nil, adapter.ErrDataNotFound
 	}
@@ -285,7 +292,8 @@ func (a *Adapter) Exists(ctx context.Context, obj block.ObjectPointer) (bool, er
 		Bucket: aws.String(qualifiedKey.StorageNamespace),
 		Key:    aws.String(qualifiedKey.Key),
 	}
-	_, err = a.clients.Get(ctx, qualifiedKey.StorageNamespace).HeadObjectWithContext(ctx, &input)
+	client := a.clients.Get(ctx, qualifiedKey.StorageNamespace)
+	_, err = client.HeadObjectWithContext(ctx, &input)
 	if isErrNotFound(err) {
 		return false, nil
 	}
@@ -310,7 +318,8 @@ func (a *Adapter) GetRange(ctx context.Context, obj block.ObjectPointer, startPo
 		Key:    aws.String(qualifiedKey.Key),
 		Range:  aws.String(fmt.Sprintf("bytes=%d-%d", startPosition, endPosition)),
 	}
-	objectOutput, err := a.clients.Get(ctx, qualifiedKey.StorageNamespace).GetObjectWithContext(ctx, &getObjectInput)
+	client := a.clients.Get(ctx, qualifiedKey.StorageNamespace)
+	objectOutput, err := client.GetObjectWithContext(ctx, &getObjectInput)
 	if isErrNotFound(err) {
 		return nil, adapter.ErrDataNotFound
 	}
@@ -379,7 +388,8 @@ func (a *Adapter) GetProperties(ctx context.Context, obj block.ObjectPointer) (b
 		Bucket: aws.String(qualifiedKey.StorageNamespace),
 		Key:    aws.String(qualifiedKey.Key),
 	}
-	s3Props, err := a.clients.Get(ctx, qualifiedKey.StorageNamespace).HeadObjectWithContext(ctx, headObjectParams)
+	client := a.clients.Get(ctx, qualifiedKey.StorageNamespace)
+	s3Props, err := client.HeadObjectWithContext(ctx, headObjectParams)
 	if err != nil {
 		return block.Properties{}, err
 	}
@@ -410,14 +420,14 @@ func (a *Adapter) Remove(ctx context.Context, obj block.ObjectPointer) error {
 	return err
 }
 
-func (a *Adapter) copyPart(ctx context.Context, sourceObj, destinationObj block.ObjectPointer, uploadID string, partNumber int64, byteRange *string) (string, error) {
+func (a *Adapter) copyPart(ctx context.Context, sourceObj, destinationObj block.ObjectPointer, uploadID string, partNumber int64, byteRange *string) (*block.UploadPartResponse, error) {
 	qualifiedKey, err := resolveNamespace(destinationObj)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	srcKey, err := resolveNamespace(sourceObj)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 
 	uploadID = a.uploadIDTranslator.TranslateUploadID(uploadID)
@@ -431,36 +441,42 @@ func (a *Adapter) copyPart(ctx context.Context, sourceObj, destinationObj block.
 	if byteRange != nil {
 		uploadPartCopyObject.CopySourceRange = byteRange
 	}
-	resp, err := a.clients.Get(ctx, qualifiedKey.StorageNamespace).UploadPartCopyWithContext(ctx, &uploadPartCopyObject)
+	client := a.clients.Get(ctx, qualifiedKey.StorageNamespace)
+	req, resp := client.UploadPartCopyRequest(&uploadPartCopyObject)
+	req.SetContext(ctx)
+	err = req.Send()
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	if resp == nil || resp.CopyPartResult == nil || resp.CopyPartResult.ETag == nil {
-		return "", ErrMissingETag
+		return nil, ErrMissingETag
 	}
-	return strings.Trim(*resp.CopyPartResult.ETag, "\""), nil
+	etag := strings.Trim(*resp.CopyPartResult.ETag, "\"")
+	// x-amz-server-side-* headers
+	headers := make(http.Header)
+	for k, v := range req.HTTPResponse.Header {
+		if strings.HasPrefix(k, "X-Amz-Server-Side-") {
+			headers[k] = v
+		}
+	}
+	return &block.UploadPartResponse{
+		ETag:   etag,
+		Header: headers,
+	}, nil
 }
 
-func (a *Adapter) UploadCopyPart(ctx context.Context, sourceObj, destinationObj block.ObjectPointer, uploadID string, partNumber int64) (string, error) {
+func (a *Adapter) UploadCopyPart(ctx context.Context, sourceObj, destinationObj block.ObjectPointer, uploadID string, partNumber int64) (*block.UploadPartResponse, error) {
 	var err error
 	defer reportMetrics("UploadCopyPart", time.Now(), nil, &err)
-	etag, err := a.copyPart(ctx, sourceObj, destinationObj, uploadID, partNumber, nil)
-	if err != nil {
-		return "", err
-	}
-	return etag, nil
+	return a.copyPart(ctx, sourceObj, destinationObj, uploadID, partNumber, nil)
 }
 
-func (a *Adapter) UploadCopyPartRange(ctx context.Context, sourceObj, destinationObj block.ObjectPointer, uploadID string, partNumber, startPosition, endPosition int64) (string, error) {
+func (a *Adapter) UploadCopyPartRange(ctx context.Context, sourceObj, destinationObj block.ObjectPointer, uploadID string, partNumber, startPosition, endPosition int64) (*block.UploadPartResponse, error) {
 	var err error
 	defer reportMetrics("UploadCopyPartRange", time.Now(), nil, &err)
-	etag, err := a.copyPart(ctx,
+	return a.copyPart(ctx,
 		sourceObj, destinationObj, uploadID, partNumber,
 		aws.String(fmt.Sprintf("bytes=%d-%d", startPosition, endPosition)))
-	if err != nil {
-		return "", err
-	}
-	return etag, nil
 }
 
 func (a *Adapter) Copy(ctx context.Context, sourceObj, destinationObj block.ObjectPointer) error {
@@ -487,12 +503,12 @@ func (a *Adapter) Copy(ctx context.Context, sourceObj, destinationObj block.Obje
 	return err
 }
 
-func (a *Adapter) CreateMultiPartUpload(ctx context.Context, obj block.ObjectPointer, r *http.Request, opts block.CreateMultiPartUploadOpts) (string, error) {
+func (a *Adapter) CreateMultiPartUpload(ctx context.Context, obj block.ObjectPointer, r *http.Request, opts block.CreateMultiPartUploadOpts) (*block.CreateMultiPartUploadResponse, error) {
 	var err error
 	defer reportMetrics("CreateMultiPartUpload", time.Now(), nil, &err)
 	qualifiedKey, err := resolveNamespace(obj)
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	input := &s3.CreateMultipartUploadInput{
 		Bucket:       aws.String(qualifiedKey.StorageNamespace),
@@ -500,9 +516,12 @@ func (a *Adapter) CreateMultiPartUpload(ctx context.Context, obj block.ObjectPoi
 		ContentType:  aws.String(""),
 		StorageClass: opts.StorageClass,
 	}
-	resp, err := a.clients.Get(ctx, qualifiedKey.StorageNamespace).CreateMultipartUploadWithContext(ctx, input)
+	client := a.clients.Get(ctx, qualifiedKey.StorageNamespace)
+	req, resp := client.CreateMultipartUploadRequest(input)
+	req.SetContext(ctx)
+	err = req.Send()
 	if err != nil {
-		return "", err
+		return nil, err
 	}
 	uploadID := *resp.UploadId
 	uploadID = a.uploadIDTranslator.SetUploadID(uploadID)
@@ -513,7 +532,10 @@ func (a *Adapter) CreateMultiPartUpload(ctx context.Context, obj block.ObjectPoi
 		"qualified_key":        qualifiedKey.Key,
 		"key":                  obj.Identifier,
 	}).Debug("created multipart upload")
-	return uploadID, err
+	return &block.CreateMultiPartUploadResponse{
+		UploadID: uploadID,
+		Header:   extractAmzServerSideHeader(req.HTTPResponse.Header),
+	}, err
 }
 
 func (a *Adapter) AbortMultiPartUpload(ctx context.Context, obj block.ObjectPointer, uploadID string) error {
@@ -529,7 +551,8 @@ func (a *Adapter) AbortMultiPartUpload(ctx context.Context, obj block.ObjectPoin
 		Key:      aws.String(qualifiedKey.Key),
 		UploadId: aws.String(uploadID),
 	}
-	_, err = a.clients.Get(ctx, qualifiedKey.StorageNamespace).AbortMultipartUploadWithContext(ctx, input)
+	client := a.clients.Get(ctx, qualifiedKey.StorageNamespace)
+	_, err = client.AbortMultipartUploadWithContext(ctx, input)
 	a.uploadIDTranslator.RemoveUploadID(uploadID)
 	a.log(ctx).WithFields(logging.Fields{
 		"upload_id":     uploadID,
@@ -540,12 +563,12 @@ func (a *Adapter) AbortMultiPartUpload(ctx context.Context, obj block.ObjectPoin
 	return err
 }
 
-func (a *Adapter) CompleteMultiPartUpload(ctx context.Context, obj block.ObjectPointer, uploadID string, multipartList *block.MultipartUploadCompletion) (*string, int64, error) {
+func (a *Adapter) CompleteMultiPartUpload(ctx context.Context, obj block.ObjectPointer, uploadID string, multipartList *block.MultipartUploadCompletion) (*block.CompleteMultiPartUploadResponse, error) {
 	var err error
 	defer reportMetrics("CompleteMultiPartUpload", time.Now(), nil, &err)
 	qualifiedKey, err := resolveNamespace(obj)
 	if err != nil {
-		return nil, 0, err
+		return nil, err
 	}
 	cmpu := &s3.CompletedMultipartUpload{Parts: multipartList.Part}
 	translatedUploadID := a.uploadIDTranslator.TranslateUploadID(uploadID)
@@ -562,22 +585,29 @@ func (a *Adapter) CompleteMultiPartUpload(ctx context.Context, obj block.ObjectP
 		"qualified_key":        qualifiedKey.Key,
 		"key":                  obj.Identifier,
 	})
-	svc := a.clients.Get(ctx, qualifiedKey.StorageNamespace)
-	resp, err := svc.CompleteMultipartUploadWithContext(ctx, input)
-
+	client := a.clients.Get(ctx, qualifiedKey.StorageNamespace)
+	req, resp := client.CompleteMultipartUploadRequest(input)
+	req.SetContext(ctx)
+	err = req.Send()
 	if err != nil {
 		lg.WithError(err).Error("CompleteMultipartUpload failed")
-		return nil, -1, err
+		return nil, err
 	}
 	lg.Debug("completed multipart upload")
 	a.uploadIDTranslator.RemoveUploadID(translatedUploadID)
 	headInput := &s3.HeadObjectInput{Bucket: &qualifiedKey.StorageNamespace, Key: &qualifiedKey.Key}
-	headResp, err := svc.HeadObjectWithContext(ctx, headInput)
+	headResp, err := client.HeadObjectWithContext(ctx, headInput)
 	if err != nil {
-		return nil, -1, err
-	} else {
-		return resp.ETag, *headResp.ContentLength, err
+		return nil, err
 	}
+
+	etag := strings.Trim(aws.StringValue(resp.ETag), `"`)
+	contentLength := aws.Int64Value(headResp.ContentLength)
+	return &block.CompleteMultiPartUploadResponse{
+		ETag:          etag,
+		ContentLength: contentLength,
+		Header:        extractAmzServerSideHeader(req.HTTPResponse.Header),
+	}, nil
 }
 
 func contains(tags []*s3.Tag, pred func(string, string) bool) bool {
@@ -671,4 +701,15 @@ func (a *Adapter) extractS3Server(resp *http.Response) {
 	a.respServerLock.Lock()
 	defer a.respServerLock.Unlock()
 	a.respServer = server
+}
+
+func extractAmzServerSideHeader(header http.Header) http.Header {
+	// return additional headers: x-amz-server-side-*
+	h := make(http.Header)
+	for k, v := range header {
+		if strings.HasPrefix(k, "X-Amz-Server-Side-") {
+			h[k] = v
+		}
+	}
+	return h
 }

--- a/pkg/gateway/operations/base.go
+++ b/pkg/gateway/operations/base.go
@@ -121,9 +121,12 @@ func (o *Operation) DeleteHeader(w http.ResponseWriter, key string) {
 }
 
 // SetHeaders sets a map of headers on the response while preserving the header's case
-func (o *Operation) SetHeaders(w http.ResponseWriter, headers map[string]string) {
+func (o *Operation) SetHeaders(w http.ResponseWriter, headers http.Header) {
+	h := w.Header()
 	for k, v := range headers {
-		o.SetHeader(w, k, v)
+		for _, val := range v {
+			h.Add(k, val)
+		}
 	}
 }
 

--- a/pkg/gateway/operations/mock_adapter_test.go
+++ b/pkg/gateway/operations/mock_adapter_test.go
@@ -61,14 +61,16 @@ func (a *mockAdapter) GetProperties(_ context.Context, _ block.ObjectPointer) (b
 func (a *mockAdapter) Remove(_ context.Context, _ block.ObjectPointer) error {
 	return errors.New("remove method not implemented in mock adapter")
 }
+
 func (a *mockAdapter) Copy(_ context.Context, _, _ block.ObjectPointer) error {
 	return errors.New("copy method not implemented in mock adapter")
 }
-func (a *mockAdapter) CreateMultiPartUpload(_ context.Context, _ block.ObjectPointer, r *http.Request, _ block.CreateMultiPartUploadOpts) (string, error) {
+
+func (a *mockAdapter) CreateMultiPartUpload(_ context.Context, _ block.ObjectPointer, r *http.Request, _ block.CreateMultiPartUploadOpts) (*block.CreateMultiPartUploadResponse, error) {
 	panic("try to create multipart in mock adapter")
 }
 
-func (a *mockAdapter) UploadPart(_ context.Context, _ block.ObjectPointer, sizeBytes int64, reader io.Reader, uploadID string, partNumber int64) (string, error) {
+func (a *mockAdapter) UploadPart(_ context.Context, _ block.ObjectPointer, sizeBytes int64, reader io.Reader, uploadID string, partNumber int64) (*block.UploadPartResponse, error) {
 	panic("try to upload part in mock adapter")
 }
 
@@ -76,15 +78,15 @@ func (a *mockAdapter) AbortMultiPartUpload(_ context.Context, _ block.ObjectPoin
 	panic("try to abort multipart in mock adapter")
 }
 
-func (a *mockAdapter) CompleteMultiPartUpload(_ context.Context, _ block.ObjectPointer, uploadID string, multipartList *block.MultipartUploadCompletion) (*string, int64, error) {
+func (a *mockAdapter) CompleteMultiPartUpload(_ context.Context, _ block.ObjectPointer, uploadID string, multipartList *block.MultipartUploadCompletion) (*block.CompleteMultiPartUploadResponse, error) {
 	panic("try to complete multipart in mock adapter")
 }
 
-func (a *mockAdapter) UploadCopyPart(_ context.Context, _, _ block.ObjectPointer, _ string, _ int64) (string, error) {
+func (a *mockAdapter) UploadCopyPart(_ context.Context, _, _ block.ObjectPointer, _ string, _ int64) (*block.UploadPartResponse, error) {
 	panic("try to upload copy part in mock adapter")
 }
 
-func (a *mockAdapter) UploadCopyPartRange(_ context.Context, _, _ block.ObjectPointer, _ string, _, _, _ int64) (string, error) {
+func (a *mockAdapter) UploadCopyPartRange(_ context.Context, _, _ block.ObjectPointer, _ string, _, _, _ int64) (*block.UploadPartResponse, error) {
 	panic("try to upload copy part range in mock adapter")
 }
 

--- a/pkg/gateway/operations/postobject.go
+++ b/pkg/gateway/operations/postobject.go
@@ -43,15 +43,14 @@ func (controller *PostObject) HandleCreateMultipartUpload(w http.ResponseWriter,
 	objName := hex.EncodeToString(uuidBytes[:])
 	storageClass := StorageClassFromHeader(req.Header)
 	opts := block.CreateMultiPartUploadOpts{StorageClass: storageClass}
-	uploadID, err := o.BlockStore.CreateMultiPartUpload(req.Context(), block.ObjectPointer{StorageNamespace: o.Repository.StorageNamespace, Identifier: objName}, req, opts)
+	resp, err := o.BlockStore.CreateMultiPartUpload(req.Context(), block.ObjectPointer{StorageNamespace: o.Repository.StorageNamespace, Identifier: objName}, req, opts)
 	if err != nil {
 		o.Log(req).WithError(err).Error("could not create multipart upload")
 		_ = o.EncodeError(w, req, gatewayErrors.Codes.ToAPIErr(gatewayErrors.ErrInternalError))
 		return
 	}
-	// uploadID, o.Path, objName, time.Now()
 	mpu := multiparts.MultipartUpload{
-		UploadID:        uploadID,
+		UploadID:        resp.UploadID,
 		Path:            o.Path,
 		CreationDate:    time.Now(),
 		PhysicalAddress: objName,
@@ -64,20 +63,15 @@ func (controller *PostObject) HandleCreateMultipartUpload(w http.ResponseWriter,
 		_ = o.EncodeError(w, req, gatewayErrors.Codes.ToAPIErr(gatewayErrors.ErrInternalError))
 		return
 	}
+	o.SetHeaders(w, resp.Header)
 	o.EncodeResponse(w, req, &serde.InitiateMultipartUploadResult{
 		Bucket:   o.Repository.Name,
 		Key:      path.WithRef(o.Path, o.Reference),
-		UploadID: uploadID,
+		UploadID: resp.UploadID,
 	}, http.StatusOK)
 }
 
-func trimQuotes(s string) string {
-	return strings.Trim(s, "\"")
-}
-
 func (controller *PostObject) HandleCompleteMultipartUpload(w http.ResponseWriter, req *http.Request, o *PathOperation) {
-	var etag *string
-	var size int64
 	o.Incr("complete_mpu")
 	uploadID := req.URL.Query().Get(CompleteMultipartUploadQueryParam)
 	req = req.WithContext(logging.AddFields(req.Context(), logging.Fields{logging.UploadIDFieldKey: uploadID}))
@@ -102,7 +96,7 @@ func (controller *PostObject) HandleCompleteMultipartUpload(w http.ResponseWrite
 		_ = o.EncodeError(w, req, gatewayErrors.Codes.ToAPIErr(gatewayErrors.ErrInternalError))
 		return
 	}
-	etag, size, err = o.BlockStore.CompleteMultiPartUpload(req.Context(),
+	resp, err := o.BlockStore.CompleteMultiPartUpload(req.Context(),
 		block.ObjectPointer{StorageNamespace: o.Repository.StorageNamespace, Identifier: objName},
 		uploadID,
 		&multipartList)
@@ -111,9 +105,8 @@ func (controller *PostObject) HandleCompleteMultipartUpload(w http.ResponseWrite
 		_ = o.EncodeError(w, req, gatewayErrors.Codes.ToAPIErr(gatewayErrors.ErrInternalError))
 		return
 	}
-	ch := trimQuotes(*etag)
-	checksum := strings.Split(ch, "-")[0]
-	err = o.finishUpload(req, checksum, objName, size, true, multiPart.Metadata, multiPart.ContentType)
+	checksum := strings.Split(resp.ETag, "-")[0]
+	err = o.finishUpload(req, checksum, objName, resp.ContentLength, true, multiPart.Metadata, multiPart.ContentType)
 	if errors.Is(err, graveler.ErrWriteToProtectedBranch) {
 		_ = o.EncodeError(w, req, gatewayErrors.Codes.ToAPIErr(gatewayErrors.ErrWriteToProtectedBranch))
 		return
@@ -134,11 +127,12 @@ func (controller *PostObject) HandleCompleteMultipartUpload(w http.ResponseWrite
 	} else {
 		location = fmt.Sprintf("%s://%s/%s/%s/%s", scheme, req.Host, o.Repository.Name, o.Reference, o.Path)
 	}
+	o.SetHeaders(w, resp.Header)
 	o.EncodeResponse(w, req, &serde.CompleteMultipartUploadResult{
 		Location: location,
 		Bucket:   o.Repository.Name,
 		Key:      path.WithRef(o.Path, o.Reference),
-		ETag:     *etag,
+		ETag:     fmt.Sprintf("\"%s\"", resp.ETag),
 	}, http.StatusOK)
 }
 

--- a/pkg/gateway/operations/postobject.go
+++ b/pkg/gateway/operations/postobject.go
@@ -63,7 +63,7 @@ func (controller *PostObject) HandleCreateMultipartUpload(w http.ResponseWriter,
 		_ = o.EncodeError(w, req, gatewayErrors.Codes.ToAPIErr(gatewayErrors.ErrInternalError))
 		return
 	}
-	o.SetHeaders(w, resp.Header)
+	o.SetHeaders(w, resp.ServerSideHeader)
 	o.EncodeResponse(w, req, &serde.InitiateMultipartUploadResult{
 		Bucket:   o.Repository.Name,
 		Key:      path.WithRef(o.Path, o.Reference),
@@ -127,7 +127,7 @@ func (controller *PostObject) HandleCompleteMultipartUpload(w http.ResponseWrite
 	} else {
 		location = fmt.Sprintf("%s://%s/%s/%s/%s", scheme, req.Host, o.Repository.Name, o.Reference, o.Path)
 	}
-	o.SetHeaders(w, resp.Header)
+	o.SetHeaders(w, resp.ServerSideHeader)
 	o.EncodeResponse(w, req, &serde.CompleteMultipartUploadResult{
 		Location: location,
 		Bucket:   o.Repository.Name,

--- a/pkg/gateway/operations/postobject.go
+++ b/pkg/gateway/operations/postobject.go
@@ -132,7 +132,7 @@ func (controller *PostObject) HandleCompleteMultipartUpload(w http.ResponseWrite
 		Location: location,
 		Bucket:   o.Repository.Name,
 		Key:      path.WithRef(o.Path, o.Reference),
-		ETag:     fmt.Sprintf("\"%s\"", resp.ETag),
+		ETag:     httputil.ETag(resp.ETag),
 	}, http.StatusOK)
 }
 

--- a/pkg/gateway/operations/putobject.go
+++ b/pkg/gateway/operations/putobject.go
@@ -203,7 +203,6 @@ func handleUploadPart(w http.ResponseWriter, req *http.Request, o *PathOperation
 			return // operation already failed
 		}
 
-		var etag string
 		src := block.ObjectPointer{
 			StorageNamespace: o.Repository.StorageNamespace,
 			Identifier:       ent.PhysicalAddress,
@@ -214,18 +213,19 @@ func handleUploadPart(w http.ResponseWriter, req *http.Request, o *PathOperation
 			Identifier:       multiPart.PhysicalAddress,
 		}
 
+		var resp *block.UploadPartResponse
 		if rang := req.Header.Get(CopySourceRangeHeader); rang != "" {
 			// if this is a copy part with a byte range:
 			parsedRange, parseErr := ghttp.ParseRange(rang, ent.Size)
 			if parseErr != nil {
 				// invalid range will silently fallback to copying the entire object. ¯\_(ツ)_/¯
-				etag, err = o.BlockStore.UploadCopyPart(req.Context(), src, dst, uploadID, partNumber)
+				resp, err = o.BlockStore.UploadCopyPart(req.Context(), src, dst, uploadID, partNumber)
 			} else {
-				etag, err = o.BlockStore.UploadCopyPartRange(req.Context(), src, dst, uploadID, partNumber, parsedRange.StartOffset, parsedRange.EndOffset)
+				resp, err = o.BlockStore.UploadCopyPartRange(req.Context(), src, dst, uploadID, partNumber, parsedRange.StartOffset, parsedRange.EndOffset)
 			}
 		} else {
 			// normal copy part that accepts another object and no byte range:
-			etag, err = o.BlockStore.UploadCopyPart(req.Context(), src, dst, uploadID, partNumber)
+			resp, err = o.BlockStore.UploadCopyPart(req.Context(), src, dst, uploadID, partNumber)
 		}
 
 		if err != nil {
@@ -236,20 +236,21 @@ func handleUploadPart(w http.ResponseWriter, req *http.Request, o *PathOperation
 
 		o.EncodeResponse(w, req, &serde.CopyObjectResult{
 			LastModified: serde.Timestamp(time.Now()),
-			ETag:         fmt.Sprintf("\"%s\"", etag),
+			ETag:         fmt.Sprintf("\"%s\"", resp.ETag),
 		}, http.StatusOK)
 		return
 	}
 
 	byteSize := req.ContentLength
-	etag, err := o.BlockStore.UploadPart(req.Context(), block.ObjectPointer{StorageNamespace: o.Repository.StorageNamespace, Identifier: multiPart.PhysicalAddress},
+	resp, err := o.BlockStore.UploadPart(req.Context(), block.ObjectPointer{StorageNamespace: o.Repository.StorageNamespace, Identifier: multiPart.PhysicalAddress},
 		byteSize, req.Body, uploadID, partNumber)
 	if err != nil {
 		o.Log(req).WithError(err).Error("part " + partNumberStr + " upload failed")
 		_ = o.EncodeError(w, req, gatewayErrors.Codes.ToAPIErr(gatewayErrors.ErrInternalError))
 		return
 	}
-	o.SetHeader(w, "ETag", etag)
+	o.SetHeaders(w, resp.Header)
+	o.SetHeader(w, "ETag", resp.ETag)
 	w.WriteHeader(http.StatusOK)
 }
 

--- a/pkg/gateway/operations/putobject.go
+++ b/pkg/gateway/operations/putobject.go
@@ -249,7 +249,7 @@ func handleUploadPart(w http.ResponseWriter, req *http.Request, o *PathOperation
 		_ = o.EncodeError(w, req, gatewayErrors.Codes.ToAPIErr(gatewayErrors.ErrInternalError))
 		return
 	}
-	o.SetHeaders(w, resp.Header)
+	o.SetHeaders(w, resp.ServerSideHeader)
 	o.SetHeader(w, "ETag", resp.ETag)
 	w.WriteHeader(http.StatusOK)
 }

--- a/pkg/gateway/operations/putobject.go
+++ b/pkg/gateway/operations/putobject.go
@@ -2,7 +2,6 @@ package operations
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -164,7 +163,7 @@ func handleCopy(w http.ResponseWriter, req *http.Request, o *PathOperation, copy
 
 	o.EncodeResponse(w, req, &serde.CopyObjectResult{
 		LastModified: serde.Timestamp(ent.CreationDate),
-		ETag:         fmt.Sprintf("\"%s\"", ent.Checksum),
+		ETag:         httputil.ETag(ent.Checksum),
 	}, http.StatusOK)
 }
 
@@ -236,7 +235,7 @@ func handleUploadPart(w http.ResponseWriter, req *http.Request, o *PathOperation
 
 		o.EncodeResponse(w, req, &serde.CopyObjectResult{
 			LastModified: serde.Timestamp(time.Now()),
-			ETag:         fmt.Sprintf("\"%s\"", resp.ETag),
+			ETag:         httputil.ETag(resp.ETag),
 		}, http.StatusOK)
 		return
 	}
@@ -250,7 +249,7 @@ func handleUploadPart(w http.ResponseWriter, req *http.Request, o *PathOperation
 		return
 	}
 	o.SetHeaders(w, resp.ServerSideHeader)
-	o.SetHeader(w, "ETag", resp.ETag)
+	o.SetHeader(w, "ETag", httputil.ETag(resp.ETag))
 	w.WriteHeader(http.StatusOK)
 }
 

--- a/pkg/httputil/formats.go
+++ b/pkg/httputil/formats.go
@@ -1,7 +1,7 @@
 package httputil
 
 import (
-	"fmt"
+	"strings"
 	"time"
 )
 
@@ -14,6 +14,9 @@ func HeaderTimestamp(ts time.Time) string {
 	return ts.UTC().Format(DateHeaderTimestampFormat)
 }
 
-func ETag(cksum string) string {
-	return fmt.Sprintf("\"%s\"", cksum)
+func ETag(checksum string) string {
+	if strings.HasPrefix(checksum, `"`) {
+		return checksum
+	}
+	return `"` + checksum + `"`
 }


### PR DESCRIPTION
Fix #2656

Multipart upload ETag calculation is different for s3 bucket when it is encrypted.
AWS S3 send server side headers as part of create/upload part responses so the caller can perform content verification currently.
In this PR:
1. S3 block adapter returns the all server side headers accepted by AWS.
2. Align ETag surrounded with double-quotes. Block adapters accept/return ETag without double-quotes and S3 Gateway is responsible to wrap the value.