### PR TITLE
Remove ambiguity around username

### DIFF
--- a/api/authorization.yml
+++ b/api/authorization.yml
@@ -107,6 +107,7 @@ components:
       type: object
       required:
         - id
+        - name
         - username
         - creation_date
         - encryptedPassword

--- a/api/authorization.yml
+++ b/api/authorization.yml
@@ -667,7 +667,7 @@ paths:
         - $ref: "#/components/parameters/PaginationAmount"
       responses:
         200:
-          description: group memeber list
+          description: group member list
           content:
             application/json:
               schema:

--- a/api/authorization.yml
+++ b/api/authorization.yml
@@ -107,7 +107,7 @@ components:
       type: object
       required:
         - id
-        - name
+        - username
         - creation_date
         - encryptedPassword
       properties:
@@ -116,6 +116,11 @@ components:
           format: int64
         name:
           type: string
+          description: replaced by username
+          deprecated: true
+        username:
+          type: string
+          description: a unique identifier for the user. In password-based authentication, this is the email.
         creation_date:
           type: integer
           format: int64

--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -549,6 +549,7 @@ components:
       properties:
         id:
           type: string
+          description: a unique identifier for the user. In password-based authentication, this is the email.
         creation_date:
           type: integer
           format: int64
@@ -579,6 +580,7 @@ components:
       properties:
         id:
           type: string
+          description: a unique identifier for the user. In password-based authentication, this is the email.
         invite_user:
           type: boolean
       required:

--- a/clients/java/api/openapi.yaml
+++ b/clients/java/api/openapi.yaml
@@ -5149,6 +5149,8 @@ components:
         email: email
       properties:
         id:
+          description: a unique identifier for the user. In password-based authentication,
+            this is the email.
           type: string
         creation_date:
           description: Unix Epoch in seconds
@@ -5190,6 +5192,8 @@ components:
         id: id
       properties:
         id:
+          description: a unique identifier for the user. In password-based authentication,
+            this is the email.
           type: string
         invite_user:
           type: boolean

--- a/clients/java/docs/User.md
+++ b/clients/java/docs/User.md
@@ -7,7 +7,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**id** | **String** |  | 
+**id** | **String** | a unique identifier for the user. In password-based authentication, this is the email. | 
 **creationDate** | **Long** | Unix Epoch in seconds | 
 **friendlyName** | **String** |  |  [optional]
 **email** | **String** |  |  [optional]

--- a/clients/java/docs/UserCreation.md
+++ b/clients/java/docs/UserCreation.md
@@ -7,7 +7,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**id** | **String** |  | 
+**id** | **String** | a unique identifier for the user. In password-based authentication, this is the email. | 
 **inviteUser** | **Boolean** |  |  [optional]
 
 

--- a/clients/java/src/main/java/io/lakefs/clients/api/model/User.java
+++ b/clients/java/src/main/java/io/lakefs/clients/api/model/User.java
@@ -53,11 +53,11 @@ public class User {
   }
 
    /**
-   * Get id
+   * a unique identifier for the user. In password-based authentication, this is the email.
    * @return id
   **/
   @javax.annotation.Nonnull
