### PR TITLE
bugfix: webui server serve main page instead of page not found

### DIFF
--- a/cmd/lakectl/cmd/common_helpers.go
+++ b/cmd/lakectl/cmd/common_helpers.go
@@ -11,7 +11,6 @@ import (
 	"os"
 	"reflect"
 	"regexp"
-	"strconv"
 	"strings"
 	"text/template"
 	"time"
@@ -24,9 +23,11 @@ import (
 	"golang.org/x/term"
 )
 
-var isTerminal = true
-var noColorRequested = false
-var verboseMode = false
+var (
+	isTerminal       = true
+	noColorRequested = false
+	verboseMode      = false
+)
 
 // ErrInvalidValueInList is an error returned when a parameter of type list contains an empty string
 var ErrInvalidValueInList = errors.New("empty string in list")
@@ -45,8 +46,10 @@ const (
 	DeathMessageWithFields    = "{{.Message|red}}\n{{.Status}}\n"
 )
 
-const internalPageSize = 1000          // when retreiving all records, use this page size under the hood
-const defaultAmountArgumentValue = 100 // when no amount is specified, use this value for the argument
+const (
+	internalPageSize           = 1000 // when retreiving all records, use this page size under the hood
+	defaultAmountArgumentValue = 100  // when no amount is specified, use this value for the argument
+)
 
 const resourceListTemplate = `{{.Table | table -}}
 {{.Pagination | paginate }}
@@ -238,11 +241,7 @@ func DieOnErrorOrUnexpectedStatusCode(response interface{}, err error, expectedS
 		Die("could not get status code from response", 1)
 	}
 	if statusCode != expectedStatusCode {
-		// redirected to not found page
-		if statusCode == http.StatusFound {
-			Die("got not-found error, probably wrong endpoint url", 1)
-		}
-		Die("got unexpected status code: "+strconv.Itoa(statusCode)+", expected: "+strconv.Itoa(expectedStatusCode), 1)
+		DieFmt("got unexpected status code: %d, expected: %d", statusCode, expectedStatusCode)
 	}
 }
 

--- a/cmd/lakectl/cmd/root.go
+++ b/cmd/lakectl/cmd/root.go
@@ -108,17 +108,10 @@ func getClient() *api.ClientWithResponses {
 	if u.Path == "" || u.Path == "/" {
 		serverEndpoint = strings.TrimRight(serverEndpoint, "/") + api.BaseURL
 	}
-	httpClient := &http.Client{
-		// avoid redirect automatically
-		CheckRedirect: func(req *http.Request, via []*http.Request) error {
-			return http.ErrUseLastResponse
-		},
-	}
 
 	client, err := api.NewClientWithResponses(
 		serverEndpoint,
 		api.WithRequestEditorFn(basicAuthProvider.Intercept),
-		api.WithHTTPClient(httpClient),
 	)
 	if err != nil {
 		Die(fmt.Sprintf("could not initialize API client: %s", err), 1)

--- a/webui/src/pages/auth/index.jsx
+++ b/webui/src/pages/auth/index.jsx
@@ -20,7 +20,6 @@ const Auth = () => {
             <Route path="/auth/resetpassword">
                 <ResetPasswordPage/>
             </Route>
-
             <Route path="/auth/credentials">
                 <CredentialsPage/>
             </Route>
@@ -33,6 +32,7 @@ const Auth = () => {
             <Route path="/auth/policies">
                 <PoliciesIndexPage/>
             </Route>
+            <Redirect to="/auth/credentials" />
         </Switch>
     )
 }

--- a/webui/src/pages/index.jsx
+++ b/webui/src/pages/index.jsx
@@ -23,6 +23,7 @@ export const IndexPage = () => {
                 <Route path="/setup">
                     <Setup/>
                 </Route>
+                <Redirect to="/repositories" />
             </Switch>
         </Router>
     );

--- a/webui/src/pages/repositories/index.jsx
+++ b/webui/src/pages/repositories/index.jsx
@@ -28,7 +28,7 @@ import Container from "react-bootstrap/Container";
 import {Link} from "../../lib/components/nav";
 import {useRouter} from "../../lib/hooks/router";
 
-import {Route, Switch} from "react-router-dom";
+import {Redirect, Route, Switch} from "react-router-dom";
 import RepositoryPage from './repository';
 import Alert from "react-bootstrap/Alert";
 

--- a/webui/src/pages/repositories/repository/index.jsx
+++ b/webui/src/pages/repositories/repository/index.jsx
@@ -52,6 +52,7 @@ const RepositoryPage = () => {
             <Route path="/repositories/:repoId/settings/branches">
                 <RepositorySettingsBranchesPage/>
             </Route>
+            <Redirect from="/repositories/:repoId" to="/repositories/:repoId/objects" />
         </Switch>
     )
 };


### PR DESCRIPTION
Revert behavior, where web UI server - instead of redirect to main page, we return the main page content.

Redirect to main page was added to handle the case of user misconfiguration - the lakectl or API client cloud identify non 2xx and report to the user that the endpoint is not configured.
A follow-up fix should address this in `lakectl doctor` as this fix will prevent the command to identify if the route is valid - getting 200 ok with a page instead of redirect.

Why did we revert to the old behavior:
The client React application uses browser router which handle the navigation on the client side.
Without having a server side that handles the routing or using HashRouter on the client, we need to serve the main page, which includes the main application to handle the URL requested by the browser.

In this change, we return our previous behavior and address defaults for some index pages.
- Redirect of repository name to browse the repository
- Redirect of non auth path to credentials
- Root level not found route will redirect to repositories

Fix #3197 
Closes #3194 