### PR TITLE
Evict user from the cache once a user reset his password

### DIFF
--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -3223,6 +3223,8 @@ func (c *Controller) UpdatePassword(w http.ResponseWriter, r *http.Request, body
 		writeError(w, http.StatusInternalServerError, http.StatusText(http.StatusInternalServerError))
 		return
 	}
+	// RemoveUserFromCache to clean the cache from the old password
+	c.Auth.RemoveUserFromCache(user.Username)
 	w.WriteHeader(http.StatusCreated)
 }
 

--- a/pkg/auth/cache.go
+++ b/pkg/auth/cache.go
@@ -16,6 +16,8 @@ type Cache interface {
 	GetUser(username string, setFn UserSetFn) (*model.User, error)
 	GetUserByID(userID int64, setFn UserSetFn) (*model.User, error)
 	GetUserPolicies(userID string, setFn UserPoliciesSetFn) ([]*model.Policy, error)
+	RemoveUser(username string)
+	RemoveUserByID(userID int64)
 }
 
 type LRUCache struct {
@@ -57,6 +59,14 @@ func (c *LRUCache) GetUserByID(userID int64, setFn UserSetFn) (*model.User, erro
 	return v.(*model.User), nil
 }
 
+func (c *LRUCache) RemoveUser(username string) {
+	c.userCache.Remove(username)
+}
+
+func (c *LRUCache) RemoveUserByID(userID int64) {
+	c.userCache.Remove(userID)
+}
+
 func (c *LRUCache) GetUserPolicies(userID string, setFn UserPoliciesSetFn) ([]*model.Policy, error) {
 	v, err := c.policyCache.GetOrSet(userID, func() (interface{}, error) { return setFn() })
 	if err != nil {
@@ -82,4 +92,10 @@ func (d *DummyCache) GetUserByID(userID int64, setFn UserSetFn) (*model.User, er
 
 func (d *DummyCache) GetUserPolicies(userID string, setFn UserPoliciesSetFn) ([]*model.Policy, error) {
 	return setFn()
+}
+
+func (d *DummyCache) RemoveUser(username string) {
+}
+
+func (d *DummyCache) RemoveUserByID(userID int64) {
 }

--- a/pkg/auth/service.go
+++ b/pkg/auth/service.go
@@ -55,6 +55,8 @@ type Service interface {
 	GetUser(ctx context.Context, username string) (*model.User, error)
 	GetUserByEmail(ctx context.Context, email string) (*model.User, error)
 	ListUsers(ctx context.Context, params *model.PaginationParams) ([]*model.User, *model.Paginator, error)
+	RemoveUserFromCache(username string)
+	RemoveUserFromCacheByID(userID int64)
 
 	// groups
 	CreateGroup(ctx context.Context, group *model.Group) error
@@ -325,6 +327,14 @@ func (s *DBAuthService) GetUserByID(ctx context.Context, userID int64) (*model.U
 		}
 		return user.(*model.User), nil
 	})
+}
+
+func (s *DBAuthService) RemoveUserFromCache(username string) {
+	s.cache.RemoveUser(username)
+}
+
+func (s *DBAuthService) RemoveUserFromCacheByID(userID int64) {
+	s.cache.RemoveUserByID(userID)
 }
 
 func (s *DBAuthService) ListUsers(ctx context.Context, params *model.PaginationParams) ([]*model.User, *model.Paginator, error) {
@@ -1124,6 +1134,14 @@ func (a *APIAuthService) GetUserByEmail(ctx context.Context, email string) (*mod
 
 		return user, err
 	})
+}
+
+func (a *APIAuthService) RemoveUserFromCache(username string) {
+	a.cache.RemoveUser(username)
+}
+
+func (a *APIAuthService) RemoveUserFromCacheByID(userID int64) {
+	a.cache.RemoveUserByID(userID)
 }
 
 func toPagination(paginator Pagination) *model.Paginator {

--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -12,6 +12,7 @@ type SetFn func() (v interface{}, err error)
 
 type Cache interface {
 	GetOrSet(k interface{}, setFn SetFn) (v interface{}, err error)
+	Remove(k interface{})
 }
 
 type GetSetCache struct {
@@ -43,6 +44,10 @@ func (c *GetSetCache) GetOrSet(k interface{}, setFn SetFn) (v interface{}, err e
 		c.lru.AddEx(k, v, c.baseExpiry+c.jitterFn())
 		return v, nil
 	})
+}
+
+func (c *GetSetCache) Remove(k interface{}) {
+	c.lru.Remove(k)
 }
 
 func NewJitterFn(jitter time.Duration) JitterFn {

--- a/pkg/graveler/settings/manager_test.go
+++ b/pkg/graveler/settings/manager_test.go
@@ -34,6 +34,9 @@ func (m *mockCache) GetOrSet(k interface{}, setFn cache.SetFn) (v interface{}, e
 	return val, nil
 }
 
+func (m *mockCache) Remove(k interface{}) {
+}
+
 func TestSaveAndGet(t *testing.T) {
 	ctx := context.Background()
 	mockCache := &mockCache{


### PR DESCRIPTION
This avoids conflict of the old password still being in the cache, resulting in failure to login with the new credentials.
Closes #3331 