### PR TITLE
Emailer config smpt_port with additional ssl and local_name

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -106,9 +106,11 @@ This reference uses `.` to denote the nesting of values.
 + `committed.sstable.memory.cache_size_bytes` (`int` : `200_000_000`) - maximal size of
   in-memory cache used for each SSTable reader.
 + `email.smtp_host` `(string)` - A string representing the URL of the SMTP host.
-+ `email.port` (`int` :   ) - An integer representing the port of the SMTP service (465, 587, 993, 25 are some standard ports)
++ `email.smtp_port` (`int`) - An integer representing the port of the SMTP service (465, 587, 993, 25 are some standard ports)
++ `email.use_ssl` (`bool : false`) - Use SSL connection with SMTP host.
 + `email.username` `(string)` - A string representing the username of the specific account at the SMTP. It's recommended to provide this value at runtime from a secret vault of some sort.
 + `email.password` `(string)` - A string representing the password of the account. It's recommended to provide this value at runtime from a secret vault of some sort.
++ `email.local_name` `(string)` - A string representing the hostname sent to the SMTP server with the HELO command. By default, "localhost" is sent.
 + `email.sender` `(string)` - A string representing the email account which is set as the sender.
 + `email.limit_every_duration` `(duration : 1m)` - Average time to wait between sending emails. The zero value means no duration and therefore no emails can be sent.
 + `email.burst` `(int: 10)` - Maximal burst of emails before applying `limit_every`.

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -412,12 +412,13 @@ func (c *Config) GetStatsFlushInterval() time.Duration {
 	return c.values.Stats.FlushInterval
 }
 
-func (c *Config) GetEmailParams() (email.EmailParams, error) {
-	return email.EmailParams{
+func (c *Config) GetEmailParams() (email.Params, error) {
+	return email.Params{
 		SMTPHost:           c.values.Email.SMTPHost,
-		Port:               c.values.Email.Port,
+		SMTPPort:           c.values.Email.SMTPPort,
 		Username:           c.values.Email.Username,
 		Password:           c.values.Email.Password,
+		LocalName:          c.values.Email.LocalName,
 		Sender:             c.values.Email.Sender,
 		LimitEveryDuration: c.values.Email.LimitEveryDuration,
 		Burst:              c.values.Email.Burst,

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -187,9 +187,11 @@ type configuration struct {
 	} `mapstructure:"security"`
 	Email struct {
 		SMTPHost           string        `mapstructure:"smtp_host"`
-		Port               int           `mapstructure:"port"`
+		SMTPPort           int           `mapstructure:"smtp_port"`
+		UseSSL             bool          `mapstructure:"use_ssl"`
 		Username           string        `mapstructure:"username"`
 		Password           string        `mapstructure:"password"`
+		LocalName          string        `mapstructure:"local_name"`
 		Sender             string        `mapstructure:"sender"`
 		LimitEveryDuration time.Duration `mapstructure:"limit_every_duration"`
 		Burst              int           `mapstructure:"burst"`

--- a/pkg/email/send_email.go
+++ b/pkg/email/send_email.go
@@ -9,29 +9,33 @@ import (
 )
 
 type Emailer struct {
-	Params  EmailParams
+	Params  Params
 	Dialer  *gomail.Dialer
 	Limiter *rate.Limiter
 }
 
 var ErrRateLimitExceeded = errors.New("rate limit exceeded")
 
-type EmailParams struct {
+type Params struct {
 	SMTPHost           string
-	Port               int
+	SMTPPort           int
+	UseSSL             bool
 	Username           string
 	Password           string
+	LocalName          string
 	Sender             string
 	LimitEveryDuration time.Duration
 	Burst              int
 	LakefsBaseURL      string
 }
 
-func NewEmailer(e EmailParams) *Emailer {
-	dialer := gomail.NewDialer(e.SMTPHost, e.Port, e.Username, e.Password)
-	limiter := rate.NewLimiter(rate.Every(e.LimitEveryDuration), e.Burst)
+func NewEmailer(p Params) *Emailer {
+	dialer := gomail.NewDialer(p.SMTPHost, p.SMTPPort, p.Username, p.Password)
+	dialer.SSL = p.UseSSL
+	dialer.LocalName = p.LocalName
+	limiter := rate.NewLimiter(rate.Every(p.LimitEveryDuration), p.Burst)
 	return &Emailer{
-		Params:  e,
+		Params:  p,
 		Dialer:  dialer,
 		Limiter: limiter,
 	}

--- a/pkg/email/template.go
+++ b/pkg/email/template.go
@@ -47,12 +47,12 @@ func buildURL(baseURL string, pth string, values map[string]string) (string, err
 }
 
 func buildEmailByTemplate(tmpl *template.Template, host string, path string, params map[string]string) (string, error) {
-	url, err := buildURL(host, path, params)
+	u, err := buildURL(host, path, params)
 	if err != nil {
 		return "", err
 	}
 	var builder strings.Builder
-	l := TemplateParams{URL: url}
+	l := TemplateParams{URL: u}
 	err = tmpl.Execute(&builder, l)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Address the following for our emailer configuration:
1. Update configuration from port to smtp_port to align with smtp_host.
2. Add use_ssl to configure mailer to use ssl not just on default ssl port.
3. Configure local_name - how we identify the domain with smtp server.