### PR TITLE
Add request ID fields to all DB and auth logs

### DIFF
--- a/pkg/api/auth_middleware.go
+++ b/pkg/api/auth_middleware.go
@@ -60,6 +60,8 @@ func checkSecurityRequirements(r *http.Request, securityRequirements openapi3.Se
 	ctx := r.Context()
 	var user *model.User
 	var err error
+
+	logger = logger.WithContext(ctx)
 	for _, securityRequirement := range securityRequirements {
 		for provider := range securityRequirement {
 			switch provider {

--- a/pkg/api/serve.go
+++ b/pkg/api/serve.go
@@ -61,11 +61,11 @@ func Serve(
 		OapiRequestValidatorWithOptions(swagger, &openapi3filter.Options{
 			AuthenticationFunc: openapi3filter.NoopAuthenticationFunc,
 		}),
-		AuthMiddleware(logger, swagger, authenticator, authService),
 		httputil.LoggingMiddleware(
 			RequestIDHeaderName,
 			logging.Fields{logging.ServiceNameFieldKey: LoggerServiceName},
 			cfg.GetLoggingTraceRequestHeaders()),
+		AuthMiddleware(logger, swagger, authenticator, authService),
 		MetricsMiddleware(swagger),
 	)
 

--- a/pkg/db/tx.go
+++ b/pkg/db/tx.go
@@ -44,11 +44,13 @@ func queryToString(q string) string {
 func (d *dbTx) Query(query string, args ...interface{}) (pgx.Rows, error) {
 	start := time.Now()
 	rows, err := d.tx.Query(d.ctx, query, args...)
-	log := d.logger.WithFields(logging.Fields{
-		"type":  "query",
-		"args":  args,
-		"query": queryToString(query),
-	})
+	log := d.logger.
+		WithContext(d.ctx).
+		WithFields(logging.Fields{
+			"type":  "query",
+			"args":  args,
+			"query": queryToString(query),
+		})
 	if err != nil {
 		log.WithError(err).Error("SQL query failed with error")
 		return nil, err
@@ -146,9 +148,9 @@ type TxOptions struct {
 	accessMode     pgx.TxAccessMode
 }
 
-func DefaultTxOptions() *TxOptions {
+func DefaultTxOptions(ctx context.Context) *TxOptions {
 	return &TxOptions{
-		logger:         logging.Default(),
+		logger:         logging.Default().WithContext(ctx),
 		isolationLevel: pgx.Serializable,
 		accessMode:     pgx.ReadWrite,
 	}


### PR DESCRIPTION
Partly of #2682.  Most important gap is causing AWS clients (and, less
crucially, Azure and GCP) to log the request ID.