### PR TITLE
Reset password API with email match to token verification

### DIFF
--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -611,6 +611,9 @@ components:
         newPassword:
           description: new password to update
           type: string
+        email:
+          description: optional user email to match the token for verification
+          type: string
       required:
         - token
         - newPassword

--- a/clients/java/api/openapi.yaml
+++ b/clients/java/api/openapi.yaml
@@ -5052,6 +5052,7 @@ components:
     UpdatePasswordByToken:
       example:
         newPassword: newPassword
+        email: email
         token: token
       properties:
         token:
@@ -5059,6 +5060,9 @@ components:
           type: string
         newPassword:
           description: new password to update
+          type: string
+        email:
+          description: optional user email to match the token for verification
           type: string
       required:
       - newPassword

--- a/clients/java/docs/UpdatePasswordByToken.md
+++ b/clients/java/docs/UpdatePasswordByToken.md
@@ -9,6 +9,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **token** | **String** | token used for authentication | 
 **newPassword** | **String** | new password to update | 
+**email** | **String** | optional user email to match the token for verification |  [optional]
 
 
 

--- a/clients/java/src/main/java/io/lakefs/clients/api/model/UpdatePasswordByToken.java
+++ b/clients/java/src/main/java/io/lakefs/clients/api/model/UpdatePasswordByToken.java
@@ -37,6 +37,10 @@ public class UpdatePasswordByToken {
   @SerializedName(SERIALIZED_NAME_NEW_PASSWORD)
   private String newPassword;
 
+  public static final String SERIALIZED_NAME_EMAIL = "email";
+  @SerializedName(SERIALIZED_NAME_EMAIL)
+  private String email;
+
 
   public UpdatePasswordByToken token(String token) {
     
@@ -84,6 +88,29 @@ public class UpdatePasswordByToken {
   }
 
 
+  public UpdatePasswordByToken email(String email) {
+    
+    this.email = email;
+    return this;
+  }
+
+   /**
+   * optional user email to match the token for verification
+   * @return email
+  **/
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "optional user email to match the token for verification")
+
+  public String getEmail() {
+    return email;
+  }
+
+
+  public void setEmail(String email) {
+    this.email = email;
+  }
+
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -94,12 +121,13 @@ public class UpdatePasswordByToken {
     }
     UpdatePasswordByToken updatePasswordByToken = (UpdatePasswordByToken) o;
     return Objects.equals(this.token, updatePasswordByToken.token) &&
-        Objects.equals(this.newPassword, updatePasswordByToken.newPassword);
+        Objects.equals(this.newPassword, updatePasswordByToken.newPassword) &&
+        Objects.equals(this.email, updatePasswordByToken.email);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(token, newPassword);
+    return Objects.hash(token, newPassword, email);
   }
 
   @Override
@@ -108,6 +136,7 @@ public class UpdatePasswordByToken {
     sb.append("class UpdatePasswordByToken {\n");
     sb.append("    token: ").append(toIndentedString(token)).append("\n");
     sb.append("    newPassword: ").append(toIndentedString(newPassword)).append("\n");
+    sb.append("    email: ").append(toIndentedString(email)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/clients/java/src/test/java/io/lakefs/clients/api/model/UpdatePasswordByTokenTest.java
+++ b/clients/java/src/test/java/io/lakefs/clients/api/model/UpdatePasswordByTokenTest.java
@@ -56,4 +56,12 @@ public class UpdatePasswordByTokenTest {
         // TODO: test newPassword
     }
 
+    /**
+     * Test the property 'email'
+     */
+    @Test
+    public void emailTest() {
+        // TODO: test email
+    }
+
 }

--- a/clients/python/docs/AuthApi.md
+++ b/clients/python/docs/AuthApi.md
@@ -2965,6 +2965,7 @@ with lakefs_client.ApiClient(configuration) as api_client:
     update_password_by_token = UpdatePasswordByToken(
         token="token_example",
         new_password="new_password_example",
+        email="email_example",
     ) # UpdatePasswordByToken | 
 
     # example passing only required values which don't have defaults set

--- a/clients/python/docs/UpdatePasswordByToken.md
+++ b/clients/python/docs/UpdatePasswordByToken.md
@@ -6,6 +6,7 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **token** | **str** | token used for authentication | 
 **new_password** | **str** | new password to update | 
+**email** | **str** | optional user email to match the token for verification | [optional] 
 **any string name** | **bool, date, datetime, dict, float, int, list, str, none_type** | any string name can be used but the value must be the correct type | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/clients/python/lakefs_client/model/update_password_by_token.py
+++ b/clients/python/lakefs_client/model/update_password_by_token.py
@@ -84,6 +84,7 @@ class UpdatePasswordByToken(ModelNormal):
         return {
             'token': (str,),  # noqa: E501
             'new_password': (str,),  # noqa: E501
+            'email': (str,),  # noqa: E501
         }
 
     @cached_property
@@ -94,6 +95,7 @@ class UpdatePasswordByToken(ModelNormal):
     attribute_map = {
         'token': 'token',  # noqa: E501
         'new_password': 'newPassword',  # noqa: E501
+        'email': 'email',  # noqa: E501
     }
 
     read_only_vars = {
@@ -141,6 +143,7 @@ class UpdatePasswordByToken(ModelNormal):
                                 Animal class but this time we won't travel
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
+            email (str): optional user email to match the token for verification. [optional]  # noqa: E501
         """
 
         _check_type = kwargs.pop('_check_type', True)
@@ -228,6 +231,7 @@ class UpdatePasswordByToken(ModelNormal):
                                 Animal class but this time we won't travel
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
+            email (str): optional user email to match the token for verification. [optional]  # noqa: E501
         """
 
         _check_type = kwargs.pop('_check_type', True)

--- a/docs/assets/js/swagger.yml
+++ b/docs/assets/js/swagger.yml
@@ -611,6 +611,9 @@ components:
         newPassword:
           description: new password to update
           type: string
+        email:
+          description: optional user email to match the token for verification
+          type: string
       required:
         - token
         - newPassword

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -3118,6 +3118,16 @@ func (c *Controller) UpdatePassword(w http.ResponseWriter, r *http.Request, body
 		writeError(w, http.StatusUnauthorized, err)
 		return
 	}
+
+	// verify provided email matched the token
+	requestEmail := StringValue(body.Email)
+	if requestEmail != "" && requestEmail != claims.Subject {
+		c.Logger.WithError(err).WithFields(logging.Fields{
+			"token":         body.Token,
+			"request_email": requestEmail,
+		}).Debug("requested email doesn't match the email provided in verified token")
+	}
+
 	user, err := c.Auth.GetUserByEmail(r.Context(), claims.Subject)
 	if err != nil {
 		c.Logger.WithError(err).WithField("email", claims.Subject).Debug("failed to retrieve user by email")


### PR DESCRIPTION
Enable optional email part of the request to match user request's email to the provided token.