### PR TITLE
Bump Spark metadata client version to 0.1.7

### DIFF
--- a/clients/spark/build.sbt
+++ b/clients/spark/build.sbt
@@ -2,7 +2,7 @@ import build.BuildType
 
 lazy val baseName = "lakefs-spark"
 
-lazy val projectVersion = "0.1.7-RC.0"
+lazy val projectVersion = "0.1.7"
 ThisBuild / isSnapshot := false
 
 // Spark versions 2.4.7 and 3.0.1 use different Scala versions.  Changing this is a deep


### PR DESCRIPTION
0.1.7-RC.0 was a success :-)