### PR TITLE
Add phase-dependent template function contenttype

### DIFF
--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -2446,6 +2446,14 @@ func testController_ExpandTemplate(t *testing.T, kvEnabled bool) {
 			t.Errorf("Expansion failed with status %d\n\t%s\n\t%+v", resp.HTTPResponse.StatusCode, string(resp.Body), resp)
 		}
 
+		contentType := resp.HTTPResponse.Header.Values("Content-Type")
+		if len(contentType) != 1 {
+			t.Errorf("Expansion returned %d content types: %v", len(contentType), contentType)
+		}
+		if contentType[0] != "application/x-conf" {
+			t.Errorf("Expansion returned content type %s not application/x-conf", contentType[0])
+		}
+
 		for _, e := range expected {
 			re := regexp.MustCompile(e.pattern)
 			if !re.Match(resp.Body) {

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -2415,7 +2415,7 @@ func testController_ExpandTemplate(t *testing.T, kvEnabled bool) {
 		resp, err := clt.ExpandTemplateWithResponse(ctx, "no/template/here", &api.ExpandTemplateParams{})
 		testutil.Must(t, err)
 		if resp.HTTPResponse.StatusCode != http.StatusNotFound {
-			t.Errorf("Expanding a nonexistent template should fail with status %d got %d\n\t%+v", http.StatusNotFound, resp.HTTPResponse.StatusCode, resp)
+			t.Errorf("Expanding a nonexistent template should fail with status %d got %d\n\t%s\n\t%+v", http.StatusNotFound, resp.HTTPResponse.StatusCode, string(resp.Body), resp)
 		}
 	})
 
@@ -2443,13 +2443,13 @@ func testController_ExpandTemplate(t *testing.T, kvEnabled bool) {
 			}))
 		testutil.Must(t, err)
 		if resp.HTTPResponse.StatusCode != http.StatusOK {
-			t.Errorf("Expanding template spark.conf.tt failed with status %d\n\t%+v", resp.HTTPResponse.StatusCode, resp)
+			t.Errorf("Expansion failed with status %d\n\t%s\n\t%+v", resp.HTTPResponse.StatusCode, string(resp.Body), resp)
 		}
 
 		for _, e := range expected {
 			re := regexp.MustCompile(e.pattern)
 			if !re.Match(resp.Body) {
-				t.Errorf("Expanded template spark.conf.tt has no %s: /%s/\n\t%s", e.name, e.pattern, string(resp.Body))
+				t.Errorf("Expansion result has no %s: /%s/\n\t%s", e.name, e.pattern, string(resp.Body))
 			}
 		}
 	})
@@ -2458,7 +2458,7 @@ func testController_ExpandTemplate(t *testing.T, kvEnabled bool) {
 		resp, err := clt.ExpandTemplateWithResponse(ctx, "fail.tt", &api.ExpandTemplateParams{})
 		testutil.Must(t, err)
 		if resp.HTTPResponse.StatusCode != http.StatusInternalServerError {
-			t.Errorf("Expanding template spark.conf.tt should fail with status %d got %d\n\t%+v", http.StatusInternalServerError, resp.HTTPResponse.StatusCode, resp)
+			t.Errorf("Expansion should fail with status %d got %d\n\t%s\n\t%+v", http.StatusInternalServerError, resp.HTTPResponse.StatusCode, string(resp.Body), resp)
 		}
 
 		parsed := make(map[string]string, 0)

--- a/pkg/templater/expander.go
+++ b/pkg/templater/expander.go
@@ -43,7 +43,7 @@ type ControlledParams struct {
 	Phase Phase
 	Auth  AuthService
 	// Headers are the HTTP response headers.  They may only be modified
-	// during PhasePrepate.
+	// during PhasePrepare.
 	Header http.Header
 	// User is the user expanding the template.
 	User *auth_model.User

--- a/pkg/templater/expander.go
+++ b/pkg/templater/expander.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
+	"net/http"
 	"path"
 	"strings"
 	"text/template"
@@ -30,11 +31,25 @@ type AuthService interface {
 	auth.CredentialsCreator
 }
 
+type Phase string
+
+const (
+	PhasePrepare Phase = "prepare"
+	PhaseExpand  Phase = "expand"
+)
+
 type ControlledParams struct {
-	Ctx  context.Context
-	Auth AuthService
+	Ctx   context.Context
+	Phase Phase
+	Auth  AuthService
+	// Headers are the HTTP response headers.  They may only be modified
+	// during PhasePrepate.
+	Header http.Header
 	// User is the user expanding the template.
 	User *auth_model.User
+	// Store is a place for funcs to keep stuff around, mostly between
+	// phases.  Each func should use its name as its index.
+	Store map[string]interface{}
 }
 
 type UncontrolledData struct {
@@ -87,9 +102,11 @@ func MakeExpander(name, tmpl string, cfg *config.Config, auth AuthService) (Expa
 func (e *expander) Expand(w io.Writer, params *Params) error {
 	// Expand with no output: verify that no template functions will
 	// fail.
+	params.Controlled.Phase = PhasePrepare
 	if err := e.expandTo(io.Discard, params); err != nil {
 		return fmt.Errorf("prepare: %w", err)
 	}
+	params.Controlled.Phase = PhaseExpand
 	if err := e.expandTo(w, params); err != nil {
 		return fmt.Errorf("execute: %w", err)
 	}

--- a/templates/content/spark.conf.tt
+++ b/templates/content/spark.conf.tt
@@ -1,7 +1,8 @@
 # SAMPLE TEMPLATE: minimal Spark lakeFSFS configuration
+{{contenttype "application/x-conf" -}}
 
 spark.hadoop.fs.s3a.impl=org.apache.hadoop.fs.s3a.S3AFileSystem
-{{with $creds := new_credentials}}
+{{with $creds := new_credentials "spark"}}
 spark.hadoop.fs.s3a.access_key={{$creds.Key}}
 spark.hadoop.fs.s3a.secret_key={{$creds.Secret}}
 {{end}}


### PR DESCRIPTION
* Make functions aware of phase ("prepare" or "expand").
* Add function to set Content-Type -- during "prepare" only.

  (Once expansion has started, writing headers will fail!)
* Fix `new_credentials` to create credentials just once.

  (Previously they were created once during "prepare" and once during "expand").