### PR TITLE
Skip metaclient tests in esti

### DIFF
--- a/.github/workflows/esti.yaml
+++ b/.github/workflows/esti.yaml
@@ -571,8 +571,8 @@ jobs:
       - name: Package Metaclient
         working-directory: clients/spark
         run: |
-          sbt lakefs-spark-client-301/assembly
-          sbt lakefs-spark-client-312-hadoop3/assembly
+          sbt 'set core3 / assembly / test := {}' lakefs-spark-client-301/assembly
+          sbt 'set core312 / assembly / test := {}' lakefs-spark-client-312-hadoop3/assembly
 
       - name: Prepare Metaclient location for export
         # upload-artifact cannot take a working-directory option (that only


### PR DESCRIPTION
These tests already run as part of the _Unit test Spark metadata client_ workflow.
