### PR TITLE
Added CHANGELOG files to hadoopFS and Spark clients

### DIFF
--- a/clients/hadoopfs/CHANGELOG.md
+++ b/clients/hadoopfs/CHANGELOG.md
@@ -1,0 +1,1 @@
+# Changelog

--- a/clients/spark/CHANGELOG.md
+++ b/clients/spark/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+## v0.2.0 - 2022-08-01
+What's new:
+- Garbage Collection on Azure (#3733, #3654)
+
+Bug fixes:
+- [GC] Respect Hadoop AWS access key configuration in S3Client (#3762)
+- exit GC in case that no GC rules are configured for a repo (#3779)


### PR DESCRIPTION
Added CHANGELOG files to hadoopFS and Spark clients in order to document the changes of our clients. The files will be updated as part of the clients release process.

* Added the last release to the Spark CHANGELOG, but didn't find anything relevant to hadoopFS to I left it blank.