### PR TITLE
bugfix - applyAll over changes iterator with tombstone record

### DIFF
--- a/pkg/graveler/committed/apply.go
+++ b/pkg/graveler/committed/apply.go
@@ -67,6 +67,8 @@ func (a *applier) applyAll(iter Iterator) (int, error) {
 			}
 		} else {
 			if iterValue.IsTombstone() {
+				// internal error but no data lost: deletion requested of a
+				// file that was not there.
 				if a.logger.IsTracing() {
 					a.logger.WithField("id", string(iterValue.Identity)).Warn("[I] unmatched delete")
 				}

--- a/pkg/graveler/committed/apply.go
+++ b/pkg/graveler/committed/apply.go
@@ -66,22 +66,22 @@ func (a *applier) applyAll(iter Iterator) (int, error) {
 				break
 			}
 		} else {
-			if a.logger.IsTracing() {
-				if iterValue.IsTombstone() {
-					// internal error but no data lost: deletion requested of a
-					// file that was not there.
+			if iterValue.IsTombstone() {
+				if a.logger.IsTracing() {
 					a.logger.WithField("id", string(iterValue.Identity)).Warn("[I] unmatched delete")
-					continue
 				}
-				a.logger.WithFields(logging.Fields{
-					"key": string(iterValue.Key),
-					"ID":  string(iterValue.Identity),
-				}).Trace("write key from iter at end")
+			} else {
+				if a.logger.IsTracing() {
+					a.logger.WithFields(logging.Fields{
+						"key": string(iterValue.Key),
+						"ID":  string(iterValue.Identity),
+					}).Trace("write key from iter at end")
+				}
+				if err := a.writer.WriteRecord(*iterValue); err != nil {
+					return 0, fmt.Errorf("write iter record: %w", err)
+				}
+				count++
 			}
-			if err := a.writer.WriteRecord(*iterValue); err != nil {
-				return 0, fmt.Errorf("write iter record: %w", err)
-			}
-			count++
 			if !iter.Next() {
 				break
 			}

--- a/pkg/graveler/committed/apply_test.go
+++ b/pkg/graveler/committed/apply_test.go
@@ -232,7 +232,7 @@ func TestApplyTombstoneNoBase(t *testing.T) {
 	}, summary)
 }
 
-func TestApplyOverTombstoneChanges(t *testing.T) {
+func TestApplyDeleteNonExistingRecord(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	defer ctrl.Finish()
 


### PR DESCRIPTION
bug:
apply operation
applyAll (over changes iterator because base is over) and we're in the middle of a range (iterValue != nil)
if the record is tombstone and we're not in Log trace
we will write the record instead of skipping it

Added a test to cover this case
 