### PR TITLE
remove statik output from git ignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,8 +47,6 @@
 
 # server excludes
 /pkg/api/gen
-/pkg/webui
-/pkg/ddl/statik.go
 .DS_Store
 
 # recordings


### PR DESCRIPTION
enable easy way to remove non generated files by statik which we no longer use.