### PR TITLE
Make GC hard-delete expired objects from Azure blob storage

### DIFF
--- a/clients/spark/build.sbt
+++ b/clients/spark/build.sbt
@@ -119,6 +119,8 @@ lazy val examples312 = generateExamplesProject(spark312Type).dependsOn(core312)
 
 lazy val root = (project in file(".")).aggregate(core2, core3, core312, examples2, examples3, examples312)
 
+// We are using the default sbt assembly merge strategy https://github.com/sbt/sbt-assembly#merge-strategy with a change
+// to the general case: use MergeStrategy.first instead of MergeStrategy.deduplicate.
 lazy val assemblySettings = Seq(
   assembly / assemblyMergeStrategy := {
     case PathList("META-INF", xs @ _*) =>

--- a/clients/spark/build.sbt
+++ b/clients/spark/build.sbt
@@ -60,6 +60,9 @@ def generateCoreProject(buildType: BuildType) =
         // version, but ask to use whatever is provided so we do not
         // override what it selects.
         "com.amazonaws" % "aws-java-sdk-bundle" % "1.12.194" % "provided",
+        "com.azure" % "azure-core" % "1.10.0",
+        "com.azure" % "azure-storage-blob" % "12.9.0",
+        "com.azure" % "azure-storage-blob-batch" % "12.7.0",
         // Snappy is JNI :-(.  However it does claim to work with
         // ClassLoaders, and (even more importantly!) using a preloaded JNI
         // version will probably continue to work because the C language API

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/ApiClient.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/ApiClient.scala
@@ -3,7 +3,10 @@ package io.treeverse.clients
 import com.google.common.cache.CacheBuilder
 import io.lakefs.clients.api
 import io.lakefs.clients.api.{ConfigApi, RetentionApi}
-import io.lakefs.clients.api.model.{GarbageCollectionPrepareRequest, GarbageCollectionPrepareResponse}
+import io.lakefs.clients.api.model.{
+  GarbageCollectionPrepareRequest,
+  GarbageCollectionPrepareResponse
+}
 import io.treeverse.clients.StorageClientType.StorageClientType
 import io.treeverse.clients.StorageUtils.{StorageTypeAzure, StorageTypeS3}
 
@@ -82,7 +85,7 @@ class ApiClient(apiUrl: String, accessKey: String, secretKey: String) {
               .normalize()
               .toString
           case StorageClientType.SDKClient => repo.getStorageNamespace
-          case _                              => throw new IllegalArgumentException
+          case _                           => throw new IllegalArgumentException
         }
         storageNamespace
       })

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/ApiClient.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/ApiClient.scala
@@ -4,7 +4,10 @@ import com.google.common.cache.CacheBuilder
 import io.lakefs.clients.api
 import io.lakefs.clients.api.RetentionApi
 import io.lakefs.clients.api.ConfigApi
-import io.lakefs.clients.api.model.{GarbageCollectionPrepareRequest, GarbageCollectionPrepareResponse}
+import io.lakefs.clients.api.model.{
+  GarbageCollectionPrepareRequest,
+  GarbageCollectionPrepareResponse
+}
 import io.treeverse.clients.StorageAccessType.StorageAccessType
 import io.treeverse.clients.StorageUtils.{StorageTypeAzure, StorageTypeS3}
 
