### PR TITLE
Don't include mui package

### DIFF
--- a/webui/package.json
+++ b/webui/package.json
@@ -20,7 +20,6 @@
     "react-diff-viewer": "^3.1.1",
     "react-dom": "^17.0.0",
     "react-icons": "^4.3.1",
-    "mui": "^0.0.1",
     "react-router-dom": "^5.2.0",
     "validator": "^13.7.0"
   },


### PR DESCRIPTION
This is unused, dead, on version 0.0.1, set for auto-upgrade.  It is pure
risk.