### PR TITLE
Prevent lakefs setup and superuser command while using auth API

### DIFF
--- a/cmd/lakefs/cmd/setup.go
+++ b/cmd/lakefs/cmd/setup.go
@@ -20,11 +20,16 @@ import (
 var setupCmd = &cobra.Command{
 	Use:     "setup",
 	Aliases: []string{"init"},
-	Short:   "Setup a new LakeFS instance with initial credentials",
+	Short:   "Setup a new lakeFS instance with initial credentials",
 	Run: func(cmd *cobra.Command, args []string) {
 		cfg := loadConfig()
-		ctx := cmd.Context()
 
+		if cfg.IsAuthTypeAPI() {
+			fmt.Printf("Can't setup lakeFS while using external auth API - auth.api.endpoint is configured.\n")
+			os.Exit(1)
+		}
+
+		ctx := cmd.Context()
 		dbParams := cfg.GetDatabaseParams()
 
 		var (

--- a/cmd/lakefs/cmd/superuser.go
+++ b/cmd/lakefs/cmd/superuser.go
@@ -23,6 +23,11 @@ var superuserCmd = &cobra.Command{
 	Short: "Create additional user with admin credentials",
 	Run: func(cmd *cobra.Command, args []string) {
 		cfg := loadConfig()
+		if cfg.IsAuthTypeAPI() {
+			fmt.Printf("Can't create additional admin while using external auth API - auth.api.endpoint is configured.\n")
+			os.Exit(1)
+		}
+
 		ctx := cmd.Context()
 		dbParams := cfg.GetDatabaseParams()
 		dbPool := db.BuildDatabaseConnection(ctx, dbParams)
@@ -92,7 +97,6 @@ var superuserCmd = &cobra.Command{
 			credentials.AccessKeyID, credentials.SecretAccessKey)
 
 		cancelFn()
-
 	},
 }
 


### PR DESCRIPTION
While configured to work with auth API, there is no sense in running setup or superuser command as the remote service is responsible of the setup.
The current commands setup a local auth database data which is not relevant while working with the API.