### PR TITLE
Upgrade spark client dependencies to be compatible with M1

### DIFF
--- a/clients/spark/build.sbt
+++ b/clients/spark/build.sbt
@@ -64,11 +64,11 @@ def generateCoreProject(buildType: BuildType) =
         // version will probably continue to work because the C language API
         // is quite stable.  Take the version documented in DataBricks
         // Runtime 7.6, and note that it changes in 8.3 :-(
-        "org.xerial.snappy" % "snappy-java" % "1.1.7.5",
+        "org.xerial.snappy" % "snappy-java" % "1.1.8.2",
         "org.scalactic" %% "scalactic" % "3.2.9",
         "org.scalatest" %% "scalatest" % "3.2.9" % "test",
-        "com.dimafeng" %% "testcontainers-scala-scalatest" % "0.39.5" % "test",
-        "com.dimafeng" %% "testcontainers-scala-munit" % "0.39.5" % "test",
+        "com.dimafeng" %% "testcontainers-scala-scalatest" % "0.39.11" % "test",
+        "com.dimafeng" %% "testcontainers-scala-munit" % "0.39.11" % "test",
         "com.lihaoyi" %% "upickle" % "1.4.0" % "test",
         "com.lihaoyi" %% "os-lib" % "0.7.8" % "test"
       ),


### PR DESCRIPTION
bumped up `testcontainers-scala` and `snappy-java` version to be compatible with M1