### PR TITLE
Use aws sdk v1 in spark metadata client

### DIFF
--- a/clients/spark/build.sbt
+++ b/clients/spark/build.sbt
@@ -95,13 +95,17 @@ lazy val spark2Type =
   new BuildType("247", scala211Version, "2.4.7", "0.9.8", "2.7.7", "hadoop2-2.0.1")
 lazy val spark3Type =
   new BuildType("301", scala212Version, "3.0.1", "0.10.11", "2.7.7", "hadoop2-2.0.1")
+lazy val spark312Type =
+  new BuildType("312", scala212Version, "3.1.2", "0.10.11", "3.2.1", "hadoop2-2.0.1")
 
 lazy val core2 = generateCoreProject(spark2Type)
 lazy val core3 = generateCoreProject(spark3Type)
+lazy val core312 = generateCoreProject(spark312Type)
 lazy val examples2 = generateExamplesProject(spark2Type).dependsOn(core2)
 lazy val examples3 = generateExamplesProject(spark3Type).dependsOn(core3)
+lazy val examples312 = generateExamplesProject(spark312Type).dependsOn(core312)
 
-lazy val root = (project in file(".")).aggregate(core2, core3, examples2, examples3)
+lazy val root = (project in file(".")).aggregate(core2, core3, core312, examples2, examples3, examples312)
 
 lazy val assemblySettings = Seq(
   assembly / assemblyMergeStrategy := (_ => MergeStrategy.first),

--- a/clients/spark/build.sbt
+++ b/clients/spark/build.sbt
@@ -53,7 +53,7 @@ def generateCoreProject(buildType: BuildType) =
         // hadoop-aws provides AWS SDK at version >= 1.7.4.  So declare this
         // version, but ask to use whatever is provided so we do not
         // override what it selects.
-        "com.amazonaws" % "aws-java-sdk-bundle" % "1.12.140" % "provided",
+        "com.amazonaws" % "aws-java-sdk-bundle" % "1.12.194" % "provided",
         // Snappy is JNI :-(.  However it does claim to work with
         // ClassLoaders, and (even more importantly!) using a preloaded JNI
         // version will probably continue to work because the C language API
@@ -85,9 +85,7 @@ def generateExamplesProject(buildType: BuildType) =
       scalacOptions += "-Ywarn-unused-import",
       libraryDependencies ++= Seq(
         "org.apache.spark" %% "spark-sql" % buildType.sparkVersion % "provided",
-        "software.amazon.awssdk" % "bom" % "2.15.15",
-        "software.amazon.awssdk" % "s3" % "2.15.15",
-        "com.amazonaws" % "aws-java-sdk" % "1.7.4" // should match hadoop-aws version(!)
+        "com.amazonaws" % "aws-java-sdk-bundle" % "1.12.194"
       ),
       assembly / mainClass := Some("io.treeverse.examples.List"),
       target := file(s"target/examples-${buildType.name}/"),

--- a/clients/spark/build.sbt
+++ b/clients/spark/build.sbt
@@ -50,7 +50,10 @@ def generateCoreProject(buildType: BuildType) =
         "com.google.guava" % "guava" % "16.0.1",
         "com.google.guava" % "failureaccess" % "1.0.1",
         "org.rogach" %% "scallop" % "4.0.3",
-        "software.amazon.awssdk" % "s3" % "2.15.15",
+        // hadoop-aws provides AWS SDK at version >= 1.7.4.  So declare this
+        // version, but ask to use whatever is provided so we do not
+        // override what it selects.
+        "com.amazonaws" % "aws-java-sdk-bundle" % "1.12.140" % "provided",
         // Snappy is JNI :-(.  However it does claim to work with
         // ClassLoaders, and (even more importantly!) using a preloaded JNI
         // version will probably continue to work because the C language API

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
@@ -12,8 +12,6 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.{StringType, StructField, StructType}
 import org.apache.spark.sql.{SparkSession, _}
 
-
-
 import com.amazonaws.ClientConfiguration
 import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
 import com.amazonaws.services.s3.model
@@ -310,7 +308,10 @@ object S3BulkDeleter {
       snPrefix: String
   ): Seq[String] = {
     if (keys.isEmpty) return Seq.empty
-    val removeKeys = keys.map(x => snPrefix.concat(x)).map(k => new model.DeleteObjectsRequest.KeyVersion(k)).asJava
+    val removeKeys = keys
+      .map(x => snPrefix.concat(x))
+      .map(k => new model.DeleteObjectsRequest.KeyVersion(k))
+      .asJava
     val delObjReq = new model.DeleteObjectsRequest(bucket).withKeys(removeKeys)
     val res = s3Client.deleteObjects(delObjReq)
     res.getDeletedObjects.asScala.map(_.getKey())
@@ -318,10 +319,11 @@ object S3BulkDeleter {
 
   private def getS3Client(region: String, numRetries: Int): AmazonS3 = {
     val configuration = new ClientConfiguration().withMaxErrorRetry(numRetries)
-    AmazonS3ClientBuilder.standard().
-      withClientConfiguration(configuration).
-      withRegion(region).
-      build()
+    AmazonS3ClientBuilder
+      .standard()
+      .withClientConfiguration(configuration)
+      .withRegion(region)
+      .build()
   }
 
   def bulkRemove(

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
@@ -249,13 +249,14 @@ object GarbageCollector {
   }
 
   def main(args: Array[String]) {
-    val spark = SparkSession.builder().getOrCreate()
     if (args.length != 2) {
       Console.err.println(
         "Usage: ... <repo_name> <region>"
       )
       System.exit(1)
     }
+
+    val spark = SparkSession.builder().appName("GarbageCollector").getOrCreate()
 
     val repo = args(0)
     val region = args(1)
@@ -290,6 +291,8 @@ object GarbageCollector {
     expiredAddresses.show()
 
     S3BulkDeleter.remove(repo, gcAddressesLocation, runID, region, spark)
+
+    spark.close()
   }
 }
 


### PR DESCRIPTION
Really need to use 1.7.4, which is what Hadoop 2.7.7 used.  But that version is **loooooooonnnnggg** gone.  So go to 1.12.140, which a version from 2022-01 (which should alleviate some AWS log4j worries).

In any case depend on the *provided* version, so we get whatever comes with hadoop-aws (which we do need to bring in some cases).