### PR TITLE
[docs] Remove link from Quickstart to defunct Katacoda tutorial

### DIFF
--- a/docs/quickstart/includes/try.md
+++ b/docs/quickstart/includes/try.md
@@ -31,27 +31,6 @@ The first thing to notice is in this environment, lakeFS comes with a repository
 ![Create Repo]({{ site.baseurl }}/assets/img/iso-env-create-repo.png)
 
 
-
-## Katacoda Tutorial
-
-Learn how to use lakeFS using the CLI and an interactive Spark shell - all from your browser, without installing anything.
-
-In the tutorial we cover:
-
-- Basic `lakectl` command line usage
-- How to read, write, list and delete objects from lakeFS using the `lakectl` command
-- Read from, and write to lakeFS using its S3 API interface using [Spark](https://spark.apache.org/){: target="_blank" }
-- Diff, commit and merge the changes created by Spark
-- Track commit history to understand changes to your data over time
-
-The web based environment provides a full working lakeFS and Spark environment, so feel free to explore it on your own.
-
-<p>
-    <a class="btn btn-green" href="https://www.katacoda.com/lakefs/scenarios/lakefs-play" target="_blank">
-        Start Katacoda Tutorial Now
-    </a>
-</p>
-
 ## Next Steps
 
 After getting acquainted with lakeFS, easily [install it on your computer](installing.html) or [deploy it on your cloud account](../deploy/index.html).


### PR DESCRIPTION
Link is 404. Katacoda has shut down.

> Thank you to the Katacoda community for your years of support. Katacoda.com is now closed. Learn more about this decision and access interactive learning on O’Reilly [here](https://www.oreilly.com/online-learning/leveraging-katacoda-technology.html)