### PR TITLE
Add uniquifying values to Esti tests with external storage access

### DIFF
--- a/.github/workflows/esti.yaml
+++ b/.github/workflows/esti.yaml
@@ -483,7 +483,7 @@ jobs:
 
       - name: Test rclone export
         env:
-          EXPORT_LOCATION: s3://esti-system-testing/${{ github.run_number }}-rclone-export-dest
+          EXPORT_LOCATION: s3://esti-system-testing/${{ github.run_number }}-rclone-export-dest/${{ steps.unique.outputs.value }}
           S3_ACCESS_KEY: ${{ secrets.ESTI_AWS_ACCESS_KEY_ID }}
           S3_SECRET_KEY: ${{ secrets.ESTI_AWS_SECRET_ACCESS_KEY }}
         working-directory: test/rclone_export
@@ -531,7 +531,7 @@ jobs:
       - name: Setup lakeFS for tests
         working-directory: test/lakectl_metastore
         env:
-          STORAGE_NAMESPACE: s3://esti-system-testing/${{ github.run_number }}-metaclient/${{ secrets.ESTI_AWS_SECRET_ACCESS_KEY }}
+          STORAGE_NAMESPACE: s3://esti-system-testing/${{ github.run_number }}-metaclient/${{ steps.unique.outputs.value }}
         run: ./setup-test.sh
 
       - name: Test using DBT and lakectl metastore commands
@@ -638,7 +638,7 @@ jobs:
         run: ./setup-test.sh
 
       - name: Copy repository ref
-        run: aws s3 cp --recursive s3://esti-system-testing-data/golden-files/gc-test-data s3://esti-system-testing/${{ github.run_number }}-spark${{ matrix.spark.version }}-metaclient/exporter
+        run: aws s3 cp --recursive s3://esti-system-testing-data/golden-files/gc-test-data s3://esti-system-testing/${{ github.run_number }}-spark${{ matrix.spark.version }}-metaclient/exporter/${{ steps.unique.outputs.value }}
 
       - name: Setup GC tests
         env:
@@ -667,7 +667,7 @@ jobs:
           STORAGE_NAMESPACE: s3://esti-system-testing/${{ github.run_number }}-spark${{ matrix.spark.version }}-metaclient/exporter/${{ steps.unique.outputs.value }}
           REPOSITORY: test-data-exporter
           CLIENT_JAR: ${{steps.import_metaclient.outputs.download-path}}/spark-assembly${{ matrix.spark.suffix }}.jar
-          EXPORT_LOCATION: s3://esti-system-testing/${{ github.run_number }}-spark${{ matrix.spark.version }}-client-export
+          EXPORT_LOCATION: s3://esti-system-testing/${{ github.run_number }}-spark${{ matrix.spark.version }}-client-export/${{ steps.unique.outputs.value }}
         working-directory: test/spark
         run: ./run-exporter-test.sh
 
@@ -714,7 +714,7 @@ jobs:
 
       - name: Check files in S3 bucket
         run: |
-            FILES_COUNT=`aws s3 ls s3://esti-system-testing/${{ github.run_number }} --recursive | wc -l`
+            FILES_COUNT=`aws s3 ls s3://esti-system-testing/${{ github.run_number }}/${{ steps.unique.outputs.value }} --recursive | wc -l`
             [ $FILES_COUNT -gt 5 ]
       - name: lakeFS Logs on s3 failure
         if: ${{ failure() }}
@@ -724,7 +724,7 @@ jobs:
         if: ${{ always() }}
         run: |
             cd esti/ops
-            docker-compose ps -q postgres && docker-compose exec -T postgres pg_dumpall --username=lakefs | gzip | aws s3 cp - s3://esti-system-testing/${{ github.run_number }}/dump.gz
+            docker-compose ps -q postgres && docker-compose exec -T postgres pg_dumpall --username=lakefs | gzip | aws s3 cp - s3://esti-system-testing/${{ github.run_number }}/${{ steps.unique.outputs.value }}/dump.gz
       - name: Run lakeFS S3 to use with local API key
         env:
           LAKEFS_STATS_ENABLED: "false"

