### PR TITLE
Allow lakeFS to serve GUI from other directory

### DIFF
--- a/pkg/api/serve.go
+++ b/pkg/api/serve.go
@@ -94,7 +94,7 @@ func Serve(
 	r.Mount("/_pprof/", httputil.ServePPROF("/_pprof/"))
 	r.Mount("/swagger.json", http.HandlerFunc(swaggerSpecHandler))
 	r.Mount(BaseURL, http.HandlerFunc(InvalidAPIEndpointHandler))
-	r.Mount("/", NewUIHandler(gatewayDomains))
+	r.Mount("/", NewUIHandler(gatewayDomains, cfg.GetUIDir()))
 	return r
 }
 

--- a/pkg/api/ui_handler.go
+++ b/pkg/api/ui_handler.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"io/fs"
 	"net/http"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -16,11 +17,19 @@ import (
 	"github.com/treeverse/lakefs/webui"
 )
 
-func NewUIHandler(gatewayDomains []string) http.Handler {
-	content, err := fs.Sub(webui.Content, "dist")
-	if err != nil {
-		// embedded UI content is missing
-		panic(err)
+func NewUIHandler(gatewayDomains []string, fsDir *string) http.Handler {
+	var (
+		content fs.FS
+		err     error
+	)
+	if fsDir == nil {
+		content, err = fs.Sub(webui.Content, "dist")
+		if err != nil {
+			// embedded UI content is missing
+			panic(err)
+		}
+	} else {
+		content = os.DirFS(*fsDir)
 	}
 	fileSystem := http.FS(content)
 	nocacheContent := middleware.NoCache(http.StripPrefix("/", http.FileServer(fileSystem)))

--- a/pkg/api/ui_handler_test.go
+++ b/pkg/api/ui_handler_test.go
@@ -19,7 +19,7 @@ func testHTTPGetPage(t *testing.T, handler http.Handler, url string) *httptest.R
 }
 
 func TestNewUIHandler_SPA(t *testing.T) {
-	handler := NewUIHandler(nil)
+	handler := NewUIHandler(nil, nil)
 
 	rrMain := testHTTPGetPage(t, handler, "/")
 	if rrMain.Code != http.StatusOK {
@@ -36,7 +36,7 @@ func TestNewUIHandler_SPA(t *testing.T) {
 }
 
 func TestNewUIHandler_GatewayError(t *testing.T) {
-	handler := NewUIHandler([]string{"s3.lakefs.dev"})
+	handler := NewUIHandler([]string{"s3.lakefs.dev"}, nil)
 	rr := httptest.NewRecorder()
 	req, err := http.NewRequest(http.MethodGet, "/", nil)
 	if err != nil {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -262,6 +262,10 @@ func (c *Config) Validate() error {
 	return nil
 }
 
+func (c *Config) GetUIDir() *string {
+	return c.values.UI.Dir
+}
+
 func (c *Config) GetDatabaseParams() dbparams.Database {
 	return dbparams.Database{
 		ConnectionString:      c.values.Database.ConnectionString.SecureValue(),

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -41,6 +41,10 @@ type configuration struct {
 		Enabled bool `mapstructure:"enabled"`
 	}
 
+	UI struct {
+		Dir *string
+	}
+
 	Logging struct {
 		Format        string   `mapstructure:"format"`
 		Level         string   `mapstructure:"level"`


### PR DESCRIPTION
lakeFS has always served a GUI built into it.  Now when configuration option
`ui.dir` has a value, serve the UI stored there.

This allows GUI plugin-in: copy the `webui/` directory, modify it as you see
fit, then `npm run build` and point `ui.dir` at `webui-copy/dist`.  I tested
it by doing just that and modifying the CSS there.