### PR TITLE
docs: Header button direct to join beta

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -25,8 +25,8 @@ aux_links:
     - 'https://lakefs.io/blog/'
 
 buttons:
-  'Get Started':
-      - 'https://docs.lakefs.io/'
+  'lakeFS Cloud':
+      - 'https://lakefs.io/join-beta/'
 
 # FOOTER
 # use "footer_content" for simple footer


### PR DESCRIPTION
Get started button in the header menu renamed to "lakeFS Cloud" and linked to https://lakefs.io/join-beta/ as per Michal Wosk instruction
Please review and approve