### PR TITLE
test: use the default key value for Esti local credentials

### DIFF
--- a/esti/main_test.go
+++ b/esti/main_test.go
@@ -71,7 +71,7 @@ func TestMain(m *testing.M) {
 		StorageNS: "esti-system-testing",
 	}
 	if *useLocalCredentials {
-		params.AdminAccessKeyID = "AKIAIOSFDNN7EXAMPLEQ"
+		params.AdminAccessKeyID = "AKIAIOSFODNN7EXAMPLE"
 		params.AdminSecretAccessKey = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
 	}
 


### PR DESCRIPTION
By using the default key value for Esti local credentials flag we enable easy local development for running the Esti tests as part of our local environment.
The system test will be enable to access to locally configured your lakeFS environment or using the the docker-compose without extra configuration.