### PR TITLE
Disable hooks run configuration

### DIFF
--- a/cmd/lakefs/cmd/import.go
+++ b/cmd/lakefs/cmd/import.go
@@ -127,6 +127,7 @@ func runImport(cmd *cobra.Command, args []string) (statusCode int) {
 		catalog.NewActionsSource(c),
 		catalog.NewActionsOutputWriter(c.BlockAdapter),
 		bufferedCollector,
+		cfg.GetActionsEnabled(),
 	)
 	c.SetHooksHandler(actionsService)
 	defer actionsService.Stop()

--- a/cmd/lakefs/cmd/run.go
+++ b/cmd/lakefs/cmd/run.go
@@ -161,7 +161,7 @@ var runCmd = &cobra.Command{
 			catalog.NewActionsSource(c),
 			catalog.NewActionsOutputWriter(c.BlockAdapter),
 			bufferedCollector,
-			cfg.GetActionsDisabled(),
+			cfg.GetActionsEnabled(),
 		)
 		c.SetHooksHandler(actionsService)
 		defer actionsService.Stop()

--- a/cmd/lakefs/cmd/run.go
+++ b/cmd/lakefs/cmd/run.go
@@ -161,6 +161,7 @@ var runCmd = &cobra.Command{
 			catalog.NewActionsSource(c),
 			catalog.NewActionsOutputWriter(c.BlockAdapter),
 			bufferedCollector,
+			cfg.GetActionsDisabled(),
 		)
 		c.SetHooksHandler(actionsService)
 		defer actionsService.Stop()

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -29,12 +29,12 @@ This reference uses `.` to denote the nesting of values.
 * `logging.format` `(one of ["json", "text"] : "text")` - Format to output log message in
 * `logging.level` `(one of ["DEBUG", "INFO", "WARN", "ERROR", "NONE"] : "DEBUG")` - Logging level to output
 * `logging.output` `(string : "-")` - Path name to write logs to. `"-"` means Standard Output
+* `actions.enabled` `(bool : true)` - Setting this to false will block hooks from being executed
 * `database.connection_string` `(string : "postgres://localhost:5432/postgres?sslmode=disable")` - PostgreSQL connection string to use
 * `database.max_open_connections` `(int : 25)` - Maximum number of open connections to the database
 * `database.max_idle_connections` `(int : 25)` - Sets the maximum number of connections in the idle connection pool
 * `database.connection_max_lifetime` `(duration : 5m)` - Sets the maximum amount of time a connection may be reused
 * `listen_address` `(string : "0.0.0.0:8000")` - A `<host>:<port>` structured string representing the address to listen on
-* `actions_disabled` `(bool : false)` - Setting this to true will block hooks from being executed
 * `auth.cache.enabled` `(bool : true)` - Whether to cache access credentials and user policies in-memory. Can greatly improve throughput when enabled.
 * `auth.cache.size` `(int : 1024)` - How many items to store in the auth cache. Systems with a very high user count should use a larger value at the expense of ~1kb of memory per cached user.
 * `auth.cache.ttl` `(time duration : "20s")` - How long to store an item in the auth cache. Using a higher value reduces load on the database, but will cause changes longer to take effect for cached users.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -34,6 +34,7 @@ This reference uses `.` to denote the nesting of values.
 * `database.max_idle_connections` `(int : 25)` - Sets the maximum number of connections in the idle connection pool
 * `database.connection_max_lifetime` `(duration : 5m)` - Sets the maximum amount of time a connection may be reused
 * `listen_address` `(string : "0.0.0.0:8000")` - A `<host>:<port>` structured string representing the address to listen on
+* `actions_disabled` `(bool : false)` - Setting this to true will block hooks from being executed
 * `auth.cache.enabled` `(bool : true)` - Whether to cache access credentials and user policies in-memory. Can greatly improve throughput when enabled.
 * `auth.cache.size` `(int : 1024)` - How many items to store in the auth cache. Systems with a very high user count should use a larger value at the expense of ~1kb of memory per cached user.
 * `auth.cache.ttl` `(time duration : "20s")` - How long to store an item in the auth cache. Using a higher value reduces load on the database, but will cause changes longer to take effect for cached users.