--- a/.github/workflows/esti.yaml
+++ b/.github/workflows/esti.yaml
@@ -271,9 +271,13 @@ jobs:
         working-directory: test/spark
         run: ./setup-test.sh
 
+      - name: Generate uniquifying value
+        id: unique
+        run:  echo "::set-output name=value::$RANDOM"
+
       - name: Test lakeFS multipart upload with Hadoop S3A
         env:
-          STORAGE_NAMESPACE: s3://esti-system-testing/${{ github.run_number }}-s3a-mpu
+          STORAGE_NAMESPACE: s3://esti-system-testing/${{ github.run_number }}-s3a-mpu/${{ steps.unique.outputs.value }}
           REPOSITORY: s3a-mpu-test
           AWS_ACCESS_KEY_ID: ${{ secrets.TESTER_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.TESTER_SECRET_ACCESS_KEY }}
@@ -282,7 +286,7 @@ jobs:
           #     a Docker container.  Bypass this somehow.
           ENDPOINT: "http://s3.local.lakefs.io:8000"
         working-directory: test/spark/s3a-multipart
-        run: docker-compose exec -T lakefs lakectl repo create "lakefs://${REPOSITORY}" ${STORAGE_NAMESPACE} -d main && sbt "run s3a://${REPOSITORY}/main/multipart.out"
+        run: docker-compose exec -T lakefs lakectl repo create "lakefs://${REPOSITORY}" "${STORAGE_NAMESPACE}" -d main && sbt "run s3a://${REPOSITORY}/main/multipart.out"
 
       - name: lakeFS logs on failure
         if: ${{ failure() }}
@@ -327,9 +331,13 @@ jobs:
         working-directory: test/spark
         run: ./setup-test.sh
 
+      - name: Generate uniquifying value
+        id: unique
+        run:  echo "::set-output name=value::$RANDOM"
+
       - name: Test lakeFS S3 with Spark 2.x
         env:
-          STORAGE_NAMESPACE: s3://esti-system-testing/${{ github.run_number }}-spark2
+          STORAGE_NAMESPACE: s3://esti-system-testing/${{ github.run_number }}-spark2/${{ steps.unique.outputs.value }}
           REPOSITORY: gateway-test-spark2
           SONNET_JAR: sonnets-246/target/sonnets-246/scala-2.11/sonnets-246_2.11-0.1.0.jar
         working-directory: test/spark
@@ -349,7 +357,7 @@ jobs:
         timeout-minutes: 8
         env:
           JARS: clients/hadoopfs/
-          STORAGE_NAMESPACE: s3://esti-system-testing/${{ github.run_number }}-spark2-client
+          STORAGE_NAMESPACE: s3://esti-system-testing/${{ github.run_number }}-spark2-client/${{ steps.unique.outputs.value }}
           AWS_ACCESS_KEY_ID: ${{ secrets.ESTI_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.ESTI_AWS_SECRET_ACCESS_KEY }}
           USE_DIRECT_ACCESS: "true"
@@ -383,6 +391,10 @@ jobs:
         working-directory: test/spark/app
         run: sbt sonnets-311/package
 
+      - name: Generate uniquifying value
+        id: unique
+        run:  echo "::set-output name=value::$RANDOM"
+
       - name: Start lakeFS for Spark tests
         uses: ./.github/actions/bootstrap-test-lakefs
         with:
@@ -400,7 +412,7 @@ jobs:
       - name: Test lakeFS S3 with Spark 3.x
         continue-on-error: true
         env:
-          STORAGE_NAMESPACE: s3://esti-system-testing/${{ github.run_number }}-spark3
+          STORAGE_NAMESPACE: s3://esti-system-testing/${{ github.run_number }}-spark3/${{ steps.unique.outputs.value }}
           REPOSITORY: gateway-test-spark3
           SONNET_JAR: sonnets-311/target/sonnets-311/scala-2.12/sonnets-311_2.12-0.1.0.jar
         working-directory: test/spark
@@ -420,7 +432,7 @@ jobs:
         timeout-minutes: 8
         env:
           JARS: clients/hadoopfs/
