### PR TITLE
Add gc report

### DIFF
--- a/clients/spark/core/src/main/scala/io/treeverse/clients/ApiClient.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/ApiClient.scala
@@ -29,11 +29,6 @@ private object ApiClient {
              )
     else
       uri
-
-  def getCommitTimeStamp(repoName: String, commitID: String, commitsApi: api.CommitsApi): Long = {
-    val commit = commitsApi.getCommit(repoName, commitID)
-    commit.getCreationDate
-  }
 }
 
 class ApiClient(apiUrl: String, accessKey: String, secretKey: String) {

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/ApiClient.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/ApiClient.scala
@@ -29,6 +29,11 @@ private object ApiClient {
              )
     else
       uri
+
+  def getCommitTimeStamp(repoName: String, commitID: String, commitsApi: api.CommitsApi): Long = {
+    val commit = commitsApi.getCommit(repoName, commitID)
+    commit.getCreationDate
+  }
 }
 
 class ApiClient(apiUrl: String, accessKey: String, secretKey: String) {
@@ -68,6 +73,11 @@ class ApiClient(apiUrl: String, accessKey: String, secretKey: String) {
       repoName,
       new GarbageCollectionPrepareRequest().previousRunId(previousRunID)
     )
+  }
+
+  def getGarbageCollectionRules(repoName: String): String = {
+    val gcRules = retentionApi.getGarbageCollectionRules(repoName)
+    gcRules.toString()
   }
 
   /** Query lakeFS for a URL to the metarange of commitID of repoName and

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
@@ -37,9 +37,9 @@ trait S3ClientBuilder extends Serializable {
    *  On Hadoop versions >=3, S3A can assume a role, and the returned S3
    *  client will similarly assume that role.
    *
-   *  @param hc (partial) Hadoop configuration of fs.s3a.
-   *  @param bucket that this client will access.
-   *  @param region to find this bucket.
+   *  @param hc         (partial) Hadoop configuration of fs.s3a.
+   *  @param bucket     that this client will access.
+   *  @param region     to find this bucket.
    *  @param numRetries number of times to retry on AWS.
    */
   def build(hc: Configuration, bucket: String, region: String, numRetries: Int): AmazonS3
@@ -464,12 +464,23 @@ object GarbageCollector {
     bulkRemove(df, MaxBulkSize, bucket, region, awsRetries, snPrefix, hcValues).toDF("addresses")
   }
 
-  private def writeParquetReport(dstRoot: String, df: DataFrame, time: String, suffix: String = "") = {
+  private def writeParquetReport(
+      dstRoot: String,
+      df: DataFrame,
+      time: String,
+      suffix: String = ""
+  ) = {
     val dstPath = dstRoot + s"/dt=${time}/${suffix}"
     df.write.parquet(dstPath)
   }
 
-  private def writeJsonSummary(dstRoot: String, numDeletedObjects: Long, gcRules: String, hcValues: Broadcast[ConfMap], time: String) = {
+  private def writeJsonSummary(
+      dstRoot: String,
+      numDeletedObjects: Long,
+      gcRules: String,
+      hcValues: Broadcast[ConfMap],
+      time: String
+  ) = {
     val dstPath = new Path(dstRoot + s"/dt=${time}/summary.json")
     val dstFS = dstPath.getFileSystem(configurationFromValues(hcValues))
     val jsonSummary = JObject("gc_rules" -> gcRules, "num_deleted_objects" -> numDeletedObjects)


### PR DESCRIPTION
closes part of #3127 
Added reports at the end of gc run, reporting the deleted objects, relevant commits and the gc rules. 
Missing commit timestamp in the commits summary. 