### PR TITLE
KV milestone tidiness 

### DIFF
--- a/pkg/actions/db_run_result_iterator.go
+++ b/pkg/actions/db_run_result_iterator.go
@@ -2,6 +2,7 @@ package actions
 
 import (
 	"context"
+	"fmt"
 
 	sq "github.com/Masterminds/squirrel"
 	"github.com/treeverse/lakefs/pkg/db"
@@ -25,7 +26,11 @@ type DBRunResultIterator struct {
 	commitID     string
 }
 
-func NewDBRunResultIterator(ctx context.Context, db db.Database, fetchSize int, repositoryID, branchID, commitID string, after string) *DBRunResultIterator {
+func NewDBRunResultIterator(ctx context.Context, db db.Database, fetchSize int, repositoryID, branchID, commitID string, after string) (*DBRunResultIterator, error) {
+	if branchID != "" && commitID != "" {
+		return nil, fmt.Errorf("can't use both branchID and CommitID: %w", ErrParamConflict)
+	}
+
 	return &DBRunResultIterator{
 		db:           db,
 		ctx:          ctx,
@@ -35,7 +40,7 @@ func NewDBRunResultIterator(ctx context.Context, db db.Database, fetchSize int, 
 		commitID:     commitID,
 		fetchSize:    fetchSize,
 		buf:          make([]*RunResult, 0, fetchSize),
-	}
+	}, nil
 }
 
 func (it *DBRunResultIterator) Next() bool {

--- a/pkg/actions/service.go
+++ b/pkg/actions/service.go
@@ -23,7 +23,7 @@ const (
 	packageName  = "actions"
 	PartitionKey = "actions"
 	reposPrefix  = "repos"
-	RunsPrefix   = "runs"
+	runsPrefix   = "runs"
 	tasksPrefix  = "tasks"
 	branchPrefix = "branches"
 	commitPrefix = "commits"
@@ -140,32 +140,32 @@ func protoFromTaskResult(m *TaskResult) *TaskResultData {
 	}
 }
 
-func BaseActionsPath(repoID string) string {
+func baseActionsPath(repoID string) string {
 	return kv.FormatPath(reposPrefix, repoID)
 }
 
 func TasksPath(repoID, runID string) string {
-	return kv.FormatPath(BaseActionsPath(repoID), tasksPrefix, runID)
+	return kv.FormatPath(baseActionsPath(repoID), tasksPrefix, runID)
 }
 
 func RunPath(repoID, runID string) string {
-	return kv.FormatPath(BaseActionsPath(repoID), RunsPrefix, runID)
+	return kv.FormatPath(baseActionsPath(repoID), runsPrefix, runID)
 }
 
-func ByBranchPath(repoID, branchID string) string {
-	return kv.FormatPath(BaseActionsPath(repoID), branchPrefix, branchID)
+func byBranchPath(repoID, branchID string) string {
+	return kv.FormatPath(baseActionsPath(repoID), branchPrefix, branchID)
 }
 
-func ByCommitPath(repoID, commitID string) string {
-	return kv.FormatPath(BaseActionsPath(repoID), commitPrefix, commitID)
+func byCommitPath(repoID, commitID string) string {
+	return kv.FormatPath(baseActionsPath(repoID), commitPrefix, commitID)
 }
 
 func RunByBranchPath(repoID, branchID, runID string) string {
-	return kv.FormatPath(ByBranchPath(repoID, branchID), runID)
+	return kv.FormatPath(byBranchPath(repoID, branchID), runID)
 }
 
 func RunByCommitPath(repoID, commitID, runID string) string {
-	return kv.FormatPath(ByCommitPath(repoID, commitID), runID)
+	return kv.FormatPath(byCommitPath(repoID, commitID), runID)
 }
 
 type Service interface {

--- a/pkg/actions/store_db.go
+++ b/pkg/actions/store_db.go
@@ -69,7 +69,7 @@ func (dbs *DBStore) GetTaskResult(ctx context.Context, repositoryID string, runI
 }
 
 func (dbs *DBStore) ListRunResults(ctx context.Context, repositoryID string, branchID, commitID string, after string) (RunResultIterator, error) {
-	return NewDBRunResultIterator(ctx, dbs.db, defaultFetchSize, repositoryID, branchID, commitID, after), nil
+	return NewDBRunResultIterator(ctx, dbs.db, defaultFetchSize, repositoryID, branchID, commitID, after)
 }
 
 func (dbs *DBStore) ListRunTaskResults(ctx context.Context, repositoryID string, runID string, after string) (TaskResultIterator, error) {

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -1716,7 +1716,8 @@ func handleAPIError(w http.ResponseWriter, err error) bool {
 		errors.Is(err, permissions.ErrInvalidAction),
 		errors.Is(err, model.ErrValidationError),
 		errors.Is(err, graveler.ErrInvalidRef),
-		errors.Is(err, graveler.ErrInvalidValue):
+		errors.Is(err, graveler.ErrInvalidValue),
+		errors.Is(err, actions.ErrParamConflict):
 		writeError(w, http.StatusBadRequest, err)
 
 	case errors.Is(err, graveler.ErrNotUnique):

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -2169,6 +2169,17 @@ func testController_ListRepositoryRuns(t *testing.T, kvEnabled bool) {
 		}
 	})
 
+	t.Run("on branch and commit", func(t *testing.T) {
+		respList, err := clt.ListRepositoryRunsWithResponse(ctx, "repo9", &api.ListRepositoryRunsParams{
+			Branch: api.StringPtr("someBranch"),
+			Commit: api.StringPtr("someCommit"),
+			Amount: api.PaginationAmountPtr(100),
+		})
+		require.NoError(t, err)
+		require.NotNil(t, respList)
+		require.Equal(t, http.StatusBadRequest, respList.StatusCode())
+	})
+
 	t.Run("on deleted branch", func(t *testing.T) {
 		// delete work branch and list them again
 		delResp, err := clt.DeleteBranchWithResponse(ctx, "repo9", "work")

--- a/pkg/auth/db_service.go
+++ b/pkg/auth/db_service.go
@@ -844,7 +844,7 @@ func (s *DBAuthService) Authorize(ctx context.Context, req *AuthorizationRequest
 }
 
 func (s *DBAuthService) ClaimTokenIDOnce(ctx context.Context, tokenID string, expiresAt int64) error {
-	return ClaimTokenIDOnce(ctx, tokenID, expiresAt, s.markTokenSingleUse)
+	return claimTokenIDOnce(ctx, tokenID, expiresAt, s.markTokenSingleUse)
 }
 
 // markTokenSingleUse returns true if token is valid for single use

--- a/pkg/auth/model/model.go
+++ b/pkg/auth/model/model.go
@@ -29,7 +29,7 @@ const (
 	usersPoliciesPrefix    = "uPolicies"
 	usersCredentialsPrefix = "uCredentials" //#nosec G101 -- False positive: this is only a kv key prefix
 	credentialsPrefix      = "credentials"
-	ExpiredTokensPrefix    = "expiredTokens"
+	expiredTokensPrefix    = "expiredTokens"
 )
 
 func UserPath(userName string) string {
@@ -61,7 +61,7 @@ func GroupPolicyPath(groupDisplayName string, policyDisplayName string) string {
 }
 
 func ExpiredTokenPath(tokenID string) string {
-	return kv.FormatPath(ExpiredTokensPrefix, tokenID)
+	return kv.FormatPath(expiredTokensPrefix, tokenID)
 }
 
 var (

--- a/pkg/auth/service.go
+++ b/pkg/auth/service.go
@@ -1093,10 +1093,10 @@ func (s *KVAuthService) Authorize(ctx context.Context, req *AuthorizationRequest
 }
 
 func (s *KVAuthService) ClaimTokenIDOnce(ctx context.Context, tokenID string, expiresAt int64) error {
-	return ClaimTokenIDOnce(ctx, tokenID, expiresAt, s.markTokenSingleUse)
+	return claimTokenIDOnce(ctx, tokenID, expiresAt, s.markTokenSingleUse)
 }
 
-func ClaimTokenIDOnce(ctx context.Context, tokenID string, expiresAt int64, markTokenSingleUse func(context.Context, string, time.Time) (bool, error)) error {
+func claimTokenIDOnce(ctx context.Context, tokenID string, expiresAt int64, markTokenSingleUse func(context.Context, string, time.Time) (bool, error)) error {
 	tokenExpiresAt := time.Unix(expiresAt, 0)
 	canUseToken, err := markTokenSingleUse(ctx, tokenID, tokenExpiresAt)
 	if err != nil {


### PR DESCRIPTION
Some small changes:
1. Fixing #3493 
2. unexport local functions
3. Fixed Runs + Tasks kv iterators to fail on entry parsing during `Next()` call.