-          STORAGE_NAMESPACE: s3://esti-system-testing/${{ github.run_number }}-spark3-client
+          STORAGE_NAMESPACE: s3://esti-system-testing/${{ github.run_number }}-spark3-client/${{ steps.unique.outputs.value }}
           AWS_ACCESS_KEY_ID: ${{ secrets.ESTI_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.ESTI_AWS_SECRET_ACCESS_KEY }}
           USE_DIRECT_ACCESS: "true"
@@ -443,7 +455,7 @@ jobs:
       LAKEFS_TAG: ${{ needs.deploy-image.outputs.tag }}
       EXPORT_TAG: ${{ needs.deploy-rclone-export-image.outputs.tag }}
       REPO: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com
-      STORAGE_NAMESPACE: s3://esti-system-testing/${{ github.run_number }}-storage-rclone-export
+
     steps:
       - name: Check-out code
         uses: actions/checkout@v2
@@ -459,9 +471,13 @@ jobs:
           LAKEFS_BLOCKSTORE_S3_CREDENTIALS_ACCESS_KEY_ID: ${{ secrets.ESTI_AWS_ACCESS_KEY_ID }}
           LAKEFS_BLOCKSTORE_S3_CREDENTIALS_SECRET_ACCESS_KEY: ${{ secrets.ESTI_AWS_SECRET_ACCESS_KEY }}
 
+      - name: Generate uniquifying value
+        id: unique
+        run:  echo "::set-output name=value::$RANDOM"
+
       - name: Setup lakeFS for tests
         env:
-          STORAGE_NAMESPACE: s3://esti-system-testing/${{ github.run_number }}-storage-rclone-export
+          STORAGE_NAMESPACE: s3://esti-system-testing/${{ github.run_number }}-storage-rclone-export/${{ steps.unique.outputs.value }}
         working-directory: test/rclone_export
         run: ./setup-test.sh
 
@@ -491,13 +507,17 @@ jobs:
           go-version: 1.17.8
         id: go
 
+      - name: Generate uniquifying value
+        id: unique
+        run:  echo "::set-output name=value::$RANDOM"
+
       - name: Start lakeFS for Metastore tests
         uses: ./.github/actions/bootstrap-test-lakefs
         with:
           compose-directory: test/lakectl_metastore
         env:
           AWS_ACCOUNT_ID: ${{ secrets.AWS_ACCOUNT_ID }}
-          STORAGE_NAMESPACE: s3://esti-system-testing/${{ github.run_number }}-metaclient
+          STORAGE_NAMESPACE: s3://esti-system-testing/${{ github.run_number }}-metaclient/${{ steps.unique.outputs.value }}
           LAKEFS_BLOCKSTORE_TYPE: s3
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
@@ -511,7 +531,7 @@ jobs:
       - name: Setup lakeFS for tests
         working-directory: test/lakectl_metastore
         env:
-          STORAGE_NAMESPACE: s3://esti-system-testing/${{ github.run_number }}-metaclient
+          STORAGE_NAMESPACE: s3://esti-system-testing/${{ github.run_number }}-metaclient/${{ secrets.ESTI_AWS_SECRET_ACCESS_KEY }}
         run: ./setup-test.sh
 
       - name: Test using DBT and lakectl metastore commands
@@ -598,6 +618,10 @@ jobs:
           name: metaclient-3x
           path: test/spark/metaclient
 
+      - name: Generate uniquifying value
+        id: unique
+        run:  echo "::set-output name=value::$RANDOM"
+
       - name: Start lakeFS for Spark tests
         uses: ./.github/actions/bootstrap-test-lakefs
         with:
@@ -618,14 +642,14 @@ jobs:
 
       - name: Setup GC tests
         env:
-          STORAGE_NAMESPACE: s3://esti-system-testing/${{ github.run_number }}-spark${{ matrix.spark.version }}-metaclient/garbage
+          STORAGE_NAMESPACE: s3://esti-system-testing/${{ github.run_number }}-spark${{ matrix.spark.version }}-metaclient/garbage/${{ steps.unique.outputs.value }}
           REPOSITORY: test-data-gc-${{ matrix.spark.version }}
         working-directory: test/spark
         run: ./setup-gc-test.sh
 
       - name: Test GC with Spark 3.x
         env:
