### PR TITLE
exit GC in case that no GC rules are configured for a repo

### DIFF
--- a/clients/spark/core/src/main/scala/io/treeverse/clients/ApiClient.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/ApiClient.scala
@@ -2,11 +2,8 @@ package io.treeverse.clients
 
 import com.google.common.cache.CacheBuilder
 import io.lakefs.clients.api
-import io.lakefs.clients.api.{ConfigApi, RetentionApi}
-import io.lakefs.clients.api.model.{
-  GarbageCollectionPrepareRequest,
-  GarbageCollectionPrepareResponse
-}
+import io.lakefs.clients.api.{ApiException, ConfigApi, RetentionApi}
+import io.lakefs.clients.api.model.{GarbageCollectionPrepareRequest, GarbageCollectionPrepareResponse}
 import io.treeverse.clients.StorageClientType.StorageClientType
 import io.treeverse.clients.StorageUtils.{StorageTypeAzure, StorageTypeS3}
 
@@ -102,6 +99,7 @@ class ApiClient(apiUrl: String, accessKey: String, secretKey: String) {
     )
   }
 
+  @throws(classOf[ApiException])
   def getGarbageCollectionRules(repoName: String): String = {
     val gcRules = retentionApi.getGarbageCollectionRules(repoName)
     gcRules.toString()

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/ApiClient.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/ApiClient.scala
@@ -3,7 +3,10 @@ package io.treeverse.clients
 import com.google.common.cache.CacheBuilder
 import io.lakefs.clients.api
 import io.lakefs.clients.api.{ApiException, ConfigApi, RetentionApi}
-import io.lakefs.clients.api.model.{GarbageCollectionPrepareRequest, GarbageCollectionPrepareResponse}
+import io.lakefs.clients.api.model.{
+  GarbageCollectionPrepareRequest,
+  GarbageCollectionPrepareResponse
+}
 import io.treeverse.clients.StorageClientType.StorageClientType
 import io.treeverse.clients.StorageUtils.{StorageTypeAzure, StorageTypeS3}
 

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/ApiClient.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/ApiClient.scala
@@ -2,7 +2,7 @@ package io.treeverse.clients
 
 import com.google.common.cache.CacheBuilder
 import io.lakefs.clients.api
-import io.lakefs.clients.api.{ApiException, ConfigApi, RetentionApi}
+import io.lakefs.clients.api.{ConfigApi, RetentionApi}
 import io.lakefs.clients.api.model.{
   GarbageCollectionPrepareRequest,
   GarbageCollectionPrepareResponse
@@ -102,7 +102,6 @@ class ApiClient(apiUrl: String, accessKey: String, secretKey: String) {
     )
   }
 
-  @throws(classOf[ApiException])
   def getGarbageCollectionRules(repoName: String): String = {
     val gcRules = retentionApi.getGarbageCollectionRules(repoName)
     gcRules.toString()

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
@@ -334,7 +334,15 @@ object GarbageCollector {
     // needed FileSystems.
     val hcValues = spark.sparkContext.broadcast(getHadoopConfigurationValues(hc, "fs."))
 
-    val gcRules = apiClient.getGarbageCollectionRules(repo)
+    var gcRules: String = ""
+    try {
+      gcRules = apiClient.getGarbageCollectionRules(repo)
+    } catch {
+      case e: Throwable =>
+        e.printStackTrace()
+        println("No GC rules found for repository: " + repo)
+        System.exit(0)
+    }
 
     val res = apiClient.prepareGarbageCollectionCommits(repo, previousRunID)
     val runID = res.getRunId

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
@@ -341,7 +341,8 @@ object GarbageCollector {
       case e: Throwable =>
         e.printStackTrace()
         println("No GC rules found for repository: " + repo)
-        System.exit(0)
+        // Exiting with a failure status code because users should not really run gc on repos without GC rules.
+        System.exit(2)
     }
 
     val res = apiClient.prepareGarbageCollectionCommits(repo, previousRunID)


### PR DESCRIPTION
Fixes #3772 

Spark logs after this fix: 

```
io.lakefs.clients.api.ApiException: Not Found
	at io.lakefs.clients.api.ApiClient.handleResponse(ApiClient.java:1029)
	at io.lakefs.clients.api.ApiClient.execute(ApiClient.java:942)
	at io.lakefs.clients.api.RetentionApi.getGarbageCollectionRulesWithHttpInfo(RetentionApi.java:158)
	at io.lakefs.clients.api.RetentionApi.getGarbageCollectionRules(RetentionApi.java:136)
	at io.treeverse.clients.ApiClient.getGarbageCollectionRules(ApiClient.scala:104)
	at io.treeverse.clients.GarbageCollector$.main(GarbageCollector.scala:333)
	at io.treeverse.clients.GarbageCollector.main(GarbageCollector.scala)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
	at org.apache.spark.deploy.JavaMainApplication.start(SparkApplication.scala:52)
	at org.apache.spark.deploy.SparkSubmit.org$apache$spark$deploy$SparkSubmit$$runMain(SparkSubmit.scala:951)
	at org.apache.spark.deploy.SparkSubmit.doRunMain$1(SparkSubmit.scala:180)
	at org.apache.spark.deploy.SparkSubmit.submit(SparkSubmit.scala:203)
	at org.apache.spark.deploy.SparkSubmit.doSubmit(SparkSubmit.scala:90)
	at org.apache.spark.deploy.SparkSubmit$$anon$2.doSubmit(SparkSubmit.scala:1030)
	at org.apache.spark.deploy.SparkSubmit$.main(SparkSubmit.scala:1039)
	at org.apache.spark.deploy.SparkSubmit.main(SparkSubmit.scala)
No GC rules found for repository: norules
```