### PR TITLE
documentation switch between versions ensure selected value is url

### DIFF
--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -87,7 +87,7 @@ layout: table_wrappers
 
             <div class="nav-category nav-version">
                 <label for="selectversion">Version:</label>
-                <select id="selectversion" name="version" onchange="javascript:location.href = '/' + this.value;">
+                <select id="selectversion" name="version" onchange="javascript:location.href = '/' + encodeURI(this.value);">
                     <option value="" selected>Latest</option>
                 </select>
             </div>


### PR DESCRIPTION
Fix extracting text from a DOM node and interpreting it as HTML, which can lead to a cross-site scripting vulnerability.