### PR TITLE
LAKECTL_INTERACTIVE env can control lakeCTL on/off terminal output

### DIFF
--- a/cmd/lakectl/cmd/root.go
+++ b/cmd/lakectl/cmd/root.go
@@ -134,9 +134,6 @@ func isSeekable(f io.Seeker) bool {
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	if noColorRequested {
-		DisableColors()
-	}
 	err := rootCmd.Execute()
 	if err != nil {
 		DieErr(err)


### PR DESCRIPTION
Using `LAKECTL_INTERACTIVE` environment variable boolean (already supported), we can force lakectl terminal (interactive on) or no terminal (interactive off).

By setting a value, it will override the default behaviour where we try to identify if the terminal is currently attached to our standard output.

Fix #3026
