### PR TITLE
GC: Flaky tests fix

### DIFF
--- a/test/spark/run-gc-test.sh
+++ b/test/spark/run-gc-test.sh
@@ -79,9 +79,9 @@ validate_gc_job() {
     if [[ ${days_ago} -gt -1 ]]; then
       local branch_name=$(echo ${branch_props} | jq -r '.branch_name')
       for location in \
-        lakefs://${repo}/${branch_name}/not_deleted_file1 \
-        lakefs://${repo}/${branch_name}/not_deleted_file2 \
-        lakefs://${repo}/${branch_name}/not_deleted_file3
+        lakefs://${repo}/main/not_deleted_file1 \
+        lakefs://${repo}/main/not_deleted_file2 \
+        lakefs://${repo}/main/not_deleted_file3
       do
         if ! run_lakectl fs cat ${location} > /dev/null; then
           echo "expected ${location} to exist"


### PR DESCRIPTION
Currently the integration tests for the garbage collector are a bit flaky... They sometimes fail when trying to validate that files that aren't supposed to be deleted are in fact not deleted. 
This PR tries to fix that by testing the "main" branch for the files and not the branch that the test was using (the files should always be on the main branch).