### PR TITLE
Improve commit log performance

### DIFF
--- a/esti/golden/lakectl_log_404.golden
+++ b/esti/golden/lakectl_log_404.golden
@@ -1,2 +1,2 @@
-branch ref: not found
+repository not found
 404 Not Found

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -70,56 +70,48 @@ func onBlock(deps *dependencies, path string) string {
 	return fmt.Sprintf("%s://%s", deps.blocks.BlockstoreType(), path)
 }
 
-var tests = map[string]func(*testing.T, bool){
-	"ListRepositoriesHandler":          testController_ListRepositoriesHandler,
-	"GetRepoHandler":                   testController_GetRepoHandler,
-	"CommitsGetBranchCommitLogHandler": testController_CommitsGetBranchCommitLogHandler,
-	"CommitsGetBranchCommitLogByPath":  testController_CommitsGetBranchCommitLogByPath,
-	"GetCommitHandler":                 testController_GetCommitHandler,
-	"CommitHandler":                    testController_CommitHandler,
-	"CreateRepositoryHandler":          testController_CreateRepositoryHandler,
-	"DeleteRepositoryHandler":          testController_DeleteRepositoryHandler,
-	"ListBranchesHandler":              testController_ListBranchesHandler,
-	"ListTagsHandler":                  testController_ListTagsHandler,
-	"GetBranchHandler":                 testController_GetBranchHandler,
-	"BranchesDiffBranchHandler":        testController_BranchesDiffBranchHandler,
-	"CreateBranchHandler":              testController_CreateBranchHandler,
-	"UploadObject":                     testController_UploadObject,
-	"DeleteBranchHandler":              testController_DeleteBranchHandler,
-	"IngestRangeHandler":               testController_IngestRangeHandler,
-	"WriteMetaRangeHandler":            testController_WriteMetaRangeHandler,
-	"ObjectsStatObjectHandler":         testController_ObjectsStatObjectHandler,
-	"ObjectsListObjectsHandler":        testController_ObjectsListObjectsHandler,
-	"ObjectsGetObjectHandler":          testController_ObjectsGetObjectHandler,
-	"ObjectsUploadObjectHandler":       testController_ObjectsUploadObjectHandler,
-	"ObjectsStageObjectHandler":        testController_ObjectsStageObjectHandler,
-	"ObjectsDeleteObjectHandler":       testController_ObjectsDeleteObjectHandler,
-	"CreatePolicyHandler":              testController_CreatePolicyHandler,
-	"ConfigHandlers":                   testController_ConfigHandlers,
-	"SetupLakeFSHandler":               testController_SetupLakeFSHandler,
-	"ListRepositoryRuns":               testController_ListRepositoryRuns,
-	"MergeDiffWithParent":              testController_MergeDiffWithParent,
-	"MergeIntoExplicitBranch":          testController_MergeIntoExplicitBranch,
-	"CreateTag":                        testController_CreateTag,
-	"Revert":                           testController_Revert,
-	"RevertConflict":                   testController_RevertConflict,
-	"ExpandTemplate":                   testController_ExpandTemplate,
+func testControllerWithKV(t *testing.T, kvEnabled bool) {
+	testController_ListRepositoriesHandler(t, kvEnabled)
+	testController_GetRepoHandler(t, kvEnabled)
+	testController_CommitsGetBranchCommitLogHandler(t, kvEnabled)
+	testController_CommitsGetBranchCommitLogByPath(t, kvEnabled)
+	testController_GetCommitHandler(t, kvEnabled)
+	testController_CommitHandler(t, kvEnabled)
+	testController_CreateRepositoryHandler(t, kvEnabled)
+	testController_DeleteRepositoryHandler(t, kvEnabled)
+	testController_ListBranchesHandler(t, kvEnabled)
+	testController_ListTagsHandler(t, kvEnabled)
+	testController_GetBranchHandler(t, kvEnabled)
+	testController_BranchesDiffBranchHandler(t, kvEnabled)
+	testController_CreateBranchHandler(t, kvEnabled)
+	testController_UploadObject(t, kvEnabled)
+	testController_DeleteBranchHandler(t, kvEnabled)
+	testController_IngestRangeHandler(t, kvEnabled)
+	testController_WriteMetaRangeHandler(t, kvEnabled)
+	testController_ObjectsStatObjectHandler(t, kvEnabled)
+	testController_ObjectsListObjectsHandler(t, kvEnabled)
+	testController_ObjectsGetObjectHandler(t, kvEnabled)
+	testController_ObjectsUploadObjectHandler(t, kvEnabled)
+	testController_ObjectsStageObjectHandler(t, kvEnabled)
+	testController_ObjectsDeleteObjectHandler(t, kvEnabled)
+	testController_CreatePolicyHandler(t, kvEnabled)
+	testController_ConfigHandlers(t, kvEnabled)
+	testController_SetupLakeFSHandler(t, kvEnabled)
+	testController_ListRepositoryRuns(t, kvEnabled)
+	testController_MergeDiffWithParent(t, kvEnabled)
+	testController_MergeIntoExplicitBranch(t, kvEnabled)
+	testController_CreateTag(t, kvEnabled)
+	testController_Revert(t, kvEnabled)
+	testController_RevertConflict(t, kvEnabled)
+	testController_ExpandTemplate(t, kvEnabled)
 }
 
 func TestKVEnabled(t *testing.T) {
-	for name, test := range tests {
-		t.Run(name, runWithKVFlag(test, true))
-	}
+	testControllerWithKV(t, true)
 }
 
 func TestKVDisabled(t *testing.T) {
-	for name, test := range tests {
-		t.Run(name, runWithKVFlag(test, false))
-	}
-}
-
-func runWithKVFlag(f func(t *testing.T, kvEnabled bool), kvEnabled bool) func(t *testing.T) {
-	return func(t *testing.T) { f(t, kvEnabled) }
+	testControllerWithKV(t, false)
 }
 
 func testController_ListRepositoriesHandler(t *testing.T, kvEnabled bool) {
@@ -2037,7 +2029,7 @@ func testController_SetupLakeFSHandler(t *testing.T, kvEnabled bool) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			handler, deps := setupHandler(t, true)
+			handler, deps := setupHandler(t, kvEnabled)
 			server := setupServer(t, handler)
 			clt := setupClientByEndpoint(t, server.URL, "", "")
 

--- a/pkg/batch/executor.go
+++ b/pkg/batch/executor.go
@@ -29,14 +29,38 @@ func (b BatchFn) Execute() (interface{}, error) {
 type DelayFn func(dur time.Duration)
 
 type Batcher interface {
-	BatchFor(key string, dur time.Duration, exec Executer) (interface{}, error)
+	BatchFor(ctx context.Context, key string, dur time.Duration, exec Executer) (interface{}, error)
 }
 
 type nonBatchingExecutor struct {
 }
 
-func (n *nonBatchingExecutor) BatchFor(_ string, _ time.Duration, exec Executer) (interface{}, error) {
+func (n *nonBatchingExecutor) BatchFor(_ context.Context, _ string, _ time.Duration, exec Executer) (interface{}, error) {
 	return exec.Execute()
+}
+
+// SkipBatchContextKey existence on a context will eliminate the request batching
+const SkipBatchContextKey = "skip_batch"
+
+// ConditionalExecutor will batch requests only if SkipBatchContextKey is not on the context
+// of the batch request.
+type ConditionalExecutor struct {
+	executor *Executor
+}
+
+func NewConditionalExecutor(logger logging.Logger) *ConditionalExecutor {
+	return &ConditionalExecutor{executor: NewExecutor(logger)}
+}
+
+func (c *ConditionalExecutor) Run(ctx context.Context) {
+	c.executor.Run(ctx)
+}
+
+func (c *ConditionalExecutor) BatchFor(ctx context.Context, key string, timeout time.Duration, exec Executer) (interface{}, error) {
+	if ctx.Value(SkipBatchContextKey) != nil {
+		return exec.Execute()
+	}
+	return c.executor.BatchFor(ctx, key, timeout, exec)
 }
 
 type response struct {
@@ -76,7 +100,7 @@ func NewExecutor(logger logging.Logger) *Executor {
 	}
 }
 
-func (e *Executor) BatchFor(key string, timeout time.Duration, exec Executer) (interface{}, error) {
+func (e *Executor) BatchFor(_ context.Context, key string, timeout time.Duration, exec Executer) (interface{}, error) {
 	cb := make(chan *response)
 	e.requests <- &request{
 		key:        key,

--- a/pkg/batch/executor.go
+++ b/pkg/batch/executor.go
@@ -32,15 +32,17 @@ type Batcher interface {
 	BatchFor(ctx context.Context, key string, dur time.Duration, exec Executer) (interface{}, error)
 }
 
-type nonBatchingExecutor struct {
-}
+type nonBatchingExecutor struct{}
+
+// contextKey used to keep values on context.Context
+type contextKey string
+
+// SkipBatchContextKey existence on a context will eliminate the request batching
+const SkipBatchContextKey contextKey = "skip_batch"
 
 func (n *nonBatchingExecutor) BatchFor(_ context.Context, _ string, _ time.Duration, exec Executer) (interface{}, error) {
 	return exec.Execute()
 }
-
-// SkipBatchContextKey existence on a context will eliminate the request batching
-const SkipBatchContextKey = "skip_batch"
 
 // ConditionalExecutor will batch requests only if SkipBatchContextKey is not on the context
 // of the batch request.

--- a/pkg/batch/executor_test.go
+++ b/pkg/batch/executor_test.go
@@ -94,7 +94,7 @@ func testReadAfterWrite(t *testing.T) {
 
 	// reader1 starts
 	go func() {
-		r1, _ := exec.BatchFor("k", time.Millisecond*50, batch.BatchFn(func() (interface{}, error) {
+		r1, _ := exec.BatchFor(context.Background(), "k", time.Millisecond*50, batch.BatchFn(func() (interface{}, error) {
 			version, _ := db.Get("v")
 			return version, nil
 		}))
@@ -118,7 +118,7 @@ func testReadAfterWrite(t *testing.T) {
 	go func() {
 		<-write1Done // ensure we start AFTER write1 has completed
 		te := trackableExecuter{batchTracker: read2Batched, execTracker: make(chan struct{})}
-		r2, _ := exec.BatchFor("k", 50*time.Millisecond, &te)
+		r2, _ := exec.BatchFor(context.Background(), "k", 50*time.Millisecond, &te)
 		r2v := r2.(string)
 		if r2v != "v1" {
 			t.Errorf("expected r2 to get v1, got %s instead", r2v)
@@ -157,7 +157,7 @@ func testBatchExpiration(t *testing.T) {
 
 	// reader1 starts
 	go func() {
-		r1, _ := exec.BatchFor("k", time.Millisecond*50, batch.BatchFn(func() (interface{}, error) {
+		r1, _ := exec.BatchFor(context.Background(), "k", time.Millisecond*50, batch.BatchFn(func() (interface{}, error) {
 			return "v1", nil
 		}))
 		if r1 != "v1" {
@@ -168,7 +168,7 @@ func testBatchExpiration(t *testing.T) {
 
 	go func() {
 		<-read1Done // ensure r2 starts after r1 has returned
-		r2, _ := exec.BatchFor("k", time.Millisecond*50, batch.BatchFn(func() (interface{}, error) {
+		r2, _ := exec.BatchFor(context.Background(), "k", time.Millisecond*50, batch.BatchFn(func() (interface{}, error) {
 			return "v2", nil
 		}))
 		if r2 != "v2" {
@@ -213,14 +213,14 @@ func testBatchByKey(t *testing.T) {
 
 	// reader1 starts
 	go func(te *trackableExecuter) {
-		_, _ = exec.BatchFor("k1", 50*time.Millisecond, te)
+		_, _ = exec.BatchFor(context.Background(), "k1", 50*time.Millisecond, te)
 		close(read1Done)
 	}(&te1)
 
 	// reader2 starts
 	go func(te *trackableExecuter) {
 		<-waitRead2 // ensure we start AFTER r1 started a new batch
-		_, err := exec.BatchFor("k2", 0, te)
+		_, err := exec.BatchFor(context.Background(), "k2", 0, te)
 		if err != nil {
 			t.Errorf("BatchFor error: %s", err)
 		}

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -10,10 +10,9 @@ import (
 	"io"
 	"strings"
 
-	"github.com/hnlq715/golang-lru/simplelru"
-
 	"github.com/cockroachdb/pebble"
 	"github.com/hashicorp/go-multierror"
+	"github.com/hnlq715/golang-lru/simplelru"
 	"github.com/treeverse/lakefs/pkg/batch"
 	"github.com/treeverse/lakefs/pkg/block"
 	"github.com/treeverse/lakefs/pkg/block/factory"
@@ -1311,7 +1310,8 @@ func listDiffHelper(it EntryDiffIterator, prefix, delimiter string, limit int, a
 }
 
 func (c *Catalog) Merge(ctx context.Context, repositoryID string, destinationBranch string, sourceRef string,
-	committer string, message string, metadata Metadata, strategy string) (string, error) {
+	committer string, message string, metadata Metadata, strategy string,
+) (string, error) {
 	destination := graveler.BranchID(destinationBranch)
 	source := graveler.Ref(sourceRef)
 	meta := graveler.Metadata(metadata)

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -10,6 +10,8 @@ import (
 	"io"
 	"strings"
 
+	"github.com/hnlq715/golang-lru/simplelru"
+
 	"github.com/cockroachdb/pebble"
 	"github.com/hashicorp/go-multierror"
 	"github.com/treeverse/lakefs/pkg/batch"
@@ -196,8 +198,9 @@ func New(ctx context.Context, cfg Config) (*Catalog, error) {
 	}
 	committedManager := committed.NewCommittedManager(sstableMetaRangeManager, sstableManager, committedParams)
 
-	executor := batch.NewExecutor(logging.Default())
-	go executor.Run(ctx)
+	// executor := batch.NewExecutor(logging.Default())
+	// go executor.Run(ctx)
+	executor := batch.NopExecutor()
 
 	var gStore Store
 	var stagingManager graveler.StagingManager
@@ -373,8 +376,7 @@ func (c *Catalog) ListRepositories(ctx context.Context, limit int, prefix, after
 	return repos, hasMore, nil
 }
 
-func (c *Catalog) GetStagingToken(ctx context.Context, repository string, branch string) (*string, error) {
-	repositoryID := graveler.RepositoryID(repository)
+func (c *Catalog) GetStagingToken(ctx context.Context, repositoryID string, branch string) (*string, error) {
 	branchID := graveler.BranchID(branch)
 	if err := validator.Validate([]validator.ValidateArg{
 		{Name: "repository", Value: repositoryID, Fn: graveler.ValidateRepositoryID},
@@ -382,7 +384,11 @@ func (c *Catalog) GetStagingToken(ctx context.Context, repository string, branch
 	}); err != nil {
 		return nil, err
 	}
-	token, err := c.Store.GetStagingToken(ctx, repositoryID, branchID)
+	repository, err := c.Store.GetRepository(ctx, graveler.RepositoryID(repositoryID))
+	if err != nil {
+		return nil, err
+	}
+	token, err := c.Store.GetStagingToken(ctx, repository, branchID)
 	if err != nil {
 		return nil, err
 	}
@@ -393,8 +399,7 @@ func (c *Catalog) GetStagingToken(ctx context.Context, repository string, branch
 	return &tokenString, nil
 }
 
-func (c *Catalog) CreateBranch(ctx context.Context, repository string, branch string, sourceBranch string) (*CommitLog, error) {
-	repositoryID := graveler.RepositoryID(repository)
+func (c *Catalog) CreateBranch(ctx context.Context, repositoryID string, branch string, sourceBranch string) (*CommitLog, error) {
 	branchID := graveler.BranchID(branch)
 	sourceRef := graveler.Ref(sourceBranch)
 	if err := validator.Validate([]validator.ValidateArg{
@@ -407,11 +412,15 @@ func (c *Catalog) CreateBranch(ctx context.Context, repository string, branch st
 		}
 		return nil, err
 	}
-	newBranch, err := c.Store.CreateBranch(ctx, repositoryID, branchID, sourceRef)
+	repository, err := c.Store.GetRepository(ctx, graveler.RepositoryID(repositoryID))
 	if err != nil {
 		return nil, err
 	}
-	commit, err := c.Store.GetCommit(ctx, repositoryID, newBranch.CommitID)
+	newBranch, err := c.Store.CreateBranch(ctx, repository, branchID, sourceRef)
+	if err != nil {
+		return nil, err
+	}
+	commit, err := c.Store.GetCommit(ctx, repository, newBranch.CommitID)
 	if err != nil {
 		return nil, err
 	}
@@ -427,8 +436,7 @@ func (c *Catalog) CreateBranch(ctx context.Context, repository string, branch st
 	return catalogCommitLog, nil
 }
 
-func (c *Catalog) DeleteBranch(ctx context.Context, repository string, branch string) error {
-	repositoryID := graveler.RepositoryID(repository)
+func (c *Catalog) DeleteBranch(ctx context.Context, repositoryID string, branch string) error {
 	branchID := graveler.BranchID(branch)
 	if err := validator.Validate([]validator.ValidateArg{
 		{Name: "repository", Value: repositoryID, Fn: graveler.ValidateRepositoryID},
@@ -436,27 +444,36 @@ func (c *Catalog) DeleteBranch(ctx context.Context, repository string, branch st
 	}); err != nil {
 		return err
 	}
-	return c.Store.DeleteBranch(ctx, repositoryID, branchID)
+	repository, err := c.Store.GetRepository(ctx, graveler.RepositoryID(repositoryID))
+	if err != nil {
+		return err
+	}
+	return c.Store.DeleteBranch(ctx, repository, branchID)
 }
 
-func (c *Catalog) ListBranches(ctx context.Context, repository string, prefix string, limit int, after string) ([]*Branch, bool, error) {
-	repositoryID := graveler.RepositoryID(repository)
-	afterBranch := graveler.BranchID(after)
-	prefixBranch := graveler.BranchID(prefix)
+func (c *Catalog) ListBranches(ctx context.Context, repositoryID string, prefix string, limit int, after string) ([]*Branch, bool, error) {
 	if err := validator.Validate([]validator.ValidateArg{
 		{Name: "repository", Value: repositoryID, Fn: graveler.ValidateRepositoryID},
 	}); err != nil {
 		return nil, false, err
 	}
+	repository, err := c.Store.GetRepository(ctx, graveler.RepositoryID(repositoryID))
+	if err != nil {
+		return nil, false, err
+	}
+
 	// normalize limit
 	if limit < 0 || limit > ListBranchesLimitMax {
 		limit = ListBranchesLimitMax
 	}
-	it, err := c.Store.ListBranches(ctx, repositoryID)
+	it, err := c.Store.ListBranches(ctx, repository)
 	if err != nil {
 		return nil, false, err
 	}
 	defer it.Close()
+
+	afterBranch := graveler.BranchID(after)
+	prefixBranch := graveler.BranchID(prefix)
 	if afterBranch < prefixBranch {
 		it.SeekGE(prefixBranch)
 	} else {
@@ -494,8 +511,7 @@ func (c *Catalog) ListBranches(ctx context.Context, repository string, prefix st
 	return branches, hasMore, nil
 }
 
-func (c *Catalog) BranchExists(ctx context.Context, repository string, branch string) (bool, error) {
-	repositoryID := graveler.RepositoryID(repository)
+func (c *Catalog) BranchExists(ctx context.Context, repositoryID string, branch string) (bool, error) {
 	branchID := graveler.BranchID(branch)
 	if err := validator.Validate([]validator.ValidateArg{
 		{Name: "repository", Value: repositoryID, Fn: graveler.ValidateRepositoryID},
@@ -503,7 +519,11 @@ func (c *Catalog) BranchExists(ctx context.Context, repository string, branch st
 	}); err != nil {
 		return false, err
 	}
-	_, err := c.Store.GetBranch(ctx, repositoryID, branchID)
+	repository, err := c.Store.GetRepository(ctx, graveler.RepositoryID(repositoryID))
+	if err != nil {
+		return false, err
+	}
+	_, err = c.Store.GetBranch(ctx, repository, branchID)
 	if errors.Is(err, graveler.ErrNotFound) {
 		return false, nil
 	}
@@ -513,8 +533,7 @@ func (c *Catalog) BranchExists(ctx context.Context, repository string, branch st
 	return true, nil
 }
 
-func (c *Catalog) GetBranchReference(ctx context.Context, repository string, branch string) (string, error) {
-	repositoryID := graveler.RepositoryID(repository)
+func (c *Catalog) GetBranchReference(ctx context.Context, repositoryID string, branch string) (string, error) {
 	branchID := graveler.BranchID(branch)
 	if err := validator.Validate([]validator.ValidateArg{
 		{Name: "repository", Value: repositoryID, Fn: graveler.ValidateRepositoryID},
@@ -522,15 +541,18 @@ func (c *Catalog) GetBranchReference(ctx context.Context, repository string, bra
 	}); err != nil {
 		return "", err
 	}
-	b, err := c.Store.GetBranch(ctx, repositoryID, branchID)
+	repository, err := c.Store.GetRepository(ctx, graveler.RepositoryID(repositoryID))
+	if err != nil {
+		return "", err
+	}
+	b, err := c.Store.GetBranch(ctx, repository, branchID)
 	if err != nil {
 		return "", err
 	}
 	return string(b.CommitID), nil
 }
 
-func (c *Catalog) ResetBranch(ctx context.Context, repository string, branch string) error {
-	repositoryID := graveler.RepositoryID(repository)
+func (c *Catalog) ResetBranch(ctx context.Context, repositoryID string, branch string) error {
 	branchID := graveler.BranchID(branch)
 	if err := validator.Validate([]validator.ValidateArg{
 		{Name: "repository", Value: repositoryID, Fn: graveler.ValidateRepositoryID},
@@ -538,11 +560,14 @@ func (c *Catalog) ResetBranch(ctx context.Context, repository string, branch str
 	}); err != nil {
 		return err
 	}
-	return c.Store.Reset(ctx, repositoryID, branchID)
+	repository, err := c.Store.GetRepository(ctx, graveler.RepositoryID(repositoryID))
+	if err != nil {
+		return err
+	}
+	return c.Store.Reset(ctx, repository, branchID)
 }
 
-func (c *Catalog) CreateTag(ctx context.Context, repository string, tagID string, ref string) (string, error) {
-	repositoryID := graveler.RepositoryID(repository)
+func (c *Catalog) CreateTag(ctx context.Context, repositoryID string, tagID string, ref string) (string, error) {
 	tag := graveler.TagID(tagID)
 	if err := validator.Validate([]validator.ValidateArg{
 		{Name: "repository", Value: repositoryID, Fn: graveler.ValidateRepositoryID},
@@ -550,19 +575,22 @@ func (c *Catalog) CreateTag(ctx context.Context, repository string, tagID string
 	}); err != nil {
 		return "", err
 	}
-	commitID, err := c.dereferenceCommitID(ctx, repositoryID, graveler.Ref(ref))
+	repository, err := c.Store.GetRepository(ctx, graveler.RepositoryID(repositoryID))
 	if err != nil {
 		return "", err
 	}
-	err = c.Store.CreateTag(ctx, repositoryID, tag, commitID)
+	commitID, err := c.dereferenceCommitID(ctx, repository, graveler.Ref(ref))
+	if err != nil {
+		return "", err
+	}
+	err = c.Store.CreateTag(ctx, repository, tag, commitID)
 	if err != nil {
 		return "", err
 	}
 	return commitID.String(), nil
 }
 
-func (c *Catalog) DeleteTag(ctx context.Context, repository string, tagID string) error {
-	repositoryID := graveler.RepositoryID(repository)
+func (c *Catalog) DeleteTag(ctx context.Context, repositoryID string, tagID string) error {
 	tag := graveler.TagID(tagID)
 	if err := validator.Validate([]validator.ValidateArg{
 		{Name: "name", Value: repositoryID, Fn: graveler.ValidateRepositoryID},
@@ -570,20 +598,27 @@ func (c *Catalog) DeleteTag(ctx context.Context, repository string, tagID string
 	}); err != nil {
 		return err
 	}
-	return c.Store.DeleteTag(ctx, repositoryID, tag)
+	repository, err := c.Store.GetRepository(ctx, graveler.RepositoryID(repositoryID))
+	if err != nil {
+		return err
+	}
+	return c.Store.DeleteTag(ctx, repository, tag)
 }
 
-func (c *Catalog) ListTags(ctx context.Context, repository string, prefix string, limit int, after string) ([]*Tag, bool, error) {
+func (c *Catalog) ListTags(ctx context.Context, repositoryID string, prefix string, limit int, after string) ([]*Tag, bool, error) {
 	if limit < 0 || limit > ListTagsLimitMax {
 		limit = ListTagsLimitMax
 	}
-	repositoryID := graveler.RepositoryID(repository)
 	if err := validator.Validate([]validator.ValidateArg{
 		{Name: "name", Value: repositoryID, Fn: graveler.ValidateRepositoryID},
 	}); err != nil {
 		return nil, false, err
 	}
-	it, err := c.Store.ListTags(ctx, repositoryID)
+	repository, err := c.Store.GetRepository(ctx, graveler.RepositoryID(repositoryID))
+	if err != nil {
+		return nil, false, err
+	}
+	it, err := c.Store.ListTags(ctx, repository)
 	if err != nil {
 		return nil, false, err
 	}
@@ -625,8 +660,7 @@ func (c *Catalog) ListTags(ctx context.Context, repository string, prefix string
 	return tags, hasMore, nil
 }
 
-func (c *Catalog) GetTag(ctx context.Context, repository string, tagID string) (string, error) {
-	repositoryID := graveler.RepositoryID(repository)
+func (c *Catalog) GetTag(ctx context.Context, repositoryID string, tagID string) (string, error) {
 	tag := graveler.TagID(tagID)
 	if err := validator.Validate([]validator.ValidateArg{
 		{Name: "name", Value: repositoryID, Fn: graveler.ValidateRepositoryID},
@@ -634,7 +668,11 @@ func (c *Catalog) GetTag(ctx context.Context, repository string, tagID string) (
 	}); err != nil {
 		return "", err
 	}
-	commit, err := c.Store.GetTag(ctx, repositoryID, tag)
+	repository, err := c.Store.GetRepository(ctx, graveler.RepositoryID(repositoryID))
+	if err != nil {
+		return "", err
+	}
+	commit, err := c.Store.GetTag(ctx, repository, tag)
 	if err != nil {
 		return "", err
 	}
@@ -643,8 +681,7 @@ func (c *Catalog) GetTag(ctx context.Context, repository string, tagID string) (
 
 // GetEntry returns the current entry for path in repository branch reference.  Returns
 // the entry with ExpiredError if it has expired from underlying storage.
-func (c *Catalog) GetEntry(ctx context.Context, repository string, reference string, path string, _ GetEntryParams) (*DBEntry, error) {
-	repositoryID := graveler.RepositoryID(repository)
+func (c *Catalog) GetEntry(ctx context.Context, repositoryID string, reference string, path string, _ GetEntryParams) (*DBEntry, error) {
 	refToGet := graveler.Ref(reference)
 	if err := validator.Validate([]validator.ValidateArg{
 		{Name: "repository", Value: repositoryID, Fn: graveler.ValidateRepositoryID},
@@ -653,7 +690,11 @@ func (c *Catalog) GetEntry(ctx context.Context, repository string, reference str
 	}); err != nil {
 		return nil, err
 	}
-	val, err := c.Store.Get(ctx, repositoryID, refToGet, graveler.Key(path))
+	repository, err := c.Store.GetRepository(ctx, graveler.RepositoryID(repositoryID))
+	if err != nil {
+		return nil, err
+	}
+	val, err := c.Store.Get(ctx, repository, refToGet, graveler.Key(path))
 	if err != nil {
 		return nil, err
 	}
@@ -704,8 +745,7 @@ func addressTypeToCatalog(t Entry_AddressType) AddressType {
 	}
 }
 
-func (c *Catalog) CreateEntry(ctx context.Context, repository string, branch string, entry DBEntry, writeConditions ...graveler.WriteConditionOption) error {
-	repositoryID := graveler.RepositoryID(repository)
+func (c *Catalog) CreateEntry(ctx context.Context, repositoryID string, branch string, entry DBEntry, writeConditions ...graveler.WriteConditionOption) error {
 	branchID := graveler.BranchID(branch)
 	ent := newEntryFromCatalogEntry(entry)
 	path := Path(entry.Path)
@@ -721,11 +761,14 @@ func (c *Catalog) CreateEntry(ctx context.Context, repository string, branch str
 	if err != nil {
 		return err
 	}
-	return c.Store.Set(ctx, repositoryID, branchID, key, *value, writeConditions...)
+	repository, err := c.Store.GetRepository(ctx, graveler.RepositoryID(repositoryID))
+	if err != nil {
+		return err
+	}
+	return c.Store.Set(ctx, repository, branchID, key, *value, writeConditions...)
 }
 
-func (c *Catalog) DeleteEntry(ctx context.Context, repository string, branch string, path string) error {
-	repositoryID := graveler.RepositoryID(repository)
+func (c *Catalog) DeleteEntry(ctx context.Context, repositoryID string, branch string, path string) error {
 	branchID := graveler.BranchID(branch)
 	p := Path(path)
 	if err := validator.Validate([]validator.ValidateArg{
@@ -735,11 +778,15 @@ func (c *Catalog) DeleteEntry(ctx context.Context, repository string, branch str
 	}); err != nil {
 		return err
 	}
+	repository, err := c.Store.GetRepository(ctx, graveler.RepositoryID(repositoryID))
+	if err != nil {
+		return err
+	}
 	key := graveler.Key(p)
-	return c.Store.Delete(ctx, repositoryID, branchID, key)
+	return c.Store.Delete(ctx, repository, branchID, key)
 }
 
-func (c *Catalog) ListEntries(ctx context.Context, repository string, reference string, prefix string, after string, delimiter string, limit int) ([]*DBEntry, bool, error) {
+func (c *Catalog) ListEntries(ctx context.Context, repositoryID string, reference string, prefix string, after string, delimiter string, limit int) ([]*DBEntry, bool, error) {
 	// normalize limit
 	if limit < 0 || limit > ListEntriesLimitMax {
 		limit = ListEntriesLimitMax
@@ -747,7 +794,6 @@ func (c *Catalog) ListEntries(ctx context.Context, repository string, reference 
 	prefixPath := Path(prefix)
 	afterPath := Path(after)
 	delimiterPath := Path(delimiter)
-	repositoryID := graveler.RepositoryID(repository)
 	refToList := graveler.Ref(reference)
 	if err := validator.Validate([]validator.ValidateArg{
 		{Name: "repository", Value: repositoryID, Fn: graveler.ValidateRepositoryID},
@@ -757,7 +803,11 @@ func (c *Catalog) ListEntries(ctx context.Context, repository string, reference 
 	}); err != nil {
 		return nil, false, err
 	}
-	iter, err := c.Store.List(ctx, repositoryID, refToList)
+	repository, err := c.Store.GetRepository(ctx, graveler.RepositoryID(repositoryID))
+	if err != nil {
+		return nil, false, err
+	}
+	iter, err := c.Store.List(ctx, repository, refToList)
 	if err != nil {
 		return nil, false, err
 	}
@@ -792,8 +842,7 @@ func (c *Catalog) ListEntries(ctx context.Context, repository string, reference 
 	return entries, hasMore, nil
 }
 
-func (c *Catalog) ResetEntry(ctx context.Context, repository string, branch string, path string) error {
-	repositoryID := graveler.RepositoryID(repository)
+func (c *Catalog) ResetEntry(ctx context.Context, repositoryID string, branch string, path string) error {
 	branchID := graveler.BranchID(branch)
 	entryPath := Path(path)
 	if err := validator.Validate([]validator.ValidateArg{
@@ -803,12 +852,15 @@ func (c *Catalog) ResetEntry(ctx context.Context, repository string, branch stri
 	}); err != nil {
 		return err
 	}
+	repository, err := c.Store.GetRepository(ctx, graveler.RepositoryID(repositoryID))
+	if err != nil {
+		return err
+	}
 	key := graveler.Key(entryPath)
-	return c.Store.ResetKey(ctx, repositoryID, branchID, key)
+	return c.Store.ResetKey(ctx, repository, branchID, key)
 }
 
-func (c *Catalog) ResetEntries(ctx context.Context, repository string, branch string, prefix string) error {
-	repositoryID := graveler.RepositoryID(repository)
+func (c *Catalog) ResetEntries(ctx context.Context, repositoryID string, branch string, prefix string) error {
 	branchID := graveler.BranchID(branch)
 	prefixPath := Path(prefix)
 	if err := validator.Validate([]validator.ValidateArg{
@@ -817,17 +869,25 @@ func (c *Catalog) ResetEntries(ctx context.Context, repository string, branch st
 	}); err != nil {
 		return err
 	}
+	repository, err := c.Store.GetRepository(ctx, graveler.RepositoryID(repositoryID))
+	if err != nil {
+		return err
+	}
 	keyPrefix := graveler.Key(prefixPath)
-	return c.Store.ResetPrefix(ctx, repositoryID, branchID, keyPrefix)
+	return c.Store.ResetPrefix(ctx, repository, branchID, keyPrefix)
 }
 
-func (c *Catalog) Commit(ctx context.Context, repository, branch, message, committer string, metadata Metadata, date *int64, sourceMetarange *string) (*CommitLog, error) {
-	repositoryID := graveler.RepositoryID(repository)
+func (c *Catalog) Commit(ctx context.Context, repositoryID, branch, message, committer string, metadata Metadata, date *int64, sourceMetarange *string) (*CommitLog, error) {
 	branchID := graveler.BranchID(branch)
 	if err := validator.Validate([]validator.ValidateArg{
 		{Name: "repository", Value: repositoryID, Fn: graveler.ValidateRepositoryID},
 		{Name: "branch", Value: branchID, Fn: graveler.ValidateBranchID},
 	}); err != nil {
+		return nil, err
+	}
+
+	repository, err := c.Store.GetRepository(ctx, graveler.RepositoryID(repositoryID))
+	if err != nil {
 		return nil, err
 	}
 
@@ -841,8 +901,7 @@ func (c *Catalog) Commit(ctx context.Context, repository, branch, message, commi
 		x := graveler.MetaRangeID(*sourceMetarange)
 		p.SourceMetaRange = &x
 	}
-
-	commitID, err := c.Store.Commit(ctx, repositoryID, branchID, p)
+	commitID, err := c.Store.Commit(ctx, repository, branchID, p)
 	if err != nil {
 		return nil, err
 	}
@@ -853,7 +912,7 @@ func (c *Catalog) Commit(ctx context.Context, repository, branch, message, commi
 		Metadata:  metadata,
 	}
 	// in order to return commit log we need the commit creation time and parents
-	commit, err := c.Store.GetCommit(ctx, repositoryID, commitID)
+	commit, err := c.Store.GetCommit(ctx, repository, commitID)
 	if err != nil {
 		return catalogCommitLog, graveler.ErrCommitNotFound
 	}
@@ -864,18 +923,21 @@ func (c *Catalog) Commit(ctx context.Context, repository, branch, message, commi
 	return catalogCommitLog, nil
 }
 
-func (c *Catalog) GetCommit(ctx context.Context, repository string, reference string) (*CommitLog, error) {
-	repositoryID := graveler.RepositoryID(repository)
+func (c *Catalog) GetCommit(ctx context.Context, repositoryID string, reference string) (*CommitLog, error) {
 	if err := validator.Validate([]validator.ValidateArg{
 		{Name: "repository", Value: repositoryID, Fn: graveler.ValidateRepositoryID},
 	}); err != nil {
 		return nil, err
 	}
-	commitID, err := c.dereferenceCommitID(ctx, repositoryID, graveler.Ref(reference))
+	repository, err := c.Store.GetRepository(ctx, graveler.RepositoryID(repositoryID))
 	if err != nil {
 		return nil, err
 	}
-	commit, err := c.Store.GetCommit(ctx, repositoryID, commitID)
+	commitID, err := c.dereferenceCommitID(ctx, repository, graveler.Ref(reference))
+	if err != nil {
+		return nil, err
+	}
+	commit, err := c.Store.GetCommit(ctx, repository, commitID)
 	if err != nil {
 		return nil, err
 	}
@@ -893,8 +955,7 @@ func (c *Catalog) GetCommit(ctx context.Context, repository string, reference st
 	return catalogCommitLog, nil
 }
 
-func (c *Catalog) ListCommits(ctx context.Context, repository string, branch string, params LogParams) ([]*CommitLog, bool, error) {
-	repositoryID := graveler.RepositoryID(repository)
+func (c *Catalog) ListCommits(ctx context.Context, repositoryID string, branch string, params LogParams) ([]*CommitLog, bool, error) {
 	branchRef := graveler.BranchID(branch)
 	if err := validator.Validate([]validator.ValidateArg{
 		{Name: "repository", Value: repositoryID, Fn: graveler.ValidateRepositoryID},
@@ -902,18 +963,23 @@ func (c *Catalog) ListCommits(ctx context.Context, repository string, branch str
 	}); err != nil {
 		return nil, false, err
 	}
-	commitID, err := c.dereferenceCommitID(ctx, repositoryID, graveler.Ref(branchRef))
+	repository, err := c.Store.GetRepository(ctx, graveler.RepositoryID(repositoryID))
+	if err != nil {
+		return nil, false, err
+	}
+
+	commitID, err := c.dereferenceCommitID(ctx, repository, graveler.Ref(branchRef))
 	if err != nil {
 		return nil, false, fmt.Errorf("branch ref: %w", err)
 	}
-	it, err := c.Store.Log(ctx, repositoryID, commitID)
+	it, err := c.Store.Log(ctx, repository, commitID)
 	if err != nil {
 		return nil, false, err
 	}
 	defer it.Close()
 	// skip until 'fromReference' if needed
 	if params.FromReference != "" {
-		fromCommitID, err := c.dereferenceCommitID(ctx, repositoryID, graveler.Ref(params.FromReference))
+		fromCommitID, err := c.dereferenceCommitID(ctx, repository, graveler.Ref(params.FromReference))
 		if err != nil {
 			return nil, false, fmt.Errorf("from ref: %w", err)
 		}
@@ -928,10 +994,14 @@ func (c *Catalog) ListCommits(ctx context.Context, repository string, branch str
 	}
 
 	// collect commits
-	var (
-		commits     []*CommitLog
-		commitCache = make(map[string]*graveler.Value)
-	)
+	var commits []*CommitLog
+
+	// commit/key to value cache - helps when fetching the same commit/key while processing parent commits
+	const commitLogCacheSize = 1024
+	commitCache, err := simplelru.NewLRU(commitLogCacheSize, nil)
+	if err != nil {
+		return nil, false, err
+	}
 
 	for it.Next() {
 		v := it.Value()
@@ -942,7 +1012,7 @@ func (c *Catalog) ListCommits(ctx context.Context, repository string, branch str
 				// skip merge commits
 				continue
 			}
-			pathInCommit, err := c.checkPathListInCommit(ctx, repositoryID, v, params.PathList, commitCache)
+			pathInCommit, err := c.checkPathListInCommit(ctx, repository, v, params.PathList, commitCache)
 			if err != nil {
 				return nil, false, err
 			}
@@ -983,9 +1053,9 @@ func (c *Catalog) ListCommits(ctx context.Context, repository string, branch str
 // checkPathListInCommit checks whether the given commit contains changes to a list of paths.
 // it searches the path in the diff between the commit, and it's parent, but do so only to commits
 // that have single parent (not merge commits)
-func (c *Catalog) checkPathListInCommit(ctx context.Context, repositoryID graveler.RepositoryID, commit *graveler.CommitRecord, pathList []PathRecord, commitCache map[string]*graveler.Value) (bool, error) {
-	left := graveler.Ref(commit.Parents[0])
-	right := graveler.Ref(commit.CommitID)
+func (c *Catalog) checkPathListInCommit(ctx context.Context, repository *graveler.RepositoryRecord, commit *graveler.CommitRecord, pathList []PathRecord, commitCache *simplelru.LRU) (bool, error) {
+	left := commit.Parents[0]
+	right := commit.CommitID
 
 	// diff iterator - open lazy, just in case we have a prefix to match
 	var diffIter graveler.DiffIterator
@@ -1002,7 +1072,7 @@ func (c *Catalog) checkPathListInCommit(ctx context.Context, repositoryID gravel
 			// get diff iterator if needed for prefix lookup
 			if diffIter == nil {
 				var err error
-				diffIter, err = c.Store.Diff(ctx, repositoryID, left, right)
+				diffIter, err = c.Store.Diff(ctx, repository, graveler.Ref(left), graveler.Ref(right))
 				if err != nil {
 					return false, err
 				}
@@ -1018,11 +1088,11 @@ func (c *Catalog) checkPathListInCommit(ctx context.Context, repositoryID gravel
 				return false, err
 			}
 		} else {
-			leftObject, err := storeGetCache(ctx, c.Store, repositoryID, left, key, commitCache)
+			leftObject, err := storeGetCache(ctx, c.Store, repository, left, key, commitCache)
 			if err != nil {
 				return false, err
 			}
-			rightObject, err := storeGetCache(ctx, c.Store, repositoryID, right, key, commitCache)
+			rightObject, err := storeGetCache(ctx, c.Store, repository, right, key, commitCache)
 			if err != nil {
 				return false, err
 			}
@@ -1038,21 +1108,22 @@ func (c *Catalog) checkPathListInCommit(ctx context.Context, repositoryID gravel
 	return false, nil
 }
 
-func storeGetCache(ctx context.Context, store graveler.KeyValueStore, repositoryID graveler.RepositoryID, ref graveler.Ref, key graveler.Key, commitCache map[string]*graveler.Value) (*graveler.Value, error) {
-	cacheKey := fmt.Sprintf("%s/%s", ref, key)
-	if o, found := commitCache[cacheKey]; found {
-		return o, nil
+// storeGetCache helper to calls Get and cache the return info 'commitCache'. This method is helpful in case of calling Get
+// on a large set of commits with the same object, and we can return the cached data we returned so far
+func storeGetCache(ctx context.Context, store graveler.KeyValueStore, repository *graveler.RepositoryRecord, commitID graveler.CommitID, key graveler.Key, commitCache *simplelru.LRU) (*graveler.Value, error) {
+	cacheKey := fmt.Sprintf("%s/%s", commitID, key)
+	if o, found := commitCache.Get(cacheKey); found {
+		return o.(*graveler.Value), nil
 	}
-	o, err := store.Get(ctx, repositoryID, ref, key)
+	o, err := store.GetByCommitID(ctx, repository, commitID, key)
 	if err != nil && !errors.Is(err, graveler.ErrNotFound) {
 		return nil, err
 	}
-	commitCache[cacheKey] = o
+	_ = commitCache.Add(cacheKey, o)
 	return o, nil
 }
 
-func (c *Catalog) Revert(ctx context.Context, repository string, branch string, params RevertParams) error {
-	repositoryID := graveler.RepositoryID(repository)
+func (c *Catalog) Revert(ctx context.Context, repositoryID string, branch string, params RevertParams) error {
 	branchID := graveler.BranchID(branch)
 	reference := graveler.Ref(params.Reference)
 	commitParams := graveler.CommitParams{
@@ -1070,12 +1141,15 @@ func (c *Catalog) Revert(ctx context.Context, repository string, branch string, 
 	}); err != nil {
 		return err
 	}
-	_, err := c.Store.Revert(ctx, repositoryID, branchID, reference, parentNumber, commitParams)
+	repository, err := c.Store.GetRepository(ctx, graveler.RepositoryID(repositoryID))
+	if err != nil {
+		return err
+	}
+	_, err = c.Store.Revert(ctx, repository, branchID, reference, parentNumber, commitParams)
 	return err
 }
 
-func (c *Catalog) Diff(ctx context.Context, repository string, leftReference string, rightReference string, params DiffParams) (Differences, bool, error) {
-	repositoryID := graveler.RepositoryID(repository)
+func (c *Catalog) Diff(ctx context.Context, repositoryID string, leftReference string, rightReference string, params DiffParams) (Differences, bool, error) {
 	left := graveler.Ref(leftReference)
 	right := graveler.Ref(rightReference)
 	if err := validator.Validate([]validator.ValidateArg{
@@ -1085,7 +1159,12 @@ func (c *Catalog) Diff(ctx context.Context, repository string, leftReference str
 	}); err != nil {
 		return nil, false, err
 	}
-	iter, err := c.Store.Diff(ctx, repositoryID, left, right)
+	repository, err := c.Store.GetRepository(ctx, graveler.RepositoryID(repositoryID))
+	if err != nil {
+		return nil, false, err
+	}
+
+	iter, err := c.Store.Diff(ctx, repository, left, right)
 	if err != nil {
 		return nil, false, err
 	}
@@ -1094,8 +1173,7 @@ func (c *Catalog) Diff(ctx context.Context, repository string, leftReference str
 	return listDiffHelper(it, params.Prefix, params.Delimiter, params.Limit, params.After)
 }
 
-func (c *Catalog) Compare(ctx context.Context, repository, leftReference string, rightReference string, params DiffParams) (Differences, bool, error) {
-	repositoryID := graveler.RepositoryID(repository)
+func (c *Catalog) Compare(ctx context.Context, repositoryID, leftReference string, rightReference string, params DiffParams) (Differences, bool, error) {
 	left := graveler.Ref(leftReference)
 	right := graveler.Ref(rightReference)
 	if err := validator.Validate([]validator.ValidateArg{
@@ -1105,7 +1183,12 @@ func (c *Catalog) Compare(ctx context.Context, repository, leftReference string,
 	}); err != nil {
 		return nil, false, err
 	}
-	iter, err := c.Store.Compare(ctx, repositoryID, left, right)
+	repository, err := c.Store.GetRepository(ctx, graveler.RepositoryID(repositoryID))
+	if err != nil {
+		return nil, false, err
+	}
+
+	iter, err := c.Store.Compare(ctx, repository, left, right)
 	if err != nil {
 		return nil, false, err
 	}
@@ -1114,8 +1197,7 @@ func (c *Catalog) Compare(ctx context.Context, repository, leftReference string,
 	return listDiffHelper(it, params.Prefix, params.Delimiter, params.Limit, params.After)
 }
 
-func (c *Catalog) DiffUncommitted(ctx context.Context, repository, branch, prefix, delimiter string, limit int, after string) (Differences, bool, error) {
-	repositoryID := graveler.RepositoryID(repository)
+func (c *Catalog) DiffUncommitted(ctx context.Context, repositoryID, branch, prefix, delimiter string, limit int, after string) (Differences, bool, error) {
 	branchID := graveler.BranchID(branch)
 	if err := validator.Validate([]validator.ValidateArg{
 		{Name: "repository", Value: repositoryID, Fn: graveler.ValidateRepositoryID},
@@ -1123,7 +1205,12 @@ func (c *Catalog) DiffUncommitted(ctx context.Context, repository, branch, prefi
 	}); err != nil {
 		return nil, false, err
 	}
-	iter, err := c.Store.DiffUncommitted(ctx, repositoryID, branchID)
+	repository, err := c.Store.GetRepository(ctx, graveler.RepositoryID(repositoryID))
+	if err != nil {
+		return nil, false, err
+	}
+
+	iter, err := c.Store.DiffUncommitted(ctx, repository, branchID)
 	if err != nil {
 		return nil, false, err
 	}
@@ -1221,8 +1308,8 @@ func listDiffHelper(it EntryDiffIterator, prefix, delimiter string, limit int, a
 	return diffs, hasMore, nil
 }
 
-func (c *Catalog) Merge(ctx context.Context, repository string, destinationBranch string, sourceRef string, committer string, message string, metadata Metadata, strategy string) (string, error) {
-	repositoryID := graveler.RepositoryID(repository)
+func (c *Catalog) Merge(ctx context.Context, repositoryID string, destinationBranch string, sourceRef string,
+	committer string, message string, metadata Metadata, strategy string) (string, error) {
 	destination := graveler.BranchID(destinationBranch)
 	source := graveler.Ref(sourceRef)
 	meta := graveler.Metadata(metadata)
@@ -1244,7 +1331,12 @@ func (c *Catalog) Merge(ctx context.Context, repository string, destinationBranc
 	}); err != nil {
 		return "", err
 	}
-	commitID, err := c.Store.Merge(ctx, repositoryID, destination, source, commitParams, strategy)
+	repository, err := c.Store.GetRepository(ctx, graveler.RepositoryID(repositoryID))
+	if err != nil {
+		return "", err
+	}
+
+	commitID, err := c.Store.Merge(ctx, repository, destination, source, commitParams, strategy)
 	if errors.Is(err, graveler.ErrConflictFound) {
 		// for compatibility with old Catalog
 		return "", err
@@ -1256,7 +1348,12 @@ func (c *Catalog) Merge(ctx context.Context, repository string, destinationBranc
 }
 
 func (c *Catalog) DumpCommits(ctx context.Context, repositoryID string) (string, error) {
-	metaRangeID, err := c.Store.DumpCommits(ctx, graveler.RepositoryID(repositoryID))
+	repository, err := c.Store.GetRepository(ctx, graveler.RepositoryID(repositoryID))
+	if err != nil {
+		return "", err
+	}
+
+	metaRangeID, err := c.Store.DumpCommits(ctx, repository)
 	if err != nil {
 		return "", err
 	}
@@ -1264,7 +1361,12 @@ func (c *Catalog) DumpCommits(ctx context.Context, repositoryID string) (string,
 }
 
 func (c *Catalog) DumpBranches(ctx context.Context, repositoryID string) (string, error) {
-	metaRangeID, err := c.Store.DumpBranches(ctx, graveler.RepositoryID(repositoryID))
+	repository, err := c.Store.GetRepository(ctx, graveler.RepositoryID(repositoryID))
+	if err != nil {
+		return "", err
+	}
+
+	metaRangeID, err := c.Store.DumpBranches(ctx, repository)
 	if err != nil {
 		return "", err
 	}
@@ -1272,7 +1374,12 @@ func (c *Catalog) DumpBranches(ctx context.Context, repositoryID string) (string
 }
 
 func (c *Catalog) DumpTags(ctx context.Context, repositoryID string) (string, error) {
-	metaRangeID, err := c.Store.DumpTags(ctx, graveler.RepositoryID(repositoryID))
+	repository, err := c.Store.GetRepository(ctx, graveler.RepositoryID(repositoryID))
+	if err != nil {
+		return "", err
+	}
+
+	metaRangeID, err := c.Store.DumpTags(ctx, repository)
 	if err != nil {
 		return "", err
 	}
@@ -1280,26 +1387,51 @@ func (c *Catalog) DumpTags(ctx context.Context, repositoryID string) (string, er
 }
 
 func (c *Catalog) LoadCommits(ctx context.Context, repositoryID, commitsMetaRangeID string) error {
-	return c.Store.LoadCommits(ctx, graveler.RepositoryID(repositoryID), graveler.MetaRangeID(commitsMetaRangeID))
+	repository, err := c.Store.GetRepository(ctx, graveler.RepositoryID(repositoryID))
+	if err != nil {
+		return err
+	}
+	return c.Store.LoadCommits(ctx, repository, graveler.MetaRangeID(commitsMetaRangeID))
 }
 
 func (c *Catalog) LoadBranches(ctx context.Context, repositoryID, branchesMetaRangeID string) error {
-	return c.Store.LoadBranches(ctx, graveler.RepositoryID(repositoryID), graveler.MetaRangeID(branchesMetaRangeID))
+	repository, err := c.Store.GetRepository(ctx, graveler.RepositoryID(repositoryID))
+	if err != nil {
+		return err
+	}
+	return c.Store.LoadBranches(ctx, repository, graveler.MetaRangeID(branchesMetaRangeID))
 }
 
 func (c *Catalog) LoadTags(ctx context.Context, repositoryID, tagsMetaRangeID string) error {
-	return c.Store.LoadTags(ctx, graveler.RepositoryID(repositoryID), graveler.MetaRangeID(tagsMetaRangeID))
+	repository, err := c.Store.GetRepository(ctx, graveler.RepositoryID(repositoryID))
+	if err != nil {
+		return err
+	}
+	return c.Store.LoadTags(ctx, repository, graveler.MetaRangeID(tagsMetaRangeID))
 }
 
 func (c *Catalog) GetMetaRange(ctx context.Context, repositoryID, metaRangeID string) (graveler.MetaRangeAddress, error) {
-	return c.Store.GetMetaRange(ctx, graveler.RepositoryID(repositoryID), graveler.MetaRangeID(metaRangeID))
+	repository, err := c.Store.GetRepository(ctx, graveler.RepositoryID(repositoryID))
+	if err != nil {
+		return "", err
+	}
+	return c.Store.GetMetaRange(ctx, repository, graveler.MetaRangeID(metaRangeID))
 }
 
 func (c *Catalog) GetRange(ctx context.Context, repositoryID, rangeID string) (graveler.RangeAddress, error) {
-	return c.Store.GetRange(ctx, graveler.RepositoryID(repositoryID), graveler.RangeID(rangeID))
+	repository, err := c.Store.GetRepository(ctx, graveler.RepositoryID(repositoryID))
+	if err != nil {
+		return "", err
+	}
+	return c.Store.GetRange(ctx, repository, graveler.RangeID(rangeID))
 }
 
 func (c *Catalog) WriteRange(ctx context.Context, repositoryID, fromSourceURI, prepend, after, continuationToken string) (*graveler.RangeInfo, *Mark, error) {
+	repository, err := c.Store.GetRepository(ctx, graveler.RepositoryID(repositoryID))
+	if err != nil {
+		return nil, nil, err
+	}
+
 	walker, err := c.walkerFactory.GetWalker(ctx, store.WalkerOptions{StorageURI: fromSourceURI})
 	if err != nil {
 		return nil, nil, fmt.Errorf("creating object-store walker: %w", err)
@@ -1311,7 +1443,7 @@ func (c *Catalog) WriteRange(ctx context.Context, repositoryID, fromSourceURI, p
 	}
 	defer it.Close()
 
-	rangeInfo, err := c.Store.WriteRange(ctx, graveler.RepositoryID(repositoryID), NewEntryToValueIterator(it))
+	rangeInfo, err := c.Store.WriteRange(ctx, repository, NewEntryToValueIterator(it))
 	if err != nil {
 		return nil, nil, fmt.Errorf("writing range from entry iterator: %w", err)
 	}
@@ -1321,37 +1453,65 @@ func (c *Catalog) WriteRange(ctx context.Context, repositoryID, fromSourceURI, p
 }
 
 func (c *Catalog) WriteMetaRange(ctx context.Context, repositoryID string, ranges []*graveler.RangeInfo) (*graveler.MetaRangeInfo, error) {
-	return c.Store.WriteMetaRange(ctx, graveler.RepositoryID(repositoryID), ranges)
+	repository, err := c.Store.GetRepository(ctx, graveler.RepositoryID(repositoryID))
+	if err != nil {
+		return nil, err
+	}
+	return c.Store.WriteMetaRange(ctx, repository, ranges)
 }
 
 func (c *Catalog) GetGarbageCollectionRules(ctx context.Context, repositoryID string) (*graveler.GarbageCollectionRules, error) {
-	return c.Store.GetGarbageCollectionRules(ctx, graveler.RepositoryID(repositoryID))
+	repository, err := c.Store.GetRepository(ctx, graveler.RepositoryID(repositoryID))
+	if err != nil {
+		return nil, err
+	}
+	return c.Store.GetGarbageCollectionRules(ctx, repository)
 }
 
 func (c *Catalog) SetGarbageCollectionRules(ctx context.Context, repositoryID string, rules *graveler.GarbageCollectionRules) error {
-	return c.Store.SetGarbageCollectionRules(ctx, graveler.RepositoryID(repositoryID), rules)
+	repository, err := c.Store.GetRepository(ctx, graveler.RepositoryID(repositoryID))
+	if err != nil {
+		return err
+	}
+	return c.Store.SetGarbageCollectionRules(ctx, repository, rules)
 }
 
 func (c *Catalog) GetBranchProtectionRules(ctx context.Context, repositoryID string) (*graveler.BranchProtectionRules, error) {
-	return c.Store.GetBranchProtectionRules(ctx, graveler.RepositoryID(repositoryID))
+	repository, err := c.Store.GetRepository(ctx, graveler.RepositoryID(repositoryID))
+	if err != nil {
+		return nil, err
+	}
+
+	return c.Store.GetBranchProtectionRules(ctx, repository)
 }
 
 func (c *Catalog) DeleteBranchProtectionRule(ctx context.Context, repositoryID string, pattern string) error {
-	return c.Store.DeleteBranchProtectionRule(ctx, graveler.RepositoryID(repositoryID), pattern)
+	repository, err := c.Store.GetRepository(ctx, graveler.RepositoryID(repositoryID))
+	if err != nil {
+		return err
+	}
+	return c.Store.DeleteBranchProtectionRule(ctx, repository, pattern)
 }
 
 func (c *Catalog) CreateBranchProtectionRule(ctx context.Context, repositoryID string, pattern string, blockedActions []graveler.BranchProtectionBlockedAction) error {
-	return c.Store.CreateBranchProtectionRule(ctx, graveler.RepositoryID(repositoryID), pattern, blockedActions)
+	repository, err := c.Store.GetRepository(ctx, graveler.RepositoryID(repositoryID))
+	if err != nil {
+		return err
+	}
+	return c.Store.CreateBranchProtectionRule(ctx, repository, pattern, blockedActions)
 }
 
-func (c *Catalog) PrepareExpiredCommits(ctx context.Context, repository string, previousRunID string) (*graveler.GarbageCollectionRunMetadata, error) {
-	repositoryID := graveler.RepositoryID(repository)
+func (c *Catalog) PrepareExpiredCommits(ctx context.Context, repositoryID string, previousRunID string) (*graveler.GarbageCollectionRunMetadata, error) {
 	if err := validator.Validate([]validator.ValidateArg{
 		{Name: "repository", Value: repositoryID, Fn: graveler.ValidateRepositoryID},
 	}); err != nil {
 		return nil, err
 	}
-	return c.Store.SaveGarbageCollectionCommits(ctx, repositoryID, previousRunID)
+	repository, err := c.Store.GetRepository(ctx, graveler.RepositoryID(repositoryID))
+	if err != nil {
+		return nil, err
+	}
+	return c.Store.SaveGarbageCollectionCommits(ctx, repository, previousRunID)
 }
 
 func (c *Catalog) Close() error {
@@ -1366,8 +1526,8 @@ func (c *Catalog) Close() error {
 }
 
 // dereferenceCommitID dereference 'ref' to a commit ID, this helper makes sure we do not point to explicit branch staging
-func (c *Catalog) dereferenceCommitID(ctx context.Context, repositoryID graveler.RepositoryID, ref graveler.Ref) (graveler.CommitID, error) {
-	resolvedRef, err := c.Store.Dereference(ctx, repositoryID, ref)
+func (c *Catalog) dereferenceCommitID(ctx context.Context, repository *graveler.RepositoryRecord, ref graveler.Ref) (graveler.CommitID, error) {
+	resolvedRef, err := c.Store.Dereference(ctx, repository, ref)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -999,7 +999,7 @@ func (c *Catalog) ListCommits(ctx context.Context, repositoryID string, branch s
 	var commits []*CommitLog
 
 	// commit/key to value cache - helps when fetching the same commit/key while processing parent commits
-	const commitLogCacheSize = 1024
+	const commitLogCacheSize = 1024 * 5
 	commitCache, err := simplelru.NewLRU(commitLogCacheSize, nil)
 	if err != nil {
 		return nil, false, err

--- a/pkg/catalog/fake_graveler_test.go
+++ b/pkg/catalog/fake_graveler_test.go
@@ -40,7 +40,7 @@ func (g *FakeGraveler) SetGarbageCollectionRules(ctx context.Context, repository
 	panic("implement me")
 }
 
-func (g *FakeGraveler) CreateBareRepository(ctx context.Context, repositoryID graveler.RepositoryID, storageNamespace graveler.StorageNamespace, branchID graveler.BranchID) (*graveler.Repository, error) {
+func (g *FakeGraveler) CreateBareRepository(ctx context.Context, repositoryID graveler.RepositoryID, storageNamespace graveler.StorageNamespace, branchID graveler.BranchID) (*graveler.RepositoryRecord, error) {
 	panic("implement me")
 }
 
@@ -92,6 +92,10 @@ func (g *FakeGraveler) Get(_ context.Context, repository *graveler.RepositoryRec
 	return v, nil
 }
 
+func (g *FakeGraveler) GetByCommitID(ctx context.Context, repository *graveler.RepositoryRecord, commitID graveler.CommitID, key graveler.Key) (*graveler.Value, error) {
+	return g.Get(ctx, repository, graveler.Ref(commitID), key)
+}
+
 func (g *FakeGraveler) Set(_ context.Context, repository *graveler.RepositoryRecord, branchID graveler.BranchID, key graveler.Key, value graveler.Value, _ ...graveler.WriteConditionOption) error {
 	if g.Err != nil {
 		return g.Err
@@ -105,18 +109,18 @@ func (g *FakeGraveler) Delete(ctx context.Context, repository *graveler.Reposito
 	panic("implement me")
 }
 
-func (g *FakeGraveler) List(_ context.Context, _ graveler.RepositoryID, _ graveler.Ref) (graveler.ValueIterator, error) {
+func (g *FakeGraveler) List(_ context.Context, _ *graveler.RepositoryRecord, _ graveler.Ref) (graveler.ValueIterator, error) {
 	if g.Err != nil {
 		return nil, g.Err
 	}
 	return g.ListIteratorFactory(), nil
 }
 
-func (g *FakeGraveler) GetRepository(ctx context.Context, repository *graveler.RepositoryRecord) (*graveler.Repository, error) {
-	panic("implement me")
+func (g *FakeGraveler) GetRepository(ctx context.Context, repositoryID graveler.RepositoryID) (*graveler.RepositoryRecord, error) {
+	return &graveler.RepositoryRecord{RepositoryID: repositoryID}, nil
 }
 
-func (g *FakeGraveler) CreateRepository(ctx context.Context, repositoryID graveler.RepositoryID, storageNamespace graveler.StorageNamespace, branchID graveler.BranchID) (*graveler.Repository, error) {
+func (g *FakeGraveler) CreateRepository(ctx context.Context, repositoryID graveler.RepositoryID, storageNamespace graveler.StorageNamespace, branchID graveler.BranchID) (*graveler.RepositoryRecord, error) {
 	panic("implement me")
 }
 
@@ -127,7 +131,7 @@ func (g *FakeGraveler) ListRepositories(ctx context.Context) (graveler.Repositor
 	return g.RepositoryIteratorFactory(), nil
 }
 
-func (g *FakeGraveler) DeleteRepository(ctx context.Context, repository *graveler.RepositoryRecord) error {
+func (g *FakeGraveler) DeleteRepository(ctx context.Context, repositoryID graveler.RepositoryID) error {
 	panic("implement me")
 }
 
@@ -182,7 +186,7 @@ func (g *FakeGraveler) Log(ctx context.Context, repository *graveler.RepositoryR
 	panic("implement me")
 }
 
-func (g *FakeGraveler) ListBranches(_ context.Context, _ graveler.RepositoryID) (graveler.BranchIterator, error) {
+func (g *FakeGraveler) ListBranches(_ context.Context, _ *graveler.RepositoryRecord) (graveler.BranchIterator, error) {
 	if g.Err != nil {
 		return nil, g.Err
 	}
@@ -225,7 +229,7 @@ func (g *FakeGraveler) ResetPrefix(ctx context.Context, repository *graveler.Rep
 	panic("implement me")
 }
 
-func (g *FakeGraveler) Revert(_ context.Context, _ graveler.RepositoryID, _ graveler.BranchID, _ graveler.Ref, _ int, _ graveler.CommitParams) (graveler.CommitID, error) {
+func (g *FakeGraveler) Revert(_ context.Context, _ *graveler.RepositoryRecord, _ graveler.BranchID, _ graveler.Ref, _ int, _ graveler.CommitParams) (graveler.CommitID, error) {
 	panic("implement me")
 }
 
@@ -240,14 +244,14 @@ func (g *FakeGraveler) DiffUncommitted(ctx context.Context, repository *graveler
 	return g.DiffIteratorFactory(), nil
 }
 
-func (g *FakeGraveler) Diff(_ context.Context, _ graveler.RepositoryID, _, _ graveler.Ref) (graveler.DiffIterator, error) {
+func (g *FakeGraveler) Diff(_ context.Context, _ *graveler.RepositoryRecord, _, _ graveler.Ref) (graveler.DiffIterator, error) {
 	if g.Err != nil {
 		return nil, g.Err
 	}
 	return g.DiffIteratorFactory(), nil
 }
 
-func (g *FakeGraveler) Compare(_ context.Context, _ graveler.RepositoryID, _, _ graveler.Ref) (graveler.DiffIterator, error) {
+func (g *FakeGraveler) Compare(_ context.Context, _ *graveler.RepositoryRecord, _, _ graveler.Ref) (graveler.DiffIterator, error) {
 	if g.Err != nil {
 		return nil, g.Err
 	}
@@ -266,15 +270,15 @@ func (g *FakeGraveler) AddCommit(ctx context.Context, repository *graveler.Repos
 	panic("implement me")
 }
 
-func (g *FakeGraveler) AddCommitNoLock(_ context.Context, _ graveler.RepositoryID, _ graveler.Commit) (graveler.CommitID, error) {
+func (g *FakeGraveler) AddCommitNoLock(_ context.Context, _ *graveler.RepositoryRecord, _ graveler.Commit) (graveler.CommitID, error) {
 	panic("implement me")
 }
 
-func (g *FakeGraveler) WriteMetaRangeByIterator(_ context.Context, _ graveler.RepositoryID, _ graveler.ValueIterator) (*graveler.MetaRangeID, error) {
+func (g *FakeGraveler) WriteMetaRangeByIterator(_ context.Context, _ *graveler.RepositoryRecord, _ graveler.ValueIterator) (*graveler.MetaRangeID, error) {
 	panic("implement me")
 }
 
-func (g *FakeGraveler) GetStagingToken(_ context.Context, _ graveler.RepositoryID, _ graveler.BranchID) (*graveler.StagingToken, error) {
+func (g *FakeGraveler) GetStagingToken(_ context.Context, _ *graveler.RepositoryRecord, _ graveler.BranchID) (*graveler.StagingToken, error) {
 	panic("implement me")
 }
 

--- a/pkg/catalog/fake_graveler_test.go
+++ b/pkg/catalog/fake_graveler_test.go
@@ -24,19 +24,19 @@ func (g *FakeGraveler) ParseRef(ref graveler.Ref) (graveler.RawRef, error) {
 	panic("implement me")
 }
 
-func (g *FakeGraveler) ResolveRawRef(ctx context.Context, repositoryID graveler.RepositoryID, rawRef graveler.RawRef) (*graveler.ResolvedRef, error) {
+func (g *FakeGraveler) ResolveRawRef(ctx context.Context, repository *graveler.RepositoryRecord, rawRef graveler.RawRef) (*graveler.ResolvedRef, error) {
 	panic("implement me")
 }
 
-func (g *FakeGraveler) SaveGarbageCollectionCommits(ctx context.Context, repositoryID graveler.RepositoryID, previousRunID string) (garbageCollectionRunMetadata *graveler.GarbageCollectionRunMetadata, err error) {
+func (g *FakeGraveler) SaveGarbageCollectionCommits(ctx context.Context, repository *graveler.RepositoryRecord, previousRunID string) (garbageCollectionRunMetadata *graveler.GarbageCollectionRunMetadata, err error) {
 	panic("implement me")
 }
 
-func (g *FakeGraveler) GetGarbageCollectionRules(ctx context.Context, repositoryID graveler.RepositoryID) (*graveler.GarbageCollectionRules, error) {
+func (g *FakeGraveler) GetGarbageCollectionRules(ctx context.Context, repository *graveler.RepositoryRecord) (*graveler.GarbageCollectionRules, error) {
 	panic("implement me")
 }
 
-func (g *FakeGraveler) SetGarbageCollectionRules(ctx context.Context, repositoryID graveler.RepositoryID, rules *graveler.GarbageCollectionRules) error {
+func (g *FakeGraveler) SetGarbageCollectionRules(ctx context.Context, repository *graveler.RepositoryRecord, rules *graveler.GarbageCollectionRules) error {
 	panic("implement me")
 }
 
@@ -44,35 +44,35 @@ func (g *FakeGraveler) CreateBareRepository(ctx context.Context, repositoryID gr
 	panic("implement me")
 }
 
-func (g *FakeGraveler) LoadCommits(ctx context.Context, repositoryID graveler.RepositoryID, metaRangeID graveler.MetaRangeID) error {
+func (g *FakeGraveler) LoadCommits(ctx context.Context, repository *graveler.RepositoryRecord, metaRangeID graveler.MetaRangeID) error {
 	panic("implement me")
 }
 
-func (g *FakeGraveler) LoadBranches(ctx context.Context, repositoryID graveler.RepositoryID, metaRangeID graveler.MetaRangeID) error {
+func (g *FakeGraveler) LoadBranches(ctx context.Context, repository *graveler.RepositoryRecord, metaRangeID graveler.MetaRangeID) error {
 	panic("implement me")
 }
 
-func (g *FakeGraveler) LoadTags(ctx context.Context, repositoryID graveler.RepositoryID, metaRangeID graveler.MetaRangeID) error {
+func (g *FakeGraveler) LoadTags(ctx context.Context, repository *graveler.RepositoryRecord, metaRangeID graveler.MetaRangeID) error {
 	panic("implement me")
 }
 
-func (g *FakeGraveler) DumpCommits(ctx context.Context, repositoryID graveler.RepositoryID) (*graveler.MetaRangeID, error) {
+func (g *FakeGraveler) DumpCommits(ctx context.Context, repository *graveler.RepositoryRecord) (*graveler.MetaRangeID, error) {
 	panic("implement me")
 }
 
-func (g *FakeGraveler) DumpBranches(ctx context.Context, repositoryID graveler.RepositoryID) (*graveler.MetaRangeID, error) {
+func (g *FakeGraveler) DumpBranches(ctx context.Context, repository *graveler.RepositoryRecord) (*graveler.MetaRangeID, error) {
 	panic("implement me")
 }
 
-func (g *FakeGraveler) DumpTags(ctx context.Context, repositoryID graveler.RepositoryID) (*graveler.MetaRangeID, error) {
+func (g *FakeGraveler) DumpTags(ctx context.Context, repository *graveler.RepositoryRecord) (*graveler.MetaRangeID, error) {
 	panic("implement me")
 }
 
-func (g *FakeGraveler) GetMetaRange(ctx context.Context, repositoryID graveler.RepositoryID, metaRangeID graveler.MetaRangeID) (graveler.MetaRangeAddress, error) {
+func (g *FakeGraveler) GetMetaRange(ctx context.Context, repository *graveler.RepositoryRecord, metaRangeID graveler.MetaRangeID) (graveler.MetaRangeAddress, error) {
 	panic("implement me")
 }
 
-func (g *FakeGraveler) GetRange(ctx context.Context, repositoryID graveler.RepositoryID, rangeID graveler.RangeID) (graveler.RangeAddress, error) {
+func (g *FakeGraveler) GetRange(ctx context.Context, repository *graveler.RepositoryRecord, rangeID graveler.RangeID) (graveler.RangeAddress, error) {
 	panic("implement me")
 }
 
@@ -80,11 +80,11 @@ func fakeGravelerBuildKey(repositoryID graveler.RepositoryID, ref graveler.Ref, 
 	return strings.Join([]string{repositoryID.String(), ref.String(), key.String()}, "/")
 }
 
-func (g *FakeGraveler) Get(_ context.Context, repositoryID graveler.RepositoryID, ref graveler.Ref, key graveler.Key) (*graveler.Value, error) {
+func (g *FakeGraveler) Get(_ context.Context, repository *graveler.RepositoryRecord, ref graveler.Ref, key graveler.Key) (*graveler.Value, error) {
 	if g.Err != nil {
 		return nil, g.Err
 	}
-	k := fakeGravelerBuildKey(repositoryID, ref, key)
+	k := fakeGravelerBuildKey(repository.RepositoryID, ref, key)
 	v := g.KeyValue[k]
 	if v == nil {
 		return nil, graveler.ErrNotFound
@@ -92,16 +92,16 @@ func (g *FakeGraveler) Get(_ context.Context, repositoryID graveler.RepositoryID
 	return v, nil
 }
 
-func (g *FakeGraveler) Set(_ context.Context, repositoryID graveler.RepositoryID, branchID graveler.BranchID, key graveler.Key, value graveler.Value, _ ...graveler.WriteConditionOption) error {
+func (g *FakeGraveler) Set(_ context.Context, repository *graveler.RepositoryRecord, branchID graveler.BranchID, key graveler.Key, value graveler.Value, _ ...graveler.WriteConditionOption) error {
 	if g.Err != nil {
 		return g.Err
 	}
-	k := fakeGravelerBuildKey(repositoryID, graveler.Ref(branchID.String()), key)
+	k := fakeGravelerBuildKey(repository.RepositoryID, graveler.Ref(branchID.String()), key)
 	g.KeyValue[k] = &value
 	return nil
 }
 
-func (g *FakeGraveler) Delete(ctx context.Context, repositoryID graveler.RepositoryID, branchID graveler.BranchID, key graveler.Key) error {
+func (g *FakeGraveler) Delete(ctx context.Context, repository *graveler.RepositoryRecord, branchID graveler.BranchID, key graveler.Key) error {
 	panic("implement me")
 }
 
@@ -112,7 +112,7 @@ func (g *FakeGraveler) List(_ context.Context, _ graveler.RepositoryID, _ gravel
 	return g.ListIteratorFactory(), nil
 }
 
-func (g *FakeGraveler) GetRepository(ctx context.Context, repositoryID graveler.RepositoryID) (*graveler.Repository, error) {
+func (g *FakeGraveler) GetRepository(ctx context.Context, repository *graveler.RepositoryRecord) (*graveler.Repository, error) {
 	panic("implement me")
 }
 
@@ -127,19 +127,19 @@ func (g *FakeGraveler) ListRepositories(ctx context.Context) (graveler.Repositor
 	return g.RepositoryIteratorFactory(), nil
 }
 
-func (g *FakeGraveler) DeleteRepository(ctx context.Context, repositoryID graveler.RepositoryID) error {
+func (g *FakeGraveler) DeleteRepository(ctx context.Context, repository *graveler.RepositoryRecord) error {
 	panic("implement me")
 }
 
-func (g *FakeGraveler) CreateBranch(ctx context.Context, repositoryID graveler.RepositoryID, branchID graveler.BranchID, ref graveler.Ref) (*graveler.Branch, error) {
+func (g *FakeGraveler) CreateBranch(ctx context.Context, repository *graveler.RepositoryRecord, branchID graveler.BranchID, ref graveler.Ref) (*graveler.Branch, error) {
 	panic("implement me")
 }
 
-func (g *FakeGraveler) UpdateBranch(ctx context.Context, repositoryID graveler.RepositoryID, branchID graveler.BranchID, ref graveler.Ref) (*graveler.Branch, error) {
+func (g *FakeGraveler) UpdateBranch(ctx context.Context, repository *graveler.RepositoryRecord, branchID graveler.BranchID, ref graveler.Ref) (*graveler.Branch, error) {
 	panic("implement me")
 }
 
-func (g *FakeGraveler) GetBranch(ctx context.Context, repositoryID graveler.RepositoryID, branchID graveler.BranchID) (*graveler.Branch, error) {
+func (g *FakeGraveler) GetBranch(ctx context.Context, repository *graveler.RepositoryRecord, branchID graveler.BranchID) (*graveler.Branch, error) {
 	if g.Err != nil {
 		return nil, g.Err
 	}
@@ -159,26 +159,26 @@ func (g *FakeGraveler) GetBranch(ctx context.Context, repositoryID graveler.Repo
 	return &graveler.Branch{CommitID: branch.CommitID, StagingToken: branch.StagingToken}, nil
 }
 
-func (g *FakeGraveler) GetTag(ctx context.Context, repositoryID graveler.RepositoryID, tagID graveler.TagID) (*graveler.CommitID, error) {
+func (g *FakeGraveler) GetTag(ctx context.Context, repository *graveler.RepositoryRecord, tagID graveler.TagID) (*graveler.CommitID, error) {
 	panic("implement me")
 }
 
-func (g *FakeGraveler) CreateTag(ctx context.Context, repositoryID graveler.RepositoryID, tagID graveler.TagID, commitID graveler.CommitID) error {
+func (g *FakeGraveler) CreateTag(ctx context.Context, repository *graveler.RepositoryRecord, tagID graveler.TagID, commitID graveler.CommitID) error {
 	panic("implement me")
 }
 
-func (g *FakeGraveler) DeleteTag(ctx context.Context, repositoryID graveler.RepositoryID, tagID graveler.TagID) error {
+func (g *FakeGraveler) DeleteTag(ctx context.Context, repository *graveler.RepositoryRecord, tagID graveler.TagID) error {
 	panic("implement me")
 }
 
-func (g *FakeGraveler) ListTags(ctx context.Context, repositoryID graveler.RepositoryID) (graveler.TagIterator, error) {
+func (g *FakeGraveler) ListTags(ctx context.Context, repository *graveler.RepositoryRecord) (graveler.TagIterator, error) {
 	if g.Err != nil {
 		return nil, g.Err
 	}
 	return g.TagIteratorFactory(), nil
 }
 
-func (g *FakeGraveler) Log(ctx context.Context, repositoryID graveler.RepositoryID, commitID graveler.CommitID) (graveler.CommitIterator, error) {
+func (g *FakeGraveler) Log(ctx context.Context, repository *graveler.RepositoryRecord, commitID graveler.CommitID) (graveler.CommitIterator, error) {
 	panic("implement me")
 }
 
@@ -189,39 +189,39 @@ func (g *FakeGraveler) ListBranches(_ context.Context, _ graveler.RepositoryID) 
 	return g.BranchIteratorFactory(), nil
 }
 
-func (g *FakeGraveler) DeleteBranch(ctx context.Context, repositoryID graveler.RepositoryID, branchID graveler.BranchID) error {
+func (g *FakeGraveler) DeleteBranch(ctx context.Context, repository *graveler.RepositoryRecord, branchID graveler.BranchID) error {
 	panic("implement me")
 }
 
-func (g *FakeGraveler) Commit(ctx context.Context, repositoryID graveler.RepositoryID, branchID graveler.BranchID, _ graveler.CommitParams) (graveler.CommitID, error) {
+func (g *FakeGraveler) Commit(ctx context.Context, repository *graveler.RepositoryRecord, branchID graveler.BranchID, _ graveler.CommitParams) (graveler.CommitID, error) {
 	panic("implement me")
 }
 
-func (g *FakeGraveler) WriteRange(ctx context.Context, repositoryID graveler.RepositoryID, it graveler.ValueIterator) (*graveler.RangeInfo, error) {
+func (g *FakeGraveler) WriteRange(ctx context.Context, repository *graveler.RepositoryRecord, it graveler.ValueIterator) (*graveler.RangeInfo, error) {
 	panic("implement me")
 }
 
-func (g *FakeGraveler) WriteMetaRange(ctx context.Context, repositoryID graveler.RepositoryID, ranges []*graveler.RangeInfo) (*graveler.MetaRangeInfo, error) {
+func (g *FakeGraveler) WriteMetaRange(ctx context.Context, repository *graveler.RepositoryRecord, ranges []*graveler.RangeInfo) (*graveler.MetaRangeInfo, error) {
 	panic("implement me")
 }
 
-func (g *FakeGraveler) GetCommit(ctx context.Context, repositoryID graveler.RepositoryID, commitID graveler.CommitID) (*graveler.Commit, error) {
+func (g *FakeGraveler) GetCommit(ctx context.Context, repository *graveler.RepositoryRecord, commitID graveler.CommitID) (*graveler.Commit, error) {
 	panic("implement me")
 }
 
-func (g *FakeGraveler) Dereference(ctx context.Context, repositoryID graveler.RepositoryID, ref graveler.Ref) (*graveler.ResolvedRef, error) {
+func (g *FakeGraveler) Dereference(ctx context.Context, repository *graveler.RepositoryRecord, ref graveler.Ref) (*graveler.ResolvedRef, error) {
 	panic("implement me")
 }
 
-func (g *FakeGraveler) Reset(ctx context.Context, repositoryID graveler.RepositoryID, branchID graveler.BranchID) error {
+func (g *FakeGraveler) Reset(ctx context.Context, repository *graveler.RepositoryRecord, branchID graveler.BranchID) error {
 	panic("implement me")
 }
 
-func (g *FakeGraveler) ResetKey(ctx context.Context, repositoryID graveler.RepositoryID, branchID graveler.BranchID, key graveler.Key) error {
+func (g *FakeGraveler) ResetKey(ctx context.Context, repository *graveler.RepositoryRecord, branchID graveler.BranchID, key graveler.Key) error {
 	panic("implement me")
 }
 
-func (g *FakeGraveler) ResetPrefix(ctx context.Context, repositoryID graveler.RepositoryID, branchID graveler.BranchID, key graveler.Key) error {
+func (g *FakeGraveler) ResetPrefix(ctx context.Context, repository *graveler.RepositoryRecord, branchID graveler.BranchID, key graveler.Key) error {
 	panic("implement me")
 }
 
@@ -229,11 +229,11 @@ func (g *FakeGraveler) Revert(_ context.Context, _ graveler.RepositoryID, _ grav
 	panic("implement me")
 }
 
-func (g *FakeGraveler) Merge(ctx context.Context, repositoryID graveler.RepositoryID, destination graveler.BranchID, source graveler.Ref, _ graveler.CommitParams, strategy string) (graveler.CommitID, error) {
+func (g *FakeGraveler) Merge(ctx context.Context, repository *graveler.RepositoryRecord, destination graveler.BranchID, source graveler.Ref, _ graveler.CommitParams, strategy string) (graveler.CommitID, error) {
 	panic("implement me")
 }
 
-func (g *FakeGraveler) DiffUncommitted(ctx context.Context, repositoryID graveler.RepositoryID, branchID graveler.BranchID) (graveler.DiffIterator, error) {
+func (g *FakeGraveler) DiffUncommitted(ctx context.Context, repository *graveler.RepositoryRecord, branchID graveler.BranchID) (graveler.DiffIterator, error) {
 	if g.Err != nil {
 		return nil, g.Err
 	}
@@ -258,11 +258,11 @@ func (g *FakeGraveler) SetHooksHandler(handler graveler.HooksHandler) {
 	g.hooks = handler
 }
 
-func (g *FakeGraveler) AddCommitToBranchHead(ctx context.Context, repositoryID graveler.RepositoryID, branchID graveler.BranchID, commit graveler.Commit) (graveler.CommitID, error) {
+func (g *FakeGraveler) AddCommitToBranchHead(ctx context.Context, repository *graveler.RepositoryRecord, branchID graveler.BranchID, commit graveler.Commit) (graveler.CommitID, error) {
 	panic("implement me")
 }
 
-func (g *FakeGraveler) AddCommit(ctx context.Context, repositoryID graveler.RepositoryID, commit graveler.Commit) (graveler.CommitID, error) {
+func (g *FakeGraveler) AddCommit(ctx context.Context, repository *graveler.RepositoryRecord, commit graveler.Commit) (graveler.CommitID, error) {
 	panic("implement me")
 }
 

--- a/pkg/db/database.go
+++ b/pkg/db/database.go
@@ -95,6 +95,9 @@ func (d *PgxDatabase) Get(ctx context.Context, dest interface{}, query string, a
 	}, func() (interface{}, error) {
 		return nil, pgxscan.Get(ctx, d.db, dest, query, args...)
 	})
+	if errors.Is(err, pgx.ErrNoRows) {
+		return ErrNotFound
+	}
 	return err
 }
 

--- a/pkg/graveler/db_graveler.go
+++ b/pkg/graveler/db_graveler.go
@@ -45,14 +45,11 @@ func (g *DBGraveler) CreateRepository(ctx context.Context, repositoryID Reposito
 		StorageNamespace: storageNamespace,
 		DefaultBranchID:  branchID,
 	}
-	err := g.RefManager.CreateRepository(ctx, repositoryID, repo)
+	repository, err := g.RefManager.CreateRepository(ctx, repositoryID, repo)
 	if err != nil {
 		return nil, err
 	}
-	return &RepositoryRecord{
-		RepositoryID: repositoryID,
-		Repository:   &repo,
-	}, nil
+	return repository, nil
 }
 
 func (g *DBGraveler) CreateBareRepository(ctx context.Context, repositoryID RepositoryID, storageNamespace StorageNamespace, defaultBranchID BranchID) (*RepositoryRecord, error) {
@@ -61,14 +58,11 @@ func (g *DBGraveler) CreateBareRepository(ctx context.Context, repositoryID Repo
 		CreationDate:     time.Now(),
 		DefaultBranchID:  defaultBranchID,
 	}
-	err := g.RefManager.CreateBareRepository(ctx, repositoryID, repo)
+	repository, err := g.RefManager.CreateBareRepository(ctx, repositoryID, repo)
 	if err != nil {
 		return nil, err
 	}
-	return &RepositoryRecord{
-		RepositoryID: repositoryID,
-		Repository:   &repo,
-	}, nil
+	return repository, nil
 }
 
 func (g *DBGraveler) ListRepositories(ctx context.Context) (RepositoryIterator, error) {

--- a/pkg/graveler/db_graveler.go
+++ b/pkg/graveler/db_graveler.go
@@ -35,24 +35,27 @@ func NewDBGraveler(branchLocker BranchLocker, committedManager CommittedManager,
 	}
 }
 
-func (g *DBGraveler) GetRepository(ctx context.Context, repositoryID RepositoryID) (*Repository, error) {
+func (g *DBGraveler) GetRepository(ctx context.Context, repositoryID RepositoryID) (*RepositoryRecord, error) {
 	return g.RefManager.GetRepository(ctx, repositoryID)
 }
 
-func (g *DBGraveler) CreateRepository(ctx context.Context, repositoryID RepositoryID, storageNamespace StorageNamespace, branchID BranchID) (*Repository, error) {
+func (g *DBGraveler) CreateRepository(ctx context.Context, repositoryID RepositoryID, storageNamespace StorageNamespace, branchID BranchID) (*RepositoryRecord, error) {
 	repo := Repository{
-		StorageNamespace: storageNamespace,
 		CreationDate:     time.Now(),
+		StorageNamespace: storageNamespace,
 		DefaultBranchID:  branchID,
 	}
 	err := g.RefManager.CreateRepository(ctx, repositoryID, repo)
 	if err != nil {
 		return nil, err
 	}
-	return &repo, nil
+	return &RepositoryRecord{
+		RepositoryID: repositoryID,
+		Repository:   &repo,
+	}, nil
 }
 
-func (g *DBGraveler) CreateBareRepository(ctx context.Context, repositoryID RepositoryID, storageNamespace StorageNamespace, defaultBranchID BranchID) (*Repository, error) {
+func (g *DBGraveler) CreateBareRepository(ctx context.Context, repositoryID RepositoryID, storageNamespace StorageNamespace, defaultBranchID BranchID) (*RepositoryRecord, error) {
 	repo := Repository{
 		StorageNamespace: storageNamespace,
 		CreationDate:     time.Now(),
@@ -62,58 +65,45 @@ func (g *DBGraveler) CreateBareRepository(ctx context.Context, repositoryID Repo
 	if err != nil {
 		return nil, err
 	}
-	return &repo, nil
+	return &RepositoryRecord{
+		RepositoryID: repositoryID,
+		Repository:   &repo,
+	}, nil
 }
 
 func (g *DBGraveler) ListRepositories(ctx context.Context) (RepositoryIterator, error) {
 	return g.RefManager.ListRepositories(ctx)
 }
 
-func (g *DBGraveler) WriteRange(ctx context.Context, repositoryID RepositoryID, it ValueIterator) (*RangeInfo, error) {
-	repo, err := g.RefManager.GetRepository(ctx, repositoryID)
-	if err != nil {
-		return nil, err
-	}
-	return g.CommittedManager.WriteRange(ctx, repo.StorageNamespace, it)
+func (g *DBGraveler) WriteRange(ctx context.Context, repository *RepositoryRecord, it ValueIterator) (*RangeInfo, error) {
+	return g.CommittedManager.WriteRange(ctx, repository.StorageNamespace, it)
 }
 
-func (g *DBGraveler) WriteMetaRange(ctx context.Context, repositoryID RepositoryID, ranges []*RangeInfo) (*MetaRangeInfo, error) {
-	repo, err := g.RefManager.GetRepository(ctx, repositoryID)
-	if err != nil {
-		return nil, err
-	}
-	return g.CommittedManager.WriteMetaRange(ctx, repo.StorageNamespace, ranges)
+func (g *DBGraveler) WriteMetaRange(ctx context.Context, repository *RepositoryRecord, ranges []*RangeInfo) (*MetaRangeInfo, error) {
+	return g.CommittedManager.WriteMetaRange(ctx, repository.StorageNamespace, ranges)
 }
 
-func (g *DBGraveler) WriteMetaRangeByIterator(ctx context.Context, repositoryID RepositoryID, it ValueIterator) (*MetaRangeID, error) {
-	repo, err := g.RefManager.GetRepository(ctx, repositoryID)
-	if err != nil {
-		return nil, err
-	}
-	return g.CommittedManager.WriteMetaRangeByIterator(ctx, repo.StorageNamespace, it, nil)
+func (g *DBGraveler) WriteMetaRangeByIterator(ctx context.Context, repository *RepositoryRecord, it ValueIterator) (*MetaRangeID, error) {
+	return g.CommittedManager.WriteMetaRangeByIterator(ctx, repository.StorageNamespace, it, nil)
 }
 
 func (g *DBGraveler) DeleteRepository(ctx context.Context, repositoryID RepositoryID) error {
 	return g.RefManager.DeleteRepository(ctx, repositoryID)
 }
 
-func (g *DBGraveler) GetCommit(ctx context.Context, repositoryID RepositoryID, commitID CommitID) (*Commit, error) {
-	return g.RefManager.GetCommit(ctx, repositoryID, commitID)
+func (g *DBGraveler) GetCommit(ctx context.Context, repository *RepositoryRecord, commitID CommitID) (*Commit, error) {
+	return g.RefManager.GetCommit(ctx, repository, commitID)
 }
 
-func (g *DBGraveler) CreateBranch(ctx context.Context, repositoryID RepositoryID, branchID BranchID, ref Ref) (*Branch, error) {
-	repo, err := g.RefManager.GetRepository(ctx, repositoryID)
-	if err != nil {
-		return nil, fmt.Errorf("get repository: %w", err)
-	}
-	storageNamespace := repo.StorageNamespace
+func (g *DBGraveler) CreateBranch(ctx context.Context, repository *RepositoryRecord, branchID BranchID, ref Ref) (*Branch, error) {
+	storageNamespace := repository.StorageNamespace
 
-	reference, err := g.Dereference(ctx, repositoryID, ref)
+	reference, err := g.Dereference(ctx, repository, ref)
 	if err != nil {
 		return nil, fmt.Errorf("source reference '%s': %w", ref, err)
 	}
 
-	_, err = g.RefManager.GetBranch(ctx, repositoryID, branchID)
+	_, err = g.RefManager.GetBranch(ctx, repository, branchID)
 	if err == nil {
 		return nil, ErrBranchExists
 	}
@@ -126,7 +116,7 @@ func (g *DBGraveler) CreateBranch(ctx context.Context, repositoryID RepositoryID
 	}
 	newBranch := Branch{
 		CommitID:     reference.CommitID,
-		StagingToken: GenerateStagingToken(repositoryID, branchID),
+		StagingToken: GenerateStagingToken(repository.RepositoryID, branchID),
 	}
 
 	preRunID := g.hooks.NewRunID()
@@ -135,7 +125,7 @@ func (g *DBGraveler) CreateBranch(ctx context.Context, repositoryID RepositoryID
 		StorageNamespace: storageNamespace,
 		EventType:        EventTypePreCreateBranch,
 		SourceRef:        ref,
-		RepositoryID:     repositoryID,
+		RepositoryID:     repository.RepositoryID,
 		BranchID:         branchID,
 		CommitID:         reference.CommitID,
 	})
@@ -147,7 +137,7 @@ func (g *DBGraveler) CreateBranch(ctx context.Context, repositoryID RepositoryID
 		}
 	}
 
-	err = g.RefManager.CreateBranch(ctx, repositoryID, branchID, newBranch)
+	err = g.RefManager.CreateBranch(ctx, repository, branchID, newBranch)
 	if err != nil {
 		return nil, fmt.Errorf("set branch '%s' to '%v': %w", branchID, newBranch, err)
 	}
@@ -158,7 +148,7 @@ func (g *DBGraveler) CreateBranch(ctx context.Context, repositoryID RepositoryID
 		StorageNamespace: storageNamespace,
 		EventType:        EventTypePostCreateBranch,
 		SourceRef:        ref,
-		RepositoryID:     repositoryID,
+		RepositoryID:     repository.RepositoryID,
 		BranchID:         branchID,
 		CommitID:         reference.CommitID,
 		PreRunID:         preRunID,
@@ -167,9 +157,9 @@ func (g *DBGraveler) CreateBranch(ctx context.Context, repositoryID RepositoryID
 	return &newBranch, nil
 }
 
-func (g *DBGraveler) UpdateBranch(ctx context.Context, repositoryID RepositoryID, branchID BranchID, ref Ref) (*Branch, error) {
-	res, err := g.branchLocker.MetadataUpdater(ctx, repositoryID, branchID, func() (interface{}, error) {
-		return g.updateBranchNoLock(ctx, repositoryID, branchID, ref)
+func (g *DBGraveler) UpdateBranch(ctx context.Context, repository *RepositoryRecord, branchID BranchID, ref Ref) (*Branch, error) {
+	res, err := g.branchLocker.MetadataUpdater(ctx, repository, branchID, func() (interface{}, error) {
+		return g.updateBranchNoLock(ctx, repository, branchID, ref)
 	})
 	if err != nil {
 		return nil, err
@@ -177,8 +167,8 @@ func (g *DBGraveler) UpdateBranch(ctx context.Context, repositoryID RepositoryID
 	return res.(*Branch), nil
 }
 
-func (g *DBGraveler) updateBranchNoLock(ctx context.Context, repositoryID RepositoryID, branchID BranchID, ref Ref) (*Branch, error) {
-	reference, err := g.Dereference(ctx, repositoryID, ref)
+func (g *DBGraveler) updateBranchNoLock(ctx context.Context, repository *RepositoryRecord, branchID BranchID, ref Ref) (*Branch, error) {
+	reference, err := g.Dereference(ctx, repository, ref)
 	if err != nil {
 		return nil, err
 	}
@@ -186,7 +176,7 @@ func (g *DBGraveler) updateBranchNoLock(ctx context.Context, repositoryID Reposi
 		return nil, fmt.Errorf("reference '%s': %w", ref, ErrDereferenceCommitWithStaging)
 	}
 
-	curBranch, err := g.RefManager.GetBranch(ctx, repositoryID, branchID)
+	curBranch, err := g.RefManager.GetBranch(ctx, repository, branchID)
 	if err != nil {
 		return nil, err
 	}
@@ -205,30 +195,26 @@ func (g *DBGraveler) updateBranchNoLock(ctx context.Context, repositoryID Reposi
 		CommitID:     reference.CommitID,
 		StagingToken: curBranch.StagingToken,
 	}
-	err = g.RefManager.SetBranch(ctx, repositoryID, branchID, newBranch)
+	err = g.RefManager.SetBranch(ctx, repository, branchID, newBranch)
 	if err != nil {
 		return nil, err
 	}
 	return &newBranch, nil
 }
 
-func (g *DBGraveler) GetBranch(ctx context.Context, repositoryID RepositoryID, branchID BranchID) (*Branch, error) {
-	return g.RefManager.GetBranch(ctx, repositoryID, branchID)
+func (g *DBGraveler) GetBranch(ctx context.Context, repository *RepositoryRecord, branchID BranchID) (*Branch, error) {
+	return g.RefManager.GetBranch(ctx, repository, branchID)
 }
 
-func (g *DBGraveler) GetTag(ctx context.Context, repositoryID RepositoryID, tagID TagID) (*CommitID, error) {
-	return g.RefManager.GetTag(ctx, repositoryID, tagID)
+func (g *DBGraveler) GetTag(ctx context.Context, repository *RepositoryRecord, tagID TagID) (*CommitID, error) {
+	return g.RefManager.GetTag(ctx, repository, tagID)
 }
 
-func (g *DBGraveler) CreateTag(ctx context.Context, repositoryID RepositoryID, tagID TagID, commitID CommitID) error {
-	repo, err := g.RefManager.GetRepository(ctx, repositoryID)
-	if err != nil {
-		return fmt.Errorf("get repository: %w", err)
-	}
-	storageNamespace := repo.StorageNamespace
+func (g *DBGraveler) CreateTag(ctx context.Context, repository *RepositoryRecord, tagID TagID, commitID CommitID) error {
+	storageNamespace := repository.StorageNamespace
 
 	// Check that Tag doesn't exist before running hook
-	_, err = g.RefManager.GetTag(ctx, repositoryID, tagID)
+	_, err := g.RefManager.GetTag(ctx, repository, tagID)
 	if err == nil {
 		return ErrTagAlreadyExists
 	}
@@ -241,7 +227,7 @@ func (g *DBGraveler) CreateTag(ctx context.Context, repositoryID RepositoryID, t
 		RunID:            preRunID,
 		StorageNamespace: storageNamespace,
 		EventType:        EventTypePreCreateTag,
-		RepositoryID:     repositoryID,
+		RepositoryID:     repository.RepositoryID,
 		CommitID:         commitID,
 		SourceRef:        commitID.Ref(),
 		TagID:            tagID,
@@ -254,7 +240,7 @@ func (g *DBGraveler) CreateTag(ctx context.Context, repositoryID RepositoryID, t
 		}
 	}
 
-	err = g.RefManager.CreateTag(ctx, repositoryID, tagID, commitID)
+	err = g.RefManager.CreateTag(ctx, repository, tagID, commitID)
 	if err != nil {
 		return err
 	}
@@ -264,7 +250,7 @@ func (g *DBGraveler) CreateTag(ctx context.Context, repositoryID RepositoryID, t
 		RunID:            postRunID,
 		StorageNamespace: storageNamespace,
 		EventType:        EventTypePostCreateTag,
-		RepositoryID:     repositoryID,
+		RepositoryID:     repository.RepositoryID,
 		CommitID:         commitID,
 		SourceRef:        commitID.Ref(),
 		TagID:            tagID,
@@ -274,15 +260,11 @@ func (g *DBGraveler) CreateTag(ctx context.Context, repositoryID RepositoryID, t
 	return nil
 }
 
-func (g *DBGraveler) DeleteTag(ctx context.Context, repositoryID RepositoryID, tagID TagID) error {
-	repo, err := g.RefManager.GetRepository(ctx, repositoryID)
-	if err != nil {
-		return fmt.Errorf("get repository: %w", err)
-	}
-	storageNamespace := repo.StorageNamespace
+func (g *DBGraveler) DeleteTag(ctx context.Context, repository *RepositoryRecord, tagID TagID) error {
+	storageNamespace := repository.StorageNamespace
 
 	// Sanity check that Tag exists before running hook.
-	commitID, err := g.RefManager.GetTag(ctx, repositoryID, tagID)
+	commitID, err := g.RefManager.GetTag(ctx, repository, tagID)
 	if err != nil {
 		return err
 	}
@@ -292,7 +274,7 @@ func (g *DBGraveler) DeleteTag(ctx context.Context, repositoryID RepositoryID, t
 		RunID:            preRunID,
 		StorageNamespace: storageNamespace,
 		EventType:        EventTypePreDeleteTag,
-		RepositoryID:     repositoryID,
+		RepositoryID:     repository.RepositoryID,
 		SourceRef:        commitID.Ref(),
 		CommitID:         *commitID,
 		TagID:            tagID,
@@ -305,7 +287,7 @@ func (g *DBGraveler) DeleteTag(ctx context.Context, repositoryID RepositoryID, t
 		}
 	}
 
-	err = g.RefManager.DeleteTag(ctx, repositoryID, tagID)
+	err = g.RefManager.DeleteTag(ctx, repository, tagID)
 	if err != nil {
 		return err
 	}
@@ -315,7 +297,7 @@ func (g *DBGraveler) DeleteTag(ctx context.Context, repositoryID RepositoryID, t
 		RunID:            postRunID,
 		StorageNamespace: storageNamespace,
 		EventType:        EventTypePostDeleteTag,
-		RepositoryID:     repositoryID,
+		RepositoryID:     repository.RepositoryID,
 		SourceRef:        commitID.Ref(),
 		CommitID:         *commitID,
 		TagID:            tagID,
@@ -324,53 +306,45 @@ func (g *DBGraveler) DeleteTag(ctx context.Context, repositoryID RepositoryID, t
 	return nil
 }
 
-func (g *DBGraveler) ListTags(ctx context.Context, repositoryID RepositoryID) (TagIterator, error) {
-	return g.RefManager.ListTags(ctx, repositoryID)
+func (g *DBGraveler) ListTags(ctx context.Context, repository *RepositoryRecord) (TagIterator, error) {
+	return g.RefManager.ListTags(ctx, repository)
 }
 
-func (g *DBGraveler) Dereference(ctx context.Context, repositoryID RepositoryID, ref Ref) (*ResolvedRef, error) {
+func (g *DBGraveler) Dereference(ctx context.Context, repository *RepositoryRecord, ref Ref) (*ResolvedRef, error) {
 	rawRef, err := g.ParseRef(ref)
 	if err != nil {
 		return nil, err
 	}
-	return g.ResolveRawRef(ctx, repositoryID, rawRef)
+	return g.ResolveRawRef(ctx, repository, rawRef)
 }
 
 func (g *DBGraveler) ParseRef(ref Ref) (RawRef, error) {
 	return g.RefManager.ParseRef(ref)
 }
 
-func (g *DBGraveler) ResolveRawRef(ctx context.Context, repositoryID RepositoryID, rawRef RawRef) (*ResolvedRef, error) {
-	return g.RefManager.ResolveRawRef(ctx, repositoryID, rawRef)
+func (g *DBGraveler) ResolveRawRef(ctx context.Context, repository *RepositoryRecord, rawRef RawRef) (*ResolvedRef, error) {
+	return g.RefManager.ResolveRawRef(ctx, repository, rawRef)
 }
 
-func (g *DBGraveler) Log(ctx context.Context, repositoryID RepositoryID, commitID CommitID) (CommitIterator, error) {
-	return g.RefManager.Log(ctx, repositoryID, commitID)
+func (g *DBGraveler) Log(ctx context.Context, repository *RepositoryRecord, commitID CommitID) (CommitIterator, error) {
+	return g.RefManager.Log(ctx, repository, commitID)
 }
 
-func (g *DBGraveler) ListBranches(ctx context.Context, repositoryID RepositoryID) (BranchIterator, error) {
-	_, err := g.GetRepository(ctx, repositoryID)
-	if err != nil {
-		return nil, err
-	}
-	return g.RefManager.ListBranches(ctx, repositoryID)
+func (g *DBGraveler) ListBranches(ctx context.Context, repository *RepositoryRecord) (BranchIterator, error) {
+	return g.RefManager.ListBranches(ctx, repository)
 }
 
-func (g *DBGraveler) DeleteBranch(ctx context.Context, repositoryID RepositoryID, branchID BranchID) error {
+func (g *DBGraveler) DeleteBranch(ctx context.Context, repository *RepositoryRecord, branchID BranchID) error {
 	var (
 		preRunID         string
 		storageNamespace StorageNamespace
 		commitID         CommitID
 	)
-	_, err := g.branchLocker.MetadataUpdater(ctx, repositoryID, branchID, func() (interface{}, error) {
-		repo, err := g.RefManager.GetRepository(ctx, repositoryID)
-		if err != nil {
-			return nil, err
-		}
-		if repo.DefaultBranchID == branchID {
+	_, err := g.branchLocker.MetadataUpdater(ctx, repository, branchID, func() (interface{}, error) {
+		if repository.DefaultBranchID == branchID {
 			return nil, ErrDeleteDefaultBranch
 		}
-		branch, err := g.RefManager.GetBranch(ctx, repositoryID, branchID)
+		branch, err := g.RefManager.GetBranch(ctx, repository, branchID)
 		if err != nil {
 			return nil, err
 		}
@@ -380,13 +354,13 @@ func (g *DBGraveler) DeleteBranch(ctx context.Context, repositoryID RepositoryID
 			return nil, err
 		}
 
-		storageNamespace = repo.StorageNamespace
+		storageNamespace = repository.StorageNamespace
 		preRunID = g.hooks.NewRunID()
 		preHookRecord := HookRecord{
 			RunID:            preRunID,
 			StorageNamespace: storageNamespace,
 			EventType:        EventTypePreDeleteBranch,
-			RepositoryID:     repositoryID,
+			RepositoryID:     repository.RepositoryID,
 			SourceRef:        commitID.Ref(),
 			BranchID:         branchID,
 		}
@@ -399,7 +373,7 @@ func (g *DBGraveler) DeleteBranch(ctx context.Context, repositoryID RepositoryID
 			}
 		}
 
-		return nil, g.RefManager.DeleteBranch(ctx, repositoryID, branchID)
+		return nil, g.RefManager.DeleteBranch(ctx, repository, branchID)
 	})
 
 	if err != nil { // Don't perform post action hook if operation finished with error
@@ -411,7 +385,7 @@ func (g *DBGraveler) DeleteBranch(ctx context.Context, repositoryID RepositoryID
 		RunID:            postRunID,
 		StorageNamespace: storageNamespace,
 		EventType:        EventTypePostDeleteBranch,
-		RepositoryID:     repositoryID,
+		RepositoryID:     repository.RepositoryID,
 		SourceRef:        commitID.Ref(),
 		BranchID:         branchID,
 		PreRunID:         preRunID,
@@ -420,53 +394,41 @@ func (g *DBGraveler) DeleteBranch(ctx context.Context, repositoryID RepositoryID
 	return nil
 }
 
-func (g *DBGraveler) GetStagingToken(ctx context.Context, repositoryID RepositoryID, branchID BranchID) (*StagingToken, error) {
-	branch, err := g.RefManager.GetBranch(ctx, repositoryID, branchID)
+func (g *DBGraveler) GetStagingToken(ctx context.Context, repository *RepositoryRecord, branchID BranchID) (*StagingToken, error) {
+	branch, err := g.RefManager.GetBranch(ctx, repository, branchID)
 	if err != nil {
 		return nil, err
 	}
 	return &branch.StagingToken, nil
 }
 
-func (g *DBGraveler) GetGarbageCollectionRules(ctx context.Context, repositoryID RepositoryID) (*GarbageCollectionRules, error) {
-	repo, err := g.RefManager.GetRepository(ctx, repositoryID)
-	if err != nil {
-		return nil, err
-	}
-	return g.garbageCollectionManager.GetRules(ctx, repo.StorageNamespace)
+func (g *DBGraveler) GetGarbageCollectionRules(ctx context.Context, repository *RepositoryRecord) (*GarbageCollectionRules, error) {
+	return g.garbageCollectionManager.GetRules(ctx, repository.StorageNamespace)
 }
 
-func (g *DBGraveler) SetGarbageCollectionRules(ctx context.Context, repositoryID RepositoryID, rules *GarbageCollectionRules) error {
-	repo, err := g.RefManager.GetRepository(ctx, repositoryID)
-	if err != nil {
-		return err
-	}
-	return g.garbageCollectionManager.SaveRules(ctx, repo.StorageNamespace, rules)
+func (g *DBGraveler) SetGarbageCollectionRules(ctx context.Context, repository *RepositoryRecord, rules *GarbageCollectionRules) error {
+	return g.garbageCollectionManager.SaveRules(ctx, repository.StorageNamespace, rules)
 }
 
-func (g *DBGraveler) SaveGarbageCollectionCommits(ctx context.Context, repositoryID RepositoryID, previousRunID string) (*GarbageCollectionRunMetadata, error) {
-	rules, err := g.GetGarbageCollectionRules(ctx, repositoryID)
+func (g *DBGraveler) SaveGarbageCollectionCommits(ctx context.Context, repository *RepositoryRecord, previousRunID string) (*GarbageCollectionRunMetadata, error) {
+	rules, err := g.GetGarbageCollectionRules(ctx, repository)
 	if err != nil {
 		return nil, fmt.Errorf("get gc rules: %w", err)
 	}
-	repo, err := g.RefManager.GetRepository(ctx, repositoryID)
-	if err != nil {
-		return nil, fmt.Errorf("get repository: %w", err)
-	}
-	previouslyExpiredCommits, err := g.garbageCollectionManager.GetRunExpiredCommits(ctx, repo.StorageNamespace, previousRunID)
+	previouslyExpiredCommits, err := g.garbageCollectionManager.GetRunExpiredCommits(ctx, repository.StorageNamespace, previousRunID)
 	if err != nil {
 		return nil, fmt.Errorf("get expired commits from previous run: %w", err)
 	}
 
-	runID, err := g.garbageCollectionManager.SaveGarbageCollectionCommits(ctx, repo.StorageNamespace, repositoryID, rules, previouslyExpiredCommits)
+	runID, err := g.garbageCollectionManager.SaveGarbageCollectionCommits(ctx, repository, rules, previouslyExpiredCommits)
 	if err != nil {
 		return nil, fmt.Errorf("save garbage collection commits: %w", err)
 	}
-	commitsLocation, err := g.garbageCollectionManager.GetCommitsCSVLocation(runID, repo.StorageNamespace)
+	commitsLocation, err := g.garbageCollectionManager.GetCommitsCSVLocation(runID, repository.StorageNamespace)
 	if err != nil {
 		return nil, err
 	}
-	addressLocation, err := g.garbageCollectionManager.GetAddressesLocation(repo.StorageNamespace)
+	addressLocation, err := g.garbageCollectionManager.GetAddressesLocation(repository.StorageNamespace)
 	if err != nil {
 		return nil, err
 	}
@@ -478,24 +440,20 @@ func (g *DBGraveler) SaveGarbageCollectionCommits(ctx context.Context, repositor
 	}, err
 }
 
-func (g *DBGraveler) GetBranchProtectionRules(ctx context.Context, repositoryID RepositoryID) (*BranchProtectionRules, error) {
-	return g.protectedBranchesManager.GetRules(ctx, repositoryID)
+func (g *DBGraveler) GetBranchProtectionRules(ctx context.Context, repository *RepositoryRecord) (*BranchProtectionRules, error) {
+	return g.protectedBranchesManager.GetRules(ctx, repository)
 }
 
-func (g *DBGraveler) DeleteBranchProtectionRule(ctx context.Context, repositoryID RepositoryID, pattern string) error {
-	return g.protectedBranchesManager.Delete(ctx, repositoryID, pattern)
+func (g *DBGraveler) DeleteBranchProtectionRule(ctx context.Context, repository *RepositoryRecord, pattern string) error {
+	return g.protectedBranchesManager.Delete(ctx, repository, pattern)
 }
 
-func (g *DBGraveler) CreateBranchProtectionRule(ctx context.Context, repositoryID RepositoryID, pattern string, blockedActions []BranchProtectionBlockedAction) error {
-	return g.protectedBranchesManager.Add(ctx, repositoryID, pattern, blockedActions)
+func (g *DBGraveler) CreateBranchProtectionRule(ctx context.Context, repository *RepositoryRecord, pattern string, blockedActions []BranchProtectionBlockedAction) error {
+	return g.protectedBranchesManager.Add(ctx, repository, pattern, blockedActions)
 }
 
-func (g *DBGraveler) Get(ctx context.Context, repositoryID RepositoryID, ref Ref, key Key) (*Value, error) {
-	repo, err := g.RefManager.GetRepository(ctx, repositoryID)
-	if err != nil {
-		return nil, err
-	}
-	reference, err := g.Dereference(ctx, repositoryID, ref)
+func (g *DBGraveler) Get(ctx context.Context, repository *RepositoryRecord, ref Ref, key Key) (*Value, error) {
+	reference, err := g.Dereference(ctx, repository, ref)
 	if err != nil {
 		return nil, err
 	}
@@ -513,24 +471,27 @@ func (g *DBGraveler) Get(ctx context.Context, repositoryID RepositoryID, ref Ref
 			return value, nil
 		}
 	}
-	commitID := reference.CommitID
-	commit, err := g.RefManager.GetCommit(ctx, repositoryID, commitID)
+	return g.GetByCommitID(ctx, repository, reference.CommitID, key)
+}
+
+func (g *DBGraveler) GetByCommitID(ctx context.Context, repository *RepositoryRecord, commitID CommitID, key Key) (*Value, error) {
+	commit, err := g.RefManager.GetCommit(ctx, repository, commitID)
 	if err != nil {
 		return nil, err
 	}
-	return g.CommittedManager.Get(ctx, repo.StorageNamespace, commit.MetaRangeID, key)
+	return g.CommittedManager.Get(ctx, repository.StorageNamespace, commit.MetaRangeID, key)
 }
 
-func (g *DBGraveler) Set(ctx context.Context, repositoryID RepositoryID, branchID BranchID, key Key, value Value, writeConditions ...WriteConditionOption) error {
-	_, err := g.branchLocker.Writer(ctx, repositoryID, branchID, func() (interface{}, error) {
-		isProtected, err := g.protectedBranchesManager.IsBlocked(ctx, repositoryID, branchID, BranchProtectionBlockedAction_STAGING_WRITE)
+func (g *DBGraveler) Set(ctx context.Context, repository *RepositoryRecord, branchID BranchID, key Key, value Value, writeConditions ...WriteConditionOption) error {
+	_, err := g.branchLocker.Writer(ctx, repository, branchID, func() (interface{}, error) {
+		isProtected, err := g.protectedBranchesManager.IsBlocked(ctx, repository, branchID, BranchProtectionBlockedAction_STAGING_WRITE)
 		if err != nil {
 			return nil, err
 		}
 		if isProtected {
 			return nil, ErrWriteToProtectedBranch
 		}
-		branch, err := g.GetBranch(ctx, repositoryID, branchID)
+		branch, err := g.GetBranch(ctx, repository, branchID)
 		if err != nil {
 			return nil, err
 		}
@@ -543,7 +504,7 @@ func (g *DBGraveler) Set(ctx context.Context, repositoryID RepositoryID, branchI
 			// Ensure the given key doesn't exist in the underlying commit first
 			// Since we're being protected by the branch locker, we're guaranteed the commit
 			// won't change before we finish the operation
-			_, err := g.Get(ctx, repositoryID, Ref(branch.CommitID), key)
+			_, err := g.Get(ctx, repository, Ref(branch.CommitID), key)
 			if err == nil {
 				// we got a key here already!
 				return nil, ErrPreconditionFailed
@@ -569,20 +530,16 @@ func (g *DBGraveler) isStagedTombstone(ctx context.Context, token StagingToken, 
 	return e == nil
 }
 
-func (g *DBGraveler) Delete(ctx context.Context, repositoryID RepositoryID, branchID BranchID, key Key) error {
-	_, err := g.branchLocker.Writer(ctx, repositoryID, branchID, func() (interface{}, error) {
-		isProtected, err := g.protectedBranchesManager.IsBlocked(ctx, repositoryID, branchID, BranchProtectionBlockedAction_STAGING_WRITE)
+func (g *DBGraveler) Delete(ctx context.Context, repository *RepositoryRecord, branchID BranchID, key Key) error {
+	_, err := g.branchLocker.Writer(ctx, repository, branchID, func() (interface{}, error) {
+		isProtected, err := g.protectedBranchesManager.IsBlocked(ctx, repository, branchID, BranchProtectionBlockedAction_STAGING_WRITE)
 		if err != nil {
 			return nil, err
 		}
 		if isProtected {
 			return nil, ErrWriteToProtectedBranch
 		}
-		repo, err := g.RefManager.GetRepository(ctx, repositoryID)
-		if err != nil {
-			return nil, err
-		}
-		branch, err := g.GetBranch(ctx, repositoryID, branchID)
+		branch, err := g.GetBranch(ctx, repository, branchID)
 		if err != nil {
 			return nil, err
 		}
@@ -591,12 +548,12 @@ func (g *DBGraveler) Delete(ctx context.Context, repositoryID RepositoryID, bran
 		err = ErrNotFound
 		if branch.CommitID != "" {
 			var commit *Commit
-			commit, err = g.RefManager.GetCommit(ctx, repositoryID, branch.CommitID)
+			commit, err = g.RefManager.GetCommit(ctx, repository, branch.CommitID)
 			if err != nil {
 				return nil, err
 			}
 			// check key in committed - do we need tombstone?
-			_, err = g.CommittedManager.Get(ctx, repo.StorageNamespace, commit.MetaRangeID, key)
+			_, err = g.CommittedManager.Get(ctx, repository.StorageNamespace, commit.MetaRangeID, key)
 		}
 
 		if errors.Is(err, ErrNotFound) {
@@ -607,7 +564,7 @@ func (g *DBGraveler) Delete(ctx context.Context, repositoryID RepositoryID, bran
 			return nil, err
 		}
 
-		// key is in committed, stage its tombstone -- regardless of whether or not it
+		// key is in committed, stage its tombstone -- regardless of whether it
 		// is also in staging.  But... if it already has a tombstone staged, return
 		// ErrNotFound.
 
@@ -623,25 +580,21 @@ func (g *DBGraveler) Delete(ctx context.Context, repositoryID RepositoryID, bran
 	return err
 }
 
-func (g *DBGraveler) List(ctx context.Context, repositoryID RepositoryID, ref Ref) (ValueIterator, error) {
-	repo, err := g.RefManager.GetRepository(ctx, repositoryID)
-	if err != nil {
-		return nil, err
-	}
-	reference, err := g.Dereference(ctx, repositoryID, ref)
+func (g *DBGraveler) List(ctx context.Context, repository *RepositoryRecord, ref Ref) (ValueIterator, error) {
+	reference, err := g.Dereference(ctx, repository, ref)
 	if err != nil {
 		return nil, err
 	}
 	var metaRangeID MetaRangeID
 	if reference.CommitID != "" {
-		commit, err := g.RefManager.GetCommit(ctx, repositoryID, reference.CommitID)
+		commit, err := g.RefManager.GetCommit(ctx, repository, reference.CommitID)
 		if err != nil {
 			return nil, err
 		}
 		metaRangeID = commit.MetaRangeID
 	}
 
-	listing, err := g.CommittedManager.List(ctx, repo.StorageNamespace, metaRangeID)
+	listing, err := g.CommittedManager.List(ctx, repository.StorageNamespace, metaRangeID)
 	if err != nil {
 		return nil, err
 	}
@@ -655,25 +608,21 @@ func (g *DBGraveler) List(ctx context.Context, repositoryID RepositoryID, ref Re
 	return listing, nil
 }
 
-func (g *DBGraveler) Commit(ctx context.Context, repositoryID RepositoryID, branchID BranchID, params CommitParams) (CommitID, error) {
+func (g *DBGraveler) Commit(ctx context.Context, repository *RepositoryRecord, branchID BranchID, params CommitParams) (CommitID, error) {
 	var preRunID string
 	var commit Commit
 	var storageNamespace StorageNamespace
-	res, err := g.branchLocker.MetadataUpdater(ctx, repositoryID, branchID, func() (interface{}, error) {
-		isProtected, err := g.protectedBranchesManager.IsBlocked(ctx, repositoryID, branchID, BranchProtectionBlockedAction_COMMIT)
+	res, err := g.branchLocker.MetadataUpdater(ctx, repository, branchID, func() (interface{}, error) {
+		isProtected, err := g.protectedBranchesManager.IsBlocked(ctx, repository, branchID, BranchProtectionBlockedAction_COMMIT)
 		if err != nil {
 			return nil, err
 		}
 		if isProtected {
 			return nil, ErrCommitToProtectedBranch
 		}
-		repo, err := g.RefManager.GetRepository(ctx, repositoryID)
-		if err != nil {
-			return "", fmt.Errorf("get repository: %w", err)
-		}
-		storageNamespace = repo.StorageNamespace
+		storageNamespace = repository.StorageNamespace
 
-		branch, err := g.RefManager.GetBranch(ctx, repositoryID, branchID)
+		branch, err := g.RefManager.GetBranch(ctx, repository, branchID)
 		if err != nil {
 			return "", fmt.Errorf("get branch: %w", err)
 		}
@@ -706,7 +655,7 @@ func (g *DBGraveler) Commit(ctx context.Context, repositoryID RepositoryID, bran
 			RunID:            preRunID,
 			EventType:        EventTypePreCommit,
 			SourceRef:        branchID.Ref(),
-			RepositoryID:     repositoryID,
+			RepositoryID:     repository.RepositoryID,
 			StorageNamespace: storageNamespace,
 			BranchID:         branchID,
 			Commit:           commit,
@@ -722,7 +671,7 @@ func (g *DBGraveler) Commit(ctx context.Context, repositoryID RepositoryID, bran
 		var branchMetaRangeID MetaRangeID
 		var parentGeneration int
 		if branch.CommitID != "" {
-			branchCommit, err := g.RefManager.GetCommit(ctx, repositoryID, branch.CommitID)
+			branchCommit, err := g.RefManager.GetCommit(ctx, repository, branch.CommitID)
 			if err != nil {
 				return "", fmt.Errorf("get commit: %w", err)
 			}
@@ -746,13 +695,13 @@ func (g *DBGraveler) Commit(ctx context.Context, repositoryID RepositoryID, bran
 		}
 
 		// add commit
-		newCommit, err := g.RefManager.AddCommit(ctx, repositoryID, commit)
+		newCommit, err := g.RefManager.AddCommit(ctx, repository, commit)
 		if err != nil {
 			return "", fmt.Errorf("add commit: %w", err)
 		}
-		err = g.RefManager.SetBranch(ctx, repositoryID, branchID, Branch{
+		err = g.RefManager.SetBranch(ctx, repository, branchID, Branch{
 			CommitID:     newCommit,
-			StagingToken: GenerateStagingToken(repositoryID, branchID),
+			StagingToken: GenerateStagingToken(repository.RepositoryID, branchID),
 		})
 		if err != nil {
 			return "", fmt.Errorf("set branch commit %s: %w", newCommit, err)
@@ -760,7 +709,7 @@ func (g *DBGraveler) Commit(ctx context.Context, repositoryID RepositoryID, bran
 		err = g.StagingManager.Drop(ctx, branch.StagingToken)
 		if err != nil {
 			g.log.WithContext(ctx).WithFields(logging.Fields{
-				"repository_id": repositoryID,
+				"repository_id": repository.RepositoryID,
 				"branch_id":     branchID,
 				"commit_id":     branch.CommitID,
 				"message":       params.Message,
@@ -777,7 +726,7 @@ func (g *DBGraveler) Commit(ctx context.Context, repositoryID RepositoryID, bran
 	err = g.hooks.PostCommitHook(ctx, HookRecord{
 		EventType:        EventTypePostCommit,
 		RunID:            postRunID,
-		RepositoryID:     repositoryID,
+		RepositoryID:     repository.RepositoryID,
 		StorageNamespace: storageNamespace,
 		SourceRef:        res.(CommitID).Ref(),
 		BranchID:         branchID,
@@ -794,16 +743,16 @@ func (g *DBGraveler) Commit(ctx context.Context, repositoryID RepositoryID, bran
 	return newCommitID, nil
 }
 
-func (g *DBGraveler) AddCommitToBranchHead(ctx context.Context, repositoryID RepositoryID, branchID BranchID, commit Commit) (CommitID, error) {
-	res, err := g.branchLocker.MetadataUpdater(ctx, repositoryID, branchID, func() (interface{}, error) {
+func (g *DBGraveler) AddCommitToBranchHead(ctx context.Context, repository *RepositoryRecord, branchID BranchID, commit Commit) (CommitID, error) {
+	res, err := g.branchLocker.MetadataUpdater(ctx, repository, branchID, func() (interface{}, error) {
 		// parentCommitID should always match the HEAD of the branch.
 		// Empty parentCommitID matches first commit of the branch.
-		parentCommitID, err := validateCommitParent(ctx, repositoryID, commit, g.RefManager)
+		parentCommitID, err := validateCommitParent(ctx, repository, commit, g.RefManager)
 		if err != nil {
 			return nil, err
 		}
 
-		branch, err := g.RefManager.GetBranch(ctx, repositoryID, branchID)
+		branch, err := g.RefManager.GetBranch(ctx, repository, branchID)
 		if err != nil {
 			return nil, err
 		}
@@ -813,17 +762,17 @@ func (g *DBGraveler) AddCommitToBranchHead(ctx context.Context, repositoryID Rep
 
 		// check if commit already exists.
 		commitID := CommitID(ident.NewHexAddressProvider().ContentAddress(commit))
-		if exists, err := CommitExists(ctx, repositoryID, commitID, g.RefManager); err != nil {
+		if exists, err := CommitExists(ctx, repository, commitID, g.RefManager); err != nil {
 			return nil, err
 		} else if exists {
 			return commitID, nil
 		}
 
-		commitID, err = g.addCommitNoLock(ctx, repositoryID, commit)
+		commitID, err = g.addCommitNoLock(ctx, repository, commit)
 		if err != nil {
 			return nil, fmt.Errorf("adding commit: %w", err)
 		}
-		_, err = g.updateBranchNoLock(ctx, repositoryID, branchID, Ref(commitID))
+		_, err = g.updateBranchNoLock(ctx, repository, branchID, Ref(commitID))
 		if err != nil {
 			return nil, err
 		}
@@ -835,25 +784,25 @@ func (g *DBGraveler) AddCommitToBranchHead(ctx context.Context, repositoryID Rep
 	return res.(CommitID), nil
 }
 
-func (g *DBGraveler) AddCommit(ctx context.Context, repositoryID RepositoryID, commit Commit) (CommitID, error) {
+func (g *DBGraveler) AddCommit(ctx context.Context, repository *RepositoryRecord, commit Commit) (CommitID, error) {
 	// at least a single parent must exists
 	if len(commit.Parents) == 0 {
 		return "", ErrAddCommitNoParent
 	}
-	_, err := validateCommitParent(ctx, repositoryID, commit, g.RefManager)
+	_, err := validateCommitParent(ctx, repository, commit, g.RefManager)
 	if err != nil {
 		return "", err
 	}
 
 	// check if commit already exists.
 	commitID := CommitID(ident.NewHexAddressProvider().ContentAddress(commit))
-	if exists, err := CommitExists(ctx, repositoryID, commitID, g.RefManager); err != nil {
+	if exists, err := CommitExists(ctx, repository, commitID, g.RefManager); err != nil {
 		return "", err
 	} else if exists {
 		return commitID, nil
 	}
 
-	commitID, err = g.addCommitNoLock(ctx, repositoryID, commit)
+	commitID, err = g.addCommitNoLock(ctx, repository, commit)
 	if err != nil {
 		return "", fmt.Errorf("adding commit: %w", err)
 	}
@@ -862,14 +811,9 @@ func (g *DBGraveler) AddCommit(ctx context.Context, repositoryID RepositoryID, c
 }
 
 // addCommitNoLock lower API used to add commit into a repository. It will verify that the commit meta-range is accessible but will not lock any metadata update.
-func (g *DBGraveler) addCommitNoLock(ctx context.Context, repositoryID RepositoryID, commit Commit) (CommitID, error) {
-	repo, err := g.RefManager.GetRepository(ctx, repositoryID)
-	if err != nil {
-		return "", fmt.Errorf("get repository %s: %w", repositoryID, err)
-	}
-
+func (g *DBGraveler) addCommitNoLock(ctx context.Context, repository *RepositoryRecord, commit Commit) (CommitID, error) {
 	// verify access to meta range
-	ok, err := g.CommittedManager.Exists(ctx, repo.StorageNamespace, commit.MetaRangeID)
+	ok, err := g.CommittedManager.Exists(ctx, repository.StorageNamespace, commit.MetaRangeID)
 	if err != nil {
 		return "", fmt.Errorf("checking for meta range %s: %w", commit.MetaRangeID, err)
 	}
@@ -878,7 +822,7 @@ func (g *DBGraveler) addCommitNoLock(ctx context.Context, repositoryID Repositor
 	}
 
 	// add commit
-	commitID, err := g.RefManager.AddCommit(ctx, repositoryID, commit)
+	commitID, err := g.RefManager.AddCommit(ctx, repository, commit)
 	if err != nil {
 		return "", fmt.Errorf("add commit: %w", err)
 	}
@@ -900,16 +844,16 @@ func (g *DBGraveler) stagingEmpty(ctx context.Context, branch *Branch) (bool, er
 	return true, nil
 }
 
-func (g *DBGraveler) Reset(ctx context.Context, repositoryID RepositoryID, branchID BranchID) error {
-	_, err := g.branchLocker.Writer(ctx, repositoryID, branchID, func() (interface{}, error) {
-		isProtected, err := g.protectedBranchesManager.IsBlocked(ctx, repositoryID, branchID, BranchProtectionBlockedAction_STAGING_WRITE)
+func (g *DBGraveler) Reset(ctx context.Context, repository *RepositoryRecord, branchID BranchID) error {
+	_, err := g.branchLocker.Writer(ctx, repository, branchID, func() (interface{}, error) {
+		isProtected, err := g.protectedBranchesManager.IsBlocked(ctx, repository, branchID, BranchProtectionBlockedAction_STAGING_WRITE)
 		if err != nil {
 			return nil, err
 		}
 		if isProtected {
 			return nil, ErrWriteToProtectedBranch
 		}
-		branch, err := g.RefManager.GetBranch(ctx, repositoryID, branchID)
+		branch, err := g.RefManager.GetBranch(ctx, repository, branchID)
 		if err != nil {
 			return nil, err
 		}
@@ -918,16 +862,16 @@ func (g *DBGraveler) Reset(ctx context.Context, repositoryID RepositoryID, branc
 	return err
 }
 
-func (g *DBGraveler) ResetKey(ctx context.Context, repositoryID RepositoryID, branchID BranchID, key Key) error {
-	_, err := g.branchLocker.Writer(ctx, repositoryID, branchID, func() (interface{}, error) {
-		isProtected, err := g.protectedBranchesManager.IsBlocked(ctx, repositoryID, branchID, BranchProtectionBlockedAction_STAGING_WRITE)
+func (g *DBGraveler) ResetKey(ctx context.Context, repository *RepositoryRecord, branchID BranchID, key Key) error {
+	_, err := g.branchLocker.Writer(ctx, repository, branchID, func() (interface{}, error) {
+		isProtected, err := g.protectedBranchesManager.IsBlocked(ctx, repository, branchID, BranchProtectionBlockedAction_STAGING_WRITE)
 		if err != nil {
 			return nil, err
 		}
 		if isProtected {
 			return nil, ErrWriteToProtectedBranch
 		}
-		branch, err := g.RefManager.GetBranch(ctx, repositoryID, branchID)
+		branch, err := g.RefManager.GetBranch(ctx, repository, branchID)
 		if err != nil {
 			return nil, err
 		}
@@ -936,16 +880,16 @@ func (g *DBGraveler) ResetKey(ctx context.Context, repositoryID RepositoryID, br
 	return err
 }
 
-func (g *DBGraveler) ResetPrefix(ctx context.Context, repositoryID RepositoryID, branchID BranchID, key Key) error {
-	_, err := g.branchLocker.Writer(ctx, repositoryID, branchID, func() (interface{}, error) {
-		isProtected, err := g.protectedBranchesManager.IsBlocked(ctx, repositoryID, branchID, BranchProtectionBlockedAction_STAGING_WRITE)
+func (g *DBGraveler) ResetPrefix(ctx context.Context, repository *RepositoryRecord, branchID BranchID, key Key) error {
+	_, err := g.branchLocker.Writer(ctx, repository, branchID, func() (interface{}, error) {
+		isProtected, err := g.protectedBranchesManager.IsBlocked(ctx, repository, branchID, BranchProtectionBlockedAction_STAGING_WRITE)
 		if err != nil {
 			return nil, err
 		}
 		if isProtected {
 			return nil, ErrWriteToProtectedBranch
 		}
-		branch, err := g.RefManager.GetBranch(ctx, repositoryID, branchID)
+		branch, err := g.RefManager.GetBranch(ctx, repository, branchID)
 		if err != nil {
 			return nil, err
 		}
@@ -960,8 +904,8 @@ func (g *DBGraveler) ResetPrefix(ctx context.Context, repositoryID RepositoryID,
 // To revert C2, we merge C1 into the branch, with C2 as the merge base.
 // That is, try to apply the diff from C2 to C1 on the tip of the branch.
 // If the commit is a merge commit, 'parentNumber' is the parent number (1-based) relative to which the revert is done.
-func (g *DBGraveler) Revert(ctx context.Context, repositoryID RepositoryID, branchID BranchID, ref Ref, parentNumber int, commitParams CommitParams) (CommitID, error) {
-	commitRecord, err := g.dereferenceCommit(ctx, repositoryID, ref)
+func (g *DBGraveler) Revert(ctx context.Context, repository *RepositoryRecord, branchID BranchID, ref Ref, parentNumber int, commitParams CommitParams) (CommitID, error) {
+	commitRecord, err := g.dereferenceCommit(ctx, repository, ref)
 	if err != nil {
 		return "", fmt.Errorf("get commit from ref %s: %w", ref, err)
 	}
@@ -976,12 +920,8 @@ func (g *DBGraveler) Revert(ctx context.Context, repositoryID RepositoryID, bran
 		}
 		parentNumber--
 	}
-	res, err := g.branchLocker.MetadataUpdater(ctx, repositoryID, branchID, func() (interface{}, error) {
-		repo, err := g.RefManager.GetRepository(ctx, repositoryID)
-		if err != nil {
-			return nil, fmt.Errorf("get repo %s: %w", repositoryID, err)
-		}
-		branch, err := g.RefManager.GetBranch(ctx, repositoryID, branchID)
+	res, err := g.branchLocker.MetadataUpdater(ctx, repository, branchID, func() (interface{}, error) {
+		branch, err := g.RefManager.GetBranch(ctx, repository, branchID)
 		if err != nil {
 			return "", fmt.Errorf("get branch %s: %w", branchID, err)
 		}
@@ -992,18 +932,18 @@ func (g *DBGraveler) Revert(ctx context.Context, repositoryID RepositoryID, bran
 		}
 		var parentMetaRangeID MetaRangeID
 		if len(commitRecord.Parents) > 0 {
-			parentCommit, err := g.dereferenceCommit(ctx, repositoryID, commitRecord.Parents[parentNumber].Ref())
+			parentCommit, err := g.dereferenceCommit(ctx, repository, commitRecord.Parents[parentNumber].Ref())
 			if err != nil {
 				return "", fmt.Errorf("get commit from ref %s: %w", commitRecord.Parents[parentNumber], err)
 			}
 			parentMetaRangeID = parentCommit.MetaRangeID
 		}
-		branchCommit, err := g.dereferenceCommit(ctx, repositoryID, branch.CommitID.Ref())
+		branchCommit, err := g.dereferenceCommit(ctx, repository, branch.CommitID.Ref())
 		if err != nil {
 			return "", fmt.Errorf("get commit from ref %s: %w", branch.CommitID, err)
 		}
 		// merge from the parent to the top of the branch, with the given ref as the merge base:
-		metaRangeID, err := g.CommittedManager.Merge(ctx, repo.StorageNamespace, branchCommit.MetaRangeID, parentMetaRangeID, commitRecord.MetaRangeID, MergeStrategyNone)
+		metaRangeID, err := g.CommittedManager.Merge(ctx, repository.StorageNamespace, branchCommit.MetaRangeID, parentMetaRangeID, commitRecord.MetaRangeID, MergeStrategyNone)
 		if err != nil {
 			if !errors.Is(err, ErrUserVisible) {
 				err = fmt.Errorf("merge: %w", err)
@@ -1017,11 +957,11 @@ func (g *DBGraveler) Revert(ctx context.Context, repositoryID RepositoryID, bran
 		commit.Parents = []CommitID{branch.CommitID}
 		commit.Metadata = commitParams.Metadata
 		commit.Generation = branchCommit.Generation + 1
-		commitID, err := g.RefManager.AddCommit(ctx, repositoryID, commit)
+		commitID, err := g.RefManager.AddCommit(ctx, repository, commit)
 		if err != nil {
 			return "", fmt.Errorf("add commit: %w", err)
 		}
-		err = g.RefManager.SetBranch(ctx, repositoryID, branchID, Branch{
+		err = g.RefManager.SetBranch(ctx, repository, branchID, Branch{
 			CommitID:     commitID,
 			StagingToken: branch.StagingToken,
 		})
@@ -1036,18 +976,14 @@ func (g *DBGraveler) Revert(ctx context.Context, repositoryID RepositoryID, bran
 	return res.(CommitID), nil
 }
 
-func (g *DBGraveler) Merge(ctx context.Context, repositoryID RepositoryID, destination BranchID, source Ref, commitParams CommitParams, strategy string) (CommitID, error) {
+func (g *DBGraveler) Merge(ctx context.Context, repository *RepositoryRecord, destination BranchID, source Ref, commitParams CommitParams, strategy string) (CommitID, error) {
 	var preRunID string
 	var storageNamespace StorageNamespace
 	var commit Commit
-	res, err := g.branchLocker.MetadataUpdater(ctx, repositoryID, destination, func() (interface{}, error) {
-		repo, err := g.RefManager.GetRepository(ctx, repositoryID)
-		if err != nil {
-			return nil, err
-		}
-		storageNamespace = repo.StorageNamespace
+	res, err := g.branchLocker.MetadataUpdater(ctx, repository, destination, func() (interface{}, error) {
+		storageNamespace = repository.StorageNamespace
 
-		branch, err := g.GetBranch(ctx, repositoryID, destination)
+		branch, err := g.GetBranch(ctx, repository, destination)
 		if err != nil {
 			return nil, fmt.Errorf("get branch: %w", err)
 		}
@@ -1058,7 +994,7 @@ func (g *DBGraveler) Merge(ctx context.Context, repositoryID RepositoryID, desti
 		if !empty {
 			return nil, fmt.Errorf("%s: %w", destination, ErrDirtyBranch)
 		}
-		fromCommit, toCommit, baseCommit, err := g.getCommitsForMerge(ctx, repositoryID, source, Ref(destination))
+		fromCommit, toCommit, baseCommit, err := g.getCommitsForMerge(ctx, repository, source, Ref(destination))
 		if err != nil {
 			return nil, err
 		}
@@ -1099,7 +1035,7 @@ func (g *DBGraveler) Merge(ctx context.Context, repositoryID RepositoryID, desti
 		err = g.hooks.PreMergeHook(ctx, HookRecord{
 			EventType:        EventTypePreMerge,
 			RunID:            preRunID,
-			RepositoryID:     repositoryID,
+			RepositoryID:     repository.RepositoryID,
 			StorageNamespace: storageNamespace,
 			BranchID:         destination,
 			SourceRef:        fromCommit.CommitID.Ref(),
@@ -1112,12 +1048,12 @@ func (g *DBGraveler) Merge(ctx context.Context, repositoryID RepositoryID, desti
 				Err:       err,
 			}
 		}
-		commitID, err := g.RefManager.AddCommit(ctx, repositoryID, commit)
+		commitID, err := g.RefManager.AddCommit(ctx, repository, commit)
 		if err != nil {
 			return nil, fmt.Errorf("add commit: %w", err)
 		}
 		branch.CommitID = commitID
-		err = g.RefManager.SetBranch(ctx, repositoryID, destination, *branch)
+		err = g.RefManager.SetBranch(ctx, repository, destination, *branch)
 		if err != nil {
 			return commitID, fmt.Errorf("update branch %s: %w", destination, err)
 		}
@@ -1130,7 +1066,7 @@ func (g *DBGraveler) Merge(ctx context.Context, repositoryID RepositoryID, desti
 	err = g.hooks.PostMergeHook(ctx, HookRecord{
 		EventType:        EventTypePostMerge,
 		RunID:            postRunID,
-		RepositoryID:     repositoryID,
+		RepositoryID:     repository.RepositoryID,
 		StorageNamespace: storageNamespace,
 		BranchID:         destination,
 		SourceRef:        res.(CommitID).Ref(),
@@ -1148,18 +1084,14 @@ func (g *DBGraveler) Merge(ctx context.Context, repositoryID RepositoryID, desti
 	return res.(CommitID), nil
 }
 
-func (g *DBGraveler) DiffUncommitted(ctx context.Context, repositoryID RepositoryID, branchID BranchID) (DiffIterator, error) {
-	repo, err := g.RefManager.GetRepository(ctx, repositoryID)
-	if err != nil {
-		return nil, err
-	}
-	branch, err := g.RefManager.GetBranch(ctx, repositoryID, branchID)
+func (g *DBGraveler) DiffUncommitted(ctx context.Context, repository *RepositoryRecord, branchID BranchID) (DiffIterator, error) {
+	branch, err := g.RefManager.GetBranch(ctx, repository, branchID)
 	if err != nil {
 		return nil, err
 	}
 	var metaRangeID MetaRangeID
 	if branch.CommitID != "" {
-		commit, err := g.RefManager.GetCommit(ctx, repositoryID, branch.CommitID)
+		commit, err := g.RefManager.GetCommit(ctx, repository, branch.CommitID)
 		if err != nil {
 			return nil, err
 		}
@@ -1172,7 +1104,7 @@ func (g *DBGraveler) DiffUncommitted(ctx context.Context, repositoryID Repositor
 	}
 	var committedValueIterator ValueIterator
 	if metaRangeID != "" {
-		committedValueIterator, err = g.CommittedManager.List(ctx, repo.StorageNamespace, metaRangeID)
+		committedValueIterator, err = g.CommittedManager.List(ctx, repository.StorageNamespace, metaRangeID)
 		if err != nil {
 			return nil, err
 		}
@@ -1182,15 +1114,15 @@ func (g *DBGraveler) DiffUncommitted(ctx context.Context, repositoryID Repositor
 
 // dereferenceCommit will dereference and load the commit record based on 'ref'.
 //   will return an error if 'ref' points to an explicit staging area
-func (g *DBGraveler) dereferenceCommit(ctx context.Context, repositoryID RepositoryID, ref Ref) (*CommitRecord, error) {
-	reference, err := g.Dereference(ctx, repositoryID, ref)
+func (g *DBGraveler) dereferenceCommit(ctx context.Context, repository *RepositoryRecord, ref Ref) (*CommitRecord, error) {
+	reference, err := g.Dereference(ctx, repository, ref)
 	if err != nil {
 		return nil, err
 	}
 	if reference.ResolvedBranchModifier == ResolvedBranchModifierStaging {
 		return nil, fmt.Errorf("reference '%s': %w", ref, ErrDereferenceCommitWithStaging)
 	}
-	commit, err := g.RefManager.GetCommit(ctx, repositoryID, reference.CommitID)
+	commit, err := g.RefManager.GetCommit(ctx, repository, reference.CommitID)
 	if err != nil {
 		return nil, err
 	}
@@ -1200,35 +1132,31 @@ func (g *DBGraveler) dereferenceCommit(ctx context.Context, repositoryID Reposit
 	}, nil
 }
 
-func (g *DBGraveler) Diff(ctx context.Context, repositoryID RepositoryID, left, right Ref) (DiffIterator, error) {
-	repo, err := g.RefManager.GetRepository(ctx, repositoryID)
+func (g *DBGraveler) Diff(ctx context.Context, repository *RepositoryRecord, left, right Ref) (DiffIterator, error) {
+	leftCommit, err := g.dereferenceCommit(ctx, repository, left)
 	if err != nil {
 		return nil, err
 	}
-	leftCommit, err := g.dereferenceCommit(ctx, repositoryID, left)
+	rightRawRef, err := g.Dereference(ctx, repository, right)
 	if err != nil {
 		return nil, err
 	}
-	rightRawRef, err := g.Dereference(ctx, repositoryID, right)
+	rightCommit, err := g.RefManager.GetCommit(ctx, repository, rightRawRef.CommitID)
 	if err != nil {
 		return nil, err
 	}
-	rightCommit, err := g.RefManager.GetCommit(ctx, repositoryID, rightRawRef.CommitID)
-	if err != nil {
-		return nil, err
-	}
-	diff, err := g.CommittedManager.Diff(ctx, repo.StorageNamespace, leftCommit.MetaRangeID, rightCommit.MetaRangeID)
+	diff, err := g.CommittedManager.Diff(ctx, repository.StorageNamespace, leftCommit.MetaRangeID, rightCommit.MetaRangeID)
 	if err != nil {
 		return nil, err
 	}
 	if rightRawRef.ResolvedBranchModifier != ResolvedBranchModifierStaging {
 		return diff, nil
 	}
-	leftValueIterator, err := g.CommittedManager.List(ctx, repo.StorageNamespace, leftCommit.MetaRangeID)
+	leftValueIterator, err := g.CommittedManager.List(ctx, repository.StorageNamespace, leftCommit.MetaRangeID)
 	if err != nil {
 		return nil, err
 	}
-	rightBranch, err := g.RefManager.GetBranch(ctx, repositoryID, rightRawRef.BranchID)
+	rightBranch, err := g.RefManager.GetBranch(ctx, repository, rightRawRef.BranchID)
 	if err != nil {
 		return nil, err
 	}
@@ -1239,16 +1167,12 @@ func (g *DBGraveler) Diff(ctx context.Context, repositoryID RepositoryID, left, 
 	return NewCombinedDiffIterator(diff, leftValueIterator, stagingIterator), nil
 }
 
-func (g *DBGraveler) Compare(ctx context.Context, repositoryID RepositoryID, left, right Ref) (DiffIterator, error) {
-	repo, err := g.RefManager.GetRepository(ctx, repositoryID)
+func (g *DBGraveler) Compare(ctx context.Context, repository *RepositoryRecord, left, right Ref) (DiffIterator, error) {
+	fromCommit, toCommit, baseCommit, err := g.getCommitsForMerge(ctx, repository, right, left)
 	if err != nil {
 		return nil, err
 	}
-	fromCommit, toCommit, baseCommit, err := g.getCommitsForMerge(ctx, repositoryID, right, left)
-	if err != nil {
-		return nil, err
-	}
-	return g.CommittedManager.Compare(ctx, repo.StorageNamespace, toCommit.MetaRangeID, fromCommit.MetaRangeID, baseCommit.MetaRangeID)
+	return g.CommittedManager.Compare(ctx, repository.StorageNamespace, toCommit.MetaRangeID, fromCommit.MetaRangeID, baseCommit.MetaRangeID)
 }
 
 func (g *DBGraveler) SetHooksHandler(handler HooksHandler) {
@@ -1259,16 +1183,16 @@ func (g *DBGraveler) SetHooksHandler(handler HooksHandler) {
 	}
 }
 
-func (g *DBGraveler) getCommitsForMerge(ctx context.Context, repositoryID RepositoryID, from Ref, to Ref) (*CommitRecord, *CommitRecord, *Commit, error) {
-	fromCommit, err := g.dereferenceCommit(ctx, repositoryID, from)
+func (g *DBGraveler) getCommitsForMerge(ctx context.Context, repository *RepositoryRecord, from Ref, to Ref) (*CommitRecord, *CommitRecord, *Commit, error) {
+	fromCommit, err := g.dereferenceCommit(ctx, repository, from)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("get commit by ref %s: %w", from, err)
 	}
-	toCommit, err := g.dereferenceCommit(ctx, repositoryID, to)
+	toCommit, err := g.dereferenceCommit(ctx, repository, to)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("get commit by branch %s: %w", to, err)
 	}
-	baseCommit, err := g.RefManager.FindMergeBase(ctx, repositoryID, fromCommit.CommitID, toCommit.CommitID)
+	baseCommit, err := g.RefManager.FindMergeBase(ctx, repository, fromCommit.CommitID, toCommit.CommitID)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("find merge base: %w", err)
 	}
@@ -1278,12 +1202,8 @@ func (g *DBGraveler) getCommitsForMerge(ctx context.Context, repositoryID Reposi
 	return fromCommit, toCommit, baseCommit, nil
 }
 
-func (g *DBGraveler) LoadCommits(ctx context.Context, repositoryID RepositoryID, metaRangeID MetaRangeID) error {
-	repo, err := g.GetRepository(ctx, repositoryID)
-	if err != nil {
-		return err
-	}
-	iter, err := g.CommittedManager.List(ctx, repo.StorageNamespace, metaRangeID)
+func (g *DBGraveler) LoadCommits(ctx context.Context, repository *RepositoryRecord, metaRangeID MetaRangeID) error {
+	iter, err := g.CommittedManager.List(ctx, repository.StorageNamespace, metaRangeID)
 	if err != nil {
 		return err
 	}
@@ -1302,7 +1222,7 @@ func (g *DBGraveler) LoadCommits(ctx context.Context, repositoryID RepositoryID,
 		if commit.GetGeneration() == 0 {
 			return fmt.Errorf("dumps created by lakeFS versions before v0.61.0 are no longer supported: %w", ErrNoCommitGeneration)
 		}
-		commitID, err := g.RefManager.AddCommit(ctx, repositoryID, Commit{
+		commitID, err := g.RefManager.AddCommit(ctx, repository, Commit{
 			Version:      CommitVersion(commit.Version),
 			Committer:    commit.GetCommitter(),
 			Message:      commit.GetMessage(),
@@ -1326,12 +1246,8 @@ func (g *DBGraveler) LoadCommits(ctx context.Context, repositoryID RepositoryID,
 	return nil
 }
 
-func (g *DBGraveler) LoadBranches(ctx context.Context, repositoryID RepositoryID, metaRangeID MetaRangeID) error {
-	repo, err := g.GetRepository(ctx, repositoryID)
-	if err != nil {
-		return err
-	}
-	iter, err := g.CommittedManager.List(ctx, repo.StorageNamespace, metaRangeID)
+func (g *DBGraveler) LoadBranches(ctx context.Context, repository *RepositoryRecord, metaRangeID MetaRangeID) error {
+	iter, err := g.CommittedManager.List(ctx, repository.StorageNamespace, metaRangeID)
 	if err != nil {
 		return err
 	}
@@ -1344,9 +1260,9 @@ func (g *DBGraveler) LoadBranches(ctx context.Context, repositoryID RepositoryID
 			return err
 		}
 		branchID := BranchID(branch.Id)
-		err = g.RefManager.SetBranch(ctx, repositoryID, branchID, Branch{
+		err = g.RefManager.SetBranch(ctx, repository, branchID, Branch{
 			CommitID:     CommitID(branch.CommitId),
-			StagingToken: GenerateStagingToken(repositoryID, branchID),
+			StagingToken: GenerateStagingToken(repository.RepositoryID, branchID),
 		})
 		if err != nil {
 			return err
@@ -1358,12 +1274,8 @@ func (g *DBGraveler) LoadBranches(ctx context.Context, repositoryID RepositoryID
 	return nil
 }
 
-func (g *DBGraveler) LoadTags(ctx context.Context, repositoryID RepositoryID, metaRangeID MetaRangeID) error {
-	repo, err := g.GetRepository(ctx, repositoryID)
-	if err != nil {
-		return err
-	}
-	iter, err := g.CommittedManager.List(ctx, repo.StorageNamespace, metaRangeID)
+func (g *DBGraveler) LoadTags(ctx context.Context, repository *RepositoryRecord, metaRangeID MetaRangeID) error {
+	iter, err := g.CommittedManager.List(ctx, repository.StorageNamespace, metaRangeID)
 	if err != nil {
 		return err
 	}
@@ -1376,7 +1288,7 @@ func (g *DBGraveler) LoadTags(ctx context.Context, repositoryID RepositoryID, me
 			return err
 		}
 		tagID := TagID(tag.Id)
-		err = g.RefManager.CreateTag(ctx, repositoryID, tagID, CommitID(tag.CommitId))
+		err = g.RefManager.CreateTag(ctx, repository, tagID, CommitID(tag.CommitId))
 		if err != nil {
 			return err
 		}
@@ -1387,28 +1299,16 @@ func (g *DBGraveler) LoadTags(ctx context.Context, repositoryID RepositoryID, me
 	return nil
 }
 
-func (g *DBGraveler) GetMetaRange(ctx context.Context, repositoryID RepositoryID, metaRangeID MetaRangeID) (MetaRangeAddress, error) {
-	repo, err := g.RefManager.GetRepository(ctx, repositoryID)
-	if err != nil {
-		return "", nil
-	}
-	return g.CommittedManager.GetMetaRange(ctx, repo.StorageNamespace, metaRangeID)
+func (g *DBGraveler) GetMetaRange(ctx context.Context, repository *RepositoryRecord, metaRangeID MetaRangeID) (MetaRangeAddress, error) {
+	return g.CommittedManager.GetMetaRange(ctx, repository.StorageNamespace, metaRangeID)
 }
 
-func (g *DBGraveler) GetRange(ctx context.Context, repositoryID RepositoryID, rangeID RangeID) (RangeAddress, error) {
-	repo, err := g.RefManager.GetRepository(ctx, repositoryID)
-	if err != nil {
-		return "", nil
-	}
-	return g.CommittedManager.GetRange(ctx, repo.StorageNamespace, rangeID)
+func (g *DBGraveler) GetRange(ctx context.Context, repository *RepositoryRecord, rangeID RangeID) (RangeAddress, error) {
+	return g.CommittedManager.GetRange(ctx, repository.StorageNamespace, rangeID)
 }
 
-func (g *DBGraveler) DumpCommits(ctx context.Context, repositoryID RepositoryID) (*MetaRangeID, error) {
-	repo, err := g.GetRepository(ctx, repositoryID)
-	if err != nil {
-		return nil, err
-	}
-	iter, err := g.RefManager.ListCommits(ctx, repositoryID)
+func (g *DBGraveler) DumpCommits(ctx context.Context, repository *RepositoryRecord) (*MetaRangeID, error) {
+	iter, err := g.RefManager.ListCommits(ctx, repository)
 	if err != nil {
 		return nil, err
 	}
@@ -1417,7 +1317,7 @@ func (g *DBGraveler) DumpCommits(ctx context.Context, repositoryID RepositoryID)
 	if err != nil {
 		return nil, err
 	}
-	return g.CommittedManager.WriteMetaRangeByIterator(ctx, repo.StorageNamespace,
+	return g.CommittedManager.WriteMetaRangeByIterator(ctx, repository.StorageNamespace,
 		commitsToValueIterator(iter),
 		Metadata{
 			EntityTypeKey:             EntityTypeCommit,
@@ -1427,12 +1327,8 @@ func (g *DBGraveler) DumpCommits(ctx context.Context, repositoryID RepositoryID)
 	)
 }
 
-func (g *DBGraveler) DumpBranches(ctx context.Context, repositoryID RepositoryID) (*MetaRangeID, error) {
-	repo, err := g.GetRepository(ctx, repositoryID)
-	if err != nil {
-		return nil, err
-	}
-	iter, err := g.RefManager.ListBranches(ctx, repositoryID)
+func (g *DBGraveler) DumpBranches(ctx context.Context, repository *RepositoryRecord) (*MetaRangeID, error) {
+	iter, err := g.RefManager.ListBranches(ctx, repository)
 	if err != nil {
 		return nil, err
 	}
@@ -1441,7 +1337,7 @@ func (g *DBGraveler) DumpBranches(ctx context.Context, repositoryID RepositoryID
 	if err != nil {
 		return nil, err
 	}
-	return g.CommittedManager.WriteMetaRangeByIterator(ctx, repo.StorageNamespace,
+	return g.CommittedManager.WriteMetaRangeByIterator(ctx, repository.StorageNamespace,
 		branchesToValueIterator(iter),
 		Metadata{
 			EntityTypeKey:             EntityTypeBranch,
@@ -1451,12 +1347,8 @@ func (g *DBGraveler) DumpBranches(ctx context.Context, repositoryID RepositoryID
 	)
 }
 
-func (g *DBGraveler) DumpTags(ctx context.Context, repositoryID RepositoryID) (*MetaRangeID, error) {
-	repo, err := g.GetRepository(ctx, repositoryID)
-	if err != nil {
-		return nil, err
-	}
-	iter, err := g.RefManager.ListTags(ctx, repositoryID)
+func (g *DBGraveler) DumpTags(ctx context.Context, repository *RepositoryRecord) (*MetaRangeID, error) {
+	iter, err := g.RefManager.ListTags(ctx, repository)
 	if err != nil {
 		return nil, err
 	}
@@ -1465,7 +1357,7 @@ func (g *DBGraveler) DumpTags(ctx context.Context, repositoryID RepositoryID) (*
 	if err != nil {
 		return nil, err
 	}
-	return g.CommittedManager.WriteMetaRangeByIterator(ctx, repo.StorageNamespace,
+	return g.CommittedManager.WriteMetaRangeByIterator(ctx, repository.StorageNamespace,
 		tagsToValueIterator(iter),
 		Metadata{
 			EntityTypeKey:             EntityTypeTag,

--- a/pkg/graveler/graveler.go
+++ b/pkg/graveler/graveler.go
@@ -91,7 +91,7 @@ const (
 // ResolvedRef include resolved information of Ref/RawRef:
 //   Type: Branch / Tag / Commit
 //   BranchID: for type ReferenceTypeBranch will hold the branch ID
-//   ResolvedBranchModifier: branch indicator if resolved to a branch latest commit, staging or none was specified.
+//   ResolvedBranchModifier: branch indicator if resolved to a branch the latest commit, staging or none was specified.
 //   CommitID: the commit ID of the branch head,  tag or specific hash.
 //   StagingToken: empty if ResolvedBranchModifier is ResolvedBranchModifierCommitted.
 //
@@ -371,27 +371,30 @@ type CommitParams struct {
 type KeyValueStore interface {
 	// Get returns value from repository / reference by key, nil value is a valid value for tombstone
 	// returns error if value does not exist
-	Get(ctx context.Context, repositoryID RepositoryID, ref Ref, key Key) (*Value, error)
+	Get(ctx context.Context, repository *RepositoryRecord, ref Ref, key Key) (*Value, error)
+
+	// GetByCommitID returns value from repository / commit by key and error if value does not exist
+	GetByCommitID(ctx context.Context, repository *RepositoryRecord, commitID CommitID, key Key) (*Value, error)
 
 	// Set stores value on repository / branch by key. nil value is a valid value for tombstone
-	Set(ctx context.Context, repositoryID RepositoryID, branchID BranchID, key Key, value Value, writeConditions ...WriteConditionOption) error
+	Set(ctx context.Context, repository *RepositoryRecord, branchID BranchID, key Key, value Value, writeConditions ...WriteConditionOption) error
 
 	// Delete value from repository / branch by key
-	Delete(ctx context.Context, repositoryID RepositoryID, branchID BranchID, key Key) error
+	Delete(ctx context.Context, repository *RepositoryRecord, branchID BranchID, key Key) error
 
 	// List lists values on repository / ref
-	List(ctx context.Context, repositoryID RepositoryID, ref Ref) (ValueIterator, error)
+	List(ctx context.Context, repository *RepositoryRecord, ref Ref) (ValueIterator, error)
 }
 
 type VersionController interface {
 	// GetRepository returns the Repository metadata object for the given RepositoryID
-	GetRepository(ctx context.Context, repositoryID RepositoryID) (*Repository, error)
+	GetRepository(ctx context.Context, repositoryID RepositoryID) (*RepositoryRecord, error)
 
 	// CreateRepository stores a new Repository under RepositoryID with the given Branch as default branch
-	CreateRepository(ctx context.Context, repositoryID RepositoryID, storageNamespace StorageNamespace, branchID BranchID) (*Repository, error)
+	CreateRepository(ctx context.Context, repositoryID RepositoryID, storageNamespace StorageNamespace, branchID BranchID) (*RepositoryRecord, error)
 
 	// CreateBareRepository stores a new Repository under RepositoryID with no initial branch or commit
-	CreateBareRepository(ctx context.Context, repositoryID RepositoryID, storageNamespace StorageNamespace, defaultBranchID BranchID) (*Repository, error)
+	CreateBareRepository(ctx context.Context, repositoryID RepositoryID, storageNamespace StorageNamespace, defaultBranchID BranchID) (*RepositoryRecord, error)
 
 	// ListRepositories returns iterator to scan repositories
 	ListRepositories(ctx context.Context) (RepositoryIterator, error)
@@ -400,100 +403,100 @@ type VersionController interface {
 	DeleteRepository(ctx context.Context, repositoryID RepositoryID) error
 
 	// CreateBranch creates branch on repository pointing to ref
-	CreateBranch(ctx context.Context, repositoryID RepositoryID, branchID BranchID, ref Ref) (*Branch, error)
+	CreateBranch(ctx context.Context, repository *RepositoryRecord, branchID BranchID, ref Ref) (*Branch, error)
 
 	// UpdateBranch updates branch on repository pointing to ref
-	UpdateBranch(ctx context.Context, repositoryID RepositoryID, branchID BranchID, ref Ref) (*Branch, error)
+	UpdateBranch(ctx context.Context, repository *RepositoryRecord, branchID BranchID, ref Ref) (*Branch, error)
 
 	// GetBranch gets branch information by branch / repository id
-	GetBranch(ctx context.Context, repositoryID RepositoryID, branchID BranchID) (*Branch, error)
+	GetBranch(ctx context.Context, repository *RepositoryRecord, branchID BranchID) (*Branch, error)
 
 	// GetTag gets tag's commit id
-	GetTag(ctx context.Context, repositoryID RepositoryID, tagID TagID) (*CommitID, error)
+	GetTag(ctx context.Context, repository *RepositoryRecord, tagID TagID) (*CommitID, error)
 
 	// CreateTag creates tag on a repository pointing to a commit id
-	CreateTag(ctx context.Context, repositoryID RepositoryID, tagID TagID, commitID CommitID) error
+	CreateTag(ctx context.Context, repository *RepositoryRecord, tagID TagID, commitID CommitID) error
 
 	// DeleteTag remove tag from a repository
-	DeleteTag(ctx context.Context, repositoryID RepositoryID, tagID TagID) error
+	DeleteTag(ctx context.Context, repository *RepositoryRecord, tagID TagID) error
 
 	// ListTags lists tags on a repository
-	ListTags(ctx context.Context, repositoryID RepositoryID) (TagIterator, error)
+	ListTags(ctx context.Context, repository *RepositoryRecord) (TagIterator, error)
 
 	// Log returns an iterator starting at commit ID up to repository root
-	Log(ctx context.Context, repositoryID RepositoryID, commitID CommitID) (CommitIterator, error)
+	Log(ctx context.Context, repository *RepositoryRecord, commitID CommitID) (CommitIterator, error)
 
 	// ListBranches lists branches on repositories
-	ListBranches(ctx context.Context, repositoryID RepositoryID) (BranchIterator, error)
+	ListBranches(ctx context.Context, repository *RepositoryRecord) (BranchIterator, error)
 
 	// DeleteBranch deletes branch from repository
-	DeleteBranch(ctx context.Context, repositoryID RepositoryID, branchID BranchID) error
+	DeleteBranch(ctx context.Context, repository *RepositoryRecord, branchID BranchID) error
 
 	// Commit the staged data and returns a commit ID that references that change
 	//   ErrNothingToCommit in case there is no data in stage
-	Commit(ctx context.Context, repositoryID RepositoryID, branchID BranchID, commitParams CommitParams) (CommitID, error)
+	Commit(ctx context.Context, repository *RepositoryRecord, branchID BranchID, commitParams CommitParams) (CommitID, error)
 
 	// WriteMetaRangeByIterator accepts a ValueIterator and writes the entire iterator to a new MetaRange
 	// and returns the result ID.
-	WriteMetaRangeByIterator(ctx context.Context, repositoryID RepositoryID, it ValueIterator) (*MetaRangeID, error)
+	WriteMetaRangeByIterator(ctx context.Context, repository *RepositoryRecord, it ValueIterator) (*MetaRangeID, error)
 
 	// AddCommitToBranchHead creates a commit in the branch from the given pre-existing tree.
 	// Returns ErrMetaRangeNotFound if the referenced metaRangeID doesn't exist.
 	// Returns ErrCommitNotHeadBranch if the branch is no longer referencing to the parentCommit
-	AddCommitToBranchHead(ctx context.Context, repositoryID RepositoryID, branchID BranchID, commit Commit) (CommitID, error)
+	AddCommitToBranchHead(ctx context.Context, repository *RepositoryRecord, branchID BranchID, commit Commit) (CommitID, error)
 
 	// AddCommit creates a dangling (no referencing branch) commit in the repo from the pre-existing commit.
 	// Returns ErrMetaRangeNotFound if the referenced metaRangeID doesn't exist.
-	AddCommit(ctx context.Context, repositoryID RepositoryID, commit Commit) (CommitID, error)
+	AddCommit(ctx context.Context, repository *RepositoryRecord, commit Commit) (CommitID, error)
 
 	// GetCommit returns the Commit metadata object for the given CommitID
-	GetCommit(ctx context.Context, repositoryID RepositoryID, commitID CommitID) (*Commit, error)
+	GetCommit(ctx context.Context, repository *RepositoryRecord, commitID CommitID) (*Commit, error)
 
 	// Dereference returns the resolved ref information based on 'ref' reference
-	Dereference(ctx context.Context, repositoryID RepositoryID, ref Ref) (*ResolvedRef, error)
+	Dereference(ctx context.Context, repository *RepositoryRecord, ref Ref) (*ResolvedRef, error)
 
 	// ParseRef returns parsed 'ref' information as raw reference
 	ParseRef(ref Ref) (RawRef, error)
 
 	// ResolveRawRef returns the ResolvedRef matching the given RawRef
-	ResolveRawRef(ctx context.Context, repositoryID RepositoryID, rawRef RawRef) (*ResolvedRef, error)
+	ResolveRawRef(ctx context.Context, repository *RepositoryRecord, rawRef RawRef) (*ResolvedRef, error)
 
 	// Reset throws all staged data on the repository / branch
-	Reset(ctx context.Context, repositoryID RepositoryID, branchID BranchID) error
+	Reset(ctx context.Context, repository *RepositoryRecord, branchID BranchID) error
 
 	// ResetKey throws all staged data under the specified key on the repository / branch
-	ResetKey(ctx context.Context, repositoryID RepositoryID, branchID BranchID, key Key) error
+	ResetKey(ctx context.Context, repository *RepositoryRecord, branchID BranchID, key Key) error
 
 	// ResetPrefix throws all staged data starting with the given prefix on the repository / branch
-	ResetPrefix(ctx context.Context, repositoryID RepositoryID, branchID BranchID, key Key) error
+	ResetPrefix(ctx context.Context, repository *RepositoryRecord, branchID BranchID, key Key) error
 
 	// Revert creates a reverse patch to the commit given as 'ref', and applies it as a new commit on the given branch.
-	Revert(ctx context.Context, repositoryID RepositoryID, branchID BranchID, ref Ref, parentNumber int, commitParams CommitParams) (CommitID, error)
+	Revert(ctx context.Context, repository *RepositoryRecord, branchID BranchID, ref Ref, parentNumber int, commitParams CommitParams) (CommitID, error)
 
 	// Merge merges 'source' into 'destination' and returns the commit id for the created merge commit.
-	Merge(ctx context.Context, repositoryID RepositoryID, destination BranchID, source Ref, commitParams CommitParams, strategy string) (CommitID, error)
+	Merge(ctx context.Context, repository *RepositoryRecord, destination BranchID, source Ref, commitParams CommitParams, strategy string) (CommitID, error)
 
 	// DiffUncommitted returns iterator to scan the changes made on the branch
-	DiffUncommitted(ctx context.Context, repositoryID RepositoryID, branchID BranchID) (DiffIterator, error)
+	DiffUncommitted(ctx context.Context, repository *RepositoryRecord, branchID BranchID) (DiffIterator, error)
 
 	// Diff returns the changes between 'left' and 'right' ref.
 	// This is similar to a two-dot (left..right) diff in git.
-	Diff(ctx context.Context, repositoryID RepositoryID, left, right Ref) (DiffIterator, error)
+	Diff(ctx context.Context, repository *RepositoryRecord, left, right Ref) (DiffIterator, error)
 
 	// Compare returns the difference between the commit where 'left' was last synced into 'right', and the most recent commit of `right`.
 	// This is similar to a three-dot (from...to) diff in git.
-	Compare(ctx context.Context, repositoryID RepositoryID, left, right Ref) (DiffIterator, error)
+	Compare(ctx context.Context, repository *RepositoryRecord, left, right Ref) (DiffIterator, error)
 
 	// SetHooksHandler set handler for all graveler hooks
 	SetHooksHandler(handler HooksHandler)
 
 	// GetStagingToken returns the token identifying current staging for branchID of
 	// repositoryID.
-	GetStagingToken(ctx context.Context, repositoryID RepositoryID, branchID BranchID) (*StagingToken, error)
+	GetStagingToken(ctx context.Context, repository *RepositoryRecord, branchID BranchID) (*StagingToken, error)
 
-	GetGarbageCollectionRules(ctx context.Context, repositoryID RepositoryID) (*GarbageCollectionRules, error)
+	GetGarbageCollectionRules(ctx context.Context, repository *RepositoryRecord) (*GarbageCollectionRules, error)
 
-	SetGarbageCollectionRules(ctx context.Context, repositoryID RepositoryID, rules *GarbageCollectionRules) error
+	SetGarbageCollectionRules(ctx context.Context, repository *RepositoryRecord, rules *GarbageCollectionRules) error
 
 	// SaveGarbageCollectionCommits saves the sets of active and expired commits, according to the branch rules for garbage collection.
 	// Returns
@@ -502,54 +505,54 @@ type VersionController interface {
 	//	- location where the information of addresses to be removed should be saved
 	// If a previousRunID is specified, commits that were already expired and their ancestors will not be considered as expired/active.
 	// Note: Ancestors of previously expired commits may still be considered if they can be reached from a non-expired commit.
-	SaveGarbageCollectionCommits(ctx context.Context, repositoryID RepositoryID, previousRunID string) (garbageCollectionRunMetadata *GarbageCollectionRunMetadata, err error)
+	SaveGarbageCollectionCommits(ctx context.Context, repository *RepositoryRecord, previousRunID string) (garbageCollectionRunMetadata *GarbageCollectionRunMetadata, err error)
 
 	// GetBranchProtectionRules return all branch protection rules for the repository
-	GetBranchProtectionRules(ctx context.Context, repositoryID RepositoryID) (*BranchProtectionRules, error)
+	GetBranchProtectionRules(ctx context.Context, repository *RepositoryRecord) (*BranchProtectionRules, error)
 
 	// DeleteBranchProtectionRule deletes the branch protection rule for the given pattern,
 	// or return ErrRuleNotExists if no such rule exists.
-	DeleteBranchProtectionRule(ctx context.Context, repositoryID RepositoryID, pattern string) error
+	DeleteBranchProtectionRule(ctx context.Context, repository *RepositoryRecord, pattern string) error
 
 	// CreateBranchProtectionRule creates a rule for the given name pattern,
 	// or returns ErrRuleAlreadyExists if there is already a rule for the pattern.
-	CreateBranchProtectionRule(ctx context.Context, repositoryID RepositoryID, pattern string, blockedActions []BranchProtectionBlockedAction) error
+	CreateBranchProtectionRule(ctx context.Context, repository *RepositoryRecord, pattern string, blockedActions []BranchProtectionBlockedAction) error
 }
 
 // Plumbing includes commands for fiddling more directly with graveler implementation
 // internals.
 type Plumbing interface {
 	// GetMetaRange returns information where metarangeID is stored.
-	GetMetaRange(ctx context.Context, repositoryID RepositoryID, metaRangeID MetaRangeID) (MetaRangeAddress, error)
+	GetMetaRange(ctx context.Context, repository *RepositoryRecord, metaRangeID MetaRangeID) (MetaRangeAddress, error)
 	// GetRange returns information where rangeID is stored.
-	GetRange(ctx context.Context, repositoryID RepositoryID, rangeID RangeID) (RangeAddress, error)
+	GetRange(ctx context.Context, repository *RepositoryRecord, rangeID RangeID) (RangeAddress, error)
 	// WriteRange creates a new Range from the iterator values.
 	// Keeps Range closing logic, so might not flush all values to the range.
-	WriteRange(ctx context.Context, repositoryID RepositoryID, it ValueIterator) (*RangeInfo, error)
+	WriteRange(ctx context.Context, repository *RepositoryRecord, it ValueIterator) (*RangeInfo, error)
 	// WriteMetaRange creates a new MetaRange from the given Ranges.
-	WriteMetaRange(ctx context.Context, repositoryID RepositoryID, ranges []*RangeInfo) (*MetaRangeInfo, error)
+	WriteMetaRange(ctx context.Context, repository *RepositoryRecord, ranges []*RangeInfo) (*MetaRangeInfo, error)
 }
 
 type Dumper interface {
 	// DumpCommits iterates through all commits and dumps them in Graveler format
-	DumpCommits(ctx context.Context, repositoryID RepositoryID) (*MetaRangeID, error)
+	DumpCommits(ctx context.Context, repository *RepositoryRecord) (*MetaRangeID, error)
 
 	// DumpBranches iterates through all branches and dumps them in Graveler format
-	DumpBranches(ctx context.Context, repositoryID RepositoryID) (*MetaRangeID, error)
+	DumpBranches(ctx context.Context, repository *RepositoryRecord) (*MetaRangeID, error)
 
 	// DumpTags iterates through all tags and dumps them in Graveler format
-	DumpTags(ctx context.Context, repositoryID RepositoryID) (*MetaRangeID, error)
+	DumpTags(ctx context.Context, repository *RepositoryRecord) (*MetaRangeID, error)
 }
 
 type Loader interface {
 	// LoadCommits iterates through all commits in Graveler format and loads them into repositoryID
-	LoadCommits(ctx context.Context, repositoryID RepositoryID, metaRangeID MetaRangeID) error
+	LoadCommits(ctx context.Context, repository *RepositoryRecord, metaRangeID MetaRangeID) error
 
 	// LoadBranches iterates through all branches in Graveler format and loads them into repositoryID
-	LoadBranches(ctx context.Context, repositoryID RepositoryID, metaRangeID MetaRangeID) error
+	LoadBranches(ctx context.Context, repository *RepositoryRecord, metaRangeID MetaRangeID) error
 
 	// LoadTags iterates through all tags in Graveler format and loads them into repositoryID
-	LoadTags(ctx context.Context, repositoryID RepositoryID, metaRangeID MetaRangeID) error
+	LoadTags(ctx context.Context, repository *RepositoryRecord, metaRangeID MetaRangeID) error
 }
 
 // Internal structures used by Graveler
@@ -623,7 +626,7 @@ type CommitIterator interface {
 // it also handles the structure of the commit graph and its traversal (notably, merge-base and log)
 type RefManager interface {
 	// GetRepository returns the Repository metadata object for the given RepositoryID
-	GetRepository(ctx context.Context, repositoryID RepositoryID) (*Repository, error)
+	GetRepository(ctx context.Context, repositoryID RepositoryID) (*RepositoryRecord, error)
 
 	// CreateRepository stores a new Repository under RepositoryID with the given Branch as default branch
 	CreateRepository(ctx context.Context, repositoryID RepositoryID, repository Repository) error
@@ -641,69 +644,69 @@ type RefManager interface {
 	ParseRef(ref Ref) (RawRef, error)
 
 	// ResolveRawRef returns the ResolvedRef matching the given RawRef
-	ResolveRawRef(ctx context.Context, repositoryID RepositoryID, rawRef RawRef) (*ResolvedRef, error)
+	ResolveRawRef(ctx context.Context, repository *RepositoryRecord, rawRef RawRef) (*ResolvedRef, error)
 
 	// GetBranch returns the Branch metadata object for the given BranchID
-	GetBranch(ctx context.Context, repositoryID RepositoryID, branchID BranchID) (*Branch, error)
+	GetBranch(ctx context.Context, repository *RepositoryRecord, branchID BranchID) (*Branch, error)
 
 	// CreateBranch creates a branch with the given id and Branch metadata
-	CreateBranch(ctx context.Context, repositoryID RepositoryID, branchID BranchID, branch Branch) error
+	CreateBranch(ctx context.Context, repository *RepositoryRecord, branchID BranchID, branch Branch) error
 
 	// SetBranch points the given BranchID at the given Branch metadata
-	SetBranch(ctx context.Context, repositoryID RepositoryID, branchID BranchID, branch Branch) error
+	SetBranch(ctx context.Context, repository *RepositoryRecord, branchID BranchID, branch Branch) error
 
 	// BranchUpdate Conditional set of branch with validation callback
-	BranchUpdate(ctx context.Context, repositoryID RepositoryID, branchID BranchID, f BranchUpdateFunc) error
+	BranchUpdate(ctx context.Context, repository *RepositoryRecord, branchID BranchID, f BranchUpdateFunc) error
 
 	// DeleteBranch deletes the branch
-	DeleteBranch(ctx context.Context, repositoryID RepositoryID, branchID BranchID) error
+	DeleteBranch(ctx context.Context, repository *RepositoryRecord, branchID BranchID) error
 
 	// ListBranches lists branches
-	ListBranches(ctx context.Context, repositoryID RepositoryID) (BranchIterator, error)
+	ListBranches(ctx context.Context, repository *RepositoryRecord) (BranchIterator, error)
 
 	// GCBranchIterator TODO (niro): Remove when DB implementation is deleted
 	// GCBranchIterator temporary WA to support both DB and KV GC BranchIterator, which iterates over branches by order of commit ID
-	GCBranchIterator(ctx context.Context, repositoryID RepositoryID) (BranchIterator, error)
+	GCBranchIterator(ctx context.Context, repository *RepositoryRecord) (BranchIterator, error)
 
 	// GetTag returns the Tag metadata object for the given TagID
-	GetTag(ctx context.Context, repositoryID RepositoryID, tagID TagID) (*CommitID, error)
+	GetTag(ctx context.Context, repository *RepositoryRecord, tagID TagID) (*CommitID, error)
 
 	// CreateTag create a given tag pointing to a commit
-	CreateTag(ctx context.Context, repositoryID RepositoryID, tagID TagID, commitID CommitID) error
+	CreateTag(ctx context.Context, repository *RepositoryRecord, tagID TagID, commitID CommitID) error
 
 	// DeleteTag deletes the tag
-	DeleteTag(ctx context.Context, repositoryID RepositoryID, tagID TagID) error
+	DeleteTag(ctx context.Context, repository *RepositoryRecord, tagID TagID) error
 
 	// ListTags lists tags
-	ListTags(ctx context.Context, repositoryID RepositoryID) (TagIterator, error)
+	ListTags(ctx context.Context, repository *RepositoryRecord) (TagIterator, error)
 
 	// GetCommit returns the Commit metadata object for the given CommitID.
-	GetCommit(ctx context.Context, repositoryID RepositoryID, commitID CommitID) (*Commit, error)
+	GetCommit(ctx context.Context, repository *RepositoryRecord, commitID CommitID) (*Commit, error)
 
 	// GetCommitByPrefix returns the Commit metadata object for the given prefix CommitID.
 	// if more than 1 commit starts with the ID prefix returns error
-	GetCommitByPrefix(ctx context.Context, repositoryID RepositoryID, prefix CommitID) (*Commit, error)
+	GetCommitByPrefix(ctx context.Context, repository *RepositoryRecord, prefix CommitID) (*Commit, error)
 
 	// AddCommit stores the Commit object, returning its ID
-	AddCommit(ctx context.Context, repositoryID RepositoryID, commit Commit) (CommitID, error)
+	AddCommit(ctx context.Context, repository *RepositoryRecord, commit Commit) (CommitID, error)
 
 	// RemoveCommit deletes commit from store - used for repository cleanup
-	RemoveCommit(ctx context.Context, repositoryID RepositoryID, commitID CommitID) error
+	RemoveCommit(ctx context.Context, repository *RepositoryRecord, commitID CommitID) error
 
 	// FindMergeBase returns the merge-base for the given CommitIDs
 	// see: https://git-scm.com/docs/git-merge-base
 	// and internally: https://github.com/treeverse/lakeFS/blob/09954804baeb36ada74fa17d8fdc13a38552394e/index/dag/commits.go
-	FindMergeBase(ctx context.Context, repositoryID RepositoryID, commitIDs ...CommitID) (*Commit, error)
+	FindMergeBase(ctx context.Context, repository *RepositoryRecord, commitIDs ...CommitID) (*Commit, error)
 
 	// Log returns an iterator starting at commit ID up to repository root
-	Log(ctx context.Context, repositoryID RepositoryID, commitID CommitID) (CommitIterator, error)
+	Log(ctx context.Context, repository *RepositoryRecord, commitID CommitID) (CommitIterator, error)
 
 	// ListCommits returns an iterator over all known commits, ordered by their commit ID
-	ListCommits(ctx context.Context, repositoryID RepositoryID) (CommitIterator, error)
+	ListCommits(ctx context.Context, repository *RepositoryRecord) (CommitIterator, error)
 
 	// GCCommitIterator TODO (niro): Remove when DB implementation is deleted
 	// GCCommitIterator temporary WA to support both DB and KV GC CommitIterator
-	GCCommitIterator(ctx context.Context, repositoryID RepositoryID) (CommitIterator, error)
+	GCCommitIterator(ctx context.Context, repository *RepositoryRecord) (CommitIterator, error)
 }
 
 // CommittedManager reads and applies committed snapshots
@@ -785,8 +788,8 @@ type StagingManager interface {
 type BranchLockerFunc func() (interface{}, error)
 
 type BranchLocker interface {
-	Writer(ctx context.Context, repositoryID RepositoryID, branchID BranchID, lockedFn BranchLockerFunc) (interface{}, error)
-	MetadataUpdater(ctx context.Context, repositoryID RepositoryID, branchID BranchID, lockeFn BranchLockerFunc) (interface{}, error)
+	Writer(ctx context.Context, repository *RepositoryRecord, branchID BranchID, lockedFn BranchLockerFunc) (interface{}, error)
+	MetadataUpdater(ctx context.Context, repository *RepositoryRecord, branchID BranchID, lockeFn BranchLockerFunc) (interface{}, error)
 }
 
 func (id RepositoryID) String() string {
@@ -862,11 +865,11 @@ func NewKVGraveler(committedManager CommittedManager, stagingManager StagingMana
 	}
 }
 
-func (g *KVGraveler) GetRepository(ctx context.Context, repositoryID RepositoryID) (*Repository, error) {
+func (g *KVGraveler) GetRepository(ctx context.Context, repositoryID RepositoryID) (*RepositoryRecord, error) {
 	return g.RefManager.GetRepository(ctx, repositoryID)
 }
 
-func (g *KVGraveler) CreateRepository(ctx context.Context, repositoryID RepositoryID, storageNamespace StorageNamespace, branchID BranchID) (*Repository, error) {
+func (g *KVGraveler) CreateRepository(ctx context.Context, repositoryID RepositoryID, storageNamespace StorageNamespace, branchID BranchID) (*RepositoryRecord, error) {
 	_, err := g.RefManager.GetRepository(ctx, repositoryID)
 	if err != nil && !errors.Is(err, ErrRepositoryNotFound) {
 		return nil, err
@@ -877,10 +880,13 @@ func (g *KVGraveler) CreateRepository(ctx context.Context, repositoryID Reposito
 	if err != nil {
 		return nil, err
 	}
-	return &repo, nil
+	return &RepositoryRecord{
+		RepositoryID: repositoryID,
+		Repository:   &repo,
+	}, nil
 }
 
-func (g *KVGraveler) CreateBareRepository(ctx context.Context, repositoryID RepositoryID, storageNamespace StorageNamespace, defaultBranchID BranchID) (*Repository, error) {
+func (g *KVGraveler) CreateBareRepository(ctx context.Context, repositoryID RepositoryID, storageNamespace StorageNamespace, defaultBranchID BranchID) (*RepositoryRecord, error) {
 	_, err := g.RefManager.GetRepository(ctx, repositoryID)
 	if err != nil && !errors.Is(err, ErrRepositoryNotFound) {
 		return nil, err
@@ -891,43 +897,34 @@ func (g *KVGraveler) CreateBareRepository(ctx context.Context, repositoryID Repo
 	if err != nil {
 		return nil, err
 	}
-	return &repo, nil
+	return &RepositoryRecord{
+		RepositoryID: repositoryID,
+		Repository:   &repo,
+	}, nil
 }
 
 func (g *KVGraveler) ListRepositories(ctx context.Context) (RepositoryIterator, error) {
 	return g.RefManager.ListRepositories(ctx)
 }
 
-func (g *KVGraveler) WriteRange(ctx context.Context, repositoryID RepositoryID, it ValueIterator) (*RangeInfo, error) {
-	repo, err := g.RefManager.GetRepository(ctx, repositoryID)
-	if err != nil {
-		return nil, err
-	}
-	return g.CommittedManager.WriteRange(ctx, repo.StorageNamespace, it)
+func (g *KVGraveler) WriteRange(ctx context.Context, repository *RepositoryRecord, it ValueIterator) (*RangeInfo, error) {
+	return g.CommittedManager.WriteRange(ctx, repository.StorageNamespace, it)
 }
 
-func (g *KVGraveler) WriteMetaRange(ctx context.Context, repositoryID RepositoryID, ranges []*RangeInfo) (*MetaRangeInfo, error) {
-	repo, err := g.RefManager.GetRepository(ctx, repositoryID)
-	if err != nil {
-		return nil, err
-	}
-	return g.CommittedManager.WriteMetaRange(ctx, repo.StorageNamespace, ranges)
+func (g *KVGraveler) WriteMetaRange(ctx context.Context, repository *RepositoryRecord, ranges []*RangeInfo) (*MetaRangeInfo, error) {
+	return g.CommittedManager.WriteMetaRange(ctx, repository.StorageNamespace, ranges)
 }
 
-func (g *KVGraveler) WriteMetaRangeByIterator(ctx context.Context, repositoryID RepositoryID, it ValueIterator) (*MetaRangeID, error) {
-	repo, err := g.RefManager.GetRepository(ctx, repositoryID)
-	if err != nil {
-		return nil, err
-	}
-	return g.CommittedManager.WriteMetaRangeByIterator(ctx, repo.StorageNamespace, it, nil)
+func (g *KVGraveler) WriteMetaRangeByIterator(ctx context.Context, repository *RepositoryRecord, it ValueIterator) (*MetaRangeID, error) {
+	return g.CommittedManager.WriteMetaRangeByIterator(ctx, repository.StorageNamespace, it, nil)
 }
 
 func (g *KVGraveler) DeleteRepository(ctx context.Context, repositoryID RepositoryID) error {
 	return g.RefManager.DeleteRepository(ctx, repositoryID)
 }
 
-func (g *KVGraveler) GetCommit(ctx context.Context, repositoryID RepositoryID, commitID CommitID) (*Commit, error) {
-	return g.RefManager.GetCommit(ctx, repositoryID, commitID)
+func (g *KVGraveler) GetCommit(ctx context.Context, repository *RepositoryRecord, commitID CommitID) (*Commit, error) {
+	return g.RefManager.GetCommit(ctx, repository, commitID)
 }
 
 func GenerateStagingToken(repositoryID RepositoryID, branchID BranchID) StagingToken {
@@ -935,13 +932,8 @@ func GenerateStagingToken(repositoryID RepositoryID, branchID BranchID) StagingT
 	return StagingToken(fmt.Sprintf("%s-%s:%s", repositoryID, branchID, uid))
 }
 
-func (g *KVGraveler) CreateBranch(ctx context.Context, repositoryID RepositoryID, branchID BranchID, ref Ref) (*Branch, error) {
-	repo, err := g.RefManager.GetRepository(ctx, repositoryID)
-	if err != nil {
-		return nil, fmt.Errorf("get repository: %w", err)
-	}
-
-	reference, err := g.Dereference(ctx, repositoryID, ref)
+func (g *KVGraveler) CreateBranch(ctx context.Context, repository *RepositoryRecord, branchID BranchID, ref Ref) (*Branch, error) {
+	reference, err := g.Dereference(ctx, repository, ref)
 	if err != nil {
 		return nil, fmt.Errorf("source reference '%s': %w", ref, err)
 	}
@@ -949,7 +941,7 @@ func (g *KVGraveler) CreateBranch(ctx context.Context, repositoryID RepositoryID
 		return nil, fmt.Errorf("source reference '%s': %w", ref, ErrCreateBranchNoCommit)
 	}
 
-	_, err = g.RefManager.GetBranch(ctx, repositoryID, branchID)
+	_, err = g.RefManager.GetBranch(ctx, repository, branchID)
 	if err == nil {
 		return nil, ErrBranchExists
 	}
@@ -959,17 +951,17 @@ func (g *KVGraveler) CreateBranch(ctx context.Context, repositoryID RepositoryID
 
 	newBranch := Branch{
 		CommitID:     reference.CommitID,
-		StagingToken: GenerateStagingToken(repositoryID, branchID),
+		StagingToken: GenerateStagingToken(repository.RepositoryID, branchID),
 		SealedTokens: make([]StagingToken, 0),
 	}
-	storageNamespace := repo.StorageNamespace
+	storageNamespace := repository.StorageNamespace
 	preRunID := g.hooks.NewRunID()
 	err = g.hooks.PreCreateBranchHook(ctx, HookRecord{
 		RunID:            preRunID,
 		StorageNamespace: storageNamespace,
 		EventType:        EventTypePreCreateBranch,
 		SourceRef:        ref,
-		RepositoryID:     repositoryID,
+		RepositoryID:     repository.RepositoryID,
 		BranchID:         branchID,
 		CommitID:         reference.CommitID,
 	})
@@ -981,7 +973,7 @@ func (g *KVGraveler) CreateBranch(ctx context.Context, repositoryID RepositoryID
 		}
 	}
 
-	err = g.RefManager.CreateBranch(ctx, repositoryID, branchID, newBranch)
+	err = g.RefManager.CreateBranch(ctx, repository, branchID, newBranch)
 	if err != nil {
 		return nil, fmt.Errorf("set branch '%s' to '%v': %w", branchID, newBranch, err)
 	}
@@ -992,7 +984,7 @@ func (g *KVGraveler) CreateBranch(ctx context.Context, repositoryID RepositoryID
 		StorageNamespace: storageNamespace,
 		EventType:        EventTypePostCreateBranch,
 		SourceRef:        ref,
-		RepositoryID:     repositoryID,
+		RepositoryID:     repository.RepositoryID,
 		BranchID:         branchID,
 		CommitID:         reference.CommitID,
 		PreRunID:         preRunID,
@@ -1001,12 +993,8 @@ func (g *KVGraveler) CreateBranch(ctx context.Context, repositoryID RepositoryID
 	return &newBranch, nil
 }
 
-func (g *KVGraveler) UpdateBranch(ctx context.Context, repositoryID RepositoryID, branchID BranchID, ref Ref) (*Branch, error) {
-	repo, err := g.GetRepository(ctx, repositoryID)
-	if err != nil {
-		return nil, err
-	}
-	reference, err := g.Dereference(ctx, repositoryID, ref)
+func (g *KVGraveler) UpdateBranch(ctx context.Context, repository *RepositoryRecord, branchID BranchID, ref Ref) (*Branch, error) {
+	reference, err := g.Dereference(ctx, repository, ref)
 	if err != nil {
 		return nil, err
 	}
@@ -1014,15 +1002,15 @@ func (g *KVGraveler) UpdateBranch(ctx context.Context, repositoryID RepositoryID
 		return nil, fmt.Errorf("reference '%s': %w", ref, ErrDereferenceCommitWithStaging)
 	}
 
-	if err := g.prepareForCommitIDUpdate(ctx, repositoryID, branchID, repo); err != nil {
+	if err := g.prepareForCommitIDUpdate(ctx, repository, branchID); err != nil {
 		return nil, err
 	}
 
 	var tokensToDrop []StagingToken
 	var newBranch *Branch
-	err = g.RefManager.BranchUpdate(ctx, repositoryID, branchID, func(currBranch *Branch) (*Branch, error) {
+	err = g.RefManager.BranchUpdate(ctx, repository, branchID, func(currBranch *Branch) (*Branch, error) {
 		// TODO(Guys) return error only on conflicts, currently returns error for any changes on staging
-		empty, err := g.isSealedEmpty(ctx, repositoryID, repo, currBranch)
+		empty, err := g.isSealedEmpty(ctx, repository, currBranch)
 		if err != nil {
 			return nil, err
 		}
@@ -1051,9 +1039,9 @@ func (g *KVGraveler) UpdateBranch(ctx context.Context, repositoryID RepositoryID
 // before adding a new staging token. It is best to use it before changing
 // the branch HEAD as a preparation for deleting the staging area.
 // see issue #3771 for more information on the algorithm used.
-func (g *KVGraveler) prepareForCommitIDUpdate(ctx context.Context, repositoryID RepositoryID, branchID BranchID, repo *Repository) error {
-	err := g.RefManager.BranchUpdate(ctx, repositoryID, branchID, func(currBranch *Branch) (*Branch, error) {
-		empty, err := g.isStagingEmpty(ctx, repositoryID, repo, currBranch)
+func (g *KVGraveler) prepareForCommitIDUpdate(ctx context.Context, repository *RepositoryRecord, branchID BranchID) error {
+	err := g.RefManager.BranchUpdate(ctx, repository, branchID, func(currBranch *Branch) (*Branch, error) {
+		empty, err := g.isStagingEmpty(ctx, repository, currBranch)
 		if err != nil {
 			return nil, err
 		}
@@ -1062,7 +1050,7 @@ func (g *KVGraveler) prepareForCommitIDUpdate(ctx context.Context, repositoryID 
 		}
 
 		currBranch.SealedTokens = append([]StagingToken{currBranch.StagingToken}, currBranch.SealedTokens...)
-		currBranch.StagingToken = GenerateStagingToken(repositoryID, branchID)
+		currBranch.StagingToken = GenerateStagingToken(repository.RepositoryID, branchID)
 		return currBranch, nil
 	})
 	if err != nil {
@@ -1074,23 +1062,19 @@ func (g *KVGraveler) prepareForCommitIDUpdate(ctx context.Context, repositoryID 
 	return nil
 }
 
-func (g *KVGraveler) GetBranch(ctx context.Context, repositoryID RepositoryID, branchID BranchID) (*Branch, error) {
-	return g.RefManager.GetBranch(ctx, repositoryID, branchID)
+func (g *KVGraveler) GetBranch(ctx context.Context, repository *RepositoryRecord, branchID BranchID) (*Branch, error) {
+	return g.RefManager.GetBranch(ctx, repository, branchID)
 }
 
-func (g *KVGraveler) GetTag(ctx context.Context, repositoryID RepositoryID, tagID TagID) (*CommitID, error) {
-	return g.RefManager.GetTag(ctx, repositoryID, tagID)
+func (g *KVGraveler) GetTag(ctx context.Context, repository *RepositoryRecord, tagID TagID) (*CommitID, error) {
+	return g.RefManager.GetTag(ctx, repository, tagID)
 }
 
-func (g *KVGraveler) CreateTag(ctx context.Context, repositoryID RepositoryID, tagID TagID, commitID CommitID) error {
-	repo, err := g.RefManager.GetRepository(ctx, repositoryID)
-	if err != nil {
-		return fmt.Errorf("get repository: %w", err)
-	}
-	storageNamespace := repo.StorageNamespace
+func (g *KVGraveler) CreateTag(ctx context.Context, repository *RepositoryRecord, tagID TagID, commitID CommitID) error {
+	storageNamespace := repository.StorageNamespace
 
 	// Check that Tag doesn't exist before running hook - Non-Atomic operation
-	_, err = g.RefManager.GetTag(ctx, repositoryID, tagID)
+	_, err := g.RefManager.GetTag(ctx, repository, tagID)
 	if err == nil {
 		return ErrTagAlreadyExists
 	}
@@ -1103,7 +1087,7 @@ func (g *KVGraveler) CreateTag(ctx context.Context, repositoryID RepositoryID, t
 		RunID:            preRunID,
 		StorageNamespace: storageNamespace,
 		EventType:        EventTypePreCreateTag,
-		RepositoryID:     repositoryID,
+		RepositoryID:     repository.RepositoryID,
 		CommitID:         commitID,
 		SourceRef:        commitID.Ref(),
 		TagID:            tagID,
@@ -1116,7 +1100,7 @@ func (g *KVGraveler) CreateTag(ctx context.Context, repositoryID RepositoryID, t
 		}
 	}
 
-	err = g.RefManager.CreateTag(ctx, repositoryID, tagID, commitID)
+	err = g.RefManager.CreateTag(ctx, repository, tagID, commitID)
 	if err != nil {
 		return err
 	}
@@ -1126,7 +1110,7 @@ func (g *KVGraveler) CreateTag(ctx context.Context, repositoryID RepositoryID, t
 		RunID:            postRunID,
 		StorageNamespace: storageNamespace,
 		EventType:        EventTypePostCreateTag,
-		RepositoryID:     repositoryID,
+		RepositoryID:     repository.RepositoryID,
 		CommitID:         commitID,
 		SourceRef:        commitID.Ref(),
 		TagID:            tagID,
@@ -1136,15 +1120,11 @@ func (g *KVGraveler) CreateTag(ctx context.Context, repositoryID RepositoryID, t
 	return nil
 }
 
-func (g *KVGraveler) DeleteTag(ctx context.Context, repositoryID RepositoryID, tagID TagID) error {
-	repo, err := g.RefManager.GetRepository(ctx, repositoryID)
-	if err != nil {
-		return fmt.Errorf("get repository: %w", err)
-	}
-	storageNamespace := repo.StorageNamespace
+func (g *KVGraveler) DeleteTag(ctx context.Context, repository *RepositoryRecord, tagID TagID) error {
+	storageNamespace := repository.StorageNamespace
 
 	// Sanity check that Tag exists before running hook.
-	commitID, err := g.RefManager.GetTag(ctx, repositoryID, tagID)
+	commitID, err := g.RefManager.GetTag(ctx, repository, tagID)
 	if err != nil {
 		return err
 	}
@@ -1154,7 +1134,7 @@ func (g *KVGraveler) DeleteTag(ctx context.Context, repositoryID RepositoryID, t
 		RunID:            preRunID,
 		StorageNamespace: storageNamespace,
 		EventType:        EventTypePreDeleteTag,
-		RepositoryID:     repositoryID,
+		RepositoryID:     repository.RepositoryID,
 		SourceRef:        commitID.Ref(),
 		CommitID:         *commitID,
 		TagID:            tagID,
@@ -1167,7 +1147,7 @@ func (g *KVGraveler) DeleteTag(ctx context.Context, repositoryID RepositoryID, t
 		}
 	}
 
-	err = g.RefManager.DeleteTag(ctx, repositoryID, tagID)
+	err = g.RefManager.DeleteTag(ctx, repository, tagID)
 	if err != nil {
 		return err
 	}
@@ -1177,7 +1157,7 @@ func (g *KVGraveler) DeleteTag(ctx context.Context, repositoryID RepositoryID, t
 		RunID:            postRunID,
 		StorageNamespace: storageNamespace,
 		EventType:        EventTypePostDeleteTag,
-		RepositoryID:     repositoryID,
+		RepositoryID:     repository.RepositoryID,
 		SourceRef:        commitID.Ref(),
 		CommitID:         *commitID,
 		TagID:            tagID,
@@ -1186,55 +1166,51 @@ func (g *KVGraveler) DeleteTag(ctx context.Context, repositoryID RepositoryID, t
 	return nil
 }
 
-func (g *KVGraveler) ListTags(ctx context.Context, repositoryID RepositoryID) (TagIterator, error) {
-	return g.RefManager.ListTags(ctx, repositoryID)
+func (g *KVGraveler) ListTags(ctx context.Context, repository *RepositoryRecord) (TagIterator, error) {
+	return g.RefManager.ListTags(ctx, repository)
 }
 
-func (g *KVGraveler) Dereference(ctx context.Context, repositoryID RepositoryID, ref Ref) (*ResolvedRef, error) {
+func (g *KVGraveler) Dereference(ctx context.Context, repository *RepositoryRecord, ref Ref) (*ResolvedRef, error) {
 	rawRef, err := g.ParseRef(ref)
 	if err != nil {
 		return nil, err
 	}
-	return g.ResolveRawRef(ctx, repositoryID, rawRef)
+	return g.ResolveRawRef(ctx, repository, rawRef)
 }
 
 func (g *KVGraveler) ParseRef(ref Ref) (RawRef, error) {
 	return g.RefManager.ParseRef(ref)
 }
 
-func (g *KVGraveler) ResolveRawRef(ctx context.Context, repositoryID RepositoryID, rawRef RawRef) (*ResolvedRef, error) {
-	return g.RefManager.ResolveRawRef(ctx, repositoryID, rawRef)
+func (g *KVGraveler) ResolveRawRef(ctx context.Context, repository *RepositoryRecord, rawRef RawRef) (*ResolvedRef, error) {
+	return g.RefManager.ResolveRawRef(ctx, repository, rawRef)
 }
 
-func (g *KVGraveler) Log(ctx context.Context, repositoryID RepositoryID, commitID CommitID) (CommitIterator, error) {
-	return g.RefManager.Log(ctx, repositoryID, commitID)
+func (g *KVGraveler) Log(ctx context.Context, repository *RepositoryRecord, commitID CommitID) (CommitIterator, error) {
+	return g.RefManager.Log(ctx, repository, commitID)
 }
 
-func (g *KVGraveler) ListBranches(ctx context.Context, repositoryID RepositoryID) (BranchIterator, error) {
-	return g.RefManager.ListBranches(ctx, repositoryID)
+func (g *KVGraveler) ListBranches(ctx context.Context, repository *RepositoryRecord) (BranchIterator, error) {
+	return g.RefManager.ListBranches(ctx, repository)
 }
 
-func (g *KVGraveler) DeleteBranch(ctx context.Context, repositoryID RepositoryID, branchID BranchID) error {
-	repo, err := g.RefManager.GetRepository(ctx, repositoryID)
-	if err != nil {
-		return err
-	}
-	if repo.DefaultBranchID == branchID {
+func (g *KVGraveler) DeleteBranch(ctx context.Context, repository *RepositoryRecord, branchID BranchID) error {
+	if repository.DefaultBranchID == branchID {
 		return ErrDeleteDefaultBranch
 	}
-	branch, err := g.RefManager.GetBranch(ctx, repositoryID, branchID)
+	branch, err := g.RefManager.GetBranch(ctx, repository, branchID)
 	if err != nil {
 		return err
 	}
 
 	commitID := branch.CommitID
-	storageNamespace := repo.StorageNamespace
+	storageNamespace := repository.StorageNamespace
 	preRunID := g.hooks.NewRunID()
 	preHookRecord := HookRecord{
 		RunID:            preRunID,
 		StorageNamespace: storageNamespace,
 		EventType:        EventTypePreDeleteBranch,
-		RepositoryID:     repositoryID,
+		RepositoryID:     repository.RepositoryID,
 		SourceRef:        commitID.Ref(),
 		BranchID:         branchID,
 	}
@@ -1248,7 +1224,7 @@ func (g *KVGraveler) DeleteBranch(ctx context.Context, repositoryID RepositoryID
 	}
 
 	// Delete branch first - afterwards remove tokens
-	err = g.RefManager.DeleteBranch(ctx, repositoryID, branchID)
+	err = g.RefManager.DeleteBranch(ctx, repository, branchID)
 	if err != nil { // Don't perform post action hook if operation finished with error
 		return err
 	}
@@ -1262,7 +1238,7 @@ func (g *KVGraveler) DeleteBranch(ctx context.Context, repositoryID RepositoryID
 		RunID:            postRunID,
 		StorageNamespace: storageNamespace,
 		EventType:        EventTypePostDeleteBranch,
-		RepositoryID:     repositoryID,
+		RepositoryID:     repository.RepositoryID,
 		SourceRef:        commitID.Ref(),
 		BranchID:         branchID,
 		PreRunID:         preRunID,
@@ -1271,58 +1247,45 @@ func (g *KVGraveler) DeleteBranch(ctx context.Context, repositoryID RepositoryID
 	return nil
 }
 
-func (g *KVGraveler) GetStagingToken(ctx context.Context, repositoryID RepositoryID, branchID BranchID) (*StagingToken, error) {
-	branch, err := g.RefManager.GetBranch(ctx, repositoryID, branchID)
+func (g *KVGraveler) GetStagingToken(ctx context.Context, repository *RepositoryRecord, branchID BranchID) (*StagingToken, error) {
+	branch, err := g.RefManager.GetBranch(ctx, repository, branchID)
 	if err != nil {
 		return nil, err
 	}
 	return &branch.StagingToken, nil
 }
 
-func (g *KVGraveler) getGarbageCollectionRules(ctx context.Context, repo *Repository) (*GarbageCollectionRules, error) {
-	return g.garbageCollectionManager.GetRules(ctx, repo.StorageNamespace)
+func (g *KVGraveler) getGarbageCollectionRules(ctx context.Context, repository *RepositoryRecord) (*GarbageCollectionRules, error) {
+	return g.garbageCollectionManager.GetRules(ctx, repository.StorageNamespace)
 }
 
-func (g *KVGraveler) GetGarbageCollectionRules(ctx context.Context, repositoryID RepositoryID) (*GarbageCollectionRules, error) {
-	repo, err := g.RefManager.GetRepository(ctx, repositoryID)
-	if err != nil {
-		return nil, err
-	}
-	return g.getGarbageCollectionRules(ctx, repo)
+func (g *KVGraveler) GetGarbageCollectionRules(ctx context.Context, repository *RepositoryRecord) (*GarbageCollectionRules, error) {
+	return g.getGarbageCollectionRules(ctx, repository)
 }
 
-func (g *KVGraveler) SetGarbageCollectionRules(ctx context.Context, repositoryID RepositoryID, rules *GarbageCollectionRules) error {
-	repo, err := g.RefManager.GetRepository(ctx, repositoryID)
-	if err != nil {
-		return err
-	}
-	return g.garbageCollectionManager.SaveRules(ctx, repo.StorageNamespace, rules)
+func (g *KVGraveler) SetGarbageCollectionRules(ctx context.Context, repository *RepositoryRecord, rules *GarbageCollectionRules) error {
+	return g.garbageCollectionManager.SaveRules(ctx, repository.StorageNamespace, rules)
 }
 
-func (g *KVGraveler) SaveGarbageCollectionCommits(ctx context.Context, repositoryID RepositoryID, previousRunID string) (*GarbageCollectionRunMetadata, error) {
-	repo, err := g.RefManager.GetRepository(ctx, repositoryID)
-	if err != nil {
-		return nil, fmt.Errorf("get repository: %w", err)
-	}
-
-	rules, err := g.getGarbageCollectionRules(ctx, repo)
+func (g *KVGraveler) SaveGarbageCollectionCommits(ctx context.Context, repository *RepositoryRecord, previousRunID string) (*GarbageCollectionRunMetadata, error) {
+	rules, err := g.getGarbageCollectionRules(ctx, repository)
 	if err != nil {
 		return nil, fmt.Errorf("get gc rules: %w", err)
 	}
-	previouslyExpiredCommits, err := g.garbageCollectionManager.GetRunExpiredCommits(ctx, repo.StorageNamespace, previousRunID)
+	previouslyExpiredCommits, err := g.garbageCollectionManager.GetRunExpiredCommits(ctx, repository.StorageNamespace, previousRunID)
 	if err != nil {
 		return nil, fmt.Errorf("get expired commits from previous run: %w", err)
 	}
 
-	runID, err := g.garbageCollectionManager.SaveGarbageCollectionCommits(ctx, repo.StorageNamespace, repositoryID, rules, previouslyExpiredCommits)
+	runID, err := g.garbageCollectionManager.SaveGarbageCollectionCommits(ctx, repository, rules, previouslyExpiredCommits)
 	if err != nil {
 		return nil, fmt.Errorf("save garbage collection commits: %w", err)
 	}
-	commitsLocation, err := g.garbageCollectionManager.GetCommitsCSVLocation(runID, repo.StorageNamespace)
+	commitsLocation, err := g.garbageCollectionManager.GetCommitsCSVLocation(runID, repository.StorageNamespace)
 	if err != nil {
 		return nil, err
 	}
-	addressLocation, err := g.garbageCollectionManager.GetAddressesLocation(repo.StorageNamespace)
+	addressLocation, err := g.garbageCollectionManager.GetAddressesLocation(repository.StorageNamespace)
 	if err != nil {
 		return nil, err
 	}
@@ -1334,16 +1297,16 @@ func (g *KVGraveler) SaveGarbageCollectionCommits(ctx context.Context, repositor
 	}, err
 }
 
-func (g *KVGraveler) GetBranchProtectionRules(ctx context.Context, repositoryID RepositoryID) (*BranchProtectionRules, error) {
-	return g.protectedBranchesManager.GetRules(ctx, repositoryID)
+func (g *KVGraveler) GetBranchProtectionRules(ctx context.Context, repository *RepositoryRecord) (*BranchProtectionRules, error) {
+	return g.protectedBranchesManager.GetRules(ctx, repository)
 }
 
-func (g *KVGraveler) DeleteBranchProtectionRule(ctx context.Context, repositoryID RepositoryID, pattern string) error {
-	return g.protectedBranchesManager.Delete(ctx, repositoryID, pattern)
+func (g *KVGraveler) DeleteBranchProtectionRule(ctx context.Context, repository *RepositoryRecord, pattern string) error {
+	return g.protectedBranchesManager.Delete(ctx, repository, pattern)
 }
 
-func (g *KVGraveler) CreateBranchProtectionRule(ctx context.Context, repositoryID RepositoryID, pattern string, blockedActions []BranchProtectionBlockedAction) error {
-	return g.protectedBranchesManager.Add(ctx, repositoryID, pattern, blockedActions)
+func (g *KVGraveler) CreateBranchProtectionRule(ctx context.Context, repository *RepositoryRecord, pattern string, blockedActions []BranchProtectionBlockedAction) error {
+	return g.protectedBranchesManager.Add(ctx, repository, pattern, blockedActions)
 }
 
 // getFromStagingArea returns the most updated value of a given key in a branch staging area.
@@ -1368,12 +1331,8 @@ func (g *KVGraveler) getFromStagingArea(ctx context.Context, b *Branch, key Key)
 	return nil, ErrNotFound // Key not in staging area
 }
 
-func (g *KVGraveler) Get(ctx context.Context, repositoryID RepositoryID, ref Ref, key Key) (*Value, error) {
-	repo, err := g.RefManager.GetRepository(ctx, repositoryID)
-	if err != nil {
-		return nil, err
-	}
-	reference, err := g.Dereference(ctx, repositoryID, ref)
+func (g *KVGraveler) Get(ctx context.Context, repository *RepositoryRecord, ref Ref, key Key) (*Value, error) {
+	reference, err := g.Dereference(ctx, repository, ref)
 	if err != nil {
 		return nil, err
 	}
@@ -1395,15 +1354,24 @@ func (g *KVGraveler) Get(ctx context.Context, repositoryID RepositoryID, ref Ref
 
 	// If key is not found in staging area (or reference is not a branch), return the key from committed
 	commitID := reference.CommitID
-	commit, err := g.RefManager.GetCommit(ctx, repositoryID, commitID)
+	commit, err := g.RefManager.GetCommit(ctx, repository, commitID)
 	if err != nil {
 		return nil, err
 	}
-	return g.CommittedManager.Get(ctx, repo.StorageNamespace, commit.MetaRangeID, key)
+	return g.CommittedManager.Get(ctx, repository.StorageNamespace, commit.MetaRangeID, key)
 }
 
-func (g *KVGraveler) Set(ctx context.Context, repositoryID RepositoryID, branchID BranchID, key Key, value Value, writeConditions ...WriteConditionOption) error {
-	isProtected, err := g.protectedBranchesManager.IsBlocked(ctx, repositoryID, branchID, BranchProtectionBlockedAction_STAGING_WRITE)
+func (g *KVGraveler) GetByCommitID(ctx context.Context, repository *RepositoryRecord, commitID CommitID, key Key) (*Value, error) {
+	// If key is not found in staging area (or reference is not a branch), return the key from committed
+	commit, err := g.RefManager.GetCommit(ctx, repository, commitID)
+	if err != nil {
+		return nil, err
+	}
+	return g.CommittedManager.Get(ctx, repository.StorageNamespace, commit.MetaRangeID, key)
+}
+
+func (g *KVGraveler) Set(ctx context.Context, repository *RepositoryRecord, branchID BranchID, key Key, value Value, writeConditions ...WriteConditionOption) error {
+	isProtected, err := g.protectedBranchesManager.IsBlocked(ctx, repository, branchID, BranchProtectionBlockedAction_STAGING_WRITE)
 	if err != nil {
 		return err
 	}
@@ -1422,7 +1390,7 @@ func (g *KVGraveler) Set(ctx context.Context, repositoryID RepositoryID, branchI
 		}
 
 		// check if the given key exist in the branch first
-		_, err := g.Get(ctx, repositoryID, Ref(branchID), key)
+		_, err := g.Get(ctx, repository, Ref(branchID), key)
 		if err == nil {
 			// we got a key here already!
 			return ErrPreconditionFailed
@@ -1441,18 +1409,18 @@ func (g *KVGraveler) Set(ctx context.Context, repositoryID RepositoryID, branchI
 		})
 	}
 
-	return g.safeBranchWrite(ctx, g.log.WithField("key", key).WithField("operation", "set"), repositoryID, branchID, setFunc)
+	return g.safeBranchWrite(ctx, g.log.WithField("key", key).WithField("operation", "set"), repository, branchID, setFunc)
 }
 
 // safeBranchWrite is a helper function that wraps a branch write operation with validation that the staging token
 // didn't change while writing to the branch.
-func (g *KVGraveler) safeBranchWrite(ctx context.Context, log logging.Logger, repositoryID RepositoryID, branchID BranchID, stagingOperation func(branch *Branch) error) error {
+func (g *KVGraveler) safeBranchWrite(ctx context.Context, log logging.Logger, repository *RepositoryRecord, branchID BranchID, stagingOperation func(branch *Branch) error) error {
 	// setTries is the number of times to repeat the set operation if the staging token changed
 	const setTries = 3
 
 	var try int
 	for try = 0; try < setTries; try++ {
-		branch, err := g.GetBranch(ctx, repositoryID, branchID)
+		branch, err := g.GetBranch(ctx, repository, branchID)
 		if err != nil {
 			return err
 		}
@@ -1464,7 +1432,7 @@ func (g *KVGraveler) safeBranchWrite(ctx context.Context, log logging.Logger, re
 
 		// Checking if the token has changed.
 		// If it changed, we need to write the changes to the branch's new staging token
-		branch, err = g.GetBranch(ctx, repositoryID, branchID)
+		branch, err = g.GetBranch(ctx, repository, branchID)
 		if err != nil {
 			return err
 		}
@@ -1485,28 +1453,24 @@ func (g *KVGraveler) safeBranchWrite(ctx context.Context, log logging.Logger, re
 	return nil
 }
 
-func (g *KVGraveler) Delete(ctx context.Context, repositoryID RepositoryID, branchID BranchID, key Key) error {
-	isProtected, err := g.protectedBranchesManager.IsBlocked(ctx, repositoryID, branchID, BranchProtectionBlockedAction_STAGING_WRITE)
+func (g *KVGraveler) Delete(ctx context.Context, repository *RepositoryRecord, branchID BranchID, key Key) error {
+	isProtected, err := g.protectedBranchesManager.IsBlocked(ctx, repository, branchID, BranchProtectionBlockedAction_STAGING_WRITE)
 	if err != nil {
 		return err
 	}
 	if isProtected {
 		return ErrWriteToProtectedBranch
 	}
-	repo, err := g.RefManager.GetRepository(ctx, repositoryID)
-	if err != nil {
-		return err
-	}
 
 	deleteEntry := func(branch *Branch) error {
-		commit, err := g.RefManager.GetCommit(ctx, repositoryID, branch.CommitID)
+		commit, err := g.RefManager.GetCommit(ctx, repository, branch.CommitID)
 		if err != nil {
 			return err
 		}
 
 		// check key in committed - do we need tombstone?
 		foundInCommitted := false
-		_, err = g.CommittedManager.Get(ctx, repo.StorageNamespace, commit.MetaRangeID, key)
+		_, err = g.CommittedManager.Get(ctx, repository.StorageNamespace, commit.MetaRangeID, key)
 		if err != nil {
 			if !errors.Is(err, ErrNotFound) {
 				// unknown error
@@ -1537,7 +1501,8 @@ func (g *KVGraveler) Delete(ctx context.Context, repositoryID RepositoryID, bran
 		return ErrNotFound
 	}
 
-	return g.safeBranchWrite(ctx, g.log.WithField("key", key).WithField("operation", "delete"), repositoryID, branchID, deleteEntry)
+	return g.safeBranchWrite(ctx, g.log.WithField("key", key).WithField("operation", "delete"),
+		repository, branchID, deleteEntry)
 }
 
 // listStagingArea Returns an iterator which is an aggregation of all changes on all the branch's staging area (staging + sealed)
@@ -1592,25 +1557,21 @@ func (g *KVGraveler) sealedTokensIterator(ctx context.Context, b *Branch) (Value
 	return changes, nil
 }
 
-func (g *KVGraveler) List(ctx context.Context, repositoryID RepositoryID, ref Ref) (ValueIterator, error) {
-	repo, err := g.RefManager.GetRepository(ctx, repositoryID)
-	if err != nil {
-		return nil, err
-	}
-	reference, err := g.Dereference(ctx, repositoryID, ref)
+func (g *KVGraveler) List(ctx context.Context, repository *RepositoryRecord, ref Ref) (ValueIterator, error) {
+	reference, err := g.Dereference(ctx, repository, ref)
 	if err != nil {
 		return nil, err
 	}
 	var metaRangeID MetaRangeID
 	if reference.CommitID != "" {
-		commit, err := g.RefManager.GetCommit(ctx, repositoryID, reference.CommitID)
+		commit, err := g.RefManager.GetCommit(ctx, repository, reference.CommitID)
 		if err != nil {
 			return nil, err
 		}
 		metaRangeID = commit.MetaRangeID
 	}
 
-	listing, err := g.CommittedManager.List(ctx, repo.StorageNamespace, metaRangeID)
+	listing, err := g.CommittedManager.List(ctx, repository.StorageNamespace, metaRangeID)
 	if err != nil {
 		return nil, err
 	}
@@ -1626,29 +1587,25 @@ func (g *KVGraveler) List(ctx context.Context, repositoryID RepositoryID, ref Re
 	return listing, nil
 }
 
-func (g *KVGraveler) Commit(ctx context.Context, repositoryID RepositoryID, branchID BranchID, params CommitParams) (CommitID, error) {
+func (g *KVGraveler) Commit(ctx context.Context, repository *RepositoryRecord, branchID BranchID, params CommitParams) (CommitID, error) {
 	var preRunID string
 	var commit Commit
 	var newCommitID CommitID
 	var storageNamespace StorageNamespace
 	var sealedToDrop []StagingToken
 
-	isProtected, err := g.protectedBranchesManager.IsBlocked(ctx, repositoryID, branchID, BranchProtectionBlockedAction_COMMIT)
+	isProtected, err := g.protectedBranchesManager.IsBlocked(ctx, repository, branchID, BranchProtectionBlockedAction_COMMIT)
 	if err != nil {
 		return "", err
 	}
 	if isProtected {
 		return "", ErrCommitToProtectedBranch
 	}
-	repo, err := g.RefManager.GetRepository(ctx, repositoryID)
-	if err != nil {
-		return "", fmt.Errorf("get repository: %w", err)
-	}
-	storageNamespace = repo.StorageNamespace
+	storageNamespace = repository.StorageNamespace
 
-	err = g.RefManager.BranchUpdate(ctx, repositoryID, branchID, func(branch *Branch) (*Branch, error) {
+	err = g.RefManager.BranchUpdate(ctx, repository, branchID, func(branch *Branch) (*Branch, error) {
 		if params.SourceMetaRange != nil {
-			empty, err := g.isStagingEmpty(ctx, repositoryID, repo, branch)
+			empty, err := g.isStagingEmpty(ctx, repository, branch)
 			if err != nil {
 				return nil, fmt.Errorf("checking empty branch: %w", err)
 			}
@@ -1657,14 +1614,14 @@ func (g *KVGraveler) Commit(ctx context.Context, repositoryID RepositoryID, bran
 			}
 		}
 		branch.SealedTokens = append([]StagingToken{branch.StagingToken}, branch.SealedTokens...)
-		branch.StagingToken = GenerateStagingToken(repositoryID, branchID)
+		branch.StagingToken = GenerateStagingToken(repository.RepositoryID, branchID)
 		return branch, nil
 	})
 	if err != nil {
 		return "", err
 	}
 
-	err = g.retryBranchUpdate(ctx, repositoryID, branchID, func(branch *Branch) (*Branch, error) {
+	err = g.retryBranchUpdate(ctx, repository, branchID, func(branch *Branch) (*Branch, error) {
 		// fill commit information - use for pre-commit and after adding the commit information used by commit
 		commit = NewCommit()
 
@@ -1683,7 +1640,7 @@ func (g *KVGraveler) Commit(ctx context.Context, repositoryID RepositoryID, bran
 			RunID:            preRunID,
 			EventType:        EventTypePreCommit,
 			SourceRef:        branchID.Ref(),
-			RepositoryID:     repositoryID,
+			RepositoryID:     repository.RepositoryID,
 			StorageNamespace: storageNamespace,
 			BranchID:         branchID,
 			Commit:           commit,
@@ -1699,7 +1656,7 @@ func (g *KVGraveler) Commit(ctx context.Context, repositoryID RepositoryID, bran
 		var branchMetaRangeID MetaRangeID
 		var parentGeneration int
 		if branch.CommitID != "" {
-			branchCommit, err := g.RefManager.GetCommit(ctx, repositoryID, branch.CommitID)
+			branchCommit, err := g.RefManager.GetCommit(ctx, repository, branch.CommitID)
 			if err != nil {
 				return nil, fmt.Errorf("get commit: %w", err)
 			}
@@ -1708,7 +1665,7 @@ func (g *KVGraveler) Commit(ctx context.Context, repositoryID RepositoryID, bran
 		}
 		commit.Generation = parentGeneration + 1
 		if params.SourceMetaRange != nil {
-			empty, err := g.isSealedEmpty(ctx, repositoryID, repo, branch)
+			empty, err := g.isSealedEmpty(ctx, repository, branch)
 			if err != nil {
 				return nil, fmt.Errorf("checking empty sealed: %w", err)
 			}
@@ -1731,7 +1688,7 @@ func (g *KVGraveler) Commit(ctx context.Context, repositoryID RepositoryID, bran
 		sealedToDrop = branch.SealedTokens
 
 		// add commit
-		newCommitID, err = g.RefManager.AddCommit(ctx, repositoryID, commit)
+		newCommitID, err = g.RefManager.AddCommit(ctx, repository, commit)
 		if err != nil {
 			return nil, fmt.Errorf("add commit: %w", err)
 		}
@@ -1750,7 +1707,7 @@ func (g *KVGraveler) Commit(ctx context.Context, repositoryID RepositoryID, bran
 	err = g.hooks.PostCommitHook(ctx, HookRecord{
 		EventType:        EventTypePostCommit,
 		RunID:            postRunID,
-		RepositoryID:     repositoryID,
+		RepositoryID:     repository.RepositoryID,
 		StorageNamespace: storageNamespace,
 		SourceRef:        newCommitID.Ref(),
 		BranchID:         branchID,
@@ -1767,7 +1724,7 @@ func (g *KVGraveler) Commit(ctx context.Context, repositoryID RepositoryID, bran
 	return newCommitID, nil
 }
 
-func (g *KVGraveler) retryBranchUpdate(ctx context.Context, repositoryID RepositoryID, branchID BranchID, f BranchUpdateFunc) error {
+func (g *KVGraveler) retryBranchUpdate(ctx context.Context, repository *RepositoryRecord, branchID BranchID, f BranchUpdateFunc) error {
 	const (
 		maxInterval = 5
 		setTries    = 3
@@ -1778,7 +1735,7 @@ func (g *KVGraveler) retryBranchUpdate(ctx context.Context, repositoryID Reposit
 	try := 1
 	err := backoff.Retry(func() error {
 		// TODO(eden) issue 3586 - if the branch commit id hasn't changed, update the fields instead of fail
-		err := g.RefManager.BranchUpdate(ctx, repositoryID, branchID, f)
+		err := g.RefManager.BranchUpdate(ctx, repository, branchID, f)
 		if err != nil && !errors.Is(err, kv.ErrPredicateFailed) {
 			return backoff.Permanent(err)
 		}
@@ -1797,7 +1754,7 @@ func (g *KVGraveler) retryBranchUpdate(ctx context.Context, repositoryID Reposit
 	return err
 }
 
-func validateCommitParent(ctx context.Context, repositoryID RepositoryID, commit Commit, manager RefManager) (CommitID, error) {
+func validateCommitParent(ctx context.Context, repository *RepositoryRecord, commit Commit, manager RefManager) (CommitID, error) {
 	if len(commit.Parents) > 1 {
 		return "", ErrMultipleParents
 	}
@@ -1806,15 +1763,15 @@ func validateCommitParent(ctx context.Context, repositoryID RepositoryID, commit
 	}
 
 	parentCommitID := commit.Parents[0]
-	_, err := manager.GetCommit(ctx, repositoryID, parentCommitID)
+	_, err := manager.GetCommit(ctx, repository, parentCommitID)
 	if err != nil {
 		return "", fmt.Errorf("get parent commit %s: %w", parentCommitID, err)
 	}
 	return parentCommitID, nil
 }
 
-func CommitExists(ctx context.Context, repositoryID RepositoryID, commitID CommitID, manager RefManager) (bool, error) {
-	_, err := manager.GetCommit(ctx, repositoryID, commitID)
+func CommitExists(ctx context.Context, repository *RepositoryRecord, commitID CommitID, manager RefManager) (bool, error) {
+	_, err := manager.GetCommit(ctx, repository, commitID)
 	if err == nil {
 		// commit already exists
 		return true, nil
@@ -1825,21 +1782,16 @@ func CommitExists(ctx context.Context, repositoryID RepositoryID, commitID Commi
 	return false, nil
 }
 
-func (g *KVGraveler) AddCommitToBranchHead(ctx context.Context, repositoryID RepositoryID, branchID BranchID, commit Commit) (CommitID, error) {
-	repo, err := g.GetRepository(ctx, repositoryID)
-	if err != nil {
-		return "", err
-	}
-
+func (g *KVGraveler) AddCommitToBranchHead(ctx context.Context, repository *RepositoryRecord, branchID BranchID, commit Commit) (CommitID, error) {
 	// parentCommitID should always match the HEAD of the branch.
 	// Empty parentCommitID matches first commit of the branch.
-	parentCommitID, err := validateCommitParent(ctx, repositoryID, commit, g.RefManager)
+	parentCommitID, err := validateCommitParent(ctx, repository, commit, g.RefManager)
 	if err != nil {
 		return "", err
 	}
 
 	// verify access to meta range
-	ok, err := g.CommittedManager.Exists(ctx, repo.StorageNamespace, commit.MetaRangeID)
+	ok, err := g.CommittedManager.Exists(ctx, repository.StorageNamespace, commit.MetaRangeID)
 	if err != nil {
 		return "", fmt.Errorf("commit missing meta range %s: %w", commit.MetaRangeID, err)
 	}
@@ -1848,12 +1800,12 @@ func (g *KVGraveler) AddCommitToBranchHead(ctx context.Context, repositoryID Rep
 	}
 
 	// add commit to our ref manager
-	commitID, err := g.RefManager.AddCommit(ctx, repositoryID, commit)
+	commitID, err := g.RefManager.AddCommit(ctx, repository, commit)
 	if err != nil {
 		return "", fmt.Errorf("adding commit: %w", err)
 	}
 
-	if err := g.prepareForCommitIDUpdate(ctx, repositoryID, branchID, repo); err != nil {
+	if err := g.prepareForCommitIDUpdate(ctx, repository, branchID); err != nil {
 		return "", err
 	}
 
@@ -1861,12 +1813,12 @@ func (g *KVGraveler) AddCommitToBranchHead(ctx context.Context, repositoryID Rep
 	// update branch with commit after verify:
 	// 1. commit parent is the current branch head
 	// 2. branch staging is empty
-	err = g.RefManager.BranchUpdate(ctx, repositoryID, branchID, func(branch *Branch) (*Branch, error) {
+	err = g.RefManager.BranchUpdate(ctx, repository, branchID, func(branch *Branch) (*Branch, error) {
 		if branch.CommitID != parentCommitID {
 			return nil, ErrCommitNotHeadBranch
 		}
 
-		empty, err := g.isSealedEmpty(ctx, repositoryID, repo, branch)
+		empty, err := g.isSealedEmpty(ctx, repository, branch)
 		if err != nil {
 			return nil, err
 		}
@@ -1892,25 +1844,25 @@ func (g *KVGraveler) AddCommitToBranchHead(ctx context.Context, repositoryID Rep
 	return commitID, nil
 }
 
-func (g *KVGraveler) AddCommit(ctx context.Context, repositoryID RepositoryID, commit Commit) (CommitID, error) {
+func (g *KVGraveler) AddCommit(ctx context.Context, repository *RepositoryRecord, commit Commit) (CommitID, error) {
 	// at least a single parent must exists
 	if len(commit.Parents) == 0 {
 		return "", ErrAddCommitNoParent
 	}
-	_, err := validateCommitParent(ctx, repositoryID, commit, g.RefManager)
+	_, err := validateCommitParent(ctx, repository, commit, g.RefManager)
 	if err != nil {
 		return "", err
 	}
 
 	// check if commit already exists.
 	commitID := CommitID(ident.NewHexAddressProvider().ContentAddress(commit))
-	if exists, err := CommitExists(ctx, repositoryID, commitID, g.RefManager); err != nil {
+	if exists, err := CommitExists(ctx, repository, commitID, g.RefManager); err != nil {
 		return "", err
 	} else if exists {
 		return commitID, nil
 	}
 
-	commitID, err = g.addCommitNoLock(ctx, repositoryID, commit)
+	commitID, err = g.addCommitNoLock(ctx, repository, commit)
 	if err != nil {
 		return "", fmt.Errorf("adding commit: %w", err)
 	}
@@ -1919,14 +1871,9 @@ func (g *KVGraveler) AddCommit(ctx context.Context, repositoryID RepositoryID, c
 }
 
 // addCommitNoLock lower API used to add commit into a repository. It will verify that the commit meta-range is accessible but will not lock any metadata update.
-func (g *KVGraveler) addCommitNoLock(ctx context.Context, repositoryID RepositoryID, commit Commit) (CommitID, error) {
-	repo, err := g.GetRepository(ctx, repositoryID)
-	if err != nil {
-		return "", fmt.Errorf("get repository %s: %w", repositoryID, err)
-	}
-
+func (g *KVGraveler) addCommitNoLock(ctx context.Context, repository *RepositoryRecord, commit Commit) (CommitID, error) {
 	// verify access to meta range
-	ok, err := g.CommittedManager.Exists(ctx, repo.StorageNamespace, commit.MetaRangeID)
+	ok, err := g.CommittedManager.Exists(ctx, repository.StorageNamespace, commit.MetaRangeID)
 	if err != nil {
 		return "", fmt.Errorf("checking for meta range %s: %w", commit.MetaRangeID, err)
 	}
@@ -1935,14 +1882,14 @@ func (g *KVGraveler) addCommitNoLock(ctx context.Context, repositoryID Repositor
 	}
 
 	// add commit
-	commitID, err := g.RefManager.AddCommit(ctx, repositoryID, commit)
+	commitID, err := g.RefManager.AddCommit(ctx, repository, commit)
 	if err != nil {
 		return "", fmt.Errorf("add commit: %w", err)
 	}
 	return commitID, nil
 }
 
-func (g *KVGraveler) isStagingEmpty(ctx context.Context, repositoryID RepositoryID, repo *Repository, branch *Branch) (bool, error) {
+func (g *KVGraveler) isStagingEmpty(ctx context.Context, repository *RepositoryRecord, branch *Branch) (bool, error) {
 	itr, err := g.listStagingArea(ctx, branch)
 	if err != nil {
 		return false, err
@@ -1950,17 +1897,17 @@ func (g *KVGraveler) isStagingEmpty(ctx context.Context, repositoryID Repository
 	defer itr.Close()
 
 	// Iterating over staging area (staging + sealed) of the branch and check for entries
-	return g.checkEmpty(ctx, repositoryID, repo, branch, itr)
+	return g.checkEmpty(ctx, repository, branch, itr)
 }
 
 // checkEmpty - staging iterator is not considered empty IFF it contains any non-tombstone entry
 // or a tombstone entry exists for a key which is already committed
-func (g *KVGraveler) checkEmpty(ctx context.Context, repositoryID RepositoryID, repo *Repository, branch *Branch, changesIt ValueIterator) (bool, error) {
-	commit, err := g.RefManager.GetCommit(ctx, repositoryID, branch.CommitID)
+func (g *KVGraveler) checkEmpty(ctx context.Context, repository *RepositoryRecord, branch *Branch, changesIt ValueIterator) (bool, error) {
+	commit, err := g.RefManager.GetCommit(ctx, repository, branch.CommitID)
 	if err != nil {
 		return false, err
 	}
-	committedList, err := g.CommittedManager.List(ctx, repo.StorageNamespace, commit.MetaRangeID)
+	committedList, err := g.CommittedManager.List(ctx, repository.StorageNamespace, commit.MetaRangeID)
 	if err != nil {
 		return false, err
 	}
@@ -1971,7 +1918,7 @@ func (g *KVGraveler) checkEmpty(ctx context.Context, repositoryID RepositoryID, 
 	return !diffIt.Next(), nil
 }
 
-func (g *KVGraveler) isSealedEmpty(ctx context.Context, repositoryID RepositoryID, repo *Repository, branch *Branch) (bool, error) {
+func (g *KVGraveler) isSealedEmpty(ctx context.Context, repository *RepositoryRecord, branch *Branch) (bool, error) {
 	if len(branch.SealedTokens) == 0 {
 		return true, nil
 	}
@@ -1980,7 +1927,7 @@ func (g *KVGraveler) isSealedEmpty(ctx context.Context, repositoryID RepositoryI
 		return false, err
 	}
 	defer itrs.Close()
-	return g.checkEmpty(ctx, repositoryID, repo, branch, itrs)
+	return g.checkEmpty(ctx, repository, branch, itrs)
 }
 
 // dropTokens deletes all staging area entries of a given branch from store
@@ -1993,8 +1940,8 @@ func (g *KVGraveler) dropTokens(ctx context.Context, tokens ...StagingToken) {
 	}
 }
 
-func (g *KVGraveler) Reset(ctx context.Context, repositoryID RepositoryID, branchID BranchID) error {
-	isProtected, err := g.protectedBranchesManager.IsBlocked(ctx, repositoryID, branchID, BranchProtectionBlockedAction_STAGING_WRITE)
+func (g *KVGraveler) Reset(ctx context.Context, repository *RepositoryRecord, branchID BranchID) error {
+	isProtected, err := g.protectedBranchesManager.IsBlocked(ctx, repository, branchID, BranchProtectionBlockedAction_STAGING_WRITE)
 	if err != nil {
 		return err
 	}
@@ -2002,13 +1949,13 @@ func (g *KVGraveler) Reset(ctx context.Context, repositoryID RepositoryID, branc
 		return ErrWriteToProtectedBranch
 	}
 	tokensToDrop := make([]StagingToken, 0)
-	err = g.RefManager.BranchUpdate(ctx, repositoryID, branchID, func(branch *Branch) (*Branch, error) {
+	err = g.RefManager.BranchUpdate(ctx, repository, branchID, func(branch *Branch) (*Branch, error) {
 		// Save current branch tokens for drop
 		tokensToDrop = append(tokensToDrop, branch.StagingToken)
 		tokensToDrop = append(tokensToDrop, branch.SealedTokens...)
 
 		// Zero tokens and try to set branch
-		branch.StagingToken = GenerateStagingToken(repositoryID, branchID)
+		branch.StagingToken = GenerateStagingToken(repository.RepositoryID, branchID)
 		branch.SealedTokens = make([]StagingToken, 0)
 		return branch, nil
 	})
@@ -2023,9 +1970,9 @@ func (g *KVGraveler) Reset(ctx context.Context, repositoryID RepositoryID, branc
 // resetKey resets given key on branch
 // Since we cannot (will not) modify sealed tokens data, we overwrite changes done on entry on a new staging token, effectively reverting it
 // to the current state in the branch committed data. If entry is not committed return an error
-func (g *KVGraveler) resetKey(ctx context.Context, repositoryID RepositoryID, branch *Branch, key Key, stagedValue *Value, st StagingToken) error {
+func (g *KVGraveler) resetKey(ctx context.Context, repository *RepositoryRecord, branch *Branch, key Key, stagedValue *Value, st StagingToken) error {
 	isCommitted := true
-	committed, err := g.Get(ctx, repositoryID, branch.CommitID.Ref(), key)
+	committed, err := g.Get(ctx, repository, branch.CommitID.Ref(), key)
 	if err != nil {
 		if !errors.Is(err, ErrNotFound) {
 			return err
@@ -2047,8 +1994,8 @@ func (g *KVGraveler) resetKey(ctx context.Context, repositoryID RepositoryID, br
 	return nil
 }
 
-func (g *KVGraveler) ResetKey(ctx context.Context, repositoryID RepositoryID, branchID BranchID, key Key) error {
-	isProtected, err := g.protectedBranchesManager.IsBlocked(ctx, repositoryID, branchID, BranchProtectionBlockedAction_STAGING_WRITE)
+func (g *KVGraveler) ResetKey(ctx context.Context, repository *RepositoryRecord, branchID BranchID, key Key) error {
+	isProtected, err := g.protectedBranchesManager.IsBlocked(ctx, repository, branchID, BranchProtectionBlockedAction_STAGING_WRITE)
 	if err != nil {
 		return err
 	}
@@ -2056,7 +2003,7 @@ func (g *KVGraveler) ResetKey(ctx context.Context, repositoryID RepositoryID, br
 		return ErrWriteToProtectedBranch
 	}
 
-	branch, err := g.RefManager.GetBranch(ctx, repositoryID, branchID)
+	branch, err := g.RefManager.GetBranch(ctx, repository, branchID)
 	if err != nil {
 		return fmt.Errorf("getting branch: %w", err)
 	}
@@ -2069,7 +2016,7 @@ func (g *KVGraveler) ResetKey(ctx context.Context, repositoryID RepositoryID, br
 		return err
 	}
 
-	err = g.resetKey(ctx, repositoryID, branch, key, staged, branch.StagingToken)
+	err = g.resetKey(ctx, repository, branch, key, staged, branch.StagingToken)
 	if err != nil {
 		if !errors.Is(err, ErrNotFound) { // Not found in staging => ignore
 			return err
@@ -2083,8 +2030,8 @@ func (g *KVGraveler) ResetKey(ctx context.Context, repositoryID RepositoryID, br
 	return nil
 }
 
-func (g *KVGraveler) ResetPrefix(ctx context.Context, repositoryID RepositoryID, branchID BranchID, key Key) error {
-	isProtected, err := g.protectedBranchesManager.IsBlocked(ctx, repositoryID, branchID, BranchProtectionBlockedAction_STAGING_WRITE)
+func (g *KVGraveler) ResetPrefix(ctx context.Context, repository *RepositoryRecord, branchID BranchID, key Key) error {
+	isProtected, err := g.protectedBranchesManager.IsBlocked(ctx, repository, branchID, BranchProtectionBlockedAction_STAGING_WRITE)
 	if err != nil {
 		return err
 	}
@@ -2093,9 +2040,9 @@ func (g *KVGraveler) ResetPrefix(ctx context.Context, repositoryID RepositoryID,
 	}
 	// New sealed tokens list after change includes current staging token
 	newSealedTokens := make([]StagingToken, 0)
-	newStagingToken := GenerateStagingToken(repositoryID, branchID)
+	newStagingToken := GenerateStagingToken(repository.RepositoryID, branchID)
 
-	err = g.RefManager.BranchUpdate(ctx, repositoryID, branchID, func(branch *Branch) (*Branch, error) {
+	err = g.RefManager.BranchUpdate(ctx, repository, branchID, func(branch *Branch) (*Branch, error) {
 		newSealedTokens = []StagingToken{branch.StagingToken}
 		newSealedTokens = append(newSealedTokens, branch.SealedTokens...)
 
@@ -2113,7 +2060,7 @@ func (g *KVGraveler) ResetPrefix(ctx context.Context, repositoryID RepositoryID,
 				break
 			}
 			wg.Go(func() error {
-				err = g.resetKey(ctx, repositoryID, branch, value.Key, value.Value, newStagingToken)
+				err = g.resetKey(ctx, repository, branch, value.Key, value.Value, newStagingToken)
 				if err != nil {
 					return err
 				}
@@ -2147,8 +2094,8 @@ type CommitIDAndSummary struct {
 // To revert C2, we merge C1 into the branch, with C2 as the merge base.
 // That is, try to apply the diff from C2 to C1 on the tip of the branch.
 // If the commit is a merge commit, 'parentNumber' is the parent number (1-based) relative to which the revert is done.
-func (g *KVGraveler) Revert(ctx context.Context, repositoryID RepositoryID, branchID BranchID, ref Ref, parentNumber int, commitParams CommitParams) (CommitID, error) {
-	commitRecord, err := g.dereferenceCommit(ctx, repositoryID, ref)
+func (g *KVGraveler) Revert(ctx context.Context, repository *RepositoryRecord, branchID BranchID, ref Ref, parentNumber int, commitParams CommitParams) (CommitID, error) {
+	commitRecord, err := g.dereferenceCommit(ctx, repository, ref)
 	if err != nil {
 		return "", fmt.Errorf("get commit from ref %s: %w", ref, err)
 	}
@@ -2164,37 +2111,33 @@ func (g *KVGraveler) Revert(ctx context.Context, repositoryID RepositoryID, bran
 		parentNumber--
 	}
 
-	repo, err := g.RefManager.GetRepository(ctx, repositoryID)
-	if err != nil {
-		return "", fmt.Errorf("get repo %s: %w", repositoryID, err)
-	}
-
-	if err := g.prepareForCommitIDUpdate(ctx, repositoryID, branchID, repo); err != nil {
+	if err := g.prepareForCommitIDUpdate(ctx, repository, branchID); err != nil {
 		return "", err
 	}
 
 	var commitID CommitID
 	var tokensToDrop []StagingToken
-	err = g.RefManager.BranchUpdate(ctx, repositoryID, branchID, func(branch *Branch) (*Branch, error) {
-		if empty, err := g.isSealedEmpty(ctx, repositoryID, repo, branch); err != nil {
+	err = g.RefManager.BranchUpdate(ctx, repository, branchID, func(branch *Branch) (*Branch, error) {
+		if empty, err := g.isSealedEmpty(ctx, repository, branch); err != nil {
 			return nil, err
 		} else if !empty {
 			return nil, fmt.Errorf("%s: %w", branchID, ErrDirtyBranch)
 		}
 		var parentMetaRangeID MetaRangeID
 		if len(commitRecord.Parents) > 0 {
-			parentCommit, err := g.dereferenceCommit(ctx, repositoryID, commitRecord.Parents[parentNumber].Ref())
+			parentCommit, err := g.dereferenceCommit(ctx, repository, commitRecord.Parents[parentNumber].Ref())
 			if err != nil {
 				return nil, fmt.Errorf("get commit from ref %s: %w", commitRecord.Parents[parentNumber], err)
 			}
 			parentMetaRangeID = parentCommit.MetaRangeID
 		}
-		branchCommit, err := g.dereferenceCommit(ctx, repositoryID, branch.CommitID.Ref())
+		branchCommit, err := g.dereferenceCommit(ctx, repository, branch.CommitID.Ref())
 		if err != nil {
 			return nil, fmt.Errorf("get commit from ref %s: %w", branch.CommitID, err)
 		}
 		// merge from the parent to the top of the branch, with the given ref as the merge base:
-		metaRangeID, err := g.CommittedManager.Merge(ctx, repo.StorageNamespace, branchCommit.MetaRangeID, parentMetaRangeID, commitRecord.MetaRangeID, MergeStrategyNone)
+		metaRangeID, err := g.CommittedManager.Merge(ctx, repository.StorageNamespace, branchCommit.MetaRangeID,
+			parentMetaRangeID, commitRecord.MetaRangeID, MergeStrategyNone)
 		if err != nil {
 			if !errors.Is(err, ErrUserVisible) {
 				err = fmt.Errorf("merge: %w", err)
@@ -2208,7 +2151,7 @@ func (g *KVGraveler) Revert(ctx context.Context, repositoryID RepositoryID, bran
 		commit.Parents = []CommitID{branch.CommitID}
 		commit.Metadata = commitParams.Metadata
 		commit.Generation = branchCommit.Generation + 1
-		commitID, err = g.RefManager.AddCommit(ctx, repositoryID, commit)
+		commitID, err = g.RefManager.AddCommit(ctx, repository, commit)
 		if err != nil {
 			return nil, fmt.Errorf("add commit: %w", err)
 		}
@@ -2226,21 +2169,15 @@ func (g *KVGraveler) Revert(ctx context.Context, repositoryID RepositoryID, bran
 	return commitID, nil
 }
 
-func (g *KVGraveler) Merge(ctx context.Context, repositoryID RepositoryID, destination BranchID, source Ref, commitParams CommitParams, strategy string) (CommitID, error) {
+func (g *KVGraveler) Merge(ctx context.Context, repository *RepositoryRecord, destination BranchID, source Ref, commitParams CommitParams, strategy string) (CommitID, error) {
 	var (
-		preRunID         string
-		storageNamespace StorageNamespace
-		commit           Commit
-		commitID         CommitID
+		preRunID string
+		commit   Commit
+		commitID CommitID
 	)
 
-	repo, err := g.RefManager.GetRepository(ctx, repositoryID)
-	if err != nil {
-		return "", err
-	}
-	storageNamespace = repo.StorageNamespace
-
-	if err := g.prepareForCommitIDUpdate(ctx, repositoryID, destination, repo); err != nil {
+	storageNamespace := repository.StorageNamespace
+	if err := g.prepareForCommitIDUpdate(ctx, repository, destination); err != nil {
 		return "", err
 	}
 
@@ -2248,15 +2185,15 @@ func (g *KVGraveler) Merge(ctx context.Context, repositoryID RepositoryID, desti
 	// No retries on any failure during the merge. If the branch changed, it's either that commit is in progress, commit occurred,
 	// or some other branch changing operation. If commit is in-progress, then staging area wasn't empty after we checked so not retrying is ok.
 	// If another commit/merge succeeded, then the user should decide whether to retry the merge.
-	err = g.RefManager.BranchUpdate(ctx, repositoryID, destination, func(branch *Branch) (*Branch, error) {
-		empty, err := g.isSealedEmpty(ctx, repositoryID, repo, branch)
+	err := g.RefManager.BranchUpdate(ctx, repository, destination, func(branch *Branch) (*Branch, error) {
+		empty, err := g.isSealedEmpty(ctx, repository, branch)
 		if err != nil {
 			return nil, fmt.Errorf("check if staging empty: %w", err)
 		}
 		if !empty {
 			return nil, fmt.Errorf("%s: %w", destination, ErrDirtyBranch)
 		}
-		fromCommit, toCommit, baseCommit, err := g.getCommitsForMerge(ctx, repositoryID, source, Ref(destination))
+		fromCommit, toCommit, baseCommit, err := g.getCommitsForMerge(ctx, repository, source, Ref(destination))
 		if err != nil {
 			return nil, err
 		}
@@ -2297,7 +2234,7 @@ func (g *KVGraveler) Merge(ctx context.Context, repositoryID RepositoryID, desti
 		err = g.hooks.PreMergeHook(ctx, HookRecord{
 			EventType:        EventTypePreMerge,
 			RunID:            preRunID,
-			RepositoryID:     repositoryID,
+			RepositoryID:     repository.RepositoryID,
 			StorageNamespace: storageNamespace,
 			BranchID:         destination,
 			SourceRef:        fromCommit.CommitID.Ref(),
@@ -2310,7 +2247,7 @@ func (g *KVGraveler) Merge(ctx context.Context, repositoryID RepositoryID, desti
 				Err:       err,
 			}
 		}
-		commitID, err = g.RefManager.AddCommit(ctx, repositoryID, commit)
+		commitID, err = g.RefManager.AddCommit(ctx, repository, commit)
 		if err != nil {
 			return nil, fmt.Errorf("add commit: %w", err)
 		}
@@ -2329,7 +2266,7 @@ func (g *KVGraveler) Merge(ctx context.Context, repositoryID RepositoryID, desti
 	err = g.hooks.PostMergeHook(ctx, HookRecord{
 		EventType:        EventTypePostMerge,
 		RunID:            postRunID,
-		RepositoryID:     repositoryID,
+		RepositoryID:     repository.RepositoryID,
 		StorageNamespace: storageNamespace,
 		BranchID:         destination,
 		SourceRef:        commitID.Ref(),
@@ -2348,18 +2285,14 @@ func (g *KVGraveler) Merge(ctx context.Context, repositoryID RepositoryID, desti
 }
 
 // DiffUncommitted returns DiffIterator between committed data and staging area of a branch
-func (g *KVGraveler) DiffUncommitted(ctx context.Context, repositoryID RepositoryID, branchID BranchID) (DiffIterator, error) {
-	repo, err := g.RefManager.GetRepository(ctx, repositoryID)
-	if err != nil {
-		return nil, err
-	}
-	branch, err := g.RefManager.GetBranch(ctx, repositoryID, branchID)
+func (g *KVGraveler) DiffUncommitted(ctx context.Context, repository *RepositoryRecord, branchID BranchID) (DiffIterator, error) {
+	branch, err := g.RefManager.GetBranch(ctx, repository, branchID)
 	if err != nil {
 		return nil, err
 	}
 	var metaRangeID MetaRangeID
 	if branch.CommitID != "" {
-		commit, err := g.RefManager.GetCommit(ctx, repositoryID, branch.CommitID)
+		commit, err := g.RefManager.GetCommit(ctx, repository, branch.CommitID)
 		if err != nil {
 			return nil, err
 		}
@@ -2372,7 +2305,7 @@ func (g *KVGraveler) DiffUncommitted(ctx context.Context, repositoryID Repositor
 	}
 	var committedValueIterator ValueIterator
 	if metaRangeID != "" {
-		committedValueIterator, err = g.CommittedManager.List(ctx, repo.StorageNamespace, metaRangeID)
+		committedValueIterator, err = g.CommittedManager.List(ctx, repository.StorageNamespace, metaRangeID)
 		if err != nil {
 			valueIterator.Close()
 			return nil, err
@@ -2383,15 +2316,15 @@ func (g *KVGraveler) DiffUncommitted(ctx context.Context, repositoryID Repositor
 
 // dereferenceCommit will dereference and load the commit record based on 'ref'.
 //   will return an error if 'ref' points to an explicit staging area
-func (g *KVGraveler) dereferenceCommit(ctx context.Context, repositoryID RepositoryID, ref Ref) (*CommitRecord, error) {
-	reference, err := g.Dereference(ctx, repositoryID, ref)
+func (g *KVGraveler) dereferenceCommit(ctx context.Context, repository *RepositoryRecord, ref Ref) (*CommitRecord, error) {
+	reference, err := g.Dereference(ctx, repository, ref)
 	if err != nil {
 		return nil, err
 	}
 	if reference.ResolvedBranchModifier == ResolvedBranchModifierStaging {
 		return nil, fmt.Errorf("reference '%s': %w", ref, ErrDereferenceCommitWithStaging)
 	}
-	commit, err := g.RefManager.GetCommit(ctx, repositoryID, reference.CommitID)
+	commit, err := g.RefManager.GetCommit(ctx, repository, reference.CommitID)
 	if err != nil {
 		return nil, err
 	}
@@ -2401,36 +2334,32 @@ func (g *KVGraveler) dereferenceCommit(ctx context.Context, repositoryID Reposit
 	}, nil
 }
 
-func (g *KVGraveler) Diff(ctx context.Context, repositoryID RepositoryID, left, right Ref) (DiffIterator, error) {
-	repo, err := g.RefManager.GetRepository(ctx, repositoryID)
+func (g *KVGraveler) Diff(ctx context.Context, repository *RepositoryRecord, left, right Ref) (DiffIterator, error) {
+	leftCommit, err := g.dereferenceCommit(ctx, repository, left)
 	if err != nil {
 		return nil, err
 	}
-	leftCommit, err := g.dereferenceCommit(ctx, repositoryID, left)
+	rightRawRef, err := g.Dereference(ctx, repository, right)
 	if err != nil {
 		return nil, err
 	}
-	rightRawRef, err := g.Dereference(ctx, repositoryID, right)
+	rightCommit, err := g.RefManager.GetCommit(ctx, repository, rightRawRef.CommitID)
 	if err != nil {
 		return nil, err
 	}
-	rightCommit, err := g.RefManager.GetCommit(ctx, repositoryID, rightRawRef.CommitID)
-	if err != nil {
-		return nil, err
-	}
-	diff, err := g.CommittedManager.Diff(ctx, repo.StorageNamespace, leftCommit.MetaRangeID, rightCommit.MetaRangeID)
+	diff, err := g.CommittedManager.Diff(ctx, repository.StorageNamespace, leftCommit.MetaRangeID, rightCommit.MetaRangeID)
 	if err != nil {
 		return nil, err
 	}
 	if rightRawRef.ResolvedBranchModifier != ResolvedBranchModifierStaging {
 		return diff, nil
 	}
-	leftValueIterator, err := g.CommittedManager.List(ctx, repo.StorageNamespace, leftCommit.MetaRangeID)
+	leftValueIterator, err := g.CommittedManager.List(ctx, repository.StorageNamespace, leftCommit.MetaRangeID)
 	if err != nil {
 		return nil, err
 	}
 
-	rightBranch, err := g.RefManager.GetBranch(ctx, repositoryID, rightRawRef.BranchID)
+	rightBranch, err := g.RefManager.GetBranch(ctx, repository, rightRawRef.BranchID)
 	if err != nil {
 		leftValueIterator.Close()
 		return nil, err
@@ -2443,16 +2372,16 @@ func (g *KVGraveler) Diff(ctx context.Context, repositoryID RepositoryID, left, 
 	return NewCombinedDiffIterator(diff, leftValueIterator, stagingIterator), nil
 }
 
-func (g *KVGraveler) getCommitsForMerge(ctx context.Context, repositoryID RepositoryID, from Ref, to Ref) (*CommitRecord, *CommitRecord, *Commit, error) {
-	fromCommit, err := g.dereferenceCommit(ctx, repositoryID, from)
+func (g *KVGraveler) getCommitsForMerge(ctx context.Context, repository *RepositoryRecord, from Ref, to Ref) (*CommitRecord, *CommitRecord, *Commit, error) {
+	fromCommit, err := g.dereferenceCommit(ctx, repository, from)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("get commit by ref %s: %w", from, err)
 	}
-	toCommit, err := g.dereferenceCommit(ctx, repositoryID, to)
+	toCommit, err := g.dereferenceCommit(ctx, repository, to)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("get commit by branch %s: %w", to, err)
 	}
-	baseCommit, err := g.RefManager.FindMergeBase(ctx, repositoryID, fromCommit.CommitID, toCommit.CommitID)
+	baseCommit, err := g.RefManager.FindMergeBase(ctx, repository, fromCommit.CommitID, toCommit.CommitID)
 	if err != nil {
 		return nil, nil, nil, fmt.Errorf("find merge base: %w", err)
 	}
@@ -2462,16 +2391,12 @@ func (g *KVGraveler) getCommitsForMerge(ctx context.Context, repositoryID Reposi
 	return fromCommit, toCommit, baseCommit, nil
 }
 
-func (g *KVGraveler) Compare(ctx context.Context, repositoryID RepositoryID, left, right Ref) (DiffIterator, error) {
-	repo, err := g.RefManager.GetRepository(ctx, repositoryID)
+func (g *KVGraveler) Compare(ctx context.Context, repository *RepositoryRecord, left, right Ref) (DiffIterator, error) {
+	fromCommit, toCommit, baseCommit, err := g.getCommitsForMerge(ctx, repository, right, left)
 	if err != nil {
 		return nil, err
 	}
-	fromCommit, toCommit, baseCommit, err := g.getCommitsForMerge(ctx, repositoryID, right, left)
-	if err != nil {
-		return nil, err
-	}
-	return g.CommittedManager.Compare(ctx, repo.StorageNamespace, toCommit.MetaRangeID, fromCommit.MetaRangeID, baseCommit.MetaRangeID)
+	return g.CommittedManager.Compare(ctx, repository.StorageNamespace, toCommit.MetaRangeID, fromCommit.MetaRangeID, baseCommit.MetaRangeID)
 }
 
 func (g *KVGraveler) SetHooksHandler(handler HooksHandler) {
@@ -2482,12 +2407,8 @@ func (g *KVGraveler) SetHooksHandler(handler HooksHandler) {
 	}
 }
 
-func (g *KVGraveler) LoadCommits(ctx context.Context, repositoryID RepositoryID, metaRangeID MetaRangeID) error {
-	repo, err := g.GetRepository(ctx, repositoryID)
-	if err != nil {
-		return err
-	}
-	iter, err := g.CommittedManager.List(ctx, repo.StorageNamespace, metaRangeID)
+func (g *KVGraveler) LoadCommits(ctx context.Context, repository *RepositoryRecord, metaRangeID MetaRangeID) error {
+	iter, err := g.CommittedManager.List(ctx, repository.StorageNamespace, metaRangeID)
 	if err != nil {
 		return err
 	}
@@ -2506,7 +2427,7 @@ func (g *KVGraveler) LoadCommits(ctx context.Context, repositoryID RepositoryID,
 		if commit.GetGeneration() == 0 {
 			return fmt.Errorf("dumps created by lakeFS versions before v0.61.0 are no longer supported: %w", ErrNoCommitGeneration)
 		}
-		commitID, err := g.RefManager.AddCommit(ctx, repositoryID, Commit{
+		commitID, err := g.RefManager.AddCommit(ctx, repository, Commit{
 			Version:      CommitVersion(commit.Version),
 			Committer:    commit.GetCommitter(),
 			Message:      commit.GetMessage(),
@@ -2530,12 +2451,8 @@ func (g *KVGraveler) LoadCommits(ctx context.Context, repositoryID RepositoryID,
 	return nil
 }
 
-func (g *KVGraveler) LoadBranches(ctx context.Context, repositoryID RepositoryID, metaRangeID MetaRangeID) error {
-	repo, err := g.GetRepository(ctx, repositoryID)
-	if err != nil {
-		return err
-	}
-	iter, err := g.CommittedManager.List(ctx, repo.StorageNamespace, metaRangeID)
+func (g *KVGraveler) LoadBranches(ctx context.Context, repository *RepositoryRecord, metaRangeID MetaRangeID) error {
+	iter, err := g.CommittedManager.List(ctx, repository.StorageNamespace, metaRangeID)
 	if err != nil {
 		return err
 	}
@@ -2548,9 +2465,9 @@ func (g *KVGraveler) LoadBranches(ctx context.Context, repositoryID RepositoryID
 			return err
 		}
 		branchID := BranchID(branch.Id)
-		err = g.RefManager.SetBranch(ctx, repositoryID, branchID, Branch{
+		err = g.RefManager.SetBranch(ctx, repository, branchID, Branch{
 			CommitID:     CommitID(branch.CommitId),
-			StagingToken: GenerateStagingToken(repositoryID, branchID),
+			StagingToken: GenerateStagingToken(repository.RepositoryID, branchID),
 			SealedTokens: make([]StagingToken, 0),
 		})
 		if err != nil {
@@ -2563,12 +2480,8 @@ func (g *KVGraveler) LoadBranches(ctx context.Context, repositoryID RepositoryID
 	return nil
 }
 
-func (g *KVGraveler) LoadTags(ctx context.Context, repositoryID RepositoryID, metaRangeID MetaRangeID) error {
-	repo, err := g.GetRepository(ctx, repositoryID)
-	if err != nil {
-		return err
-	}
-	iter, err := g.CommittedManager.List(ctx, repo.StorageNamespace, metaRangeID)
+func (g *KVGraveler) LoadTags(ctx context.Context, repository *RepositoryRecord, metaRangeID MetaRangeID) error {
+	iter, err := g.CommittedManager.List(ctx, repository.StorageNamespace, metaRangeID)
 	if err != nil {
 		return err
 	}
@@ -2581,7 +2494,7 @@ func (g *KVGraveler) LoadTags(ctx context.Context, repositoryID RepositoryID, me
 			return err
 		}
 		tagID := TagID(tag.Id)
-		err = g.RefManager.CreateTag(ctx, repositoryID, tagID, CommitID(tag.CommitId))
+		err = g.RefManager.CreateTag(ctx, repository, tagID, CommitID(tag.CommitId))
 		if err != nil {
 			return err
 		}
@@ -2589,28 +2502,16 @@ func (g *KVGraveler) LoadTags(ctx context.Context, repositoryID RepositoryID, me
 	return iter.Err()
 }
 
-func (g *KVGraveler) GetMetaRange(ctx context.Context, repositoryID RepositoryID, metaRangeID MetaRangeID) (MetaRangeAddress, error) {
-	repo, err := g.RefManager.GetRepository(ctx, repositoryID)
-	if err != nil {
-		return "", nil
-	}
-	return g.CommittedManager.GetMetaRange(ctx, repo.StorageNamespace, metaRangeID)
+func (g *KVGraveler) GetMetaRange(ctx context.Context, repository *RepositoryRecord, metaRangeID MetaRangeID) (MetaRangeAddress, error) {
+	return g.CommittedManager.GetMetaRange(ctx, repository.StorageNamespace, metaRangeID)
 }
 
-func (g *KVGraveler) GetRange(ctx context.Context, repositoryID RepositoryID, rangeID RangeID) (RangeAddress, error) {
-	repo, err := g.RefManager.GetRepository(ctx, repositoryID)
-	if err != nil {
-		return "", nil
-	}
-	return g.CommittedManager.GetRange(ctx, repo.StorageNamespace, rangeID)
+func (g *KVGraveler) GetRange(ctx context.Context, repository *RepositoryRecord, rangeID RangeID) (RangeAddress, error) {
+	return g.CommittedManager.GetRange(ctx, repository.StorageNamespace, rangeID)
 }
 
-func (g *KVGraveler) DumpCommits(ctx context.Context, repositoryID RepositoryID) (*MetaRangeID, error) {
-	repo, err := g.GetRepository(ctx, repositoryID)
-	if err != nil {
-		return nil, err
-	}
-	iter, err := g.RefManager.ListCommits(ctx, repositoryID)
+func (g *KVGraveler) DumpCommits(ctx context.Context, repository *RepositoryRecord) (*MetaRangeID, error) {
+	iter, err := g.RefManager.ListCommits(ctx, repository)
 	if err != nil {
 		return nil, err
 	}
@@ -2619,7 +2520,7 @@ func (g *KVGraveler) DumpCommits(ctx context.Context, repositoryID RepositoryID)
 	if err != nil {
 		return nil, err
 	}
-	return g.CommittedManager.WriteMetaRangeByIterator(ctx, repo.StorageNamespace,
+	return g.CommittedManager.WriteMetaRangeByIterator(ctx, repository.StorageNamespace,
 		commitsToValueIterator(iter),
 		Metadata{
 			EntityTypeKey:             EntityTypeCommit,
@@ -2629,12 +2530,8 @@ func (g *KVGraveler) DumpCommits(ctx context.Context, repositoryID RepositoryID)
 	)
 }
 
-func (g *KVGraveler) DumpBranches(ctx context.Context, repositoryID RepositoryID) (*MetaRangeID, error) {
-	repo, err := g.GetRepository(ctx, repositoryID)
-	if err != nil {
-		return nil, err
-	}
-	iter, err := g.RefManager.ListBranches(ctx, repositoryID)
+func (g *KVGraveler) DumpBranches(ctx context.Context, repository *RepositoryRecord) (*MetaRangeID, error) {
+	iter, err := g.RefManager.ListBranches(ctx, repository)
 	if err != nil {
 		return nil, err
 	}
@@ -2643,7 +2540,7 @@ func (g *KVGraveler) DumpBranches(ctx context.Context, repositoryID RepositoryID
 	if err != nil {
 		return nil, err
 	}
-	return g.CommittedManager.WriteMetaRangeByIterator(ctx, repo.StorageNamespace,
+	return g.CommittedManager.WriteMetaRangeByIterator(ctx, repository.StorageNamespace,
 		branchesToValueIterator(iter),
 		Metadata{
 			EntityTypeKey:             EntityTypeBranch,
@@ -2653,12 +2550,8 @@ func (g *KVGraveler) DumpBranches(ctx context.Context, repositoryID RepositoryID
 	)
 }
 
-func (g *KVGraveler) DumpTags(ctx context.Context, repositoryID RepositoryID) (*MetaRangeID, error) {
-	repo, err := g.GetRepository(ctx, repositoryID)
-	if err != nil {
-		return nil, err
-	}
-	iter, err := g.RefManager.ListTags(ctx, repositoryID)
+func (g *KVGraveler) DumpTags(ctx context.Context, repository *RepositoryRecord) (*MetaRangeID, error) {
+	iter, err := g.RefManager.ListTags(ctx, repository)
 	if err != nil {
 		return nil, err
 	}
@@ -2667,7 +2560,7 @@ func (g *KVGraveler) DumpTags(ctx context.Context, repositoryID RepositoryID) (*
 	if err != nil {
 		return nil, err
 	}
-	return g.CommittedManager.WriteMetaRangeByIterator(ctx, repo.StorageNamespace,
+	return g.CommittedManager.WriteMetaRangeByIterator(ctx, repository.StorageNamespace,
 		tagsToValueIterator(iter),
 		Metadata{
 			EntityTypeKey:             EntityTypeTag,
@@ -2877,7 +2770,7 @@ type GarbageCollectionManager interface {
 	GetRules(ctx context.Context, storageNamespace StorageNamespace) (*GarbageCollectionRules, error)
 	SaveRules(ctx context.Context, storageNamespace StorageNamespace, rules *GarbageCollectionRules) error
 
-	SaveGarbageCollectionCommits(ctx context.Context, storageNamespace StorageNamespace, repositoryID RepositoryID, rules *GarbageCollectionRules, previouslyExpiredCommits []CommitID) (string, error)
+	SaveGarbageCollectionCommits(ctx context.Context, repository *RepositoryRecord, rules *GarbageCollectionRules, previouslyExpiredCommits []CommitID) (string, error)
 	GetRunExpiredCommits(ctx context.Context, storageNamespace StorageNamespace, runID string) ([]CommitID, error)
 	GetCommitsCSVLocation(runID string, sn StorageNamespace) (string, error)
 	GetAddressesLocation(sn StorageNamespace) (string, error)
@@ -2886,15 +2779,15 @@ type GarbageCollectionManager interface {
 type ProtectedBranchesManager interface {
 	// Add creates a rule for the given name pattern, blocking the given actions.
 	// Returns ErrRuleAlreadyExists if there is already a rule for the given pattern.
-	Add(ctx context.Context, repositoryID RepositoryID, branchNamePattern string, blockedActions []BranchProtectionBlockedAction) error
+	Add(ctx context.Context, repository *RepositoryRecord, branchNamePattern string, blockedActions []BranchProtectionBlockedAction) error
 	// Delete deletes the rule for the given name pattern, or returns ErrRuleNotExists if there is no such rule.
-	Delete(ctx context.Context, repositoryID RepositoryID, branchNamePattern string) error
+	Delete(ctx context.Context, repository *RepositoryRecord, branchNamePattern string) error
 	// Get returns the list of blocked actions for the given name pattern, or nil if no rule was defined for the pattern.
-	Get(ctx context.Context, repositoryID RepositoryID, branchNamePattern string) ([]BranchProtectionBlockedAction, error)
+	Get(ctx context.Context, repository *RepositoryRecord, branchNamePattern string) ([]BranchProtectionBlockedAction, error)
 	// GetRules returns all branch protection rules for the repository
-	GetRules(ctx context.Context, repositoryID RepositoryID) (*BranchProtectionRules, error)
+	GetRules(ctx context.Context, repository *RepositoryRecord) (*BranchProtectionRules, error)
 	// IsBlocked returns whether the action is blocked by any branch protection rule matching the given branch.
-	IsBlocked(ctx context.Context, repositoryID RepositoryID, branchID BranchID, action BranchProtectionBlockedAction) (bool, error)
+	IsBlocked(ctx context.Context, repository *RepositoryRecord, branchID BranchID, action BranchProtectionBlockedAction) (bool, error)
 }
 
 // NewRepoInstanceID Returns a new unique identifier for the repository instance

--- a/pkg/graveler/graveler.go
+++ b/pkg/graveler/graveler.go
@@ -629,10 +629,10 @@ type RefManager interface {
 	GetRepository(ctx context.Context, repositoryID RepositoryID) (*RepositoryRecord, error)
 
 	// CreateRepository stores a new Repository under RepositoryID with the given Branch as default branch
-	CreateRepository(ctx context.Context, repositoryID RepositoryID, repository Repository) error
+	CreateRepository(ctx context.Context, repositoryID RepositoryID, repository Repository) (*RepositoryRecord, error)
 
 	// CreateBareRepository stores a new repository under RepositoryID without creating an initial commit and branch
-	CreateBareRepository(ctx context.Context, repositoryID RepositoryID, repository Repository) error
+	CreateBareRepository(ctx context.Context, repositoryID RepositoryID, repository Repository) (*RepositoryRecord, error)
 
 	// ListRepositories lists repositories
 	ListRepositories(ctx context.Context) (RepositoryIterator, error)
@@ -876,14 +876,11 @@ func (g *KVGraveler) CreateRepository(ctx context.Context, repositoryID Reposito
 	}
 
 	repo := NewRepository(storageNamespace, branchID)
-	err = g.RefManager.CreateRepository(ctx, repositoryID, repo)
+	repository, err := g.RefManager.CreateRepository(ctx, repositoryID, repo)
 	if err != nil {
 		return nil, err
 	}
-	return &RepositoryRecord{
-		RepositoryID: repositoryID,
-		Repository:   &repo,
-	}, nil
+	return repository, nil
 }
 
 func (g *KVGraveler) CreateBareRepository(ctx context.Context, repositoryID RepositoryID, storageNamespace StorageNamespace, defaultBranchID BranchID) (*RepositoryRecord, error) {
@@ -893,14 +890,11 @@ func (g *KVGraveler) CreateBareRepository(ctx context.Context, repositoryID Repo
 	}
 
 	repo := NewRepository(storageNamespace, defaultBranchID)
-	err = g.RefManager.CreateBareRepository(ctx, repositoryID, repo)
+	repository, err := g.RefManager.CreateBareRepository(ctx, repositoryID, repo)
 	if err != nil {
 		return nil, err
 	}
-	return &RepositoryRecord{
-		RepositoryID: repositoryID,
-		Repository:   &repo,
-	}, nil
+	return repository, nil
 }
 
 func (g *KVGraveler) ListRepositories(ctx context.Context) (RepositoryIterator, error) {

--- a/pkg/graveler/graveler_test.go
+++ b/pkg/graveler/graveler_test.go
@@ -199,7 +199,7 @@ func testGravelerList(t *testing.T, kvEnabled bool) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			listing, err := tt.r.List(ctx, "", "")
+			listing, err := tt.r.List(ctx, repository, "")
 			if !errors.Is(err, tt.expectedErr) {
 				t.Fatalf("wrong error, expected:%s got:%s", tt.expectedErr, err)
 			}
@@ -292,7 +292,7 @@ func testGravelerGet(t *testing.T, kvEnabled bool) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			Value, err := tt.r.Get(context.Background(), "", "", []byte("key"))
+			Value, err := tt.r.Get(context.Background(), repository, "", []byte("key"))
 			if err != tt.expectedErr {
 				t.Fatalf("wrong error, expected:%v got:%v", tt.expectedErr, err)
 			}
@@ -376,7 +376,7 @@ func testGravelerSet(t *testing.T, kvEnabled bool) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			store := newGraveler(t, kvEnabled, tt.committedMgr, tt.stagingMgr, tt.refMgr, nil, testutil.NewProtectedBranchesManagerFake())
-			err := store.Set(context.Background(), "", "branch-1", newSetVal.Key, *newSetVal.Value, graveler.IfAbsent(tt.ifAbsent))
+			err := store.Set(context.Background(), repository, "branch-1", newSetVal.Key, *newSetVal.Value, graveler.IfAbsent(tt.ifAbsent))
 			if err != tt.expectedErr {
 				t.Fatalf("wrong error, expected:%v got:%v", tt.expectedErr, err)
 			}
@@ -497,7 +497,7 @@ func TestGravelerGet_Advanced(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			Value, err := tt.r.Get(context.Background(), "", "", []byte("staged"))
+			Value, err := tt.r.Get(context.Background(), repository, "", []byte("staged"))
 			if err != tt.expectedErr {
 				t.Fatalf("wrong error, expected:%v got:%v", tt.expectedErr, err)
 			}
@@ -717,7 +717,7 @@ func TestGraveler_Diff(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
-			diff, err := tt.r.Diff(ctx, "repo", "ref1", "b1")
+			diff, err := tt.r.Diff(ctx, repository, "ref1", "b1")
 			if err != tt.expectedErr {
 				t.Fatalf("wrong error, expected:%s got:%s", tt.expectedErr, err)
 			}
@@ -832,7 +832,7 @@ func testGravelerDiffUncommitted(t *testing.T, kvEnabled bool) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
-			diff, err := tt.r.DiffUncommitted(ctx, "repo", "branch")
+			diff, err := tt.r.DiffUncommitted(ctx, repository, "branch")
 			if err != tt.expectedErr {
 				t.Fatalf("wrong error, expected:%s got:%s", tt.expectedErr, err)
 			}
@@ -951,7 +951,7 @@ func TestGravelerDiffUncommitted_Advanced(t *testing.T) {
 	})
 
 	ctx := context.Background()
-	diff, err := r.DiffUncommitted(ctx, "repo", "branch")
+	diff, err := r.DiffUncommitted(ctx, repository, "branch")
 	require.NoError(t, err)
 	// compare iterators
 	for diff.Next() {
@@ -980,13 +980,13 @@ func TestGraveler_CreateBranch(t *testing.T) {
 
 func testGravelerCreateBranch(t *testing.T, kvEnabled bool) {
 	gravel := newGraveler(t, kvEnabled, nil, nil, &testutil.RefsFake{Err: graveler.ErrBranchNotFound, CommitID: "8888888798e3aeface8e62d1c7072a965314b4"}, nil, nil)
-	_, err := gravel.CreateBranch(context.Background(), "", "", "")
+	_, err := gravel.CreateBranch(context.Background(), repository, "", "")
 	if err != nil {
 		t.Fatal("unexpected error on create branch", err)
 	}
 	// test create branch when branch exists
 	gravel = newGraveler(t, kvEnabled, nil, nil, &testutil.RefsFake{Branch: &graveler.Branch{}}, nil, nil)
-	_, err = gravel.CreateBranch(context.Background(), "", "", "")
+	_, err = gravel.CreateBranch(context.Background(), repository, "", "")
 	if !errors.Is(err, graveler.ErrBranchExists) {
 		t.Fatal("did not get expected error, expected ErrBranchExists")
 	}
@@ -1004,12 +1004,12 @@ func TestGraveler_UpdateBranch(t *testing.T) {
 func testGravelerUpdateBranch(t *testing.T, kvEnabled bool) {
 	gravel := newGraveler(t, kvEnabled, nil, &testutil.StagingFake{ValueIterator: testutil.NewValueIteratorFake([]graveler.ValueRecord{{Key: graveler.Key("foo/one"), Value: &graveler.Value{}}})},
 		&testutil.RefsFake{Branch: &graveler.Branch{}, UpdateErr: kv.ErrPredicateFailed}, nil, nil)
-	_, err := gravel.UpdateBranch(context.Background(), "", "", "")
+	_, err := gravel.UpdateBranch(context.Background(), repository, "", "")
 	require.ErrorIs(t, err, graveler.ErrConflictFound)
 
 	gravel = newGraveler(t, kvEnabled, &testutil.CommittedFake{ValueIterator: testutil.NewValueIteratorFake([]graveler.ValueRecord{})}, &testutil.StagingFake{ValueIterator: testutil.NewValueIteratorFake([]graveler.ValueRecord{})},
 		&testutil.RefsFake{Branch: &graveler.Branch{StagingToken: "st1", CommitID: "commit1"}, Commits: map[graveler.CommitID]*graveler.Commit{"commit1": {}}}, nil, nil)
-	_, err = gravel.UpdateBranch(context.Background(), "", "", "")
+	_, err = gravel.UpdateBranch(context.Background(), repository, "", "")
 	require.NoError(t, err)
 }
 
@@ -1037,7 +1037,6 @@ func testGravelerCommit(t *testing.T, kvEnabled bool) {
 	}
 	type args struct {
 		ctx             context.Context
-		repositoryID    graveler.RepositoryID
 		branchID        graveler.BranchID
 		committer       string
 		message         string
@@ -1062,12 +1061,11 @@ func testGravelerCommit(t *testing.T, kvEnabled bool) {
 					Commits: map[graveler.CommitID]*graveler.Commit{expectedCommitID: {MetaRangeID: expectedRangeID}}},
 			},
 			args: args{
-				ctx:          nil,
-				repositoryID: "repo",
-				branchID:     "branch",
-				committer:    "committer",
-				message:      "a message",
-				metadata:     graveler.Metadata{},
+				ctx:       nil,
+				branchID:  "branch",
+				committer: "committer",
+				message:   "a message",
+				metadata:  graveler.Metadata{},
 			},
 			want:        expectedCommitID,
 			values:      values,
@@ -1085,7 +1083,6 @@ func testGravelerCommit(t *testing.T, kvEnabled bool) {
 			},
 			args: args{
 				ctx:             nil,
-				repositoryID:    "repo",
 				branchID:        "branch",
 				committer:       "committer",
 				message:         "a message",
@@ -1109,7 +1106,6 @@ func testGravelerCommit(t *testing.T, kvEnabled bool) {
 			},
 			args: args{
 				ctx:             nil,
-				repositoryID:    "repo",
 				branchID:        "branch",
 				committer:       "committer",
 				message:         "a message",
@@ -1129,12 +1125,11 @@ func testGravelerCommit(t *testing.T, kvEnabled bool) {
 					Commits: map[graveler.CommitID]*graveler.Commit{expectedCommitID: {MetaRangeID: expectedRangeID}}},
 			},
 			args: args{
-				ctx:          nil,
-				repositoryID: "repo",
-				branchID:     "branch",
-				committer:    "committer",
-				message:      "a message",
-				metadata:     nil,
+				ctx:       nil,
+				branchID:  "branch",
+				committer: "committer",
+				message:   "a message",
+				metadata:  nil,
 			},
 			want:        expectedCommitID,
 			values:      values,
@@ -1150,12 +1145,11 @@ func testGravelerCommit(t *testing.T, kvEnabled bool) {
 					Commits: map[graveler.CommitID]*graveler.Commit{expectedCommitID: {MetaRangeID: expectedRangeID}}},
 			},
 			args: args{
-				ctx:          nil,
-				repositoryID: "repo",
-				branchID:     "branch",
-				committer:    "committer",
-				message:      "a message",
-				metadata:     nil,
+				ctx:       nil,
+				branchID:  "branch",
+				committer: "committer",
+				message:   "a message",
+				metadata:  nil,
 			},
 			want:        expectedCommitID,
 			values:      values,
@@ -1172,12 +1166,11 @@ func testGravelerCommit(t *testing.T, kvEnabled bool) {
 					Commits:   map[graveler.CommitID]*graveler.Commit{expectedCommitID: {MetaRangeID: expectedRangeID}}},
 			},
 			args: args{
-				ctx:          nil,
-				repositoryID: "repo",
-				branchID:     "branch",
-				committer:    "committer",
-				message:      "a message",
-				metadata:     nil,
+				ctx:       nil,
+				branchID:  "branch",
+				committer: "committer",
+				message:   "a message",
+				metadata:  nil,
 			},
 			want:        expectedCommitID,
 			values:      values,
@@ -1193,12 +1186,11 @@ func testGravelerCommit(t *testing.T, kvEnabled bool) {
 					Commits: map[graveler.CommitID]*graveler.Commit{expectedCommitID: {MetaRangeID: expectedRangeID}}},
 			},
 			args: args{
-				ctx:          nil,
-				repositoryID: "repo",
-				branchID:     "branch",
-				committer:    "committer",
-				message:      "a message",
-				metadata:     graveler.Metadata{},
+				ctx:       nil,
+				branchID:  "branch",
+				committer: "committer",
+				message:   "a message",
+				metadata:  graveler.Metadata{},
 			},
 			want:        expectedCommitID,
 			values:      values,
@@ -1215,12 +1207,11 @@ func testGravelerCommit(t *testing.T, kvEnabled bool) {
 				ProtectedBranchesManager: testutil.NewProtectedBranchesManagerFake("branch"),
 			},
 			args: args{
-				ctx:          nil,
-				repositoryID: "repo",
-				branchID:     "branch",
-				committer:    "committer",
-				message:      "a message",
-				metadata:     graveler.Metadata{},
+				ctx:       nil,
+				branchID:  "branch",
+				committer: "committer",
+				message:   "a message",
+				metadata:  graveler.Metadata{},
 			},
 			values:      values,
 			expectedErr: graveler.ErrCommitToProtectedBranch,
@@ -1235,12 +1226,11 @@ func testGravelerCommit(t *testing.T, kvEnabled bool) {
 					Commits: map[graveler.CommitID]*graveler.Commit{expectedCommitID: {MetaRangeID: expectedRangeID}}},
 			},
 			args: args{
-				ctx:          nil,
-				repositoryID: "repo",
-				branchID:     "branch",
-				committer:    "committer",
-				message:      "a message",
-				metadata:     graveler.Metadata{},
+				ctx:       nil,
+				branchID:  "branch",
+				committer: "committer",
+				message:   "a message",
+				metadata:  graveler.Metadata{},
 			},
 			want:        expectedCommitID,
 			values:      graveler.NewCombinedIterator(multipleValues...),
@@ -1256,7 +1246,7 @@ func testGravelerCommit(t *testing.T, kvEnabled bool) {
 			}
 			g := newGraveler(t, kvEnabled, tt.fields.CommittedManager, tt.fields.StagingManager, tt.fields.RefManager, nil, tt.fields.ProtectedBranchesManager)
 
-			got, err := g.Commit(context.Background(), tt.args.repositoryID, tt.args.branchID, graveler.CommitParams{
+			got, err := g.Commit(context.Background(), repository, tt.args.branchID, graveler.CommitParams{
 				Committer:       tt.args.committer,
 				Message:         tt.args.message,
 				Metadata:        tt.args.metadata,
@@ -1341,10 +1331,9 @@ func testGravelerMergeInvalidRef(t *testing.T, kvEnabled bool) {
 
 	// test merge invalid ref
 	ctx := context.Background()
-	const mergeRepositoryID = "repoID"
 	const commitCommitter = "committer"
 	const mergeMessage = "message"
-	_, err := g.Merge(ctx, mergeRepositoryID, mergeDestination, "unexpectedRef", graveler.CommitParams{
+	_, err := g.Merge(ctx, repository, mergeDestination, "unexpectedRef", graveler.CommitParams{
 		Committer: commitCommitter,
 		Message:   mergeMessage,
 		Metadata:  graveler.Metadata{"key1": "val1"},
@@ -1369,7 +1358,6 @@ func testGravelerAddCommitToBranchHead(t *testing.T, kvEnabled bool) {
 		expectedParentCommitID   = graveler.CommitID("expectedParentCommitId")
 		unexpectedParentCommitID = graveler.CommitID("unexpectedParentCommitId")
 		expectedRangeID          = graveler.MetaRangeID("expectedRangeID")
-		expectedRepositoryID     = graveler.RepositoryID("expectedRangeID")
 		expectedBranchID         = graveler.BranchID("expectedBranchID")
 	)
 
@@ -1404,12 +1392,11 @@ func testGravelerAddCommitToBranchHead(t *testing.T, kvEnabled bool) {
 					},
 				}},
 			args: args{
-				ctx:          nil,
-				repositoryID: "repo",
-				branchID:     "branch",
-				committer:    "committer",
-				message:      "a message",
-				metadata:     graveler.Metadata{},
+				ctx:       nil,
+				branchID:  "branch",
+				committer: "committer",
+				message:   "a message",
+				metadata:  graveler.Metadata{},
 			},
 			want:        expectedCommitID,
 			expectedErr: nil,
@@ -1426,12 +1413,11 @@ func testGravelerAddCommitToBranchHead(t *testing.T, kvEnabled bool) {
 					},
 				}},
 			args: args{
-				ctx:          nil,
-				repositoryID: "repo",
-				branchID:     "branch",
-				committer:    "committer",
-				message:      "a message",
-				metadata:     graveler.Metadata{},
+				ctx:       nil,
+				branchID:  "branch",
+				committer: "committer",
+				message:   "a message",
+				metadata:  graveler.Metadata{},
 			},
 			want:        graveler.CommitID(""),
 			expectedErr: graveler.ErrCommitNotHeadBranch,
@@ -1446,12 +1432,11 @@ func testGravelerAddCommitToBranchHead(t *testing.T, kvEnabled bool) {
 					Commits: map[graveler.CommitID]*graveler.Commit{expectedParentCommitID: {MetaRangeID: expectedRangeID}}},
 			},
 			args: args{
-				ctx:          nil,
-				repositoryID: "repo",
-				branchID:     "branch",
-				committer:    "committer",
-				message:      "a message",
-				metadata:     nil,
+				ctx:       nil,
+				branchID:  "branch",
+				committer: "committer",
+				message:   "a message",
+				metadata:  nil,
 			},
 			want:        expectedCommitID,
 			expectedErr: graveler.ErrMetaRangeNotFound,
@@ -1467,12 +1452,11 @@ func testGravelerAddCommitToBranchHead(t *testing.T, kvEnabled bool) {
 					Commits:   map[graveler.CommitID]*graveler.Commit{expectedParentCommitID: {MetaRangeID: expectedRangeID}}},
 			},
 			args: args{
-				ctx:          nil,
-				repositoryID: "repo",
-				branchID:     "branch",
-				committer:    "committer",
-				message:      "a message",
-				metadata:     nil,
+				ctx:       nil,
+				branchID:  "branch",
+				committer: "committer",
+				message:   "a message",
+				metadata:  nil,
 			},
 			want:        expectedCommitID,
 			expectedErr: graveler.ErrConflictFound,
@@ -1482,7 +1466,7 @@ func testGravelerAddCommitToBranchHead(t *testing.T, kvEnabled bool) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			g := newGraveler(t, kvEnabled, tt.fields.CommittedManager, tt.fields.StagingManager, tt.fields.RefManager, nil, testutil.NewProtectedBranchesManagerFake())
-			got, err := g.AddCommitToBranchHead(context.Background(), expectedRepositoryID, expectedBranchID, graveler.Commit{
+			got, err := g.AddCommitToBranchHead(context.Background(), repository, expectedBranchID, graveler.Commit{
 				Committer:   tt.args.committer,
 				Message:     tt.args.message,
 				MetaRangeID: expectedRangeID,
@@ -1530,7 +1514,6 @@ func testGravelerAddCommit(t *testing.T, kvEnabled bool) {
 		expectedCommitID       = graveler.CommitID("expectedCommitId")
 		expectedParentCommitID = graveler.CommitID("expectedParentCommitId")
 		expectedRangeID        = graveler.MetaRangeID("expectedRangeID")
-		expectedRepositoryID   = graveler.RepositoryID("expectedRepoID")
 	)
 
 	type fields struct {
@@ -1564,11 +1547,10 @@ func testGravelerAddCommit(t *testing.T, kvEnabled bool) {
 					},
 				}},
 			args: args{
-				ctx:          nil,
-				repositoryID: "repo",
-				committer:    "committer",
-				message:      "a message",
-				metadata:     graveler.Metadata{},
+				ctx:       nil,
+				committer: "committer",
+				message:   "a message",
+				metadata:  graveler.Metadata{},
 			},
 			want:        expectedCommitID,
 			expectedErr: nil,
@@ -1583,11 +1565,10 @@ func testGravelerAddCommit(t *testing.T, kvEnabled bool) {
 					Commits: map[graveler.CommitID]*graveler.Commit{expectedParentCommitID: {MetaRangeID: expectedRangeID}}},
 			},
 			args: args{
-				ctx:          nil,
-				repositoryID: "repo",
-				committer:    "committer",
-				message:      "a message",
-				metadata:     nil,
+				ctx:       nil,
+				committer: "committer",
+				message:   "a message",
+				metadata:  nil,
 			},
 			want:        expectedCommitID,
 			expectedErr: graveler.ErrMetaRangeNotFound,
@@ -1623,11 +1604,10 @@ func testGravelerAddCommit(t *testing.T, kvEnabled bool) {
 					Commits:   map[graveler.CommitID]*graveler.Commit{expectedParentCommitID: {MetaRangeID: expectedRangeID}}},
 			},
 			args: args{
-				ctx:          nil,
-				repositoryID: "repo",
-				committer:    "committer",
-				message:      "a message",
-				metadata:     nil,
+				ctx:       nil,
+				committer: "committer",
+				message:   "a message",
+				metadata:  nil,
 			},
 			want:        expectedCommitID,
 			expectedErr: graveler.ErrConflictFound,
@@ -1646,7 +1626,7 @@ func testGravelerAddCommit(t *testing.T, kvEnabled bool) {
 			if !tt.args.missingParents {
 				commit.Parents = graveler.CommitParents{expectedParentCommitID}
 			}
-			got, err := g.AddCommit(context.Background(), expectedRepositoryID, commit)
+			got, err := g.AddCommit(context.Background(), repository, commit)
 			if !errors.Is(err, tt.expectedErr) {
 				t.Fatalf("unexpected err got = %v, wanted = %v", err, tt.expectedErr)
 			}
@@ -1832,7 +1812,7 @@ func testGravelerDelete(t *testing.T, kvEnabled bool) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
 			g := newGraveler(t, kvEnabled, tt.fields.CommittedManager, tt.fields.StagingManager, tt.fields.RefManager, nil, testutil.NewProtectedBranchesManagerFake())
-			if err := g.Delete(ctx, tt.args.repositoryID, tt.args.branchID, tt.args.key); !errors.Is(err, tt.expectedErr) {
+			if err := g.Delete(ctx, repository, tt.args.branchID, tt.args.key); !errors.Is(err, tt.expectedErr) {
 				t.Errorf("Delete() returned unexpected error. got = %v, expected %v", err, tt.expectedErr)
 			}
 
@@ -1879,7 +1859,6 @@ func testGravelerPreCommitHook(t *testing.T, kvEnabled bool) {
 	}
 	// tests
 	errSomethingBad := errors.New("something bad")
-	const commitRepositoryID = "repoID"
 	const commitBranchID = "branchID"
 	const commitCommitter = "committer"
 	const commitMessage = "message"
@@ -1915,7 +1894,7 @@ func testGravelerPreCommitHook(t *testing.T, kvEnabled bool) {
 				g.SetHooksHandler(h)
 			}
 			// call commit
-			_, err := g.Commit(ctx, commitRepositoryID, commitBranchID, graveler.CommitParams{
+			_, err := g.Commit(ctx, repository, commitBranchID, graveler.CommitParams{
 				Committer: commitCommitter,
 				Message:   commitMessage,
 				Metadata:  commitMetadata,
@@ -1934,8 +1913,8 @@ func testGravelerPreCommitHook(t *testing.T, kvEnabled bool) {
 			if !h.Called {
 				return
 			}
-			if h.RepositoryID != commitRepositoryID {
-				t.Errorf("Hook repository '%s', expected '%s'", h.RepositoryID, commitRepositoryID)
+			if h.RepositoryID != repository.RepositoryID {
+				t.Errorf("Hook repository '%s', expected '%s'", h.RepositoryID, repository.RepositoryID)
 			}
 			if h.BranchID != commitBranchID {
 				t.Errorf("Hook branch '%s', expected '%s'", h.BranchID, commitBranchID)
@@ -2024,7 +2003,7 @@ func testGravelerPreMergeHook(t *testing.T, kvEnabled bool) {
 				g.SetHooksHandler(h)
 			}
 			// call merge
-			_, err := g.Merge(ctx, mergeRepositoryID, mergeDestination, expectedCommitID.Ref(), graveler.CommitParams{
+			_, err := g.Merge(ctx, repository, mergeDestination, expectedCommitID.Ref(), graveler.CommitParams{
 				Committer: commitCommitter,
 				Message:   mergeMessage,
 				Metadata:  mergeMetadata,
@@ -2084,7 +2063,6 @@ func TestGraveler_CreateTag(t *testing.T) {
 
 func testGravelerCreateTag(t *testing.T, kvEnabled bool) {
 	// prepare graveler
-	const repositoryID = "repoID"
 	const commitID = graveler.CommitID("commitID")
 	const tagID = graveler.TagID("tagID")
 	committedManager := &testutil.CommittedFake{}
@@ -2120,7 +2098,7 @@ func testGravelerCreateTag(t *testing.T, kvEnabled bool) {
 				refManager.Err = tt.err
 			}
 			g := newGraveler(t, kvEnabled, committedManager, stagingManager, refManager, nil, testutil.NewProtectedBranchesManagerFake())
-			err := g.CreateTag(ctx, repositoryID, tagID, commitID)
+			err := g.CreateTag(ctx, repository, tagID, commitID)
 
 			// verify we got an error
 			if !errors.Is(err, tt.err) {
@@ -2188,7 +2166,7 @@ func testGravelerPreCreateTagHook(t *testing.T, kvEnabled bool) {
 				g.SetHooksHandler(h)
 			}
 
-			err := g.CreateTag(ctx, repositoryID, expectedTagID, expectedCommitID)
+			err := g.CreateTag(ctx, repository, expectedTagID, expectedCommitID)
 
 			// verify we got an error
 			if !errors.Is(err, tt.err) {
@@ -2278,7 +2256,7 @@ func testGravelerPreDeleteTagHook(t *testing.T, kvEnabled bool) {
 				g.SetHooksHandler(h)
 			}
 
-			err := g.DeleteTag(ctx, repositoryID, expectedTagID)
+			err := g.DeleteTag(ctx, repository, expectedTagID)
 
 			// verify we got an error
 			if !errors.Is(err, tt.err) {
@@ -2372,7 +2350,7 @@ func testGravelerPreCreateBranchHook(t *testing.T, kvEnabled bool) {
 			refManager.Err = graveler.ErrBranchNotFound
 
 			newBranch := newBranchPrefix + strconv.Itoa(i)
-			_, err := g.CreateBranch(ctx, repositoryID, graveler.BranchID(newBranch), graveler.Ref(sourceBranchID))
+			_, err := g.CreateBranch(ctx, repository, graveler.BranchID(newBranch), graveler.Ref(sourceBranchID))
 
 			// verify we got an error
 			if !errors.Is(err, tt.err) {
@@ -2468,7 +2446,7 @@ func testGravelerPreDeleteBranchHook(t *testing.T, kvEnabled bool) {
 				g.SetHooksHandler(h)
 			}
 
-			err := g.DeleteBranch(ctx, repositoryID, graveler.BranchID(sourceBranchID))
+			err := g.DeleteBranch(ctx, repository, graveler.BranchID(sourceBranchID))
 
 			// verify we got an error
 			if !errors.Is(err, tt.err) {

--- a/pkg/graveler/graveler_test.go
+++ b/pkg/graveler/graveler_test.go
@@ -1968,7 +1968,6 @@ func testGravelerPreMergeHook(t *testing.T, kvEnabled bool) {
 	}
 	// tests
 	errSomethingBad := errors.New("first error")
-	const mergeRepositoryID = "repoID"
 	const commitCommitter = "committer"
 	const mergeMessage = "message"
 	mergeMetadata := graveler.Metadata{"key1": "val1"}
@@ -2033,8 +2032,8 @@ func testGravelerPreMergeHook(t *testing.T, kvEnabled bool) {
 			if !h.Called {
 				return
 			}
-			if h.RepositoryID != mergeRepositoryID {
-				t.Errorf("Hook repository '%s', expected '%s'", h.RepositoryID, mergeRepositoryID)
+			if h.RepositoryID != repository.RepositoryID {
+				t.Errorf("Hook repository '%s', expected '%s'", h.RepositoryID, repository.RepositoryID)
 			}
 			if h.BranchID != mergeDestination {
 				t.Errorf("Hook branch (destination) '%s', expected '%s'", h.BranchID, mergeDestination)
@@ -2119,7 +2118,6 @@ func TestGraveler_PreCreateTagHook(t *testing.T) {
 
 func testGravelerPreCreateTagHook(t *testing.T, kvEnabled bool) {
 	// prepare graveler
-	const repositoryID = "repoID"
 	const expectedRangeID = graveler.MetaRangeID("expectedRangeID")
 	const expectedCommitID = graveler.CommitID("expectedCommitID")
 	const expectedTagID = graveler.TagID("expectedTagID")
@@ -2184,8 +2182,8 @@ func testGravelerPreCreateTagHook(t *testing.T, kvEnabled bool) {
 			if !h.Called {
 				return
 			}
-			if h.RepositoryID != repositoryID {
-				t.Errorf("Hook repository '%s', expected '%s'", h.RepositoryID, repositoryID)
+			if h.RepositoryID != repository.RepositoryID {
+				t.Errorf("Hook repository '%s', expected '%s'", h.RepositoryID, repository.RepositoryID)
 			}
 			if h.CommitID != expectedCommitID {
 				t.Errorf("Hook commit ID '%s', expected '%s'", h.BranchID, expectedCommitID)
@@ -2208,7 +2206,6 @@ func TestGraveler_PreDeleteTagHook(t *testing.T) {
 
 func testGravelerPreDeleteTagHook(t *testing.T, kvEnabled bool) {
 	// prepare graveler
-	const repositoryID = "repoID"
 	const expectedRangeID = graveler.MetaRangeID("expectedRangeID")
 	const expectedCommitID = graveler.CommitID("expectedCommitID")
 	const expectedTagID = graveler.TagID("expectedTagID")
@@ -2274,8 +2271,8 @@ func testGravelerPreDeleteTagHook(t *testing.T, kvEnabled bool) {
 			if !h.Called {
 				return
 			}
-			if h.RepositoryID != repositoryID {
-				t.Errorf("Hook repository '%s', expected '%s'", h.RepositoryID, repositoryID)
+			if h.RepositoryID != repository.RepositoryID {
+				t.Errorf("Hook repository '%s', expected '%s'", h.RepositoryID, repository.RepositoryID)
 			}
 			if h.TagID != expectedTagID {
 				t.Errorf("Hook tag ID '%s', expected '%s'", h.TagID, expectedTagID)
@@ -2294,7 +2291,6 @@ func TestGraveler_PreCreateBranchHook(t *testing.T) {
 }
 
 func testGravelerPreCreateBranchHook(t *testing.T, kvEnabled bool) {
-	const repositoryID = "repoID"
 	const expectedRangeID = graveler.MetaRangeID("expectedRangeID")
 	const sourceCommitID = graveler.CommitID("sourceCommitID")
 	const sourceBranchID = graveler.CommitID("sourceBranchID")
@@ -2368,8 +2364,8 @@ func testGravelerPreCreateBranchHook(t *testing.T, kvEnabled bool) {
 			if !h.Called {
 				return
 			}
-			if h.RepositoryID != repositoryID {
-				t.Errorf("Hook repository '%s', expected '%s'", h.RepositoryID, repositoryID)
+			if h.RepositoryID != repository.RepositoryID {
+				t.Errorf("Hook repository '%s', expected '%s'", h.RepositoryID, repository.RepositoryID)
 			}
 			if h.CommitID != sourceCommitID {
 				t.Errorf("Hook commit ID '%s', expected '%s'", h.BranchID, sourceCommitID)
@@ -2392,7 +2388,6 @@ func TestGraveler_PreDeleteBranchHook(t *testing.T) {
 
 func testGravelerPreDeleteBranchHook(t *testing.T, kvEnabled bool) {
 	// prepare graveler
-	const repositoryID = "repoID"
 	const expectedRangeID = graveler.MetaRangeID("expectedRangeID")
 	const sourceCommitID = graveler.CommitID("sourceCommitID")
 	const sourceBranchID = graveler.CommitID("sourceBranchID")
@@ -2464,8 +2459,8 @@ func testGravelerPreDeleteBranchHook(t *testing.T, kvEnabled bool) {
 			if !h.Called {
 				return
 			}
-			if h.RepositoryID != repositoryID {
-				t.Errorf("Hook repository '%s', expected '%s'", h.RepositoryID, repositoryID)
+			if h.RepositoryID != repository.RepositoryID {
+				t.Errorf("Hook repository '%s', expected '%s'", h.RepositoryID, repository.RepositoryID)
 			}
 			if h.BranchID != graveler.BranchID(sourceBranchID) {
 				t.Errorf("Hook branch ID '%s', expected '%s'", h.BranchID, sourceBranchID)

--- a/pkg/graveler/ref/db_manager.go
+++ b/pkg/graveler/ref/db_manager.go
@@ -61,7 +61,7 @@ func NewPGRefManager(executor batch.Batcher, db db.Database, addressProvider ide
 
 func (m *DBManager) GetRepository(ctx context.Context, repositoryID graveler.RepositoryID) (*graveler.RepositoryRecord, error) {
 	key := fmt.Sprintf("GetRepository:%s", repositoryID)
-	repository, err := m.batchExecutor.BatchFor(key, MaxBatchDelay, batch.BatchFn(func() (interface{}, error) {
+	repository, err := m.batchExecutor.BatchFor(ctx, key, MaxBatchDelay, batch.BatchFn(func() (interface{}, error) {
 		repo := &graveler.Repository{}
 		err := m.db.Get(ctx, repo, `SELECT storage_namespace, creation_date, default_branch FROM graveler_repositories WHERE id = $1`, repositoryID)
 		if err != nil {
@@ -189,7 +189,7 @@ func (m *DBManager) ResolveRawRef(ctx context.Context, repository *graveler.Repo
 
 func (m *DBManager) GetBranch(ctx context.Context, repository *graveler.RepositoryRecord, branchID graveler.BranchID) (*graveler.Branch, error) {
 	key := fmt.Sprintf("GetBranch:%s:%s", repository.RepositoryID, branchID)
-	b, err := m.batchExecutor.BatchFor(key, MaxBatchDelay, batch.BatchFn(func() (interface{}, error) {
+	b, err := m.batchExecutor.BatchFor(ctx, key, MaxBatchDelay, batch.BatchFn(func() (interface{}, error) {
 		var rec branchRecord
 		err := m.db.Get(ctx, &rec, `SELECT commit_id, staging_token FROM graveler_branches WHERE repository_id = $1 AND id = $2`,
 			repository.RepositoryID, branchID)
@@ -271,7 +271,7 @@ func (m *DBManager) GCBranchIterator(ctx context.Context, repository *graveler.R
 
 func (m *DBManager) GetTag(ctx context.Context, repository *graveler.RepositoryRecord, tagID graveler.TagID) (*graveler.CommitID, error) {
 	key := fmt.Sprintf("GetTag:%s:%s", repository.RepositoryID, tagID)
-	commitID, err := m.batchExecutor.BatchFor(key, MaxBatchDelay, batch.BatchFn(func() (interface{}, error) {
+	commitID, err := m.batchExecutor.BatchFor(ctx, key, MaxBatchDelay, batch.BatchFn(func() (interface{}, error) {
 		var commitID graveler.CommitID
 		err := m.db.Get(ctx, &commitID, `SELECT commit_id FROM graveler_tags WHERE repository_id = $1 AND id = $2`,
 			repository.RepositoryID, tagID)
@@ -330,7 +330,7 @@ func (m *DBManager) ListTags(ctx context.Context, repository *graveler.Repositor
 
 func (m *DBManager) GetCommitByPrefix(ctx context.Context, repository *graveler.RepositoryRecord, prefix graveler.CommitID) (*graveler.Commit, error) {
 	key := fmt.Sprintf("GetCommitByPrefix:%s:%s", repository.RepositoryID, prefix)
-	commit, err := m.batchExecutor.BatchFor(key, MaxBatchDelay, batch.BatchFn(func() (interface{}, error) {
+	commit, err := m.batchExecutor.BatchFor(ctx, key, MaxBatchDelay, batch.BatchFn(func() (interface{}, error) {
 		return m.db.Transact(ctx, func(tx db.Tx) (interface{}, error) {
 			records := make([]*commitRecord, 0)
 			// LIMIT 2 is used to test if a truncated commit ID resolves to *one* commit.
@@ -367,7 +367,7 @@ func (m *DBManager) GetCommitByPrefix(ctx context.Context, repository *graveler.
 
 func (m *DBManager) GetCommit(ctx context.Context, repository *graveler.RepositoryRecord, commitID graveler.CommitID) (*graveler.Commit, error) {
 	key := fmt.Sprintf("GetCommit:%s:%s", repository.RepositoryID, commitID)
-	commit, err := m.batchExecutor.BatchFor(key, MaxBatchDelay, batch.BatchFn(func() (interface{}, error) {
+	commit, err := m.batchExecutor.BatchFor(ctx, key, MaxBatchDelay, batch.BatchFn(func() (interface{}, error) {
 		var rec commitRecord
 		err := m.db.Get(ctx, &rec, `SELECT committer, message, creation_date, parents, meta_range_id, metadata, version, generation
 					FROM graveler_commits WHERE repository_id = $1 AND id = $2`,

--- a/pkg/graveler/ref/kv_migrate_test.go
+++ b/pkg/graveler/ref/kv_migrate_test.go
@@ -71,9 +71,9 @@ func TestMigrate(t *testing.T) {
 	verifyMigrationResults(t, ctx, kvMgr, dbMgr, stagingMgr, settingsMgr)
 }
 
-func createTagInitialCommit(t *testing.T, ctx context.Context, mgr graveler.RefManager, repoID graveler.RepositoryID) {
+func createTagInitialCommit(t *testing.T, ctx context.Context, mgr graveler.RefManager, repository *graveler.RepositoryRecord) {
 	res := make([]graveler.CommitRecord, 0)
-	commits, err := mgr.ListCommits(ctx, repoID)
+	commits, err := mgr.ListCommits(ctx, repository)
 	require.NoError(t, err)
 	defer commits.Close()
 	for commits.Next() {
@@ -81,7 +81,7 @@ func createTagInitialCommit(t *testing.T, ctx context.Context, mgr graveler.RefM
 	}
 	require.Equal(t, len(res), 1)
 
-	if err := mgr.CreateTag(ctx, repoID, graveler.TagID("tag_"+string(res[0].CommitID)), res[0].CommitID); err != nil {
+	if err := mgr.CreateTag(ctx, repository, graveler.TagID("tag_"+string(res[0].CommitID)), res[0].CommitID); err != nil {
 		t.Fatalf("Create Tag: %s", err)
 	}
 }
@@ -91,7 +91,8 @@ func createMigrateTestData(t *testing.T, ctx context.Context, mgr graveler.RefMa
 	for i := 0; i < NumRepositories; i++ {
 		repoID := graveler.RepositoryID("repo_" + strconv.Itoa(i))
 		repo := graveler.Repository{StorageNamespace: graveler.StorageNamespace(strconv.Itoa(i)), CreationDate: time.Now(), DefaultBranchID: "main"}
-		if err := mgr.CreateRepository(ctx, repoID, repo); err != nil {
+		repository, err := mgr.CreateRepository(ctx, repoID, repo)
+		if err != nil {
 			t.Fatalf("Create Repository: %s", err)
 		}
 		// Add repo settings for every second repo
@@ -111,12 +112,12 @@ func createMigrateTestData(t *testing.T, ctx context.Context, mgr graveler.RefMa
 			testutil.Must(t, blockstore.Put(ctx, objectPointer, int64(len(data)), bytes.NewReader(data), block.PutOpts{}))
 		}
 
-		createTagInitialCommit(t, ctx, mgr, repoID)
+		createTagInitialCommit(t, ctx, mgr, repository)
 
 		for b := 0; b < numBranches; b++ {
 			name := "branch_" + strconv.Itoa(b)
 			stagingToken := graveler.StagingToken(name + "_test_token_" + strconv.Itoa(b))
-			if err := mgr.CreateBranch(ctx, repoID, graveler.BranchID(name),
+			if err := mgr.CreateBranch(ctx, repository, graveler.BranchID(name),
 				graveler.Branch{CommitID: graveler.CommitID(strconv.Itoa(b)),
 					StagingToken: stagingToken,
 					SealedTokens: []graveler.StagingToken{"token"},
@@ -127,7 +128,7 @@ func createMigrateTestData(t *testing.T, ctx context.Context, mgr graveler.RefMa
 		}
 
 		for c := 0; c < numCommits; c++ {
-			commitID, err := mgr.AddCommit(ctx, repoID,
+			commitID, err := mgr.AddCommit(ctx, repository,
 				graveler.Commit{Version: graveler.CurrentCommitVersion,
 					Committer:    "tester",
 					Message:      strconv.Itoa(c),
@@ -141,7 +142,7 @@ func createMigrateTestData(t *testing.T, ctx context.Context, mgr graveler.RefMa
 				t.Fatalf("Create Commit: %s", err)
 			}
 
-			if err := mgr.CreateTag(ctx, graveler.RepositoryID("repo_"+strconv.Itoa(i)), graveler.TagID("tag_"+commitID), commitID); err != nil {
+			if err := mgr.CreateTag(ctx, repository, graveler.TagID("tag_"+commitID), commitID); err != nil {
 				t.Fatalf("Create Tag: %s", err)
 			}
 		}
@@ -169,29 +170,29 @@ func createStagingData(t *testing.T, ctx context.Context, dbPool db.Database, br
 	testutil.MustDo(t, "Create staging data", err)
 }
 
-func verifyCommitTagResults(t *testing.T, ctx context.Context, kvMgr, dbMgr graveler.RefManager, repoID graveler.RepositoryID) {
-	commits, err := kvMgr.ListCommits(ctx, repoID)
+func verifyCommitTagResults(t *testing.T, ctx context.Context, kvMgr, dbMgr graveler.RefManager, repository *graveler.RepositoryRecord) {
+	commits, err := kvMgr.ListCommits(ctx, repository)
 	require.NoError(t, err)
 	defer commits.Close()
 	commitNum := 0
 	for commits.Next() {
 		commit := commits.Value()
-		kvc, err := kvMgr.GetCommit(ctx, repoID, commit.CommitID)
+		kvc, err := kvMgr.GetCommit(ctx, repository, commit.CommitID)
 		require.NoError(t, err)
-		dbm, err := dbMgr.GetCommit(ctx, repoID, commit.CommitID)
+		dbm, err := dbMgr.GetCommit(ctx, repository, commit.CommitID)
 		require.NoError(t, err)
 		dbm.CreationDate = dbm.CreationDate.UTC()
 		require.Equal(t, kvc, dbm)
 		commitNum += 1
 
 		// verify tag
-		tag, err := kvMgr.GetTag(ctx, repoID, graveler.TagID("tag_"+commit.CommitID))
+		tag, err := kvMgr.GetTag(ctx, repository, graveler.TagID("tag_"+commit.CommitID))
 		require.NoError(t, err)
 		require.Equal(t, *tag, commit.CommitID)
 	}
 	require.Equal(t, commitNum, numCommits+1)
 
-	tags, err := kvMgr.ListTags(ctx, repoID)
+	tags, err := kvMgr.ListTags(ctx, repository)
 	require.NoError(t, err)
 	defer tags.Close()
 	numTags := 0
@@ -201,16 +202,16 @@ func verifyCommitTagResults(t *testing.T, ctx context.Context, kvMgr, dbMgr grav
 	require.Equal(t, commitNum, numTags)
 }
 
-func verifyBranchResults(t *testing.T, ctx context.Context, kvMgr, dbMgr graveler.RefManager, stagingMgr graveler.StagingManager, repoID graveler.RepositoryID) {
-	branches, err := kvMgr.ListBranches(ctx, repoID)
+func verifyBranchResults(t *testing.T, ctx context.Context, kvMgr, dbMgr graveler.RefManager, stagingMgr graveler.StagingManager, repository *graveler.RepositoryRecord) {
+	branches, err := kvMgr.ListBranches(ctx, repository)
 	require.NoError(t, err)
 	defer branches.Close()
 	branchesNum := 0
 	for branches.Next() {
 		b := branches.Value()
-		bkv, err := kvMgr.GetBranch(ctx, repoID, b.BranchID)
+		bkv, err := kvMgr.GetBranch(ctx, repository, b.BranchID)
 		require.NoError(t, err)
-		bdb, err := dbMgr.GetBranch(ctx, repoID, b.BranchID)
+		bdb, err := dbMgr.GetBranch(ctx, repository, b.BranchID)
 		require.NoError(t, err)
 		require.Equal(t, bkv, bdb)
 		branchesNum += 1
@@ -276,7 +277,7 @@ func verifyMigrationResults(t *testing.T, ctx context.Context, kvMgr, dbMgr grav
 
 		// verify settings
 		testSettings := settings.ExampleSettings{}
-		data, err := settingsMgr.Get(ctx, repo.RepositoryID, branch.ProtectionSettingKey, &testSettings)
+		data, err := settingsMgr.Get(ctx, kvr, branch.ProtectionSettingKey, &testSettings)
 		if repoNum%2 == 0 {
 			require.Equal(t, data.(*settings.ExampleSettings).ExampleStr, repo.RepositoryID.String())
 			require.Equal(t, data.(*settings.ExampleSettings).ExampleInt, int32(repoNum))
@@ -285,8 +286,8 @@ func verifyMigrationResults(t *testing.T, ctx context.Context, kvMgr, dbMgr grav
 		}
 
 		// verify repository entities
-		verifyCommitTagResults(t, ctx, kvMgr, dbMgr, repo.RepositoryID)
-		verifyBranchResults(t, ctx, kvMgr, dbMgr, stagingMgr, repo.RepositoryID)
+		verifyCommitTagResults(t, ctx, kvMgr, dbMgr, kvr)
+		verifyBranchResults(t, ctx, kvMgr, dbMgr, stagingMgr, kvr)
 		repoNum += 1
 	}
 	require.Equal(t, repoNum, NumRepositories)

--- a/pkg/graveler/ref/manager.go
+++ b/pkg/graveler/ref/manager.go
@@ -73,7 +73,7 @@ func NewKVRefManager(executor batch.Batcher, kvStore kv.StoreMessage, addressPro
 	}
 }
 
-func (m *KVManager) getRepository(ctx context.Context, repositoryID graveler.RepositoryID) (*graveler.Repository, error) {
+func (m *KVManager) getRepository(ctx context.Context, repositoryID graveler.RepositoryID) (*graveler.RepositoryRecord, error) {
 	key := fmt.Sprintf("GetRepository:%s", repositoryID)
 	repository, err := m.batchExecutor.BatchFor(key, MaxBatchDelay, batch.BatchFn(func() (interface{}, error) {
 		data := graveler.RepositoryData{}
@@ -81,7 +81,7 @@ func (m *KVManager) getRepository(ctx context.Context, repositoryID graveler.Rep
 		if err != nil {
 			return nil, err
 		}
-		return graveler.RepoFromProto(&data).Repository, nil
+		return graveler.RepoFromProto(&data), nil
 	}))
 	if errors.Is(err, kv.ErrNotFound) {
 		err = graveler.ErrRepositoryNotFound
@@ -89,22 +89,10 @@ func (m *KVManager) getRepository(ctx context.Context, repositoryID graveler.Rep
 	if err != nil {
 		return nil, err
 	}
-	return repository.(*graveler.Repository), nil
+	return repository.(*graveler.RepositoryRecord), nil
 }
 
-// getRepositoryRec returns RepositoryRecord
-func (m *KVManager) getRepositoryRec(ctx context.Context, repositoryID graveler.RepositoryID) (*graveler.RepositoryRecord, error) {
-	repo, err := m.getRepository(ctx, repositoryID)
-	if err != nil {
-		return nil, err
-	}
-	return &graveler.RepositoryRecord{
-		RepositoryID: repositoryID,
-		Repository:   repo,
-	}, nil
-}
-
-func (m *KVManager) GetRepository(ctx context.Context, repositoryID graveler.RepositoryID) (*graveler.Repository, error) {
+func (m *KVManager) GetRepository(ctx context.Context, repositoryID graveler.RepositoryID) (*graveler.RepositoryRecord, error) {
 	repo, err := m.getRepository(ctx, repositoryID)
 	if err != nil {
 		return nil, err
@@ -142,7 +130,10 @@ func (m *KVManager) CreateRepository(ctx context.Context, repositoryID graveler.
 	firstCommit.Message = graveler.FirstCommitMsg
 	firstCommit.Generation = 1
 
-	repo := &graveler.RepositoryRecord{RepositoryID: repositoryID, Repository: &repository}
+	repo := &graveler.RepositoryRecord{
+		RepositoryID: repositoryID,
+		Repository:   &repository,
+	}
 	// If branch creation fails - this commit will become dangling. This is a known issue that can be resolved via garbage collection
 	commitID, err := m.addCommit(ctx, graveler.RepoPartition(repo), firstCommit)
 	if err != nil {
@@ -175,8 +166,8 @@ func (m *KVManager) updateRepoState(ctx context.Context, repo *graveler.Reposito
 	return m.kvStore.SetMsg(ctx, graveler.RepositoriesPartition(), []byte(graveler.RepoPath(repo.RepositoryID)), graveler.ProtoFromRepo(repo))
 }
 
-func (m *KVManager) deleteRepositoryBranches(ctx context.Context, repositoryID graveler.RepositoryID) error {
-	itr, err := m.ListBranches(ctx, repositoryID)
+func (m *KVManager) deleteRepositoryBranches(ctx context.Context, repository *graveler.RepositoryRecord) error {
+	itr, err := m.ListBranches(ctx, repository)
 	if err != nil {
 		return err
 	}
@@ -185,14 +176,14 @@ func (m *KVManager) deleteRepositoryBranches(ctx context.Context, repositoryID g
 	for itr.Next() {
 		b := itr.Value()
 		wg.Go(func() error {
-			return m.DeleteBranch(ctx, repositoryID, b.BranchID)
+			return m.DeleteBranch(ctx, repository, b.BranchID)
 		})
 	}
 	return wg.Wait().ErrorOrNil()
 }
 
-func (m *KVManager) deleteRepositoryTags(ctx context.Context, repositoryID graveler.RepositoryID) error {
-	itr, err := m.ListTags(ctx, repositoryID)
+func (m *KVManager) deleteRepositoryTags(ctx context.Context, repository *graveler.RepositoryRecord) error {
+	itr, err := m.ListTags(ctx, repository)
 	if err != nil {
 		return err
 	}
@@ -201,14 +192,14 @@ func (m *KVManager) deleteRepositoryTags(ctx context.Context, repositoryID grave
 	for itr.Next() {
 		tag := itr.Value()
 		wg.Go(func() error {
-			return m.DeleteTag(ctx, repositoryID, tag.TagID)
+			return m.DeleteTag(ctx, repository, tag.TagID)
 		})
 	}
 	return wg.Wait().ErrorOrNil()
 }
 
-func (m *KVManager) deleteRepositoryCommits(ctx context.Context, repositoryID graveler.RepositoryID) error {
-	itr, err := m.ListCommits(ctx, repositoryID)
+func (m *KVManager) deleteRepositoryCommits(ctx context.Context, repository *graveler.RepositoryRecord) error {
+	itr, err := m.ListCommits(ctx, repository)
 	if err != nil {
 		return err
 	}
@@ -217,7 +208,7 @@ func (m *KVManager) deleteRepositoryCommits(ctx context.Context, repositoryID gr
 	for itr.Next() {
 		commit := itr.Value()
 		wg.Go(func() error {
-			return m.RemoveCommit(ctx, repositoryID, commit.CommitID)
+			return m.RemoveCommit(ctx, repository, commit.CommitID)
 		})
 	}
 	return wg.Wait().ErrorOrNil()
@@ -227,13 +218,13 @@ func (m *KVManager) deleteRepository(ctx context.Context, repo *graveler.Reposit
 	// ctx := context.Background() TODO (niro): When running this async create a new context and remove ctx from signature
 	var wg multierror.Group
 	wg.Go(func() error {
-		return m.deleteRepositoryBranches(ctx, repo.RepositoryID)
+		return m.deleteRepositoryBranches(ctx, repo)
 	})
 	wg.Go(func() error {
-		return m.deleteRepositoryTags(ctx, repo.RepositoryID)
+		return m.deleteRepositoryTags(ctx, repo)
 	})
 	wg.Go(func() error {
-		return m.deleteRepositoryCommits(ctx, repo.RepositoryID)
+		return m.deleteRepositoryCommits(ctx, repo)
 	})
 
 	if err := wg.Wait().ErrorOrNil(); err != nil {
@@ -245,7 +236,7 @@ func (m *KVManager) deleteRepository(ctx context.Context, repo *graveler.Reposit
 }
 
 func (m *KVManager) DeleteRepository(ctx context.Context, repositoryID graveler.RepositoryID) error {
-	repo, err := m.getRepositoryRec(ctx, repositoryID)
+	repo, err := m.GetRepository(ctx, repositoryID)
 	if err != nil {
 		return err
 	}
@@ -258,7 +249,7 @@ func (m *KVManager) DeleteRepository(ctx context.Context, repositoryID graveler.
 		}
 	}
 
-	// TODO (niro): This should be a background delete process
+	// TODO(niro): This should be a background delete process
 	return m.deleteRepository(ctx, repo)
 }
 
@@ -266,12 +257,12 @@ func (m *KVManager) ParseRef(ref graveler.Ref) (graveler.RawRef, error) {
 	return ParseRef(ref)
 }
 
-func (m *KVManager) ResolveRawRef(ctx context.Context, repositoryID graveler.RepositoryID, raw graveler.RawRef) (*graveler.ResolvedRef, error) {
-	return ResolveRawRef(ctx, m, m.addressProvider, repositoryID, raw)
+func (m *KVManager) ResolveRawRef(ctx context.Context, repository *graveler.RepositoryRecord, raw graveler.RawRef) (*graveler.ResolvedRef, error) {
+	return ResolveRawRef(ctx, m, m.addressProvider, repository, raw)
 }
 
-func (m *KVManager) getBranchWithPredicate(ctx context.Context, repo *graveler.RepositoryRecord, branchID graveler.BranchID) (*graveler.Branch, kv.Predicate, error) {
-	key := fmt.Sprintf("GetBranch:%s:%s", repo.RepositoryID, branchID)
+func (m *KVManager) getBranchWithPredicate(ctx context.Context, repository *graveler.RepositoryRecord, branchID graveler.BranchID) (*graveler.Branch, kv.Predicate, error) {
+	key := fmt.Sprintf("GetBranch:%s:%s", repository.RepositoryID, branchID)
 	type branchPred struct {
 		*graveler.Branch
 		kv.Predicate
@@ -279,11 +270,11 @@ func (m *KVManager) getBranchWithPredicate(ctx context.Context, repo *graveler.R
 	result, err := m.batchExecutor.BatchFor(key, MaxBatchDelay, batch.BatchFn(func() (interface{}, error) {
 		key := graveler.BranchPath(branchID)
 		data := graveler.BranchData{}
-		pred, err := m.kvStore.GetMsg(ctx, graveler.RepoPartition(repo), []byte(key), &data)
+		pred, err := m.kvStore.GetMsg(ctx, graveler.RepoPartition(repository), []byte(key), &data)
 		if err != nil {
 			return nil, err
 		}
-		return &branchPred{branchFromProto(&data), pred}, nil
+		return &branchPred{Branch: branchFromProto(&data), Predicate: pred}, nil
 	}))
 	if errors.Is(err, kv.ErrNotFound) {
 		err = graveler.ErrBranchNotFound
@@ -295,12 +286,8 @@ func (m *KVManager) getBranchWithPredicate(ctx context.Context, repo *graveler.R
 	return branchWithPred.Branch, branchWithPred.Predicate, nil
 }
 
-func (m *KVManager) GetBranch(ctx context.Context, repositoryID graveler.RepositoryID, branchID graveler.BranchID) (*graveler.Branch, error) {
-	repo, err := m.getRepositoryRec(ctx, repositoryID)
-	if err != nil {
-		return nil, err
-	}
-	branch, _, err := m.getBranchWithPredicate(ctx, repo, branchID)
+func (m *KVManager) GetBranch(ctx context.Context, repository *graveler.RepositoryRecord, branchID graveler.BranchID) (*graveler.Branch, error) {
+	branch, _, err := m.getBranchWithPredicate(ctx, repository, branchID)
 	return branch, err
 }
 
@@ -312,29 +299,16 @@ func (m *KVManager) createBranch(ctx context.Context, repositoryPartition string
 	return err
 }
 
-func (m *KVManager) CreateBranch(ctx context.Context, repositoryID graveler.RepositoryID, branchID graveler.BranchID, branch graveler.Branch) error {
-	repo, err := m.getRepositoryRec(ctx, repositoryID)
-	if err != nil {
-		return err
-	}
-
-	return m.createBranch(ctx, graveler.RepoPartition(repo), branchID, branch)
+func (m *KVManager) CreateBranch(ctx context.Context, repository *graveler.RepositoryRecord, branchID graveler.BranchID, branch graveler.Branch) error {
+	return m.createBranch(ctx, graveler.RepoPartition(repository), branchID, branch)
 }
 
-func (m *KVManager) SetBranch(ctx context.Context, repositoryID graveler.RepositoryID, branchID graveler.BranchID, branch graveler.Branch) error {
-	repo, err := m.getRepositoryRec(ctx, repositoryID)
-	if err != nil {
-		return err
-	}
-	return m.kvStore.SetMsg(ctx, graveler.RepoPartition(repo), []byte(graveler.BranchPath(branchID)), protoFromBranch(branchID, &branch))
+func (m *KVManager) SetBranch(ctx context.Context, repository *graveler.RepositoryRecord, branchID graveler.BranchID, branch graveler.Branch) error {
+	return m.kvStore.SetMsg(ctx, graveler.RepoPartition(repository), []byte(graveler.BranchPath(branchID)), protoFromBranch(branchID, &branch))
 }
 
-func (m *KVManager) BranchUpdate(ctx context.Context, repositoryID graveler.RepositoryID, branchID graveler.BranchID, f graveler.BranchUpdateFunc) error {
-	repo, err := m.getRepositoryRec(ctx, repositoryID)
-	if err != nil {
-		return err
-	}
-	b, pred, err := m.getBranchWithPredicate(ctx, repo, branchID)
+func (m *KVManager) BranchUpdate(ctx context.Context, repository *graveler.RepositoryRecord, branchID graveler.BranchID, f graveler.BranchUpdateFunc) error {
+	b, pred, err := m.getBranchWithPredicate(ctx, repository, branchID)
 	if err != nil {
 		return err
 	}
@@ -343,47 +317,31 @@ func (m *KVManager) BranchUpdate(ctx context.Context, repositoryID graveler.Repo
 	if err != nil || newBranch == nil {
 		return err
 	}
-	return m.kvStore.SetMsgIf(ctx, graveler.RepoPartition(repo), []byte(graveler.BranchPath(branchID)), protoFromBranch(branchID, newBranch), pred)
+	return m.kvStore.SetMsgIf(ctx, graveler.RepoPartition(repository), []byte(graveler.BranchPath(branchID)), protoFromBranch(branchID, newBranch), pred)
 }
 
-func (m *KVManager) DeleteBranch(ctx context.Context, repositoryID graveler.RepositoryID, branchID graveler.BranchID) error {
-	repo, err := m.getRepositoryRec(ctx, repositoryID)
+func (m *KVManager) DeleteBranch(ctx context.Context, repository *graveler.RepositoryRecord, branchID graveler.BranchID) error {
+	_, err := m.GetBranch(ctx, repository, branchID)
 	if err != nil {
 		return err
 	}
-	_, err = m.GetBranch(ctx, repositoryID, branchID)
-	if err != nil {
-		return err
-	}
-	return m.kvStore.DeleteMsg(ctx, graveler.RepoPartition(repo), []byte(graveler.BranchPath(branchID)))
+	return m.kvStore.DeleteMsg(ctx, graveler.RepoPartition(repository), []byte(graveler.BranchPath(branchID)))
 }
 
-func (m *KVManager) ListBranches(ctx context.Context, repositoryID graveler.RepositoryID) (graveler.BranchIterator, error) {
-	repo, err := m.getRepositoryRec(ctx, repositoryID)
-	if err != nil {
-		return nil, err
-	}
-	return NewBranchSimpleIterator(ctx, &m.kvStore, repo)
+func (m *KVManager) ListBranches(ctx context.Context, repository *graveler.RepositoryRecord) (graveler.BranchIterator, error) {
+	return NewBranchSimpleIterator(ctx, &m.kvStore, repository)
 }
 
-func (m *KVManager) GCBranchIterator(ctx context.Context, repositoryID graveler.RepositoryID) (graveler.BranchIterator, error) {
-	repo, err := m.getRepositoryRec(ctx, repositoryID)
-	if err != nil {
-		return nil, err
-	}
-	return NewBranchByCommitIterator(ctx, &m.kvStore, repo)
+func (m *KVManager) GCBranchIterator(ctx context.Context, repository *graveler.RepositoryRecord) (graveler.BranchIterator, error) {
+	return NewBranchByCommitIterator(ctx, &m.kvStore, repository)
 }
 
-func (m *KVManager) GetTag(ctx context.Context, repositoryID graveler.RepositoryID, tagID graveler.TagID) (*graveler.CommitID, error) {
-	key := fmt.Sprintf("GetTag:%s:%s", repositoryID, tagID)
+func (m *KVManager) GetTag(ctx context.Context, repository *graveler.RepositoryRecord, tagID graveler.TagID) (*graveler.CommitID, error) {
+	key := fmt.Sprintf("GetTag:%s:%s", repository.RepositoryID, tagID)
 	commitID, err := m.batchExecutor.BatchFor(key, MaxBatchDelay, batch.BatchFn(func() (interface{}, error) {
-		repo, err := m.getRepositoryRec(ctx, repositoryID)
-		if err != nil {
-			return nil, err
-		}
 		tagKey := graveler.TagPath(tagID)
 		t := graveler.TagData{}
-		_, err = m.kvStore.GetMsg(ctx, graveler.RepoPartition(repo), []byte(tagKey), &t)
+		_, err := m.kvStore.GetMsg(ctx, graveler.RepoPartition(repository), []byte(tagKey), &t)
 		if err != nil {
 			return nil, err
 		}
@@ -399,17 +357,13 @@ func (m *KVManager) GetTag(ctx context.Context, repositoryID graveler.Repository
 	return commitID.(*graveler.CommitID), nil
 }
 
-func (m *KVManager) CreateTag(ctx context.Context, repositoryID graveler.RepositoryID, tagID graveler.TagID, commitID graveler.CommitID) error {
-	repo, err := m.getRepositoryRec(ctx, repositoryID)
-	if err != nil {
-		return err
-	}
+func (m *KVManager) CreateTag(ctx context.Context, repository *graveler.RepositoryRecord, tagID graveler.TagID, commitID graveler.CommitID) error {
 	t := &graveler.TagData{
 		Id:       tagID.String(),
 		CommitId: commitID.String(),
 	}
 	tagKey := graveler.TagPath(tagID)
-	err = m.kvStore.SetMsgIf(ctx, graveler.RepoPartition(repo), []byte(tagKey), t, nil)
+	err := m.kvStore.SetMsgIf(ctx, graveler.RepoPartition(repository), []byte(tagKey), t, nil)
 	if err != nil {
 		if errors.Is(err, kv.ErrPredicateFailed) {
 			err = graveler.ErrTagAlreadyExists
@@ -419,32 +373,20 @@ func (m *KVManager) CreateTag(ctx context.Context, repositoryID graveler.Reposit
 	return nil
 }
 
-func (m *KVManager) DeleteTag(ctx context.Context, repositoryID graveler.RepositoryID, tagID graveler.TagID) error {
-	repo, err := m.getRepositoryRec(ctx, repositoryID)
-	if err != nil {
-		return err
-	}
+func (m *KVManager) DeleteTag(ctx context.Context, repository *graveler.RepositoryRecord, tagID graveler.TagID) error {
 	tagKey := graveler.TagPath(tagID)
 	// TODO (issue 3640) align with delete tag DB - return ErrNotFound when tag does not exist
-	return m.kvStore.DeleteMsg(ctx, graveler.RepoPartition(repo), []byte(tagKey))
+	return m.kvStore.DeleteMsg(ctx, graveler.RepoPartition(repository), []byte(tagKey))
 }
 
-func (m *KVManager) ListTags(ctx context.Context, repositoryID graveler.RepositoryID) (graveler.TagIterator, error) {
-	repo, err := m.getRepositoryRec(ctx, repositoryID)
-	if err != nil {
-		return nil, err
-	}
-	return NewKVTagIterator(ctx, &m.kvStore, repo)
+func (m *KVManager) ListTags(ctx context.Context, repository *graveler.RepositoryRecord) (graveler.TagIterator, error) {
+	return NewKVTagIterator(ctx, &m.kvStore, repository)
 }
 
-func (m *KVManager) GetCommitByPrefix(ctx context.Context, repositoryID graveler.RepositoryID, prefix graveler.CommitID) (*graveler.Commit, error) {
-	key := fmt.Sprintf("GetCommitByPrefix:%s:%s", repositoryID, prefix)
+func (m *KVManager) GetCommitByPrefix(ctx context.Context, repository *graveler.RepositoryRecord, prefix graveler.CommitID) (*graveler.Commit, error) {
+	key := fmt.Sprintf("GetCommitByPrefix:%s:%s", repository.RepositoryID, prefix)
 	commit, err := m.batchExecutor.BatchFor(key, MaxBatchDelay, batch.BatchFn(func() (interface{}, error) {
-		repo, err := m.getRepositoryRec(ctx, repositoryID)
-		if err != nil {
-			return nil, err
-		}
-		it, err := NewKVOrderedCommitIterator(ctx, &m.kvStore, repo, false)
+		it, err := NewKVOrderedCommitIterator(ctx, &m.kvStore, repository, false)
 		if err != nil {
 			return nil, err
 		}
@@ -473,16 +415,12 @@ func (m *KVManager) GetCommitByPrefix(ctx context.Context, repositoryID graveler
 	return commit.(*graveler.Commit), nil
 }
 
-func (m *KVManager) GetCommit(ctx context.Context, repositoryID graveler.RepositoryID, commitID graveler.CommitID) (*graveler.Commit, error) {
-	key := fmt.Sprintf("GetCommit:%s:%s", repositoryID, commitID)
+func (m *KVManager) GetCommit(ctx context.Context, repository *graveler.RepositoryRecord, commitID graveler.CommitID) (*graveler.Commit, error) {
+	key := fmt.Sprintf("GetCommit:%s:%s", repository.RepositoryID, commitID)
 	commit, err := m.batchExecutor.BatchFor(key, MaxBatchDelay, batch.BatchFn(func() (interface{}, error) {
-		repo, err := m.getRepositoryRec(ctx, repositoryID)
-		if err != nil {
-			return nil, err
-		}
 		commitKey := graveler.CommitPath(commitID)
 		c := graveler.CommitData{}
-		_, err = m.kvStore.GetMsg(ctx, graveler.RepoPartition(repo), []byte(commitKey), &c)
+		_, err := m.kvStore.GetMsg(ctx, graveler.RepoPartition(repository), []byte(commitKey), &c)
 		if err != nil {
 			return nil, err
 		}
@@ -510,53 +448,31 @@ func (m *KVManager) addCommit(ctx context.Context, repoPartition string, commit 
 	return graveler.CommitID(commitID), nil
 }
 
-func (m *KVManager) AddCommit(ctx context.Context, repositoryID graveler.RepositoryID, commit graveler.Commit) (graveler.CommitID, error) {
-	repo, err := m.getRepositoryRec(ctx, repositoryID)
-	if err != nil {
-		return "", err
-	}
-
-	return m.addCommit(ctx, graveler.RepoPartition(repo), commit)
+func (m *KVManager) AddCommit(ctx context.Context, repository *graveler.RepositoryRecord, commit graveler.Commit) (graveler.CommitID, error) {
+	return m.addCommit(ctx, graveler.RepoPartition(repository), commit)
 }
 
-func (m *KVManager) RemoveCommit(ctx context.Context, repositoryID graveler.RepositoryID, commitID graveler.CommitID) error {
-	repo, err := m.getRepositoryRec(ctx, repositoryID)
-	if err != nil {
-		return err
-	}
-
+func (m *KVManager) RemoveCommit(ctx context.Context, repository *graveler.RepositoryRecord, commitID graveler.CommitID) error {
 	commitKey := graveler.CommitPath(commitID)
-	return m.kvStore.DeleteMsg(ctx, graveler.RepoPartition(repo), []byte(commitKey))
+	return m.kvStore.DeleteMsg(ctx, graveler.RepoPartition(repository), []byte(commitKey))
 }
 
-func (m *KVManager) FindMergeBase(ctx context.Context, repositoryID graveler.RepositoryID, commitIDs ...graveler.CommitID) (*graveler.Commit, error) {
+func (m *KVManager) FindMergeBase(ctx context.Context, repository *graveler.RepositoryRecord, commitIDs ...graveler.CommitID) (*graveler.Commit, error) {
 	const allowedCommitsToCompare = 2
 	if len(commitIDs) != allowedCommitsToCompare {
 		return nil, graveler.ErrInvalidMergeBase
 	}
-	return FindMergeBase(ctx, m, repositoryID, commitIDs[0], commitIDs[1])
+	return FindMergeBase(ctx, m, repository, commitIDs[0], commitIDs[1])
 }
 
-func (m *KVManager) Log(ctx context.Context, repositoryID graveler.RepositoryID, from graveler.CommitID) (graveler.CommitIterator, error) {
-	_, err := m.getRepositoryRec(ctx, repositoryID)
-	if err != nil {
-		return nil, err
-	}
-	return NewCommitIterator(ctx, repositoryID, from, m), nil
+func (m *KVManager) Log(ctx context.Context, repository *graveler.RepositoryRecord, from graveler.CommitID) (graveler.CommitIterator, error) {
+	return NewCommitIterator(ctx, repository, from, m), nil
 }
 
-func (m *KVManager) ListCommits(ctx context.Context, repositoryID graveler.RepositoryID) (graveler.CommitIterator, error) {
-	repo, err := m.getRepositoryRec(ctx, repositoryID)
-	if err != nil {
-		return nil, err
-	}
-	return NewKVOrderedCommitIterator(ctx, &m.kvStore, repo, false)
+func (m *KVManager) ListCommits(ctx context.Context, repository *graveler.RepositoryRecord) (graveler.CommitIterator, error) {
+	return NewKVOrderedCommitIterator(ctx, &m.kvStore, repository, false)
 }
 
-func (m *KVManager) GCCommitIterator(ctx context.Context, repositoryID graveler.RepositoryID) (graveler.CommitIterator, error) {
-	repo, err := m.getRepositoryRec(ctx, repositoryID)
-	if err != nil {
-		return nil, err
-	}
-	return NewKVOrderedCommitIterator(ctx, &m.kvStore, repo, true)
+func (m *KVManager) GCCommitIterator(ctx context.Context, repository *graveler.RepositoryRecord) (graveler.CommitIterator, error) {
+	return NewKVOrderedCommitIterator(ctx, &m.kvStore, repository, true)
 }

--- a/pkg/graveler/ref/manager.go
+++ b/pkg/graveler/ref/manager.go
@@ -75,7 +75,7 @@ func NewKVRefManager(executor batch.Batcher, kvStore kv.StoreMessage, addressPro
 
 func (m *KVManager) getRepository(ctx context.Context, repositoryID graveler.RepositoryID) (*graveler.RepositoryRecord, error) {
 	key := fmt.Sprintf("GetRepository:%s", repositoryID)
-	repository, err := m.batchExecutor.BatchFor(key, MaxBatchDelay, batch.BatchFn(func() (interface{}, error) {
+	repository, err := m.batchExecutor.BatchFor(ctx, key, MaxBatchDelay, batch.BatchFn(func() (interface{}, error) {
 		data := graveler.RepositoryData{}
 		_, err := m.kvStore.GetMsg(ctx, graveler.RepositoriesPartition(), []byte(graveler.RepoPath(repositoryID)), &data)
 		if err != nil {
@@ -270,7 +270,7 @@ func (m *KVManager) getBranchWithPredicate(ctx context.Context, repository *grav
 		*graveler.Branch
 		kv.Predicate
 	}
-	result, err := m.batchExecutor.BatchFor(key, MaxBatchDelay, batch.BatchFn(func() (interface{}, error) {
+	result, err := m.batchExecutor.BatchFor(ctx, key, MaxBatchDelay, batch.BatchFn(func() (interface{}, error) {
 		key := graveler.BranchPath(branchID)
 		data := graveler.BranchData{}
 		pred, err := m.kvStore.GetMsg(ctx, graveler.RepoPartition(repository), []byte(key), &data)
@@ -341,7 +341,7 @@ func (m *KVManager) GCBranchIterator(ctx context.Context, repository *graveler.R
 
 func (m *KVManager) GetTag(ctx context.Context, repository *graveler.RepositoryRecord, tagID graveler.TagID) (*graveler.CommitID, error) {
 	key := fmt.Sprintf("GetTag:%s:%s", repository.RepositoryID, tagID)
-	commitID, err := m.batchExecutor.BatchFor(key, MaxBatchDelay, batch.BatchFn(func() (interface{}, error) {
+	commitID, err := m.batchExecutor.BatchFor(ctx, key, MaxBatchDelay, batch.BatchFn(func() (interface{}, error) {
 		tagKey := graveler.TagPath(tagID)
 		t := graveler.TagData{}
 		_, err := m.kvStore.GetMsg(ctx, graveler.RepoPartition(repository), []byte(tagKey), &t)
@@ -388,7 +388,7 @@ func (m *KVManager) ListTags(ctx context.Context, repository *graveler.Repositor
 
 func (m *KVManager) GetCommitByPrefix(ctx context.Context, repository *graveler.RepositoryRecord, prefix graveler.CommitID) (*graveler.Commit, error) {
 	key := fmt.Sprintf("GetCommitByPrefix:%s:%s", repository.RepositoryID, prefix)
-	commit, err := m.batchExecutor.BatchFor(key, MaxBatchDelay, batch.BatchFn(func() (interface{}, error) {
+	commit, err := m.batchExecutor.BatchFor(ctx, key, MaxBatchDelay, batch.BatchFn(func() (interface{}, error) {
 		it, err := NewKVOrderedCommitIterator(ctx, &m.kvStore, repository, false)
 		if err != nil {
 			return nil, err
@@ -420,7 +420,7 @@ func (m *KVManager) GetCommitByPrefix(ctx context.Context, repository *graveler.
 
 func (m *KVManager) GetCommit(ctx context.Context, repository *graveler.RepositoryRecord, commitID graveler.CommitID) (*graveler.Commit, error) {
 	key := fmt.Sprintf("GetCommit:%s:%s", repository.RepositoryID, commitID)
-	commit, err := m.batchExecutor.BatchFor(key, MaxBatchDelay, batch.BatchFn(func() (interface{}, error) {
+	commit, err := m.batchExecutor.BatchFor(ctx, key, MaxBatchDelay, batch.BatchFn(func() (interface{}, error) {
 		commitKey := graveler.CommitPath(commitID)
 		c := graveler.CommitData{}
 		_, err := m.kvStore.GetMsg(ctx, graveler.RepoPartition(repository), []byte(commitKey), &c)

--- a/pkg/graveler/ref/merge_base_finder_test.go
+++ b/pkg/graveler/ref/merge_base_finder_test.go
@@ -15,7 +15,9 @@ type MockCommitGetter struct {
 	visited    map[graveler.CommitID]int
 }
 
-func (g *MockCommitGetter) GetCommit(_ context.Context, _ graveler.RepositoryID, commitID graveler.CommitID) (*graveler.Commit, error) {
+var repository = &graveler.RepositoryRecord{RepositoryID: "ref-test-repo"}
+
+func (g *MockCommitGetter) GetCommit(_ context.Context, _ *graveler.RepositoryRecord, commitID graveler.CommitID) (*graveler.Commit, error) {
 	if commit, ok := g.byCommitID[commitID]; ok {
 		g.visited[commitID] += 1
 		return commit, nil
@@ -322,7 +324,7 @@ func TestFindMergeBase(t *testing.T) {
 	for _, cas := range cases {
 		t.Run(cas.Name, func(t *testing.T) {
 			getter := cas.Getter()
-			base, err := ref.FindMergeBase(context.Background(), getter, "", cas.Left, cas.Right)
+			base, err := ref.FindMergeBase(context.Background(), getter, repository, cas.Left, cas.Right)
 			if err != nil {
 				t.Fatalf("unexpected error %v", err)
 			}
@@ -331,7 +333,7 @@ func TestFindMergeBase(t *testing.T) {
 			// flip right and left and expect the same result, reset visited to keep track of the second round visits
 			getter.visited = map[graveler.CommitID]int{}
 			base, err = ref.FindMergeBase(
-				context.Background(), getter, "", cas.Right, cas.Left)
+				context.Background(), getter, repository, cas.Right, cas.Left)
 			if err != nil {
 				t.Fatalf("unexpected error %v", err)
 			}
@@ -372,22 +374,22 @@ func TestGrid(t *testing.T) {
 		}
 	}
 	getter := newReader(kv)
-	c, err := ref.FindMergeBase(context.Background(), getter, "", "7-4", "5-6")
+	c, err := ref.FindMergeBase(context.Background(), getter, repository, "7-4", "5-6")
 	testutil.Must(t, err)
 	verifyResult(t, c, []string{"5-4"}, getter.visited)
 
 	getter.visited = map[graveler.CommitID]int{}
-	c, err = ref.FindMergeBase(context.Background(), getter, "", "1-2", "2-1")
+	c, err = ref.FindMergeBase(context.Background(), getter, repository, "1-2", "2-1")
 	testutil.Must(t, err)
 	verifyResult(t, c, []string{"1-1"}, getter.visited)
 
 	getter.visited = map[graveler.CommitID]int{}
-	c, err = ref.FindMergeBase(context.Background(), getter, "", "0-9", "9-0")
+	c, err = ref.FindMergeBase(context.Background(), getter, repository, "0-9", "9-0")
 	testutil.Must(t, err)
 	verifyResult(t, c, []string{"0-0"}, getter.visited)
 
 	getter.visited = map[graveler.CommitID]int{}
-	c, err = ref.FindMergeBase(context.Background(), getter, "", "6-9", "9-6")
+	c, err = ref.FindMergeBase(context.Background(), getter, repository, "6-9", "9-6")
 	testutil.Must(t, err)
 	verifyResult(t, c, []string{"6-6"}, getter.visited)
 }

--- a/pkg/graveler/ref/repository_iterator_test.go
+++ b/pkg/graveler/ref/repository_iterator_test.go
@@ -18,11 +18,12 @@ func TestDBRepositoryIterator(t *testing.T) {
 
 	// prepare data
 	for _, repoId := range repos {
-		testutil.Must(t, r.CreateRepository(context.Background(), repoId, graveler.Repository{
+		_, err := r.CreateRepository(context.Background(), repoId, graveler.Repository{
 			StorageNamespace: "s3://foo",
 			CreationDate:     time.Now(),
 			DefaultBranchID:  "main",
-		}))
+		})
+		testutil.Must(t, err)
 	}
 
 	t.Run("listing all repos", func(t *testing.T) {
@@ -101,11 +102,12 @@ func TestKVRepositoryIterator(t *testing.T) {
 
 	// prepare data
 	for _, repoId := range repos {
-		testutil.Must(t, r.CreateRepository(context.Background(), repoId, graveler.Repository{
+		_, err := r.CreateRepository(context.Background(), repoId, graveler.Repository{
 			StorageNamespace: "s3://foo",
 			CreationDate:     time.Now(),
 			DefaultBranchID:  "main",
-		}))
+		})
+		testutil.Must(t, err)
 	}
 
 	t.Run("listing all repos", func(t *testing.T) {

--- a/pkg/graveler/ref/resolve_ref.go
+++ b/pkg/graveler/ref/resolve_ref.go
@@ -10,13 +10,13 @@ import (
 )
 
 type Store interface {
-	GetBranch(ctx context.Context, repositoryID graveler.RepositoryID, branchID graveler.BranchID) (*graveler.Branch, error)
-	GetTag(ctx context.Context, repositoryID graveler.RepositoryID, tagID graveler.TagID) (*graveler.CommitID, error)
-	GetCommitByPrefix(ctx context.Context, repositoryID graveler.RepositoryID, prefix graveler.CommitID) (*graveler.Commit, error)
-	GetCommit(ctx context.Context, repositoryID graveler.RepositoryID, prefix graveler.CommitID) (*graveler.Commit, error)
+	GetBranch(ctx context.Context, repository *graveler.RepositoryRecord, branchID graveler.BranchID) (*graveler.Branch, error)
+	GetTag(ctx context.Context, repository *graveler.RepositoryRecord, tagID graveler.TagID) (*graveler.CommitID, error)
+	GetCommitByPrefix(ctx context.Context, repository *graveler.RepositoryRecord, prefix graveler.CommitID) (*graveler.Commit, error)
+	GetCommit(ctx context.Context, repository *graveler.RepositoryRecord, prefix graveler.CommitID) (*graveler.Commit, error)
 }
 
-type revResolverFunc func(context.Context, Store, ident.AddressProvider, graveler.RepositoryID, string) (*graveler.ResolvedRef, error)
+type revResolverFunc func(context.Context, Store, ident.AddressProvider, *graveler.RepositoryRecord, string) (*graveler.ResolvedRef, error)
 
 var hashRegexp = regexp.MustCompile("^[a-fA-F0-9]{1,64}$")
 
@@ -25,10 +25,10 @@ func isAHash(part string) bool {
 }
 
 // revResolve return the first resolve of 'rev' - by hash, branch or tag
-func revResolve(ctx context.Context, store Store, addressProvider ident.AddressProvider, repositoryID graveler.RepositoryID, rev string) (*graveler.ResolvedRef, error) {
+func revResolve(ctx context.Context, store Store, addressProvider ident.AddressProvider, repository *graveler.RepositoryRecord, rev string) (*graveler.ResolvedRef, error) {
 	resolvers := []revResolverFunc{revResolveAHash, revResolveBranch, revResolveTag}
 	for _, resolveHelper := range resolvers {
-		r, err := resolveHelper(ctx, store, addressProvider, repositoryID, rev)
+		r, err := resolveHelper(ctx, store, addressProvider, repository, rev)
 		if err != nil {
 			return nil, err
 		}
@@ -39,8 +39,8 @@ func revResolve(ctx context.Context, store Store, addressProvider ident.AddressP
 	return nil, graveler.ErrNotFound
 }
 
-func ResolveRawRef(ctx context.Context, store Store, addressProvider ident.AddressProvider, repositoryID graveler.RepositoryID, rawRef graveler.RawRef) (*graveler.ResolvedRef, error) {
-	rr, err := revResolve(ctx, store, addressProvider, repositoryID, rawRef.BaseRef)
+func ResolveRawRef(ctx context.Context, store Store, addressProvider ident.AddressProvider, repository *graveler.RepositoryRecord, rawRef graveler.RawRef) (*graveler.ResolvedRef, error) {
+	rr, err := revResolve(ctx, store, addressProvider, repository, rawRef.BaseRef)
 	if err != nil {
 		return nil, err
 	}
@@ -84,7 +84,7 @@ func ResolveRawRef(ctx context.Context, store Store, addressProvider ident.Addre
 		case graveler.RefModTypeTilde:
 			// skip mod.ValueNumeric iterations
 			for i := 0; i < mod.Value; i++ {
-				commit, err := store.GetCommit(ctx, repositoryID, baseCommit)
+				commit, err := store.GetCommit(ctx, repository, baseCommit)
 				if err != nil {
 					return nil, err
 				}
@@ -99,7 +99,7 @@ func ResolveRawRef(ctx context.Context, store Store, addressProvider ident.Addre
 				continue
 			}
 			// get the commit and extract parents
-			c, err := store.GetCommitByPrefix(ctx, repositoryID, baseCommit)
+			c, err := store.GetCommitByPrefix(ctx, repository, baseCommit)
 			if err != nil {
 				return nil, err
 			}
@@ -123,11 +123,11 @@ func ResolveRawRef(ctx context.Context, store Store, addressProvider ident.Addre
 	}, nil
 }
 
-func revResolveAHash(ctx context.Context, store Store, addressProvider ident.AddressProvider, repositoryID graveler.RepositoryID, rev string) (*graveler.ResolvedRef, error) {
+func revResolveAHash(ctx context.Context, store Store, addressProvider ident.AddressProvider, repository *graveler.RepositoryRecord, rev string) (*graveler.ResolvedRef, error) {
 	if !isAHash(rev) {
 		return nil, nil
 	}
-	commit, err := store.GetCommitByPrefix(ctx, repositoryID, graveler.CommitID(rev))
+	commit, err := store.GetCommitByPrefix(ctx, repository, graveler.CommitID(rev))
 	if errors.Is(err, graveler.ErrNotFound) {
 		return nil, nil
 	}
@@ -144,9 +144,9 @@ func revResolveAHash(ctx context.Context, store Store, addressProvider ident.Add
 	}, nil
 }
 
-func revResolveBranch(ctx context.Context, store Store, _ ident.AddressProvider, repositoryID graveler.RepositoryID, rev string) (*graveler.ResolvedRef, error) {
+func revResolveBranch(ctx context.Context, store Store, _ ident.AddressProvider, repository *graveler.RepositoryRecord, rev string) (*graveler.ResolvedRef, error) {
 	branchID := graveler.BranchID(rev)
-	branch, err := store.GetBranch(ctx, repositoryID, branchID)
+	branch, err := store.GetBranch(ctx, repository, branchID)
 	if errors.Is(err, graveler.ErrNotFound) {
 		return nil, nil
 	}
@@ -165,8 +165,8 @@ func revResolveBranch(ctx context.Context, store Store, _ ident.AddressProvider,
 	}, nil
 }
 
-func revResolveTag(ctx context.Context, store Store, _ ident.AddressProvider, repositoryID graveler.RepositoryID, rev string) (*graveler.ResolvedRef, error) {
-	commitID, err := store.GetTag(ctx, repositoryID, graveler.TagID(rev))
+func revResolveTag(ctx context.Context, store Store, _ ident.AddressProvider, repository *graveler.RepositoryRecord, rev string) (*graveler.ResolvedRef, error) {
+	commitID, err := store.GetTag(ctx, repository, graveler.TagID(rev))
 	if errors.Is(err, graveler.ErrNotFound) {
 		return nil, nil
 	}

--- a/pkg/graveler/ref/resolve_ref_test.go
+++ b/pkg/graveler/ref/resolve_ref_test.go
@@ -363,7 +363,7 @@ func TestResolveRef_DereferenceWithGraph(t *testing.T) {
 		resolve := func(base graveler.CommitID, mod string, expected graveler.CommitID) {
 			t.Helper()
 			reference := string(base) + mod
-			resolved, err := resolveRef(context.Background(), tt.refManager, ident.NewHexAddressProvider(), graveler.Ref(reference))
+			resolved, err := resolveRef(context.Background(), tt.refManager, ident.NewHexAddressProvider(), repository, graveler.Ref(reference))
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -403,7 +403,7 @@ func TestResolveRef_DereferenceWithGraph(t *testing.T) {
 	}
 }
 
-func resolveRef(ctx context.Context, store ref.Store, addressProvider ident.AddressProvider, reference graveler.Ref) (*graveler.ResolvedRef, error) {
+func resolveRef(ctx context.Context, store ref.Store, addressProvider ident.AddressProvider, repository *graveler.RepositoryRecord, reference graveler.Ref) (*graveler.ResolvedRef, error) {
 	rawRef, err := ref.ParseRef(reference)
 	if err != nil {
 		return nil, err

--- a/pkg/graveler/ref/resolve_ref_test.go
+++ b/pkg/graveler/ref/resolve_ref_test.go
@@ -17,13 +17,14 @@ func TestResolveRawRef(t *testing.T) {
 	r := testRefManager(t)
 	for _, tt := range r {
 		ctx := context.Background()
-		testutil.Must(t, tt.refManager.CreateRepository(ctx, "repo1", graveler.Repository{
+		repository, err := tt.refManager.CreateRepository(ctx, "repo1", graveler.Repository{
 			StorageNamespace: "s3://",
 			CreationDate:     time.Now(),
 			DefaultBranchID:  "main",
-		}))
+		})
+		testutil.Must(t, err)
 
-		mainBranch, err := tt.refManager.GetBranch(ctx, "repo1", "main")
+		mainBranch, err := tt.refManager.GetBranch(ctx, repository, "main")
 		if err != nil {
 			t.Fatalf("Failed to get main branch information: %s", err)
 		}
@@ -42,7 +43,7 @@ func TestResolveRawRef(t *testing.T) {
 			if previous != "" {
 				c.Parents = append(c.Parents, previous)
 			}
-			cid, err := tt.refManager.AddCommit(ctx, "repo1", c)
+			cid, err := tt.refManager.AddCommit(ctx, repository, c)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -50,7 +51,7 @@ func TestResolveRawRef(t *testing.T) {
 			ts.Add(time.Minute)
 		}
 
-		iter, err := tt.refManager.Log(ctx, "repo1", previous)
+		iter, err := tt.refManager.Log(ctx, repository, previous)
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
@@ -95,19 +96,19 @@ func TestResolveRawRef(t *testing.T) {
 		}
 
 		branch1CommitID := commitLog[3]
-		testutil.Must(t, tt.refManager.SetBranch(ctx, "repo1", "branch1", graveler.Branch{
+		testutil.Must(t, tt.refManager.SetBranch(ctx, repository, "branch1", graveler.Branch{
 			CommitID:     branch1CommitID,
 			StagingToken: "token1",
 		}))
 
 		branch2CommitID := commitLog[16]
-		testutil.Must(t, tt.refManager.SetBranch(ctx, "repo1", "branch2", graveler.Branch{
+		testutil.Must(t, tt.refManager.SetBranch(ctx, repository, "branch2", graveler.Branch{
 			CommitID:     branch2CommitID,
 			StagingToken: "token2",
 		}))
 
 		tagCommitID := commitLog[9]
-		testutil.Must(t, tt.refManager.CreateTag(ctx, "repo1", "v1.0", tagCommitID))
+		testutil.Must(t, tt.refManager.CreateTag(ctx, repository, "v1.0", tagCommitID))
 
 		commitCommitID := commitLog[11]
 
@@ -226,7 +227,7 @@ func TestResolveRawRef(t *testing.T) {
 					}
 					return
 				}
-				resolvedRef, err := tt.refManager.ResolveRawRef(ctx, "repo1", rawRef)
+				resolvedRef, err := tt.refManager.ResolveRawRef(ctx, repository, rawRef)
 				if err != nil {
 					if cas.ExpectedErr == nil || !errors.Is(err, cas.ExpectedErr) {
 						t.Fatalf("unexpected error while resolve '%s': %v, expected: %s", cas.Ref, err, cas.ExpectedErr)
@@ -254,11 +255,12 @@ func TestResolveRef_SameDate(t *testing.T) {
 	r := testRefManager(t)
 	for _, tt := range r {
 		ctx := context.Background()
-		testutil.Must(t, tt.refManager.CreateRepository(ctx, "repo1", graveler.Repository{
+		repository, err := tt.refManager.CreateRepository(ctx, "repo1", graveler.Repository{
 			StorageNamespace: "s3://",
 			CreationDate:     time.Now(),
 			DefaultBranchID:  "main",
-		}))
+		})
+		testutil.Must(t, err)
 
 		ts, _ := time.Parse(time.RFC3339, "2020-12-01T15:00:00Z")
 		addCommit := func(message string, parents ...graveler.CommitID) graveler.CommitID {
@@ -272,7 +274,7 @@ func TestResolveRef_SameDate(t *testing.T) {
 			for _, p := range parents {
 				c.Parents = append(c.Parents, p)
 			}
-			cid, err := tt.refManager.AddCommit(ctx, "repo1", c)
+			cid, err := tt.refManager.AddCommit(ctx, repository, c)
 			testutil.MustDo(t, "add commit", err)
 			return cid
 		}
@@ -282,7 +284,7 @@ func TestResolveRef_SameDate(t *testing.T) {
 		c4 := addCommit("c4", c3)
 		c5 := addCommit("c5", c4, c2)
 
-		it, err := tt.refManager.Log(ctx, "repo1", c5)
+		it, err := tt.refManager.Log(ctx, repository, c5)
 		testutil.MustDo(t, "Log request", err)
 		var commitIDs []graveler.CommitID
 		for it.Next() {
@@ -326,11 +328,12 @@ func TestResolveRef_DereferenceWithGraph(t *testing.T) {
 	*/
 	r := testRefManager(t)
 	for _, tt := range r {
-		testutil.Must(t, tt.refManager.CreateRepository(context.Background(), "repo1", graveler.Repository{
+		repository, err := tt.refManager.CreateRepository(context.Background(), "repo1", graveler.Repository{
 			StorageNamespace: "s3://",
 			CreationDate:     time.Now(),
 			DefaultBranchID:  "main",
-		}))
+		})
+		testutil.Must(t, err)
 
 		ts, _ := time.Parse(time.RFC3339, "2020-12-01T15:00:00Z")
 		addCommit := func(parents ...graveler.CommitID) graveler.CommitID {
@@ -340,7 +343,7 @@ func TestResolveRef_DereferenceWithGraph(t *testing.T) {
 			for _, p := range parents {
 				commit.Parents = append(commit.Parents, p)
 			}
-			cid, err := tt.refManager.AddCommit(context.Background(), "repo1", commit)
+			cid, err := tt.refManager.AddCommit(context.Background(), repository, commit)
 			testutil.MustDo(t, "add commit", err)
 			ts = ts.Add(time.Second)
 			return cid
@@ -360,7 +363,7 @@ func TestResolveRef_DereferenceWithGraph(t *testing.T) {
 		resolve := func(base graveler.CommitID, mod string, expected graveler.CommitID) {
 			t.Helper()
 			reference := string(base) + mod
-			resolved, err := resolveRef(context.Background(), tt.refManager, ident.NewHexAddressProvider(), "repo1", graveler.Ref(reference))
+			resolved, err := resolveRef(context.Background(), tt.refManager, ident.NewHexAddressProvider(), graveler.Ref(reference))
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
 			}
@@ -400,10 +403,10 @@ func TestResolveRef_DereferenceWithGraph(t *testing.T) {
 	}
 }
 
-func resolveRef(ctx context.Context, store ref.Store, addressProvider ident.AddressProvider, repositoryID graveler.RepositoryID, reference graveler.Ref) (*graveler.ResolvedRef, error) {
+func resolveRef(ctx context.Context, store ref.Store, addressProvider ident.AddressProvider, reference graveler.Ref) (*graveler.ResolvedRef, error) {
 	rawRef, err := ref.ParseRef(reference)
 	if err != nil {
 		return nil, err
 	}
-	return ref.ResolveRawRef(ctx, store, addressProvider, repositoryID, rawRef)
+	return ref.ResolveRawRef(ctx, store, addressProvider, repository, rawRef)
 }

--- a/pkg/graveler/ref/tag_iterator_test.go
+++ b/pkg/graveler/ref/tag_iterator_test.go
@@ -15,24 +15,22 @@ func TestDBTagIterator(t *testing.T) {
 	r, db := testRefManagerWithDB(t)
 	tags := []graveler.TagID{"a", "aa", "b", "c", "e", "d", "f", "g"}
 	ctx := context.Background()
-	repo := &graveler.RepositoryRecord{
-		RepositoryID: "repo1",
-		Repository: &graveler.Repository{
-			StorageNamespace: "s3://foo",
-			CreationDate:     time.Now(),
-			DefaultBranchID:  "main",
-		},
-	}
-	testutil.Must(t, r.CreateRepository(ctx, repo.RepositoryID, *repo.Repository))
+
+	repository, err := r.CreateRepository(ctx, "repo1", graveler.Repository{
+		StorageNamespace: "s3://foo",
+		CreationDate:     time.Now(),
+		DefaultBranchID:  "main",
+	})
+	testutil.Must(t, err)
 
 	// prepare data
 	for _, b := range tags {
-		err := r.CreateTag(ctx, repo.RepositoryID, b, "c1")
+		err := r.CreateTag(ctx, repository, b, "c1")
 		testutil.Must(t, err)
 	}
 
 	t.Run("listing all tags", func(t *testing.T) {
-		iter, err := ref.NewDBTagIterator(ctx, db, repo.RepositoryID, 3)
+		iter, err := ref.NewDBTagIterator(ctx, db, repository.RepositoryID, 3)
 		testutil.Must(t, err)
 		ids := make([]graveler.TagID, 0)
 		for iter.Next() {
@@ -50,7 +48,7 @@ func TestDBTagIterator(t *testing.T) {
 	})
 
 	t.Run("listing tags using prefix", func(t *testing.T) {
-		iter, err := ref.NewDBTagIterator(ctx, db, repo.RepositoryID, 3)
+		iter, err := ref.NewDBTagIterator(ctx, db, repository.RepositoryID, 3)
 		testutil.Must(t, err)
 		iter.SeekGE("b")
 		ids := make([]graveler.TagID, 0)
@@ -69,7 +67,7 @@ func TestDBTagIterator(t *testing.T) {
 	})
 
 	t.Run("empty value SeekGE", func(t *testing.T) {
-		iter, err := ref.NewDBTagIterator(ctx, db, repo.RepositoryID, 3)
+		iter, err := ref.NewDBTagIterator(ctx, db, repository.RepositoryID, 3)
 		testutil.Must(t, err)
 		iter.SeekGE("b")
 
@@ -79,7 +77,7 @@ func TestDBTagIterator(t *testing.T) {
 	})
 
 	t.Run("listing tags SeekGE", func(t *testing.T) {
-		iter, err := ref.NewDBTagIterator(ctx, db, repo.RepositoryID, 3)
+		iter, err := ref.NewDBTagIterator(ctx, db, repository.RepositoryID, 3)
 		testutil.Must(t, err)
 		iter.SeekGE("b")
 		ids := make([]graveler.TagID, 0)
@@ -117,24 +115,21 @@ func TestKVTagIterator(t *testing.T) {
 	r, kvstore := testRefManagerWithKV(t)
 	tags := []graveler.TagID{"a", "aa", "b", "c", "e", "d", "f", "g"}
 	ctx := context.Background()
-	repo := &graveler.RepositoryRecord{
-		RepositoryID: "repo1",
-		Repository: &graveler.Repository{
-			StorageNamespace: "s3://foo",
-			CreationDate:     time.Now(),
-			DefaultBranchID:  "main",
-		},
-	}
-	testutil.Must(t, r.CreateRepository(ctx, repo.RepositoryID, *repo.Repository))
+	repository, err := r.CreateRepository(ctx, "repo1", graveler.Repository{
+		StorageNamespace: "s3://foo",
+		CreationDate:     time.Now(),
+		DefaultBranchID:  "main",
+	})
+	testutil.Must(t, err)
 
 	// prepare data
 	for _, b := range tags {
-		err := r.CreateTag(ctx, repo.RepositoryID, b, "c1")
+		err := r.CreateTag(ctx, repository, b, "c1")
 		testutil.Must(t, err)
 	}
 
 	t.Run("listing all tags", func(t *testing.T) {
-		iter, err := ref.NewKVTagIterator(ctx, &kvstore, repo)
+		iter, err := ref.NewKVTagIterator(ctx, &kvstore, repository)
 		testutil.Must(t, err)
 		ids := make([]graveler.TagID, 0)
 		for iter.Next() {
@@ -152,7 +147,7 @@ func TestKVTagIterator(t *testing.T) {
 	})
 
 	t.Run("listing tags using prefix", func(t *testing.T) {
-		iter, err := ref.NewKVTagIterator(ctx, &kvstore, repo)
+		iter, err := ref.NewKVTagIterator(ctx, &kvstore, repository)
 		testutil.Must(t, err)
 		iter.SeekGE("b")
 		ids := make([]graveler.TagID, 0)
@@ -171,7 +166,7 @@ func TestKVTagIterator(t *testing.T) {
 	})
 
 	t.Run("listing tags SeekGE", func(t *testing.T) {
-		iter, err := ref.NewKVTagIterator(ctx, &kvstore, repo)
+		iter, err := ref.NewKVTagIterator(ctx, &kvstore, repository)
 		testutil.Must(t, err)
 		iter.SeekGE("b")
 		ids := make([]graveler.TagID, 0)
@@ -205,7 +200,7 @@ func TestKVTagIterator(t *testing.T) {
 	})
 
 	t.Run("empty value SeekGE", func(t *testing.T) {
-		iter, err := ref.NewKVTagIterator(ctx, &kvstore, repo)
+		iter, err := ref.NewKVTagIterator(ctx, &kvstore, repository)
 		testutil.Must(t, err)
 		iter.SeekGE("b")
 

--- a/pkg/graveler/retention/expired_commits_test.go
+++ b/pkg/graveler/retention/expired_commits_test.go
@@ -291,8 +291,10 @@ func TestExpiredCommits(t *testing.T) {
 			gcCommits, err := GetGarbageCollectionCommits(ctx, NewGCStartingPointIterator(
 				testutil.NewFakeCommitIterator(findMainAncestryLeaves(now, tst.headsRetentionDays, tst.commits)),
 				testutil.NewFakeBranchIterator(branches)), &RepositoryCommitGetter{
-				refManager:   refManagerMock,
-				repositoryID: "test",
+				refManager: refManagerMock,
+				repository: &graveler.RepositoryRecord{
+					RepositoryID: "test",
+				},
 			}, garbageCollectionRules, previouslyExpiredCommitIDs)
 			if err != nil {
 				t.Fatalf("failed to find expired commits: %v", err)

--- a/pkg/graveler/retention/expired_commits_test.go
+++ b/pkg/graveler/retention/expired_commits_test.go
@@ -260,6 +260,9 @@ func TestExpiredCommits(t *testing.T) {
 			ctrl := gomock.NewController(t)
 			refManagerMock := mock.NewMockRefManager(ctrl)
 			ctx := context.Background()
+			repositoryRecord := &graveler.RepositoryRecord{
+				RepositoryID: "test",
+			}
 			garbageCollectionRules := &graveler.GarbageCollectionRules{DefaultRetentionDays: 5, BranchRetentionDays: make(map[string]int32)}
 			var branches []*graveler.BranchRecord
 			for head, retentionDays := range tst.headsRetentionDays {
@@ -281,7 +284,7 @@ func TestExpiredCommits(t *testing.T) {
 				id := graveler.CommitID(commitID)
 				commitMap[id] = &graveler.Commit{Message: commitID, Parents: testCommit.parents, CreationDate: now.AddDate(0, 0, -testCommit.daysPassed), Version: graveler.CurrentCommitVersion}
 				if !previouslyExpired[id] {
-					refManagerMock.EXPECT().GetCommit(ctx, graveler.RepositoryID("test"), id).Return(commitMap[id], nil).MaxTimes(2)
+					refManagerMock.EXPECT().GetCommit(ctx, repositoryRecord, id).Return(commitMap[id], nil).MaxTimes(2)
 				}
 			}
 			previouslyExpiredCommitIDs := make([]graveler.CommitID, len(tst.previouslyExpired))
@@ -292,9 +295,7 @@ func TestExpiredCommits(t *testing.T) {
 				testutil.NewFakeCommitIterator(findMainAncestryLeaves(now, tst.headsRetentionDays, tst.commits)),
 				testutil.NewFakeBranchIterator(branches)), &RepositoryCommitGetter{
 				refManager: refManagerMock,
-				repository: &graveler.RepositoryRecord{
-					RepositoryID: "test",
-				},
+				repository: repositoryRecord,
 			}, garbageCollectionRules, previouslyExpiredCommitIDs)
 			if err != nil {
 				t.Fatalf("failed to find expired commits: %v", err)

--- a/pkg/graveler/settings/manager.go
+++ b/pkg/graveler/settings/manager.go
@@ -28,13 +28,13 @@ type cacheKey struct {
 
 type updateFunc func(proto.Message) error
 
-// TODO (niro): Remove interface once DB implementation is deleted
+// Manager - TODO(niro): Remove interface once DB implementation is deleted
 type Manager interface {
-	// TODO (niro): Delete Save (unused)
-	Save(context.Context, graveler.RepositoryID, string, proto.Message) error
-	GetLatest(context.Context, graveler.RepositoryID, string, proto.Message) (proto.Message, error)
-	Get(context.Context, graveler.RepositoryID, string, proto.Message) (proto.Message, error)
-	Update(context.Context, graveler.RepositoryID, string, proto.Message, updateFunc) error
+	// Save - TODO(niro): Delete Save (unused)
+	Save(context.Context, *graveler.RepositoryRecord, string, proto.Message) error
+	GetLatest(context.Context, *graveler.RepositoryRecord, string, proto.Message) (proto.Message, error)
+	Get(context.Context, *graveler.RepositoryRecord, string, proto.Message) (proto.Message, error)
+	Update(context.Context, *graveler.RepositoryRecord, string, proto.Message, updateFunc) error
 	WithCache(cache cache.Cache)
 }
 
@@ -72,15 +72,10 @@ func NewManager(refManager graveler.RefManager, store kv.StoreMessage, options .
 }
 
 // Save persists the given setting under the given repository and key. Overrides settings key in KV Store
-func (m *KVManager) Save(ctx context.Context, repositoryID graveler.RepositoryID, key string, setting proto.Message) error {
-	repo, err := m.refManager.GetRepository(ctx, repositoryID)
-	if err != nil {
-		return err
-	}
-
-	logSetting(logging.FromContext(ctx), repositoryID, key, setting, "saving repository-level setting")
+func (m *KVManager) Save(ctx context.Context, repository *graveler.RepositoryRecord, key string, setting proto.Message) error {
+	logSetting(logging.FromContext(ctx), repository.RepositoryID, key, setting, "saving repository-level setting")
 	// Write key in KV Store
-	return m.store.SetMsg(ctx, graveler.RepoPartition(&graveler.RepositoryRecord{RepositoryID: repositoryID, Repository: repo}), []byte(graveler.SettingsPath(key)), setting)
+	return m.store.SetMsg(ctx, graveler.RepoPartition(repository), []byte(graveler.SettingsPath(key)), setting)
 }
 
 func (m *KVManager) getWithPredicate(ctx context.Context, repo *graveler.RepositoryRecord, key string, data proto.Message) (kv.Predicate, error) {
@@ -94,34 +89,29 @@ func (m *KVManager) getWithPredicate(ctx context.Context, repo *graveler.Reposit
 	return pred, nil
 }
 
-func (m *KVManager) GetLatest(ctx context.Context, repositoryID graveler.RepositoryID, key string, settingTemplate proto.Message) (proto.Message, error) {
-	repo, err := m.refManager.GetRepository(ctx, repositoryID)
-	if err != nil {
-		return nil, err
-	}
-
+func (m *KVManager) GetLatest(ctx context.Context, repository *graveler.RepositoryRecord, key string, settingTemplate proto.Message) (proto.Message, error) {
 	data := settingTemplate.ProtoReflect().Interface()
-	_, err = m.getWithPredicate(ctx, &graveler.RepositoryRecord{RepositoryID: repositoryID, Repository: repo}, key, data)
+	_, err := m.getWithPredicate(ctx, repository, key, data)
 	if err != nil {
 		if errors.Is(err, kv.ErrNotFound) {
 			err = graveler.ErrNotFound
 		}
 		return nil, err
 	}
-	logSetting(logging.FromContext(ctx), repositoryID, key, data, "got repository-level setting")
+	logSetting(logging.FromContext(ctx), repository.RepositoryID, key, data, "got repository-level setting")
 	return data, nil
 }
 
 // Get fetches the setting under the given repository and key, and returns the result.
 // The result is eventually consistent: it is not guaranteed to be the most up-to-date setting. The cache expiry period is 1 second.
 // The settingTemplate parameter is used to determine the returned type.
-func (m *KVManager) Get(ctx context.Context, repositoryID graveler.RepositoryID, key string, settingTemplate proto.Message) (proto.Message, error) {
+func (m *KVManager) Get(ctx context.Context, repository *graveler.RepositoryRecord, key string, settingTemplate proto.Message) (proto.Message, error) {
 	k := cacheKey{
-		RepositoryID: repositoryID,
+		RepositoryID: repository.RepositoryID,
 		Key:          key,
 	}
 	setting, err := m.cache.GetOrSet(k, func() (v interface{}, err error) {
-		return m.GetLatest(ctx, repositoryID, key, settingTemplate)
+		return m.GetLatest(ctx, repository, key, settingTemplate)
 	})
 	if err != nil {
 		return nil, err
@@ -131,7 +121,7 @@ func (m *KVManager) Get(ctx context.Context, repositoryID graveler.RepositoryID,
 
 // Update atomically gets a setting, performs the update function, and persists the setting to the store.
 // The settingTemplate parameter is used to determine the type passed to the update function.
-func (m *KVManager) Update(ctx context.Context, repositoryID graveler.RepositoryID, key string, settingTemplate proto.Message, update updateFunc) error {
+func (m *KVManager) Update(ctx context.Context, repository *graveler.RepositoryRecord, key string, settingTemplate proto.Message, update updateFunc) error {
 	const (
 		maxIntervalSec = 2
 		maxElapsedSec  = 5
@@ -141,25 +131,20 @@ func (m *KVManager) Update(ctx context.Context, repositoryID graveler.Repository
 	bo.MaxElapsedTime = maxElapsedSec * time.Second
 
 	err := backoff.Retry(func() error {
-		repo, err := m.refManager.GetRepository(ctx, repositoryID)
-		if err != nil {
-			return backoff.Permanent(err)
-		}
-
 		data := settingTemplate.ProtoReflect().Interface()
-		pred, err := m.getWithPredicate(ctx, &graveler.RepositoryRecord{RepositoryID: repositoryID, Repository: repo}, key, data)
+		pred, err := m.getWithPredicate(ctx, repository, key, data)
 		if errors.Is(err, graveler.ErrNotFound) {
 			data = proto.Clone(settingTemplate)
 		} else if err != nil {
 			return backoff.Permanent(err)
 		}
 
-		logSetting(logging.FromContext(ctx), repositoryID, key, data, "update repository-level setting")
+		logSetting(logging.FromContext(ctx), repository.RepositoryID, key, data, "update repository-level setting")
 		err = update(data)
 		if err != nil {
 			return backoff.Permanent(err)
 		}
-		err = m.store.SetMsgIf(ctx, graveler.RepoPartition(&graveler.RepositoryRecord{RepositoryID: repositoryID, Repository: repo}), []byte(graveler.SettingsPath(key)), data, pred)
+		err = m.store.SetMsgIf(ctx, graveler.RepoPartition(repository), []byte(graveler.SettingsPath(key)), data, pred)
 		if errors.Is(err, kv.ErrPredicateFailed) {
 			logging.Default().WithError(err).Warn("Predicate failed on settings update. Retrying")
 			err = graveler.ErrPreconditionFailed

--- a/pkg/graveler/settings/manager_test.go
+++ b/pkg/graveler/settings/manager_test.go
@@ -26,6 +26,14 @@ type mockCache struct {
 	c map[interface{}]interface{}
 }
 
+var repository = &graveler.RepositoryRecord{
+	RepositoryID: "example-repo",
+	Repository: &graveler.Repository{
+		StorageNamespace: "mem://my-storage",
+		DefaultBranchID:  "main",
+	},
+}
+
 func (m *mockCache) GetOrSet(k interface{}, setFn cache.SetFn) (v interface{}, err error) {
 	if val, ok := m.c[k]; ok {
 		return val, nil
@@ -63,25 +71,25 @@ func TestSaveAndGet(t *testing.T) {
 			m, _ := prepareTest(t, ctx, tt.kvEnabled, mc, nil)
 			emptySettings := &settings.ExampleSettings{}
 			firstSettings := &settings.ExampleSettings{ExampleInt: 5, ExampleStr: "hello", ExampleMap: map[string]int32{"boo": 6}}
-			err := m.Save(ctx, "example-repo", "settingKey", firstSettings)
+			err := m.Save(ctx, repository, "settingKey", firstSettings)
 			testutil.Must(t, err)
-			gotSettings, err := m.Get(ctx, "example-repo", "settingKey", emptySettings)
+			gotSettings, err := m.Get(ctx, repository, "settingKey", emptySettings)
 			testutil.Must(t, err)
 			if diff := deep.Equal(firstSettings, gotSettings); diff != nil {
 				t.Fatal("got unexpected settings:", diff)
 			}
 			secondSettings := &settings.ExampleSettings{ExampleInt: 15, ExampleStr: "hi", ExampleMap: map[string]int32{"boo": 16}}
-			err = m.Save(ctx, "example-repo", "settingKey", secondSettings)
+			err = m.Save(ctx, repository, "settingKey", secondSettings)
 			testutil.Must(t, err)
 			// the result should be cached, and we should get the first settings:
-			gotSettings, err = m.Get(ctx, "example-repo", "settingKey", emptySettings)
+			gotSettings, err = m.Get(ctx, repository, "settingKey", emptySettings)
 			testutil.Must(t, err)
 			if diff := deep.Equal(firstSettings, gotSettings); diff != nil {
 				t.Fatal("got unexpected settings:", diff)
 			}
 			// after clearing the mc, we should get the new settings:
 			mc.c = make(map[interface{}]interface{})
-			gotSettings, err = m.Get(ctx, "example-repo", "settingKey", emptySettings)
+			gotSettings, err = m.Get(ctx, repository, "settingKey", emptySettings)
 			testutil.Must(t, err)
 			if diff := deep.Equal(secondSettings, gotSettings); diff != nil {
 				t.Fatal("got unexpected settings:", diff)
@@ -94,7 +102,7 @@ func TestUpdate(t *testing.T) {
 	ctx := context.Background()
 	m, _ := prepareTest(t, ctx, true, nil, nil)
 	initialData := &settings.ExampleSettings{ExampleInt: 5, ExampleStr: "hello", ExampleMap: map[string]int32{"boo": 6}}
-	testutil.Must(t, m.Save(ctx, "example-repo", "settingKey", initialData))
+	testutil.Must(t, m.Save(ctx, repository, "settingKey", initialData))
 
 	validationData := &settings.ExampleSettings{
 		ExampleInt: initialData.ExampleInt + 1,
@@ -108,8 +116,8 @@ func TestUpdate(t *testing.T) {
 		return nil
 	}
 	emptySettings := &settings.ExampleSettings{}
-	require.NoError(t, m.Update(ctx, "example-repo", "settingKey", emptySettings, update))
-	gotSettings, err := m.Get(ctx, "example-repo", "settingKey", emptySettings)
+	require.NoError(t, m.Update(ctx, repository, "settingKey", emptySettings, update))
+	gotSettings, err := m.Get(ctx, repository, "settingKey", emptySettings)
 	require.NoError(t, err)
 	if diff := deep.Equal(validationData, gotSettings); diff != nil {
 		t.Fatal("got unexpected settings:", diff)
@@ -126,11 +134,11 @@ func TestUpdate(t *testing.T) {
 		settingsToEdit.(*settings.ExampleSettings).ExampleStr = initialData.ExampleStr
 		settingsToEdit.(*settings.ExampleSettings).ExampleInt = initialData.ExampleInt
 		settingsToEdit.(*settings.ExampleSettings).ExampleMap["boo"] = initialData.ExampleMap["boo"]
-		require.NoError(t, m.Save(ctx, "example-repo", "settingKey", badData))
+		require.NoError(t, m.Save(ctx, repository, "settingKey", badData))
 		return nil
 	}
-	require.NoError(t, m.Update(ctx, "example-repo", "settingKey", emptySettings, update))
-	gotSettings, err = m.Get(ctx, "example-repo", "settingKey", emptySettings)
+	require.NoError(t, m.Update(ctx, repository, "settingKey", emptySettings, update))
+	gotSettings, err = m.Get(ctx, repository, "settingKey", emptySettings)
 	require.NoError(t, err)
 	if diff := deep.Equal(initialData, gotSettings); diff != nil {
 		t.Fatal("got unexpected settings:", diff)
@@ -142,11 +150,11 @@ func TestUpdate(t *testing.T) {
 		settingsToEdit.(*settings.ExampleSettings).ExampleInt = badData.ExampleInt
 		settingsToEdit.(*settings.ExampleSettings).ExampleMap["boo"] = badData.ExampleMap["boo"]
 		validationData.ExampleInt = validationData.ExampleInt + 1
-		require.NoError(t, m.Save(ctx, "example-repo", "settingKey", validationData))
+		require.NoError(t, m.Save(ctx, repository, "settingKey", validationData))
 		return nil
 	}
-	require.ErrorIs(t, m.Update(ctx, "example-repo", "settingKey", emptySettings, update), graveler.ErrTooManyTries)
-	gotSettings, err = m.GetLatest(ctx, "example-repo", "settingKey", emptySettings)
+	require.ErrorIs(t, m.Update(ctx, repository, "settingKey", emptySettings, update), graveler.ErrTooManyTries)
+	gotSettings, err = m.GetLatest(ctx, repository, "settingKey", emptySettings)
 	if diff := deep.Equal(validationData, gotSettings); diff != nil {
 		t.Fatal("got unexpected settings:", diff)
 	}
@@ -156,8 +164,8 @@ func TestUpdate(t *testing.T) {
 	update = func(settingsToEdit proto.Message) error {
 		return testErr
 	}
-	require.ErrorIs(t, m.Update(ctx, "example-repo", "settingKey", emptySettings, update), testErr)
-	gotSettings, err = m.GetLatest(ctx, "example-repo", "settingKey", emptySettings)
+	require.ErrorIs(t, m.Update(ctx, repository, "settingKey", emptySettings, update), testErr)
+	gotSettings, err = m.GetLatest(ctx, repository, "settingKey", emptySettings)
 	if diff := deep.Equal(validationData, gotSettings); diff != nil {
 		t.Fatal("got unexpected settings:", diff)
 	}
@@ -182,7 +190,7 @@ func TestUpdateWithLock(t *testing.T) {
 	})
 	emptySettings := &settings.ExampleSettings{}
 	expectedSettings := &settings.ExampleSettings{ExampleInt: 5, ExampleStr: "hello", ExampleMap: map[string]int32{"boo": 6}}
-	err := m.Save(ctx, "example-repo", "settingKey", expectedSettings)
+	err := m.Save(ctx, repository, "settingKey", expectedSettings)
 	testutil.Must(t, err)
 	update := func(settingsToEdit proto.Message) error {
 		settingsToEdit.(*settings.ExampleSettings).ExampleInt++
@@ -193,13 +201,13 @@ func TestUpdateWithLock(t *testing.T) {
 	wg.Add(IncrementCount)
 	for i := 0; i < IncrementCount; i++ {
 		go func() {
-			testutil.Must(t, m.Update(ctx, "example-repo", "settingKey", emptySettings, update))
+			testutil.Must(t, m.Update(ctx, repository, "settingKey", emptySettings, update))
 			wg.Done()
 		}()
 	}
 	wg.Wait()
 	testutil.Must(t, err)
-	gotSettings, err := m.Get(ctx, "example-repo", "settingKey", emptySettings)
+	gotSettings, err := m.Get(ctx, repository, "settingKey", emptySettings)
 	testutil.Must(t, err)
 	expectedSettings.ExampleInt += IncrementCount
 	expectedSettings.ExampleMap["boo"] += IncrementCount
@@ -213,7 +221,7 @@ func TestStoredSettings(t *testing.T) {
 	ctx := context.Background()
 	m, blockAdapter := prepareTest(t, ctx, false, nil, nil)
 	expectedSettings := &settings.ExampleSettings{ExampleInt: 5, ExampleStr: "hello", ExampleMap: map[string]int32{"boo": 6}}
-	err := m.Save(ctx, "example-repo", "settingKey", expectedSettings)
+	err := m.Save(ctx, repository, "settingKey", expectedSettings)
 	testutil.Must(t, err)
 	reader, err := blockAdapter.Get(ctx, block.ObjectPointer{
 		StorageNamespace: "mem://my-storage",
@@ -252,13 +260,13 @@ func TestEmpty(t *testing.T) {
 		t.Run("TestEmpty"+kvSuffix, func(t *testing.T) {
 			m, _ := prepareTest(t, ctx, tt.kvEnabled, nil, nil)
 			emptySettings := &settings.ExampleSettings{}
-			_, err := m.Get(ctx, "example-repo", "settingKey", emptySettings)
+			_, err := m.Get(ctx, repository, "settingKey", emptySettings)
 			// the key was not set, an error should be returned
 			if err != graveler.ErrNotFound {
 				t.Fatalf("expected error %v, got %v", graveler.ErrNotFound, err)
 			}
 			// when using Update on an unset key, the update function gets an empty setting object to operate on
-			err = m.Update(ctx, "example-repo", "settingKey", emptySettings, func(setting proto.Message) error {
+			err = m.Update(ctx, repository, "settingKey", emptySettings, func(setting proto.Message) error {
 				s := setting.(*settings.ExampleSettings)
 				if s.ExampleMap == nil {
 					s.ExampleMap = make(map[string]int32)
@@ -268,7 +276,7 @@ func TestEmpty(t *testing.T) {
 				return nil
 			})
 			testutil.Must(t, err)
-			gotSettings, err := m.Get(ctx, "example-repo", "settingKey", emptySettings)
+			gotSettings, err := m.Get(ctx, repository, "settingKey", emptySettings)
 			testutil.Must(t, err)
 			expectedSettings := &settings.ExampleSettings{ExampleInt: 1, ExampleMap: map[string]int32{"boo": 1}}
 			if diff := deep.Equal(expectedSettings, gotSettings); diff != nil {
@@ -281,10 +289,6 @@ func TestEmpty(t *testing.T) {
 func prepareTest(t *testing.T, ctx context.Context, kvEnabled bool, cache cache.Cache, branchLockCallback func(context.Context, graveler.RepositoryID, graveler.BranchID, func() (interface{}, error)) (interface{}, error)) (settings.Manager, block.Adapter) {
 	ctrl := gomock.NewController(t)
 	refManager := mock.NewMockRefManager(ctrl)
-	repo := &graveler.Repository{
-		StorageNamespace: "mem://my-storage",
-		DefaultBranchID:  "main",
-	}
 
 	blockAdapter := mem.New()
 	branchLock := mock.NewMockBranchLocker(ctrl)
@@ -298,7 +302,7 @@ func prepareTest(t *testing.T, ctx context.Context, kvEnabled bool, cache cache.
 	if cache != nil {
 		opts = append(opts, settings.WithCache(cache))
 	}
-	branchLock.EXPECT().MetadataUpdater(ctx, gomock.Eq(graveler.RepositoryID("example-repo")), graveler.BranchID("main"), gomock.Any()).DoAndReturn(cb).AnyTimes()
+	branchLock.EXPECT().MetadataUpdater(ctx, gomock.Eq(repository.RepositoryID), graveler.BranchID("main"), gomock.Any()).DoAndReturn(cb).AnyTimes()
 	var m settings.Manager
 	if kvEnabled {
 		kvStore := kvtest.GetStore(ctx, t)
@@ -307,6 +311,6 @@ func prepareTest(t *testing.T, ctx context.Context, kvEnabled bool, cache cache.
 		m = settings.NewDBManager(refManager, branchLock, blockAdapter, "_lakefs", opts...)
 	}
 
-	refManager.EXPECT().GetRepository(ctx, gomock.Eq(graveler.RepositoryID("example-repo"))).AnyTimes().Return(repo, nil)
+	refManager.EXPECT().GetRepository(ctx, gomock.Eq(repository.RepositoryID)).AnyTimes().Return(repository, nil)
 	return m, blockAdapter
 }

--- a/pkg/graveler/testutil/fakes.go
+++ b/pkg/graveler/testutil/fakes.go
@@ -244,7 +244,7 @@ type RefsFake struct {
 	SealedTokens        []graveler.StagingToken
 }
 
-func (m *RefsFake) CreateBranch(_ context.Context, _ graveler.RepositoryID, _ graveler.BranchID, branch graveler.Branch) error {
+func (m *RefsFake) CreateBranch(_ context.Context, _ *graveler.RepositoryRecord, _ graveler.BranchID, branch graveler.Branch) error {
 	if m.Branch != nil {
 		return graveler.ErrBranchExists
 	}
@@ -255,7 +255,7 @@ func (m *RefsFake) CreateBranch(_ context.Context, _ graveler.RepositoryID, _ gr
 	return nil
 }
 
-func (m *RefsFake) FillGenerations(_ context.Context, _ graveler.RepositoryID) error {
+func (m *RefsFake) FillGenerations(_ context.Context, _ *graveler.RepositoryRecord) error {
 	panic("implement me")
 }
 
@@ -263,11 +263,11 @@ func (m *RefsFake) CreateBareRepository(_ context.Context, _ graveler.Repository
 	panic("implement me")
 }
 
-func (m *RefsFake) ListCommits(_ context.Context, _ graveler.RepositoryID) (graveler.CommitIterator, error) {
+func (m *RefsFake) ListCommits(_ context.Context, _ *graveler.RepositoryRecord) (graveler.CommitIterator, error) {
 	return nil, nil
 }
 
-func (m *RefsFake) GCCommitIterator(_ context.Context, _ graveler.RepositoryID) (graveler.CommitIterator, error) {
+func (m *RefsFake) GCCommitIterator(_ context.Context, _ *graveler.RepositoryRecord) (graveler.CommitIterator, error) {
 	return nil, nil
 }
 
@@ -278,7 +278,7 @@ func (m *RefsFake) ParseRef(ref graveler.Ref) (graveler.RawRef, error) {
 	}, nil
 }
 
-func (m *RefsFake) ResolveRawRef(_ context.Context, _ graveler.RepositoryID, rawRef graveler.RawRef) (*graveler.ResolvedRef, error) {
+func (m *RefsFake) ResolveRawRef(_ context.Context, _ *graveler.RepositoryRecord, rawRef graveler.RawRef) (*graveler.ResolvedRef, error) {
 	if m.Refs != nil {
 		ref := graveler.Ref(rawRef.BaseRef)
 		if res, ok := m.Refs[ref]; ok {
@@ -310,8 +310,10 @@ func (m *RefsFake) ResolveRawRef(_ context.Context, _ graveler.RepositoryID, raw
 	}, nil
 }
 
-func (m *RefsFake) GetRepository(context.Context, graveler.RepositoryID) (*graveler.Repository, error) {
-	return &graveler.Repository{}, nil
+func (m *RefsFake) GetRepository(_ context.Context, repositoryID graveler.RepositoryID) (*graveler.RepositoryRecord, error) {
+	return &graveler.RepositoryRecord{
+		RepositoryID: repositoryID,
+	}, nil
 }
 
 func (m *RefsFake) CreateRepository(context.Context, graveler.RepositoryID, graveler.Repository) error {
@@ -326,15 +328,15 @@ func (m *RefsFake) DeleteRepository(context.Context, graveler.RepositoryID) erro
 	return nil
 }
 
-func (m *RefsFake) GetBranch(context.Context, graveler.RepositoryID, graveler.BranchID) (*graveler.Branch, error) {
+func (m *RefsFake) GetBranch(context.Context, *graveler.RepositoryRecord, graveler.BranchID) (*graveler.Branch, error) {
 	return m.Branch, m.Err
 }
 
-func (m *RefsFake) SetBranch(context.Context, graveler.RepositoryID, graveler.BranchID, graveler.Branch) error {
+func (m *RefsFake) SetBranch(context.Context, *graveler.RepositoryRecord, graveler.BranchID, graveler.Branch) error {
 	return nil
 }
 
-func (m *RefsFake) BranchUpdate(_ context.Context, _ graveler.RepositoryID, _ graveler.BranchID, update graveler.BranchUpdateFunc) error {
+func (m *RefsFake) BranchUpdate(_ context.Context, _ *graveler.RepositoryRecord, _ graveler.BranchID, update graveler.BranchUpdateFunc) error {
 	_, err := update(m.Branch)
 	if m.UpdateErr != nil {
 		return m.UpdateErr
@@ -342,35 +344,35 @@ func (m *RefsFake) BranchUpdate(_ context.Context, _ graveler.RepositoryID, _ gr
 	return err
 }
 
-func (m *RefsFake) DeleteBranch(context.Context, graveler.RepositoryID, graveler.BranchID) error {
+func (m *RefsFake) DeleteBranch(context.Context, *graveler.RepositoryRecord, graveler.BranchID) error {
 	return nil
 }
 
-func (m *RefsFake) ListBranches(context.Context, graveler.RepositoryID) (graveler.BranchIterator, error) {
+func (m *RefsFake) ListBranches(context.Context, *graveler.RepositoryRecord) (graveler.BranchIterator, error) {
 	return m.ListBranchesRes, nil
 }
 
-func (m *RefsFake) GCBranchIterator(context.Context, graveler.RepositoryID) (graveler.BranchIterator, error) {
+func (m *RefsFake) GCBranchIterator(context.Context, *graveler.RepositoryRecord) (graveler.BranchIterator, error) {
 	return m.ListBranchesRes, nil
 }
 
-func (m *RefsFake) GetTag(context.Context, graveler.RepositoryID, graveler.TagID) (*graveler.CommitID, error) {
+func (m *RefsFake) GetTag(context.Context, *graveler.RepositoryRecord, graveler.TagID) (*graveler.CommitID, error) {
 	return m.TagCommitID, m.Err
 }
 
-func (m *RefsFake) CreateTag(context.Context, graveler.RepositoryID, graveler.TagID, graveler.CommitID) error {
+func (m *RefsFake) CreateTag(context.Context, *graveler.RepositoryRecord, graveler.TagID, graveler.CommitID) error {
 	return nil
 }
 
-func (m *RefsFake) DeleteTag(context.Context, graveler.RepositoryID, graveler.TagID) error {
+func (m *RefsFake) DeleteTag(context.Context, *graveler.RepositoryRecord, graveler.TagID) error {
 	return nil
 }
 
-func (m *RefsFake) ListTags(context.Context, graveler.RepositoryID) (graveler.TagIterator, error) {
+func (m *RefsFake) ListTags(context.Context, *graveler.RepositoryRecord) (graveler.TagIterator, error) {
 	return m.ListTagsRes, nil
 }
 
-func (m *RefsFake) GetCommit(_ context.Context, _ graveler.RepositoryID, id graveler.CommitID) (*graveler.Commit, error) {
+func (m *RefsFake) GetCommit(_ context.Context, _ *graveler.RepositoryRecord, id graveler.CommitID) (*graveler.Commit, error) {
 	if val, ok := m.Commits[id]; ok {
 		return val, nil
 	}
@@ -378,11 +380,11 @@ func (m *RefsFake) GetCommit(_ context.Context, _ graveler.RepositoryID, id grav
 	return nil, graveler.ErrCommitNotFound
 }
 
-func (m *RefsFake) GetCommitByPrefix(_ context.Context, _ graveler.RepositoryID, _ graveler.CommitID) (*graveler.Commit, error) {
+func (m *RefsFake) GetCommitByPrefix(_ context.Context, _ *graveler.RepositoryRecord, _ graveler.CommitID) (*graveler.Commit, error) {
 	return &graveler.Commit{}, nil
 }
 
-func (m *RefsFake) AddCommit(_ context.Context, _ graveler.RepositoryID, commit graveler.Commit) (graveler.CommitID, error) {
+func (m *RefsFake) AddCommit(_ context.Context, _ *graveler.RepositoryRecord, commit graveler.Commit) (graveler.CommitID, error) {
 	if m.CommitErr != nil {
 		return "", m.CommitErr
 	}
@@ -396,16 +398,16 @@ func (m *RefsFake) AddCommit(_ context.Context, _ graveler.RepositoryID, commit 
 	return m.CommitID, nil
 }
 
-func (m *RefsFake) RemoveCommit(_ context.Context, _ graveler.RepositoryID, commitID graveler.CommitID) error {
+func (m *RefsFake) RemoveCommit(_ context.Context, _ *graveler.RepositoryRecord, commitID graveler.CommitID) error {
 	delete(m.Commits, commitID)
 	return nil
 }
 
-func (m *RefsFake) FindMergeBase(context.Context, graveler.RepositoryID, ...graveler.CommitID) (*graveler.Commit, error) {
+func (m *RefsFake) FindMergeBase(context.Context, *graveler.RepositoryRecord, ...graveler.CommitID) (*graveler.Commit, error) {
 	return &graveler.Commit{}, nil
 }
 
-func (m *RefsFake) Log(context.Context, graveler.RepositoryID, graveler.CommitID) (graveler.CommitIterator, error) {
+func (m *RefsFake) Log(context.Context, *graveler.RepositoryRecord, graveler.CommitID) (graveler.CommitIterator, error) {
 	return m.CommitIter, nil
 }
 
@@ -833,7 +835,7 @@ func NewProtectedBranchesManagerFake(protectedBranches ...string) *ProtectedBran
 	return &ProtectedBranchesManagerFake{protectedBranches: protectedBranches}
 }
 
-func (p ProtectedBranchesManagerFake) IsBlocked(_ context.Context, _ graveler.RepositoryID, branchID graveler.BranchID, _ graveler.BranchProtectionBlockedAction) (bool, error) {
+func (p ProtectedBranchesManagerFake) IsBlocked(_ context.Context, _ *graveler.RepositoryRecord, branchID graveler.BranchID, _ graveler.BranchProtectionBlockedAction) (bool, error) {
 	for _, branch := range p.protectedBranches {
 		if branch == string(branchID) {
 			return true, nil

--- a/pkg/graveler/testutil/fakes.go
+++ b/pkg/graveler/testutil/fakes.go
@@ -259,7 +259,7 @@ func (m *RefsFake) FillGenerations(_ context.Context, _ *graveler.RepositoryReco
 	panic("implement me")
 }
 
-func (m *RefsFake) CreateBareRepository(_ context.Context, _ graveler.RepositoryID, _ graveler.Repository) error {
+func (m *RefsFake) CreateBareRepository(_ context.Context, _ graveler.RepositoryID, _ graveler.Repository) (*graveler.RepositoryRecord, error) {
 	panic("implement me")
 }
 
@@ -316,8 +316,11 @@ func (m *RefsFake) GetRepository(_ context.Context, repositoryID graveler.Reposi
 	}, nil
 }
 
-func (m *RefsFake) CreateRepository(context.Context, graveler.RepositoryID, graveler.Repository) error {
-	return nil
+func (m *RefsFake) CreateRepository(ctx context.Context, repositoryID graveler.RepositoryID, repository graveler.Repository) (*graveler.RepositoryRecord, error) {
+	return &graveler.RepositoryRecord{
+		RepositoryID: repositoryID,
+		Repository:   &repository,
+	}, nil
 }
 
 func (m *RefsFake) ListRepositories(context.Context) (graveler.RepositoryIterator, error) {

--- a/pkg/graveler/validate.go
+++ b/pkg/graveler/validate.go
@@ -101,15 +101,19 @@ func ValidateCommitID(v interface{}) error {
 }
 
 func ValidateRepositoryID(v interface{}) error {
-	s, ok := v.(RepositoryID)
-	if !ok {
+	var repositoryID string
+	switch s := v.(type) {
+	case string:
+		repositoryID = s
+	case RepositoryID:
+		repositoryID = s.String()
+	default:
 		panic(ErrInvalidType)
 	}
-
-	if len(s) == 0 {
+	if len(repositoryID) == 0 {
 		return ErrRequiredValue
 	}
-	if !validator.ReValidRepositoryID.MatchString(s.String()) {
+	if !validator.ReValidRepositoryID.MatchString(repositoryID) {
 		return ErrInvalidRepositoryID
 	}
 	return nil

--- a/pkg/onboard/catalog_actions.go
+++ b/pkg/onboard/catalog_actions.go
@@ -109,33 +109,27 @@ func (c *CatalogRepoActions) ApplyImport(ctx context.Context, it Iterator, _ boo
 }
 
 func (c *CatalogRepoActions) Init(ctx context.Context, baseCommit graveler.CommitID) error {
-	if baseCommit == "" {
-		return c.initBranch(ctx)
-	}
 	repository, err := c.entryCatalog.GetRepository(ctx, c.repositoryID)
 	if err != nil {
 		return err
 	}
 	c.repository = repository
-
 	c.previousCommitID = baseCommit
+	if baseCommit == "" {
+		return c.initBranch(ctx)
+	}
 	return nil
 }
 
 func (c *CatalogRepoActions) initBranch(ctx context.Context) error {
-	repository, err := c.entryCatalog.GetRepository(ctx, c.repositoryID)
-	if err != nil {
-		return err
-	}
-
 	c.branchID = DefaultImportBranchName
-	branch, err := c.entryCatalog.GetBranch(ctx, repository, DefaultImportBranchName)
+	branch, err := c.entryCatalog.GetBranch(ctx, c.repository, DefaultImportBranchName)
 	if err != nil {
 		if !errors.Is(err, graveler.ErrBranchNotFound) {
 			return err
 		}
 		// first import, let's create the branch
-		branch, err = c.entryCatalog.CreateBranch(ctx, repository, DefaultImportBranchName, graveler.Ref(c.defaultBranchID))
+		branch, err = c.entryCatalog.CreateBranch(ctx, c.repository, DefaultImportBranchName, graveler.Ref(c.defaultBranchID))
 		if err != nil {
 			return fmt.Errorf("creating default branch %s: %w", DefaultImportBranchName, err)
 		}

--- a/pkg/onboard/catalog_actions.go
+++ b/pkg/onboard/catalog_actions.go
@@ -25,7 +25,8 @@ type CatalogRepoActions struct {
 	committer string
 
 	defaultBranchID graveler.BranchID
-	repoID          graveler.RepositoryID
+	repositoryID    graveler.RepositoryID
+	repository      *graveler.RepositoryRecord
 	logger          logging.Logger
 	entryCatalog    EntryCatalog
 	prefixes        []string
@@ -44,20 +45,21 @@ func (c *CatalogRepoActions) Progress() []*cmdutils.Progress {
 
 // EntryCatalog is a facet for a catalog.Store
 type EntryCatalog interface {
-	WriteMetaRangeByIterator(ctx context.Context, repositoryID graveler.RepositoryID, it graveler.ValueIterator) (*graveler.MetaRangeID, error)
-	AddCommitToBranchHead(ctx context.Context, repositoryID graveler.RepositoryID, branchID graveler.BranchID, commit graveler.Commit) (graveler.CommitID, error)
-	List(ctx context.Context, repositoryID graveler.RepositoryID, ref graveler.Ref) (graveler.ValueIterator, error)
-	AddCommit(ctx context.Context, repositoryID graveler.RepositoryID, commit graveler.Commit) (graveler.CommitID, error)
-	UpdateBranch(ctx context.Context, repositoryID graveler.RepositoryID, branchID graveler.BranchID, ref graveler.Ref) (*graveler.Branch, error)
-	GetBranch(ctx context.Context, repositoryID graveler.RepositoryID, branchID graveler.BranchID) (*graveler.Branch, error)
-	CreateBranch(ctx context.Context, repositoryID graveler.RepositoryID, branchID graveler.BranchID, ref graveler.Ref) (*graveler.Branch, error)
-	GetCommit(ctx context.Context, repositoryID graveler.RepositoryID, commitID graveler.CommitID) (*graveler.Commit, error)
+	GetRepository(ctx context.Context, repositoryID graveler.RepositoryID) (*graveler.RepositoryRecord, error)
+	WriteMetaRangeByIterator(ctx context.Context, repository *graveler.RepositoryRecord, it graveler.ValueIterator) (*graveler.MetaRangeID, error)
+	AddCommitToBranchHead(ctx context.Context, repository *graveler.RepositoryRecord, branchID graveler.BranchID, commit graveler.Commit) (graveler.CommitID, error)
+	List(ctx context.Context, repository *graveler.RepositoryRecord, ref graveler.Ref) (graveler.ValueIterator, error)
+	AddCommit(ctx context.Context, repository *graveler.RepositoryRecord, commit graveler.Commit) (graveler.CommitID, error)
+	UpdateBranch(ctx context.Context, repository *graveler.RepositoryRecord, branchID graveler.BranchID, ref graveler.Ref) (*graveler.Branch, error)
+	GetBranch(ctx context.Context, repository *graveler.RepositoryRecord, branchID graveler.BranchID) (*graveler.Branch, error)
+	CreateBranch(ctx context.Context, repository *graveler.RepositoryRecord, branchID graveler.BranchID, ref graveler.Ref) (*graveler.Branch, error)
+	GetCommit(ctx context.Context, repository *graveler.RepositoryRecord, commitID graveler.CommitID) (*graveler.Commit, error)
 }
 
 func NewCatalogRepoActions(config *Config, logger logging.Logger) *CatalogRepoActions {
 	return &CatalogRepoActions{
 		entryCatalog:    config.Store,
-		repoID:          config.RepositoryID,
+		repositoryID:    config.RepositoryID,
 		defaultBranchID: config.DefaultBranchID,
 		committer:       config.CommitUsername,
 		logger:          logger,
@@ -86,15 +88,14 @@ func (c *CatalogRepoActions) ApplyImport(ctx context.Context, it Iterator, _ boo
 	if importBase == "" {
 		importBase = graveler.Ref(c.previousCommitID)
 	}
-
-	listIt, err := c.entryCatalog.List(ctx, c.repoID, importBase)
+	listIt, err := c.entryCatalog.List(ctx, c.repository, importBase)
 	if err != nil {
 		return nil, fmt.Errorf("listing commit: %w", err)
 	}
 	defer listIt.Close()
 
 	listingIterator := catalog.NewEntryListingIterator(catalog.NewValueToEntryIterator(listIt), "", "")
-	c.createdMetaRangeID, err = c.entryCatalog.WriteMetaRangeByIterator(ctx, c.repoID,
+	c.createdMetaRangeID, err = c.entryCatalog.WriteMetaRangeByIterator(ctx, c.repository,
 		catalog.NewEntryToValueIterator(newPrefixMergeIterator(
 			NewValueToEntryIterator(invIt, c.progress), listingIterator, c.prefixes)))
 	if err != nil {
@@ -111,20 +112,30 @@ func (c *CatalogRepoActions) Init(ctx context.Context, baseCommit graveler.Commi
 	if baseCommit == "" {
 		return c.initBranch(ctx)
 	}
+	repository, err := c.entryCatalog.GetRepository(ctx, c.repositoryID)
+	if err != nil {
+		return err
+	}
+	c.repository = repository
 
 	c.previousCommitID = baseCommit
 	return nil
 }
 
 func (c *CatalogRepoActions) initBranch(ctx context.Context) error {
+	repository, err := c.entryCatalog.GetRepository(ctx, c.repositoryID)
+	if err != nil {
+		return err
+	}
+
 	c.branchID = DefaultImportBranchName
-	branch, err := c.entryCatalog.GetBranch(ctx, c.repoID, DefaultImportBranchName)
+	branch, err := c.entryCatalog.GetBranch(ctx, repository, DefaultImportBranchName)
 	if err != nil {
 		if !errors.Is(err, graveler.ErrBranchNotFound) {
 			return err
 		}
 		// first import, let's create the branch
-		branch, err = c.entryCatalog.CreateBranch(ctx, c.repoID, DefaultImportBranchName, graveler.Ref(c.defaultBranchID))
+		branch, err = c.entryCatalog.CreateBranch(ctx, repository, DefaultImportBranchName, graveler.Ref(c.defaultBranchID))
 		if err != nil {
 			return fmt.Errorf("creating default branch %s: %w", DefaultImportBranchName, err)
 		}
@@ -151,7 +162,7 @@ func (c *CatalogRepoActions) Commit(ctx context.Context, commitMsg string, metad
 	commit.MetaRangeID = *c.createdMetaRangeID
 	commit.Metadata = graveler.Metadata(metadata)
 	if c.previousCommitID != "" {
-		previousCommit, err := c.entryCatalog.GetCommit(ctx, c.repoID, c.previousCommitID)
+		previousCommit, err := c.entryCatalog.GetCommit(ctx, c.repository, c.previousCommitID)
 		if err != nil {
 			return "", fmt.Errorf("getting previous commit %s: %w", c.previousCommitID, err)
 		}
@@ -161,12 +172,12 @@ func (c *CatalogRepoActions) Commit(ctx context.Context, commitMsg string, metad
 	var commitID graveler.CommitID
 	var err error
 	if c.branchID != "" {
-		commitID, err = c.entryCatalog.AddCommitToBranchHead(ctx, c.repoID, c.branchID, commit)
+		commitID, err = c.entryCatalog.AddCommitToBranchHead(ctx, c.repository, c.branchID, commit)
 		if err != nil {
 			return "", fmt.Errorf("creating commit from existing metarange %s: %w", *c.createdMetaRangeID, err)
 		}
 	} else {
-		commitID, err = c.entryCatalog.AddCommit(ctx, c.repoID, commit)
+		commitID, err = c.entryCatalog.AddCommit(ctx, c.repository, commit)
 		if err != nil {
 			return "", fmt.Errorf("adding commit %s: %w", *c.createdMetaRangeID, err)
 		}


### PR DESCRIPTION
- Passing repository information instead of repository ID
- Use LRU cache while cache traverse
- Remove transaction for get repository and get commit
- Disable batch executer on list commits flow

Closes #3889
