### PR TITLE
Document how to assume role in the Spark metadata client

### DIFF
--- a/docs/integrations/spark.md
+++ b/docs/integrations/spark.md
@@ -36,8 +36,6 @@ Using the S3A gateway is easier to configure and may be more suitable for legacy
 small-scale applications.  Using the lakeFS FileSystem requires somewhat more complex
 configuration, but offers greatly increased performance.
 
-
-
 ## Access lakeFS using the S3A gateway
 
 To use this mode you configure the Spark application to use S3A using the S3-compatible
@@ -192,7 +190,6 @@ df.write.partitionBy("example-column").parquet(s"s3a://${repo}/${branch}/output-
 ```
 
 The data is now created in lakeFS as new changes in your branch. You can now commit these changes, or revert them.
-
 
 ## Access lakeFS using the lakeFS-specific Hadoop FileSystem
 

--- a/docs/reference/spark-client.md
+++ b/docs/reference/spark-client.md
@@ -21,23 +21,45 @@ Utilize the power of Spark to interact with the metadata on lakeFS. Possible use
 
 Start Spark Shell / PySpark with the `--packages` flag:
 
-Spark 3.0.1:
+<div class="tabs">
+  <ul>
+    <li><a href="#packages-2">Spark 2.x</a></li>
+	<li><a href="#packages-3-hadoop2">Spark 3.x</a></li>
+	<li><a href="#packages-3-hadoop3">Spark 3.x on Hadoop 3.x</a></li>
+  </ul>
+  <div markdown="1" id="packages-2">
+  This client is compiled for Spark 2.4.7 and tested with it, but can work for higher versions.
 
-```bash
-spark-shell --packages io.lakefs:lakefs-spark-client-301_2.12:0.1.6
-```
+  ```bash
+  spark-shell --packages io.lakefs:lakefs-spark-client-247_2.11:0.1.7
+  ```
+  
+  Alternatively an assembled jar is available on S3, at
+  s3://treeverse-clients-us-east/lakefs-spark-client-247/0.1.7/lakefs-spark-client-247-assembly-0.1.7.jar
+  </div>
 
-Spark 2.4.7:
+<div markdown="1" id="packages-3-hadoop2">
+  This client is compiled for Spark 3.0.1 with Hadoop 2 and tested with it, but can work for
+  higher versions.
 
-```bash
-spark-shell --packages io.lakefs:lakefs-spark-client-247_2.11:0.1.6
-```
+  ```bash
+  spark-shell --packages io.lakefs:lakefs-spark-client-301_2.12:0.1.7
+  ```
+  
+  Alternatively an assembled jar is available on S3, at
+  s3://treeverse-clients-us-east/lakefs-spark-client-301/0.1.7/lakefs-spark-client-301-assembly-0.1.7.jar
+  </div> 
 
-Alternatively, the Jars are publicly available on S3:
+  <div markdown="1" id="packages-3-hadoop3">
+  This client is compiled for Spark 3.1.2 with Hadoop 3.2.1, but can work for other Spark
+  versions and higher Hadoop versions.
+  
+  ```bash
+  spark-shell --packages io.lakefs:lakefs-spark-client-312-hadoop3-assembly_2.12:0.1.7
+  ```
 
-* Spark 3.0.1: `s3://treeverse-clients-us-east/lakefs-spark-client-301_2.12/0.1.0/lakefs-spark-client-301_2.12-0.1.6.jar`
-
-* Spark 2.4.7: `s3://treeverse-clients-us-east/lakefs-spark-client-247_2.11/0.1.0/lakefs-spark-client-247_2.11-0.1.6.jar`
+  Alternatively an assembled jar is available on S3, at
+  s3://treeverse-clients-us-east/lakefs-spark-client-312-hadoop3/0.1.7/lakefs-spark-client-312-hadoop3-assembly-0.1.7.jar
 
 ## Configuration
 
@@ -59,6 +81,16 @@ Alternatively, the Jars are publicly available on S3:
    | `spark.hadoop.fs.s3a.access.key` | Access key to use for accessing underlying storage on S3 |
    | `spark.hadoop.fs.s3a.secret.key` | Corresponding secret key to use with S3 access key       |
 
+   The client includes support for assuming a separate role on S3A when
+   running on Hadoop 3: it can read and use the same configuration used by
+   S3AFileSystem to assume a role for S3A.  Apache Hadoop AWS support
+   details [Working with IAM Assumed Roles][s3a-assumed-role].  You will
+   need to use the following Hadoop configurations:
+   
+   | Configuration                     | Description                                                          |
+   |-----------------------------------|----------------------------------------------------------------------|
+   | `fs.s3a.aws.credentials.provider` | Set to `org.apache.hadoop.fs.s3a.auth.AssumedRoleCredentialProvider` |
+   | `fs.s3a.assumed.role.arn`         | Set to the ARN of the role to assume                                 |
 
 ## Examples
 
@@ -97,3 +129,5 @@ Alternatively, the Jars are publicly available on S3:
     */
    ```
 
+
+[s3a-assumed-role]:  https://hadoop.apache.org/docs/stable/hadoop-aws/tools/hadoop-aws/assumed_roles.html#Configuring_Assumed_Roles

--- a/docs/reference/spark-client.md
+++ b/docs/reference/spark-client.md
@@ -35,10 +35,10 @@ Start Spark Shell / PySpark with the `--packages` flag:
   ```
   
   Alternatively an assembled jar is available on S3, at
-  s3://treeverse-clients-us-east/lakefs-spark-client-247/0.1.7/lakefs-spark-client-247-assembly-0.1.7.jar
+  `s3://treeverse-clients-us-east/lakefs-spark-client-247/0.1.7/lakefs-spark-client-247-assembly-0.1.7.jar`
   </div>
 
-<div markdown="1" id="packages-3-hadoop2">
+  <div markdown="1" id="packages-3-hadoop2">
   This client is compiled for Spark 3.0.1 with Hadoop 2 and tested with it, but can work for
   higher versions.
 
@@ -47,7 +47,7 @@ Start Spark Shell / PySpark with the `--packages` flag:
   ```
   
   Alternatively an assembled jar is available on S3, at
-  s3://treeverse-clients-us-east/lakefs-spark-client-301/0.1.7/lakefs-spark-client-301-assembly-0.1.7.jar
+  `s3://treeverse-clients-us-east/lakefs-spark-client-301/0.1.7/lakefs-spark-client-301-assembly-0.1.7.jar`
   </div> 
 
   <div markdown="1" id="packages-3-hadoop3">
@@ -59,7 +59,8 @@ Start Spark Shell / PySpark with the `--packages` flag:
   ```
 
   Alternatively an assembled jar is available on S3, at
-  s3://treeverse-clients-us-east/lakefs-spark-client-312-hadoop3/0.1.7/lakefs-spark-client-312-hadoop3-assembly-0.1.7.jar
+  `s3://treeverse-clients-us-east/lakefs-spark-client-312-hadoop3/0.1.7/lakefs-spark-client-312-hadoop3-assembly-0.1.7.jar`
+  </div>
 
 ## Configuration
 
@@ -81,11 +82,14 @@ Start Spark Shell / PySpark with the `--packages` flag:
    | `spark.hadoop.fs.s3a.access.key` | Access key to use for accessing underlying storage on S3 |
    | `spark.hadoop.fs.s3a.secret.key` | Corresponding secret key to use with S3 access key       |
 
-   The client includes support for assuming a separate role on S3A when
-   running on Hadoop 3: it can read and use the same configuration used by
-   S3AFileSystem to assume a role for S3A.  Apache Hadoop AWS support
-   details [Working with IAM Assumed Roles][s3a-assumed-role].  You will
-   need to use the following Hadoop configurations:
+   ### Assuming role on S3 (Hadoop 3 only)
+
+   The client includes support for assuming a separate role on S3 when
+   running on Hadoop 3.  It uses the same configuration used by
+   `S3AFileSystem` to assume the role on S3A.  Apache Hadoop AWS
+   documentation has details under "[Working with IAM Assumed
+   Roles][s3a-assumed-role]".  You will need to use the following Hadoop
+   configurations:
    
    | Configuration                     | Description                                                          |
    |-----------------------------------|----------------------------------------------------------------------|


### PR DESCRIPTION
Also reformat its documentation options, fix paths for 0.1.7, and add a mention of newly-added Hadoop 3 support in Spark 3.1.2+.