### PR TITLE
Merge managed gc on Spark 3.1.2 to trunk

### DIFF
--- a/.github/workflows/esti.yaml
+++ b/.github/workflows/esti.yaml
@@ -550,7 +550,9 @@ jobs:
 
       - name: Package Metaclient
         working-directory: clients/spark
-        run: sbt lakefs-spark-client-301/assembly
+        run: |
+          sbt lakefs-spark-client-301/assembly
+          sbt lakefs-spark-client-312-hadoop3/assembly
 
       - name: Prepare Metaclient location for export
         # upload-artifact cannot take a working-directory option (that only
@@ -560,6 +562,7 @@ jobs:
         run: |
           mkdir -p /tmp/export
           cp target/core-301/scala-2.12/lakefs-spark-client-301-assembly*.jar /tmp/export/spark-assembly.jar
+          cp target/core-312-hadoop3/scala-2.12/lakefs-spark-client-312-hadoop3-assembly*.jar /tmp/export/spark-assembly-hadoop3.jar
 
       - name: Export Metaclient
         uses: actions/upload-artifact@v3
@@ -575,9 +578,15 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        spark: [3.2.1, 3.1.2, 3.0.2]
+        spark:
+          - version: 3.2.1
+            suffix: "-hadoop3"
+          - version: 3.1.2
+            suffix: ""
+          - version: 3.0.2
+            suffix: ""
     env:
-      SPARK_TAG: ${{ matrix.spark }}
+      SPARK_TAG: ${{ matrix.spark.version }}
     steps:
       - name: Check-out code
         uses: actions/checkout@v2
@@ -605,36 +614,36 @@ jobs:
         run: ./setup-test.sh
 
       - name: Copy repository ref
-        run: aws s3 cp --recursive s3://esti-system-testing-data/golden-files/gc-test-data s3://esti-system-testing/${{ github.run_number }}-spark${{ matrix.spark }}-metaclient/exporter
+        run: aws s3 cp --recursive s3://esti-system-testing-data/golden-files/gc-test-data s3://esti-system-testing/${{ github.run_number }}-spark${{ matrix.spark.version }}-metaclient/exporter
 
       - name: Setup GC tests
         env:
-          STORAGE_NAMESPACE: s3://esti-system-testing/${{ github.run_number }}-spark${{ matrix.spark }}-metaclient/garbage
-          REPOSITORY: test-data-gc-${{ matrix.spark }}
+          STORAGE_NAMESPACE: s3://esti-system-testing/${{ github.run_number }}-spark${{ matrix.spark.version }}-metaclient/garbage
+          REPOSITORY: test-data-gc-${{ matrix.spark.version }}
         working-directory: test/spark
         run: ./setup-gc-test.sh
 
       - name: Test GC with Spark 3.x
         env:
           STORAGE_NAMESPACE: s3://esti-system-testing/${{ github.run_number }}-spark${{ matrix.spark }}-metaclient/garbage
-          REPOSITORY: test-data-gc-${{ matrix.spark }}
-          CLIENT_JAR: ${{steps.import_metaclient.outputs.download-path}}/spark-assembly.jar
+          REPOSITORY: test-data-gc-${{ matrix.spark.version }}
+          CLIENT_JAR: ${{steps.import_metaclient.outputs.download-path}}/spark-assembly${{ matrix.spark.suffix }}.jar
         working-directory: test/spark
         run: ./run-gc-test.sh
 
       - name: Setup Exporter tests
         env:
-          STORAGE_NAMESPACE: s3://esti-system-testing/${{ github.run_number }}-spark${{ matrix.spark }}-metaclient/exporter
+          STORAGE_NAMESPACE: s3://esti-system-testing/${{ github.run_number }}-spark${{ matrix.spark.version }}-metaclient/exporter
           REPOSITORY: test-data-exporter
         working-directory: test/spark
         run: ./setup-exporter-test.sh
 
       - name: Test Exporter with Spark 3.x
         env:
-          STORAGE_NAMESPACE: s3://esti-system-testing/${{ github.run_number }}-spark${{ matrix.spark }}-metaclient/exporter
+          STORAGE_NAMESPACE: s3://esti-system-testing/${{ github.run_number }}-spark${{ matrix.spark.version }}-metaclient/exporter
           REPOSITORY: test-data-exporter
