### PR TITLE
Default storage namespace

### DIFF
--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -757,7 +757,8 @@ components:
           type: string
         blockstore_namespace_ValidityRegex:
           type: string
-
+        default_namespace_prefix:
+          type: string
     VersionConfig:
       type: object
       properties:

--- a/clients/java/api/openapi.yaml
+++ b/clients/java/api/openapi.yaml
@@ -5202,12 +5202,15 @@ components:
         blockstore_namespace_example: blockstore_namespace_example
         blockstore_namespace_ValidityRegex: blockstore_namespace_ValidityRegex
         blockstore_type: blockstore_type
+        default_namespace_prefix: default_namespace_prefix
       properties:
         blockstore_type:
           type: string
         blockstore_namespace_example:
           type: string
         blockstore_namespace_ValidityRegex:
+          type: string
+        default_namespace_prefix:
           type: string
       required:
       - blockstore_namespace_ValidityRegex

--- a/clients/java/docs/StorageConfig.md
+++ b/clients/java/docs/StorageConfig.md
@@ -10,6 +10,7 @@ Name | Type | Description | Notes
 **blockstoreType** | **String** |  | 
 **blockstoreNamespaceExample** | **String** |  | 
 **blockstoreNamespaceValidityRegex** | **String** |  | 
+**defaultNamespacePrefix** | **String** |  |  [optional]
 
 
 

