### PR TITLE
Fix naming in apply

### DIFF
--- a/pkg/graveler/committed/apply.go
+++ b/pkg/graveler/committed/apply.go
@@ -20,14 +20,14 @@ var ErrInvalidState = errors.New("invalid apply state")
 // ReferenceType represents the type of the reference
 
 type applier struct {
-	ctx                   context.Context
-	logger                logging.Logger
-	writer                MetaRangeWriter
-	source                Iterator
-	diffs                 Iterator
-	opts                  *ApplyOptions
-	summary               graveler.DiffSummary
-	haveDiffs, haveSource bool
+	ctx                     context.Context
+	logger                  logging.Logger
+	writer                  MetaRangeWriter
+	base                    Iterator
+	changes                 Iterator
+	opts                    *ApplyOptions
+	summary                 graveler.DiffSummary
+	haveChanges, haveSource bool
 }
 
 // applyAll applies all changes from Iterator to writer and returns the number of writes
@@ -118,47 +118,47 @@ func (a *applier) incrementDiffSummary(typ graveler.DiffType) {
 }
 
 func (a *applier) apply() error {
-	a.haveSource, a.haveDiffs = a.source.Next(), a.diffs.Next()
-	for a.haveSource && a.haveDiffs {
+	a.haveSource, a.haveChanges = a.base.Next(), a.changes.Next()
+	for a.haveSource && a.haveChanges {
 		select {
 		case <-a.ctx.Done():
 			return a.ctx.Err()
 		default:
 		}
-		sourceValue, sourceRange := a.source.Value()
-		diffValue, diffRange := a.diffs.Value()
+		baseValue, baseRange := a.base.Value()
+		changeValue, changeRange := a.changes.Value()
 		var err error
 		switch {
-		case diffValue == nil && sourceValue == nil:
-			err = a.applyBothRanges(diffRange, sourceRange)
-		case diffValue == nil && sourceValue != nil:
-			err = a.applyDiffRangeSourceKey(diffRange, sourceValue)
-		case sourceValue == nil && diffValue != nil:
-			err = a.applySourceRangeDiffKey(sourceRange, diffValue)
+		case changeValue == nil && baseValue == nil:
+			err = a.applyBothRanges(changeRange, baseRange)
+		case changeValue == nil && baseValue != nil:
+			err = a.applyChangeRangeSourceKey(changeRange, baseValue)
+		case baseValue == nil && changeValue != nil:
+			err = a.applySourceRangeChangeKey(baseRange, changeValue)
 		default:
-			err = a.applyBothKeys(sourceValue, diffValue)
+			err = a.applyBothKeys(baseValue, changeValue)
 		}
 		if err != nil {
 			return err
 		}
 	}
-	if err := a.source.Err(); err != nil {
+	if err := a.base.Err(); err != nil {
 		return err
 	}
-	if err := a.diffs.Err(); err != nil {
+	if err := a.changes.Err(); err != nil {
 		if errors.Is(err, graveler.ErrConflictFound) {
 			a.incrementDiffSummary(graveler.DiffTypeConflict)
 		}
 		return err
 	}
 	if a.haveSource {
-		if _, err := a.applyAll(a.source); err != nil {
+		if _, err := a.applyAll(a.base); err != nil {
 			return err
 		}
 	}
 
-	if a.haveDiffs {
-		numAdded, err := a.applyAll(a.diffs)
+	if a.haveChanges {
+		numAdded, err := a.applyAll(a.changes)
 		if err != nil {
 			return err
 		}
@@ -170,34 +170,34 @@ func (a *applier) apply() error {
 	if !a.opts.AllowEmpty && !a.hasChanges(a.summary) {
 		return graveler.ErrNoChanges
 	}
-	return a.diffs.Err()
+	return a.changes.Err()
 }
 
-func (a *applier) applyBothKeys(sourceValue *graveler.ValueRecord, diffValue *graveler.ValueRecord) error {
-	c := bytes.Compare(sourceValue.Key, diffValue.Key)
+func (a *applier) applyBothKeys(baseValue *graveler.ValueRecord, changeValue *graveler.ValueRecord) error {
+	c := bytes.Compare(baseValue.Key, changeValue.Key)
 	if c < 0 {
-		// select record from source
+		// select record from base
 		if a.logger.IsTracing() {
 			a.logger.WithFields(logging.Fields{
-				"key": string(sourceValue.Key),
-				"ID":  string(sourceValue.Identity),
-			}).Trace("write key from source")
+				"key": string(baseValue.Key),
+				"ID":  string(baseValue.Identity),
+			}).Trace("write key from base")
 		}
-		if err := a.writer.WriteRecord(*sourceValue); err != nil {
-			return fmt.Errorf("write source record: %w", err)
+		if err := a.writer.WriteRecord(*baseValue); err != nil {
+			return fmt.Errorf("write base record: %w", err)
 		}
 	} else {
-		// select record from diffs, possibly (c==0) overwriting source
+		// select record from changes, possibly (c==0) overwriting base
 		switch {
-		case !diffValue.IsTombstone():
+		case !changeValue.IsTombstone():
 			if a.logger.IsTracing() {
 				a.logger.WithFields(logging.Fields{
-					"key":       string(diffValue.Key),
-					"ID":        string(diffValue.Identity),
-					"tombstone": diffValue.IsTombstone(),
-				}).Trace("write key from diffs")
+					"key":       string(changeValue.Key),
+					"ID":        string(changeValue.Identity),
+					"tombstone": changeValue.IsTombstone(),
+				}).Trace("write key from changes")
 			}
-			if err := a.writer.WriteRecord(*diffValue); err != nil {
+			if err := a.writer.WriteRecord(*changeValue); err != nil {
 				return fmt.Errorf("write added record: %w", err)
 			}
 			diffType := graveler.DiffTypeAdded
@@ -208,77 +208,77 @@ func (a *applier) applyBothKeys(sourceValue *graveler.ValueRecord, diffValue *gr
 		case c > 0:
 			// internal error but no data lost: deletion requested of a
 			// file that was not there.
-			a.logger.WithField("id", string(diffValue.Identity)).Warn("[I] unmatched delete")
+			a.logger.WithField("id", string(changeValue.Identity)).Warn("[I] unmatched delete")
 		default:
 			// Delete: simply don't copy to output.
 			a.incrementDiffSummary(graveler.DiffTypeRemoved)
 		}
 	}
 	if c >= 0 {
-		// used up this record from diffs
-		a.haveDiffs = a.diffs.Next()
+		// used up this record from changes
+		a.haveChanges = a.changes.Next()
 	}
 	if c <= 0 {
-		// used up this record from source
-		a.haveSource = a.source.Next()
+		// used up this record from base
+		a.haveSource = a.base.Next()
 	}
 	return nil
 }
 
-func (a *applier) applySourceRangeDiffKey(sourceRange *Range, diffValue *graveler.ValueRecord) error {
-	if bytes.Compare(sourceRange.MaxKey, diffValue.Key) < 0 {
+func (a *applier) applySourceRangeChangeKey(baseRange *Range, changeValue *graveler.ValueRecord) error {
+	if bytes.Compare(baseRange.MaxKey, changeValue.Key) < 0 {
 		// Source at start of range which we do not need to scan --
 		// write and skip that entire range.
 		if a.logger.IsTracing() {
 			a.logger.WithFields(logging.Fields{
-				"from": string(sourceRange.MinKey),
-				"to":   string(sourceRange.MaxKey),
-				"ID":   sourceRange.ID,
-			}).Trace("copy entire source range")
+				"from": string(baseRange.MinKey),
+				"to":   string(baseRange.MaxKey),
+				"ID":   baseRange.ID,
+			}).Trace("copy entire base range")
 		}
 
-		if err := a.writer.WriteRange(*sourceRange); err != nil {
-			return fmt.Errorf("copy source range %s: %w", sourceRange.ID, err)
+		if err := a.writer.WriteRange(*baseRange); err != nil {
+			return fmt.Errorf("copy base range %s: %w", baseRange.ID, err)
 		}
-		a.haveSource = a.source.NextRange()
+		a.haveSource = a.base.NextRange()
 	} else {
 		// Source is at start of range which we need to scan, enter it.
-		a.haveSource = a.source.Next()
+		a.haveSource = a.base.Next()
 	}
 	return nil
 }
 
-func (a *applier) applyDiffRangeSourceKey(diffRange *Range, sourceValue *graveler.ValueRecord) error {
-	if bytes.Compare(diffRange.MinKey, sourceValue.Key) > 0 {
-		// source is before diff range
-		if err := a.writer.WriteRecord(*sourceValue); err != nil {
-			return fmt.Errorf("write source record: %w", err)
+func (a *applier) applyChangeRangeSourceKey(changeRange *Range, baseValue *graveler.ValueRecord) error {
+	if bytes.Compare(changeRange.MinKey, baseValue.Key) > 0 {
+		// base is before change range
+		if err := a.writer.WriteRecord(*baseValue); err != nil {
+			return fmt.Errorf("write base record: %w", err)
 		}
-		a.haveSource = a.source.Next()
+		a.haveSource = a.base.Next()
 		return nil
 	}
-	if bytes.Compare(diffRange.MaxKey, sourceValue.Key) >= 0 {
-		// diffs is at start of range which we need to scan, enter it.
-		a.haveDiffs = a.diffs.Next()
+	if bytes.Compare(changeRange.MaxKey, baseValue.Key) >= 0 {
+		// changes is at start of range which we need to scan, enter it.
+		a.haveChanges = a.changes.Next()
 		return nil
 	}
-	// diffs at start of range which was completely added or removed --
+	// changes at start of range which was completely added or removed --
 	// write and skip that entire range.
-	if diffRange.Tombstone {
-		a.addIntoDiffSummary(graveler.DiffTypeRemoved, int(diffRange.Count))
+	if changeRange.Tombstone {
+		a.addIntoDiffSummary(graveler.DiffTypeRemoved, int(changeRange.Count))
 	} else {
 		if a.logger.IsTracing() {
 			a.logger.WithFields(logging.Fields{
-				"from": string(diffRange.MinKey),
-				"to":   string(diffRange.MaxKey),
-				"ID":   diffRange.ID,
-			}).Trace("copy entire diff range")
+				"from": string(changeRange.MinKey),
+				"to":   string(changeRange.MaxKey),
+				"ID":   changeRange.ID,
+			}).Trace("copy entire change range")
 		}
-		if err := a.writer.WriteRange(*diffRange); err != nil {
-			return fmt.Errorf("copy diff range %s: %w", diffRange.ID, err)
+		if err := a.writer.WriteRange(*changeRange); err != nil {
+			return fmt.Errorf("copy change range %s: %w", changeRange.ID, err)
 		}
-		a.addIntoDiffSummary(graveler.DiffTypeAdded, int(diffRange.Count))
-		a.haveDiffs = a.diffs.NextRange()
+		a.addIntoDiffSummary(graveler.DiffTypeAdded, int(changeRange.Count))
+		a.haveChanges = a.changes.NextRange()
 	}
 	return nil
 }
@@ -308,65 +308,65 @@ func CompareRanges(rangeA, rangeB *Range) RangeCompareSate {
 	}
 }
 
-func (a *applier) applyBothRanges(diffRange *Range, sourceRange *Range) error {
-	comp := CompareRanges(sourceRange, diffRange)
+func (a *applier) applyBothRanges(changeRange *Range, baseRange *Range) error {
+	comp := CompareRanges(baseRange, changeRange)
 	switch comp {
 	case RangeCompareSameID:
-		if !diffRange.Tombstone {
-			return fmt.Errorf("%w - range already exists in apply source", ErrInvalidState)
+		if !changeRange.Tombstone {
+			return fmt.Errorf("%w - range already exists in apply base", ErrInvalidState)
 		}
-		a.addIntoDiffSummary(graveler.DiffTypeRemoved, int(diffRange.Count))
-		a.haveSource = a.source.NextRange()
-		a.haveDiffs = a.diffs.NextRange()
+		a.addIntoDiffSummary(graveler.DiffTypeRemoved, int(changeRange.Count))
+		a.haveSource = a.base.NextRange()
+		a.haveChanges = a.changes.NextRange()
 
 	case RangeCompareSameBounds:
-		// insert diff move both
-		if err := a.writer.WriteRange(*diffRange); err != nil {
-			return fmt.Errorf("copy diff range %s: %w", diffRange.ID, err)
+		// insert change move both
+		if err := a.writer.WriteRange(*changeRange); err != nil {
+			return fmt.Errorf("copy change range %s: %w", changeRange.ID, err)
 		}
-		// When this optimization (inserting the whole range in case base and source are identical) is used. we can't be sure of the diff summary. e.g 4 files added 2 removed or 3 files changed.
+		// When this optimization (inserting the whole range in case base and base are identical) is used. we can't be sure of the diff summary. e.g 4 files added 2 removed or 3 files changed.
 		a.setMissingInfo()
-		a.haveDiffs = a.diffs.NextRange()
-		a.haveSource = a.source.NextRange()
+		a.haveChanges = a.changes.NextRange()
+		a.haveSource = a.base.NextRange()
 
 	case RangeCompareAfter:
-		if diffRange.Tombstone {
+		if changeRange.Tombstone {
 			// internal error but no data lost: deletion requested of a
 			// range that was not there.
 			a.logger.WithFields(logging.Fields{
-				"from": string(diffRange.MinKey),
-				"to":   string(diffRange.MaxKey),
-				"ID":   string(diffRange.ID),
+				"from": string(changeRange.MinKey),
+				"to":   string(changeRange.MaxKey),
+				"ID":   string(changeRange.ID),
 			}).Warn("[I] unmatched delete")
 		} else {
-			// insert diff
-			if err := a.writer.WriteRange(*diffRange); err != nil {
-				return fmt.Errorf("copy diff range %s: %w", diffRange.ID, err)
+			// insert change
+			if err := a.writer.WriteRange(*changeRange); err != nil {
+				return fmt.Errorf("copy change range %s: %w", changeRange.ID, err)
 			}
-			a.addIntoDiffSummary(graveler.DiffTypeAdded, int(diffRange.Count))
+			a.addIntoDiffSummary(graveler.DiffTypeAdded, int(changeRange.Count))
 		}
-		a.haveDiffs = a.diffs.NextRange()
+		a.haveChanges = a.changes.NextRange()
 	case RangeCompareBefore:
-		// insert source
-		if err := a.writer.WriteRange(*sourceRange); err != nil {
-			return fmt.Errorf("copy source range %s: %w", sourceRange.ID, err)
+		// insert base
+		if err := a.writer.WriteRange(*baseRange); err != nil {
+			return fmt.Errorf("copy base range %s: %w", baseRange.ID, err)
 		}
-		a.haveSource = a.source.NextRange()
+		a.haveSource = a.base.NextRange()
 	case RangeCompareOverlapping:
-		a.haveSource = a.source.Next()
-		a.haveDiffs = a.diffs.Next()
+		a.haveSource = a.base.Next()
+		a.haveChanges = a.changes.Next()
 		// enter both
 	}
 	return nil
 }
 
-func Apply(ctx context.Context, writer MetaRangeWriter, source Iterator, diffs Iterator, opts *ApplyOptions) (graveler.DiffSummary, error) {
+func Apply(ctx context.Context, writer MetaRangeWriter, base Iterator, changes Iterator, opts *ApplyOptions) (graveler.DiffSummary, error) {
 	a := applier{
 		ctx:     ctx,
 		logger:  logging.FromContext(ctx),
 		writer:  writer,
-		source:  source,
-		diffs:   diffs,
+		base:    base,
+		changes: changes,
 		opts:    opts,
 		summary: graveler.DiffSummary{Count: make(map[graveler.DiffType]int)},
 	}

--- a/pkg/graveler/committed/apply_test.go
+++ b/pkg/graveler/committed/apply_test.go
@@ -52,7 +52,7 @@ func TestApplyAdd(t *testing.T) {
 	}, summary)
 }
 
-func TestChangeRangesWithinSourceRange(t *testing.T) {
+func TestChangeRangesWithinBaseRange(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -84,7 +84,7 @@ func TestChangeRangesWithinSourceRange(t *testing.T) {
 	}, summary)
 }
 
-func TestSourceRangesWithinChangeRange(t *testing.T) {
+func TestBaseRangesWithinChangeRange(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
@@ -231,7 +231,7 @@ func TestApplyTombstoneNoBase(t *testing.T) {
 		Count: map[graveler.DiffType]int{},
 	}, summary)
 }
-func TestApplyCopiesLeftoverSources(t *testing.T) {
+func TestApplyCopiesLeftoverBase(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 

--- a/pkg/graveler/committed/apply_test.go
+++ b/pkg/graveler/committed/apply_test.go
@@ -25,25 +25,25 @@ func TestApplyAdd(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	source := testutil.NewFakeIterator()
-	source.
+	base := testutil.NewFakeIterator()
+	base.
 		AddRange(&committed.Range{ID: "one", MinKey: committed.Key("a"), MaxKey: committed.Key("cz"), Count: 2}).
-		AddValueRecords(makeV("a", "source:a"), makeV("c", "source:c")).
+		AddValueRecords(makeV("a", "base:a"), makeV("c", "base:c")).
 		AddRange(&committed.Range{ID: "two", MinKey: committed.Key("d"), MaxKey: committed.Key("d"), Count: 1}).
-		AddValueRecords(makeV("d", "source:d"))
-	diffs := testutil.NewFakeIterator()
-	diffs.
+		AddValueRecords(makeV("d", "base:d"))
+	changes := testutil.NewFakeIterator()
+	changes.
 		AddRange(&committed.Range{ID: "b", MinKey: committed.Key("b"), MaxKey: committed.Key("f"), Count: 3}).
 		AddValueRecords(makeV("b", "dest:b"), makeV("e", "dest:e"), makeV("f", "dest:f"))
 	writer := mock.NewMockMetaRangeWriter(ctrl)
-	writer.EXPECT().WriteRecord(gomock.Eq(*makeV("a", "source:a")))
+	writer.EXPECT().WriteRecord(gomock.Eq(*makeV("a", "base:a")))
 	writer.EXPECT().WriteRecord(gomock.Eq(*makeV("b", "dest:b")))
-	writer.EXPECT().WriteRecord(gomock.Eq(*makeV("c", "source:c")))
+	writer.EXPECT().WriteRecord(gomock.Eq(*makeV("c", "base:c")))
 	writer.EXPECT().WriteRange(gomock.Eq(committed.Range{ID: "two", MinKey: committed.Key("d"), MaxKey: committed.Key("d"), Count: 1}))
 	writer.EXPECT().WriteRecord(gomock.Eq(*makeV("e", "dest:e")))
 	writer.EXPECT().WriteRecord(gomock.Eq(*makeV("f", "dest:f")))
 
-	summary, err := committed.Apply(context.Background(), writer, source, diffs, &committed.ApplyOptions{})
+	summary, err := committed.Apply(context.Background(), writer, base, changes, &committed.ApplyOptions{})
 	assert.NoError(t, err)
 	assert.Equal(t, graveler.DiffSummary{
 		Count: map[graveler.DiffType]int{
@@ -52,30 +52,30 @@ func TestApplyAdd(t *testing.T) {
 	}, summary)
 }
 
-func TestDiffRangesWithinSourceRange(t *testing.T) {
+func TestChangeRangesWithinSourceRange(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	source := testutil.NewFakeIterator()
-	source.
+	base := testutil.NewFakeIterator()
+	base.
 		AddRange(&committed.Range{ID: "outer-range", MinKey: committed.Key("k1"), MaxKey: committed.Key("k6"), Count: 2}).
-		AddValueRecords(makeV("k1", "source:k1"), makeV("k6", "source:k6")).
+		AddValueRecords(makeV("k1", "base:k1"), makeV("k6", "base:k6")).
 		AddRange(&committed.Range{ID: "last", MinKey: committed.Key("k10"), MaxKey: committed.Key("k13"), Count: 2}).
-		AddValueRecords(makeV("k10", "source:k10"), makeV("k13", "source:k13"))
-	diffs := testutil.NewFakeIterator()
-	diffs.
+		AddValueRecords(makeV("k10", "base:k10"), makeV("k13", "base:k13"))
+	changes := testutil.NewFakeIterator()
+	changes.
 		AddRange(&committed.Range{ID: "inner-range-1", MinKey: committed.Key("k2"), MaxKey: committed.Key("k3"), Count: 2}).
 		AddValueRecords(makeV("k2", "dest:k2"), makeV("k3", "dest:k3")).
 		AddRange(&committed.Range{ID: "inner-range-2", MinKey: committed.Key("k4"), MaxKey: committed.Key("k5"), Count: 2}).
 		AddValueRecords(makeV("k4", "dest:k4"), makeV("k5", "dest:k5"))
 	writer := mock.NewMockMetaRangeWriter(ctrl)
-	writer.EXPECT().WriteRecord(gomock.Eq(*makeV("k1", "source:k1")))
+	writer.EXPECT().WriteRecord(gomock.Eq(*makeV("k1", "base:k1")))
 	writer.EXPECT().WriteRecord(gomock.Eq(*makeV("k2", "dest:k2")))
 	writer.EXPECT().WriteRecord(gomock.Eq(*makeV("k3", "dest:k3")))
 	writer.EXPECT().WriteRange(gomock.Eq(committed.Range{ID: "inner-range-2", MinKey: committed.Key("k4"), MaxKey: committed.Key("k5"), Count: 2}))
-	writer.EXPECT().WriteRecord(gomock.Eq(*makeV("k6", "source:k6")))
+	writer.EXPECT().WriteRecord(gomock.Eq(*makeV("k6", "base:k6")))
 	writer.EXPECT().WriteRange(gomock.Eq(committed.Range{ID: "last", MinKey: committed.Key("k10"), MaxKey: committed.Key("k13"), Count: 2}))
-	summary, err := committed.Apply(context.Background(), writer, source, diffs, &committed.ApplyOptions{})
+	summary, err := committed.Apply(context.Background(), writer, base, changes, &committed.ApplyOptions{})
 	assert.NoError(t, err)
 	assert.Equal(t, graveler.DiffSummary{
 		Count: map[graveler.DiffType]int{
@@ -84,31 +84,31 @@ func TestDiffRangesWithinSourceRange(t *testing.T) {
 	}, summary)
 }
 
-func TestSourceRangesWithinDiffRange(t *testing.T) {
+func TestSourceRangesWithinChangeRange(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	source := testutil.NewFakeIterator()
-	source.
+	base := testutil.NewFakeIterator()
+	base.
 		AddRange(&committed.Range{ID: "inner-range-1", MinKey: committed.Key("k2"), MaxKey: committed.Key("k3"), Count: 2}).
-		AddValueRecords(makeV("k2", "source:k2"), makeV("k3", "source:k3")).
+		AddValueRecords(makeV("k2", "base:k2"), makeV("k3", "base:k3")).
 		AddRange(&committed.Range{ID: "inner-range-2", MinKey: committed.Key("k4"), MaxKey: committed.Key("k5"), Count: 2}).
-		AddValueRecords(makeV("k4", "source:k4"), makeV("k5", "source:k5"))
+		AddValueRecords(makeV("k4", "base:k4"), makeV("k5", "base:k5"))
 
-	diffs := testutil.NewFakeIterator()
-	diffs.
+	changes := testutil.NewFakeIterator()
+	changes.
 		AddRange(&committed.Range{ID: "outer-range", MinKey: committed.Key("k1"), MaxKey: committed.Key("k6"), Count: 2}).
-		AddValueRecords(makeV("k1", "diffs:k1"), makeV("k6", "diffs:k6")).
+		AddValueRecords(makeV("k1", "changes:k1"), makeV("k6", "changes:k6")).
 		AddRange(&committed.Range{ID: "last", MinKey: committed.Key("k10"), MaxKey: committed.Key("k13"), Count: 2}).
-		AddValueRecords(makeV("k10", "diffs:k10"), makeV("k13", "diffs:k13"))
+		AddValueRecords(makeV("k10", "changes:k10"), makeV("k13", "changes:k13"))
 	writer := mock.NewMockMetaRangeWriter(ctrl)
-	writer.EXPECT().WriteRecord(gomock.Eq(*makeV("k1", "diffs:k1")))
-	writer.EXPECT().WriteRecord(gomock.Eq(*makeV("k2", "source:k2")))
-	writer.EXPECT().WriteRecord(gomock.Eq(*makeV("k3", "source:k3")))
+	writer.EXPECT().WriteRecord(gomock.Eq(*makeV("k1", "changes:k1")))
+	writer.EXPECT().WriteRecord(gomock.Eq(*makeV("k2", "base:k2")))
+	writer.EXPECT().WriteRecord(gomock.Eq(*makeV("k3", "base:k3")))
 	writer.EXPECT().WriteRange(gomock.Eq(committed.Range{ID: "inner-range-2", MinKey: committed.Key("k4"), MaxKey: committed.Key("k5"), Count: 2}))
-	writer.EXPECT().WriteRecord(gomock.Eq(*makeV("k6", "diffs:k6")))
+	writer.EXPECT().WriteRecord(gomock.Eq(*makeV("k6", "changes:k6")))
 	writer.EXPECT().WriteRange(gomock.Eq(committed.Range{ID: "last", MinKey: committed.Key("k10"), MaxKey: committed.Key("k13"), Count: 2}))
-	summary, err := committed.Apply(context.Background(), writer, source, diffs, &committed.ApplyOptions{})
+	summary, err := committed.Apply(context.Background(), writer, base, changes, &committed.ApplyOptions{})
 	assert.NoError(t, err)
 	assert.Equal(t, graveler.DiffSummary{
 		Count: map[graveler.DiffType]int{
@@ -121,27 +121,27 @@ func TestApplyReplace(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	source := testutil.NewFakeIterator()
-	source.
-		AddRange(&committed.Range{ID: "source:one", MinKey: committed.Key("a"), MaxKey: committed.Key("cz"), Count: 3}).
-		AddValueRecords(makeV("a", "source:a"), makeV("b", "source:b"), makeV("c", "source:c")).
+	base := testutil.NewFakeIterator()
+	base.
+		AddRange(&committed.Range{ID: "base:one", MinKey: committed.Key("a"), MaxKey: committed.Key("cz"), Count: 3}).
+		AddValueRecords(makeV("a", "base:a"), makeV("b", "base:b"), makeV("c", "base:c")).
 		AddRange(&committed.Range{ID: "two", MinKey: committed.Key("d"), MaxKey: committed.Key("dz"), Count: 1}).
-		AddValueRecords(makeV("d", "source:d")).
+		AddValueRecords(makeV("d", "base:d")).
 		AddRange(&committed.Range{ID: "three", MinKey: committed.Key("e"), MaxKey: committed.Key("ez"), Count: 1}).
-		AddValueRecords(makeV("e", "source:e"))
-	diffs := testutil.NewFakeIterator()
-	diffs.
-		AddRange(&committed.Range{ID: "diffs:one", MinKey: committed.Key("b"), MaxKey: committed.Key("e"), Count: 2}).
-		AddValueRecords(makeV("b", "diffs:b"), makeV("e", "diffs:e"))
+		AddValueRecords(makeV("e", "base:e"))
+	changes := testutil.NewFakeIterator()
+	changes.
+		AddRange(&committed.Range{ID: "changes:one", MinKey: committed.Key("b"), MaxKey: committed.Key("e"), Count: 2}).
+		AddValueRecords(makeV("b", "changes:b"), makeV("e", "changes:e"))
 
 	writer := mock.NewMockMetaRangeWriter(ctrl)
-	writer.EXPECT().WriteRecord(gomock.Eq(*makeV("a", "source:a")))
-	writer.EXPECT().WriteRecord(gomock.Eq(*makeV("b", "diffs:b")))
-	writer.EXPECT().WriteRecord(gomock.Eq(*makeV("c", "source:c")))
+	writer.EXPECT().WriteRecord(gomock.Eq(*makeV("a", "base:a")))
+	writer.EXPECT().WriteRecord(gomock.Eq(*makeV("b", "changes:b")))
+	writer.EXPECT().WriteRecord(gomock.Eq(*makeV("c", "base:c")))
 	writer.EXPECT().WriteRange(gomock.Eq(committed.Range{ID: "two", MinKey: committed.Key("d"), MaxKey: committed.Key("dz"), Count: 1}))
-	writer.EXPECT().WriteRecord(gomock.Eq(*makeV("e", "diffs:e")))
+	writer.EXPECT().WriteRecord(gomock.Eq(*makeV("e", "changes:e")))
 
-	summary, err := committed.Apply(context.Background(), writer, source, diffs, &committed.ApplyOptions{})
+	summary, err := committed.Apply(context.Background(), writer, base, changes, &committed.ApplyOptions{})
 	assert.NoError(t, err)
 	assert.Equal(t, graveler.DiffSummary{
 		Count: map[graveler.DiffType]int{
@@ -154,24 +154,24 @@ func TestApplyDelete(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	source := testutil.NewFakeIterator()
-	source.
+	base := testutil.NewFakeIterator()
+	base.
 		AddRange(&committed.Range{ID: "one", MinKey: committed.Key("a"), MaxKey: committed.Key("cz"), Count: 3}).
-		AddValueRecords(makeV("a", "source:a"), makeV("b", "source:b"), makeV("c", "source:c")).
+		AddValueRecords(makeV("a", "base:a"), makeV("b", "base:b"), makeV("c", "base:c")).
 		AddRange(&committed.Range{ID: "two", MinKey: committed.Key("d"), MaxKey: committed.Key("dz"), Count: 1}).
-		AddValueRecords(makeV("d", "source:d")).
+		AddValueRecords(makeV("d", "base:d")).
 		AddRange(&committed.Range{ID: "three", MinKey: committed.Key("ez"), MaxKey: committed.Key("ez"), Count: 1}).
-		AddValueRecords(makeV("e", "source:e"))
-	diffs := testutil.NewFakeIterator()
-	diffs.
-		AddRange(&committed.Range{ID: "diffs:one", MinKey: committed.Key("b"), MaxKey: committed.Key("e"), Count: 2}).
+		AddValueRecords(makeV("e", "base:e"))
+	changes := testutil.NewFakeIterator()
+	changes.
+		AddRange(&committed.Range{ID: "changes:one", MinKey: committed.Key("b"), MaxKey: committed.Key("e"), Count: 2}).
 		AddValueRecords(makeTombstoneV("b"), makeTombstoneV("e"))
 	writer := mock.NewMockMetaRangeWriter(ctrl)
-	writer.EXPECT().WriteRecord(gomock.Eq(*makeV("a", "source:a")))
-	writer.EXPECT().WriteRecord(gomock.Eq(*makeV("c", "source:c")))
+	writer.EXPECT().WriteRecord(gomock.Eq(*makeV("a", "base:a")))
+	writer.EXPECT().WriteRecord(gomock.Eq(*makeV("c", "base:c")))
 	writer.EXPECT().WriteRange(gomock.Eq(committed.Range{ID: "two", MinKey: committed.Key("d"), MaxKey: committed.Key("dz"), Count: 1}))
 
-	summary, err := committed.Apply(context.Background(), writer, source, diffs, &committed.ApplyOptions{})
+	summary, err := committed.Apply(context.Background(), writer, base, changes, &committed.ApplyOptions{})
 	assert.NoError(t, err)
 	assert.Equal(t, graveler.DiffSummary{
 		Count: map[graveler.DiffType]int{
@@ -180,29 +180,29 @@ func TestApplyDelete(t *testing.T) {
 	}, summary)
 }
 
-func TestApplyCopiesLeftoverDiffs(t *testing.T) {
+func TestApplyCopiesLeftoverChanges(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	source := testutil.NewFakeIterator()
-	source.
+	base := testutil.NewFakeIterator()
+	base.
 		AddRange(&committed.Range{ID: "one", MinKey: committed.Key("a"), MaxKey: committed.Key("cz"), Count: 3}).
-		AddValueRecords(makeV("a", "source:a"), makeV("b", "source:b"), makeV("c", "source:c")).
+		AddValueRecords(makeV("a", "base:a"), makeV("b", "base:b"), makeV("c", "base:c")).
 		AddRange(&committed.Range{ID: "two", MinKey: committed.Key("d"), MaxKey: committed.Key("dz"), Count: 1}).
-		AddValueRecords(makeV("d", "source:d"))
-	diffs := testutil.NewFakeIterator()
-	diffs.
-		AddRange(&committed.Range{ID: "diffs:one", MinKey: committed.Key("b"), MaxKey: committed.Key("f"), Count: 3}).
-		AddValueRecords(makeV("b", "diffs:b"), makeV("e", "diffs:e"), makeV("f", "diffs:f"))
+		AddValueRecords(makeV("d", "base:d"))
+	changes := testutil.NewFakeIterator()
+	changes.
+		AddRange(&committed.Range{ID: "changes:one", MinKey: committed.Key("b"), MaxKey: committed.Key("f"), Count: 3}).
+		AddValueRecords(makeV("b", "changes:b"), makeV("e", "changes:e"), makeV("f", "changes:f"))
 
 	writer := mock.NewMockMetaRangeWriter(ctrl)
-	writer.EXPECT().WriteRecord(gomock.Eq(*makeV("a", "source:a")))
-	writer.EXPECT().WriteRecord(gomock.Eq(*makeV("b", "diffs:b")))
-	writer.EXPECT().WriteRecord(gomock.Eq(*makeV("c", "source:c")))
+	writer.EXPECT().WriteRecord(gomock.Eq(*makeV("a", "base:a")))
+	writer.EXPECT().WriteRecord(gomock.Eq(*makeV("b", "changes:b")))
+	writer.EXPECT().WriteRecord(gomock.Eq(*makeV("c", "base:c")))
 	writer.EXPECT().WriteRange(gomock.Eq(committed.Range{ID: "two", MinKey: committed.Key("d"), MaxKey: committed.Key("dz"), Count: 1}))
-	writer.EXPECT().WriteRecord(gomock.Eq(*makeV("e", "diffs:e")))
-	writer.EXPECT().WriteRecord(gomock.Eq(*makeV("f", "diffs:f")))
-	summary, err := committed.Apply(context.Background(), writer, source, diffs, &committed.ApplyOptions{})
+	writer.EXPECT().WriteRecord(gomock.Eq(*makeV("e", "changes:e")))
+	writer.EXPECT().WriteRecord(gomock.Eq(*makeV("f", "changes:f")))
+	summary, err := committed.Apply(context.Background(), writer, base, changes, &committed.ApplyOptions{})
 	assert.NoError(t, err)
 	assert.Equal(t, graveler.DiffSummary{
 		Count: map[graveler.DiffType]int{
@@ -216,16 +216,16 @@ func TestApplyTombstoneNoBase(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	source := testutil.NewFakeIterator()
+	base := testutil.NewFakeIterator()
 
-	diffs := testutil.NewFakeIterator()
-	diffs.
-		AddRange(&committed.Range{ID: "diffs:one", MinKey: committed.Key("b"), MaxKey: committed.Key("f"), Count: 3, Tombstone: true}).
+	changes := testutil.NewFakeIterator()
+	changes.
+		AddRange(&committed.Range{ID: "changes:one", MinKey: committed.Key("b"), MaxKey: committed.Key("f"), Count: 3, Tombstone: true}).
 		AddValueRecords(makeTombstoneV("b"), makeTombstoneV("e"), makeTombstoneV("f"))
 
 	writer := mock.NewMockMetaRangeWriter(ctrl)
 
-	summary, err := committed.Apply(context.Background(), writer, source, diffs, &committed.ApplyOptions{})
+	summary, err := committed.Apply(context.Background(), writer, base, changes, &committed.ApplyOptions{})
 	assert.Error(t, err, graveler.ErrNoChanges)
 	assert.Equal(t, graveler.DiffSummary{
 		Count: map[graveler.DiffType]int{},
@@ -238,28 +238,28 @@ func TestApplyCopiesLeftoverSources(t *testing.T) {
 	range1 := &committed.Range{ID: "one", MinKey: committed.Key("a"), MaxKey: committed.Key("cz"), Count: 3}
 	range2 := &committed.Range{ID: "two", MinKey: committed.Key("d"), MaxKey: committed.Key("dz"), Count: 1}
 	range4 := &committed.Range{ID: "four", MinKey: committed.Key("g"), MaxKey: committed.Key("hz"), Count: 2}
-	source := testutil.NewFakeIterator()
-	source.
+	base := testutil.NewFakeIterator()
+	base.
 		AddRange(range1).
-		AddValueRecords(makeV("a", "source:a"), makeV("b", "source:b"), makeV("c", "source:c")).
+		AddValueRecords(makeV("a", "base:a"), makeV("b", "base:b"), makeV("c", "base:c")).
 		AddRange(range2).
-		AddValueRecords(makeV("d", "source:d")).
+		AddValueRecords(makeV("d", "base:d")).
 		AddRange(&committed.Range{ID: "three", MaxKey: committed.Key("ez"), Count: 1}).
-		AddValueRecords(makeV("e", "source:e"), makeV("f", "source:f")).
+		AddValueRecords(makeV("e", "base:e"), makeV("f", "base:f")).
 		AddRange(range4).
-		AddValueRecords(makeV("g", "source:g"), makeV("h", "source:h"))
+		AddValueRecords(makeV("g", "base:g"), makeV("h", "base:h"))
 
-	diffs := testutil.NewValueIteratorFake([]graveler.ValueRecord{
+	changes := testutil.NewValueIteratorFake([]graveler.ValueRecord{
 		*makeTombstoneV("e"),
 	})
 
 	writer := mock.NewMockMetaRangeWriter(ctrl)
 	writer.EXPECT().WriteRange(gomock.Eq(*range1))
 	writer.EXPECT().WriteRange(gomock.Eq(*range2))
-	writer.EXPECT().WriteRecord(gomock.Eq(*makeV("f", "source:f")))
+	writer.EXPECT().WriteRecord(gomock.Eq(*makeV("f", "base:f")))
 	writer.EXPECT().WriteRange(gomock.Eq(*range4))
 
-	summary, err := committed.Apply(context.Background(), writer, source, committed.NewIteratorWrapper(diffs), &committed.ApplyOptions{})
+	summary, err := committed.Apply(context.Background(), writer, base, committed.NewIteratorWrapper(changes), &committed.ApplyOptions{})
 	assert.NoError(t, err)
 	assert.Equal(t, graveler.DiffSummary{
 		Count: map[graveler.DiffType]int{
@@ -274,19 +274,19 @@ func TestApplyNoChangesFails(t *testing.T) {
 
 	range1 := &committed.Range{ID: "one", MinKey: committed.Key("a"), MaxKey: committed.Key("cz"), Count: 3}
 	range2 := &committed.Range{ID: "two", MinKey: committed.Key("d"), MaxKey: committed.Key("dz"), Count: 1}
-	source := testutil.NewFakeIterator()
-	source.
+	base := testutil.NewFakeIterator()
+	base.
 		AddRange(range1).
-		AddValueRecords(makeV("a", "source:a"), makeV("b", "source:b"), makeV("c", "source:c")).
+		AddValueRecords(makeV("a", "base:a"), makeV("b", "base:b"), makeV("c", "base:c")).
 		AddRange(range2).
-		AddValueRecords(makeV("d", "source:d"))
+		AddValueRecords(makeV("d", "base:d"))
 
-	diffs := testutil.NewFakeIterator()
+	changes := testutil.NewFakeIterator()
 
 	writer := mock.NewMockMetaRangeWriter(ctrl)
 	writer.EXPECT().WriteRange(gomock.Any()).AnyTimes()
 
-	_, err := committed.Apply(context.Background(), writer, source, diffs, &committed.ApplyOptions{})
+	_, err := committed.Apply(context.Background(), writer, base, changes, &committed.ApplyOptions{})
 	assert.Error(t, err, graveler.ErrNoChanges)
 }
 
@@ -294,41 +294,41 @@ func TestApplyCancelContext(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 
-	t.Run("source", func(t *testing.T) {
-		source := testutil.NewFakeIterator().
+	t.Run("base", func(t *testing.T) {
+		base := testutil.NewFakeIterator().
 			AddRange(&committed.Range{ID: "one", MinKey: committed.Key("a"), MaxKey: committed.Key("cz"), Count: 2}).
-			AddValueRecords(makeV("a", "source:a"), makeV("c", "source:c"))
-		diffs := testutil.NewFakeIterator()
+			AddValueRecords(makeV("a", "base:a"), makeV("c", "base:c"))
+		changes := testutil.NewFakeIterator()
 		writer := mock.NewMockMetaRangeWriter(ctrl)
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
-		_, err := committed.Apply(ctx, writer, source, diffs, &committed.ApplyOptions{})
+		_, err := committed.Apply(ctx, writer, base, changes, &committed.ApplyOptions{})
 		assert.True(t, errors.Is(err, context.Canceled), "context canceled error")
 	})
 
-	t.Run("diff", func(t *testing.T) {
-		source := testutil.NewFakeIterator()
-		diffs := testutil.NewFakeIterator().
+	t.Run("change", func(t *testing.T) {
+		base := testutil.NewFakeIterator()
+		changes := testutil.NewFakeIterator().
 			AddRange(&committed.Range{ID: "one", MinKey: committed.Key("b"), MaxKey: committed.Key("b"), Count: 1}).
 			AddValueRecords(makeV("b", "dest:b"))
 		writer := mock.NewMockMetaRangeWriter(ctrl)
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
-		_, err := committed.Apply(ctx, writer, source, diffs, &committed.ApplyOptions{})
+		_, err := committed.Apply(ctx, writer, base, changes, &committed.ApplyOptions{})
 		assert.True(t, errors.Is(err, context.Canceled), "context canceled error")
 	})
 
-	t.Run("source_and_diff", func(t *testing.T) {
-		source := testutil.NewFakeIterator().
+	t.Run("base_and_change", func(t *testing.T) {
+		base := testutil.NewFakeIterator().
 			AddRange(&committed.Range{ID: "one", MinKey: committed.Key("a"), MaxKey: committed.Key("cz"), Count: 3}).
-			AddValueRecords(makeV("a", "source:a"), makeV("c", "source:c"))
-		diffs := testutil.NewFakeIterator().
+			AddValueRecords(makeV("a", "base:a"), makeV("c", "base:c"))
+		changes := testutil.NewFakeIterator().
 			AddRange(&committed.Range{ID: "one", MinKey: committed.Key("b"), MaxKey: committed.Key("b"), Count: 1}).
 			AddValueRecords(makeV("b", "dest:b"))
 		writer := mock.NewMockMetaRangeWriter(ctrl)
 		ctx, cancel := context.WithCancel(context.Background())
 		cancel()
-		_, err := committed.Apply(ctx, writer, source, diffs, &committed.ApplyOptions{})
+		_, err := committed.Apply(ctx, writer, base, changes, &committed.ApplyOptions{})
 		assert.True(t, errors.Is(err, context.Canceled), "context canceled error")
 	})
 }

--- a/pkg/graveler/committed/merge_iterator_test.go
+++ b/pkg/graveler/committed/merge_iterator_test.go
@@ -581,7 +581,7 @@ func TestMergeSeek(t *testing.T) {
 	base := makeBaseIterator(baseKeys)
 	ctx := context.Background()
 	it := committed.NewMergeIterator(ctx, committed.NewDiffIteratorWrapper(diffIt), base)
-	// expected diffs, +k1, -k2, Chng:k3,+k7, Conf:k9,
+	// expected changes, +k1, -k2, Chng:k3,+k7, Conf:k9,
 	defer it.Close()
 	tests := []struct {
 		seekTo              string
@@ -846,7 +846,7 @@ func TestMergeSeekWithRange(t *testing.T) {
 		AddValueRecords(makeV("k8", "i8"), makeV("k9", "i9"))
 	ctx := context.Background()
 	it := committed.NewMergeIterator(ctx, diffIt, baseIt)
-	// expected diffs, +k1, -k2, Chng:k3,+k7, Conf:k9,
+	// expected changes, +k1, -k2, Chng:k3,+k7, Conf:k9,
 	defer it.Close()
 	tests := []struct {
 		seekTo             string
@@ -962,7 +962,7 @@ func TestCompareSeek(t *testing.T) {
 	base := makeBaseIterator(baseKeys)
 	ctx := context.Background()
 	it := committed.NewCompareValueIterator(ctx, committed.NewDiffIteratorWrapper(diffIt), base)
-	// expected diffs, +k1, -k2, Chng:k3,+k7, Conf:k9,
+	// expected changes, +k1, -k2, Chng:k3,+k7, Conf:k9,
 	defer it.Close()
 	tests := []struct {
 		seekTo             string

--- a/pkg/graveler/committed/merge_iterator_test.go
+++ b/pkg/graveler/committed/merge_iterator_test.go
@@ -581,7 +581,7 @@ func TestMergeSeek(t *testing.T) {
 	base := makeBaseIterator(baseKeys)
 	ctx := context.Background()
 	it := committed.NewMergeIterator(ctx, committed.NewDiffIteratorWrapper(diffIt), base)
-	// expected changes, +k1, -k2, Chng:k3,+k7, Conf:k9,
+	// expected diffs, +k1, -k2, Chng:k3,+k7, Conf:k9,
 	defer it.Close()
 	tests := []struct {
 		seekTo              string
@@ -846,7 +846,7 @@ func TestMergeSeekWithRange(t *testing.T) {
 		AddValueRecords(makeV("k8", "i8"), makeV("k9", "i9"))
 	ctx := context.Background()
 	it := committed.NewMergeIterator(ctx, diffIt, baseIt)
-	// expected changes, +k1, -k2, Chng:k3,+k7, Conf:k9,
+	// expected diffs, +k1, -k2, Chng:k3,+k7, Conf:k9,
 	defer it.Close()
 	tests := []struct {
 		seekTo             string
@@ -962,7 +962,7 @@ func TestCompareSeek(t *testing.T) {
 	base := makeBaseIterator(baseKeys)
 	ctx := context.Background()
 	it := committed.NewCompareValueIterator(ctx, committed.NewDiffIteratorWrapper(diffIt), base)
-	// expected changes, +k1, -k2, Chng:k3,+k7, Conf:k9,
+	// expected diffs, +k1, -k2, Chng:k3,+k7, Conf:k9,
 	defer it.Close()
 	tests := []struct {
 		seekTo             string


### PR DESCRIPTION
We use confusing terms in the applier:
* We call the commit on which we apply the changes _source_. This is confusing since it's not really a source of anything, and typically in a merge operation this would the merge _destination_. Suggested new name: _base_ (since "base" is also a term in the merge operation this may not be the best name, so I'm open to other suggestions).
* We call the iterator containing the changes _diffs_ - but these are not diffs, these are only the new values and they are not similar to other diffs in our code. Suggested new name: _changes_.