### PR TITLE
Multipart commit

### DIFF
--- a/pkg/graveler/committed/manager.go
+++ b/pkg/graveler/committed/manager.go
@@ -57,7 +57,7 @@ func (c *committedManager) List(ctx context.Context, ns graveler.StorageNamespac
 }
 
 func (c *committedManager) WriteMetaRange(ctx context.Context, ns graveler.StorageNamespace, it graveler.ValueIterator, metadata graveler.Metadata) (*graveler.MetaRangeID, error) {
-	writer := c.metaRangeManager.NewWriter(ctx, ns, metadata)
+	writer := c.metaRangeManager.NewWriterCloser(ctx, ns, metadata)
 	defer func() {
 		if err := writer.Abort(); err != nil {
 			c.logger.Errorf("Aborting write to meta range: %w", err)
@@ -133,7 +133,7 @@ func (c *committedManager) Merge(ctx context.Context, ns graveler.StorageNamespa
 }
 
 func (c *committedManager) applyOnDiffWithRanges(ctx context.Context, ns graveler.StorageNamespace, rangeID graveler.MetaRangeID, diffs Iterator) (graveler.MetaRangeID, graveler.DiffSummary, error) {
-	mwWriter := c.metaRangeManager.NewWriter(ctx, ns, nil)
+	mwWriter := c.metaRangeManager.NewWriterCloser(ctx, ns, nil)
 	defer func() {
 		err := mwWriter.Abort()
 		if err != nil {
@@ -163,7 +163,7 @@ func (c *committedManager) applyOnDiffWithRanges(ctx context.Context, ns gravele
 }
 
 func (c *committedManager) Commit(ctx context.Context, ns graveler.StorageNamespace, baseMetaRangeID graveler.MetaRangeID, changes graveler.ValueIterator) (graveler.MetaRangeID, graveler.DiffSummary, error) {
-	mwWriter := c.metaRangeManager.NewWriter(ctx, ns, nil)
+	mwWriter := c.metaRangeManager.NewWriterCloser(ctx, ns, nil)
 	defer func() {
 		err := mwWriter.Abort()
 		if err != nil {

--- a/pkg/graveler/committed/manager.go
+++ b/pkg/graveler/committed/manager.go
@@ -6,9 +6,8 @@ import (
 	"errors"
 	"fmt"
 
-	"github.com/treeverse/lakefs/pkg/logging"
-
 	"github.com/treeverse/lakefs/pkg/graveler"
+	"github.com/treeverse/lakefs/pkg/logging"
 )
 
 type committedManager struct {

--- a/pkg/graveler/committed/merge_test.go
+++ b/pkg/graveler/committed/merge_test.go
@@ -596,7 +596,7 @@ func Test_merge(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			defer ctrl.Finish()
 			ctx := context.Background()
-			writer := mock.NewMockMetaRangeWriter(ctrl)
+			writer := mock.NewMockMetaRangeWriterCloser(ctrl)
 			for _, action := range tst.expectedActions {
 				switch action.action {
 				case actionTypeWriteRecord:
@@ -606,7 +606,7 @@ func Test_merge(t *testing.T) {
 				}
 			}
 			metaRangeManager := mock.NewMockMetaRangeManager(ctrl)
-			metaRangeManager.EXPECT().NewWriter(gomock.Any(), gomock.Any(), gomock.Any()).Return(writer)
+			metaRangeManager.EXPECT().NewWriterCloser(gomock.Any(), gomock.Any(), gomock.Any()).Return(writer)
 			sourceKey := graveler.MetaRangeID("source")
 			destKey := graveler.MetaRangeID("dest")
 			baseKey := graveler.MetaRangeID("base")

--- a/pkg/graveler/committed/meta_range_manager.go
+++ b/pkg/graveler/committed/meta_range_manager.go
@@ -82,7 +82,7 @@ func (m *metaRangeManager) GetValue(ctx context.Context, ns graveler.StorageName
 	}, nil
 }
 
-func (m *metaRangeManager) NewWriter(ctx context.Context, ns graveler.StorageNamespace, metadata graveler.Metadata) MetaRangeWriter {
+func (m *metaRangeManager) NewWriterCloser(ctx context.Context, ns graveler.StorageNamespace, metadata graveler.Metadata) MetaRangeWriterCloser {
 	return NewGeneralMetaRangeWriter(ctx,
 		m.rangeManager,
 		m.metaManager,
@@ -92,6 +92,22 @@ func (m *metaRangeManager) NewWriter(ctx context.Context, ns graveler.StorageNam
 		},
 		Namespace(ns),
 		metadata)
+}
+
+func (m *metaRangeManager) NewPartWriterCloser(ctx context.Context, ns graveler.StorageNamespace, metadata graveler.Metadata) MetaRangeWriterPartCloser {
+	return NewGeneralMetaRangeWriterPartCloser(ctx,
+		m.rangeManager,
+		m.metaManager,
+		&m.params,
+		func(key graveler.Key) bool {
+			return breakByRaggedness(m.params.RangeSizeEntriesRaggedness, key)
+		},
+		Namespace(ns),
+		metadata)
+}
+
+func (m *metaRangeManager) CompleteMultipartMetaRange(ctx context.Context, namespace Namespace, metadata graveler.Metadata, ranges []Range) (*graveler.MetaRangeID, error) {
+	return CompleteMultipartMetaRange(ctx, namespace, metadata, m.rangeManager, ranges)
 }
 
 func (m *metaRangeManager) ShouldBreakByRaggedness(key graveler.Key) bool {

--- a/pkg/graveler/committed/multipart_commit.go
+++ b/pkg/graveler/committed/multipart_commit.go
@@ -1,0 +1,217 @@
+package committed
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/treeverse/lakefs/pkg/graveler"
+	"github.com/treeverse/lakefs/pkg/logging"
+)
+
+type result struct {
+	ranges  []Range
+	summary graveler.DiffSummary
+}
+
+type multipartCommitter struct {
+	ctx    context.Context
+	logger logging.Logger
+
+	parts   []graveler.MultipartCommitPartData
+	opts    *CommitOptions
+	summary graveler.DiffSummary
+
+	resCh            chan result
+	errorCh          chan error
+	commitPartDataCh chan graveler.MultipartCommitPartData
+	numOfWorkers     int
+	namespace        Namespace
+	baseMetarangeID  graveler.MetaRangeID
+	metaRangeManager MetaRangeManager
+}
+
+func (m *multipartCommitter) commitPart(part graveler.MultipartCommitPartData) ([]Range, graveler.DiffSummary, error) {
+	mwWriter := m.metaRangeManager.NewPartWriterCloser(m.ctx, graveler.StorageNamespace(m.namespace), nil)
+	defer func() {
+		err := mwWriter.Abort()
+		if err != nil {
+			logging.Default().WithError(err).Error("Abort failed after Commit")
+		}
+	}()
+	metaRangeIterator, err := m.metaRangeManager.NewMetaRangeIterator(m.ctx, graveler.StorageNamespace(m.namespace), m.baseMetarangeID)
+	boundedIterator := NewTempWrapperBoundedIterator(metaRangeIterator, part.From, part.To)
+	summary := graveler.DiffSummary{
+		Count: map[graveler.DiffType]int{},
+	}
+	if err != nil {
+		return nil, summary, fmt.Errorf("get metarange ns=%s id=%s: %w", m.namespace, m.baseMetarangeID, err)
+	}
+	defer metaRangeIterator.Close()
+	// TODO(Guys): change to multipart
+	summary, err = Commit(m.ctx, mwWriter, boundedIterator, part.Changes, &CommitOptions{})
+	if err != nil {
+		if !errors.Is(err, graveler.ErrUserVisible) {
+			err = fmt.Errorf("commit ns=%s id=%s: %w", m.namespace, m.baseMetarangeID, err)
+		}
+		return nil, summary, err
+	}
+	ranges, err := mwWriter.ClosePart()
+	if err != nil {
+		return nil, summary, err
+	}
+	return ranges, summary, err
+}
+
+func (m *multipartCommitter) worker(jobsChan chan graveler.MultipartCommitPartData, resChan chan result, errChan chan error) {
+	for j := range jobsChan {
+		ranges, summary, err := m.commitPart(j)
+		if err != nil {
+			errChan <- err
+		} else {
+			resChan <- result{
+				ranges:  ranges,
+				summary: summary,
+			}
+		}
+	}
+}
+
+func (m *multipartCommitter) commit() (graveler.MetaRangeID, graveler.DiffSummary, error) {
+	// init channels
+	m.errorCh = make(chan error)
+	m.resCh = make(chan result)
+	m.commitPartDataCh = make(chan graveler.MultipartCommitPartData)
+	defer func() {
+		close(m.resCh)
+		close(m.errorCh)
+		close(m.commitPartDataCh)
+	}()
+	// init workers
+	for i := 0; i <= m.numOfWorkers; i++ {
+		go m.worker(m.commitPartDataCh, m.resCh, m.errorCh)
+	}
+
+	newParts := make([]graveler.MultipartCommitPartData, 0)
+	for _, part := range m.parts {
+		if part.Changes != nil {
+			newParts = append(newParts, part)
+		}
+	}
+	// goroutine to send all jobs
+	go func(ctx context.Context, parts []graveler.MultipartCommitPartData) {
+		for _, part := range parts {
+			select {
+			case <-ctx.Done():
+				return
+			default:
+			}
+			fmt.Printf("sending part from: %s to:%s changes:%s\n", part.From, part.To, part.Changes)
+			if part.Changes == nil {
+				fmt.Printf("Not sure what happened from %s to %s\n", part.From, part.To)
+			} else {
+				m.commitPartDataCh <- part
+			}
+		}
+	}(m.ctx, newParts)
+
+	ranges := make([]Range, 0)
+	var summary graveler.DiffSummary
+	summary.Count = make(map[graveler.DiffType]int, 4) // TODO(Guys): change
+	fmt.Printf("newParts length is %d\n", len(newParts))
+	for i := 0; i < len(newParts); i++ {
+		select {
+		case r := <-m.resCh:
+			fmt.Printf("%d:Adding %d ranges\n", i, len(r.ranges))
+			ranges = append(ranges, r.ranges...)
+			summary.Incomplete = summary.Incomplete || r.summary.Incomplete
+			summary.Count[graveler.DiffTypeRemoved] += r.summary.Count[graveler.DiffTypeRemoved]
+			summary.Count[graveler.DiffTypeAdded] += r.summary.Count[graveler.DiffTypeAdded]
+			summary.Count[graveler.DiffTypeChanged] += r.summary.Count[graveler.DiffTypeChanged]
+		case err := <-m.errorCh:
+			close(m.resCh)
+			return "", summary, err
+		case <-m.ctx.Done():
+			close(m.resCh)
+			return "", summary, nil
+		}
+	}
+	fmt.Println("Done")
+	// TODO(Guys): call function with RangeManager
+	newID, err := m.metaRangeManager.CompleteMultipartMetaRange(m.ctx, m.namespace, nil, ranges)
+	if newID == nil {
+		return "", summary, fmt.Errorf("close writer ns=%s metarange id=%s: %w", m.namespace, m.metaRangeManager, err)
+	}
+	return *newID, summary, err
+}
+
+func MultipartCommit(ctx context.Context, parts []graveler.MultipartCommitPartData, opts *CommitOptions, numOfWorkers int, baseMetaRangeID graveler.MetaRangeID, namespace Namespace, manager MetaRangeManager) (graveler.MetaRangeID, graveler.DiffSummary, error) {
+	m := multipartCommitter{
+		ctx:              ctx,
+		logger:           logging.FromContext(ctx),
+		parts:            parts,
+		opts:             opts,
+		summary:          graveler.DiffSummary{},
+		numOfWorkers:     numOfWorkers,
+		namespace:        namespace,
+		baseMetarangeID:  baseMetaRangeID,
+		metaRangeManager: manager,
+	}
+	return m.commit()
+}
+
+// TODO(Guys): good name might be iteratorSlice
+type TempWrapperBoundedIterator struct {
+	Iterator
+	from, to graveler.Key
+}
+
+// TODO(Guys): this is a temporary iterator for
+
+func NewTempWrapperBoundedIterator(iter Iterator, from, to graveler.Key) *TempWrapperBoundedIterator {
+	t := &TempWrapperBoundedIterator{
+		Iterator: iter,
+		from:     from,
+		to:       to,
+	}
+	if from != nil {
+		t.SeekGE(from)
+	}
+	return t
+}
+func (t *TempWrapperBoundedIterator) SeekGE(id graveler.Key) {
+	key := id
+	if t.from != nil && bytes.Compare(t.from, id) <= 0 {
+		key = t.from
+	}
+	t.Iterator.SeekGE(key)
+}
+
+func (t *TempWrapperBoundedIterator) Next() bool {
+	if !t.Iterator.Next() {
+		return false
+	}
+	if t.to == nil {
+		return true
+	}
+	record, rng := t.Iterator.Value()
+	if record != nil {
+		return bytes.Compare(record.Key, t.to) <= 0
+	}
+	return bytes.Compare(rng.MinKey, t.to) <= 0
+}
+
+func (t *TempWrapperBoundedIterator) NextRange() bool {
+	if !t.Iterator.NextRange() {
+		return false
+	}
+	if t.to == nil {
+		return true
+	}
+	record, rng := t.Iterator.Value()
+	if record != nil {
+		return bytes.Compare(record.Key, t.to) <= 0
+	}
+	return bytes.Compare(rng.MinKey, t.to) <= 0
+}

--- a/pkg/graveler/graveler.go
+++ b/pkg/graveler/graveler.go
@@ -1270,6 +1270,9 @@ func (g *Graveler) Commit(ctx context.Context, repositoryID RepositoryID, branch
 				}
 			}()
 			commit.MetaRangeID, _, err = g.CommittedManager.MultipartCommit(ctx, storageNamespace, branchMetaRangeID, parts)
+			if err != nil {
+				return "", fmt.Errorf("multipart commit: %w", err)
+			}
 		} else {
 			changes, err := g.StagingManager.List(ctx, branch.StagingToken, ListingMaxBatchSize, nil, nil)
 			if err != nil {

--- a/pkg/graveler/staging/iterator.go
+++ b/pkg/graveler/staging/iterator.go
@@ -3,6 +3,7 @@ package staging
 import (
 	"bytes"
 	"context"
+
 	"github.com/treeverse/lakefs/pkg/db"
 	"github.com/treeverse/lakefs/pkg/graveler"
 	"github.com/treeverse/lakefs/pkg/logging"

--- a/pkg/graveler/testutil/fakes.go
+++ b/pkg/graveler/testutil/fakes.go
@@ -27,8 +27,12 @@ type CommittedFake struct {
 	AppliedData   AppliedData
 }
 
-func (c *CommittedFake) GetBreakingPoints(ctx context.Context, ns graveler.StorageNamespace, baseMetaRangeID graveler.MetaRangeID) ([]graveler.Key, error) {
+func (c *CommittedFake) MultipartCommit(ctx context.Context, ns graveler.StorageNamespace, baseMetaRangeID graveler.MetaRangeID, parts []graveler.MultipartCommitPartData) (graveler.MetaRangeID, graveler.DiffSummary, error) {
 	// TODO implement me
+	panic("implement me")
+}
+
+func (c *CommittedFake) GetBreakingPoints(ctx context.Context, ns graveler.StorageNamespace, baseMetaRangeID graveler.MetaRangeID) ([]graveler.Key, error) {
 	return make([]graveler.Key, 0), nil
 }
 


### PR DESCRIPTION
This draft PR is the second part of the parallel commit

It's currently messy with many todo's 
It was tested on the same commit from https://github.com/treeverse/lakeFS/issues/2875
on an m5d.4xlarge machine (16 vCPUs):
- No data in cache (need to download from S3): 27 Sec
- With Data in cache: 22 Sec

