### PR TITLE
Look up existing S3 client in cache only once

### DIFF
--- a/pkg/block/s3/client_cache.go
+++ b/pkg/block/s3/client_cache.go
@@ -76,7 +76,8 @@ func (c *ClientCache) getBucketRegion(ctx context.Context, bucket string) string
 // Get returns an AWS client configured to the region of the given bucket.
 func (c *ClientCache) Get(ctx context.Context, bucket string) s3iface.S3API {
 	region := c.getBucketRegion(ctx, bucket)
-	if _, hasClient := c.regionToS3Client.Load(region); !hasClient {
+	svc, hasClient := c.regionToS3Client.Load(region)
+	if !hasClient {
 		logging.FromContext(ctx).WithField("bucket", bucket).WithField("region", region).Debug("creating client for region")
 		svc := c.clientFactory(c.awsSession, &aws.Config{Region: swag.String(region)})
 		c.regionToS3Client.Store(region, svc)
@@ -85,6 +86,5 @@ func (c *ClientCache) Get(ctx context.Context, bucket string) s3iface.S3API {
 		}
 		return svc
 	}
-	svc, _ := c.regionToS3Client.Load(region)
 	return svc.(s3iface.S3API)
 }


### PR DESCRIPTION
The entire cache is heavily optimized to use an existing S3 client -- which
happens moments after that S3 client is first used.  When no client exists,
it races (against itself) to create a new one.  The previous revision might
return a newer client during such a race than this new revision.  But if we
ever *delete* from the cache, it may return a nil.  The newer revision will
never fail in this way.  These races exist in both revisions, are harmless,
and both the older and the newer client will be safe to use.