### PR TITLE
Use int64 for StreamingReader size

### DIFF
--- a/pkg/block/s3/adapter.go
+++ b/pkg/block/s3/adapter.go
@@ -208,7 +208,7 @@ func (a *Adapter) streamToS3(ctx context.Context, sdkRequest *request.Request, s
 
 	req.Body = io.NopCloser(&StreamingReader{
 		Reader: reader,
-		Size:   int(sizeBytes),
+		Size:   sizeBytes,
 		Time:   sigTime,
 		StreamSigner: v4.NewStreamSigner(
 			aws.StringValue(sdkRequest.Config.Region),

--- a/pkg/block/s3/stream.go
+++ b/pkg/block/s3/stream.go
@@ -20,14 +20,14 @@ const (
 
 type StreamingReader struct {
 	Reader       io.Reader
-	Size         int
+	Size         int64
 	StreamSigner *v4.StreamSigner
 	Time         time.Time
 	ChunkSize    int
 	ChunkTimeout time.Duration
 
 	currentChunk io.Reader
-	totalRead    int
+	totalRead    int64
 	eof          bool
 }
 
@@ -86,7 +86,7 @@ var ErrReaderTimeout = errors.New("reader timeout")
 func (s *StreamingReader) readNextChunk() error {
 	buf := make([]byte, s.ChunkSize)
 	n, err := ReadAllWithTimeout(s.Reader, buf, s.ChunkTimeout, minChunkSize)
-	s.totalRead += n
+	s.totalRead += int64(n)
 	buf = buf[:n]
 	if err != nil && !isEOF(err) && !errors.Is(err, ErrReaderTimeout) {
 		// actual error happened

--- a/pkg/block/s3/stream_test.go
+++ b/pkg/block/s3/stream_test.go
@@ -108,7 +108,7 @@ func TestS3StreamingReader_Read(t *testing.T) {
 
 			data := &s3a.StreamingReader{
 				Reader:       r,
-				Size:         len(cas.Input),
+				Size:         int64(len(cas.Input)),
 				StreamSigner: v4.NewStreamSigner("us-east-1", s3.ServiceName, sigSeed, keys),
 				Time:         sigTime,
 				ChunkSize:    cas.ChunkSize,


### PR DESCRIPTION
It *can* be used on the API for a large streaming upload.  That will be slow
but must still give a correct result.  (Go has much 64-bit confusion, say in
the `len(...)` return type.)