### PR TITLE
Give more chars from body in TRACE logs and make request readable

### DIFF
--- a/pkg/httputil/tracing.go
+++ b/pkg/httputil/tracing.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	MaxBodyBytes                      = 100
+	MaxBodyBytes                      = 750
 	RequestTracingMaxRequestBodySize  = 1024 * 1024 * 50  // 50KB
 	RequestTracingMaxResponseBodySize = 1024 * 1024 * 150 // 150KB
 )
@@ -137,7 +137,6 @@ func TracingMiddleware(requestIDHeaderName string, fields logging.Fields, traceR
 				"took":             time.Since(startTime),
 				"status_code":      responseWriter.StatusCode,
 				"sent_bytes":       responseWriter.ResponseSize,
-				"request_body":     requestBodyTracer.bodyRecorder.Buffer,
 				"response_body":    presentBody(responseWriter.BodyRecorder.Buffer),
 				"response_headers": responseWriter.Header(),
 			}

--- a/pkg/httputil/tracing.go
+++ b/pkg/httputil/tracing.go
@@ -9,7 +9,7 @@ import (
 )
 
 const (
-	MaxBodyBytes                      = 750
+	MaxBodyBytes                      = 750               // Log lines will be < 2KiB
 	RequestTracingMaxRequestBodySize  = 1024 * 1024 * 50  // 50KB
 	RequestTracingMaxResponseBodySize = 1024 * 1024 * 150 // 150KB
 )
@@ -137,6 +137,7 @@ func TracingMiddleware(requestIDHeaderName string, fields logging.Fields, traceR
 				"took":             time.Since(startTime),
 				"status_code":      responseWriter.StatusCode,
 				"sent_bytes":       responseWriter.ResponseSize,
+				"request_body":     presentBody(requestBodyTracer.bodyRecorder.Buffer),
 				"response_body":    presentBody(responseWriter.BodyRecorder.Buffer),
 				"response_headers": responseWriter.Header(),
 			}


### PR DESCRIPTION
Modify API request tracing middleware to give more bytes in the response body string `response_body`.  And trim
away the response byte *numbers*, which merely bloat the logs but are never useful.