### PR TITLE
webUI - Get user from api when not in cache

### DIFF
--- a/webui/src/lib/api/index.js
+++ b/webui/src/lib/api/index.js
@@ -175,7 +175,7 @@ class Auth {
 
         const user = await this.getCurrentUser();
 
-        cache.set('user', {...user, accessKeyId});
+        cache.set('user',user);
         return user;
     }
 

--- a/webui/src/lib/api/index.js
+++ b/webui/src/lib/api/index.js
@@ -200,7 +200,6 @@ class Auth {
     }
 
     async getCurrentUser() {
-        // get current user and cache it
         const userResponse = await apiRequest('/user')
         const body = await userResponse.json();
         return body.user;

--- a/webui/src/lib/api/index.js
+++ b/webui/src/lib/api/index.js
@@ -173,10 +173,7 @@ class Auth {
             throw new AuthenticationError('unknown authentication error');
         }
 
-        // get current user and cache it
-        const userResponse = await apiRequest('/user')
-        const body = await userResponse.json();
-        const user = body.user;
+        const user = await this.getCurrentUser();
 
         cache.set('user', {...user, accessKeyId});
         return user;
@@ -193,8 +190,20 @@ class Auth {
         cache.delete('user');
     }
 
+    async getCurrentUserWithCache() {
+        let user = cache.get('user')
+        if (!user) {
+            user = await this.getCurrentUser();
+            cache.set('user', user);
+        }
+        return user
+    }
+
     async getCurrentUser() {
-        return cache.get('user');
+        // get current user and cache it
+        const userResponse = await apiRequest('/user')
+        const body = await userResponse.json();
+        return body.user;
     }
 
     async listUsers(prefix = "", after = "", amount = DEFAULT_LISTING_AMOUNT) {

--- a/webui/src/lib/components/navbar.jsx
+++ b/webui/src/lib/components/navbar.jsx
@@ -20,7 +20,7 @@ const NavUserInfo = () => {
         <Navbar.Collapse className="justify-content-end">
             <NavDropdown title={user.friendly_name || user.id} className="navbar-username" alignRight>
                 <NavDropdown.Header>
-                    User: <code>{user.accessKeyId}</code>
+                    User: <code>{user.accessKeyId || user.id}</code>
                 </NavDropdown.Header>
 
                 <NavDropdown.Divider/>

--- a/webui/src/lib/components/navbar.jsx
+++ b/webui/src/lib/components/navbar.jsx
@@ -19,18 +19,6 @@ const NavUserInfo = () => {
     return (
         <Navbar.Collapse className="justify-content-end">
             <NavDropdown title={user.friendly_name || user.id} className="navbar-username" alignRight>
-                <NavDropdown.Header>
-                    User: <code>{user.accessKeyId || user.id}</code>
-                </NavDropdown.Header>
-
-                <NavDropdown.Divider/>
-
-                <NavDropdown.Item
-                    href="/auth/credentials"
-                    onSelect={()=> router.push('/auth/credentials')}>
-                        Manage My Credentials
-                </NavDropdown.Item>
-
                 <NavDropdown.Item
                     onSelect={()=> {
                         auth.logout().then(() => {

--- a/webui/src/lib/hooks/user.jsx
+++ b/webui/src/lib/hooks/user.jsx
@@ -3,7 +3,7 @@ import {auth} from "../api";
 
 
 const useUser = () => {
-    const { response, loading, error } = useAPI(() => auth.getCurrentUser(), []);
+    const { response, loading, error } = useAPI(() => auth.getCurrentUserWithCache(), []);
     return { user: response, loading, error };
 }
 


### PR DESCRIPTION
Currently:
-  The user information is saved in the local cache on login.
-  The login token is saved in cookie
- user navbar (which includes logout) is shown only if the is user information in the cache

In case the local cache was erased for some reason, users will not have an option to logout 

This PR fixes this partly 
- we will see the user in the navbar and have an option to logout but the value under `user:` will not be available 