### PR TITLE
[gc] Use right number of partitions to get each of limited size

### DIFF
--- a/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
@@ -366,7 +366,7 @@ object GarbageCollector {
 
   private def repartitionBySize(df: DataFrame, maxSize: Int, column: String): DataFrame = {
     val nRows = df.count()
-    val nPartitions = math.max(1, math.floor(nRows / maxSize)).toInt
+    val nPartitions = math.max(1, math.ceil(nRows / maxSize)).toInt
     df.repartitionByRange(nPartitions, col(column))
   }
 


### PR DESCRIPTION
We have `nRows` files to split into `k` partitions, and we want each
partition to have size at most `maxSize` (think 1000, because we can delete
up to 1000 objects in each AWS S3 bulk deletion).  So we must have

    k * maxSize >= nRows > (k-1) * maxSize

or (because `k`, `k-1` are both ints)

    k >= ceil(n / maxSize) >= k >= floor(n / maxSize) >= k-1

Since we want `k` as small as possible,

    k = ceil(n / maxSize)

and `floor` does not work.