### PR TITLE
Garbage Collector: Eliminate double slash in URL

### DIFF
--- a/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
@@ -365,8 +365,8 @@ object GarbageCollector {
       remove(storageNamespace, gcAddressesLocation, expiredAddresses, runID, region, hcValues)
 
     val commitsDF = getCommitsDF(runID, gcCommitsLocation, spark)
-    val reportLogsDst = s"${storageNamespace}_lakefs/logs/gc/summary/"
-    val reportExpiredDst = s"${storageNamespace}_lakefs/logs/gc/expired_addresses/"
+    val reportLogsDst = concatToGCLogsPrefix(storageNamespace, "summary")
+    val reportExpiredDst = concatToGCLogsPrefix(storageNamespace, "expired_addresses")
 
     val time = DateTimeFormatter.ISO_INSTANT.format(java.time.Clock.systemUTC.instant())
     writeParquetReport(commitsDF, reportLogsDst, time, "commits.parquet")
@@ -378,9 +378,14 @@ object GarbageCollector {
       .write
       .partitionBy("run_id")
       .mode(SaveMode.Overwrite)
-      .parquet(s"${storageNamespace}_lakefs/logs/gc/deleted_objects/${time}/deleted.parquet")
+      .parquet(concatToGCLogsPrefix(storageNamespace, s"deleted_objects/$time/deleted.parquet"))
 
     spark.close()
+  }
+
+  private def concatToGCLogsPrefix(storageNameSpace: String, key: String): String = {
+    val strippedKey = key.stripPrefix("/")
+    s"${storageNameSpace}_lakefs/logs/gc/$strippedKey"
   }
 
   private def repartitionBySize(df: DataFrame, maxSize: Int, column: String): DataFrame = {

--- a/pkg/graveler/retention/garbage_collection_manager.go
+++ b/pkg/graveler/retention/garbage_collection_manager.go
@@ -19,9 +19,9 @@ import (
 )
 
 const (
-	configFileSuffixTemplate    = "/%s/retention/gc/rules/config.json"
-	addressesFilePrefixTemplate = "/%s/retention/gc/addresses/"
-	commitsFileSuffixTemplate   = "/%s/retention/gc/commits/run_id=%s/commits.csv"
+	configFileSuffixTemplate    = "%s/retention/gc/rules/config.json"
+	addressesFilePrefixTemplate = "%s/retention/gc/addresses/"
+	commitsFileSuffixTemplate   = "%s/retention/gc/commits/run_id=%s/commits.csv"
 )
 
 type GarbageCollectionManager struct {


### PR DESCRIPTION
Both the lakeFS server and the Garbage Collector client write to the underlying storage during the garbage collection process.
At times, and in both parts, it generates and writes to paths with double slashes.
For example: `s3://some-bucket/some-path//_lakefs/logs/gc/summary`.
This PR aims to fix this problem.

### Problems:
1. The lakeFS server sends the suffix of the different paths with `/` as a delimiter as the first character to the `formatPathWithNamespace` function that expects it to not include the delimiter as a prefix.
2. The GC code attached a `/` prefix to the `_lakefs` path. That resulted in a double slash if the storage namespace ended with a slash.

### Mitigation: 
1. **lakeFS**: Pass the appropriate suffixes to the `formatPathWithNamespace` function.
2. **GarbageCollector**: Make sure that the storage namespace ends with a slash and build the location properly.

### How was this tested?
Ran the GC process with a previously double slashed generated path and made sure it changed its behavior to a single slash.

---
**Clarification**
Although the code itself generates a double slash path, the final entry, in S3, has no double slash in it.

Closes #2732 