--- a/clients/java/src/main/java/io/lakefs/clients/api/model/StorageConfig.java
+++ b/clients/java/src/main/java/io/lakefs/clients/api/model/StorageConfig.java
@@ -41,6 +41,10 @@ public class StorageConfig {
   @SerializedName(SERIALIZED_NAME_BLOCKSTORE_NAMESPACE_VALIDITY_REGEX)
   private String blockstoreNamespaceValidityRegex;
 
+  public static final String SERIALIZED_NAME_DEFAULT_NAMESPACE_PREFIX = "default_namespace_prefix";
+  @SerializedName(SERIALIZED_NAME_DEFAULT_NAMESPACE_PREFIX)
+  private String defaultNamespacePrefix;
+
 
   public StorageConfig blockstoreType(String blockstoreType) {
     
@@ -111,6 +115,29 @@ public class StorageConfig {
   }
 
 
+  public StorageConfig defaultNamespacePrefix(String defaultNamespacePrefix) {
+    
+    this.defaultNamespacePrefix = defaultNamespacePrefix;
+    return this;
+  }
+
+   /**
+   * Get defaultNamespacePrefix
+   * @return defaultNamespacePrefix
+  **/
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "")
+
+  public String getDefaultNamespacePrefix() {
+    return defaultNamespacePrefix;
+  }
+
+
+  public void setDefaultNamespacePrefix(String defaultNamespacePrefix) {
+    this.defaultNamespacePrefix = defaultNamespacePrefix;
+  }
+
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -122,12 +149,13 @@ public class StorageConfig {
     StorageConfig storageConfig = (StorageConfig) o;
     return Objects.equals(this.blockstoreType, storageConfig.blockstoreType) &&
         Objects.equals(this.blockstoreNamespaceExample, storageConfig.blockstoreNamespaceExample) &&
-        Objects.equals(this.blockstoreNamespaceValidityRegex, storageConfig.blockstoreNamespaceValidityRegex);
+        Objects.equals(this.blockstoreNamespaceValidityRegex, storageConfig.blockstoreNamespaceValidityRegex) &&
+        Objects.equals(this.defaultNamespacePrefix, storageConfig.defaultNamespacePrefix);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(blockstoreType, blockstoreNamespaceExample, blockstoreNamespaceValidityRegex);
+    return Objects.hash(blockstoreType, blockstoreNamespaceExample, blockstoreNamespaceValidityRegex, defaultNamespacePrefix);
   }
 
   @Override
@@ -137,6 +165,7 @@ public class StorageConfig {
     sb.append("    blockstoreType: ").append(toIndentedString(blockstoreType)).append("\n");
     sb.append("    blockstoreNamespaceExample: ").append(toIndentedString(blockstoreNamespaceExample)).append("\n");
     sb.append("    blockstoreNamespaceValidityRegex: ").append(toIndentedString(blockstoreNamespaceValidityRegex)).append("\n");
+    sb.append("    defaultNamespacePrefix: ").append(toIndentedString(defaultNamespacePrefix)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/clients/java/src/test/java/io/lakefs/clients/api/model/StorageConfigTest.java
+++ b/clients/java/src/test/java/io/lakefs/clients/api/model/StorageConfigTest.java
@@ -64,4 +64,12 @@ public class StorageConfigTest {
         // TODO: test blockstoreNamespaceValidityRegex
     }
 
+    /**
+     * Test the property 'defaultNamespacePrefix'
+     */
+    @Test
+    public void defaultNamespacePrefixTest() {
+        // TODO: test defaultNamespacePrefix
+    }
+
 }

--- a/clients/python/docs/StorageConfig.md
+++ b/clients/python/docs/StorageConfig.md
@@ -7,6 +7,7 @@ Name | Type | Description | Notes
 **blockstore_type** | **str** |  | 
 **blockstore_namespace_example** | **str** |  | 
 **blockstore_namespace_validity_regex** | **str** |  | 
+**default_namespace_prefix** | **str** |  | [optional] 
 **any string name** | **bool, date, datetime, dict, float, int, list, str, none_type** | any string name can be used but the value must be the correct type | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/clients/python/lakefs_client/model/storage_config.py
+++ b/clients/python/lakefs_client/model/storage_config.py
@@ -85,6 +85,7 @@ class StorageConfig(ModelNormal):
             'blockstore_type': (str,),  # noqa: E501
             'blockstore_namespace_example': (str,),  # noqa: E501
             'blockstore_namespace_validity_regex': (str,),  # noqa: E501
+            'default_namespace_prefix': (str,),  # noqa: E501
         }
 
     @cached_property
@@ -96,6 +97,7 @@ class StorageConfig(ModelNormal):
         'blockstore_type': 'blockstore_type',  # noqa: E501
         'blockstore_namespace_example': 'blockstore_namespace_example',  # noqa: E501
         'blockstore_namespace_validity_regex': 'blockstore_namespace_ValidityRegex',  # noqa: E501
+        'default_namespace_prefix': 'default_namespace_prefix',  # noqa: E501
     }
 
     read_only_vars = {
@@ -144,6 +146,7 @@ class StorageConfig(ModelNormal):
                                 Animal class but this time we won't travel
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
+            default_namespace_prefix (str): [optional]  # noqa: E501
         """
 
         _check_type = kwargs.pop('_check_type', True)
@@ -233,6 +236,7 @@ class StorageConfig(ModelNormal):
                                 Animal class but this time we won't travel
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
+            default_namespace_prefix (str): [optional]  # noqa: E501
         """
 
         _check_type = kwargs.pop('_check_type', True)

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -51,6 +51,9 @@ This reference uses `.` to denote the nesting of values.
 * `auth.ldap.default_user_group` `(string : )` - Create all LDAP users in this group.  Defaults to `Viewers`.
 * `auth.ldap.user_filter` `(string : )` - Additional filter for users.
 * `blockstore.type` `(one of ["local", "s3", "gs", "azure", "mem"] : required)`.  Block adapter to use. This controls where the underlying data will be stored
+* `blockstore.default_namespace_prefix` `(string : )` - Use this to help your users choose a storage namespace for their repositories. 
+   When creating a repository from the UI, the storage namespace will be filled with this default value as a prefix.
+   The user may still change it to something else 
 * `blockstore.local.path` `(string: "~/lakefs/data")` - When using the local Block Adapter, which directory to store files in
 * `blockstore.gs.credentials_file` `(string : )` - If specified will be used as a file path of the JSON file that contains your Google service account key
 * `blockstore.gs.credentials_json` `(string : )` - If specified will be used as JSON string that contains your Google service account key (when credentials_file is not set)
@@ -73,13 +76,13 @@ This reference uses `.` to denote the nesting of values.
   + `committed.local_cache.size_bytes` (`int` : `1073741824`) - bytes for local cache to use on disk.  The cache may use more storage for short periods of time.
   + `committed.local_cache.dir` (`string`, `~/lakefs/local_tier`) - directory to store local cache.
   +	`committed.local_cache.range_proportion` (`float` : `0.9`) - proportion of local cache to
-	use for storing ranges (leaves of committed metadata storage).
+    use for storing ranges (leaves of committed metadata storage).
   + `committed.local_cache.range.open_readers` (`int` : `500`) - maximal number of unused open
     SSTable readers to keep for ranges.
   + `committed.local_cache.range.num_shards` (`int` : `30`) - sharding factor for open SSTable
     readers for ranges.  Should be at least `sqrt(committed.local_cache.range.open_readers)`.
   + `committed.local_cache.metarange_proportion` (`float` : `0.1`) - proportion of local cache
-	to use for storing metaranges (roots of committed metadata storage).
+    to use for storing metaranges (roots of committed metadata storage).
   + `committed.local_cache.metarange.open_readers` (`int` : `50`) - maximal number of unused open
     SSTable readers to keep for metaranges.
   + `committed.local_cache.metarange.num_shards` (`int` : `10`) - sharding factor for open

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -52,8 +52,8 @@ This reference uses `.` to denote the nesting of values.
 * `auth.ldap.user_filter` `(string : )` - Additional filter for users.
 * `blockstore.type` `(one of ["local", "s3", "gs", "azure", "mem"] : required)`.  Block adapter to use. This controls where the underlying data will be stored
 * `blockstore.default_namespace_prefix` `(string : )` - Use this to help your users choose a storage namespace for their repositories. 
-   When creating a repository from the UI, the storage namespace will be filled with this default value as a prefix.
-   The user may still change it to something else 
+   If specified, the storage namespace will be filled with this default value as a prefix, when creating a repository from the UI.
+   The user may still change it to something else.
 * `blockstore.local.path` `(string: "~/lakefs/data")` - When using the local Block Adapter, which directory to store files in
 * `blockstore.gs.credentials_file` `(string : )` - If specified will be used as a file path of the JSON file that contains your Google service account key
 * `blockstore.gs.credentials_json` `(string : )` - If specified will be used as JSON string that contains your Google service account key (when credentials_file is not set)

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -76,13 +76,13 @@ This reference uses `.` to denote the nesting of values.
   + `committed.local_cache.size_bytes` (`int` : `1073741824`) - bytes for local cache to use on disk.  The cache may use more storage for short periods of time.
   + `committed.local_cache.dir` (`string`, `~/lakefs/local_tier`) - directory to store local cache.
   +	`committed.local_cache.range_proportion` (`float` : `0.9`) - proportion of local cache to
-    use for storing ranges (leaves of committed metadata storage).
+	use for storing ranges (leaves of committed metadata storage).
   + `committed.local_cache.range.open_readers` (`int` : `500`) - maximal number of unused open
     SSTable readers to keep for ranges.
   + `committed.local_cache.range.num_shards` (`int` : `30`) - sharding factor for open SSTable
     readers for ranges.  Should be at least `sqrt(committed.local_cache.range.open_readers)`.
   + `committed.local_cache.metarange_proportion` (`float` : `0.1`) - proportion of local cache
-    to use for storing metaranges (roots of committed metadata storage).
+	to use for storing metaranges (roots of committed metadata storage).
   + `committed.local_cache.metarange.open_readers` (`int` : `50`) - maximal number of unused open
     SSTable readers to keep for metaranges.
   + `committed.local_cache.metarange.num_shards` (`int` : `10`) - sharding factor for open

--- a/docs/reference/object-model.md
+++ b/docs/reference/object-model.md
@@ -146,8 +146,12 @@ other user-defined merge strategies for handling conflicts are on the roadmap.
 _Underlying storage_ is the area on some other object store that lakeFS uses to store object
 contents and some of its metadata.  We sometimes refer to underlying storage as _physical_.
 The path used to store the contents of an object is then termed a _physical path_.  The object
-itself on underlying storage is never modified, except to remove it entirely during some
+itself in the underlying storage is never modified, except to remove it entirely during some
 cleanups.
+
+When creating a lakeFS repository, you assign it with a _storage namespace_. The repository's
+storage namespace is the prefix in the underlying storage where data for this repository
+will be stored.
 
 A lot of what lakeFS does is to manage how lakeFS paths translate to _physical paths_ on the
 object store.  This mapping is generally **not** straightforward.  Importantly (and unlike

--- a/docs/reference/object-model.md
+++ b/docs/reference/object-model.md
@@ -146,7 +146,7 @@ other user-defined merge strategies for handling conflicts are on the roadmap.
 _Underlying storage_ is the area on some other object store that lakeFS uses to store object
 contents and some of its metadata.  We sometimes refer to underlying storage as _physical_.
 The path used to store the contents of an object is then termed a _physical path_.  The object
-itself in the underlying storage is never modified, except to remove it entirely during some
+itself on underlying storage is never modified, except to remove it entirely during some
 cleanups.
 
 When creating a lakeFS repository, you assign it with a _storage namespace_. The repository's

--- a/docs/setup/create-repo.md
+++ b/docs/setup/create-repo.md
@@ -30,16 +30,18 @@ Note: If you already have lakeFS credentials, skip to step 2 and login.
    
 ## Create the repository
 
-1. Click `Create Repository`
+1. Click _Create Repository_.
     
    ![Create Repository]({{ site.baseurl }}/assets/img/create_repo_s3.png)
 
-   Under `Storage Namespace`, be sure to set the path to the bucket you've configured in a [previous step](./storage/index.md).
-   
-   
+1. Set the _Storage Namespace_ to a location in the bucket you've configured in a [previous step](./storage/index.md).
+   The _storage namespace_ is a location in the
+   [underlying storage](https://docs.lakefs.io/reference/object-model.html#concepts-unique-to-lakefs)
+   where data for this repository will be stored.
+
 # Next steps
 
-After creating a repo, you can import your existing data into it. lakeFS offers an [Import API](import.md) to bring your data without copying it.
+After creating a repository, you can import your existing data into it. lakeFS offers an [Import API](import.md) to bring your data without copying it.
 Alternatively, if you wish to copy existing data from an S3 bucket to lakeFS, use [DistCp](../integrations/distcp.md) or [Rclone](../integrations/rclone.md).
 
 Check out the usage guides under [Integrations](../integrations/index.md) for other options.

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -1114,6 +1114,7 @@ func (c *Controller) GetStorageConfig(w http.ResponseWriter, r *http.Request) {
 		BlockstoreType:                   c.Config.GetBlockstoreType(),
 		BlockstoreNamespaceValidityRegex: info.ValidityRegex,
 		BlockstoreNamespaceExample:       info.Example,
+		DefaultNamespacePrefix:           swag.String(c.Config.GetBlockstoreDefaultNamespacePrefix()),
 	}
 	writeResponse(w, http.StatusOK, response)
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -121,6 +121,7 @@ const (
 
 	BlockstoreTypeKey                    = "blockstore.type"
 	BlockstoreLocalPathKey               = "blockstore.local.path"
+	BlockstoreDefaultNamespacePrefixKey  = "blockstore.default_namespace_prefix"
 	BlockstoreS3RegionKey                = "blockstore.s3.region"
 	BlockstoreS3StreamingChunkSizeKey    = "blockstore.s3.streaming_chunk_size"
 	BlockstoreS3StreamingChunkTimeoutKey = "blockstore.s3.streaming_chunk_timeout"
@@ -302,6 +303,10 @@ func (c *Config) GetAwsConfig() *aws.Config {
 
 func (c *Config) GetBlockstoreType() string {
 	return c.values.Blockstore.Type
+}
+
+func (c *Config) GetBlockstoreDefaultNamespacePrefix() string {
+	return c.values.Blockstore.DefaultNamespacePrefix
 }
 
 func (c *Config) GetBlockAdapterS3Params() (blockparams.S3, error) {

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -101,8 +101,9 @@ type configuration struct {
 		LDAP *LDAP
 	}
 	Blockstore struct {
-		Type  string `validate:"required"`
-		Local *struct {
+		Type                   string `validate:"required"`
+		DefaultNamespacePrefix string `mapstructure:"default_namespace_prefix"`
+		Local                  *struct {
 			Path string
 		}
 		S3 *struct {

--- a/webui/src/lib/components/repositoryCreateForm.jsx
+++ b/webui/src/lib/components/repositoryCreateForm.jsx
@@ -60,14 +60,11 @@ export const RepositoryCreateForm = ({ config, onSubmit, onCancel, error = null,
             if (!formValid) {
                 return;
             }
-            const repoCreation = {
+             onSubmit({
                 name: repoNameField.current.value,
+                storage_namespace: storageNamespaceField.current.value,
                 default_branch: defaultBranchField.current.value
-            }
-            if (storageNamespaceField.current) {
-                repoCreation.storage_namespace = storageNamespaceField.current.value
-            }
-            onSubmit(repoCreation);
+            });
         }}>
 	    {config?.warnings && <Warnings warnings={config.warnings}/>}
 

--- a/webui/src/lib/components/repositoryCreateForm.jsx
+++ b/webui/src/lib/components/repositoryCreateForm.jsx
@@ -60,7 +60,7 @@ export const RepositoryCreateForm = ({ config, onSubmit, onCancel, error = null,
             if (!formValid) {
                 return;
             }
-             onSubmit({
+            onSubmit({
                 name: repoNameField.current.value,
                 storage_namespace: storageNamespaceField.current.value,
                 default_branch: defaultBranchField.current.value

--- a/webui/src/lib/components/repositoryCreateForm.jsx
+++ b/webui/src/lib/components/repositoryCreateForm.jsx
@@ -1,11 +1,14 @@
-import React, {useRef, useState} from 'react';
+import React, {useCallback, useEffect, useRef, useState} from 'react';
 
 import Form from "react-bootstrap/Form";
 import Alert from "react-bootstrap/Alert";
 import Button from "react-bootstrap/Button";
 import Row from "react-bootstrap/Row";
 import Col from "react-bootstrap/Col";
-import {Warnings} from "../../lib/components/controls";
+import {TooltipButton, Warnings} from "../../lib/components/controls";
+import {InfoIcon} from "@primer/octicons-react";
+import Tooltip from "react-bootstrap/Tooltip";
+import {OverlayTrigger} from "react-bootstrap";
 
 const DEFAULT_BLOCKSTORE_EXAMPLE = "e.g. s3://example-bucket/";
 const DEFAULT_BLOCKSTORE_VALIDITY_REGEX = new RegExp(`^s3://`);
@@ -15,19 +18,24 @@ export const RepositoryCreateForm = ({ config, onSubmit, onCancel, error = null,
     const repoValidityRegex = /^[a-z0-9][a-z0-9-]{2,62}$/;
 
     const [formValid, setFormValid] = useState(false);
-    const [repoValid, setRepoValid] = useState(true);
+    const [repoValid, setRepoValid] = useState(null);
+    const defaultNamespacePrefix = config.default_namespace_prefix
 
-    const [storageNamespaceValid, setStorageNamespaceValid] = useState(true);
+    const [storageNamespaceValid, setStorageNamespaceValid] = useState(defaultNamespacePrefix ? true : null);
     const [defaultBranchValid, setDefaultBranchValid] = useState(true);
 
     const storageNamespaceField = useRef(null);
     const defaultBranchField = useRef(null);
     const repoNameField = useRef(null);
 
-    const checkRepoValidity = () => {
+    const onRepoNameChange = () => {
         const isRepoValid = repoValidityRegex.test(repoNameField.current.value);
         setRepoValid(isRepoValid);
         setFormValid(isRepoValid && storageNamespaceValid && defaultBranchValid);
+        if (isRepoValid && defaultNamespacePrefix) {
+            storageNamespaceField.current.value = defaultNamespacePrefix + "/" + repoNameField.current.value
+            checkStorageNamespaceValidity()
+        }
     };
 
     const checkStorageNamespaceValidity = () => {
@@ -52,31 +60,40 @@ export const RepositoryCreateForm = ({ config, onSubmit, onCancel, error = null,
             if (!formValid) {
                 return;
             }
-            onSubmit({
+            const repoCreation = {
                 name: repoNameField.current.value,
-                storage_namespace: storageNamespaceField.current.value,
                 default_branch: defaultBranchField.current.value
-            });
+            }
+            if (storageNamespaceField.current) {
+                repoCreation.storage_namespace = storageNamespaceField.current.value
+            }
+            onSubmit(repoCreation);
         }}>
 	    {config?.warnings && <Warnings warnings={config.warnings}/>}
 
             <Form.Group as={Row} controlId="id">
                 <Form.Label column sm={fieldNameOffset}>Repository ID</Form.Label>
                 <Col sm={sm}>
-                    <Form.Control type="text" autoFocus ref={repoNameField} onChange={checkRepoValidity}/>
-                    {!repoValid &&
+                    <Form.Control type="text" autoFocus ref={repoNameField} onChange={onRepoNameChange}/>
+                    {repoValid === false &&
                     <Form.Text className="text-danger">
                         Min 2 characters. Only lowercase alphanumeric characters and {'\'-\''} allowed.
                     </Form.Text>
                     }
                 </Col>
             </Form.Group>
-
             <Form.Group as={Row}>
-                <Form.Label column sm={fieldNameOffset}>Storage Namespace</Form.Label>
+                <Form.Label column sm={fieldNameOffset}>
+                    Storage Namespace&nbsp;
+                    <OverlayTrigger placement="bottom" overlay={<Tooltip style={{"font-size": "s"}}>What should I type here?</Tooltip>}>
+                        <a href="https://docs.lakefs.io/reference/object-model.html#concepts-unique-to-lakefs" target={"_blank"} rel="noopener noreferrer">
+                            <InfoIcon/>
+                        </a>
+                    </OverlayTrigger>
+                </Form.Label>
                 <Col sm={sm}>
-                    <Form.Control type="text" ref={storageNamespaceField} placeholder={storageNamespaceExample} onChange={checkStorageNamespaceValidity}/>
-                    {!storageNamespaceValid &&
+                    <Form.Control type="text" ref={storageNamespaceField} placeholder={storageNamespaceExample} onChange={checkStorageNamespaceValidity} />
+                    {storageNamespaceValid === false &&
                     <Form.Text className="text-danger">
                         {"Can only create repository with storage type: " + storageType}
                     </Form.Text>
@@ -87,7 +104,7 @@ export const RepositoryCreateForm = ({ config, onSubmit, onCancel, error = null,
                 <Form.Label column sm={fieldNameOffset}>Default Branch</Form.Label>
                 <Col sm={sm}>
                     <Form.Control type="text" ref={defaultBranchField} placeholder="defaultBranch" defaultValue={"main"} onChange={checkDefaultBranchValidity}/>
-                    {!defaultBranchValid &&
+                    {defaultBranchValid === false &&
                     <Form.Text className="text-danger">
                         Invalid Branch.
                     </Form.Text>


### PR DESCRIPTION
Added a new configuration `blockstore.default_namespace_prefix`.
When specified, the storage namespace field in the UI will be auto-filled.
The specified value will be the prefix, and the repository name will be added to it.

![image](https://user-images.githubusercontent.com/3149885/154477098-794082e0-dc7b-48af-8cbb-cf78bc7fbb56.png)

### Extra
* Added a (?) icon near the storage namespace field, linking to the docs.
* Small docs improvements.