### PR TITLE
[2550] Dont show GetStarted for empty commit

### DIFF
--- a/webui/src/lib/components/repository/tree.jsx
+++ b/webui/src/lib/components/repository/tree.jsx
@@ -288,7 +288,7 @@ const GetStarted = ({ onUpload }) => {
 export const Tree = ({ repo, reference, results, after, onPaginate, nextPage, onUpload, onDelete, showActions = false, path = "" }) => {
 
     let body;
-    if (results.length === 0 && path === "" && reference.type === "branch") {
+    if (results.length === 0 && path === "" && reference.type === RefTypeBranch) {
         // empty state!
         body = <GetStarted onUpload={onUpload}/>;
     } else {

--- a/webui/src/lib/components/repository/tree.jsx
+++ b/webui/src/lib/components/repository/tree.jsx
@@ -288,7 +288,7 @@ const GetStarted = ({ onUpload }) => {
 export const Tree = ({ repo, reference, results, after, onPaginate, nextPage, onUpload, onDelete, showActions = false, path = "" }) => {
 
     let body;
-    if (results.length === 0 && path === "") {
+    if (results.length === 0 && path === "" && reference.type === "branch") {
         // empty state!
         body = <GetStarted onUpload={onUpload}/>;
     } else {


### PR DESCRIPTION
Fixes #2550

Only showing the GetStarted Page when the user is on main branch and branch is empty.

Selecting refs would show results even if empty