### PR TITLE
Remove login hint

### DIFF
--- a/webui/src/pages/auth/login.jsx
+++ b/webui/src/pages/auth/login.jsx
@@ -34,9 +34,6 @@ const LoginForm = () => {
                         }}>
                             <Form.Group controlId="username">
                                 <Form.Control type="text" placeholder="Access Key ID" autoFocus/>
-                                <Form.Text className="text-muted">
-                                    <em>Running lakeFS for the first time? setup initial credentials by running <code>lakefs init</code></em>
-                                </Form.Text>
                             </Form.Group>
 
                             <Form.Group controlId="password">


### PR DESCRIPTION
When you go to the login paged and no setup was done - we automatically redirect to the setup page.
Therefore, we no longer require the suggestion to run `lakefs init`.

Edit: the redirection part was done in #2772 