### PR TITLE
Feature/parallel commit

### DIFF
--- a/pkg/graveler/committed/meta_range.go
+++ b/pkg/graveler/committed/meta_range.go
@@ -80,6 +80,9 @@ type MetaRangeManager interface {
 	// NewRangeWriter returns a writer that is used for creating new MetaRanges
 	NewWriter(ctx context.Context, ns graveler.StorageNamespace, metadata graveler.Metadata) MetaRangeWriter
 
+	// ShouldBreakByRaggedness returns true if the given key is a breaking point by the raggedness parameter
+	ShouldBreakByRaggedness(key graveler.Key) bool
+
 	// NewMetaRangeIterator returns an Iterator over the MetaRange with id.
 	NewMetaRangeIterator(ctx context.Context, ns graveler.StorageNamespace, metaRangeID graveler.MetaRangeID) (Iterator, error)
 

--- a/pkg/graveler/committed/meta_range_writer_test.go
+++ b/pkg/graveler/committed/meta_range_writer_test.go
@@ -26,6 +26,9 @@ var params = committed.Params{
 	MaxUploaders:               3,
 }
 
+func noBreak(_ graveler.Key) bool {
+	return false
+}
 func TestWriter_WriteRecords(t *testing.T) {
 	ctx := context.Background()
 	ctrl := gomock.NewController(t)
@@ -53,7 +56,8 @@ func TestWriter_WriteRecords(t *testing.T) {
 	rangeManagerMeta := mock.NewMockRangeManager(ctrl)
 	rangeManagerMeta.EXPECT().GetWriter(gomock.Any(), gomock.Any(), gomock.Any()).Return(fakeMetaWriter, nil)
 	namespace := committed.Namespace("ns")
-	w := committed.NewGeneralMetaRangeWriter(ctx, rangeManager, rangeManagerMeta, &params, namespace, nil)
+
+	w := committed.NewGeneralMetaRangeWriter(ctx, rangeManager, rangeManagerMeta, &params, noBreak, namespace, nil)
 
 	// Add first record
 	firstRecord := graveler.ValueRecord{
@@ -104,7 +108,7 @@ func TestWriter_OverlappingRanges(t *testing.T) {
 	namespace := committed.Namespace("ns")
 	rng := committed.Range{MinKey: committed.Key("a"), MaxKey: committed.Key("g")}
 	rng2 := committed.Range{MinKey: committed.Key("c"), MaxKey: committed.Key("l")}
-	w := committed.NewGeneralMetaRangeWriter(ctx, rangeManager, rangeManager, &params, namespace, nil)
+	w := committed.NewGeneralMetaRangeWriter(ctx, rangeManager, rangeManager, &params, noBreak, namespace, nil)
 	err := w.WriteRange(rng)
 	if err != nil {
 		t.Fatalf("unexpected error %s", err)
@@ -164,7 +168,7 @@ func TestWriter_RecordRangeAndClose(t *testing.T) {
 		},
 	}))
 
-	w := committed.NewGeneralMetaRangeWriter(ctx, rangeManager, rangeManagerMeta, &params, namespace, nil)
+	w := committed.NewGeneralMetaRangeWriter(ctx, rangeManager, rangeManagerMeta, &params, noBreak, namespace, nil)
 	err := w.WriteRecord(record)
 	if err != nil {
 		t.Fatalf("unexpected error %s", err)

--- a/pkg/graveler/graveler.go
+++ b/pkg/graveler/graveler.go
@@ -652,6 +652,9 @@ type CommittedManager interface {
 	// it returns a new MetaRangeID that is expected to be immediately addressable
 	Commit(ctx context.Context, ns StorageNamespace, baseMetaRangeID MetaRangeID, changes ValueIterator) (MetaRangeID, DiffSummary, error)
 
+	// GetBreakingPoints returns all the maxKeys of ranges that broke on that maxKey due to raggedness
+	GetBreakingPoints(ctx context.Context, ns StorageNamespace, baseMetaRangeID MetaRangeID) ([]Key, error)
+
 	// GetMetaRange returns information where metarangeID is stored.
 	GetMetaRange(ctx context.Context, ns StorageNamespace, metaRangeID MetaRangeID) (MetaRangeInfo, error)
 	// GetRange returns information where rangeID is stored.
@@ -1301,6 +1304,19 @@ func (g *Graveler) Commit(ctx context.Context, repositoryID RepositoryID, branch
 			Error("Post-commit hook failed")
 	}
 	return newCommitID, nil
+}
+
+func (g *Graveler) getCommitBreakingPoints(ctx context.Context, storageNamespace StorageNamespace, mID MetaRangeID) ([]Key, error) {
+	possibleBreakingPoints, err := g.CommittedManager.GetBreakingPoints(ctx, storageNamespace, mID)
+	if err != nil {
+		return nil, err
+	}
+	// TODO(Guys): implement this
+	// for all breaking points get the breaking points that:
+	// 1. won't be deleted from staging
+	// 2. contains changes introduced in staging
+	_ = possibleBreakingPoints
+	return nil, err
 }
 
 func newStagingToken(repositoryID RepositoryID, branchID BranchID) StagingToken {

--- a/pkg/graveler/staging/manager.go
+++ b/pkg/graveler/staging/manager.go
@@ -80,8 +80,8 @@ func (p *Manager) DropKey(ctx context.Context, st graveler.StagingToken, key gra
 }
 
 // List returns an iterator of staged values on the staging token st
-func (p *Manager) List(ctx context.Context, st graveler.StagingToken, batchSize int) (graveler.ValueIterator, error) {
-	return NewStagingIterator(ctx, p.db, p.log, st, batchSize), nil
+func (p *Manager) List(ctx context.Context, st graveler.StagingToken, batchSize int, from graveler.Key, to graveler.Key) (graveler.ValueIterator, error) {
+	return NewStagingIterator(ctx, p.db, p.log, st, batchSize, from, to), nil
 }
 
 func (p *Manager) Drop(ctx context.Context, st graveler.StagingToken) error {

--- a/pkg/graveler/staging/manager_test.go
+++ b/pkg/graveler/staging/manager_test.go
@@ -87,12 +87,12 @@ func TestDrop(t *testing.T) {
 	if !errors.Is(err, graveler.ErrNotFound) {
 		t.Fatalf("after dropping staging area, expected ErrNotFound in Get. got err=%v, got value=%v", err, v)
 	}
-	it, _ := s.List(ctx, "t1", 0)
+	it, _ := s.List(ctx, "t1", 0, nil, nil)
 	if it.Next() {
 		t.Fatal("expected staging area with token t1 to be empty, got non-empty iterator")
 	}
 	it.Close()
-	it, _ = s.List(ctx, "t2", 0)
+	it, _ = s.List(ctx, "t2", 0, nil, nil)
 	count := 0
 	for it.Next() {
 		if string(it.Value().Data) != fmt.Sprintf("value%d", count) {
@@ -125,7 +125,7 @@ func TestDropByPrefix(t *testing.T) {
 	_, err = s.Get(ctx, "t1", []byte("key0000"))
 	// key0000 does not start with the deleted prefix - should be returned
 	testutil.Must(t, err)
-	it, _ := s.List(ctx, "t1", 0)
+	it, _ := s.List(ctx, "t1", 0, nil, nil)
 	count := 0
 	for it.Next() {
 		count++
@@ -134,7 +134,7 @@ func TestDropByPrefix(t *testing.T) {
 	if count != numOfValues-1000 {
 		t.Errorf("got unexpected number of results after drop. expected=%d, got=%d", numOfValues-1000, count)
 	}
-	it, _ = s.List(ctx, "t2", 0)
+	it, _ = s.List(ctx, "t2", 0, nil, nil)
 	count = 0
 	for it.Next() {
 		count++
@@ -230,7 +230,7 @@ func TestDropPrefixBytes(t *testing.T) {
 			}
 			err := s.DropByPrefix(ctx, st, tst.prefix)
 			testutil.Must(t, err)
-			it, err := s.List(ctx, st, 0)
+			it, err := s.List(ctx, st, 0, nil, nil)
 			testutil.Must(t, err)
 			count := 0
 			for it.Next() {
@@ -256,7 +256,7 @@ func TestList(t *testing.T) {
 			testutil.Must(t, err)
 		}
 		res := make([]*graveler.ValueRecord, 0, numOfValues)
-		it, _ := s.List(ctx, token, 0)
+		it, _ := s.List(ctx, token, 0, nil, nil)
 		for it.Next() {
 			res = append(res, it.Value())
 		}
@@ -285,7 +285,7 @@ func TestSeek(t *testing.T) {
 		err := s.Set(ctx, "t1", []byte(fmt.Sprintf("key%04d", i)), newTestValue("identity1", "value1"), true)
 		testutil.Must(t, err)
 	}
-	it, _ := s.List(ctx, "t1", 0)
+	it, _ := s.List(ctx, "t1", 0, nil, nil)
 	if it.SeekGE([]byte("key0050")); !it.Next() {
 		t.Fatal("iterator seek expected to return true, got false")
 	}
@@ -324,7 +324,7 @@ func TestNilValue(t *testing.T) {
 	if e != nil {
 		t.Errorf("got unexpected value. expected=nil, got=%s", e)
 	}
-	it, err := s.List(ctx, "t1", 0)
+	it, err := s.List(ctx, "t1", 0, nil, nil)
 	testutil.Must(t, err)
 	if !it.Next() {
 		t.Fatalf("expected to get key from list")
@@ -390,7 +390,7 @@ func TestDeleteAndTombstone(t *testing.T) {
 		if string(e.Identity) != "identity1" {
 			t.Fatalf("got unexpected value identity. expected=%s, got=%s", "identity1", string(e.Identity))
 		}
-		it, err := s.List(ctx, "t1", 0)
+		it, err := s.List(ctx, "t1", 0, nil, nil)
 		testutil.Must(t, err)
 		if !it.Next() {
 			t.Fatalf("expected to get key from list")

--- a/pkg/graveler/testutil/fakes.go
+++ b/pkg/graveler/testutil/fakes.go
@@ -155,7 +155,7 @@ func (s *StagingFake) DropKey(_ context.Context, _ graveler.StagingToken, key gr
 	return nil
 }
 
-func (s *StagingFake) List(context.Context, graveler.StagingToken, int) (graveler.ValueIterator, error) {
+func (s *StagingFake) List(context.Context, graveler.StagingToken, int, graveler.Key, graveler.Key) (graveler.ValueIterator, error) {
 	if s.Err != nil {
 		return nil, s.Err
 	}

--- a/pkg/graveler/testutil/fakes.go
+++ b/pkg/graveler/testutil/fakes.go
@@ -27,6 +27,11 @@ type CommittedFake struct {
 	AppliedData   AppliedData
 }
 
+func (c *CommittedFake) GetBreakingPoints(ctx context.Context, ns graveler.StorageNamespace, baseMetaRangeID graveler.MetaRangeID) ([]graveler.Key, error) {
+	// TODO implement me
+	return make([]graveler.Key, 0), nil
+}
+
 type MetaRangeFake struct {
 	id graveler.MetaRangeID
 }


### PR DESCRIPTION
# This is a draft of the first step of parallel commit
It contains the first step of parallel commit which is
- finding valid breaking points - a valid breaking point is a max-key that was chosen due to raggedness, exists in the base commit, and should exist on the commit result 
- support `from` and `to` when listing staged data