### PR TITLE
Add GUI templates expansion client

### DIFF
--- a/docs/assets/js/swagger.yml
+++ b/docs/assets/js/swagger.yml
@@ -3516,25 +3516,30 @@ paths:
                 $ref: "#/components/schemas/StorageConfig"
         401:
           $ref: "#/components/responses/Unauthorized"
-  /templates:
+  /templates/{template_location}:
     get:
       tags:
         - templates
       operationId: expandTemplate
       description: fetch and expand template
       parameters:
-        - in: query
+        - in: path
           name: template_location
           required: true
           schema:
             type: string
-            description: URL of the template; must be relative (to a URL configured on the server).
+          description: URL of the template; must be relative (to a URL configured on the server).
+          example: spark.conf.tt
         - in: query
           name: params
           schema:
             type: object
             additionalProperties:
               type: string
+            example:
+              lakefs_url: https://lakefs.example.com
+          style: form
+          explode: true
       responses:
         200:
           description: expanded template

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -14,7 +14,6 @@
         "bootstrap": "^4.6.0",
         "http-proxy-middleware": "^1.1.1",
         "moment": "^2.29.2",
-        "mui": "^0.0.1",
         "query-string": "^7.1.1",
         "react": "^17.0.0",
         "react-bootstrap": "^1.5.2",
@@ -22,6 +21,8 @@
         "react-dom": "^17.0.0",
         "react-icons": "^4.3.1",
         "react-router-dom": "^5.2.0",
+        "react-step-wizard": "^5.3.11",
+        "react-transition-group": "^4.4.2",
         "validator": "^13.7.0"
       },
       "devDependencies": {
@@ -6435,11 +6436,6 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "devOptional": true
     },
-    "node_modules/mui": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/mui/-/mui-0.0.1.tgz",
-      "integrity": "sha1-Rppx8JMpaVJiceyTncWVmAZZB2I="
-    },
     "node_modules/nanoid": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
@@ -7110,6 +7106,14 @@
       },
       "peerDependencies": {
         "react": "^16.0.0 || ^17.0.0"
+      }
+    },
+    "node_modules/react-step-wizard": {
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/react-step-wizard/-/react-step-wizard-5.3.11.tgz",
+      "integrity": "sha512-TD3ocUdt4XWvisTNEiATh+cFuh1RK0LgvYqOResTIhLtFmdWnXzFVaNIZJ3qzW5Bm6yeotzZ4KAmRjmsqBXnWQ==",
+      "peerDependencies": {
+        "react": ">=15.0.1"
       }
     },
     "node_modules/react-test-renderer": {
@@ -13142,11 +13146,6 @@
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "devOptional": true
     },
-    "mui": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/mui/-/mui-0.0.1.tgz",
-      "integrity": "sha1-Rppx8JMpaVJiceyTncWVmAZZB2I="
-    },
     "nanoid": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
@@ -13644,6 +13643,12 @@
         "object-assign": "^4.1.1",
         "react-is": "^16.12.0 || ^17.0.0"
       }
+    },
+    "react-step-wizard": {
+      "version": "5.3.11",
+      "resolved": "https://registry.npmjs.org/react-step-wizard/-/react-step-wizard-5.3.11.tgz",
+      "integrity": "sha512-TD3ocUdt4XWvisTNEiATh+cFuh1RK0LgvYqOResTIhLtFmdWnXzFVaNIZJ3qzW5Bm6yeotzZ4KAmRjmsqBXnWQ==",
+      "requires": {}
     },
     "react-test-renderer": {
       "version": "17.0.2",

--- a/webui/src/lib/api/index.js
+++ b/webui/src/lib/api/index.js
@@ -896,7 +896,7 @@ class Templates {
         if (!response.ok) {
             throw new Error(await extractError(response));
         }
-        return await response.text();
+        return response.text();
     }
 }
 

--- a/webui/src/lib/api/index.js
+++ b/webui/src/lib/api/index.js
@@ -883,6 +883,23 @@ class MetaRanges {
         return response.json();
     }
 }
+
+class Templates {
+    async expandTemplate(templateLocation, params) {
+        const urlParams = new URLSearchParams();
+        for (const [k, v] of Object.entries(params)) {
+            urlParams.set(k, v);
+        }
+        const response = await apiRequest(
+            encodeURI(`/templates/${templateLocation}?${urlParams.toString()}`),
+            { method: 'GET' });
+        if (!response.ok) {
+            throw new Error(await extractError(response));
+        }
+        return await response.text();
+    }
+}
+
 export const repositories = new Repositories();
 export const branches = new Branches();
 export const tags = new Tags();
@@ -897,3 +914,4 @@ export const config = new Config();
 export const branchProtectionRules = new BranchProtectionRules();
 export const ranges = new Ranges();
 export const metaRanges = new MetaRanges();
+export const templates = new Templates();


### PR DESCRIPTION
Returns the _text_ of the expanded response.  This may need to be changed to
just the plain response -- e.g. perhaps for downloading, or to avoid double
expansion in memory?

Tested by applying the attached diffs and _seeing_ a template expansion on the main page!
[test-expand-template.diffs.gz](https://github.com/treeverse/lakeFS/files/9091151/test-expand-template.diffs.gz)