-          CLIENT_JAR: ${{steps.import_metaclient.outputs.download-path}}/spark-assembly.jar
-          EXPORT_LOCATION: s3://esti-system-testing/${{ github.run_number }}-spark${{ matrix.spark }}-client-export
+          CLIENT_JAR: ${{steps.import_metaclient.outputs.download-path}}/spark-assembly${{ matrix.spark.suffix }}.jar
+          EXPORT_LOCATION: s3://esti-system-testing/${{ github.run_number }}-spark${{ matrix.spark.version }}-client-export
         working-directory: test/spark
         run: ./run-exporter-test.sh
 

--- a/clients/spark/build.sbt
+++ b/clients/spark/build.sbt
@@ -133,7 +133,7 @@ lazy val s3UploadSettings = Seq(
     (assemblyOutputPath in assembly).value ->
       s"${name.value}/${version.value}/${(assemblyJarName in assembly).value}"
   ),
-  s3Upload / s3Host := "bobotreeverse-clients-us-east.s3.amazonaws.com",
+  s3Upload / s3Host := "treeverse-clients-us-east.s3.amazonaws.com",
   s3Upload / s3Progress := true
 )
 

--- a/clients/spark/core/src/main/hadoop2/scala/io/treeverse/clients/conditional/S3ClientBuilder.scala
+++ b/clients/spark/core/src/main/hadoop2/scala/io/treeverse/clients/conditional/S3ClientBuilder.scala
@@ -1,0 +1,17 @@
+package io.treeverse.clients.conditional
+
+import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
+import com.amazonaws.ClientConfiguration
+import org.apache.hadoop.conf.Configuration
+
+object S3ClientBuilder extends io.treeverse.clients.S3ClientBuilder {
+  def build(hc: Configuration, bucket: String, region: String, numRetries: Int): AmazonS3 = {
+    val configuration = new ClientConfiguration().withMaxErrorRetry(numRetries)
+
+    val builder = AmazonS3ClientBuilder
+      .standard()
+      .withClientConfiguration(configuration)
+      .withRegion(region)
+    builder.build
+  }
+}

