### PR TITLE
Don't log secure strings by default

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -252,7 +252,7 @@ func (c *Config) Validate() error {
 
 func (c *Config) GetDatabaseParams() dbparams.Database {
 	return dbparams.Database{
-		ConnectionString:      c.values.Database.ConnectionString.String(),
+		ConnectionString:      c.values.Database.ConnectionString.SecureValue(),
 		MaxOpenConnections:    c.values.Database.MaxOpenConnections,
 		MaxIdleConnections:    c.values.Database.MaxIdleConnections,
 		ConnectionMaxLifetime: c.values.Database.ConnectionMaxLifetime,
@@ -286,9 +286,9 @@ func (c *Config) GetAwsConfig() *aws.Config {
 			secretAccessKey = c.values.Blockstore.S3.Credentials.AccessSecretKey
 		}
 		cfg.Credentials = credentials.NewStaticCredentials(
-			c.values.Blockstore.S3.Credentials.AccessKeyID.String(),
-			secretAccessKey.String(),
-			c.values.Blockstore.S3.Credentials.SessionToken.String(),
+			c.values.Blockstore.S3.Credentials.AccessKeyID.SecureValue(),
+			secretAccessKey.SecureValue(),
+			c.values.Blockstore.S3.Credentials.SessionToken.SecureValue(),
 		)
 	}
 

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -31,8 +31,14 @@ func DecodeStrings(fromValue reflect.Value, toValue reflect.Value) (interface{},
 
 type SecureString string
 
-func (s *SecureString) String() string {
-	return string(*s)
+// String returns an elided version.  It is safe to call for logging.
+func (_ SecureString) String() string {
+	return "[SECRET]"
+}
+
+// SecureValue returns the actual value of s as a string.
+func (s SecureString) SecureValue() string {
+	return string(s)
 }
 
 // LDAP holds configuration for authenticating on an LDAP server.

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -10,9 +10,11 @@ import (
 // of strings.
 type Strings []string
 
-var ourStringsType = reflect.TypeOf(Strings{})
-var stringType = reflect.TypeOf("")
-var stringSliceType = reflect.TypeOf([]string{})
+var (
+	ourStringsType  = reflect.TypeOf(Strings{})
+	stringType      = reflect.TypeOf("")
+	stringSliceType = reflect.TypeOf([]string{})
+)
 
 // decodeStrings is a mapstructure.HookFuncType that decodes a single string value or a slice
 // of strings into Strings.
@@ -32,7 +34,7 @@ func DecodeStrings(fromValue reflect.Value, toValue reflect.Value) (interface{},
 type SecureString string
 
 // String returns an elided version.  It is safe to call for logging.
-func (_ SecureString) String() string {
+func (SecureString) String() string {
 	return "[SECRET]"
 }
 

--- a/pkg/validator/validate.go
+++ b/pkg/validator/validate.go
@@ -28,6 +28,10 @@ type ValidateArg struct {
 	Fn    ValidateFunc
 }
 
+type Secured interface {
+	SecureValue() string
+}
+
 func Validate(args []ValidateArg) error {
 	for _, arg := range args {
 		err := arg.Fn(arg.Value)
@@ -43,6 +47,10 @@ func MakeValidateOptional(fn ValidateFunc) ValidateFunc {
 		switch s := v.(type) {
 		case string:
 			if len(s) == 0 {
+				return nil
+			}
+		case Secured:
+			if len(s.SecureValue()) == 0 {
 				return nil
 			}
 		case fmt.Stringer:


### PR DESCRIPTION
Prevent type `SecureString` from being logged or otherwise stringified by
accident.  Add a method `SecureValue` to allow access to their value that
cannot happen accidentally and is clearly flagged.