### PR TITLE
Auth entity validate not empty

### DIFF
--- a/pkg/auth/model/validation.go
+++ b/pkg/auth/model/validation.go
@@ -14,7 +14,7 @@ var (
 
 func ValidateAuthEntityID(name string) error {
 	if len(name) == 0 {
-		return ErrValidationError
+		return fmt.Errorf("empty name: %w", ErrValidationError)
 	}
 	return nil
 }

--- a/pkg/auth/model/validation.go
+++ b/pkg/auth/model/validation.go
@@ -3,7 +3,6 @@ package model
 import (
 	"errors"
 	"fmt"
-	"regexp"
 
 	"github.com/aws/aws-sdk-go/aws/arn"
 	"github.com/treeverse/lakefs/pkg/permissions"
@@ -11,12 +10,10 @@ import (
 
 var (
 	ErrValidationError = errors.New("validation error")
-
-	EntityIDRegexp = regexp.MustCompile(`^[\w+=.,@\-]{1,127}$`)
 )
 
 func ValidateAuthEntityID(name string) error {
-	if !EntityIDRegexp.MatchString(name) {
+	if len(name) == 0 {
 		return ErrValidationError
 	}
 	return nil


### PR DESCRIPTION
Remove pattern validation for auth entity ID, also known as username.

Part of #2773.