### PR TITLE
Route to user's page when clicking on a user

### DIFF
--- a/webui/src/pages/auth/index.jsx
+++ b/webui/src/pages/auth/index.jsx
@@ -24,11 +24,11 @@ const Auth = () => {
             <Route path="/auth/credentials">
                 <CredentialsPage/>
             </Route>
-            <Route exact path="/auth/users">
-                <UsersIndexPage/>
-            </Route>
             <Route path="/auth/users/create">
                 <ActivateInvitedUserPage/>
+            </Route>
+            <Route path="/auth/users">
+                <UsersIndexPage/>
             </Route>
             <Route path="/auth/groups">
                 <GroupsIndexPage/>


### PR DESCRIPTION
This pr fixes a bug created as a result of https://github.com/treeverse/lakeFS/commit/4727b0777f006522805bf71570d4c89f69a50a68. 

### Problem 
On Users -> click on username routes to http://localhost:8000/auth/credentials instead of http://localhost:3000/auth/users/userid/groups

### Root cause  
 As part of the pr above, we've added the following route to the user activation page:  
```
 <Route path="/auth/users/create">
                <ActivateInvitedUserPage/>
 </Route>
```
and the "exact" path property to the route
  <Route exact path="/auth/users">
                <UsersIndexPage/>
</Route>
The order of routes was: 
1.  `<Route exact path="/auth/users">`
2. `<Route path="/auth/users/create">`
This made non of the routes match a URL of the form `http://localhost:3000/auth/users/userid/groups`, and therefore resulted in a redirect to `<Redirect to="/auth/credentials" /> `

### Solution 
This pr contains a short-term fix: remove the exact keyword and change the order of routes to 
1. `<Route path="/auth/users/create">`
2. `<Route path="/auth/users">`

This way,  `http://localhost:3000/auth/users/userid/groups` does not match 1 but matches 2 and we get the desired page. 

### Long term solution 
Change the modeling, and replace `<Route path="/auth/users/create">` with something in the lines of `<Route path="/auth/createusers">`
               
