### PR TITLE
Fix create repo min character limit issue

### DIFF
--- a/webui/src/lib/components/repositoryCreateForm.jsx
+++ b/webui/src/lib/components/repositoryCreateForm.jsx
@@ -74,7 +74,7 @@ export const RepositoryCreateForm = ({ config, onSubmit, onCancel, error = null,
                     <Form.Control type="text" autoFocus ref={repoNameField} onChange={onRepoNameChange}/>
                     {repoValid === false &&
                     <Form.Text className="text-danger">
-                        Min 2 characters. Only lowercase alphanumeric characters and {'\'-\''} allowed.
+                        Min 3 characters. Only lowercase alphanumeric characters and {'\'-\''} allowed.
                     </Form.Text>
                     }
                 </Col>


### PR DESCRIPTION
Currently, there exists a bug upon which the Create A New Repository
form states that repo ID's must be at least 2 characters, but in
actuality it does not allow less than 3. We update the regex string so
that the minimum is now 2 characters.

Closes #2967