### PR TITLE
multipart.tracker benchmarks

### DIFF
--- a/pkg/gateway/multiparts/main_test.go
+++ b/pkg/gateway/multiparts/main_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/ory/dockertest/v3"
 
 	_ "github.com/treeverse/lakefs/pkg/kv/mem"
+	_ "github.com/treeverse/lakefs/pkg/kv/postgres"
 	"github.com/treeverse/lakefs/pkg/logging"
 	"github.com/treeverse/lakefs/pkg/testutil"
 )

--- a/pkg/kv/kvtest/store.go
+++ b/pkg/kv/kvtest/store.go
@@ -12,7 +12,7 @@ import (
 	"github.com/treeverse/lakefs/pkg/kv"
 )
 
-type MakeStore func(t *testing.T, ctx context.Context) kv.Store
+type MakeStore func(t testing.TB, ctx context.Context) kv.Store
 
 var runTestID = nanoid.MustGenerate("abcdef1234567890", 8)
 
@@ -274,7 +274,7 @@ func testStoreScan(t *testing.T, ms MakeStore) {
 }
 
 func MakeStoreByName(name, dsn string) MakeStore {
-	return func(t *testing.T, ctx context.Context) kv.Store {
+	return func(t testing.TB, ctx context.Context) kv.Store {
 		t.Helper()
 		store, err := kv.Open(ctx, name, dsn)
 		if err != nil {


### PR DESCRIPTION
Benchmarking PostgresDB vs KV-Mem vs KV-Postgres with the following:
* Create operation
* Sequential Get opertations
* Random Get operations
* Sequential Delete operatrions
* Mix of 10% Create, 80% Get and 10% Delete operations
All of the above can run individually to benchmark a specific op, or all together, as shown below

Sample output:
```
$ go test -bench=BenchmarkMultipartsTracker -benchtime=10000x
goos: linux
goarch: amd64
pkg: github.com/treeverse/lakefs/pkg/gateway/multiparts
cpu: 11th Gen Intel(R) Core(TM) i7-1185G7 @ 3.00GHz
BenchmarkMultipartsTrackerCreate/benchmarkCreateOp_DB-8         	   10000	    422947 ns/op
BenchmarkMultipartsTrackerCreate/benchmarkCreateOp_KVmem-8      	   10000	      1744 ns/op
BenchmarkMultipartsTrackerCreate/benchmarkCreateOp_KVpg-8       	   10000	    343066 ns/op
BenchmarkMultipartsTrackerGetSeq/benchmarkGetOpSeq_DB-8         	   10000	   1002876 ns/op
BenchmarkMultipartsTrackerGetSeq/benchmarkGetOpSeq_KVmem-8      	   10000	     16226 ns/op
BenchmarkMultipartsTrackerGetSeq/benchmarkGetOpSeq_KVpg-8       	   10000	    126026 ns/op
BenchmarkMultipartsTrackerGetRand/benchmarkGetOpRand_DB-8       	   10000	    208291 ns/op
BenchmarkMultipartsTrackerGetRand/benchmarkGetOpRand_KVmem-8    	   10000	      2384 ns/op
BenchmarkMultipartsTrackerGetRand/benchmarkGetOpRand_KVpg-8     	   10000	     34168 ns/op
BenchmarkMultipartsTrackerDelete/benchmarkDeleteOpSeq_DB-8      	   10000	    408299 ns/op
BenchmarkMultipartsTrackerDelete/benchmarkDeleteOpSeq_KVmem-8   	   10000	      1515 ns/op
BenchmarkMultipartsTrackerDelete/benchmarkDeleteOpSeq_KVpg-8    	   10000	    409746 ns/op
BenchmarkMultipartsTrackerMix/benchmarkMixedOps_DB-8            	   10000	    161558 ns/op
BenchmarkMultipartsTrackerMix/benchmarkMixedOps_KVmem-8         	   10000	       733.1 ns/op
BenchmarkMultipartsTrackerMix/benchmarkMixedOps_KVpg-8          	   10000	     86964 ns/op
PASS
ok  	github.com/treeverse/lakefs/pkg/gateway/multiparts	70.690s

```