### PR TITLE
return code 409 instead of 500 for revert conflict

### DIFF
--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -2435,6 +2435,8 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         404:
           $ref: "#/components/responses/NotFound"
+        409:
+          $ref: "#/components/responses/Conflict"
         default:
           $ref: "#/components/responses/ServerError"
 

--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -2436,7 +2436,11 @@ paths:
         404:
           $ref: "#/components/responses/NotFound"
         409:
-          $ref: "#/components/responses/Conflict"
+          description: Conflict Found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
         default:
           $ref: "#/components/responses/ServerError"
 

--- a/clients/java/api/openapi.yaml
+++ b/clients/java/api/openapi.yaml
@@ -2542,6 +2542,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: Resource Not Found
+        "409":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Conflict Found
         default:
           content:
             application/json:

--- a/clients/java/docs/BranchesApi.md
+++ b/clients/java/docs/BranchesApi.md
@@ -635,5 +635,6 @@ null (empty response body)
 **204** | revert successful |  -  |
 **401** | Unauthorized |  -  |
 **404** | Resource Not Found |  -  |
+**409** | Conflict Found |  -  |
 **0** | Internal Server Error |  -  |
 

--- a/clients/java/src/main/java/io/lakefs/clients/api/BranchesApi.java
+++ b/clients/java/src/main/java/io/lakefs/clients/api/BranchesApi.java
@@ -932,6 +932,7 @@ public class BranchesApi {
         <tr><td> 204 </td><td> revert successful </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Resource Not Found </td><td>  -  </td></tr>
+        <tr><td> 409 </td><td> Conflict Found </td><td>  -  </td></tr>
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
      */
@@ -1004,6 +1005,7 @@ public class BranchesApi {
         <tr><td> 204 </td><td> revert successful </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Resource Not Found </td><td>  -  </td></tr>
+        <tr><td> 409 </td><td> Conflict Found </td><td>  -  </td></tr>
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
      */
@@ -1025,6 +1027,7 @@ public class BranchesApi {
         <tr><td> 204 </td><td> revert successful </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Resource Not Found </td><td>  -  </td></tr>
+        <tr><td> 409 </td><td> Conflict Found </td><td>  -  </td></tr>
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
      */
@@ -1048,6 +1051,7 @@ public class BranchesApi {
         <tr><td> 204 </td><td> revert successful </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Resource Not Found </td><td>  -  </td></tr>
+        <tr><td> 409 </td><td> Conflict Found </td><td>  -  </td></tr>
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
      */

--- a/clients/python/docs/BranchesApi.md
+++ b/clients/python/docs/BranchesApi.md
@@ -764,6 +764,7 @@ void (empty response body)
 **204** | revert successful |  -  |
 **401** | Unauthorized |  -  |
 **404** | Resource Not Found |  -  |
+**409** | Conflict Found |  -  |
 **0** | Internal Server Error |  -  |
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)

--- a/docs/assets/js/swagger.yml
+++ b/docs/assets/js/swagger.yml
@@ -25,11 +25,11 @@ components:
     cookie_auth:
       type: apiKey
       in: cookie
-      name: access_token
+      name: internal_auth_session
     oidc_auth:
       type: apiKey
       in: cookie
-      name: auth_session
+      name: oidc_auth_session
   parameters:
     PaginationPrefix:
       in: query
@@ -2435,6 +2435,12 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         404:
           $ref: "#/components/responses/NotFound"
+        409:
+          description: Conflict Found
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
         default:
           $ref: "#/components/responses/ServerError"
 

--- a/esti/rollback_test.go
+++ b/esti/rollback_test.go
@@ -2,6 +2,7 @@ package esti
 
 import (
 	"fmt"
+	"net/http"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -243,4 +244,50 @@ func TestRevert(t *testing.T) {
 	// assert file2 content
 	body := string(getObjResp.Body)
 	require.Equal(t, objContent2, body, fmt.Sprintf("path: %s, expected: %s, actual:%s", objPath2, objContent2, body))
+}
+
+func TestRevertConflict(t *testing.T) {
+	ctx, _, repo := setupTest(t)
+	objPath1 := "1.txt"
+
+	// upload file
+	uploadFileRandomData(ctx, t, repo, mainBranch, objPath1, false)
+	f, err := found(ctx, repo, mainBranch, objPath1)
+	require.NoError(t, err)
+	require.True(t, f, "uploaded object found")
+
+	// first commit
+	commitResp, err := client.CommitWithResponse(ctx, repo, mainBranch, &api.CommitParams{}, api.CommitJSONRequestBody{
+		Message: "first commit for 1.txt",
+	})
+
+	require.NoError(t, err, "failed to commit changes")
+	require.NoErrorf(t, verifyResponse(commitResp.HTTPResponse, commitResp.Body),
+		"failed to commit changes repo %s branch %s", repo, mainBranch)
+
+	commitId := commitResp.JSON201.Id
+
+	// overriding the file with another file
+	uploadFileRandomData(ctx, t, repo, mainBranch, objPath1, false)
+	f, err = found(ctx, repo, mainBranch, objPath1)
+	require.NoError(t, err)
+	require.True(t, f, "uploaded object found")
+
+	// second commit
+	commitResp, err = client.CommitWithResponse(ctx, repo, mainBranch, &api.CommitParams{}, api.CommitJSONRequestBody{
+		Message: "second commit for 1.txt",
+	})
+
+	require.NoError(t, err, "failed to commit changes")
+	require.NoErrorf(t, verifyResponse(commitResp.HTTPResponse, commitResp.Body),
+		"failed to commit changes repo %s branch %s", repo, mainBranch)
+
+	// revert first commit - should result with a conflict
+	revertResp, err := client.RevertBranchWithResponse(ctx, repo, mainBranch, api.RevertBranchJSONRequestBody{
+		Ref: commitId,
+	})
+	require.NoError(t, err, "unexpected error when attempting revert")
+	if revertResp.HTTPResponse.StatusCode != http.StatusConflict {
+		t.Fatalf("unexpected error %d for conflicting revert. Expected %d", revertResp.HTTPResponse.StatusCode, http.StatusConflict)
+	}
 }

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -1751,7 +1751,8 @@ func handleAPIError(w http.ResponseWriter, err error) bool {
 		errors.Is(err, actions.ErrParamConflict):
 		writeError(w, http.StatusBadRequest, err)
 
-	case errors.Is(err, graveler.ErrNotUnique):
+	case errors.Is(err, graveler.ErrNotUnique),
+		errors.Is(err, graveler.ErrConflictFound):
 		writeError(w, http.StatusConflict, err)
 
 	case errors.Is(err, catalog.ErrFeatureNotSupported):


### PR DESCRIPTION
`handleAPIError` mapped `graveler.ErrConflictFound` to the default `http.StatusInternalServerError (500)` instead of the expected `http.StatusConflict (409)`
Fixed that and added an `Esti` test to create a conflict, attempt a revert and verify the status code