### PR TITLE
lakectl abuse link-same-object

### DIFF
--- a/cmd/lakectl/cmd/abuse.go
+++ b/cmd/lakectl/cmd/abuse.go
@@ -436,7 +436,7 @@ func init() {
 	abuseListCmd.Flags().Int("parallelism", defaultParallelism, "amount of lists to do in parallel")
 
 	abuseCmd.AddCommand(abuseLinkSameObjectCmd)
-	abuseLinkSameObjectCmd.Flags().Int("amount", defaultAmount, "amount of lists to do")
-	abuseLinkSameObjectCmd.Flags().Int("parallelism", defaultParallelism, "amount of link objects to do in parallel")
+	abuseLinkSameObjectCmd.Flags().Int("amount", defaultAmount, "amount of link object to do")
+	abuseLinkSameObjectCmd.Flags().Int("parallelism", defaultParallelism, "amount of link object to do in parallel")
 	abuseLinkSameObjectCmd.Flags().String("key", "abuse-read-key", "key used for the test")
 }

--- a/cmd/lakectl/cmd/abuse.go
+++ b/cmd/lakectl/cmd/abuse.go
@@ -437,6 +437,6 @@ func init() {
 
 	abuseCmd.AddCommand(abuseLinkSameObjectCmd)
 	abuseLinkSameObjectCmd.Flags().Int("amount", defaultAmount, "amount of lists to do")
-	abuseLinkSameObjectCmd.Flags().Int("parallelism", defaultParallelism, "amount of lists to do in parallel")
+	abuseLinkSameObjectCmd.Flags().Int("parallelism", defaultParallelism, "amount of link objects to do in parallel")
 	abuseLinkSameObjectCmd.Flags().String("key", "abuse-read-key", "key used for the test")
 }

--- a/cmd/lakectl/cmd/abuse.go
+++ b/cmd/lakectl/cmd/abuse.go
@@ -108,9 +108,9 @@ var abuseLinkSameObjectCmd = &cobra.Command{
 		key := MustString(cmd.Flags().GetString("key"))
 
 		Fmt("Source ref: %s\n", u.String())
-		Fmt("Key: %s\n", key)
+		Fmt("Object key: %s\n", key)
 
-		generator := stress.NewGenerator("read", parallelism, stress.WithSignalHandlersFor(os.Interrupt, syscall.SIGTERM))
+		generator := stress.NewGenerator("get-and-link", parallelism, stress.WithSignalHandlersFor(os.Interrupt, syscall.SIGTERM))
 
 		// setup generator to use the key
 		generator.Setup(func(add stress.GeneratorAddFn) {
@@ -438,5 +438,5 @@ func init() {
 	abuseCmd.AddCommand(abuseLinkSameObjectCmd)
 	abuseLinkSameObjectCmd.Flags().Int("amount", defaultAmount, "amount of link object to do")
 	abuseLinkSameObjectCmd.Flags().Int("parallelism", defaultParallelism, "amount of link object to do in parallel")
-	abuseLinkSameObjectCmd.Flags().String("key", "abuse-read-key", "key used for the test")
+	abuseLinkSameObjectCmd.Flags().String("key", "linked-object", "key used for the test")
 }

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -155,6 +155,26 @@ lakectl abuse help [command] [flags]
 
 
 
+### lakectl abuse link-same-object
+
+Link the same object in parallel.
+
+```
+lakectl abuse link-same-object <source ref uri> [flags]
+```
+
+#### Options
+{:.no_toc}
+
+```
+      --amount int        amount of lists to do (default 1000000)
+  -h, --help              help for link-same-object
+      --key string        key used for the test (default "abuse-read-key")
+      --parallelism int   amount of lists to do in parallel (default 100)
+```
+
+
+
 ### lakectl abuse list
 
 List from the source ref
@@ -211,26 +231,6 @@ lakectl abuse random-write <source branch uri> [flags]
   -h, --help              help for random-write
       --parallelism int   amount of writes to do in parallel (default 100)
       --prefix string     prefix to create paths under (default "abuse/")
-```
-
-
-
-### lakectl abuse read-key
-
-Read the same key from a file and generate random reads from the source ref for those keys.
-
-```
-lakectl abuse read-key <source ref uri> [flags]
-```
-
-#### Options
-{:.no_toc}
-
-```
-      --amount int        amount of lists to do (default 1000000)
-  -h, --help              help for read-key
-      --key string        key used for the test (default "abuse-read-key")
-      --parallelism int   amount of lists to do in parallel (default 100)
 ```
 
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -215,6 +215,26 @@ lakectl abuse random-write <source branch uri> [flags]
 
 
 
+### lakectl abuse read-key
+
+Read the same key from a file and generate random reads from the source ref for those keys.
+
+```
+lakectl abuse read-key <source ref uri> [flags]
+```
+
+#### Options
+{:.no_toc}
+
+```
+      --amount int        amount of lists to do (default 1000000)
+  -h, --help              help for read-key
+      --key string        key used for the test (default "abuse-read-key")
+      --parallelism int   amount of lists to do in parallel (default 100)
+```
+
+
+
 ### lakectl actions
 
 Manage Actions commands

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -167,10 +167,10 @@ lakectl abuse link-same-object <source ref uri> [flags]
 {:.no_toc}
 
 ```
-      --amount int        amount of lists to do (default 1000000)
+      --amount int        amount of link object to do (default 1000000)
   -h, --help              help for link-same-object
       --key string        key used for the test (default "abuse-read-key")
-      --parallelism int   amount of lists to do in parallel (default 100)
+      --parallelism int   amount of link object to do in parallel (default 100)
 ```
 
 

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -169,7 +169,7 @@ lakectl abuse link-same-object <source ref uri> [flags]
 ```
       --amount int        amount of link object to do (default 1000000)
   -h, --help              help for link-same-object
-      --key string        key used for the test (default "abuse-read-key")
+      --key string        key used for the test (default "linked-object")
       --parallelism int   amount of link object to do in parallel (default 100)
 ```
 

--- a/pkg/api/helpers/errors.go
+++ b/pkg/api/helpers/errors.go
@@ -102,6 +102,9 @@ func (e UserVisibleAPIError) Unwrap() error {
 // unsuccessful HTTPResponse field and uses its message, along with a Body
 // that it assumes is an api.Error.
 func ResponseAsError(response interface{}) error {
+	if response == nil {
+		return nil
+	}
 	if httpResponse, ok := response.(*http.Response); ok {
 		return HTTPResponseAsError(httpResponse)
 	}


### PR DESCRIPTION
Abuse command that will get a link to stage and link object in parallel.
The command was created to capture the case of parallel write to the same key.
In our pg staging implementation while using serializable transaction this cased failure when the number of retries reached the current max.

Close #3854