-          STORAGE_NAMESPACE: s3://esti-system-testing/${{ github.run_number }}-spark${{ matrix.spark }}-metaclient/garbage
+          STORAGE_NAMESPACE: s3://esti-system-testing/${{ github.run_number }}-spark${{ matrix.spark }}-metaclient/garbage/${{ steps.unique.outputs.value }}
           REPOSITORY: test-data-gc-${{ matrix.spark.version }}
           CLIENT_JAR: ${{steps.import_metaclient.outputs.download-path}}/spark-assembly${{ matrix.spark.suffix }}.jar
         working-directory: test/spark
@@ -633,14 +657,14 @@ jobs:
 
       - name: Setup Exporter tests
         env:
-          STORAGE_NAMESPACE: s3://esti-system-testing/${{ github.run_number }}-spark${{ matrix.spark.version }}-metaclient/exporter
+          STORAGE_NAMESPACE: s3://esti-system-testing/${{ github.run_number }}-spark${{ matrix.spark.version }}-metaclient/exporter/${{ steps.unique.outputs.value }}
           REPOSITORY: test-data-exporter
         working-directory: test/spark
         run: ./setup-exporter-test.sh
 
       - name: Test Exporter with Spark 3.x
         env:
-          STORAGE_NAMESPACE: s3://esti-system-testing/${{ github.run_number }}-spark${{ matrix.spark.version }}-metaclient/exporter
+          STORAGE_NAMESPACE: s3://esti-system-testing/${{ github.run_number }}-spark${{ matrix.spark.version }}-metaclient/exporter/${{ steps.unique.outputs.value }}
           REPOSITORY: test-data-exporter
           CLIENT_JAR: ${{steps.import_metaclient.outputs.download-path}}/spark-assembly${{ matrix.spark.suffix }}.jar
           EXPORT_LOCATION: s3://esti-system-testing/${{ github.run_number }}-spark${{ matrix.spark.version }}-client-export
@@ -667,6 +691,10 @@ jobs:
       - name: Check-out code
         uses: actions/checkout@v2
 
+      - name: Generate uniquifying value
+        id: unique
+        run:  echo "::set-output name=value::$RANDOM"
+
       - name: Start lakeFS with S3 tests
         uses: ./.github/actions/bootstrap-test-lakefs
         with:
@@ -679,7 +707,7 @@ jobs:
           DOCKER_REG: ${{ steps.login-ecr.outputs.registry }}
           ESTI_TEST_DATA_ACCESS: true,false
           ESTI_BLOCKSTORE_TYPE: s3
-          ESTI_STORAGE_NAMESPACE: s3://esti-system-testing/${{ github.run_number }}
+          ESTI_STORAGE_NAMESPACE: s3://esti-system-testing/${{ github.run_number }}/${{ steps.unique.outputs.value }}
           ESTI_AWS_ACCESS_KEY_ID: ${{ secrets.ESTI_AWS_ACCESS_KEY_ID }}
           ESTI_AWS_SECRET_ACCESS_KEY: ${{ secrets.ESTI_AWS_SECRET_ACCESS_KEY }}
           ESTI_VERSION: ${{ steps.version.outputs.tag }}
@@ -704,7 +732,7 @@ jobs:
           DOCKER_REG: ${{ steps.login-ecr.outputs.registry }}
           ESTI_TEST_DATA_ACCESS: true,false
           ESTI_BLOCKSTORE_TYPE: s3
-          ESTI_STORAGE_NAMESPACE: s3://esti-system-testing/${{ github.run_number }}-local-api-key
+          ESTI_STORAGE_NAMESPACE: s3://esti-system-testing/${{ github.run_number }}-local-api-key/${{ steps.unique.outputs.value }}
         run: |
           docker-compose -f esti/ops/docker-compose.yaml down -v
           docker-compose -f esti/ops/docker-compose.yaml up --quiet-pull --exit-code-from=esti
@@ -722,6 +750,11 @@ jobs:
     steps:
       - name: Check-out code
         uses: actions/checkout@v2
+
+      - name: Generate uniquifying value
+        id: unique
+        run:  echo "::set-output name=value::$RANDOM"
+
       - name: Start lakeFS with GS tests
         uses: ./.github/actions/bootstrap-test-lakefs
         with:
