### PR TITLE
Improvements to "Understanding lakeFS" section

### DIFF
--- a/docs/faq.md
+++ b/docs/faq.md
@@ -12,7 +12,7 @@ has_children: false
 lakeFS is completely free and open source and licensed under the [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0) License. We maintain a public [product roadmap](https://docs.lakefs.io/understand/roadmap.html) and [Slack channel](https://lakefs.io/slack) for open discussions.
 
 ### 2. How does lakeFS data versioning work?
-lakeFS uses a copy-on-write mechanism to avoid data duplication. For example, creating a new branch is a metadata-only operation: no objects are actually copied. Only when an object changes does lakeFS create another [version of the data](https://lakefs.io/data-versioning/) in the storage. For more information, see [Data Model](https://docs.lakefs.io/understand/data-model.html).
+lakeFS uses a copy-on-write mechanism to avoid data duplication. For example, creating a new branch is a metadata-only operation: no objects are actually copied. Only when an object changes does lakeFS create another [version of the data](https://lakefs.io/data-versioning/) in the storage. For more information, see [Versioning internals](./understand/versioning-internals.md).
 
 ### 3. How do I get support for my lakeFS installation?
 We are extremely responsive on our slack channel, and we make sure to prioritize and with the community the issues most urgent for it. For SLA based support, please contact us at [support@treeverse.io](mailto:support@treeverse.io).

--- a/docs/setup/create-repo.md
+++ b/docs/setup/create-repo.md
@@ -47,7 +47,7 @@ When you first open the lakeFS UI, you will be asked to create an initial admin 
 
 1. Set the _Storage Namespace_ to a location in the bucket you've configured in a [previous step](./storage/index.md).
    The _storage namespace_ is a location in the
-   [underlying storage](https://docs.lakefs.io/reference/object-model.html#concepts-unique-to-lakefs)
+   [underlying storage](../understand/object-model.md#concepts-unique-to-lakefs)
    where data for this repository will be stored.
 
 1. Click _Create Repository_.

--- a/docs/understand/architecture.md
+++ b/docs/understand/architecture.md
@@ -22,7 +22,7 @@ lakeFS is distributed as a single binary encapsulating several logical services:
 The server itself is stateless, meaning you can easily add more instances to handle bigger load.
 
 lakeFS stores data in an underlying object store ([GCS](https://cloud.google.com/storage), [ABS](https://azure.microsoft.com/en-us/services/storage/blobs/),
-[S3](https://aws.amazon.com/s3/) or any S3-compatible stores like [MinIO](https://min.io/) or [Ceph](https://docs.ceph.com/)), with some of its metadata stored in [PostgreSQL](https://www.postgresql.org/){:target="_blank"} (see [Data Model](data-model.md)).
+[S3](https://aws.amazon.com/s3/) or any S3-compatible stores like [MinIO](https://min.io/) or [Ceph](https://docs.ceph.com/)), with some of its metadata stored in [PostgreSQL](https://www.postgresql.org/){:target="_blank"} (see [Versioning internals](../understand/versioning-internals.md)).
 
 <!-- The below draw.io diagram source can be found here: https://drive.google.com/file/d/1lctPtGVEmOlCNHi3jiW4XXmyQQFkxzyx/view?usp=sharing -->
 
@@ -63,7 +63,7 @@ See the [roadmap](roadmap.md) for information on future plans for storage compat
 ### Graveler
 
 Graveler handles lakeFS versioning by translating lakeFS addresses to the actual stored objects.
-To learn about the data model used to store lakeFS metadata, see the [data model section](data-model.md).
+To learn about the data model used to store lakeFS metadata, see the [data model section](versioning-internals.md).
 
 ### Authentication & Authorization Service
 

--- a/docs/understand/object-model.md
+++ b/docs/understand/object-model.md
@@ -2,9 +2,10 @@
 layout: default
 title: Object Model 
 description: The lakeFS object model blends the object models of git and of object stores such as S3.  Here are the explicit definitions.
-parent: Reference
-nav_order: 70
+parent: Understanding lakeFS
+nav_order: 22
 has_children: false
+redirect_from: ../reference/object_model.html
 ---
 
 # Object Model

--- a/docs/understand/sizing-guide.md
+++ b/docs/understand/sizing-guide.md
@@ -101,7 +101,7 @@ while the entire data set usually grows over time.
 This means lakeFS will provide predictable performance: 
 committing 100 changes will take roughly the same amount of time whether the resulting commit contains 500 or 500 million objects.
 
-See [Data Model](data-model.md) for more information.
+See [Data Model](versioning-internals.md) for more information.
 
 Scaling throughput depends very much on the amount of CPU cores available to lakeFS. 
 In many cases it is easier to scale lakeFS across a fleet of smaller cloud instances (or containers) 

--- a/docs/understand/versioning-internals.md
+++ b/docs/understand/versioning-internals.md
@@ -1,15 +1,14 @@
 ---
 layout: default
-title: Data Model
+title: Versioning Internals
 parent: Understanding lakeFS
-description: This page explains the lakeFS Data Model
+description: How lakeFS does versioning
 nav_order: 20
 has_children: false
-redirect_from: ../architecture/data-model.html
----
-# Data Model
+redirect_from: ["../architecture/data-model.html","../understand/data-model.html"]
+--- 
+# Versioning Internals
 {: .no_toc }
-
 
 {% include toc.html %}
 


### PR DESCRIPTION
1. Move "Object Model" section to be under "understanding lakeFS".
2. Rename "Data model" to "versioning internals".
