### PR TITLE
UI enable row revert action when possible

### DIFF
--- a/webui/src/lib/components/repository/changes.jsx
+++ b/webui/src/lib/components/repository/changes.jsx
@@ -149,7 +149,11 @@ export const TreeEntryRow = ({entry, relativeTo = "", leaf = false, dirExpanded,
     if (!leaf) {
         rowActions.push(new RowAction(<GraphIcon/>, showSummary ? "Hide summary" : "Calculate change summary", showSummary, () => setShowSummary(!showSummary)))
     }
-    rowActions.push(new RowAction(<HistoryIcon/>, "Revert changes", false, () => {setShowRevertConfirm(true)}))
+    if (onRevert) {
+        rowActions.push(new RowAction(<HistoryIcon/>, "Revert changes", false, () => {
+            setShowRevertConfirm(true)
+        }))
+    }
     return (
         <tr className={rowClass}>
             <td className="pl-4 col-auto p-2">{diffIndicator}</td>


### PR DESCRIPTION
UI tree component render 'revert' row action always.
On compare view, there is no onRevert callback to handle any revert operation (as design).
This fix remove the row action in the case of no revert operation is associated.

Close #3161
