### PR TITLE
Upgrade workflow to use CodeQL v2

### DIFF
--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -27,7 +27,7 @@ jobs:
         go-version: 1.17.8
 
     - name: Initialize CodeQL Go
-      uses: github/codeql-action/init@v1
+      uses: github/codeql-action/init@v2
       with:
         languages: go, javascript
         config-file: ./.github/codeql/codeql-config.yaml
@@ -35,5 +35,5 @@ jobs:
     - run: make gen
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      uses: github/codeql-action/analyze@v2
 


### PR DESCRIPTION
Code scanning: deprecation of CodeQL Action v1

Following the instruction on how to upgrade from v1:
https://github.blog/changelog/2022-04-27-code-scanning-deprecation-of-codeql-action-v1/