### PR TITLE
Exclude body validation on openapi object upload

### DIFF
--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -2581,7 +2581,7 @@ paths:
       tags:
         - objects
       operationId: uploadObject
-      x-validation-exclude-body: false
+      x-validation-exclude-body: true
       requestBody:
         content:
           multipart/form-data:

--- a/clients/java/api/openapi.yaml
+++ b/clients/java/api/openapi.yaml
@@ -3128,7 +3128,7 @@ paths:
           description: Internal Server Error
       tags:
       - objects
-      x-validation-exclude-body: false
+      x-validation-exclude-body: true
       x-contentType: multipart/form-data
       x-accepts: application/json
     put:

--- a/docs/assets/js/swagger.yml
+++ b/docs/assets/js/swagger.yml
@@ -757,7 +757,8 @@ components:
           type: string
         blockstore_namespace_ValidityRegex:
           type: string
-
+        default_namespace_prefix:
+          type: string
     VersionConfig:
       type: object
       properties:
@@ -2580,7 +2581,7 @@ paths:
       tags:
         - objects
       operationId: uploadObject
-      x-validation-exclude-body: false
+      x-validation-exclude-body: true
       requestBody:
         content:
           multipart/form-data:


### PR DESCRIPTION
Fix #2907 

Skip upload object body validation that read the complete request body