--- a/clients/spark/core/src/main/hadoop3/scala/io/treeverse/clients/conditional/S3ClientBuilder.scala
+++ b/clients/spark/core/src/main/hadoop3/scala/io/treeverse/clients/conditional/S3ClientBuilder.scala
@@ -1,0 +1,34 @@
+package io.treeverse.clients.conditional
+
+import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
+import com.amazonaws.ClientConfiguration
+import org.apache.hadoop.conf.Configuration
+
+object S3ClientBuilder extends io.treeverse.clients.S3ClientBuilder {
+  def build(hc: Configuration, bucket: String, region: String, numRetries: Int): AmazonS3 = {
+    import org.apache.hadoop.fs.s3a.Constants
+    import org.apache.hadoop.fs.s3a.auth.AssumedRoleCredentialProvider
+
+    val configuration = new ClientConfiguration().withMaxErrorRetry(numRetries)
+
+    // TODO(ariels): Support different per-bucket configuration methods.
+    //     Possibly pre-generate a FileSystem to access the desired bucket,
+    //     and query for its credentials provider.  And cache them, in case
+    //     some objects live in different buckets.
+    val credentialsProvider =
+      if (hc.get(Constants.AWS_CREDENTIALS_PROVIDER) == AssumedRoleCredentialProvider.NAME)
+        Some(new AssumedRoleCredentialProvider(new java.net.URI("s3a://" + bucket), hc))
+      else None
+
+    val builder = AmazonS3ClientBuilder
+      .standard()
+      .withClientConfiguration(configuration)
+      .withRegion(region)
+    val builderWithCredentials = credentialsProvider match {
+      case Some(cp) => builder.withCredentials(cp)
+      case None     => builder
+    }
+
+    builderWithCredentials.build
+  }
+}

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/ApiClient.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/ApiClient.scala
@@ -13,9 +13,10 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.Callable
 
 private object ApiClient {
-  def translateS3String(uri: String): String =
-    raw"^s3:/".r.replaceAllIn(uri, "s3a")
-
+  /**
+   * Translate the protocol of uri from "standard"-ish "s3" to "s3a", to
+   * trigger processing by S3AFileSystem.
+   */
   def translateS3(uri: URI): URI =
     if (uri.getScheme == "s3")
       new URI("s3a",
@@ -69,6 +70,10 @@ class ApiClient(apiUrl: String, accessKey: String, secretKey: String) {
     )
   }
 
+  /**
+   * Query lakeFS for a URL to the metarange of commitID of repoName and
+   * translate that URL to use an appropriate Hadoop FileSystem.
+   */
   def getMetaRangeURL(repoName: String, commitID: String): String = {
     val commit = commitsApi.getCommit(repoName, commitID)
     val metaRangeID = commit.getMetaRangeId
@@ -79,6 +84,10 @@ class ApiClient(apiUrl: String, accessKey: String, secretKey: String) {
     } else ""
   }
 
+  /**
+   * Query lakeFS for a URL to the range of rangeID of repoName and
+   * translate that URL to use an appropriate Hadoop FileSystem.
+   */
   def getRangeURL(repoName: String, rangeID: String): String = {
     val range = metadataApi.getRange(repoName, rangeID)
     val location = range.getLocation

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/ApiClient.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/ApiClient.scala
@@ -13,6 +13,9 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.Callable
 
 private object ApiClient {
+  def translateS3String(uri: String): String =
+    raw"^s3:/".r.replaceAllIn(uri, "s3a")
+
   def translateS3(uri: URI): URI =
     if (uri.getScheme == "s3")
       new URI("s3a",

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/ApiClient.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/ApiClient.scala
@@ -13,9 +13,9 @@ import java.util.concurrent.TimeUnit
 import java.util.concurrent.Callable
 
 private object ApiClient {
-  /**
-   * Translate the protocol of uri from "standard"-ish "s3" to "s3a", to
-   * trigger processing by S3AFileSystem.
+
+  /** Translate the protocol of uri from "standard"-ish "s3" to "s3a", to
+   *  trigger processing by S3AFileSystem.
    */
   def translateS3(uri: URI): URI =
     if (uri.getScheme == "s3")
@@ -70,9 +70,8 @@ class ApiClient(apiUrl: String, accessKey: String, secretKey: String) {
     )
   }
 
-  /**
-   * Query lakeFS for a URL to the metarange of commitID of repoName and
-   * translate that URL to use an appropriate Hadoop FileSystem.
+  /** Query lakeFS for a URL to the metarange of commitID of repoName and
+   *  translate that URL to use an appropriate Hadoop FileSystem.
    */
   def getMetaRangeURL(repoName: String, commitID: String): String = {
     val commit = commitsApi.getCommit(repoName, commitID)
@@ -84,9 +83,8 @@ class ApiClient(apiUrl: String, accessKey: String, secretKey: String) {
     } else ""
   }
 
-  /**
-   * Query lakeFS for a URL to the range of rangeID of repoName and
-   * translate that URL to use an appropriate Hadoop FileSystem.
+  /** Query lakeFS for a URL to the range of rangeID of repoName and
+   *  translate that URL to use an appropriate Hadoop FileSystem.
    */
   def getRangeURL(repoName: String, rangeID: String): String = {
     val range = metadataApi.getRange(repoName, rangeID)

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
@@ -7,23 +7,39 @@ import io.treeverse.clients.LakeFSContext.{
   LAKEFS_CONF_API_URL_KEY
 }
 import org.apache.hadoop.conf.Configuration
+import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.rdd.RDD
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.{StringType, StructField, StructType}
 import org.apache.spark.sql.{SparkSession, _}
-import software.amazon.awssdk.core.client.config.ClientOverrideConfiguration
-import software.amazon.awssdk.core.retry.RetryPolicy
-import software.amazon.awssdk.core.retry.backoff.BackoffStrategy
-import software.amazon.awssdk.regions.Region
-import software.amazon.awssdk.services.s3.S3Client
-import software.amazon.awssdk.services.s3.model.{Delete, DeleteObjectsRequest, ObjectIdentifier}
+
+import com.amazonaws.ClientConfiguration
+import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
+import com.amazonaws.services.s3.model
 
 import java.net.URI
 import collection.JavaConverters._
 
 object GarbageCollector {
+  type ConfMap = List[(String, String)]
 
   case class APIConfigurations(apiURL: String, accessKey: String, secretKey: String)
+
+  /**
+   * @return a serializable summary of values in hc starting with prefix.
+   */
+  def getHadoopConfigurationValues(hc: Configuration, prefix: String): ConfMap =
+    hc.iterator.asScala
+      .filter(_.getKey.startsWith(prefix))
+      .map(e => (e.getKey, e.getValue))
+      .toList
+      .asInstanceOf[ConfMap]
+
+  def configurationFromValues(v: Broadcast[ConfMap]) = {
+    val hc = new Configuration()
+    v.value.foreach({ case (k, v) => hc.set(k, v) })
+    hc
+  }
 
   def getCommitsDF(runID: String, commitDFLocation: String, spark: SparkSession): Dataset[Row] = {
     spark.read
@@ -35,15 +51,16 @@ object GarbageCollector {
   private def getRangeTuples(
       commitID: String,
       repo: String,
-      conf: APIConfigurations
+      apiConf: APIConfigurations,
+      hcValues: Broadcast[ConfMap]
   ): Set[(String, Array[Byte], Array[Byte])] = {
     val location =
-      new ApiClient(conf.apiURL, conf.accessKey, conf.secretKey).getMetaRangeURL(repo, commitID)
+      new ApiClient(apiConf.apiURL, apiConf.accessKey, apiConf.secretKey).getMetaRangeURL(repo, commitID)
     // continue on empty location, empty location is a result of a commit with no metaRangeID (e.g 'Repository created' commit)
     if (location == "") Set()
     else
       SSTableReader
-        .forMetaRange(new Configuration(), location)
+        .forMetaRange(configurationFromValues(hcValues), ApiClient.translateS3String(location))
         .newIterator()
         .map(range =>
           (new String(range.id), range.message.minKey.toByteArray, range.message.maxKey.toByteArray)
@@ -54,10 +71,11 @@ object GarbageCollector {
   def getRangesDFFromCommits(
       commits: Dataset[Row],
       repo: String,
-      conf: APIConfigurations
+      apiConf: APIConfigurations,
+      hcValues: Broadcast[ConfMap]
   ): Dataset[Row] = {
     val get_range_tuples = udf((commitID: String) => {
-      getRangeTuples(commitID, repo, conf).toSeq
+      getRangeTuples(commitID, repo, apiConf, hcValues).toSeq
     })
 
     commits.distinct
@@ -73,13 +91,14 @@ object GarbageCollector {
 
   def getRangeAddresses(
       rangeID: String,
-      conf: APIConfigurations,
-      repo: String
+      apiConf: APIConfigurations,
+      repo: String,
+      hcValues: Broadcast[ConfMap]
   ): Seq[String] = {
     val location =
-      new ApiClient(conf.apiURL, conf.accessKey, conf.secretKey).getRangeURL(repo, rangeID)
+      new ApiClient(apiConf.apiURL, apiConf.accessKey, apiConf.secretKey).getRangeURL(repo, rangeID)
     SSTableReader
-      .forRange(new Configuration(), location)
+      .forRange(configurationFromValues(hcValues), ApiClient.translateS3String(location))
       .newIterator()
       .map(a => a.message.address)
       .toSeq
@@ -87,17 +106,18 @@ object GarbageCollector {
 
   def getEntryTuples(
       rangeID: String,
-      conf: APIConfigurations,
-      repo: String
+      apiConf: APIConfigurations,
+      repo: String,
+      hcValues: Broadcast[ConfMap]
   ): Set[(String, String, Boolean, Long)] = {
     def getSeconds(ts: Option[Timestamp]): Long = {
       ts.getOrElse(0).asInstanceOf[Timestamp].seconds
     }
 
     val location =
-      new ApiClient(conf.apiURL, conf.accessKey, conf.secretKey).getRangeURL(repo, rangeID)
+      new ApiClient(apiConf.apiURL, apiConf.accessKey, apiConf.secretKey).getRangeURL(repo, rangeID)
     SSTableReader
-      .forRange(new Configuration(), location)
+      .forRange(configurationFromValues(hcValues), ApiClient.translateS3String(location))
       .newIterator()
       .map(a =>
         (
@@ -112,24 +132,25 @@ object GarbageCollector {
 
   /** @param leftRangeIDs
    *  @param rightRangeIDs
-   *  @param conf
+   *  @param apiConf
    *  @return tuples of type (key, address, isRelative, lastModified) for every address existing in leftRanges and not in rightRanges
    */
   def leftAntiJoinAddresses(
       leftRangeIDs: Set[String],
       rightRangeIDs: Set[String],
-      conf: APIConfigurations,
-      repo: String
+      apiConf: APIConfigurations,
+      repo: String,
+      hcValues: Broadcast[ConfMap]
   ): Set[(String, String, Boolean, Long)] = {
-    distinctEntryTuples(leftRangeIDs, conf, repo)
+    distinctEntryTuples(leftRangeIDs, apiConf, repo, hcValues)
 
-    val leftTuples = distinctEntryTuples(leftRangeIDs, conf, repo)
-    val rightTuples = distinctEntryTuples(rightRangeIDs, conf, repo)
+    val leftTuples = distinctEntryTuples(leftRangeIDs, apiConf, repo, hcValues)
+    val rightTuples = distinctEntryTuples(rightRangeIDs, apiConf, repo, hcValues)
     leftTuples -- rightTuples
   }
 
-  private def distinctEntryTuples(rangeIDs: Set[String], conf: APIConfigurations, repo: String) = {
-    val tuples = rangeIDs.map((rangeID: String) => getEntryTuples(rangeID, conf, repo))
+  private def distinctEntryTuples(rangeIDs: Set[String], apiConf: APIConfigurations, repo: String, hcValues: Broadcast[ConfMap]) = {
+    val tuples = rangeIDs.map((rangeID: String) => getEntryTuples(rangeID, apiConf, repo, hcValues))
     if (tuples.isEmpty) Set[(String, String, Boolean, Long)]() else tuples.reduce(_.union(_))
   }
 
@@ -140,11 +161,12 @@ object GarbageCollector {
    */
   def getExpiredEntriesFromRanges(
       ranges: Dataset[Row],
-      conf: APIConfigurations,
-      repo: String
+      apiConf: APIConfigurations,
+      repo: String,
+      hcValues: Broadcast[ConfMap]
   ): Dataset[Row] = {
     val left_anti_join_addresses = udf((x: Seq[String], y: Seq[String]) => {
-      leftAntiJoinAddresses(x.toSet, y.toSet, conf, repo).toSeq
+      leftAntiJoinAddresses(x.toSet, y.toSet, apiConf, repo, hcValues).toSeq
     })
     val expiredRangesDF = ranges.where("expired")
     val activeRangesDF = ranges.where("!expired")
@@ -213,28 +235,30 @@ object GarbageCollector {
       runID: String,
       commitDFLocation: String,
       spark: SparkSession,
-      conf: APIConfigurations
+      apiConf: APIConfigurations,
+      hcValues: Broadcast[ConfMap]
   ): Dataset[Row] = {
     val commitsDF = getCommitsDF(runID, commitDFLocation, spark)
-    val rangesDF = getRangesDFFromCommits(commitsDF, repo, conf)
-    val expired = getExpiredEntriesFromRanges(rangesDF, conf, repo)
+    val rangesDF = getRangesDFFromCommits(commitsDF, repo, apiConf, hcValues)
+    val expired = getExpiredEntriesFromRanges(rangesDF, apiConf, repo, hcValues)
 
     val activeRangesDF = rangesDF.where("!expired")
-    subtractDeduplications(expired, activeRangesDF, conf, repo, spark)
+    subtractDeduplications(expired, activeRangesDF, apiConf, repo, spark, hcValues)
   }
 
   private def subtractDeduplications(
       expired: Dataset[Row],
       activeRangesDF: Dataset[Row],
-      conf: APIConfigurations,
+      apiConf: APIConfigurations,
       repo: String,
-      spark: SparkSession
+      spark: SparkSession,
+      hcValues: Broadcast[ConfMap]
   ): Dataset[Row] = {
     val activeRangesRDD: RDD[String] =
       activeRangesDF.select("range_id").rdd.distinct().map(x => x.getString(0))
     val activeAddresses: RDD[String] = activeRangesRDD
       .flatMap(range => {
-        getRangeAddresses(range, conf, repo)
+        getRangeAddresses(range, apiConf, repo, hcValues)
       })
       .distinct()
     val activeAddressesRows: RDD[Row] = activeAddresses.map(x => Row(x))
@@ -249,7 +273,6 @@ object GarbageCollector {
   }
 
   def main(args: Array[String]) {
-    val spark = SparkSession.builder().getOrCreate()
     if (args.length != 2) {
       Console.err.println(
         "Usage: ... <repo_name> <region>"
@@ -257,16 +280,22 @@ object GarbageCollector {
       System.exit(1)
     }
 
+    val spark = SparkSession.builder().appName("GarbageCollector").getOrCreate()
+
     val repo = args(0)
     val region = args(1)
     val previousRunID =
       "" //args(2) // TODO(Guys): get previous runID from arguments or from storage
     val hc = spark.sparkContext.hadoopConfiguration
+
+    val hcValues = spark.sparkContext.broadcast(getHadoopConfigurationValues(hc, "fs."))
+
     val apiURL = hc.get(LAKEFS_CONF_API_URL_KEY)
     val accessKey = hc.get(LAKEFS_CONF_API_ACCESS_KEY_KEY)
     val secretKey = hc.get(LAKEFS_CONF_API_SECRET_KEY_KEY)
-    val res = new ApiClient(apiURL, accessKey, secretKey)
-      .prepareGarbageCollectionCommits(repo, previousRunID)
+    val apiClient = new ApiClient(apiURL, accessKey, secretKey)
+
+    val res = apiClient.prepareGarbageCollectionCommits(repo, previousRunID)
     val runID = res.getRunId
     println("apiURL: " + apiURL)
 
@@ -278,7 +307,8 @@ object GarbageCollector {
                                                runID,
                                                gcCommitsLocation,
                                                spark,
-                                               APIConfigurations(apiURL, accessKey, secretKey)
+                                               APIConfigurations(apiURL, accessKey, secretKey),
+                                               hcValues
                                               ).withColumn("run_id", lit(runID))
     spark.conf.set("spark.sql.sources.partitionOverwriteMode", "dynamic")
     expiredAddresses.write
@@ -289,11 +319,20 @@ object GarbageCollector {
     println("Expired addresses:")
     expiredAddresses.show()
 
-    S3BulkDeleter.remove(repo, gcAddressesLocation, runID, region, spark)
-  }
-}
+    val storageNamespace = new ApiClient(apiURL, accessKey, secretKey).getStorageNamespace(repo)
 
-object S3BulkDeleter {
+    val removed = remove(storageNamespace, gcAddressesLocation, expiredAddresses, runID, region, hcValues)
+
+    // BUG(ariels): Write to some other location!
+    removed.withColumn("run_id", lit(runID))
+      .write
+      .partitionBy("run_id")
+      .mode(SaveMode.Overwrite)
+      .parquet(gcAddressesLocation + ".deleted")
+
+    spark.close()
+  }
+
   private def repartitionBySize(df: DataFrame, maxSize: Int, column: String): DataFrame = {
     val nRows = df.count()
     val nPartitions = math.max(1, math.floor(nRows / maxSize)).toInt
@@ -303,37 +342,56 @@ object S3BulkDeleter {
   private def delObjIteration(
       bucket: String,
       keys: Seq[String],
-      s3Client: S3Client,
+      s3Client: AmazonS3,
       snPrefix: String
   ): Seq[String] = {
-    if (keys.isEmpty) None
-    val removeKeys =
-      keys.map(x => ObjectIdentifier.builder().key(snPrefix.concat(x)).build()).asJava
-    val delObj = Delete.builder().objects(removeKeys).build()
-    val delObjReq = DeleteObjectsRequest.builder.delete(delObj).bucket(bucket).build()
+    if (keys.isEmpty) return Seq.empty
+    val removeKeyNames = keys.map(x => snPrefix.concat(x))
+
+    println("Remove keys:", removeKeyNames.take(100).mkString(", "))
+
+    val removeKeys = removeKeyNames.map(k => new model.DeleteObjectsRequest.KeyVersion(k)).asJava
+
+    val delObjReq = new model.DeleteObjectsRequest(bucket).withKeys(removeKeys)
     val res = s3Client.deleteObjects(delObjReq)
-    res.deleted().asScala.map(_.key())
+    res.getDeletedObjects.asScala.map(_.getKey())
   }
 
-  private def getS3Client(region: String, numRetries: Int) = {
-    val retryPolicy = RetryPolicy
-      .builder()
-      .backoffStrategy(BackoffStrategy.defaultThrottlingStrategy())
-      .numRetries(numRetries)
-      .build()
-    val configuration = ClientOverrideConfiguration.builder().retryPolicy(retryPolicy).build()
-    S3Client.builder.region(Region.of(region)).overrideConfiguration(configuration).build
+  private def getS3Client(hc: Configuration, bucket: String, region: String, numRetries: Int): AmazonS3 = {
+    import org.apache.hadoop.fs.s3a.Constants
+    import org.apache.hadoop.fs.s3a.auth.AssumedRoleCredentialProvider
+
+    val configuration = new ClientConfiguration().withMaxErrorRetry(numRetries)
+
+    // TODO(ariels): Support different per-bucket configuration methods.
+    //     Possibly pre-generate a FileSystem to access the desired bucket,
+    //     and query for its credentials provider.  And cache them, in case
+    //     some objects live in different buckets.
+    val credentialsProvider = if (hc.get(Constants.AWS_CREDENTIALS_PROVIDER) == AssumedRoleCredentialProvider.NAME)
+      Some(new AssumedRoleCredentialProvider(new java.net.URI("s3a://" + bucket), hc)) else None
+
+    val builder = AmazonS3ClientBuilder
+      .standard()
+      .withClientConfiguration(configuration)
+      .withRegion(region)
+    val builderWithCredentials = credentialsProvider match {
+      case Some(cp) => builder.withCredentials(cp)
+      case None => builder
+    }
+
+    builderWithCredentials.build
   }
 
   def bulkRemove(
       readKeysDF: DataFrame,
       bulkSize: Int,
-      spark: SparkSession,
       bucket: String,
       region: String,
       numRetries: Int,
-      snPrefix: String
+      snPrefix: String,
+      hcValues: Broadcast[ConfMap]
   ): Dataset[String] = {
+    val spark = org.apache.spark.sql.SparkSession.active
     import spark.implicits._
     val repartitionedKeys = repartitionBySize(readKeysDF, bulkSize, "address")
     val bulkedKeyStrings = repartitionedKeys
@@ -341,27 +399,24 @@ object S3BulkDeleter {
       .map(_.getString(0)) // get address as string (address is in index 0 of row)
     bulkedKeyStrings
       .mapPartitions(iter => {
+        val s3Client = getS3Client(configurationFromValues(hcValues), bucket, region, numRetries)
         iter
           .grouped(bulkSize)
-          .flatMap(delObjIteration(bucket, _, getS3Client(region, numRetries), snPrefix))
+          .flatMap(delObjIteration(bucket, _, s3Client, snPrefix))
       })
   }
 
   def remove(
-      repo: String,
+      storageNamespace: String,
       addressDFLocation: String,
+      expiredAddresses: Dataset[Row],
       runID: String,
       region: String,
-      spark: SparkSession
+      hcValues: Broadcast[ConfMap]
   ) = {
     val MaxBulkSize = 1000
     val awsRetries = 1000
 
-    val hc = spark.sparkContext.hadoopConfiguration
-    val apiURL = hc.get(LAKEFS_CONF_API_URL_KEY)
-    val accessKey = hc.get(LAKEFS_CONF_API_ACCESS_KEY_KEY)
-    val secretKey = hc.get(LAKEFS_CONF_API_SECRET_KEY_KEY)
-    val storageNamespace = new ApiClient(apiURL, accessKey, secretKey).getStorageNamespace(repo)
     println("storageNamespace: " + storageNamespace)
     val uri = new URI(storageNamespace)
     val bucket = uri.getHost
@@ -371,28 +426,11 @@ object S3BulkDeleter {
       if (addSuffixSlash.startsWith("/")) addSuffixSlash.substring(1) else addSuffixSlash
     println("addressDFLocation: " + addressDFLocation)
 
-    val df = spark.read
-      .parquet(addressDFLocation)
+    val df = expiredAddresses
       .where(col("run_id") === runID)
       .where(col("relative") === true)
-    val res =
-      bulkRemove(df, MaxBulkSize, spark, bucket, region, awsRetries, snPrefix)
-        .toDF("addresses")
-        .collect()
-  }
 
-  def main(args: Array[String]): Unit = {
-    if (args.length != 4) {
-      Console.err.println(
-        "Usage: ... <repo_name> <runID> <region> s3://storageNamespace/prepared_addresses_table"
-      )
-      System.exit(1)
-    }
-    val repo = args(0)
-    val runID = args(1)
-    val region = args(2)
-    val addressesDFLocation = args(3)
-    val spark = SparkSession.builder().getOrCreate()
-    remove(repo, addressesDFLocation, runID, region, spark)
+    bulkRemove(df, MaxBulkSize, bucket, region, awsRetries, snPrefix, hcValues).toDF("addresses")
   }
 }
+

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
@@ -13,20 +13,38 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.{StringType, StructField, StructType}
 import org.apache.spark.sql.{SparkSession, _}
 
-import com.amazonaws.ClientConfiguration
-import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
+import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model
 
 import java.net.URI
 import collection.JavaConverters._
+
+/** Interface to build an S3 client.  The object
+ *  io.treeverse.clients.conditional.S3ClientBuilder -- conditionally
+ *  defined in a separate file according to the supported Hadoop version --
+ *  implements this trait.  (Scala requires companion objects to be defined
+ *  in the same file, so it cannot be a companion.)
+ */
+trait S3ClientBuilder extends Serializable {
+
+  /** Return a configured Amazon S3 client similar to the one S3A would use.
+   *  On Hadoop versions >=3, S3A can assume a role, and the returned S3
+   *  client will similarly assume that role.
+   *
+   *  @param hc (partial) Hadoop configuration of fs.s3a.
+   *  @param bucket that this client will access.
+   *  @param region to find this bucket.
+   *  @param numRetries number of times to retry on AWS.
+   */
+  def build(hc: Configuration, bucket: String, region: String, numRetries: Int): AmazonS3
+}
 
 object GarbageCollector {
   type ConfMap = List[(String, String)]
 
   case class APIConfigurations(apiURL: String, accessKey: String, secretKey: String)
 
-  /**
-   * @return a serializable summary of values in hc starting with prefix.
+  /** @return a serializable summary of values in hc starting with prefix.
    */
   def getHadoopConfigurationValues(hc: Configuration, prefix: String): ConfMap =
     hc.iterator.asScala
@@ -55,7 +73,8 @@ object GarbageCollector {
       hcValues: Broadcast[ConfMap]
   ): Set[(String, Array[Byte], Array[Byte])] = {
     val location =
-      new ApiClient(apiConf.apiURL, apiConf.accessKey, apiConf.secretKey).getMetaRangeURL(repo, commitID)
+      new ApiClient(apiConf.apiURL, apiConf.accessKey, apiConf.secretKey)
+        .getMetaRangeURL(repo, commitID)
     // continue on empty location, empty location is a result of a commit with no metaRangeID (e.g 'Repository created' commit)
     if (location == "") Set()
     else
@@ -149,7 +168,12 @@ object GarbageCollector {
     leftTuples -- rightTuples
   }
 
-  private def distinctEntryTuples(rangeIDs: Set[String], apiConf: APIConfigurations, repo: String, hcValues: Broadcast[ConfMap]) = {
+  private def distinctEntryTuples(
+      rangeIDs: Set[String],
+      apiConf: APIConfigurations,
+      repo: String,
+      hcValues: Broadcast[ConfMap]
+  ) = {
     val tuples = rangeIDs.map((rangeID: String) => getEntryTuples(rangeID, apiConf, repo, hcValues))
     if (tuples.isEmpty) Set[(String, String, Boolean, Long)]() else tuples.reduce(_.union(_))
   }
@@ -326,10 +350,12 @@ object GarbageCollector {
 
     val storageNamespace = new ApiClient(apiURL, accessKey, secretKey).getStorageNamespace(repo)
 
-    val removed = remove(storageNamespace, gcAddressesLocation, expiredAddresses, runID, region, hcValues)
+    val removed =
+      remove(storageNamespace, gcAddressesLocation, expiredAddresses, runID, region, hcValues)
 
     // BUG(ariels): Write to some other location!
-    removed.withColumn("run_id", lit(runID))
+    removed
+      .withColumn("run_id", lit(runID))
       .write
       .partitionBy("run_id")
       .mode(SaveMode.Overwrite)
@@ -362,30 +388,13 @@ object GarbageCollector {
     res.getDeletedObjects.asScala.map(_.getKey())
   }
 
-  private def getS3Client(hc: Configuration, bucket: String, region: String, numRetries: Int): AmazonS3 = {
-    import org.apache.hadoop.fs.s3a.Constants
-    import org.apache.hadoop.fs.s3a.auth.AssumedRoleCredentialProvider
-
-    val configuration = new ClientConfiguration().withMaxErrorRetry(numRetries)
-
-    // TODO(ariels): Support different per-bucket configuration methods.
-    //     Possibly pre-generate a FileSystem to access the desired bucket,
-    //     and query for its credentials provider.  And cache them, in case
-    //     some objects live in different buckets.
-    val credentialsProvider = if (hc.get(Constants.AWS_CREDENTIALS_PROVIDER) == AssumedRoleCredentialProvider.NAME)
-      Some(new AssumedRoleCredentialProvider(new java.net.URI("s3a://" + bucket), hc)) else None
-
-    val builder = AmazonS3ClientBuilder
-      .standard()
-      .withClientConfiguration(configuration)
-      .withRegion(region)
-    val builderWithCredentials = credentialsProvider match {
-      case Some(cp) => builder.withCredentials(cp)
-      case None => builder
-    }
-
-    builderWithCredentials.build
-  }
+  private def getS3Client(
+      hc: Configuration,
+      bucket: String,
+      region: String,
+      numRetries: Int
+  ): AmazonS3 =
+    io.treeverse.clients.conditional.S3ClientBuilder.build(hc, bucket, region, numRetries)
 
   def bulkRemove(
       readKeysDF: DataFrame,
@@ -438,4 +447,3 @@ object GarbageCollector {
     bulkRemove(df, MaxBulkSize, bucket, region, awsRetries, snPrefix, hcValues).toDF("addresses")
   }
 }
-

--- a/clients/spark/project/types.scala
+++ b/clients/spark/project/types.scala
@@ -6,5 +6,6 @@ class BuildType(
     val sparkVersion: String,
     val scalapbVersion: String,
     val hadoopVersion: String,
+    val hadoopFlavour: String, // If set, a directory of additional sources to compile
     val gcpConnectorVersion: String
 )


### PR DESCRIPTION
After #3229 we can build all metadata client versions safely.  Let's merge back to trunk!

## For changelog:

* Support configured S3A assume-role in Spark Garbage Collector code on Spark 3.1.2 with Hadoop 3.