-  @ApiModelProperty(required = true, value = "")
+  @ApiModelProperty(required = true, value = "a unique identifier for the user. In password-based authentication, this is the email.")
 
   public String getId() {
     return id;

--- a/clients/java/src/main/java/io/lakefs/clients/api/model/UserCreation.java
+++ b/clients/java/src/main/java/io/lakefs/clients/api/model/UserCreation.java
@@ -45,11 +45,11 @@ public class UserCreation {
   }
 
    /**
-   * Get id
+   * a unique identifier for the user. In password-based authentication, this is the email.
    * @return id
   **/
   @javax.annotation.Nonnull
-  @ApiModelProperty(required = true, value = "")
+  @ApiModelProperty(required = true, value = "a unique identifier for the user. In password-based authentication, this is the email.")
 
   public String getId() {
     return id;

--- a/clients/python/docs/User.md
+++ b/clients/python/docs/User.md
@@ -4,7 +4,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**id** | **str** |  | 
+**id** | **str** | a unique identifier for the user. In password-based authentication, this is the email. | 
 **creation_date** | **int** | Unix Epoch in seconds | 
 **friendly_name** | **str** |  | [optional] 
 **email** | **str** |  | [optional] 

--- a/clients/python/docs/UserCreation.md
+++ b/clients/python/docs/UserCreation.md
@@ -4,7 +4,7 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**id** | **str** |  | 
+**id** | **str** | a unique identifier for the user. In password-based authentication, this is the email. | 
 **invite_user** | **bool** |  | [optional] 
 **any string name** | **bool, date, datetime, dict, float, int, list, str, none_type** | any string name can be used but the value must be the correct type | [optional]
 

--- a/clients/python/lakefs_client/model/user.py
+++ b/clients/python/lakefs_client/model/user.py
@@ -111,7 +111,7 @@ class User(ModelNormal):
         """User - a model defined in OpenAPI
 
         Args:
-            id (str):
+            id (str): a unique identifier for the user. In password-based authentication, this is the email.
             creation_date (int): Unix Epoch in seconds
 
         Keyword Args:
@@ -200,7 +200,7 @@ class User(ModelNormal):
         """User - a model defined in OpenAPI
 
         Args:
-            id (str):
+            id (str): a unique identifier for the user. In password-based authentication, this is the email.
             creation_date (int): Unix Epoch in seconds
 
         Keyword Args:

--- a/clients/python/lakefs_client/model/user_creation.py
+++ b/clients/python/lakefs_client/model/user_creation.py
@@ -107,7 +107,7 @@ class UserCreation(ModelNormal):
         """UserCreation - a model defined in OpenAPI
 
         Args:
-            id (str):
+            id (str): a unique identifier for the user. In password-based authentication, this is the email.
 
         Keyword Args:
             _check_type (bool): if True, values for parameters in openapi_types
@@ -193,7 +193,7 @@ class UserCreation(ModelNormal):
         """UserCreation - a model defined in OpenAPI
 
         Args:
-            id (str):
+            id (str): a unique identifier for the user. In password-based authentication, this is the email.
 
         Keyword Args:
             _check_type (bool): if True, values for parameters in openapi_types

--- a/cmd/lakectl/cmd/auth.go
+++ b/cmd/lakectl/cmd/auth.go
@@ -591,6 +591,7 @@ var authPoliciesDelete = &cobra.Command{
 }
 
 func addPaginationFlags(cmd *cobra.Command) {
+	cmd.Flags().SortFlags = false
 	cmd.Flags().Int("amount", defaultAmountArgumentValue, "how many results to return")
 	cmd.Flags().String("after", "", "show results after this value (used for pagination)")
 }
@@ -598,32 +599,28 @@ func addPaginationFlags(cmd *cobra.Command) {
 //nolint:gochecknoinits
 func init() {
 	// users
-	authUsersCreate.Flags().String("id", "", "user identifier")
+	authUsersCreate.Flags().String("id", "", "Username")
 	_ = authUsersCreate.MarkFlagRequired("id")
 
-	authUsersDelete.Flags().String("id", "", "user identifier")
+	authUsersDelete.Flags().String("id", "", "Username (email for password-based users)")
 	_ = authUsersDelete.MarkFlagRequired("id")
 
-	addPaginationFlags(authUsersList)
-
-	addPaginationFlags(authUsersGroupsList)
-	authUsersGroupsList.Flags().String("id", "", "user identifier")
+	authUsersGroupsList.Flags().String("id", "", "Username (email for password-based users)")
 	_ = authUsersGroupsList.MarkFlagRequired("id")
 
 	authUsersGroups.AddCommand(authUsersGroupsList)
 
-	addPaginationFlags(authUsersPoliciesList)
 	authUsersPoliciesList.Flags().Bool("effective", false,
 		"list all distinct policies attached to the user, even through group memberships")
-	authUsersPoliciesList.Flags().String("id", "", "user identifier")
+	authUsersPoliciesList.Flags().String("id", "", "Username (email for password-based users)")
 	_ = authUsersPoliciesList.MarkFlagRequired("id")
 
-	authUsersPoliciesAttach.Flags().String("id", "", "user identifier")
+	authUsersPoliciesAttach.Flags().String("id", "", "Username (email for password-based users)")
 	_ = authUsersPoliciesAttach.MarkFlagRequired("id")
 	authUsersPoliciesAttach.Flags().String("policy", "", "policy identifier")
 	_ = authUsersPoliciesAttach.MarkFlagRequired("policy")
 
-	authUsersPoliciesDetach.Flags().String("id", "", "user identifier")
+	authUsersPoliciesDetach.Flags().String("id", "", "Username (email for password-based users)")
 	_ = authUsersPoliciesDetach.MarkFlagRequired("id")
 	authUsersPoliciesDetach.Flags().String("policy", "", "policy identifier")
 	_ = authUsersPoliciesDetach.MarkFlagRequired("policy")
@@ -632,12 +629,11 @@ func init() {
 	authUsersPolicies.AddCommand(authUsersPoliciesAttach)
 	authUsersPolicies.AddCommand(authUsersPoliciesDetach)
 
-	authUsersCredentialsList.Flags().String("id", "", "user identifier (default: current user)")
-	addPaginationFlags(authUsersCredentialsList)
+	authUsersCredentialsList.Flags().String("id", "", "Username (email for password-based users). Defaults to current user.")
 
-	authUsersCredentialsCreate.Flags().String("id", "", "user identifier (default: current user)")
+	authUsersCredentialsCreate.Flags().String("id", "", "Username (email for password-based users). Defaults to current user.")
 
-	authUsersCredentialsDelete.Flags().String("id", "", "user identifier (default: current user)")
+	authUsersCredentialsDelete.Flags().String("id", "", "Username (email for password-based users). Defaults to current user.")
 	authUsersCredentialsDelete.Flags().String("access-key-id", "", "access key ID to delete")
 	_ = authUsersCredentialsDelete.MarkFlagRequired("access-key-id")
 
@@ -661,25 +657,21 @@ func init() {
 	authGroupsDelete.Flags().String("id", "", "group identifier")
 	_ = authGroupsDelete.MarkFlagRequired("id")
 
-	addPaginationFlags(authGroupsList)
-
 	authGroupsAddMember.Flags().String("id", "", "group identifier")
-	authGroupsAddMember.Flags().String("user", "", "user identifier to add to the group")
+	authGroupsAddMember.Flags().String("user", "", "Username (email for password-based users). Defaults to current user.")
 	_ = authGroupsAddMember.MarkFlagRequired("id")
 	_ = authGroupsAddMember.MarkFlagRequired("user")
 	authGroupsRemoveMember.Flags().String("id", "", "group identifier")
-	authGroupsRemoveMember.Flags().String("user", "", "user identifier to add to the group")
+	authGroupsRemoveMember.Flags().String("user", "", "Username (email for password-based users). Defaults to current user.")
 	_ = authGroupsRemoveMember.MarkFlagRequired("id")
 	_ = authGroupsRemoveMember.MarkFlagRequired("user")
 	authGroupsListMembers.Flags().String("id", "", "group identifier")
-	addPaginationFlags(authGroupsListMembers)
 	_ = authGroupsListMembers.MarkFlagRequired("id")
 
 	authGroupsMembers.AddCommand(authGroupsAddMember)
 	authGroupsMembers.AddCommand(authGroupsRemoveMember)
 	authGroupsMembers.AddCommand(authGroupsListMembers)
 
-	addPaginationFlags(authGroupsPoliciesList)
 	authGroupsPoliciesList.Flags().String("id", "", "group identifier")
 	_ = authGroupsPoliciesList.MarkFlagRequired("id")
 
@@ -716,8 +708,6 @@ func init() {
 	authPoliciesShow.Flags().String("id", "", "policy identifier")
 	_ = authPoliciesShow.MarkFlagRequired("id")
 
-	addPaginationFlags(authPoliciesList)
-
 	authPolicies.AddCommand(authPoliciesDelete)
 	authPolicies.AddCommand(authPoliciesCreate)
 	authPolicies.AddCommand(authPoliciesShow)
@@ -726,4 +716,12 @@ func init() {
 
 	// main auth cmd
 	rootCmd.AddCommand(authCmd)
+	addPaginationFlags(authUsersList)
+	addPaginationFlags(authUsersGroupsList)
+	addPaginationFlags(authUsersPoliciesList)
+	addPaginationFlags(authUsersCredentialsList)
+	addPaginationFlags(authGroupsList)
+	addPaginationFlags(authGroupsListMembers)
+	addPaginationFlags(authGroupsPoliciesList)
+	addPaginationFlags(authPoliciesList)
 }

--- a/cmd/lakectl/cmd/auth.go
+++ b/cmd/lakectl/cmd/auth.go
@@ -611,30 +611,30 @@ func init() {
 	authUsersGroups.AddCommand(authUsersGroupsList)
 
 	authUsersPoliciesList.Flags().Bool("effective", false,
-		"list all distinct policies attached to the user, even through group memberships")
+		"List all distinct policies attached to the user, including by group memberships")
 	authUsersPoliciesList.Flags().String("id", "", "Username (email for password-based users)")
 	_ = authUsersPoliciesList.MarkFlagRequired("id")
 
 	authUsersPoliciesAttach.Flags().String("id", "", "Username (email for password-based users)")
 	_ = authUsersPoliciesAttach.MarkFlagRequired("id")
-	authUsersPoliciesAttach.Flags().String("policy", "", "policy identifier")
+	authUsersPoliciesAttach.Flags().String("policy", "", "Policy identifier")
 	_ = authUsersPoliciesAttach.MarkFlagRequired("policy")
 
 	authUsersPoliciesDetach.Flags().String("id", "", "Username (email for password-based users)")
 	_ = authUsersPoliciesDetach.MarkFlagRequired("id")
-	authUsersPoliciesDetach.Flags().String("policy", "", "policy identifier")
+	authUsersPoliciesDetach.Flags().String("policy", "", "Policy identifier")
 	_ = authUsersPoliciesDetach.MarkFlagRequired("policy")
 
 	authUsersPolicies.AddCommand(authUsersPoliciesList)
 	authUsersPolicies.AddCommand(authUsersPoliciesAttach)
 	authUsersPolicies.AddCommand(authUsersPoliciesDetach)
 
-	authUsersCredentialsList.Flags().String("id", "", "Username (email for password-based users). Defaults to current user.")
+	authUsersCredentialsList.Flags().String("id", "", "Username (email for password-based users, default: current user)")
 
-	authUsersCredentialsCreate.Flags().String("id", "", "Username (email for password-based users). Defaults to current user.")
+	authUsersCredentialsCreate.Flags().String("id", "", "Username (email for password-based users, default: current user)")
 
-	authUsersCredentialsDelete.Flags().String("id", "", "Username (email for password-based users). Defaults to current user.")
-	authUsersCredentialsDelete.Flags().String("access-key-id", "", "access key ID to delete")
+	authUsersCredentialsDelete.Flags().String("id", "", "Username (email for password-based users, default: current user)")
+	authUsersCredentialsDelete.Flags().String("access-key-id", "", "Access key ID to delete")
 	_ = authUsersCredentialsDelete.MarkFlagRequired("access-key-id")
 
 	authUsersCredentials.AddCommand(authUsersCredentialsList)
@@ -651,38 +651,38 @@ func init() {
 	authCmd.AddCommand(authUsers)
 
 	// groups
-	authGroupsCreate.Flags().String("id", "", "group identifier")
+	authGroupsCreate.Flags().String("id", "", "Group identifier")
 	_ = authGroupsCreate.MarkFlagRequired("id")
 
-	authGroupsDelete.Flags().String("id", "", "group identifier")
+	authGroupsDelete.Flags().String("id", "", "Group identifier")
 	_ = authGroupsDelete.MarkFlagRequired("id")
 
-	authGroupsAddMember.Flags().String("id", "", "group identifier")
-	authGroupsAddMember.Flags().String("user", "", "Username (email for password-based users). Defaults to current user.")
+	authGroupsAddMember.Flags().String("id", "", "Group identifier")
+	authGroupsAddMember.Flags().String("user", "", "Username (email for password-based users, default: current user)")
 	_ = authGroupsAddMember.MarkFlagRequired("id")
 	_ = authGroupsAddMember.MarkFlagRequired("user")
-	authGroupsRemoveMember.Flags().String("id", "", "group identifier")
-	authGroupsRemoveMember.Flags().String("user", "", "Username (email for password-based users). Defaults to current user.")
+	authGroupsRemoveMember.Flags().String("id", "", "Group identifier")
+	authGroupsRemoveMember.Flags().String("user", "", "Username (email for password-based users, default: current user)")
 	_ = authGroupsRemoveMember.MarkFlagRequired("id")
 	_ = authGroupsRemoveMember.MarkFlagRequired("user")
-	authGroupsListMembers.Flags().String("id", "", "group identifier")
+	authGroupsListMembers.Flags().String("id", "", "Group identifier")
 	_ = authGroupsListMembers.MarkFlagRequired("id")
 
 	authGroupsMembers.AddCommand(authGroupsAddMember)
 	authGroupsMembers.AddCommand(authGroupsRemoveMember)
 	authGroupsMembers.AddCommand(authGroupsListMembers)
 
-	authGroupsPoliciesList.Flags().String("id", "", "group identifier")
+	authGroupsPoliciesList.Flags().String("id", "", "Group identifier")
 	_ = authGroupsPoliciesList.MarkFlagRequired("id")
 
-	authGroupsPoliciesAttach.Flags().String("id", "", "user identifier")
+	authGroupsPoliciesAttach.Flags().String("id", "", "User identifier")
 	_ = authGroupsPoliciesAttach.MarkFlagRequired("id")
-	authGroupsPoliciesAttach.Flags().String("policy", "", "policy identifier")
+	authGroupsPoliciesAttach.Flags().String("policy", "", "Policy identifier")
 	_ = authGroupsPoliciesAttach.MarkFlagRequired("policy")
 
-	authGroupsPoliciesDetach.Flags().String("id", "", "user identifier")
+	authGroupsPoliciesDetach.Flags().String("id", "", "User identifier")
 	_ = authGroupsPoliciesDetach.MarkFlagRequired("id")
-	authGroupsPoliciesDetach.Flags().String("policy", "", "policy identifier")
+	authGroupsPoliciesDetach.Flags().String("policy", "", "Policy identifier")
 	_ = authGroupsPoliciesDetach.MarkFlagRequired("policy")
 
 	authGroupsPolicies.AddCommand(authGroupsPoliciesList)
@@ -697,15 +697,15 @@ func init() {
 	authCmd.AddCommand(authGroups)
 
 	// policies
-	authPoliciesCreate.Flags().String("id", "", "policy identifier")
+	authPoliciesCreate.Flags().String("id", "", "Policy identifier")
 	_ = authPoliciesCreate.MarkFlagRequired("id")
 	authPoliciesCreate.Flags().String("statement-document", "", "JSON statement document path (or \"-\" for stdin)")
 	_ = authPoliciesCreate.MarkFlagRequired("statement-document")
 
-	authPoliciesDelete.Flags().String("id", "", "policy identifier")
+	authPoliciesDelete.Flags().String("id", "", "Policy identifier")
 	_ = authPoliciesDelete.MarkFlagRequired("id")
 
-	authPoliciesShow.Flags().String("id", "", "policy identifier")
+	authPoliciesShow.Flags().String("id", "", "Policy identifier")
 	_ = authPoliciesShow.MarkFlagRequired("id")
 
 	authPolicies.AddCommand(authPoliciesDelete)

--- a/docs/assets/js/swagger.yml
+++ b/docs/assets/js/swagger.yml
@@ -549,6 +549,7 @@ components:
       properties:
         id:
           type: string
+          description: a unique identifier for the user. In password-based authentication, this is the email.
         creation_date:
           type: integer
           format: int64
@@ -579,6 +580,7 @@ components:
       properties:
         id:
           type: string
+          description: a unique identifier for the user. In password-based authentication, this is the email.
         invite_user:
           type: boolean
       required:

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -422,7 +422,7 @@ lakectl auth groups create [flags]
 
 ```
   -h, --help        help for create
-      --id string   group identifier
+      --id string   Group identifier
 ```
 
 
@@ -440,7 +440,7 @@ lakectl auth groups delete [flags]
 
 ```
   -h, --help        help for delete
-      --id string   group identifier
+      --id string   Group identifier
 ```
 
 
@@ -513,8 +513,8 @@ lakectl auth groups members add [flags]
 
 ```
   -h, --help          help for add
-      --id string     group identifier
-      --user string   Username (email for password-based users). Defaults to current user.
+      --id string     Group identifier
+      --user string   Username (email for password-based users, default: current user)
 ```
 
 
@@ -554,7 +554,7 @@ lakectl auth groups members list [flags]
 {:.no_toc}
 
 ```
-      --id string      group identifier
+      --id string      Group identifier
       --amount int     how many results to return (default 100)
       --after string   show results after this value (used for pagination)
   -h, --help           help for list
@@ -575,8 +575,8 @@ lakectl auth groups members remove [flags]
 
 ```
   -h, --help          help for remove
-      --id string     group identifier
-      --user string   Username (email for password-based users). Defaults to current user.
+      --id string     Group identifier
+      --user string   Username (email for password-based users, default: current user)
 ```
 
 
@@ -607,8 +607,8 @@ lakectl auth groups policies attach [flags]
 
 ```
   -h, --help            help for attach
-      --id string       user identifier
-      --policy string   policy identifier
+      --id string       User identifier
+      --policy string   Policy identifier
 ```
 
 
@@ -626,8 +626,8 @@ lakectl auth groups policies detach [flags]
 
 ```
   -h, --help            help for detach
-      --id string       user identifier
-      --policy string   policy identifier
+      --id string       User identifier
+      --policy string   Policy identifier
 ```
 
 
@@ -667,7 +667,7 @@ lakectl auth groups policies list [flags]
 {:.no_toc}
 
 ```
-      --id string      group identifier
+      --id string      Group identifier
       --amount int     how many results to return (default 100)
       --after string   show results after this value (used for pagination)
   -h, --help           help for list
@@ -724,7 +724,7 @@ lakectl auth policies create [flags]
 
 ```
   -h, --help                        help for create
-      --id string                   policy identifier
+      --id string                   Policy identifier
       --statement-document string   JSON statement document path (or "-" for stdin)
 ```
 
@@ -743,7 +743,7 @@ lakectl auth policies delete [flags]
 
 ```
   -h, --help        help for delete
-      --id string   policy identifier
+      --id string   Policy identifier
 ```
 
 
@@ -803,7 +803,7 @@ lakectl auth policies show [flags]
 
 ```
   -h, --help        help for show
-      --id string   policy identifier
+      --id string   Policy identifier
 ```
 
 
@@ -865,7 +865,7 @@ lakectl auth users credentials create [flags]
 
 ```
   -h, --help        help for create
-      --id string   Username (email for password-based users). Defaults to current user.
+      --id string   Username (email for password-based users, default: current user)
 ```
 
 
@@ -882,9 +882,9 @@ lakectl auth users credentials delete [flags]
 {:.no_toc}
 
 ```
-      --access-key-id string   access key ID to delete
+      --access-key-id string   Access key ID to delete
   -h, --help                   help for delete
-      --id string              Username (email for password-based users). Defaults to current user.
+      --id string              Username (email for password-based users, default: current user)
 ```
 
 
@@ -924,7 +924,7 @@ lakectl auth users credentials list [flags]
 {:.no_toc}
 
 ```
-      --id string      Username (email for password-based users). Defaults to current user.
+      --id string      Username (email for password-based users, default: current user)
       --amount int     how many results to return (default 100)
       --after string   show results after this value (used for pagination)
   -h, --help           help for list
@@ -1075,7 +1075,7 @@ lakectl auth users policies attach [flags]
 ```
   -h, --help            help for attach
       --id string       Username (email for password-based users)
-      --policy string   policy identifier
+      --policy string   Policy identifier
 ```
 
 
@@ -1094,7 +1094,7 @@ lakectl auth users policies detach [flags]
 ```
   -h, --help            help for detach
       --id string       Username (email for password-based users)
-      --policy string   policy identifier
+      --policy string   Policy identifier
 ```
 
 
@@ -1134,7 +1134,7 @@ lakectl auth users policies list [flags]
 {:.no_toc}
 
 ```
-      --effective      list all distinct policies attached to the user, even through group memberships
+      --effective      List all distinct policies attached to the user, including by group memberships
       --id string      Username (email for password-based users)
       --amount int     how many results to return (default 100)
       --after string   show results after this value (used for pagination)

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -480,8 +480,8 @@ lakectl auth groups list [flags]
 {:.no_toc}
 
 ```
-      --after string   show results after this value (used for pagination)
       --amount int     how many results to return (default 100)
+      --after string   show results after this value (used for pagination)
   -h, --help           help for list
 ```
 
@@ -514,7 +514,7 @@ lakectl auth groups members add [flags]
 ```
   -h, --help          help for add
       --id string     group identifier
-      --user string   user identifier to add to the group
+      --user string   Username (email for password-based users). Defaults to current user.
 ```
 
 
@@ -554,10 +554,10 @@ lakectl auth groups members list [flags]
 {:.no_toc}
 
 ```
-      --after string   show results after this value (used for pagination)
-      --amount int     how many results to return (default 100)
-  -h, --help           help for list
       --id string      group identifier
+      --amount int     how many results to return (default 100)
+      --after string   show results after this value (used for pagination)
+  -h, --help           help for list
 ```
 
 
@@ -576,7 +576,7 @@ lakectl auth groups members remove [flags]
 ```
   -h, --help          help for remove
       --id string     group identifier
-      --user string   user identifier to add to the group
+      --user string   Username (email for password-based users). Defaults to current user.
 ```
 
 
@@ -667,10 +667,10 @@ lakectl auth groups policies list [flags]
 {:.no_toc}
 
 ```
-      --after string   show results after this value (used for pagination)
-      --amount int     how many results to return (default 100)
-  -h, --help           help for list
       --id string      group identifier
+      --amount int     how many results to return (default 100)
+      --after string   show results after this value (used for pagination)
+  -h, --help           help for list
 ```
 
 
@@ -783,8 +783,8 @@ lakectl auth policies list [flags]
 {:.no_toc}
 
 ```
-      --after string   show results after this value (used for pagination)
       --amount int     how many results to return (default 100)
+      --after string   show results after this value (used for pagination)
   -h, --help           help for list
 ```
 
@@ -834,7 +834,7 @@ lakectl auth users create [flags]
 
 ```
   -h, --help        help for create
-      --id string   user identifier
+      --id string   Username
 ```
 
 
@@ -865,7 +865,7 @@ lakectl auth users credentials create [flags]
 
 ```
   -h, --help        help for create
-      --id string   user identifier (default: current user)
+      --id string   Username (email for password-based users). Defaults to current user.
 ```
 
 
@@ -884,7 +884,7 @@ lakectl auth users credentials delete [flags]
 ```
       --access-key-id string   access key ID to delete
   -h, --help                   help for delete
-      --id string              user identifier (default: current user)
+      --id string              Username (email for password-based users). Defaults to current user.
 ```
 
 
@@ -924,10 +924,10 @@ lakectl auth users credentials list [flags]
 {:.no_toc}
 
 ```
-      --after string   show results after this value (used for pagination)
+      --id string      Username (email for password-based users). Defaults to current user.
       --amount int     how many results to return (default 100)
+      --after string   show results after this value (used for pagination)
   -h, --help           help for list
-      --id string      user identifier (default: current user)
 ```
 
 
@@ -945,7 +945,7 @@ lakectl auth users delete [flags]
 
 ```
   -h, --help        help for delete
-      --id string   user identifier
+      --id string   Username (email for password-based users)
 ```
 
 
@@ -998,10 +998,10 @@ lakectl auth users groups list [flags]
 {:.no_toc}
 
 ```
-      --after string   show results after this value (used for pagination)
+      --id string      Username (email for password-based users)
       --amount int     how many results to return (default 100)
+      --after string   show results after this value (used for pagination)
   -h, --help           help for list
-      --id string      user identifier
 ```
 
 
@@ -1041,8 +1041,8 @@ lakectl auth users list [flags]
 {:.no_toc}
 
 ```
-      --after string   show results after this value (used for pagination)
       --amount int     how many results to return (default 100)
+      --after string   show results after this value (used for pagination)
   -h, --help           help for list
 ```
 
@@ -1074,7 +1074,7 @@ lakectl auth users policies attach [flags]
 
 ```
   -h, --help            help for attach
-      --id string       user identifier
+      --id string       Username (email for password-based users)
       --policy string   policy identifier
 ```
 
@@ -1093,7 +1093,7 @@ lakectl auth users policies detach [flags]
 
 ```
   -h, --help            help for detach
-      --id string       user identifier
+      --id string       Username (email for password-based users)
       --policy string   policy identifier
 ```
 
@@ -1134,11 +1134,11 @@ lakectl auth users policies list [flags]
 {:.no_toc}
 
 ```
-      --after string   show results after this value (used for pagination)
-      --amount int     how many results to return (default 100)
       --effective      list all distinct policies attached to the user, even through group memberships
+      --id string      Username (email for password-based users)
+      --amount int     how many results to return (default 100)
+      --after string   show results after this value (used for pagination)
   -h, --help           help for list
-      --id string      user identifier
 ```
 
 

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -840,22 +840,22 @@ func (c *Controller) generateResetPasswordToken(email string, duration time.Dura
 
 func (c *Controller) CreateUser(w http.ResponseWriter, r *http.Request, body CreateUserJSONRequestBody) {
 	invite := swag.BoolValue(body.InviteUser)
-	id := body.Id
+	username := body.Id
 	var parsedEmail *string
 	if invite {
-		addr, err := mail.ParseAddress(body.Id)
+		addr, err := mail.ParseAddress(username)
 		if err != nil {
-			c.Logger.WithError(err).WithField("user_id", id).Warn("failed parsing email")
+			c.Logger.WithError(err).WithField("user_id", username).Warn("failed parsing email")
 			writeError(w, http.StatusBadRequest, "Invalid email format")
 			return
 		}
-		id = strings.ToLower(addr.Address)
+		username = strings.ToLower(addr.Address)
 		parsedEmail = &addr.Address
 	}
 	if !c.authorize(w, r, permissions.Node{
 		Permission: permissions.Permission{
 			Action:   permissions.CreateUserAction,
-			Resource: permissions.UserArn(id),
+			Resource: permissions.UserArn(username),
 		},
 	}) {
 		return
@@ -873,7 +873,7 @@ func (c *Controller) CreateUser(w http.ResponseWriter, r *http.Request, body Cre
 	}
 	u := &model.User{
 		CreatedAt:    time.Now().UTC(),
-		Username:     id,
+		Username:     username,
 		FriendlyName: nil,
 		Source:       "internal",
 		Email:        parsedEmail,

--- a/pkg/auth/model/model.go
+++ b/pkg/auth/model/model.go
@@ -94,7 +94,8 @@ type SuperuserConfiguration struct {
 
 type User struct {
 	CreatedAt time.Time `db:"created_at"`
-	Username  string    `db:"display_name" json:"display_name"`
+	// Username is a unique identifier for the user. In password-based authentication, it is the email.
+	Username string `db:"display_name" json:"display_name"`
 	// FriendlyName, if set, is a shorter name for the user than
 	// Username.  Unlike Username it does not identify the user (it
 	// might not be unique); use it in the user's GUI rather than in

--- a/pkg/auth/service.go
+++ b/pkg/auth/service.go
@@ -1199,9 +1199,13 @@ func (a *APIAuthService) getFirstUser(ctx context.Context, userKey *userKey, par
 			return nil, ErrNotFound
 		}
 		u := results[0]
+		username := u.Username
+		if username == "" {
+			username = swag.StringValue(u.Name)
+		}
 		return &model.User{
 			CreatedAt:         time.Unix(u.CreationDate, 0),
-			Username:          u.Name,
+			Username:          username,
 			FriendlyName:      u.FriendlyName,
 			Email:             u.Email,
 			EncryptedPassword: u.EncryptedPassword,
@@ -1228,9 +1232,13 @@ func (a *APIAuthService) GetUser(ctx context.Context, username string) (*model.U
 			return nil, err
 		}
 		u := resp.JSON200
+		returnedUsername := u.Username
+		if returnedUsername == "" {
+			returnedUsername = swag.StringValue(u.Name)
+		}
 		return &model.User{
 			CreatedAt:         time.Unix(u.CreationDate, 0),
-			Username:          u.Name,
+			Username:          returnedUsername,
 			FriendlyName:      u.FriendlyName,
 			Email:             u.Email,
 			EncryptedPassword: u.EncryptedPassword,
@@ -1273,9 +1281,13 @@ func (a *APIAuthService) ListUsers(ctx context.Context, params *model.Pagination
 	results := resp.JSON200.Results
 	users := make([]*model.User, len(results))
 	for i, r := range results {
+		username := r.Username
+		if username == "" {
+			username = swag.StringValue(r.Name)
+		}
 		users[i] = &model.User{
 			CreatedAt:         time.Unix(r.CreationDate, 0),
-			Username:          r.Name,
+			Username:          username,
 			FriendlyName:      r.FriendlyName,
 			Email:             r.Email,
 			EncryptedPassword: nil,
@@ -1439,9 +1451,13 @@ func (a *APIAuthService) ListGroupUsers(ctx context.Context, groupDisplayName st
 	members := make([]*model.User, len(resp.JSON200.Results))
 
 	for i, r := range resp.JSON200.Results {
+		username := r.Username
+		if username == "" {
+			username = swag.StringValue(r.Name)
+		}
 		members[i] = &model.User{
 			CreatedAt:    time.Unix(r.CreationDate, 0),
-			Username:     r.Name,
+			Username:     username,
 			FriendlyName: r.FriendlyName,
 			Email:        r.Email,
 		}

--- a/pkg/auth/service.go
+++ b/pkg/auth/service.go
@@ -1201,7 +1201,7 @@ func (a *APIAuthService) getFirstUser(ctx context.Context, userKey *userKey, par
 		u := results[0]
 		username := u.Username
 		if username == "" {
-			username = swag.StringValue(u.Name)
+			username = u.Name
 		}
 		return &model.User{
 			CreatedAt:         time.Unix(u.CreationDate, 0),
@@ -1234,7 +1234,7 @@ func (a *APIAuthService) GetUser(ctx context.Context, username string) (*model.U
 		u := resp.JSON200
 		returnedUsername := u.Username
 		if returnedUsername == "" {
-			returnedUsername = swag.StringValue(u.Name)
+			returnedUsername = u.Name
 		}
 		return &model.User{
 			CreatedAt:         time.Unix(u.CreationDate, 0),
@@ -1283,7 +1283,7 @@ func (a *APIAuthService) ListUsers(ctx context.Context, params *model.Pagination
 	for i, r := range results {
 		username := r.Username
 		if username == "" {
-			username = swag.StringValue(r.Name)
+			username = r.Name
 		}
 		users[i] = &model.User{
 			CreatedAt:         time.Unix(r.CreationDate, 0),
@@ -1453,7 +1453,7 @@ func (a *APIAuthService) ListGroupUsers(ctx context.Context, groupDisplayName st
 	for i, r := range resp.JSON200.Results {
 		username := r.Username
 		if username == "" {
-			username = swag.StringValue(r.Name)
+			username = r.Name
 		}
 		members[i] = &model.User{
 			CreatedAt:    time.Unix(r.CreationDate, 0),


### PR DESCRIPTION
1. Add description to id field in API.
2. Add description to user ID field in lakectl.
3. Add "username" field to Auth API and deprecate "name".
4. (Bonus) reorder flags on lakectl auth commands so that pagination flags are at the bottom.