### PR TITLE
Added branch exsitence check to createMultiPart

### DIFF
--- a/pkg/gateway/operations/postobject.go
+++ b/pkg/gateway/operations/postobject.go
@@ -39,6 +39,17 @@ func (controller *PostObject) RequiredPermissions(_ *http.Request, repoID, _, pa
 
 func (controller *PostObject) HandleCreateMultipartUpload(w http.ResponseWriter, req *http.Request, o *PathOperation) {
 	o.Incr("create_mpu")
+	branchExists, err := o.Catalog.BranchExists(req.Context(), o.Repository.Name, o.Reference)
+	if err != nil {
+		o.Log(req).WithError(err).Error("could not check if branch exists")
+		_ = o.EncodeError(w, req, gatewayErrors.Codes.ToAPIErr(gatewayErrors.ErrInternalError))
+		return
+	}
+	if !branchExists {
+		o.Log(req).Debug("branch not found")
+		_ = o.EncodeError(w, req, gatewayErrors.Codes.ToAPIErr(gatewayErrors.ErrNoSuchBucket))
+		return
+	}
 	uuidBytes := [16]byte(uuid.New())
 	objName := hex.EncodeToString(uuidBytes[:])
 	storageClass := StorageClassFromHeader(req.Header)
@@ -149,18 +160,6 @@ func (controller *PostObject) Handle(w http.ResponseWriter, req *http.Request, o
 	// POST is only supported for CreateMultipartUpload/CompleteMultipartUpload
 	// https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html
 	// https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html
-	branchExists, err := o.Catalog.BranchExists(req.Context(), o.Repository.Name, o.Reference)
-	if err != nil {
-		o.Log(req).WithError(err).Error("could not check if branch exists")
-		_ = o.EncodeError(w, req, gatewayErrors.Codes.ToAPIErr(gatewayErrors.ErrInternalError))
-		return
-	}
-	if !branchExists {
-		o.Log(req).Debug("branch not found")
-		_ = o.EncodeError(w, req, gatewayErrors.Codes.ToAPIErr(gatewayErrors.ErrNoSuchBucket))
-		return
-	}
-
 	_, mpuCreateParamExist := req.URL.Query()[CreateMultipartUploadQueryParam]
 	if mpuCreateParamExist {
 		controller.HandleCreateMultipartUpload(w, req, o)


### PR DESCRIPTION
Comes fixing a bug, when using AWS CLI to copy to a non-existing branch. Initially, Lakefs would begin uploading file parts to the server only to be rejected by the fact the branch does not exist. This creates unnecessary and unwanted work. The fix comes in the form of verifying the branch exists before any action or work is created and not only at the upload phase (which obviously is required in any case).
It is worth noting that in any case, the AWS CLI does do some background work in every copy even if the copy fails. This is non Lakefs related as can be seen in their documentation. To additionally verify this, a cp to a non-existing AWS bucket was done and the results were the same (with no Lakefs involved).
Closes #2509 