### PR TITLE
Updated the contribution guide with a note about java on Apple M1

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -42,6 +42,9 @@ Our [Go release workflow](https://github.com/treeverse/lakeFS/blob/master/.githu
    1. [Maven](https://maven.apache.org/) to build and test Spark client codes.
    1. *Optional* - [PostgreSQL 11](https://www.postgresql.org/docs/11/tutorial-install.html) (useful for running and debugging locally)
 
+   * With Apple M1, you can install Java from Oracle, but it will use Rosetta 2, which may result in poor performance.
+   Another option is to use [Azul Zulu Builds for Java JDK](https://www.azul.com/downloads/?package=jdk).
+   
 1. Install statik:
 
    ```shell

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -42,8 +42,7 @@ Our [Go release workflow](https://github.com/treeverse/lakeFS/blob/master/.githu
    1. [Maven](https://maven.apache.org/) to build and test Spark client codes.
    1. *Optional* - [PostgreSQL 11](https://www.postgresql.org/docs/11/tutorial-install.html) (useful for running and debugging locally)
 
-   * With Apple M1, you can install Java from Oracle, but it will use Rosetta 2, which may result in poor performance.
-   Another option is to use [Azul Zulu Builds for Java JDK](https://www.azul.com/downloads/?package=jdk).
+   * With Apple M1, you can use [Azul Zulu Builds for Java JDK](https://www.azul.com/downloads/?package=jdk).
    
 1. Install statik:
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -42,7 +42,7 @@ Our [Go release workflow](https://github.com/treeverse/lakeFS/blob/master/.githu
    1. [Maven](https://maven.apache.org/) to build and test Spark client codes.
    1. *Optional* - [PostgreSQL 11](https://www.postgresql.org/docs/11/tutorial-install.html) (useful for running and debugging locally)
 
-   * With Apple M1, you can use [Azul Zulu Builds for Java JDK](https://www.azul.com/downloads/?package=jdk).
+   * With Apple M1, you can install Java from [Azul Zulu Builds for Java JDK](https://www.azul.com/downloads/?package=jdk).
    
 1. Install statik:
 


### PR DESCRIPTION
close: #2562

Since Java from Oracle is not yet build for M1 Silicon chip yet, we added a note in the contribution guide about options to download java on M1. 