### PR TITLE
Docs: clarify storage terms

### DIFF
--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -75,6 +75,13 @@ A repository is a collection of objects with common history tracking. lakeFS man
 ### Rollback
 A rollback is an atomic operation reversing the effects of a previous commit. If a developer introduces a new code version to production and discovers that it has a critical bug, they can simply roll back to the previous version. In lakeFS, a rollback is an atomic action that prevents the data consumers from receiving low-quality data until the issue is resolved. Learn more about how lakeFS supports the [rollback](/use_cases/rollback.md) operation.
 
+### Storage Namespace
+The storage namespace is a location in the underlying storage dedicated to a specific repository.
+lakeFS uses it to store the repository's objects and some of its metadata.
+
+### Underlying Storage
+The underlying storage is a location in some object store where lakeFS keeps your objects and some metadata.
+
 ### Tag
 A tag is an immutable pointer to a single commit. Tags have readable names. Because tags are commits, a repository can be read from any tag. Example tags:
 

--- a/docs/understand/object-model.md
+++ b/docs/understand/object-model.md
@@ -147,7 +147,7 @@ As a format-agnostic system, lakeFS currently merges by complete files. Format-s
 other user-defined merge strategies for handling conflicts are on the roadmap.
 
 ## Concepts unique to lakeFS
-The _underlying storage_ is a location in an object store where lakeFS keeps your objects and some metadata.
+The _underlying storage_ is a location in an object store where lakeFS keeps your objects and some immutable metadata.
 
 When creating a lakeFS repository, you assign it with a _storage namespace_. The repository's
 storage namespace is a location in the underlying storage where data for this repository

--- a/docs/understand/object-model.md
+++ b/docs/understand/object-model.md
@@ -147,16 +147,16 @@ As a format-agnostic system, lakeFS currently merges by complete files. Format-s
 other user-defined merge strategies for handling conflicts are on the roadmap.
 
 ## Concepts unique to lakeFS
-
-_Underlying storage_ is the area on some other object store that lakeFS uses to store object
-contents and some of its metadata. We sometimes refer to underlying storage as _physical_.
-The path used to store the contents of an object is then termed a _physical path_. The object
-itself on underlying storage is never modified, except to remove it entirely during some
-cleanups.
+The _underlying storage_ is a location in an object store where lakeFS keeps your objects and some metadata.
 
 When creating a lakeFS repository, you assign it with a _storage namespace_. The repository's
-storage namespace is the prefix in the underlying storage where data for this repository
+storage namespace is a location in the underlying storage where data for this repository
 will be stored.
+
+We sometimes refer to underlying storage as _physical_. The path used to store the contents of an object is then termed a _physical path_.
+Once lakeFS saves an object in the underlying storage it is never modified, except to remove it
+entirely during some cleanups.
+
 
 A lot of what lakeFS does is to manage how lakeFS paths translate to _physical paths_ on the
 object store. This mapping is generally **not** straightforward. Importantly (and contrary to


### PR DESCRIPTION
- add storage terms to glossary 
- clarify underlying storage in "object model" page