### PR TITLE
Live configuration reload will change logging level

### DIFF
--- a/cmd/lakefs/cmd/run.go
+++ b/cmd/lakefs/cmd/run.go
@@ -96,7 +96,7 @@ var runCmd = &cobra.Command{
 		viper.WatchConfig()
 		viper.OnConfigChange(func(in fsnotify.Event) {
 			lvl := viper.GetString(config.LoggingLevelKey)
-			fmt.Println("Changing log level to", lvl)
+			logger.WithField("toLevel", lvl).Info("Changing log level")
 			logging.SetLevel(lvl)
 		})
 

--- a/cmd/lakefs/cmd/run.go
+++ b/cmd/lakefs/cmd/run.go
@@ -15,10 +15,12 @@ import (
 	"time"
 
 	"github.com/dlmiddlecote/sqlstats"
+	"github.com/fsnotify/fsnotify"
 	"github.com/go-ldap/ldap/v3"
 	"github.com/golang-migrate/migrate/v4"
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/spf13/cobra"
+	"github.com/spf13/viper"
 	"github.com/treeverse/lakefs/pkg/actions"
 	"github.com/treeverse/lakefs/pkg/api"
 	"github.com/treeverse/lakefs/pkg/auth"
@@ -91,6 +93,13 @@ var runCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		logger := logging.Default()
 		cfg := loadConfig()
+		viper.WatchConfig()
+		viper.OnConfigChange(func(in fsnotify.Event) {
+			lvl := viper.GetString("logging.level")
+			fmt.Println("Changing log level to", lvl)
+			logging.SetLevel(lvl)
+		})
+
 		ctx := cmd.Context()
 		logger.WithField("version", version.Version).Info("lakeFS run")
 
@@ -118,7 +127,7 @@ var runCmd = &cobra.Command{
 			LockDB: lockdbPool,
 		})
 		if err != nil {
-			logger.WithError(err).Fatal("failed to create c")
+			logger.WithError(err).Fatal("failed to create catalog")
 		}
 		defer func() { _ = c.Close() }()
 

--- a/cmd/lakefs/cmd/run.go
+++ b/cmd/lakefs/cmd/run.go
@@ -95,7 +95,7 @@ var runCmd = &cobra.Command{
 		cfg := loadConfig()
 		viper.WatchConfig()
 		viper.OnConfigChange(func(in fsnotify.Event) {
-			lvl := viper.GetString("logging.level")
+			lvl := viper.GetString(config.LoggingLevelKey)
 			fmt.Println("Changing log level to", lvl)
 			logging.SetLevel(lvl)
 		})

--- a/go.mod
+++ b/go.mod
@@ -27,6 +27,7 @@ require (
 	github.com/dlmiddlecote/sqlstats v1.0.2
 	github.com/docker/cli v20.10.10+incompatible // indirect
 	github.com/docker/docker v20.10.10+incompatible // indirect
+	github.com/fsnotify/fsnotify v1.4.9 // indirect
 	github.com/georgysavva/scany v0.2.7
 	github.com/getkin/kin-openapi v0.53.0
 	github.com/go-chi/chi/v5 v5.0.0


### PR DESCRIPTION
lakeFS reads the logging level when it is changed in the configuration file, and change the logging on the fly without restarting the app.

To enable more configuration properties to change, we should propagate them properly in the same manner. Since this isn't always trivial, I suggest we do it per property, when needed.