@@ -732,7 +765,7 @@ jobs:
           LAKEFS_BLOCKSTORE_TYPE: gs
           LAKEFS_BLOCKSTORE_GS_CREDENTIALS_JSON: ${{ secrets.LAKEFS_BLOCKSTORE_GS_CREDENTIALS_JSON }}
           ESTI_BLOCKSTORE_TYPE: gs
-          ESTI_STORAGE_NAMESPACE: gs://esti-system-testing/${{ github.run_number }}
+          ESTI_STORAGE_NAMESPACE: gs://esti-system-testing/${{ github.run_number }}/${{ steps.unique.outputs.value }}
       - name: lakeFS Logs on GS failure
         if: ${{ failure() }}
         continue-on-error: true
@@ -751,6 +784,11 @@ jobs:
     steps:
       - name: Check-out code
         uses: actions/checkout@v2
+
+      - name: Generate uniquifying value
+        id: unique
+        run:  echo "::set-output name=value::$RANDOM"
+
       - name: Start lakeFS with Azure tests
         uses: ./.github/actions/bootstrap-test-lakefs
         with:
@@ -762,7 +800,7 @@ jobs:
           LAKEFS_BLOCKSTORE_AZURE_STORAGE_ACCOUNT: esti
           LAKEFS_BLOCKSTORE_AZURE_STORAGE_ACCESS_KEY: ${{ secrets.LAKEFS_BLOCKSTORE_AZURE_STORAGE_ACCESS_KEY2 }}
           ESTI_BLOCKSTORE_TYPE: azure
-          ESTI_STORAGE_NAMESPACE: https://esti.blob.core.windows.net/esti-system-testing/${{ github.run_number }}
+          ESTI_STORAGE_NAMESPACE: https://esti.blob.core.windows.net/esti-system-testing/${{ github.run_number }}/${{ steps.unique.outputs.value }}
       - name: lakeFS Logs on Azure failure
         if: ${{ failure() }}
         continue-on-error: true

--- a/.github/workflows/esti.yaml
+++ b/.github/workflows/esti.yaml
@@ -592,8 +592,74 @@ jobs:
           if-no-files-found: error
           retention-days: 7
 
-  metadata-client-spark3:
-    name: Test lakeFS metadata client with Spark 3.x
+  metadata-client-gc-spark3:
+    name: Test lakeFS metadata client GC with Spark 3.x
+    needs: [deploy-image, build-spark3-metadata-client]
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        spark:
+          - version: 3.2.1
+            suffix: "-hadoop3"
+          - version: 3.1.2
+            suffix: ""
+          - version: 3.0.2
+            suffix: ""
+    env:
+      SPARK_TAG: ${{ matrix.spark.version }}
+    steps:
+      - name: Check-out code
+        uses: actions/checkout@v2
+
+      - name: Import Metaclient
+        id: import_metaclient
+        uses: actions/download-artifact@v3
+        with:
+          name: metaclient-3x
+          path: test/spark/metaclient
+
+      - name: Generate uniquifying value
+        id: unique
+        run:  echo "::set-output name=value::$RANDOM"
+
+      - name: Start lakeFS for Spark tests
+        uses: ./.github/actions/bootstrap-test-lakefs
+        with:
+          compose-directory: test/spark
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          LAKEFS_BLOCKSTORE_TYPE: s3
+          LAKEFS_BLOCKSTORE_S3_CREDENTIALS_ACCESS_KEY_ID: ${{ secrets.ESTI_AWS_ACCESS_KEY_ID }}
+          LAKEFS_BLOCKSTORE_S3_CREDENTIALS_SECRET_ACCESS_KEY: ${{ secrets.ESTI_AWS_SECRET_ACCESS_KEY }}
+
+      - name: Setup lakeFS for metadata client tests
+        working-directory: test/spark
+        run: ./setup-test.sh
+
+      - name: Setup GC tests
+        env:
+          STORAGE_NAMESPACE: s3://esti-system-testing/${{ github.run_number }}-spark${{ matrix.spark.version }}-metaclient/garbage/${{ steps.unique.outputs.value }}
+          REPOSITORY: test-data-gc-${{ matrix.spark.version }}
+        working-directory: test/spark
+        run: ./setup-gc-test.sh
+
+      - name: Test GC with Spark 3.x
+        env:
+          STORAGE_NAMESPACE: s3://esti-system-testing/${{ github.run_number }}-spark${{ matrix.spark }}-metaclient/garbage/${{ steps.unique.outputs.value }}
+          REPOSITORY: test-data-gc-${{ matrix.spark.version }}
+          CLIENT_JAR: ${{steps.import_metaclient.outputs.download-path}}/spark-assembly${{ matrix.spark.suffix }}.jar
+        working-directory: test/spark
+        run: ./run-gc-test.sh
+
+      - name: lakeFS Logs on Spark with gateway failure
+        if: ${{ failure() }}
+        continue-on-error: true
+        working-directory: test/spark
+        run: docker-compose logs --tail=1000 lakefs
+
+  metadata-client-export-spark3:
+    name: Test lakeFS metadata client export with Spark 3.x
     needs: [deploy-image, build-spark3-metadata-client]
     runs-on: ubuntu-20.04
     strategy:
