### PR TITLE
Release Spark metadata client

### DIFF
--- a/clients/spark/CHANGELOG.md
+++ b/clients/spark/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.1 - 2022-08-18
+Bug fixes:
+- [GC] Added configuration flag of lakeFS client timeout to spark-submit command (#3905)
+
 ## v0.2.0 - 2022-08-01
 What's new:
 - Garbage Collection on Azure (#3733, #3654)

--- a/clients/spark/build.sbt
+++ b/clients/spark/build.sbt
@@ -2,7 +2,7 @@ import build.BuildType
 
 lazy val baseName = "lakefs-spark"
 
-lazy val projectVersion = "0.2.0"
+lazy val projectVersion = "0.2.1"
 ThisBuild / isSnapshot := false
 
 // Spark versions 2.4.7 and 3.0.1 use different Scala versions.  Changing this is a deep


### PR DESCRIPTION
close #3924
Updated release notes for version 0.2.1, bump the version in build file. 
