### PR TITLE
Don't double-encode query params in WebUI templates client

### DIFF
--- a/webui/src/lib/api/index.js
+++ b/webui/src/lib/api/index.js
@@ -891,7 +891,7 @@ class Templates {
             urlParams.set(k, v);
         }
         const response = await apiRequest(
-            encodeURI(`/templates/${templateLocation}?${urlParams.toString()}`),
+            `/templates/${encodeURI(templateLocation)}?${urlParams.toString()}`,
             { method: 'GET' });
         if (!response.ok) {
             throw new Error(await extractError(response));


### PR DESCRIPTION
Tested using the diff'ed client code from #3647. 

Fixes #3681.