### PR TITLE
Reduce S3A MPU test runtime and size-of-data

### DIFF
--- a/test/spark/s3a-multipart/src/main/scala/S3AMultipart.scala
+++ b/test/spark/s3a-multipart/src/main/scala/S3AMultipart.scala
@@ -13,8 +13,8 @@ object S3AMultipart extends App {
 
   override def main(args: Array[String]) {
     val partSize = 5 << 20 // Must be >= 5MiB on AWS S3.
-    val fileSize = 4 * partSize
-    val writeSize = 16384
+    val fileSize = 2 * partSize
+    val writeSize = 1 << 18
 
     if (args.length != 1) {
       Console.err.println("Usage: ... s3://bucket/path/to/object")


### PR DESCRIPTION
* Smaller file: easier upload.  (Still 10MiB, which is above the 5MiB
  theshold for multipart upload!).
* Bump write sizes 16x: fewer, faster network operations.

_Should_ reduce occurrences of #3686.
