### PR TITLE
Auth module in Esti migration test

### DIFF
--- a/esti/migrate_test.go
+++ b/esti/migrate_test.go
@@ -148,7 +148,7 @@ func preMigrateTests(t *testing.T) {
 	// all pre tests execution
 	t.Run("TestPreMigrateMultipart", testPreMigrateMultipart)
 	t.Run("TestPreMigrateActions", testPreMigrateActions)
-	t.Run("TestPreMigrateAuth", TestPreMigrateAuth)
+	t.Run("TestPreMigrateAuth", testPreMigrateAuth)
 
 	saveStateInLakeFS(t)
 }
@@ -337,7 +337,7 @@ func testPostMigrateActions(t *testing.T) {
 	require.Equal(t, len(branchResp.JSON200.Results), 3)
 }
 
-func TestPreMigrateAuth(t *testing.T) {
+func testPreMigrateAuth(t *testing.T) {
 	ctx, _, repo := setupTest(t)
 
 	// creating a viewer, developer, superuser and admin and verifying their roles and permissions

--- a/esti/migrate_test.go
+++ b/esti/migrate_test.go
@@ -407,8 +407,8 @@ func testPreMigrateAuth(t *testing.T) {
 		AccessKeyID:     adminCreds.AccessKeyId,
 		SecretAccessKey: adminCreds.SecretAccessKey,
 	}
-	state.Auth.AdminUser.Username = uid
-	state.Auth.AdminUser.Credentials = &authCredentials{
+	state.Auth.CustomUser.Username = uid
+	state.Auth.CustomUser.Credentials = &authCredentials{
 		AccessKeyID:     customCreds.AccessKeyId,
 		SecretAccessKey: customCreds.SecretAccessKey,
 	}

--- a/esti/migrate_test.go
+++ b/esti/migrate_test.go
@@ -65,7 +65,7 @@ type authState struct {
 	DeveloperUser authUser `json:"developer_user"`
 	SuperUser     authUser `json:"super_user"`
 	AdminUser     authUser `json:"admin_user"`
-	CustomUser    authUser `json:custom_user"`
+	CustomUser    authUser `json:"custom_user"`
 }
 
 type userPermissions struct {
@@ -437,7 +437,6 @@ func testPostMigrateAuth(t *testing.T) {
 		AccessKeyId:     state.Auth.CustomUser.Credentials.AccessKeyID,
 		SecretAccessKey: state.Auth.CustomUser.Credentials.SecretAccessKey,
 	}
-	verifyUserPermissions(t, ctx, state.Auth.Repo, "customUser", customUserCreds, customPermissions)
 
 	// adding a policy to the custom created group (created on DB and migrated) and verify it is added successfully
 	pid := "ReadReposPolicy"

--- a/esti/migrate_test.go
+++ b/esti/migrate_test.go
@@ -147,7 +147,7 @@ func preMigrateTests(t *testing.T) {
 	// all pre tests execution
 	t.Run("TestPreMigrateMultipart", testPreMigrateMultipart)
 	t.Run("TestPreMigrateActions", testPreMigrateActions)
-	t.Run("TestPreMigrateAuth", TestPreMigrateAuth)
+	t.Run("TestPreMigrateAuth", testPreMigrateAuth)
 
 	saveStateInLakeFS(t)
 }
@@ -336,7 +336,7 @@ func testPostMigrateActions(t *testing.T) {
 	require.Equal(t, len(branchResp.JSON200.Results), 3)
 }
 
-func TestPreMigrateAuth(t *testing.T) {
+func testPreMigrateAuth(t *testing.T) {
 	ctx, _, repo := setupTest(t)
 
 	// creating a viewer, developer, superuser and admin and verifying their roles and permissions

--- a/esti/migrate_test.go
+++ b/esti/migrate_test.go
@@ -355,7 +355,6 @@ func testPreMigrateAuth(t *testing.T) {
 	// the created group (and so, the user) has permissions to only list repositories, and so
 	// is expected to succeed with that but to fail reading the repository. This is done to
 	// later verify that a custom created groups and policies are migrated correctly
-
 	respCreateGroup, err := client.CreateGroupWithResponse(ctx, api.CreateGroupJSONRequestBody{
 		Id: authCustomGroupName,
 	})

--- a/esti/migrate_test.go
+++ b/esti/migrate_test.go
@@ -4,18 +4,22 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"testing"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/service/s3"
+	nanoid "github.com/matoous/go-nanoid/v2"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 	"github.com/thanhpk/randstr"
 	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/auth"
 	"github.com/treeverse/lakefs/pkg/graveler"
 	"github.com/treeverse/lakefs/pkg/logging"
+	"github.com/treeverse/lakefs/pkg/testutil"
 )
 
 // state to be used
@@ -24,6 +28,7 @@ var state migrateTestState
 type migrateTestState struct {
 	Multiparts multipartsState
 	Actions    actionsState
+	Auth       authState
 }
 
 type multipartsState struct {
@@ -44,6 +49,34 @@ type actionsState struct {
 	Runs        []*actionRun `json:"runs"`
 }
 
+type authCredentials struct {
+	AccessKeyID     string `json:"access_key_id"`
+	SecretAccessKey string `json:"secret_access_key"`
+}
+
+type authUser struct {
+	Username    string           `json:"username"`
+	Credentials *authCredentials `json:"credentials"`
+}
+
+type authState struct {
+	Repo          string   `json:"repo"`
+	ViewerUser    authUser `json:"viewer_user"`
+	DeveloperUser authUser `json:"developer_user"`
+	SuperUser     authUser `json:"super_user"`
+	AdminUser     authUser `json:"admin_user"`
+	CustomUser    authUser `json:custom_user"`
+}
+
+type userPermissions struct {
+	canCreateUser   bool
+	canListUsers    bool
+	canListRepos    bool
+	canReadRepo     bool
+	canCreateBranch bool
+	canDeleteBranch bool
+}
+
 const (
 	migrateMultipartsFile     = "multipart_file"
 	migrateMultipartsFilepath = mainBranch + "/" + migrateMultipartsFile
@@ -51,6 +84,53 @@ const (
 	migrateStateObjectPath    = "state.json"
 	migratePrePartsCount      = 3
 	migratePostPartsCount     = 2
+)
+
+var (
+	viewerPermissions = &userPermissions{
+		canCreateUser:   false,
+		canListUsers:    false,
+		canListRepos:    true,
+		canReadRepo:     true,
+		canCreateBranch: false,
+		canDeleteBranch: false,
+	}
+
+	developerPermissions = &userPermissions{
+		canCreateUser:   false,
+		canListUsers:    false,
+		canListRepos:    true,
+		canReadRepo:     true,
+		canCreateBranch: true,
+		canDeleteBranch: true,
+	}
+
+	superUserPermissions = &userPermissions{
+		canCreateUser:   false,
+		canListUsers:    false,
+		canListRepos:    true,
+		canReadRepo:     true,
+		canCreateBranch: true,
+		canDeleteBranch: true,
+	}
+
+	adminPermissions = &userPermissions{
+		canCreateUser:   true,
+		canListUsers:    true,
+		canListRepos:    true,
+		canReadRepo:     true,
+		canCreateBranch: true,
+		canDeleteBranch: true,
+	}
+
+	customPermissions = &userPermissions{
+		canCreateUser:   false,
+		canListUsers:    false,
+		canListRepos:    true,
+		canReadRepo:     false,
+		canCreateBranch: false,
+		canDeleteBranch: false,
+	}
 )
 
 func TestMigrate(t *testing.T) {
@@ -67,6 +147,7 @@ func preMigrateTests(t *testing.T) {
 	// all pre tests execution
 	t.Run("TestPreMigrateMultipart", testPreMigrateMultipart)
 	t.Run("TestPreMigrateActions", testPreMigrateActions)
+	t.Run("TestPreMigrateAuth", TestPreMigrateAuth)
 
 	saveStateInLakeFS(t)
 }
@@ -76,7 +157,8 @@ func postMigrateTests(t *testing.T) {
 
 	// all post tests execution
 	t.Run("TestPostMigrateMultipart", testPostMigrateMultipart)
-	t.Run("testPostMigrateActions", testPostMigrateActions)
+	t.Run("TestPostMigrateActions", testPostMigrateActions)
+	t.Run("TestPostMigrateAuth", testPostMigrateAuth)
 }
 
 func saveStateInLakeFS(t *testing.T) {
@@ -252,4 +334,185 @@ func testPostMigrateActions(t *testing.T) {
 	branchResp, err := client.ListRepositoryRunsWithResponse(ctx, state.Actions.Repo, &api.ListRepositoryRunsParams{Branch: &branch})
 	require.NoError(t, err, "failed to list runs")
 	require.Equal(t, len(branchResp.JSON200.Results), 3)
+}
+
+func TestPreMigrateAuth(t *testing.T) {
+	ctx, _, repo := setupTest(t)
+
+	// creating a viewer, developer, superuser and admin and verifying their roles and permissions
+	viewerCreds := createUserWithCredentialsInGroup(t, ctx, "testViewer", auth.ViewersGroup)
+	developerCreds := createUserWithCredentialsInGroup(t, ctx, "testDeveloper", auth.DevelopersGroup)
+	superUserCreds := createUserWithCredentialsInGroup(t, ctx, "testSuperUser", auth.SuperUsersGroup)
+	adminCreds := createUserWithCredentialsInGroup(t, ctx, "testAdmin", auth.AdminsGroup)
+
+	verifyUserPermissions(t, ctx, repo, "viewer", viewerCreds, viewerPermissions)
+	verifyUserPermissions(t, ctx, repo, "developer", developerCreds, developerPermissions)
+	verifyUserPermissions(t, ctx, repo, "superUser", superUserCreds, superUserPermissions)
+	verifyUserPermissions(t, ctx, repo, "admin", adminCreds, adminPermissions)
+
+	// creating a group with permissions, adding a user and verify permissions
+	// the created group (and so, the user) has permissions to only list repositories, and so
+	// is expected to succeed with that but to fail reading the repository. This is done to
+	// later verify that a custom created groups and policies are migrated correctly
+	gid := "user-defined-group"
+	respCreateGroup, err := client.CreateGroupWithResponse(ctx, api.CreateGroupJSONRequestBody{
+		Id: gid,
+	})
+	require.NoError(t, err, "Admin failed while creating group")
+	require.Equal(t, http.StatusCreated, respCreateGroup.StatusCode(), "Admin unexpectedly failed to create group")
+
+	pid := "TestPolicy"
+	respCreatePolicy, err := client.CreatePolicyWithResponse(ctx, api.CreatePolicyJSONRequestBody{
+		CreationDate: api.Int64Ptr(time.Now().Unix()),
+		Id:           pid,
+		Statement: []api.Statement{
+			{
+				Action:   []string{"fs:ListRepositories"},
+				Effect:   "allow",
+				Resource: "*",
+			},
+		},
+	})
+	require.NoError(t, err, "Admin failed while creating policy")
+	require.Equal(t, http.StatusCreated, respCreatePolicy.StatusCode(), "Admin unexpectedly failed to create policy")
+
+	respAddPolicy, err := client.AttachPolicyToGroupWithResponse(ctx, gid, pid)
+	require.NoError(t, err, "Admin failed while adding policy to group")
+	require.Equal(t, http.StatusCreated, respAddPolicy.StatusCode(), "Admin unexpectedly failed to add policy to group")
+
+	uid := "test-user"
+	customCreds := createUserWithCredentialsInGroup(t, ctx, uid, gid)
+	verifyUserPermissions(t, ctx, repo, "customUser", customCreds, customPermissions)
+
+	// Hardening relevant test data for post-migrate
+	state.Auth.Repo = repo
+	state.Auth.ViewerUser.Username = "testViewer"
+	state.Auth.ViewerUser.Credentials = &authCredentials{
+		AccessKeyID:     viewerCreds.AccessKeyId,
+		SecretAccessKey: viewerCreds.SecretAccessKey,
+	}
+	state.Auth.DeveloperUser.Username = "testdeveloper"
+	state.Auth.DeveloperUser.Credentials = &authCredentials{
+		AccessKeyID:     developerCreds.AccessKeyId,
+		SecretAccessKey: developerCreds.SecretAccessKey,
+	}
+	state.Auth.SuperUser.Username = "testSuperUser"
+	state.Auth.SuperUser.Credentials = &authCredentials{
+		AccessKeyID:     superUserCreds.AccessKeyId,
+		SecretAccessKey: superUserCreds.SecretAccessKey,
+	}
+	state.Auth.AdminUser.Username = "testAdmin"
+	state.Auth.AdminUser.Credentials = &authCredentials{
+		AccessKeyID:     adminCreds.AccessKeyId,
+		SecretAccessKey: adminCreds.SecretAccessKey,
+	}
+	state.Auth.AdminUser.Username = uid
+	state.Auth.AdminUser.Credentials = &authCredentials{
+		AccessKeyID:     customCreds.AccessKeyId,
+		SecretAccessKey: customCreds.SecretAccessKey,
+	}
+}
+
+func testPostMigrateAuth(t *testing.T) {
+	ctx, _, _ := setupTest(t)
+	verifyUserPermissions(t, ctx, state.Auth.Repo, "viewer", &api.CredentialsWithSecret{
+		AccessKeyId:     state.Auth.ViewerUser.Credentials.AccessKeyID,
+		SecretAccessKey: state.Auth.ViewerUser.Credentials.SecretAccessKey,
+	}, viewerPermissions)
+	verifyUserPermissions(t, ctx, state.Auth.Repo, "developer", &api.CredentialsWithSecret{
+		AccessKeyId:     state.Auth.DeveloperUser.Credentials.AccessKeyID,
+		SecretAccessKey: state.Auth.DeveloperUser.Credentials.SecretAccessKey,
+	}, developerPermissions)
+	verifyUserPermissions(t, ctx, state.Auth.Repo, "superUser", &api.CredentialsWithSecret{
+		AccessKeyId:     state.Auth.SuperUser.Credentials.AccessKeyID,
+		SecretAccessKey: state.Auth.SuperUser.Credentials.SecretAccessKey,
+	}, superUserPermissions)
+	verifyUserPermissions(t, ctx, state.Auth.Repo, "admin", &api.CredentialsWithSecret{
+		AccessKeyId:     state.Auth.AdminUser.Credentials.AccessKeyID,
+		SecretAccessKey: state.Auth.AdminUser.Credentials.SecretAccessKey,
+	}, adminPermissions)
+	verifyUserPermissions(t, ctx, state.Auth.Repo, "customUser", &api.CredentialsWithSecret{
+		AccessKeyId:     state.Auth.CustomUser.Credentials.AccessKeyID,
+		SecretAccessKey: state.Auth.CustomUser.Credentials.SecretAccessKey,
+	}, customPermissions)
+}
+
+func createUserWithCredentialsInGroup(t *testing.T, ctx context.Context, username, groupID string) *api.CredentialsWithSecret {
+	adminClient := client
+	_, err := adminClient.CreateUserWithResponse(ctx, api.CreateUserJSONRequestBody{
+		Id: username,
+	})
+	require.NoError(t, err, "Failed to create user "+username)
+
+	_, err = adminClient.AddGroupMembershipWithResponse(ctx, groupID, username)
+	require.NoError(t, err, "Failed to add group "+groupID+" to user "+username)
+
+	// give the user access credentials
+	r, err := adminClient.CreateCredentialsWithResponse(ctx, username)
+	require.NoError(t, err, "Failed to create credentials for user "+username)
+	require.Equal(t, http.StatusCreated, r.StatusCode(), "Failed to create credentials for user "+username)
+
+	return r.JSON201
+}
+
+func verifyUserPermissions(t *testing.T, ctx context.Context, repo, userType string, creds *api.CredentialsWithSecret, userPerms *userPermissions) {
+	endpointUrl := testutil.ParseEndpointURL(logger, viper.GetString("endpoint_url"))
+
+	userClient, err := testutil.NewClientFromCreds(logger, creds.AccessKeyId, creds.SecretAccessKey, endpointUrl)
+	require.NoError(t, err, "failed to initialize client for %s by credentials", userType)
+
+	createUserResp, err := userClient.CreateUserWithResponse(ctx, api.CreateUserJSONRequestBody{
+		Id: "no-such-user",
+	})
+	require.NoError(t, err, "%s failed to send CreaterUser request", userType)
+	if userPerms.canCreateUser {
+		require.Equal(t, http.StatusCreated, createUserResp.StatusCode(), "unexpected failure for %s - CreateUser", userType)
+	} else {
+		require.Equal(t, http.StatusUnauthorized, createUserResp.StatusCode(), "unexpected success for %s - CreateUser", userType)
+	}
+
+	listUsersResp, err := userClient.ListUsersWithResponse(ctx, &api.ListUsersParams{})
+	require.NoError(t, err, "%s failed to send ListUsers request", userType)
+	if userPerms.canListUsers {
+		require.Equal(t, http.StatusOK, listUsersResp.StatusCode(), "unexpected failure for %s - ListUsers", userType)
+	} else {
+		require.Equal(t, http.StatusUnauthorized, listUsersResp.StatusCode(), "unexpected success for %s - ListUsers", userType)
+	}
+
+	listReposResp, err := userClient.ListRepositoriesWithResponse(ctx, &api.ListRepositoriesParams{})
+	require.NoError(t, err, "failed to send ListRepositories request", userType)
+	if userPerms.canListRepos {
+		require.Equal(t, http.StatusOK, listReposResp.StatusCode(), "unexpected failure for %s - ListRepos", userType)
+	} else {
+		require.Equal(t, http.StatusUnauthorized, listReposResp.StatusCode(), "unexpected success for %s - ListRepos", userType)
+	}
+
+	getRepoResp, err := userClient.GetRepositoryWithResponse(ctx, repo)
+	require.NoError(t, err, "failed to send GetRepository request", userType)
+	if userPerms.canReadRepo {
+		require.Equal(t, http.StatusOK, getRepoResp.StatusCode(), "unexpected failure for %s - GetRepo", userType)
+	} else {
+		require.Equal(t, http.StatusUnauthorized, getRepoResp.StatusCode(), "unexpected success for %s - GetRepo", userType)
+	}
+
+	branchID, _ := nanoid.New(6)
+	branchName := fmt.Sprintf("br-%s", branchID)
+	respCreateBranch, err := userClient.CreateBranchWithResponse(ctx, repo, api.CreateBranchJSONRequestBody{
+		Name:   branchName,
+		Source: mainBranch,
+	})
+	require.NoError(t, err, "failed to send CreateBranch request", userType)
+	if userPerms.canCreateBranch {
+		require.Equal(t, http.StatusCreated, respCreateBranch.StatusCode(), "unexpected failure for %s - CreateBranch", userType)
+	} else {
+		require.Equal(t, http.StatusUnauthorized, respCreateBranch.StatusCode(), "unexpected success for %s - CreateBranch", userType)
+	}
+
+	respDeleteBranch, err := userClient.DeleteBranchWithResponse(ctx, repo, branchName)
+	require.NoError(t, err, "failed to send DeleteBranch request", userType)
+	if userPerms.canCreateBranch {
+		require.Equal(t, http.StatusNoContent, respDeleteBranch.StatusCode(), "unexpected failure for %s - DeleteBranch", userType)
+	} else {
+		require.Equal(t, http.StatusUnauthorized, respDeleteBranch.StatusCode(), "unexpected success for %s - DeleteBranch", userType)
+	}
 }

--- a/esti/migrate_test.go
+++ b/esti/migrate_test.go
@@ -55,7 +55,6 @@ type authCredentials struct {
 }
 
 type authUser struct {
-	Username    string           `json:"username"`
 	Credentials *authCredentials `json:"credentials"`
 }
 
@@ -386,27 +385,22 @@ func testPreMigrateAuth(t *testing.T) {
 
 	// Hardening relevant test data for post-migrate
 	state.Auth.Repo = repo
-	state.Auth.ViewerUser.Username = "testViewer"
 	state.Auth.ViewerUser.Credentials = &authCredentials{
 		AccessKeyID:     viewerCreds.AccessKeyId,
 		SecretAccessKey: viewerCreds.SecretAccessKey,
 	}
-	state.Auth.DeveloperUser.Username = "testdeveloper"
 	state.Auth.DeveloperUser.Credentials = &authCredentials{
 		AccessKeyID:     developerCreds.AccessKeyId,
 		SecretAccessKey: developerCreds.SecretAccessKey,
 	}
-	state.Auth.SuperUser.Username = "testSuperUser"
 	state.Auth.SuperUser.Credentials = &authCredentials{
 		AccessKeyID:     superUserCreds.AccessKeyId,
 		SecretAccessKey: superUserCreds.SecretAccessKey,
 	}
-	state.Auth.AdminUser.Username = "testAdmin"
 	state.Auth.AdminUser.Credentials = &authCredentials{
 		AccessKeyID:     adminCreds.AccessKeyId,
 		SecretAccessKey: adminCreds.SecretAccessKey,
 	}
-	state.Auth.CustomUser.Username = uid
 	state.Auth.CustomUser.Credentials = &authCredentials{
 		AccessKeyID:     customCreds.AccessKeyId,
 		SecretAccessKey: customCreds.SecretAccessKey,

--- a/esti/migrate_test.go
+++ b/esti/migrate_test.go
@@ -487,8 +487,10 @@ func verifyUserPermissions(t *testing.T, ctx context.Context, repo, userType str
 	userClient, err := testutil.NewClientFromCreds(logger, creds.AccessKeyId, creds.SecretAccessKey, endpointUrl)
 	require.NoError(t, err, "failed to initialize client for %s by credentials", userType)
 
+	userID, _ := nanoid.New(6)
+	userName := fmt.Sprintf("user-%s", userID)
 	createUserResp, err := userClient.CreateUserWithResponse(ctx, api.CreateUserJSONRequestBody{
-		Id: "no-such-user",
+		Id: userName,
 	})
 	require.NoError(t, err, "%s failed to send CreaterUser request", userType)
 	if userPerms.canCreateUser {


### PR DESCRIPTION
Pre migration - creating users in various groups, attempting various operations and expecting success/failure based on the group permission and the operation (basic sanity)
Post migration - verifying that all the above is migrated successfully by retrying the same operation and expecting the same results. In addition, adding policy to a previously added group (created over `DB`) and expecting correct behavior