### PR TITLE
Remove statik package installation procedure in contributing page, re… (#2998)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -74,12 +74,12 @@ clean:
 check-licenses: check-licenses-go-mod check-licenses-npm
 
 check-licenses-go-mod:
-	go install github.com/google/go-licenses@latest
+	$(GOCMD) install github.com/google/go-licenses@latest
 	$(GOBINPATH)/go-licenses check ./cmd/$(LAKEFS_BINARY_NAME)
 	$(GOBINPATH)/go-licenses check ./cmd/$(LAKECTL_BINARY_NAME)
 
 check-licenses-npm:
-	go install github.com/senseyeio/diligent/cmd/diligent@latest
+	$(GOCMD) install github.com/senseyeio/diligent/cmd/diligent@latest
 	# The -i arg is a workaround to ignore NPM scoped packages until https://github.com/senseyeio/diligent/issues/77 is fixed
 	$(GOBINPATH)/diligent check -w permissive -i ^@[^/]+?/[^/]+ $(UI_DIR)
 

--- a/Makefile
+++ b/Makefile
@@ -74,12 +74,12 @@ clean:
 check-licenses: check-licenses-go-mod check-licenses-npm
 
 check-licenses-go-mod:
-	go get github.com/google/go-licenses
+	go install github.com/google/go-licenses@latest
 	$(GOBINPATH)/go-licenses check ./cmd/$(LAKEFS_BINARY_NAME)
 	$(GOBINPATH)/go-licenses check ./cmd/$(LAKECTL_BINARY_NAME)
 
 check-licenses-npm:
-	go get github.com/senseyeio/diligent/cmd/diligent
+	go install github.com/senseyeio/diligent/cmd/diligent@latest
 	# The -i arg is a workaround to ignore NPM scoped packages until https://github.com/senseyeio/diligent/issues/77 is fixed
 	$(GOBINPATH)/diligent check -w permissive -i ^@[^/]+?/[^/]+ $(UI_DIR)
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -43,14 +43,6 @@ Our [Go release workflow](https://github.com/treeverse/lakeFS/blob/master/.githu
    1. *Optional* - [PostgreSQL 11](https://www.postgresql.org/docs/11/tutorial-install.html) (useful for running and debugging locally)
 
    * With Apple M1, you can install Java from [Azul Zulu Builds for Java JDK](https://www.azul.com/downloads/?package=jdk).
-   
-1. Install statik:
-
-   ```shell
-   go get github.com/rakyll/statik
-   ```
-
-   Make sure `(go env GOPATH)/bin` is in your `$PATH` (or at least, that the `statik` binary is).
 
 1. Clone the repository from https://github.com/treeverse/lakeFS (gives you read-only access to the repository. To contribute, see the next section).
 1. Build the project:


### PR DESCRIPTION
In go version 1.17 command 'go get' is deprecated.
Edit Makefile and modify all go get commands to use go install instead.
Remove statik package installation procedure in contributing doc as it is installed as part of the make build.
fixes #2998 