### PR TITLE
Add lakectl abuse commit

### DIFF
--- a/cmd/lakectl/cmd/abuse.go
+++ b/cmd/lakectl/cmd/abuse.go
@@ -194,7 +194,11 @@ var abuseCommitCmd = &cobra.Command{
 					Error: err,
 					Took:  time.Since(start),
 				}
-				time.Sleep(gapDuration)
+				select {
+				case <-ctx.Done():
+					return
+				case <-time.After(gapDuration):
+				}
 			}
 		})
 	},

--- a/cmd/lakectl/cmd/abuse.go
+++ b/cmd/lakectl/cmd/abuse.go
@@ -6,6 +6,7 @@ import (
 	"math/rand"
 	"net/http"
 	"os"
+	"strconv"
 	"strings"
 	"syscall"
 	"time"
@@ -152,6 +153,53 @@ var abuseRandomWritesCmd = &cobra.Command{
 	},
 }
 
+var abuseCommitCmd = &cobra.Command{
+	Use:    "commit <source ref uri>",
+	Short:  "Commits to the source ref repeatedly",
+	Hidden: false,
+	Args:   cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		u := MustParseRefURI("source ref", args[0])
+		amount := MustInt(cmd.Flags().GetInt("amount"))
+		gapDuration := MustDuration(cmd.Flags().GetDuration("gap"))
+
+		Fmt("Source branch: %s\n", u.String())
+		generator := stress.NewGenerator(1, stress.WithSignalHandlersFor(os.Interrupt, syscall.SIGTERM))
+
+		// generate randomly selected keys as input
+		rand.Seed(time.Now().Unix())
+		generator.Setup(func(add stress.GeneratorAddFn) {
+			for i := 0; i < amount; i++ {
+				add(strconv.Itoa(i + 1))
+			}
+		})
+
+		// generate randomly selected keys as input
+		client := getClient()
+		resp, err := client.GetRepositoryWithResponse(cmd.Context(), u.Repository)
+		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusOK)
+
+		// execute the things!
+		generator.Run(func(input chan string, output chan stress.Result) {
+			ctx := cmd.Context()
+			client := getClient()
+			for work := range input {
+				start := time.Now()
+				resp, err := client.CommitWithResponse(ctx, u.Repository, u.Ref, &api.CommitParams{},
+					api.CommitJSONRequestBody(api.CommitCreation{Message: work}))
+				if err == nil && resp.StatusCode() != http.StatusOK {
+					err = helpers.ResponseAsError(resp)
+				}
+				output <- stress.Result{
+					Error: err,
+					Took:  time.Since(start),
+				}
+				time.Sleep(gapDuration)
+			}
+		})
+	},
+}
+
 var abuseCreateBranchesCmd = &cobra.Command{
 	Use:    "create-branches <source ref uri>",
 	Short:  "Create a lot of branches very quickly.",
@@ -261,4 +309,8 @@ func init() {
 	abuseRandomWritesCmd.Flags().String("prefix", "abuse/", "prefix to create paths under")
 	abuseRandomWritesCmd.Flags().Int("amount", 1000000, "amount of writes to do")
 	abuseRandomWritesCmd.Flags().Int("parallelism", 100, "amount of writes to do in parallel")
+
+	abuseCmd.AddCommand(abuseCommitCmd)
+	abuseCommitCmd.Flags().Int("amount", 100, "amount of commits to do")
+	abuseCommitCmd.Flags().Duration("gap", 2*time.Second, "duration to wait between commits")
 }

--- a/cmd/lakectl/cmd/input.go
+++ b/cmd/lakectl/cmd/input.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"time"
 
 	"github.com/manifoldco/promptui"
 	"github.com/spf13/pflag"
@@ -131,6 +132,13 @@ func MustInt64(v int64, err error) int64 {
 }
 
 func MustBool(v bool, err error) bool {
+	if err != nil {
+		DieErr(err)
+	}
+	return v
+}
+
+func MustDuration(v time.Duration, err error) time.Duration {
 	if err != nil {
 		DieErr(err)
 	}

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -94,7 +94,7 @@ Abuse a running lakeFS instance. See sub commands for more info.
 
 ### lakectl abuse commit
 
-Commits to the source ref every 2 seconds
+Commits to the source ref repeatedly
 
 ```
 lakectl abuse commit <source ref uri> [flags]
@@ -105,7 +105,7 @@ lakectl abuse commit <source ref uri> [flags]
 
 ```
       --amount int     amount of commits to do (default 100)
-      --gap duration   time in seconds to wait between commits (default 2ns)
+      --gap duration   duration to wait between commits (default 2s)
   -h, --help           help for commit
 ```
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -92,6 +92,25 @@ Abuse a running lakeFS instance. See sub commands for more info.
 
 
 
+### lakectl abuse commit
+
+Commits to the source ref every 2 seconds
+
+```
+lakectl abuse commit <source ref uri> [flags]
+```
+
+#### Options
+{:.no_toc}
+
+```
+      --amount int     amount of commits to do (default 100)
+      --gap duration   time in seconds to wait between commits (default 2ns)
+  -h, --help           help for commit
+```
+
+
+
 ### lakectl abuse create-branches
 
 Create a lot of branches very quickly.


### PR DESCRIPTION
Part of #3571 

A command to repeatedly commit to the source branch. Together with `abuse random-write`, it grants the ability to benchmark lakeFS over KV/DB commit-during-write flow.