--- a/pkg/api/serve_test.go
+++ b/pkg/api/serve_test.go
@@ -97,6 +97,7 @@ func setupHandler(t testing.TB, blockstoreType string, opts ...testutil.GetDBOpt
 		catalog.NewActionsSource(c),
 		catalog.NewActionsOutputWriter(c.BlockAdapter),
 		collector,
+		true,
 	)
 	c.SetHooksHandler(actionsService)
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -368,6 +368,10 @@ func (c *Config) GetListenAddress() string {
 	return c.values.ListenAddress
 }
 
+func (c *Config) GetActionsDisabled() bool {
+	return c.values.ActionsDisabled
+}
+
 func (c *Config) GetStatsEnabled() bool {
 	return c.values.Stats.Enabled
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -54,6 +54,8 @@ const (
 	DefaultS3GatewayRegion     = "us-east-1"
 	DefaultS3MaxRetries        = 5
 
+	DefaultActionsEnabled = true
+
 	DefaultStatsEnabled       = true
 	DefaultStatsAddr          = "https://stats.treeverse.io"
 	DefaultStatsFlushInterval = time.Second * 30
@@ -110,6 +112,8 @@ const (
 	LoggingLevelKey  = "logging.level"
 	LoggingOutputKey = "logging.output"
 
+	ActionsEnabledKey = "actions.enabled"
+
 	AuthCacheEnabledKey = "auth.cache.enabled"
 	AuthCacheSizeKey    = "auth.cache.size"
 	AuthCacheTTLKey     = "auth.cache.ttl"
@@ -161,6 +165,8 @@ func setDefaults() {
 	viper.SetDefault(LoggingFormatKey, DefaultLoggingFormat)
 	viper.SetDefault(LoggingLevelKey, DefaultLoggingLevel)
 	viper.SetDefault(LoggingOutputKey, DefaultLoggingOutput)
+
+	viper.SetDefault(ActionsEnabledKey, DefaultActionsEnabled)
 
 	viper.SetDefault(AuthCacheEnabledKey, DefaultAuthCacheEnabled)
 	viper.SetDefault(AuthCacheSizeKey, DefaultAuthCacheSize)
@@ -368,8 +374,8 @@ func (c *Config) GetListenAddress() string {
 	return c.values.ListenAddress
 }
 
-func (c *Config) GetActionsDisabled() bool {
-	return c.values.ActionsDisabled
+func (c *Config) GetActionsEnabled() bool {
+	return c.values.Actions.Enabled
 }
 
 func (c *Config) GetStatsEnabled() bool {

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -67,8 +67,10 @@ type S3AuthInfo struct {
 type configuration struct {
 	ListenAddress string `mapstructure:"listen_address"`
 
-	// ActionsDisabled set to true will block any hook execution
-	ActionsDisabled bool `mapstructure:"actions_disabled"`
+	Actions struct {
+		// ActionsEnabled set to false will block any hook execution
+		Enabled bool `mapstructure:"actions_enabled"`
+	}
 
 	Logging struct {
 		Format string `mapstructure:"format"`

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -69,7 +69,7 @@ type configuration struct {
 
 	Actions struct {
 		// ActionsEnabled set to false will block any hook execution
-		Enabled bool `mapstructure:"actions_enabled"`
+		Enabled bool `mapstructure:"enabled"`
 	}
 
 	Logging struct {

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -67,6 +67,9 @@ type S3AuthInfo struct {
 type configuration struct {
 	ListenAddress string `mapstructure:"listen_address"`
 
+	// ActionsDisabled set to true will block any hook execution
+	ActionsDisabled bool `mapstructure:"actions_disabled"`
+
 	Logging struct {
 		Format string `mapstructure:"format"`
 		Level  string `mapstructure:"level"`

--- a/pkg/loadtest/local_load_test.go
+++ b/pkg/loadtest/local_load_test.go
@@ -82,6 +82,7 @@ func TestLocalLoad(t *testing.T) {
 		catalog.NewActionsSource(c),
 		catalog.NewActionsOutputWriter(c.BlockAdapter),
 		&nullCollector{},
+		true,
 	)
 	c.SetHooksHandler(actionsService)
 


### PR DESCRIPTION
closes #2879 
Adding a configuration to disable the execution of hooks. The user can still see the results of old hooks that ran before, when the hooks weren't disabled. Since all API calls and UI views that involved hooks are only for fetching the data, they were not blocked. 
The prefix `_lakefs_actions/...` is still writeable but files uploaded to that path are treated similarly to any other path. A log line indicating that the hooks were skipped as written when appropriate.