### PR TITLE
lakectl: fix crash when diff is big

### DIFF
--- a/cmd/lakectl/cmd/diff.go
+++ b/cmd/lakectl/cmd/diff.go
@@ -15,7 +15,7 @@ const (
 	diffCmdMaxArgs = 2
 
 	minDiffPageSize = 50
-	maxDiffPageSize = 100000
+	maxDiffPageSize = 1000
 
 	twoWayFlagName = "two-way"
 	diffTypeTwoDot = "two_dot"


### PR DESCRIPTION
`lakectl diff` uses exponentially growing page sizes, starting from 50 and doubling on every page.

The server doesn't allow page size > 1000.
