### PR TITLE
3085 lakectl ingest adds multiple excess slash to object name

### DIFF
--- a/cmd/lakectl/cmd/ingest.go
+++ b/cmd/lakectl/cmd/ingest.go
@@ -64,7 +64,7 @@ var ingestCmd = &cobra.Command{
 		if lakefsURI.Path != nil {
 			path = *lakefsURI.Path
 		}
-		if !strings.HasSuffix(path, PathDelimiter) {
+		if len(path) > 0 && !strings.HasSuffix(path, PathDelimiter) {
 			path = path + PathDelimiter // append a path delimiter (slash) if not passed by the user
 		}
 		go func() {

--- a/cmd/lakectl/cmd/ingest.go
+++ b/cmd/lakectl/cmd/ingest.go
@@ -65,7 +65,7 @@ var ingestCmd = &cobra.Command{
 			path = *lakefsURI.Path
 		}
 		if len(path) > 0 && !strings.HasSuffix(path, PathDelimiter) {
-			path = path + PathDelimiter // append a path delimiter (slash) if not passed by the user
+			path = path + PathDelimiter // append a path delimiter (slash) if not passed by the user, and it's not an empty path in lakeFS
 		}
 		go func() {
 			err := store.Walk(ctx, from, func(e store.ObjectStoreEntry) error {

--- a/cmd/lakectl/cmd/store/s3.go
+++ b/cmd/lakectl/cmd/store/s3.go
@@ -35,7 +35,7 @@ func (s *S3Walker) Walk(ctx context.Context, storageURI *url.URL, walkFn func(e 
 	// trimPrefix will be used to hold the actual value needed to be trimmed from the keys returned by the
 	// ListObjects function below. As the prefix itself might contain partial key, it cannot be used for the
 	// trim purpose, as this will create partial object names. The trimPrefix is the 'complete' prefix of the
-	// prefix, i.e. up to the first seperator ("/"), if exists, or an empty string. When the trimPrefix is
+	// prefix, i.e. up to the first separator ("/"), if exists, or an empty string. When the trimPrefix is
 	// trimmed from the key, the remains will be the object name.
 	// Example:
 	// Say we have the following keys:

--- a/cmd/lakectl/cmd/store/s3.go
+++ b/cmd/lakectl/cmd/store/s3.go
@@ -47,7 +47,7 @@ func (s *S3Walker) Walk(ctx context.Context, storageURI *url.URL, walkFn func(e 
 			addr := fmt.Sprintf("s3://%s/%s", bucket, key)
 			ent := ObjectStoreEntry{
 				FullKey:     key,
-				RelativeKey: strings.TrimPrefix(key, prefix),
+				RelativeKey: strings.TrimPrefix(strings.TrimPrefix(key, prefix), "/"),
 				Address:     addr,
 				ETag:        strings.Trim(aws.StringValue(record.ETag), "\""),
 				Mtime:       aws.TimeValue(record.LastModified),

--- a/cmd/lakectl/cmd/store/s3.go
+++ b/cmd/lakectl/cmd/store/s3.go
@@ -32,16 +32,15 @@ func (s *S3Walker) Walk(ctx context.Context, storageURI *url.URL, walkFn func(e 
 	const maxKeys = 1000
 	prefix := strings.TrimLeft(storageURI.Path, "/")
 
-	// trimPrefix will be used to hold the actual value needed to be trimmed from the keys returned by the
-	// ListObjects function below. As the prefix itself might contain partial key, it cannot be used for the
-	// trim purpose, as this will create partial object names. The trimPrefix is the 'complete' prefix of the
-	// prefix, i.e. up to the first separator ("/"), if exists, or an empty string. When the trimPrefix is
+	// basePath is the path relative to which the walk is done. The key of the resulting entries will be relative to this path.
+	// As the original prefix might not end with a separator, it cannot be used for the
+	// trim purpose, as this will create partial "folder" names. When the basePath is
 	// trimmed from the key, the remains will be the object name.
 	// Example:
 	// Say we have the following keys:
 	// pref/object
 	// pref/obj/another
-	// If we specify prefix="pref/obj" (both keys will be listed) then trimPrefix="pref/" and the trim result
+	// If we specify prefix="pref/obj" (both keys will be listed) then basePath="pref/" and the trim result
 	// for the keys will be:
 	// object
 	// obj/another

--- a/cmd/lakectl/cmd/store/s3.go
+++ b/cmd/lakectl/cmd/store/s3.go
@@ -44,7 +44,7 @@ func (s *S3Walker) Walk(ctx context.Context, storageURI *url.URL, walkFn func(e 
 	// for the keys will be:
 	// object
 	// obj/another
-	var trimPrefix string
+	var basePath string
 	if idx := strings.LastIndex(prefix, "/"); idx != -1 {
 		trimPrefix = prefix[:idx+1]
 	}

--- a/cmd/lakectl/cmd/store/s3.go
+++ b/cmd/lakectl/cmd/store/s3.go
@@ -31,6 +31,10 @@ func (s *S3Walker) Walk(ctx context.Context, storageURI *url.URL, walkFn func(e 
 	var continuation *string
 	const maxKeys = 1000
 	prefix := strings.TrimLeft(storageURI.Path, "/")
+	var trimPrefix string
+	if idx := strings.LastIndex(prefix, "/"); idx != -1 {
+		trimPrefix = prefix[:idx+1]
+	}
 	bucket := storageURI.Host
 	for {
 		result, err := s.s3.ListObjectsV2WithContext(ctx, &s3.ListObjectsV2Input{
@@ -47,7 +51,7 @@ func (s *S3Walker) Walk(ctx context.Context, storageURI *url.URL, walkFn func(e 
 			addr := fmt.Sprintf("s3://%s/%s", bucket, key)
 			ent := ObjectStoreEntry{
 				FullKey:     key,
-				RelativeKey: strings.TrimPrefix(strings.TrimPrefix(key, prefix), "/"),
+				RelativeKey: strings.TrimPrefix(key, trimPrefix),
 				Address:     addr,
 				ETag:        strings.Trim(aws.StringValue(record.ETag), "\""),
 				Mtime:       aws.TimeValue(record.LastModified),

--- a/cmd/lakectl/cmd/store/s3.go
+++ b/cmd/lakectl/cmd/store/s3.go
@@ -31,6 +31,20 @@ func (s *S3Walker) Walk(ctx context.Context, storageURI *url.URL, walkFn func(e 
 	var continuation *string
 	const maxKeys = 1000
 	prefix := strings.TrimLeft(storageURI.Path, "/")
+
+	// trimPrefix will be used to hold the actual value needed to be trimmed from the keys returned by the
+	// ListObjects function below. As the prefix itself might contain partial key, it cannot be used for the
+	// trim purpose, as this will create partial object names. The trimPrefix is the 'complete' prefix of the
+	// prefix, i.e. up to the first seperator ("/"), if exists, or an empty string. When the trimPrefix is
+	// trimmed from the key, the remains will be the object name.
+	// Example:
+	// Say we have the following keys:
+	// pref/object
+	// pref/obj/another
+	// If we specify prefix="pref/obj" (both keys will be listed) then trimPrefix="pref/" and the trim result
+	// for the keys will be:
+	// object
+	// obj/another
 	var trimPrefix string
 	if idx := strings.LastIndex(prefix, "/"); idx != -1 {
 		trimPrefix = prefix[:idx+1]

--- a/cmd/lakectl/cmd/store/s3.go
+++ b/cmd/lakectl/cmd/store/s3.go
@@ -46,7 +46,7 @@ func (s *S3Walker) Walk(ctx context.Context, storageURI *url.URL, walkFn func(e 
 	// obj/another
 	var basePath string
 	if idx := strings.LastIndex(prefix, "/"); idx != -1 {
-		trimPrefix = prefix[:idx+1]
+		basePath = prefix[:idx+1]
 	}
 	bucket := storageURI.Host
 	for {
@@ -64,7 +64,7 @@ func (s *S3Walker) Walk(ctx context.Context, storageURI *url.URL, walkFn func(e 
 			addr := fmt.Sprintf("s3://%s/%s", bucket, key)
 			ent := ObjectStoreEntry{
 				FullKey:     key,
-				RelativeKey: strings.TrimPrefix(key, trimPrefix),
+				RelativeKey: strings.TrimPrefix(key, basePath),
 				Address:     addr,
 				ETag:        strings.Trim(aws.StringValue(record.ETag), "\""),
 				Mtime:       aws.TimeValue(record.LastModified),


### PR DESCRIPTION
Fixed `ingest` function not to add a `"/"` if the to path ends wirh rhe branch name (and thus ends with `"/"`)
Fixed `S3` `Walk` to correctly trim prefixes: with `"/"` if exists, and partial prefixes too

Tested manually with `--from` `s3:://mybucket/data/`, `s3:://mybucket/data` and `s3:://mybucket/da`
Opened #3109 for adding tests