@@ -77,14 +80,14 @@ class ApiClient(apiUrl: String, accessKey: String, secretKey: String) {
       new CallableFn(() => {
         val repo = repositoriesApi.getRepository(repoName)
 
-        val storageNamespace =  accessType match {
-          case StorageAccessType.HadoopFS  =>
+        val storageNamespace = accessType match {
+          case StorageAccessType.HadoopFS =>
             ApiClient
               .translateURI(URI.create(repo.getStorageNamespace), getBlockstoreType())
               .normalize()
               .toString
-          case StorageAccessType.DirectAccess  => repo.getStorageNamespace
-          case _ => throw new IllegalArgumentException
+          case StorageAccessType.DirectAccess => repo.getStorageNamespace
+          case _                              => throw new IllegalArgumentException
         }
         storageNamespace
       })
@@ -120,7 +123,11 @@ class ApiClient(apiUrl: String, accessKey: String, secretKey: String) {
     if (metaRangeID != "") {
       val metaRange = metadataApi.getMetaRange(repoName, metaRangeID)
       val location = metaRange.getLocation
-      URI.create(getStorageNamespace(repoName, StorageAccessType.HadoopFS) + "/").resolve(location).normalize().toString
+      URI
+        .create(getStorageNamespace(repoName, StorageAccessType.HadoopFS) + "/")
+        .resolve(location)
+        .normalize()
+        .toString
     } else ""
   }
 
@@ -130,7 +137,10 @@ class ApiClient(apiUrl: String, accessKey: String, secretKey: String) {
   def getRangeURL(repoName: String, rangeID: String): String = {
     val range = metadataApi.getRange(repoName, rangeID)
     val location = range.getLocation
-    URI.create(getStorageNamespace(repoName, StorageAccessType.HadoopFS) + "/" + location).normalize().toString
+    URI
+      .create(getStorageNamespace(repoName, StorageAccessType.HadoopFS) + "/" + location)
+      .normalize()
+      .toString
   }
 
   def getBranchHEADCommit(repoName: String, branch: String): String =

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/ApiClient.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/ApiClient.scala
@@ -4,23 +4,27 @@ import com.google.common.cache.CacheBuilder
 import io.lakefs.clients.api
 import io.lakefs.clients.api.RetentionApi
 import io.lakefs.clients.api.ConfigApi
-import io.lakefs.clients.api.model.{
-  GarbageCollectionPrepareRequest,
-  GarbageCollectionPrepareResponse
-}
+import io.lakefs.clients.api.model.{GarbageCollectionPrepareRequest, GarbageCollectionPrepareResponse}
+import io.treeverse.clients.StorageAccessType.StorageAccessType
+import io.treeverse.clients.StorageUtils.{StorageTypeAzure, StorageTypeS3}
 
 import java.net.URI
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.Callable
 
+// The different types of storage access the metadata client uses.
+object StorageAccessType extends Enumeration {
+  type StorageAccessType = Value
+
+  val DirectAccess, HadoopFS = Value
+}
+
 private object ApiClient {
-  val StorageTypeS3 = "s3"
-  val StorageTypeAzure = "azure"
 
   /** Translate uri according to two cases:
    *  If the storage type is s3 then translate the protocol of uri from "standard"-ish "s3" to "s3a", to
    *  trigger processing by S3AFileSystem.
-   *  If the storage type is azure then translate the uri to abfs schema.
+   *  If the storage type is azure then translate the uri to abfs schema to trigger processing by AzureBlobFileSystem.
    */
   def translateURI(uri: URI, storageType: String): URI = {
     if ((storageType == StorageTypeS3) && (uri.getScheme == "s3")) {
@@ -37,7 +41,7 @@ private object ApiClient {
       /** get the host and path from url of type: https://StorageAccountName.blob.core.windows.net/Container[/BlobName],
        *  extract the storage account, container and blob path, and use them in abfs url
        */
-      val storageAccountName = uri.getHost.split('.')(0)
+      val storageAccountName = StorageUtils.AzureBlob.uriToStorageAccountName(uri)
       val Array(_, container, blobPath) = uri.getPath.split("/", 3)
       return new URI(
         s"abfs://${container}@${storageAccountName}.dfs.core.windows.net/${blobPath}"
@@ -67,16 +71,22 @@ class ApiClient(apiUrl: String, accessKey: String, secretKey: String) {
     def call(): String = fn()
   }
 
-  def getStorageNamespace(repoName: String): String = {
+  def getStorageNamespace(repoName: String, accessType: StorageAccessType): String = {
     storageNamespaceCache.get(
       repoName,
       new CallableFn(() => {
         val repo = repositoriesApi.getRepository(repoName)
 
-        ApiClient
-          .translateURI(URI.create(repo.getStorageNamespace), getBlockstoreType())
-          .normalize()
-          .toString
+        val storageNamespace =  accessType match {
+          case StorageAccessType.HadoopFS  =>
+            ApiClient
+              .translateURI(URI.create(repo.getStorageNamespace), getBlockstoreType())
+              .normalize()
+              .toString
+          case StorageAccessType.DirectAccess  => repo.getStorageNamespace
+          case _ => throw new IllegalArgumentException
+        }
+        storageNamespace
       })
     )
   }
@@ -110,7 +120,7 @@ class ApiClient(apiUrl: String, accessKey: String, secretKey: String) {
     if (metaRangeID != "") {
       val metaRange = metadataApi.getMetaRange(repoName, metaRangeID)
       val location = metaRange.getLocation
-      URI.create(getStorageNamespace(repoName) + "/").resolve(location).normalize().toString
+      URI.create(getStorageNamespace(repoName, StorageAccessType.HadoopFS) + "/").resolve(location).normalize().toString
     } else ""
   }
 
@@ -120,7 +130,7 @@ class ApiClient(apiUrl: String, accessKey: String, secretKey: String) {
   def getRangeURL(repoName: String, rangeID: String): String = {
     val range = metadataApi.getRange(repoName, rangeID)
     val location = range.getLocation
-    URI.create(getStorageNamespace(repoName) + "/" + location).normalize().toString
+    URI.create(getStorageNamespace(repoName, StorageAccessType.HadoopFS) + "/" + location).normalize().toString
   }
 
   def getBranchHEADCommit(repoName: String, branch: String): String =

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/BulkRemoverFactory.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/BulkRemoverFactory.scala
@@ -13,7 +13,7 @@ import io.treeverse.clients.StorageUtils.S3._
 import io.treeverse.clients.StorageUtils._
 import org.apache.hadoop.conf.Configuration
 
-import java.net.{URI, URL}
+import java.net.URI
 import java.nio.charset.Charset
 import java.util.stream.Collectors
 import collection.JavaConverters._
@@ -105,16 +105,16 @@ object BulkRemoverFactory {
 
       val blobBatchClient = getBlobBatchClient(hc, storageAccountUrl, storageAccountName)
 
-      val extractUrlIfBlobDeleted = new java.util.function.Function[Response[Void], URL]() {
-        def apply(response: Response[Void]): URL = {
+      val extractUrlIfBlobDeleted = new java.util.function.Function[Response[Void], URI]() {
+        def apply(response: Response[Void]): URI = {
           if (response.getStatusCode == 200) {
             response.getRequest.getUrl
           }
-          new URL(EmptyString)
+          new URI(EmptyString)
         }
       }
-      val urlToString = new java.util.function.Function[URL, String]() {
-        def apply(url: URL): String = url.toString
+      val uriToString = new java.util.function.Function[URI, String]() {
+        def apply(uri: URI): String = uri.toString
       }
       val isNonEmptyString = new java.util.function.Predicate[String]() {
         override def test(s: String): Boolean = !EmptyString.equals(s)
@@ -122,11 +122,11 @@ object BulkRemoverFactory {
 
       try {
         val responses = blobBatchClient.deleteBlobs(removeKeys, DeleteSnapshotsOptionType.INCLUDE)
-        // TODO(Tals): extract urls of successfully deleted objects from response, the current version does not do that.
+        // TODO(Tals): extract uris of successfully deleted objects from response, the current version does not do that.
         responses
           .stream()
-          .map[URL](extractUrlIfBlobDeleted)
-          .map[String](urlToString)
+          .map[URI](extractUrlIfBlobDeleted)
+          .map[String](uriToString)
           .filter(isNonEmptyString)
           .collect(Collectors.toList())
           .asScala

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/BulkRemoverFactory.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/BulkRemoverFactory.scala
@@ -120,13 +120,12 @@ object BulkRemoverFactory {
         override def test(s: String): Boolean = !EmptyString.equals(s)
       }
 
-      var deletedBlobs = Seq[String]()
       try {
         val responses = blobBatchClient.deleteBlobs(removeKeys, DeleteSnapshotsOptionType.INCLUDE)
         // TODO(Tals): extract urls of successfully deleted objects from response, the current version does not do that.
-        deletedBlobs ++ responses
-          .mapPage[URL](extractUrlIfBlobDeleted)
+        responses
           .stream()
+          .map[URL](extractUrlIfBlobDeleted)
           .map[String](urlToString)
           .filter(isNonEmptyString)
           .collect(Collectors.toList())
@@ -135,8 +134,8 @@ object BulkRemoverFactory {
       } catch {
         case e: Throwable =>
           e.printStackTrace()
+          Seq.empty
       }
-      deletedBlobs
     }
 
     private def getBlobBatchClient(

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/BulkRemoverFactory.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/BulkRemoverFactory.scala
@@ -1,0 +1,155 @@
+package io.treeverse.clients
+
+import com.amazonaws.services.kinesisfirehose.model.RetryOptions
+import com.amazonaws.services.s3.{AmazonS3, model}
+import com.azure.core.http.HttpClient
+import com.azure.core.http.rest.Response
+import com.azure.storage.blob.batch.{BlobBatchClient, BlobBatchClientBuilder}
+import com.azure.storage.blob.models.DeleteSnapshotsOptionType
+import com.azure.storage.blob.{BlobServiceClient, BlobServiceClientBuilder}
+import com.azure.storage.common.StorageSharedKeyCredential
+import com.azure.storage.common.policy.RequestRetryOptions
+import io.treeverse.clients.StorageUtils.AzureBlob._
+import io.treeverse.clients.StorageUtils.S3._
+import io.treeverse.clients.StorageUtils._
+import org.apache.hadoop.conf.Configuration
+
+import java.net.URI
+import java.nio.charset.Charset
+import collection.JavaConverters._
+
+trait BulkRemover {
+  /**
+   * Provides the max bulk size allowed by the underlying SDK client that does the actual deletion.
+   *
+   * @return max bulk size
+   */
+  def getMaxBulkSize(): Int
+
+  /**
+   * Constructs object URIs so that they are consumable by the SDK client that does the actual deletion.
+   *
+   * @param keys keys of objects to be removed
+   * @param storageNamespace the storage namespace in which the objects are stored
+   * @return object URIs of the keys
+   */
+  def constructRemoveKeyNames( keys: Seq[String], storageNamespace: String): Seq[String]
+
+  /**
+   * Bulk delete objects from the underlying storage.
+   *
+   * @param keys of objects to delete
+   * @param storageNamespace the storage namespace in which the objects are stored
+   * @return objects that removed successfully
+   */
+  def deleteObjects(keys: Seq[String], storageNamespace: String) : Seq[String]
+}
+
+object BulkRemoverFactory {
+
+  private class S3BulkRemover(hc: Configuration, storageNamespace: String, region: String) extends BulkRemover {
+    val uri = new URI(storageNamespace)
+    val bucket = uri.getHost
+
+    override def deleteObjects(keys: Seq[String], storageNamespace: String): Seq[String] = {
+      val removeKeyNames = constructRemoveKeyNames(keys, storageNamespace)
+      println("Remove keys:", removeKeyNames.take(100).mkString(", "))
+      val removeKeys = removeKeyNames.map(k => new model.DeleteObjectsRequest.KeyVersion(k)).asJava
+
+      val delObjReq = new model.DeleteObjectsRequest(bucket).withKeys(removeKeys)
+      val s3Client = getS3Client(hc, bucket, region, S3NumRetries)
+      val res = s3Client.deleteObjects(delObjReq)
+      res.getDeletedObjects.asScala.map(_.getKey())
+    }
+
+    private def getS3Client(
+                             hc: Configuration,
+                             bucket: String,
+                             region: String,
+                             numRetries: Int
+                           ): AmazonS3 =
+      io.treeverse.clients.conditional.S3ClientBuilder.build(hc, bucket, region, numRetries)
+
+    override def constructRemoveKeyNames(keys: Seq[String], storageNamespace: String): Seq[String] = {
+      println("storageNamespace: " + storageNamespace) // example storage namespace s3://bucket/repoDir/
+      val uri = new URI(storageNamespace)
+      val key = uri.getPath
+      val addSuffixSlash = if (key.endsWith("/")) key else key.concat("/")
+      val snPrefix =
+        if (addSuffixSlash.startsWith("/")) addSuffixSlash.substring(1) else addSuffixSlash
+
+      if (keys.isEmpty) return Seq.empty
+      keys.map(x => snPrefix.concat(x))
+    }
+
+    override def getMaxBulkSize(): Int = {
+      S3MaxBulkSize
+    }
+  }
+
+  private class AzureBlobBulkRemover(hc: Configuration, storageNamespace: String) extends BulkRemover {
+    val uri = new URI(storageNamespace)
+    val storageAccountUrl = StorageUtils.AzureBlob.uriToStorageAccountUrl(uri)
+    val storageAccountName = StorageUtils.AzureBlob.uriToStorageAccountName(uri)
+
+    override def deleteObjects(keys: Seq[String], storageNamespace: String): Seq[String] = {
+      val removeKeyNames = constructRemoveKeyNames(keys, storageNamespace)
+      println("Remove keys:", removeKeyNames.take(100).mkString(", "))
+      val removeKeys = removeKeyNames.asJava
+
+      val blobBatchClient = getBlobBatchClient(hc, storageAccountUrl, storageAccountName)
+
+      //TODO (Tals): extract urls of successfully deleted objects from response, the current version does not do that.
+      try {
+        val responses = blobBatchClient.deleteBlobs(removeKeys, DeleteSnapshotsOptionType.INCLUDE)
+        responses.mapPage((response: Response[Void]) => {
+            if (response.getStatusCode == 200) {
+              response.getRequest.getUrl
+            }
+          })
+          .mapPage(url => url.toString)
+          .asScala.toSeq
+      } catch {
+        case e: Throwable =>
+          e.printStackTrace()
+          Seq.empty
+      }
+    }
+
+    private def getBlobBatchClient(hc: Configuration, storageAccountUrl: String, storageAccountName: String): BlobBatchClient = {
+      val storageAccountKeyPropName = StorageAccountKeyPropertyPattern.replaceFirst(StorageAccNamePlaceHolder, storageAccountName)
+      val storageAccountKey = hc.get(storageAccountKeyPropName)
+
+      val blobServiceClientSharedKey: BlobServiceClient =
+        new BlobServiceClientBuilder().endpoint(storageAccountUrl)
+          .credential(new StorageSharedKeyCredential(storageAccountName, storageAccountKey))
+          .retryOptions(new RequestRetryOptions()) // Sets the default retry options for each request done through the client https://docs.microsoft.com/en-us/java/api/com.azure.storage.common.policy.requestretryoptions.requestretryoptions?view=azure-java-stable#com-azure-storage-common-policy-requestretryoptions-requestretryoptions()
+          .httpClient(HttpClient.createDefault())
+          .buildClient
+
+      new BlobBatchClientBuilder(blobServiceClientSharedKey).buildClient
+    }
+
+    override def constructRemoveKeyNames(keys: Seq[String], storageNamespace: String): Seq[String] = {
+      println("storageNamespace: " + storageNamespace)
+      val addSuffixSlash = if (storageNamespace.endsWith("/")) storageNamespace else storageNamespace.concat("/")
+
+      if (keys.isEmpty) return Seq.empty
+      keys.map(x => addSuffixSlash.concat(x)).map(x => x.getBytes(Charset.forName("UTF-8"))).map(x => new String(x))
+    }
+
+    override def getMaxBulkSize(): Int = {
+      AzureBlobMaxBulkSize
+    }
+  }
+
+  def apply(storageType: String, hc: Configuration, storageNamespace: String, region: String): BulkRemover = {
+    if (storageType == StorageTypeS3) {
+      new S3BulkRemover(hc, storageNamespace, region)
+    } else if (storageType == StorageTypeAzure) {
+      new AzureBlobBulkRemover(hc, storageNamespace)
+    } else {
+      throw new IllegalArgumentException("Invalid argument.")
+    }
+  }
+}

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/Exporter.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/Exporter.scala
@@ -30,7 +30,7 @@ class Exporter(
   }
 
   def exportAllFromCommit(commitID: String): Unit = {
-    val ns = apiClient.getStorageNamespace(repoName, StorageAccessType.HadoopFS)
+    val ns = apiClient.getStorageNamespace(repoName, StorageClientType.HadoopFS)
     val df = LakeFSContext.newDF(spark, repoName, commitID)
 
     val tableName = randPrefix() + "_commit"
@@ -89,7 +89,7 @@ class Exporter(
 
   def exportFrom(branch: String, prevCommitID: String): Unit = {
     val commitID = apiClient.getBranchHEADCommit(repoName, branch)
-    val ns = apiClient.getStorageNamespace(repoName, StorageAccessType.HadoopFS)
+    val ns = apiClient.getStorageNamespace(repoName, StorageClientType.HadoopFS)
 
     val newDF = LakeFSContext.newDF(spark, repoName, commitID)
     val prevDF = LakeFSContext.newDF(spark, repoName, prevCommitID)

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/Exporter.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/Exporter.scala
@@ -30,7 +30,7 @@ class Exporter(
   }
 
   def exportAllFromCommit(commitID: String): Unit = {
-    val ns = apiClient.getStorageNamespace(repoName)
+    val ns = apiClient.getStorageNamespace(repoName, StorageAccessType.HadoopFS)
     val df = LakeFSContext.newDF(spark, repoName, commitID)
 
     val tableName = randPrefix() + "_commit"
@@ -89,7 +89,7 @@ class Exporter(
 
   def exportFrom(branch: String, prevCommitID: String): Unit = {
     val commitID = apiClient.getBranchHEADCommit(repoName, branch)
-    val ns = apiClient.getStorageNamespace(repoName)
+    val ns = apiClient.getStorageNamespace(repoName, StorageAccessType.HadoopFS)
 
     val newDF = LakeFSContext.newDF(spark, repoName, commitID)
     val prevDF = LakeFSContext.newDF(spark, repoName, prevCommitID)

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/StorageUtils.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/StorageUtils.scala
@@ -8,23 +8,23 @@ object StorageUtils {
   val SchemeDelimiter = "://"
 
   object AzureBlob {
-    val StorageAccountKeyPropertyPattern = "fs.azure.account.key.<storageAccountName>.dfs.core.windows.net"
+    val StorageAccountKeyPropertyPattern =
+      "fs.azure.account.key.<storageAccountName>.dfs.core.windows.net"
     val StorageAccNamePlaceHolder = "<storageAccountName>"
     // https://docs.microsoft.com/en-us/dotnet/api/overview/azure/storage.blobs.batch-readme#key-concepts
     // Note that there is no official java SDK documentation of the max batch size, therefore assuming the above.
     val AzureBlobMaxBulkSize = 256
 
-    /**
-     * Converts storage namespace URIs of the form https://<storageAccountName>.blob.core.windows.net/<container>/<path-in-container>
-     * to storage account URL of the form https://<storageAccountName>.blob.core.windows.net and storage namespace format is
-     * @param storageNsURI
-     * @return
+    /** Converts storage namespace URIs of the form https://<storageAccountName>.blob.core.windows.net/<container>/<path-in-container>
+     *  to storage account URL of the form https://<storageAccountName>.blob.core.windows.net and storage namespace format is
+     *  @param storageNsURI
+     *  @return
      */
     def uriToStorageAccountUrl(storageNsURI: URI): String = {
-      storageNsURI.getScheme + SchemeDelimiter +  storageNsURI.getHost
+      storageNsURI.getScheme + SchemeDelimiter + storageNsURI.getHost
     }
 
-    def uriToStorageAccountName(storageNsURI: URI): String ={
+    def uriToStorageAccountName(storageNsURI: URI): String = {
       storageNsURI.getHost.split('.')(0)
     }
   }
@@ -34,4 +34,3 @@ object StorageUtils {
     val S3NumRetries = 1000
   }
 }
-

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/StorageUtils.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/StorageUtils.scala
@@ -1,0 +1,37 @@
+package io.treeverse.clients
+
+import java.net.URI
+
+object StorageUtils {
+  val StorageTypeS3 = "s3"
+  val StorageTypeAzure = "azure"
+  val SchemeDelimiter = "://"
+
+  object AzureBlob {
+    val StorageAccountKeyPropertyPattern = "fs.azure.account.key.<storageAccountName>.dfs.core.windows.net"
+    val StorageAccNamePlaceHolder = "<storageAccountName>"
+    // https://docs.microsoft.com/en-us/dotnet/api/overview/azure/storage.blobs.batch-readme#key-concepts
+    // Note that there is no official java SDK documentation of the max batch size, therefore assuming the above.
+    val AzureBlobMaxBulkSize = 256
+
+    /**
+     * Converts storage namespace URIs of the form https://<storageAccountName>.blob.core.windows.net/<container>/<path-in-container>
+     * to storage account URL of the form https://<storageAccountName>.blob.core.windows.net and storage namespace format is
+     * @param storageNsURI
+     * @return
+     */
+    def uriToStorageAccountUrl(storageNsURI: URI): String = {
+      storageNsURI.getScheme + SchemeDelimiter +  storageNsURI.getHost
+    }
+
+    def uriToStorageAccountName(storageNsURI: URI): String ={
+      storageNsURI.getHost.split('.')(0)
+    }
+  }
+
+  object S3 {
+    val S3MaxBulkSize = 1000
+    val S3NumRetries = 1000
+  }
+}
+

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/StorageUtils.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/StorageUtils.scala
@@ -5,7 +5,6 @@ import java.net.URI
 object StorageUtils {
   val StorageTypeS3 = "s3"
   val StorageTypeAzure = "azure"
-  val SchemeDelimiter = "://"
 
   object AzureBlob {
     val StorageAccountKeyPropertyPattern =
@@ -21,7 +20,7 @@ object StorageUtils {
      *  @return
      */
     def uriToStorageAccountUrl(storageNsURI: URI): String = {
-      storageNsURI.getScheme + SchemeDelimiter + storageNsURI.getHost
+      storageNsURI.getScheme + "://" + storageNsURI.getHost
     }
 
     def uriToStorageAccountName(storageNsURI: URI): String = {


### PR DESCRIPTION
Closes #3546 

### In this review
* Use Azure SDK to bulk delete expired objects from Azure blob. 
* Add sbt merge strategy setting that discards changes done to the assembled META-INF directory (based on https://stackoverflow.com/questions/46287789/running-an-uber-jar-from-sbt-assembly-results-in-error-could-not-find-or-load-m)

### Not in this review
Currently, objects are deleted, but the status of the deleteBlobs operation is not captured, resulting in a misleading GC end-of-run report. This will be handled separately in https://github.com/treeverse/lakeFS/issues/3734

### How was this tested 
Tested Manually with lakeFS connected to Azure, watching expired objects getting removed. 

### Note to reviewers 
* Its recommended to review by commits. 
* ~The current version of the code does not compile with Spark 2.4.7 and Scala 2.11 due to https://stackoverflow.com/a/43664779/11553804~
 