### PR TITLE
Clarify that the template URL is relative

### DIFF
--- a/design/open/ttv-wizard-mvp.md
+++ b/design/open/ttv-wizard-mvp.md
@@ -57,7 +57,7 @@ The following templates will be saved within the lakeFS binary and be directed b
 - **Request**:
   - Method: `GET`
   - Parameters:
-    - Template URL (`template_location`): `string` - URL of the template.  Retrieved from the query string, must be relative.
+    - Template URL (`template_location`): `string` - URL of the template.  Retrieved from the query string, must be relative (to a URL configured on the server).
     - Any other configurations required for the templates: `string` - retrieved from query string.
 - **Response**:
   - Return value: The expanded template

--- a/design/open/ttv-wizard-mvp.md
+++ b/design/open/ttv-wizard-mvp.md
@@ -57,8 +57,8 @@ The following templates will be saved within the lakeFS binary and be directed b
 - **Request**:
   - Method: `GET`
   - Parameters:
-    - Template URL (`template_location`): `string` - retrieved from query string.
-    - Any other configurations required for the templates: `string` - retrieved from query string
+    - Template URL (`template_location`): `string` - URL of the template.  Retrieved from the query string, must be relative.
+    - Any other configurations required for the templates: `string` - retrieved from query string.
 - **Response**:
   - Return value: The expanded template
   - Headers:


### PR DESCRIPTION
All template URLs must be interpreted relative to some base URL -- or it becomes too easy to mistakenly phrase a too-permissive permission to read a template.