### PR TITLE
Optimize SeekGE in committed iterator

### DIFF
--- a/pkg/graveler/committed/iterator.go
+++ b/pkg/graveler/committed/iterator.go
@@ -136,23 +136,24 @@ func (rvi *iterator) Close() {
 
 func (rvi *iterator) SeekGE(key graveler.Key) {
 	var err error
-	// TODO(ariels): rangesIt might already be on correct range.
-	rvi.rangesIt.SeekGE(Key(key))
-	if err = rvi.rangesIt.Err(); err != nil {
-		rvi.err = err
-		return
-	}
-	if !rvi.NextRange() {
-		return // Reached end.
-	}
-	rvi.started = true // "Started": rangesIt is valid.
-	if bytes.Compare(key, rvi.rng.MinKey) <= 0 {
-		// the given key is before the next range
-		rvi.beforeRange = true
-		return
-	}
-	if !rvi.loadIt() {
-		return
+	if rvi.rng == nil || bytes.Compare(key, rvi.rng.MinKey) < 0 || bytes.Compare(key, rvi.rng.MaxKey) > 0 {
+		rvi.rangesIt.SeekGE(Key(key))
+		if err = rvi.rangesIt.Err(); err != nil {
+			rvi.err = err
+			return
+		}
+		if !rvi.NextRange() {
+			return // Reached end.
+		}
+		rvi.started = true // "Started": rangesIt is valid.
+		if bytes.Compare(key, rvi.rng.MinKey) <= 0 {
+			// the given key is before the next range
+			rvi.beforeRange = true
+			return
+		}
+		if !rvi.loadIt() {
+			return
+		}
 	}
 	rvi.it.SeekGE(key)
 	// Ready to call Next to see values.

--- a/pkg/graveler/committed/iterator.go
+++ b/pkg/graveler/committed/iterator.go
@@ -134,30 +134,30 @@ func (rvi *iterator) Close() {
 	rvi.it.Close()
 }
 
-func (rvi *iterator) loadRange(key graveler.Key) {
+func (rvi *iterator) loadRange(key graveler.Key) bool {
 	rvi.rangesIt.SeekGE(Key(key))
 	if err := rvi.rangesIt.Err(); err != nil {
 		rvi.err = err
-		return
+		return false
 	}
 	if !rvi.NextRange() {
-		return // Reached end.
+		return false // Reached end.
 	}
 	rvi.started = true // "Started": rangesIt is valid.
 	if bytes.Compare(key, rvi.rng.MinKey) <= 0 {
 		// the given key is before the next range
 		rvi.beforeRange = true
-		return
+		return false
 	}
-	if !rvi.loadIt() {
-		return
-	}
+	return rvi.loadIt()
 }
 
 func (rvi *iterator) SeekGE(key graveler.Key) {
 	if rvi.rng == nil || bytes.Compare(key, rvi.rng.MinKey) < 0 || bytes.Compare(key, rvi.rng.MaxKey) > 0 {
 		// no current range, or new key outside current range boundaries
-		rvi.loadRange(key)
+		if !rvi.loadRange(key) {
+			return
+		}
 	}
 	rvi.it.SeekGE(key)
 	// Ready to call Next to see values.

--- a/pkg/graveler/committed/iterator.go
+++ b/pkg/graveler/committed/iterator.go
@@ -141,7 +141,7 @@ func (rvi *iterator) loadRange(key graveler.Key) bool {
 		return false
 	}
 	if !rvi.NextRange() {
-		return false // Reached end.
+		return false // Reached end.3
 	}
 	rvi.started = true // "Started": rangesIt is valid.
 	if bytes.Compare(key, rvi.rng.MinKey) <= 0 {
@@ -153,7 +153,7 @@ func (rvi *iterator) loadRange(key graveler.Key) bool {
 }
 
 func (rvi *iterator) SeekGE(key graveler.Key) {
-	if rvi.rng == nil || bytes.Compare(key, rvi.rng.MinKey) < 0 || bytes.Compare(key, rvi.rng.MaxKey) > 0 {
+	if rvi.rng == nil || rvi.it == nil || bytes.Compare(key, rvi.rng.MinKey) < 0 || bytes.Compare(key, rvi.rng.MaxKey) > 0 {
 		// no current range, or new key outside current range boundaries
 		if !rvi.loadRange(key) {
 			return

--- a/pkg/graveler/committed/iterator.go
+++ b/pkg/graveler/committed/iterator.go
@@ -133,6 +133,7 @@ func (rvi *iterator) Close() {
 	}
 	rvi.it.Close()
 }
+
 func (rvi *iterator) loadRange(key graveler.Key) {
 	rvi.rangesIt.SeekGE(Key(key))
 	if err := rvi.rangesIt.Err(); err != nil {

--- a/pkg/graveler/committed/iterator.go
+++ b/pkg/graveler/committed/iterator.go
@@ -141,7 +141,7 @@ func (rvi *iterator) loadRange(key graveler.Key) bool {
 		return false
 	}
 	if !rvi.NextRange() {
-		return false // Reached end.3
+		return false // Reached end
 	}
 	rvi.started = true // "Started": rangesIt is valid.
 	if bytes.Compare(key, rvi.rng.MinKey) <= 0 {


### PR DESCRIPTION
When seeking multiple times in the same range, do not instantiate a new iterator to the underlying SSTable.