### PR TITLE
UI api encode URI component for path parameters

### DIFF
--- a/webui/src/lib/api/index.js
+++ b/webui/src/lib/api/index.js
@@ -2,21 +2,22 @@ export const API_ENDPOINT = '/api/v1';
 export const DEFAULT_LISTING_AMOUNT = 100;
 
 export const SETUP_STATE_INITIALIZED = "initialized"
-export const SETUP_STATE_NOT_INITIALIZED = "not_initialized"
+
 class LocalCache {
     get(key) {
-        const value = localStorage.getItem(key)
-        if (value !== null)
-            return JSON.parse(value)
-        return null
+        const value = localStorage.getItem(key);
+        if (value !== null) {
+            return JSON.parse(value);
+        }
+        return null;
     }
 
     set(key, value) {
-        localStorage.setItem(key, JSON.stringify(value))
+        localStorage.setItem(key, JSON.stringify(value));
     }
 
     delete(key) {
-        localStorage.removeItem(key)
+        localStorage.removeItem(key);
     }
 }
 
@@ -67,11 +68,10 @@ const apiRequest = async (uri, requestData = {}, additionalHeaders = {}) => {
     if (response.status === 401) {
         const errorMessage = await extractError(response);
         if (errorMessage === authenticationError) {
-            cache.delete('user')
+            cache.delete('user');
             throw new AuthenticationError('Authentication Error');
-        } else {
-            throw new AuthorizationError(errorMessage);
         }
+        throw new AuthorizationError(errorMessage);
     }
 
     return response;
@@ -226,7 +226,7 @@ class Auth {
 
     async listGroupMembers(groupId, after, amount = DEFAULT_LISTING_AMOUNT) {
         const query = qs({after, amount});
-        const response = await apiRequest(`/auth/groups/${groupId}/members?${query}`);
+        const response = await apiRequest(`/auth/groups/${encodeURIComponent(groupId)}/members?`+query);
         if (response.status !== 200) {
             throw new Error(`could not list group members: ${await extractError(response)}`);
         }
@@ -234,49 +234,49 @@ class Auth {
     }
 
     async addUserToGroup(userId, groupId) {
-        const response = await apiRequest(`/auth/groups/${groupId}/members/${userId}`, {method: 'PUT'});
+        const response = await apiRequest(`/auth/groups/${encodeURIComponent(groupId)}/members/${encodeURIComponent(userId)}`, {method: 'PUT'});
         if (response.status !== 201) {
             throw new Error(await extractError(response));
         }
     }
 
     async removeUserFromGroup(userId, groupId) {
-        const response = await apiRequest(`/auth/groups/${groupId}/members/${userId}`, {method: 'DELETE'});
+        const response = await apiRequest(`/auth/groups/${encodeURIComponent(groupId)}/members/${encodeURIComponent(userId)}`, {method: 'DELETE'});
         if (response.status !== 204) {
             throw new Error(await extractError(response));
         }
     }
 
     async attachPolicyToUser(userId, policyId) {
-        const response = await apiRequest(`/auth/users/${userId}/policies/${policyId}`, {method: 'PUT'});
+        const response = await apiRequest(`/auth/users/${encodeURIComponent(userId)}/policies/${encodeURIComponent(policyId)}`, {method: 'PUT'});
         if (response.status !== 201) {
             throw new Error(await extractError(response));
         }
     }
 
     async detachPolicyFromUser(userId, policyId) {
-        const response = await apiRequest(`/auth/users/${userId}/policies/${policyId}`, {method: 'DELETE'});
+        const response = await apiRequest(`/auth/users/${encodeURIComponent(userId)}/policies/$encodeURIComponent({policyId)}`, {method: 'DELETE'});
         if (response.status !== 204) {
             throw new Error(await extractError(response));
         }
     }
 
     async attachPolicyToGroup(groupId, policyId) {
-        const response = await apiRequest(`/auth/groups/${groupId}/policies/${policyId}`, {method: 'PUT'});
+        const response = await apiRequest(`/auth/groups/${encodeURIComponent(roupId)}/policies/${encodeURIComponent(policyId)}`, {method: 'PUT'});
         if (response.status !== 201) {
             throw new Error(await extractError(response));
         }
     }
 
     async detachPolicyFromGroup(groupId, policyId) {
-        const response = await apiRequest(`/auth/groups/${groupId}/policies/${policyId}`, {method: 'DELETE'});
+        const response = await apiRequest(`/auth/groups/${encodeURIComponent(groupId)}/policies/${encodeURIComponent(policyId)}`, {method: 'DELETE'});
         if (response.status !== 204) {
             throw new Error(await extractError(response));
         }
     }
 
     async deleteCredentials(userId, accessKeyId) {
-        const response = await apiRequest(`/auth/users/${userId}/credentials/${accessKeyId}`, {method: 'DELETE'});
+        const response = await apiRequest(`/auth/users/${encodeURIComponent(userId)}/credentials/${encodeURIComponent(accessKeyId)}`, {method: 'DELETE'});
         if (response.status !== 204) {
             throw new Error(await extractError(response));
         }
@@ -313,7 +313,7 @@ class Auth {
 
     async editPolicy(policyId, policyDocument) {
         const policy = {id: policyId, ...JSON.parse(policyDocument)};
-        const response = await apiRequest(`/auth/policies/${policyId}`, {
+        const response = await apiRequest(`/auth/policies/${encodeURIComponent(policyId)}`, {
             method: 'PUT',
             body: json(policy)
         });
@@ -325,7 +325,7 @@ class Auth {
 
     async listCredentials(userId, after, amount = DEFAULT_LISTING_AMOUNT) {
         const query = qs({after, amount});
-        const response = await apiRequest(`/auth/users/${userId}/credentials?${query}`);
+        const response = await apiRequest(`/auth/users/${encodeURIComponent(userId)}/credentials?`+query);
         if (response.status !== 200) {
             throw new Error(`could not list credentials: ${await extractError(response)}`);
         }
@@ -333,7 +333,7 @@ class Auth {
     }
 
     async createCredentials(userId) {
-        const response = await apiRequest(`/auth/users/${userId}/credentials`, {
+        const response = await apiRequest(`/auth/users/${encodeURIComponent(userId)}/credentials`, {
             method: 'POST',
         });
         if (response.status !== 201) {
@@ -344,7 +344,7 @@ class Auth {
 
     async listUserGroups(userId, after, amount = DEFAULT_LISTING_AMOUNT) {
         const query = qs({after, amount});
-        const response = await apiRequest(`/auth/users/${userId}/groups?${query}`);
+        const response = await apiRequest(`/auth/users/${encodeURIComponent(userId)}/groups?`+query);
         if (response.status !== 200) {
             throw new Error(`could not list user groups: ${await extractError(response)}`);
         }
@@ -352,11 +352,12 @@ class Auth {
     }
 
     async listUserPolicies(userId, effective = false, after = "", amount = DEFAULT_LISTING_AMOUNT) {
-        let params = {after, amount};
+        const params = {after, amount};
         if (effective) {
             params.effective =  'true'
         }
-        const response = await apiRequest(`/auth/users/${userId}/policies?${qs(params)}`);
+        const query = qa(params);
+        const response = await apiRequest(`/auth/users/${encodeURIComponent(userId)}/policies?`+query);
         if (response.status !== 200) {
             throw new Error(`could not list policies: ${await extractError(response)}`);
         }
@@ -364,7 +365,7 @@ class Auth {
     }
 
     async getPolicy(policyId) {
-        const response = await apiRequest(`/auth/policies/${policyId}`);
+        const response = await apiRequest(`/auth/policies/${encodeURIComponent(policyId)}`);
         if (response.status !== 200) {
             throw new Error(`could not get policy: ${await extractError(response)}`);
         }
@@ -372,8 +373,8 @@ class Auth {
     }
 
     async listGroupPolicies(groupId, after, amount = DEFAULT_LISTING_AMOUNT) {
-        let params = {after, amount};
-        const response = await apiRequest(`/auth/groups/${groupId}/policies?${qs(params)}`);
+        const query = qs({after, amount});
+        const response = await apiRequest(`/auth/groups/${encodeURIComponent(groupId)}/policies?`+query);
         if (response.status !== 200) {
             throw new Error(`could not list policies: ${await extractError(response)}`);
         }
@@ -381,7 +382,7 @@ class Auth {
     }
 
     async deleteUser(userId) {
-        const response = await apiRequest(`/auth/users/${userId}`, {method: 'DELETE'});
+        const response = await apiRequest(`/auth/users/${encodeURIComponent(userId)}`, {method: 'DELETE'});
         if (response.status !== 204) {
             throw new Error(await extractError(response));
         }
@@ -396,7 +397,7 @@ class Auth {
     }
 
     async deleteGroup(groupId) {
-        const response = await apiRequest(`/auth/groups/${groupId}`, {method: 'DELETE'});
+        const response = await apiRequest(`/auth/groups/${encodeURIComponent(groupId)}`, {method: 'DELETE'});
         if (response.status !== 204) {
             throw new Error(await extractError(response));
         }
@@ -410,7 +411,7 @@ class Auth {
     }
 
     async deletePolicy(policyId) {
-        const response = await apiRequest(`/auth/policies/${policyId}`, {method: 'DELETE'});
+        const response = await apiRequest(`/auth/policies/${encodeURIComponent(policyId)}`, {method: 'DELETE'});
         if (response.status !== 204) {
             throw new Error(await extractError(response));
         }
@@ -457,7 +458,7 @@ class Repositories {
     }
 
     async delete(repoId) {
-        const response = await apiRequest(`/repositories/${repoId}`, {method: 'DELETE'});
+        const response = await apiRequest(`/repositories/${encodeURIComponent(repoId)}`, {method: 'DELETE'});
         if (response.status !== 204) {
             throw new Error(await extractError(response));
         }
@@ -467,7 +468,7 @@ class Repositories {
 class Branches {
 
     async get(repoId, branchId) {
-        const response = await apiRequest(`/repositories/${repoId}/branches/${branchId}`);
+        const response = await apiRequest(`/repositories/${encodeURIComponent(repoId)}/branches/${encodeURIComponent(branchId)}`);
         if (response.status === 400) {
             throw new BadRequestError('invalid get branch request');
         } else if (response.status === 404) {
@@ -479,7 +480,7 @@ class Branches {
     }
 
     async create(repoId, name, source) {
-        const response = await apiRequest(`/repositories/${repoId}/branches`, {
+        const response = await apiRequest(`/repositories/${encodeURIComponent(repoId)}/branches`, {
             method: 'POST',
             body: json({name, source}),
         });
@@ -490,7 +491,7 @@ class Branches {
     }
 
     async delete(repoId, name) {
-        const response = await apiRequest(`/repositories/${repoId}/branches/${name}`, {
+        const response = await apiRequest(`/repositories/${encodeURIComponent(repoId)}/branches/${encodeURIComponent(name)}`, {
             method: 'DELETE',
         });
         if (response.status !== 204) {
@@ -499,7 +500,7 @@ class Branches {
     }
 
     async revert(repoId, branch, options) {
-        const response = await apiRequest(`/repositories/${repoId}/branches/${branch}`, {
+        const response = await apiRequest(`/repositories/${encodeURIComponent(repoId)}/branches/${encodeURIComponent(branch)}`, {
             method: 'PUT',
             body: json(options),
         });
@@ -510,7 +511,7 @@ class Branches {
 
     async list(repoId, prefix = "", after = "", amount = DEFAULT_LISTING_AMOUNT) {
         const query = qs({prefix, after, amount});
-        const response = await apiRequest(`/repositories/${repoId}/branches?${query}`);
+        const response = await apiRequest(`/repositories/${encodeURIComponent(repoId)}/branches?`+query);
         if (response.status !== 200) {
             throw new Error(`could not list branches: ${await extractError(response)}`);
         }
@@ -521,7 +522,7 @@ class Branches {
 
 class Tags {
     async get(repoId, tagId) {
-        const response = await apiRequest(`/repositories/${repoId}/tags/${tagId}`);
+        const response = await apiRequest(`/repositories/${encodeURIComponent(repoId)}/tags/${encodeURIComponent(tagId)}`);
         if (response.status === 404) {
             throw new NotFoundError(`could not find tag ${tagId}`);
         } else if (response.status !== 200) {
@@ -532,7 +533,7 @@ class Tags {
 
     async list(repoId, prefix = "", after = "", amount = DEFAULT_LISTING_AMOUNT) {
         const query = qs({prefix, after, amount});
-        const response = await apiRequest(`/repositories/${repoId}/tags?${query}`);
+        const response = await apiRequest(`/repositories/${encodeURIComponent(repoId)}/tags?`+query);
         if (response.status !== 200) {
             throw new Error(`could not list tags: ${await extractError(response)}`);
         }
@@ -540,7 +541,7 @@ class Tags {
     }
 
     async create(repoId, id, ref) {
-        const response = await apiRequest(`/repositories/${repoId}/tags`, {
+        const response = await apiRequest(`/repositories/${encodeURIComponent(repoId)}/tags`, {
             method: 'POST',
             body: json({id, ref}),
         });
@@ -551,7 +552,7 @@ class Tags {
     }
 
     async delete(repoId, name) {
-        const response = await apiRequest(`/repositories/${repoId}/tags/${name}`, {
+        const response = await apiRequest(`/repositories/${encodeURIComponent(repoId)}/tags/${encodeURIComponent(name)}`, {
             method: 'DELETE',
         });
         if (response.status !== 204) {
@@ -565,7 +566,7 @@ class Objects {
 
     async list(repoId, ref, tree, after = "", amount = DEFAULT_LISTING_AMOUNT, readUncommitted = true, delimiter = "/") {
         const query = qs({prefix:tree, amount, after, readUncommitted, delimiter});
-        const response = await apiRequest(`/repositories/${repoId}/refs/${ref}/objects/ls?${query}`);
+        const response = await apiRequest(`/repositories/${encodeURIComponent(repoId)}/refs/${encodeURIComponent(ref)}/objects/ls?`+query);
         if (response.status !== 200) {
             throw new Error(await extractError(response));
         }
@@ -577,7 +578,7 @@ class Objects {
         data.append('content', fileObject);
         window.data = data;
         const query = qs({path});
-        const response = await apiRequest(`/repositories/${repoId}/branches/${branchId}/objects?${query}`, {
+        const response = await apiRequest(`/repositories/${encodeURIComponent(repoId)}/branches/${encodeURIComponent(branchId)}/objects?`+query, {
             method: 'POST',
             body: data,
             headers: new Headers({'Accept': 'application/json'})
@@ -590,7 +591,7 @@ class Objects {
 
     async delete(repoId, branchId, path) {
         const query = qs({path});
-        const response = await apiRequest(`/repositories/${repoId}/branches/${branchId}/objects?${query}`, {
+        const response = await apiRequest(`/repositories/${encodeURIComponent(repoId)}/branches/${encodeURIComponent(branchId)}/objects?`+query, {
             method: 'DELETE',
         });
         if (response.status !== 204) {
@@ -600,7 +601,7 @@ class Objects {
 
     async get(repoId, ref, path) {
         const query = qs({path});
-        const response = await apiRequest(`/repositories/${repoId}/refs/${ref}/objects?${query}`, {
+        const response = await apiRequest(`/repositories/${encodeURIComponent(repoId)}/refs/${encodeURIComponent(ref)}/objects?`+query, {
             method: 'GET',
         });
         if (response.status !== 200) {
@@ -611,7 +612,7 @@ class Objects {
 
     async getStat(repoId, ref, path) {
         const query = qs({path});
-        const response = await apiRequest(`/repositories/${repoId}/refs/${ref}/objects/stat?${query}`);
+        const response = await apiRequest(`/repositories/${encodeURIComponent(repoId)}/refs/${encodeURIComponent(ref)}/objects/stat?`+query);
         if (response.status !== 200) {
             throw new Error(await extractError(response));
         }
@@ -622,7 +623,7 @@ class Objects {
 class Commits {
     async log(repoId, refId, after = "", amount = DEFAULT_LISTING_AMOUNT) {
         const query = qs({after, amount});
-        const response = await apiRequest(`/repositories/${repoId}/refs/${refId}/commits?${query}`);
+        const response = await apiRequest(`/repositories/${encodeURIComponent(repoId)}/refs/${encodeURIComponent(refId)}/commits?`+query);
         if (response.status !== 200) {
             throw new Error(await extractError(response));
         }
@@ -630,7 +631,7 @@ class Commits {
     }
 
     async get(repoId, commitId) {
-        const response = await apiRequest(`/repositories/${repoId}/commits/${commitId}`);
+        const response = await apiRequest(`/repositories/${encodeURIComponent(repoId)}/commits/${encodeURIComponent(commitId)}`);
         if (response.status === 404) {
             throw new NotFoundError(`could not find commit ${commitId}`);
         } else if (response.status !== 200) {
@@ -640,7 +641,7 @@ class Commits {
     }
 
     async commit(repoId, branchId, message, metadata ={}) {
-        const response = await apiRequest(`/repositories/${repoId}/branches/${branchId}/commits`, {
+        const response = await apiRequest(`/repositories/${encodeURIComponent(repoId)}/branches/${encodeURIComponent(branchId)}/commits`, {
             method: 'POST',
             body: json({message, metadata}),
         });
@@ -655,7 +656,7 @@ class Refs {
 
     async changes(repoId, branchId, after, prefix, delimiter, amount = DEFAULT_LISTING_AMOUNT) {
         const query = qs({after, prefix, delimiter, amount});
-        const response = await apiRequest(`/repositories/${repoId}/branches/${branchId}/diff?${query}`);
+        const response = await apiRequest(`/repositories/${encodeURIComponent(repoId)}/branches/${encodeURIComponent(branchId)}/diff?`+query);
         if (response.status !== 200) {
             throw new Error(await extractError(response));
         }
@@ -664,7 +665,7 @@ class Refs {
 
     async diff(repoId, leftRef, rightRef, after, prefix = "", delimiter = "", amount = DEFAULT_LISTING_AMOUNT) {
         const query = qs({after, amount, delimiter, prefix});
-        const response = await apiRequest(`/repositories/${repoId}/refs/${leftRef}/diff/${rightRef}?${query}`);
+        const response = await apiRequest(`/repositories/${encodeURIComponent(repoId)}/refs/${encodeURIComponent(leftRef)}/diff/${encodeURIComponent(rightRef)}?`+query);
         if (response.status !== 200) {
             throw new Error(await extractError(response));
         }
@@ -672,7 +673,7 @@ class Refs {
     }
 
     async merge(repoId, sourceBranch, destinationBranch) {
-        const response = await apiRequest(`/repositories/${repoId}/refs/${sourceBranch}/merge/${destinationBranch}`, {
+        const response = await apiRequest(`/repositories/${encodeURIComponent(repoId)}/refs/${encodeURIComponent(sourceBranch)}/merge/${encodeURIComponent(destinationBranch)}`, {
             method: 'POST',
             body: '{}',
         });
@@ -693,7 +694,7 @@ class Actions {
 
     async listRuns(repoId, branch = "", commit = "", after = "", amount = DEFAULT_LISTING_AMOUNT) {
         const query = qs({branch, commit, after, amount});
-        const response = await apiRequest(`/repositories/${repoId}/actions/runs?${query}`);
+        const response = await apiRequest(`/repositories/${encodeURIComponent(repoId)}/actions/runs?`+query);
         if (response.status !== 200) {
             throw new Error(`could not list actions runs: ${await extractError(response)}`);
         }
@@ -701,7 +702,7 @@ class Actions {
     }
 
     async getRun(repoId, runId) {
-        const response = await apiRequest(`/repositories/${repoId}/actions/runs/${runId}`);
+        const response = await apiRequest(`/repositories/${encodeURIComponent(repoId)}/actions/runs/${encodeURIComponent(runId)}`);
         if (response.status !== 200) {
             throw new Error(`could not get actions run: ${await extractError(response)}`);
         }
@@ -710,7 +711,7 @@ class Actions {
 
     async listRunHooks(repoId, runId, after = "", amount = DEFAULT_LISTING_AMOUNT) {
         const query = qs({after, amount});
-        const response = await apiRequest(`/repositories/${repoId}/actions/runs/${runId}/hooks?${query}`);
+        const response = await apiRequest(`/repositories/${encodeURIComponent(repoId)}/actions/runs/${encodeURIComponent(runId)}/hooks?`+query);
         if (response.status !== 200) {
             throw new Error(`could not list actions run hooks: ${await extractError(response)}`)
         }
@@ -718,7 +719,7 @@ class Actions {
     }
 
     async getRunHookOutput(repoId, runId, hookRunId) {
-        const response = await apiRequest(`/repositories/${repoId}/actions/runs/${runId}/hooks/${hookRunId}/output`, {
+        const response = await apiRequest(`/repositories/${encodeURIComponent(repoId)}/actions/runs/${encodeURIComponent(runId)}/hooks/${encodeURIComponent(hookRunId)}/output`, {
             headers: {"Content-Type": "application/octet-stream"},
         });
         if (response.status !== 200) {
@@ -731,7 +732,7 @@ class Actions {
 
 class Retention {
     async getGCPolicy(repoID) {
-        const response = await apiRequest(`/repositories/${repoID}/gc/rules`);
+        const response = await apiRequest(`/repositories/${encodeURIComponent(repoID)}/gc/rules`);
         if (response.status === 404) {
             throw new NotFoundError('policy not found')
         }
@@ -742,7 +743,7 @@ class Retention {
     }
 
     async setGCPolicy(repoID,policy) {
-        const response = await apiRequest(`/repositories/${repoID}/gc/rules`,{
+        const response = await apiRequest(`/repositories/${encodeURIComponent(repoID)}/gc/rules`,{
             method: 'POST',
             body: policy
         });
@@ -820,7 +821,7 @@ class Config {
 
 class BranchProtectionRules {
     async getRules(repoID) {
-        const response = await apiRequest(`/repositories/${repoID}/branch_protection`);
+        const response = await apiRequest(`/repositories/${encodeURIComponent(repoID)}/branch_protection`);
         if (response.status === 404) {
             throw new NotFoundError('branch protection rules not found')
         }
@@ -830,13 +831,13 @@ class BranchProtectionRules {
         return response.json();
     }
     async createRule(repoID, pattern) {
-        const response = await apiRequest(`/repositories/${repoID}/branch_protection`, {method: 'POST', body: JSON.stringify({pattern: pattern})});
+        const response = await apiRequest(`/repositories/${encodeURIComponent(repoID)}/branch_protection`, {method: 'POST', body: JSON.stringify({pattern: pattern})});
         if (response.status !== 204) {
             throw new Error(`could not create protection rule: ${await extractError(response)}`);
         }
     }
     async deleteRule(repoID, pattern) {
-        const response = await apiRequest(`/repositories/${repoID}/branch_protection`, {method: 'DELETE', body: JSON.stringify({pattern: pattern})});
+        const response = await apiRequest(`/repositories/${encodeURIComponent(repoID)}/branch_protection`, {method: 'DELETE', body: JSON.stringify({pattern: pattern})});
         if (response.status === 404) {
             throw new NotFoundError('branch protection rule not found')
         }

--- a/webui/src/lib/api/index.js
+++ b/webui/src/lib/api/index.js
@@ -262,7 +262,7 @@ class Auth {
     }
 
     async attachPolicyToGroup(groupId, policyId) {
-        const response = await apiRequest(`/auth/groups/${encodeURIComponent(roupId)}/policies/${encodeURIComponent(policyId)}`, {method: 'PUT'});
+        const response = await apiRequest(`/auth/groups/${encodeURIComponent(groupId)}/policies/${encodeURIComponent(policyId)}`, {method: 'PUT'});
         if (response.status !== 201) {
             throw new Error(await extractError(response));
         }


### PR DESCRIPTION
Encode all URI parameters we encode on API calls.
Example: `/auth/users/${userId)`
The `userId` value can be 'my.name+test@gmail.com` which needs to be encoded as 'my.name%2Btest@gmail.com` when used as URL. 
Without encoding, the value will not match while processing on the receiver side.
