### PR TITLE
create branch name validation message

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -386,6 +386,9 @@ func (c *Catalog) CreateBranch(ctx context.Context, repository string, branch st
 		{Name: "branch", Value: branchID, Fn: graveler.ValidateBranchID},
 		{Name: "ref", Value: sourceRef, Fn: graveler.ValidateRef},
 	}); err != nil {
+		if errors.Is(err, graveler.ErrInvalidBranchID) {
+			return nil, fmt.Errorf("%w: branch id must consist of letters, digits, underscores and dashes, and cannot start with a dash", err)
+		}
 		return nil, err
 	}
 	newBranch, err := c.Store.CreateBranch(ctx, repositoryID, branchID, sourceRef)

--- a/pkg/graveler/errors.go
+++ b/pkg/graveler/errors.go
@@ -23,7 +23,7 @@ var (
 	ErrNoMergeBase                  = errors.New("no merge base")
 	ErrInvalidRef                   = fmt.Errorf("ref: %w", ErrInvalidValue)
 	ErrInvalidCommitID              = fmt.Errorf("commit id: %w", ErrInvalidValue)
-	ErrInvalidBranchID              = fmt.Errorf("branch id: %w can contain only letters, numbers, underscores, and dashes (not at the beginning)", ErrInvalidValue)
+	ErrInvalidBranchID              = fmt.Errorf("branch id: %w", ErrInvalidValue)
 	ErrInvalidTagID                 = fmt.Errorf("tag id: %w", ErrInvalidValue)
 	ErrInvalid                      = errors.New("validation error")
 	ErrInvalidType                  = fmt.Errorf("invalid type: %w", ErrInvalid)

--- a/pkg/graveler/errors.go
+++ b/pkg/graveler/errors.go
@@ -23,7 +23,7 @@ var (
 	ErrNoMergeBase                  = errors.New("no merge base")
 	ErrInvalidRef                   = fmt.Errorf("ref: %w", ErrInvalidValue)
 	ErrInvalidCommitID              = fmt.Errorf("commit id: %w", ErrInvalidValue)
-	ErrInvalidBranchID              = fmt.Errorf("branch id: %w", ErrInvalidValue)
+	ErrInvalidBranchID              = fmt.Errorf("branch id: %w can contain only letters, numbers, underscores, and dashes (not at the beginning)", ErrInvalidValue)
 	ErrInvalidTagID                 = fmt.Errorf("tag id: %w", ErrInvalidValue)
 	ErrInvalid                      = errors.New("validation error")
 	ErrInvalidType                  = fmt.Errorf("invalid type: %w", ErrInvalid)


### PR DESCRIPTION
fixes #2894 

`argument branch: branch id: invalid value: validation error can contain only letters, numbers, underscores, and dashes (not at the beginning)`