### PR TITLE
[GC] Respect Hadoop AWS access key configuration in S3Client

### DIFF
--- a/.github/workflows/esti.yaml
+++ b/.github/workflows/esti.yaml
@@ -647,6 +647,18 @@ jobs:
         working-directory: test/spark
         run: ./run-gc-test.sh
 
+      - name: Spark executor logs on failure
+        if: ${{ failure() }}
+        continue-on-error: true
+        working-directory: test/spark
+        run: docker-compose logs --tail=50000 spark-worker
+
+      - name: Spark driver logs on failure
+        if: ${{ failure() }}
+        continue-on-error: true
+        working-directory: test/spark
+        run: docker-compose logs --tail=50000 spark ; docker ps
+
       - name: lakeFS Logs on Spark with gateway failure
         if: ${{ failure() }}
         continue-on-error: true

--- a/clients/spark/core/src/main/hadoop2/scala/io/treeverse/clients/conditional/S3ClientBuilder.scala
+++ b/clients/spark/core/src/main/hadoop2/scala/io/treeverse/clients/conditional/S3ClientBuilder.scala
@@ -6,12 +6,30 @@ import org.apache.hadoop.conf.Configuration
 
 object S3ClientBuilder extends io.treeverse.clients.S3ClientBuilder {
   def build(hc: Configuration, bucket: String, region: String, numRetries: Int): AmazonS3 = {
+    import org.apache.hadoop.fs.s3a.Constants
+    import com.amazonaws.auth.{BasicAWSCredentials, AWSStaticCredentialsProvider}
+
     val configuration = new ClientConfiguration().withMaxErrorRetry(numRetries)
+
+    val credentialsProvider =
+      if (hc.get(Constants.ACCESS_KEY) != null)
+        Some(
+          new AWSStaticCredentialsProvider(
+            new BasicAWSCredentials(hc.get(Constants.ACCESS_KEY), hc.get(Constants.SECRET_KEY))
+          )
+        )
+      else None
 
     val builder = AmazonS3ClientBuilder
       .standard()
       .withClientConfiguration(configuration)
       .withRegion(region)
-    builder.build
+
+    val builderWithCredentials = credentialsProvider match {
+      case Some(cp) => builder.withCredentials(cp)
+      case None     => builder
+    }
+
+    builderWithCredentials.build
   }
 }

--- a/clients/spark/core/src/main/hadoop3/scala/io/treeverse/clients/conditional/S3ClientBuilder.scala
+++ b/clients/spark/core/src/main/hadoop3/scala/io/treeverse/clients/conditional/S3ClientBuilder.scala
@@ -3,8 +3,11 @@ package io.treeverse.clients.conditional
 import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
 import com.amazonaws.ClientConfiguration
 import org.apache.hadoop.conf.Configuration
