### PR TITLE
Removed '\n' so the output is purely identical to origin when calling Lakectl fs cat

### DIFF
--- a/cmd/lakectl/cmd/fs.go
+++ b/cmd/lakectl/cmd/fs.go
@@ -136,7 +136,7 @@ var fsCatCmd = &cobra.Command{
 			DieOnResponseError(resp, err)
 			contents = resp.Body
 		}
-		Fmt("%s\n", string(contents))
+		Fmt("%s", string(contents))
 	},
 }
 


### PR DESCRIPTION
Fixing a bug that printed a new line to the output, when fs cat was called. This can cause inconsistencies when piping the output for instance into a file. 
This does **not** the issue that the file is fully copied to memory and not piece by piece to a set buffer of fixed length. A separate issue was opened for that. Issue #2846.
Closes #2821 