### PR TITLE
Fix get user by email should have different cache instance

### DIFF
--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -837,7 +837,7 @@ func (c *Controller) inviteUserRequest(emailAddr string) error {
 func (c *Controller) CreateUser(w http.ResponseWriter, r *http.Request, body CreateUserJSONRequestBody) {
 	invite := swag.BoolValue(body.InviteUser)
 	id := body.Id
-	var email *string
+	var parsedEmail *string
 	if invite {
 		addr, err := mail.ParseAddress(body.Id)
 		if err != nil {
@@ -846,7 +846,7 @@ func (c *Controller) CreateUser(w http.ResponseWriter, r *http.Request, body Cre
 			return
 		}
 		id = strings.ToLower(addr.Address)
-		email = &addr.Address
+		parsedEmail = &addr.Address
 	}
 	if !c.authorize(w, r, permissions.Node{
 		Permission: permissions.Permission{
@@ -861,7 +861,7 @@ func (c *Controller) CreateUser(w http.ResponseWriter, r *http.Request, body Cre
 		Username:     id,
 		FriendlyName: nil,
 		Source:       "internal",
-		Email:        email,
+		Email:        parsedEmail,
 	}
 	ctx := r.Context()
 	c.LogAction(ctx, "create_user")

--- a/pkg/auth/service.go
+++ b/pkg/auth/service.go
@@ -299,7 +299,7 @@ func (s *DBAuthService) GetUser(ctx context.Context, username string) (*model.Us
 }
 
 func (s *DBAuthService) GetUserByEmail(ctx context.Context, email string) (*model.User, error) {
-	return s.cache.GetUser(email, func() (*model.User, error) {
+	return s.cache.GetUserByEmail(email, func() (*model.User, error) {
 		user, err := s.db.Transact(ctx, func(tx db.Tx) (interface{}, error) {
 			return getUserByEmail(tx, email)
 		}, db.ReadOnly())


### PR DESCRIPTION
Get user by email used the user's cache while loading user information by email.
This PR fix this behaviour, as the email and the username are two different identifiers and should use different cache instances.