@@ -639,21 +705,6 @@ jobs:
 
       - name: Copy repository ref
         run: aws s3 cp --recursive s3://esti-system-testing-data/golden-files/gc-test-data s3://esti-system-testing/${{ github.run_number }}-spark${{ matrix.spark.version }}-metaclient/exporter/${{ steps.unique.outputs.value }}
-
-      - name: Setup GC tests
-        env:
-          STORAGE_NAMESPACE: s3://esti-system-testing/${{ github.run_number }}-spark${{ matrix.spark.version }}-metaclient/garbage/${{ steps.unique.outputs.value }}
-          REPOSITORY: test-data-gc-${{ matrix.spark.version }}
-        working-directory: test/spark
-        run: ./setup-gc-test.sh
-
-      - name: Test GC with Spark 3.x
-        env:
-          STORAGE_NAMESPACE: s3://esti-system-testing/${{ github.run_number }}-spark${{ matrix.spark }}-metaclient/garbage/${{ steps.unique.outputs.value }}
-          REPOSITORY: test-data-gc-${{ matrix.spark.version }}
-          CLIENT_JAR: ${{steps.import_metaclient.outputs.download-path}}/spark-assembly${{ matrix.spark.suffix }}.jar
-        working-directory: test/spark
-        run: ./run-gc-test.sh
 
       - name: Setup Exporter tests
         env:

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
@@ -366,7 +366,7 @@ object GarbageCollector {
 
   private def repartitionBySize(df: DataFrame, maxSize: Int, column: String): DataFrame = {
     val nRows = df.count()
-    val nPartitions = math.max(1, math.floor(nRows / maxSize)).toInt
+    val nPartitions = math.max(1, math.ceil(nRows / maxSize)).toInt
     df.repartitionByRange(nPartitions, col(column))
   }
 

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
@@ -366,7 +366,7 @@ object GarbageCollector {
 
   private def repartitionBySize(df: DataFrame, maxSize: Int, column: String): DataFrame = {
     val nRows = df.count()
-    val nPartitions = math.max(1, math.ceil(nRows / maxSize)).toInt
+    val nPartitions = math.max(1, math.floor(nRows / maxSize)).toInt
     df.repartitionByRange(nPartitions, col(column))
   }
 

--- a/test/spark/run-exporter-test.sh
+++ b/test/spark/run-exporter-test.sh
@@ -1,5 +1,6 @@
 #!/bin/bash -aux
 
+set -o pipefail
 
 REPOSITORY=${REPOSITORY//./-}
 # Run Export
@@ -12,7 +13,15 @@ trap 'rm -f -- $s3_out $lakectl_out' INT TERM EXIT
 
 docker-compose exec -T lakefs lakectl fs ls --recursive --no-color "lakefs://${REPOSITORY}/main/" | awk '{print $8}' | sort > ${lakectl_out}
 
-aws s3 ls --recursive ${EXPORT_LOCATION}/ | awk '{print $4}'| cut -d/ -f 3-  | grep -v EXPORT_ | sort > ${s3_out}
+export_bucket=`echo $EXPORT_LOCATION | sed -E 's!^s3://([^/]*)/.*!\1!'`
+export_key=`echo $EXPORT_LOCATION | sed -E 's!^s3://[^/]*/!!'`
+
+aws s3api list-objects-v2 \
+        --bucket "$export_bucket" --prefix "$export_key" \
+	--query "Contents[].[Key]" --output text | \
+    sed "s%^${export_key}/%%" | \
+    fgrep -v EXPORT_ | \
+    sort > ${s3_out}
 
 if ! diff ${lakectl_out} ${s3_out}; then
   echo "The export's location and lakeFS should contain same objects"

--- a/test/spark/run-exporter-test.sh
+++ b/test/spark/run-exporter-test.sh
@@ -12,7 +12,7 @@ trap 'rm -f -- $s3_out $lakectl_out' INT TERM EXIT
 
 docker-compose exec -T lakefs lakectl fs ls --recursive --no-color "lakefs://${REPOSITORY}/main/" | awk '{print $8}' | sort > ${lakectl_out}
 
-aws s3 ls --recursive ${EXPORT_LOCATION} | awk '{print $4}'| cut -d/ -f 2-  | grep -v EXPORT_ | sort > ${s3_out}
+aws s3 ls --recursive ${EXPORT_LOCATION}/ | awk '{print $4}'| cut -d/ -f 3-  | grep -v EXPORT_ | sort > ${s3_out}
 
 if ! diff ${lakectl_out} ${s3_out}; then
   echo "The export's location and lakeFS should contain same objects"

--- a/test/spark/run-gc-test.sh
+++ b/test/spark/run-gc-test.sh
@@ -14,7 +14,7 @@ run_lakectl() {
 }
 
 run_gc () {
-  docker-compose run -v ${CLIENT_JAR}:/client/client.jar -T --no-deps --rm spark-submit bash -c "spark-submit --master spark://spark:7077 --class io.treeverse.clients.GarbageCollector -c spark.hadoop.lakefs.api.url=http://docker.lakefs.io:8000/api/v1 -c spark.hadoop.lakefs.api.access_key=\${TESTER_ACCESS_KEY_ID} -c spark.hadoop.lakefs.api.secret_key=\${TESTER_SECRET_ACCESS_KEY} -c spark.hadoop.fs.s3a.access.key=\${LAKEFS_BLOCKSTORE_S3_CREDENTIALS_ACCESS_KEY_ID} -c spark.hadoop.fs.s3a.secret.key=\${LAKEFS_BLOCKSTORE_S3_CREDENTIALS_SECRET_ACCESS_KEY} -c spark.sql.shuffle.partitions=7 /client/client.jar $1 us-east-1"
+  docker-compose run -v ${CLIENT_JAR}:/client/client.jar -T --no-deps --rm spark-submit bash -c "spark-submit --master spark://spark:7077 --class io.treeverse.clients.GarbageCollector -c spark.hadoop.lakefs.api.url=http://docker.lakefs.io:8000/api/v1 -c spark.hadoop.lakefs.api.access_key=\${TESTER_ACCESS_KEY_ID} -c spark.hadoop.lakefs.api.secret_key=\${TESTER_SECRET_ACCESS_KEY} -c spark.hadoop.fs.s3a.access.key=\${LAKEFS_BLOCKSTORE_S3_CREDENTIALS_ACCESS_KEY_ID} -c spark.hadoop.fs.s3a.secret.key=\${LAKEFS_BLOCKSTORE_S3_CREDENTIALS_SECRET_ACCESS_KEY} -c spark.sql.shuffle.partitions=7 -c spark.default.parallelism=13 /client/client.jar $1 us-east-1"
 }
 
 clean_repo() {


### PR DESCRIPTION
 * Add a random suffix to _all_ external `s3://...` URLs used in Esti.
 * Split metadata client test into separate GC, export modes.  This allows them to run in parallel and makes Esti succeed more often.

   Not really _required_ for this PR... but it **does** make Esti pass rather than time out when GitHub actions are loaded, so _helpful_ to produce this PR.
