### PR TITLE
Fix: Modify hooks to run on committed data only

### DIFF
--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -1907,8 +1907,8 @@ func TestController_ListRepositoryRuns(t *testing.T) {
 		})
 		verifyResponseOK(t, respList, err)
 		runsCount := len(respList.JSON200.Results)
-		if runsCount != contentCount+1 {
-			t.Fatalf("ListRepositoryRuns() got %d results, expected %d+1", runsCount, contentCount)
+		if runsCount != contentCount {
+			t.Fatalf("ListRepositoryRuns() got %d results, expected %d", runsCount, contentCount)
 		}
 	})
 

--- a/pkg/graveler/graveler_test.go
+++ b/pkg/graveler/graveler_test.go
@@ -717,8 +717,8 @@ func TestGraveler_PreMergeHook(t *testing.T) {
 			if h.BranchID != mergeDestination {
 				t.Errorf("Hook branch (destination) '%s', expected '%s'", h.BranchID, mergeDestination)
 			}
-			if h.SourceRef.String() != expectedCommitID.String() {
-				t.Errorf("Hook source '%s', expected '%s'", h.SourceRef, expectedCommitID)
+			if h.SourceRef.String() != destinationCommitID.String() {
+				t.Errorf("Hook source '%s', expected '%s'", h.SourceRef, destinationCommitID)
 			}
 			if h.Commit.Message != mergeMessage {
 				t.Errorf("Hook merge message '%s', expected '%s'", h.Commit.Message, mergeMessage)


### PR DESCRIPTION
Hooks data (action files) should be taken from committed data only and not from unstaged data.
Modify hook records source ref to the relevant commit ID:

- in Merge action
- - provide the commit ID of the destination branch
- in Commit action
- - Provide the commit ID of the base commit