+import org.slf4j.{Logger, LoggerFactory}
 
 object S3ClientBuilder extends io.treeverse.clients.S3ClientBuilder {
+  val logger: Logger = LoggerFactory.getLogger(getClass.toString + "[hadoop3]")
+
   def build(hc: Configuration, bucket: String, region: String, numRetries: Int): AmazonS3 = {
     import org.apache.hadoop.fs.s3a.Constants
     import org.apache.hadoop.fs.s3a.auth.AssumedRoleCredentialProvider
@@ -17,15 +20,21 @@ object S3ClientBuilder extends io.treeverse.clients.S3ClientBuilder {
     //     and query for its credentials provider.  And cache them, in case
     //     some objects live in different buckets.
     val credentialsProvider =
-      if (hc.get(Constants.AWS_CREDENTIALS_PROVIDER) == AssumedRoleCredentialProvider.NAME)
+      if (hc.get(Constants.AWS_CREDENTIALS_PROVIDER) == AssumedRoleCredentialProvider.NAME) {
+        logger.info("Use configured AssumedRoleCredentialProvider for bucket {}", bucket)
         Some(new AssumedRoleCredentialProvider(new java.net.URI("s3a://" + bucket), hc))
-      else if (hc.get(Constants.ACCESS_KEY) != null)
+      } else if (hc.get(Constants.ACCESS_KEY) != null) {
+        logger.info(
+          "Use access key ID {} {}",
+          hc.get(Constants.ACCESS_KEY): Any,
+          if (hc.get(Constants.SECRET_KEY) == null) "(missing secret key)" else "secret key ******"
+        )
         Some(
           new AWSStaticCredentialsProvider(
             new BasicAWSCredentials(hc.get(Constants.ACCESS_KEY), hc.get(Constants.SECRET_KEY))
           )
         )
-      else None
+      } else None
 
     val builder = AmazonS3ClientBuilder
       .standard()

--- a/clients/spark/core/src/main/hadoop3/scala/io/treeverse/clients/conditional/S3ClientBuilder.scala
+++ b/clients/spark/core/src/main/hadoop3/scala/io/treeverse/clients/conditional/S3ClientBuilder.scala
@@ -8,6 +8,7 @@ object S3ClientBuilder extends io.treeverse.clients.S3ClientBuilder {
   def build(hc: Configuration, bucket: String, region: String, numRetries: Int): AmazonS3 = {
     import org.apache.hadoop.fs.s3a.Constants
     import org.apache.hadoop.fs.s3a.auth.AssumedRoleCredentialProvider
+    import com.amazonaws.auth.{BasicAWSCredentials, AWSStaticCredentialsProvider}
 
     val configuration = new ClientConfiguration().withMaxErrorRetry(numRetries)
 
@@ -18,6 +19,12 @@ object S3ClientBuilder extends io.treeverse.clients.S3ClientBuilder {
     val credentialsProvider =
       if (hc.get(Constants.AWS_CREDENTIALS_PROVIDER) == AssumedRoleCredentialProvider.NAME)
         Some(new AssumedRoleCredentialProvider(new java.net.URI("s3a://" + bucket), hc))
+      else if (hc.get(Constants.ACCESS_KEY) != null)
+        Some(
+          new AWSStaticCredentialsProvider(
+            new BasicAWSCredentials(hc.get(Constants.ACCESS_KEY), hc.get(Constants.SECRET_KEY))
+          )
+        )
       else None
 
     val builder = AmazonS3ClientBuilder

--- a/test/spark/run-gc-test.sh
+++ b/test/spark/run-gc-test.sh
@@ -14,7 +14,7 @@ run_lakectl() {
 }
 
 run_gc () {
-  docker-compose run -v ${CLIENT_JAR}:/client/client.jar -T --no-deps --rm spark-submit bash -c "spark-submit -v --master spark://spark:7077 --class io.treeverse.clients.GarbageCollector -c spark.hadoop.lakefs.api.url=http://docker.lakefs.io:8000/api/v1 -c spark.hadoop.lakefs.api.access_key=\${TESTER_ACCESS_KEY_ID} -c spark.hadoop.lakefs.api.secret_key=\${TESTER_SECRET_ACCESS_KEY} -c spark.hadoop.fs.s3a.access.key=\${LAKEFS_BLOCKSTORE_S3_CREDENTIALS_ACCESS_KEY_ID} -c spark.hadoop.fs.s3a.secret.key=\${LAKEFS_BLOCKSTORE_S3_CREDENTIALS_SECRET_ACCESS_KEY} -c spark.sql.shuffle.partitions=7 -c spark.default.parallelism=13 /client/client.jar $1 us-east-1"
+  docker-compose run -v ${CLIENT_JAR}:/client/client.jar -T --no-deps --rm spark-submit bash -c "spark-submit -v --master spark://spark:7077 --class io.treeverse.clients.GarbageCollector -c spark.hadoop.lakefs.api.url=http://docker.lakefs.io:8000/api/v1 -c spark.hadoop.lakefs.api.access_key=\${TESTER_ACCESS_KEY_ID} -c spark.hadoop.lakefs.api.secret_key=\${TESTER_SECRET_ACCESS_KEY} -c spark.hadoop.fs.s3a.access.key=\${AWS_ACCESS_KEY_ID} -c spark.hadoop.fs.s3a.secret.key=\${AWS_SECRET_ACCESS_KEY} -c spark.sql.shuffle.partitions=7 -c spark.default.parallelism=13 /client/client.jar $1 us-east-1"
 }
 
 clean_repo() {


### PR DESCRIPTION
If access key id and secret key appear in S3A configuration, use them to
configure the AWS credentials for the S3 client.

Unfortuately we _cannot_ generate the same AWS credentials as S3A does it --
it is not exported.

Fixes #3758.