### PR TITLE
log commits with optional limit

### DIFF
--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -2240,7 +2240,7 @@ paths:
               type: string
         - in: query
           name: limit
-      - description: limit the number of items in return to 'amount'. Without further indication on actual number of items.
+          description: limit the number of items in return to 'amount'. Without further indication on actual number of items.
           schema:
             type: boolean
       responses:

--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -2240,7 +2240,7 @@ paths:
               type: string
         - in: query
           name: limit
-          description: limit the number of items in return to amount. no more indication to search if number of items reach the mount.
+      - description: limit the number of items in return to 'amount'. Without further indication on actual number of items.
           schema:
             type: boolean
       responses:

--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -2238,6 +2238,11 @@ paths:
             type: array
             items:
               type: string
+        - in: query
+          name: limit
+          description: limit the number of items in return to amount. no more indication to search if number of items reach the mount.
+          schema:
+            type: boolean
       responses:
         200:
           description: commit log

--- a/clients/java/api/openapi.yaml
+++ b/clients/java/api/openapi.yaml
@@ -2168,8 +2168,8 @@ paths:
             type: string
           type: array
         style: form
-      - description: limit the number of items in return to amount. no more indication
-          to search if number of items reach the mount.
+      - description: limit the number of items in return to 'amount'. Without further
+          indication on actual number of items.
         explode: true
         in: query
         name: limit

--- a/clients/java/api/openapi.yaml
+++ b/clients/java/api/openapi.yaml
@@ -2168,6 +2168,15 @@ paths:
             type: string
           type: array
         style: form
+      - description: limit the number of items in return to amount. no more indication
+          to search if number of items reach the mount.
+        explode: true
+        in: query
+        name: limit
+        required: false
+        schema:
+          type: boolean
+        style: form
       responses:
         "200":
           content:

--- a/clients/java/docs/RefsApi.md
+++ b/clients/java/docs/RefsApi.md
@@ -200,7 +200,7 @@ Name | Type | Description  | Notes
 
 <a name="logCommits"></a>
 # **logCommits**
-> CommitList logCommits(repository, ref, after, amount, objects, prefixes)
+> CommitList logCommits(repository, ref, after, amount, objects, prefixes, limit)
 
 get commit log from ref. If both objects and prefixes are empty, return all commits.
 
@@ -247,8 +247,9 @@ public class Example {
     Integer amount = 100; // Integer | how many items to return
     List<String> objects = Arrays.asList(); // List<String> | list of paths, each element is a path of a specific object
     List<String> prefixes = Arrays.asList(); // List<String> | list of paths, each element is a path of a prefix
+    Boolean limit = true; // Boolean | limit the number of items in return to amount. no more indication to search if number of items reach the mount.
     try {
-      CommitList result = apiInstance.logCommits(repository, ref, after, amount, objects, prefixes);
+      CommitList result = apiInstance.logCommits(repository, ref, after, amount, objects, prefixes, limit);
       System.out.println(result);
     } catch (ApiException e) {
       System.err.println("Exception when calling RefsApi#logCommits");
@@ -271,6 +272,7 @@ Name | Type | Description  | Notes
  **amount** | **Integer**| how many items to return | [optional] [default to 100]
  **objects** | [**List&lt;String&gt;**](String.md)| list of paths, each element is a path of a specific object | [optional]
  **prefixes** | [**List&lt;String&gt;**](String.md)| list of paths, each element is a path of a prefix | [optional]
+ **limit** | **Boolean**| limit the number of items in return to amount. no more indication to search if number of items reach the mount. | [optional]
 
 ### Return type
 

--- a/clients/java/docs/RefsApi.md
+++ b/clients/java/docs/RefsApi.md
@@ -247,7 +247,7 @@ public class Example {
     Integer amount = 100; // Integer | how many items to return
     List<String> objects = Arrays.asList(); // List<String> | list of paths, each element is a path of a specific object
     List<String> prefixes = Arrays.asList(); // List<String> | list of paths, each element is a path of a prefix
-    Boolean limit = true; // Boolean | limit the number of items in return to amount. no more indication to search if number of items reach the mount.
+    Boolean limit = true; // Boolean | limit the number of items in return to 'amount'. Without further indication on actual number of items.
     try {
       CommitList result = apiInstance.logCommits(repository, ref, after, amount, objects, prefixes, limit);
       System.out.println(result);
@@ -272,7 +272,7 @@ Name | Type | Description  | Notes
  **amount** | **Integer**| how many items to return | [optional] [default to 100]
  **objects** | [**List&lt;String&gt;**](String.md)| list of paths, each element is a path of a specific object | [optional]
  **prefixes** | [**List&lt;String&gt;**](String.md)| list of paths, each element is a path of a prefix | [optional]
- **limit** | **Boolean**| limit the number of items in return to amount. no more indication to search if number of items reach the mount. | [optional]
+ **limit** | **Boolean**| limit the number of items in return to &#39;amount&#39;. Without further indication on actual number of items. | [optional]
 
 ### Return type
 

--- a/clients/java/src/main/java/io/lakefs/clients/api/RefsApi.java
+++ b/clients/java/src/main/java/io/lakefs/clients/api/RefsApi.java
@@ -387,7 +387,7 @@ public class RefsApi {
      * @param amount how many items to return (optional, default to 100)
      * @param objects list of paths, each element is a path of a specific object (optional)
      * @param prefixes list of paths, each element is a path of a prefix (optional)
-     * @param limit limit the number of items in return to amount. no more indication to search if number of items reach the mount. (optional)
+     * @param limit limit the number of items in return to &#39;amount&#39;. Without further indication on actual number of items. (optional)
      * @param _callback Callback for upload/download progress
      * @return Call to execute
      * @throws ApiException If fail to serialize the request body object
@@ -480,7 +480,7 @@ public class RefsApi {
      * @param amount how many items to return (optional, default to 100)
      * @param objects list of paths, each element is a path of a specific object (optional)
      * @param prefixes list of paths, each element is a path of a prefix (optional)
-     * @param limit limit the number of items in return to amount. no more indication to search if number of items reach the mount. (optional)
+     * @param limit limit the number of items in return to &#39;amount&#39;. Without further indication on actual number of items. (optional)
      * @return CommitList
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -506,7 +506,7 @@ public class RefsApi {
      * @param amount how many items to return (optional, default to 100)
      * @param objects list of paths, each element is a path of a specific object (optional)
      * @param prefixes list of paths, each element is a path of a prefix (optional)
-     * @param limit limit the number of items in return to amount. no more indication to search if number of items reach the mount. (optional)
+     * @param limit limit the number of items in return to &#39;amount&#39;. Without further indication on actual number of items. (optional)
      * @return ApiResponse&lt;CommitList&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -533,7 +533,7 @@ public class RefsApi {
      * @param amount how many items to return (optional, default to 100)
      * @param objects list of paths, each element is a path of a specific object (optional)
      * @param prefixes list of paths, each element is a path of a prefix (optional)
-     * @param limit limit the number of items in return to amount. no more indication to search if number of items reach the mount. (optional)
+     * @param limit limit the number of items in return to &#39;amount&#39;. Without further indication on actual number of items. (optional)
      * @param _callback The callback to be executed when the API call finishes
      * @return The request call
      * @throws ApiException If fail to process the API call, e.g. serializing the request body object

--- a/clients/java/src/main/java/io/lakefs/clients/api/RefsApi.java
+++ b/clients/java/src/main/java/io/lakefs/clients/api/RefsApi.java
@@ -387,6 +387,7 @@ public class RefsApi {
      * @param amount how many items to return (optional, default to 100)
      * @param objects list of paths, each element is a path of a specific object (optional)
      * @param prefixes list of paths, each element is a path of a prefix (optional)
+     * @param limit limit the number of items in return to amount. no more indication to search if number of items reach the mount. (optional)
      * @param _callback Callback for upload/download progress
      * @return Call to execute
      * @throws ApiException If fail to serialize the request body object
@@ -399,7 +400,7 @@ public class RefsApi {
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call logCommitsCall(String repository, String ref, String after, Integer amount, List<String> objects, List<String> prefixes, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call logCommitsCall(String repository, String ref, String after, Integer amount, List<String> objects, List<String> prefixes, Boolean limit, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -429,6 +430,10 @@ public class RefsApi {
             localVarCollectionQueryParams.addAll(localVarApiClient.parameterToPairs("multi", "prefixes", prefixes));
         }
 
+        if (limit != null) {
+            localVarQueryParams.addAll(localVarApiClient.parameterToPair("limit", limit));
+        }
+
         final String[] localVarAccepts = {
             "application/json"
         };
@@ -448,7 +453,7 @@ public class RefsApi {
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call logCommitsValidateBeforeCall(String repository, String ref, String after, Integer amount, List<String> objects, List<String> prefixes, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call logCommitsValidateBeforeCall(String repository, String ref, String after, Integer amount, List<String> objects, List<String> prefixes, Boolean limit, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'repository' is set
         if (repository == null) {
@@ -461,7 +466,7 @@ public class RefsApi {
         }
         
 
-        okhttp3.Call localVarCall = logCommitsCall(repository, ref, after, amount, objects, prefixes, _callback);
+        okhttp3.Call localVarCall = logCommitsCall(repository, ref, after, amount, objects, prefixes, limit, _callback);
         return localVarCall;
 
     }
@@ -475,6 +480,7 @@ public class RefsApi {
      * @param amount how many items to return (optional, default to 100)
      * @param objects list of paths, each element is a path of a specific object (optional)
      * @param prefixes list of paths, each element is a path of a prefix (optional)
+     * @param limit limit the number of items in return to amount. no more indication to search if number of items reach the mount. (optional)
      * @return CommitList
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -486,8 +492,8 @@ public class RefsApi {
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
      */
-    public CommitList logCommits(String repository, String ref, String after, Integer amount, List<String> objects, List<String> prefixes) throws ApiException {
-        ApiResponse<CommitList> localVarResp = logCommitsWithHttpInfo(repository, ref, after, amount, objects, prefixes);
+    public CommitList logCommits(String repository, String ref, String after, Integer amount, List<String> objects, List<String> prefixes, Boolean limit) throws ApiException {
+        ApiResponse<CommitList> localVarResp = logCommitsWithHttpInfo(repository, ref, after, amount, objects, prefixes, limit);
         return localVarResp.getData();
     }
 
@@ -500,6 +506,7 @@ public class RefsApi {
      * @param amount how many items to return (optional, default to 100)
      * @param objects list of paths, each element is a path of a specific object (optional)
      * @param prefixes list of paths, each element is a path of a prefix (optional)
+     * @param limit limit the number of items in return to amount. no more indication to search if number of items reach the mount. (optional)
      * @return ApiResponse&lt;CommitList&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -511,8 +518,8 @@ public class RefsApi {
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<CommitList> logCommitsWithHttpInfo(String repository, String ref, String after, Integer amount, List<String> objects, List<String> prefixes) throws ApiException {
-        okhttp3.Call localVarCall = logCommitsValidateBeforeCall(repository, ref, after, amount, objects, prefixes, null);
+    public ApiResponse<CommitList> logCommitsWithHttpInfo(String repository, String ref, String after, Integer amount, List<String> objects, List<String> prefixes, Boolean limit) throws ApiException {
+        okhttp3.Call localVarCall = logCommitsValidateBeforeCall(repository, ref, after, amount, objects, prefixes, limit, null);
         Type localVarReturnType = new TypeToken<CommitList>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
@@ -526,6 +533,7 @@ public class RefsApi {
      * @param amount how many items to return (optional, default to 100)
      * @param objects list of paths, each element is a path of a specific object (optional)
      * @param prefixes list of paths, each element is a path of a prefix (optional)
+     * @param limit limit the number of items in return to amount. no more indication to search if number of items reach the mount. (optional)
      * @param _callback The callback to be executed when the API call finishes
      * @return The request call
      * @throws ApiException If fail to process the API call, e.g. serializing the request body object
@@ -538,9 +546,9 @@ public class RefsApi {
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call logCommitsAsync(String repository, String ref, String after, Integer amount, List<String> objects, List<String> prefixes, final ApiCallback<CommitList> _callback) throws ApiException {
+    public okhttp3.Call logCommitsAsync(String repository, String ref, String after, Integer amount, List<String> objects, List<String> prefixes, Boolean limit, final ApiCallback<CommitList> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = logCommitsValidateBeforeCall(repository, ref, after, amount, objects, prefixes, _callback);
+        okhttp3.Call localVarCall = logCommitsValidateBeforeCall(repository, ref, after, amount, objects, prefixes, limit, _callback);
         Type localVarReturnType = new TypeToken<CommitList>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;

--- a/clients/java/src/test/java/io/lakefs/clients/api/RefsApiTest.java
+++ b/clients/java/src/test/java/io/lakefs/clients/api/RefsApiTest.java
@@ -91,7 +91,8 @@ public class RefsApiTest {
         Integer amount = null;
         List<String> objects = null;
         List<String> prefixes = null;
-                CommitList response = api.logCommits(repository, ref, after, amount, objects, prefixes);
+        Boolean limit = null;
+                CommitList response = api.logCommits(repository, ref, after, amount, objects, prefixes, limit);
         // TODO: test validations
     }
     

--- a/clients/python/docs/RefsApi.md
+++ b/clients/python/docs/RefsApi.md
@@ -304,7 +304,7 @@ with lakefs_client.ApiClient(configuration) as api_client:
     prefixes = [
         "prefixes_example",
     ] # [str] | list of paths, each element is a path of a prefix (optional)
-    limit = True # bool | limit the number of items in return to amount. no more indication to search if number of items reach the mount. (optional)
+    limit = True # bool | limit the number of items in return to 'amount'. Without further indication on actual number of items. (optional)
 
     # example passing only required values which don't have defaults set
     try:
@@ -335,7 +335,7 @@ Name | Type | Description  | Notes
  **amount** | **int**| how many items to return | [optional] if omitted the server will use the default value of 100
  **objects** | **[str]**| list of paths, each element is a path of a specific object | [optional]
  **prefixes** | **[str]**| list of paths, each element is a path of a prefix | [optional]
- **limit** | **bool**| limit the number of items in return to amount. no more indication to search if number of items reach the mount. | [optional]
+ **limit** | **bool**| limit the number of items in return to &#39;amount&#39;. Without further indication on actual number of items. | [optional]
 
 ### Return type
 

--- a/clients/python/docs/RefsApi.md
+++ b/clients/python/docs/RefsApi.md
@@ -304,6 +304,7 @@ with lakefs_client.ApiClient(configuration) as api_client:
     prefixes = [
         "prefixes_example",
     ] # [str] | list of paths, each element is a path of a prefix (optional)
+    limit = True # bool | limit the number of items in return to amount. no more indication to search if number of items reach the mount. (optional)
 
     # example passing only required values which don't have defaults set
     try:
@@ -317,7 +318,7 @@ with lakefs_client.ApiClient(configuration) as api_client:
     # and optional values
     try:
         # get commit log from ref. If both objects and prefixes are empty, return all commits.
-        api_response = api_instance.log_commits(repository, ref, after=after, amount=amount, objects=objects, prefixes=prefixes)
+        api_response = api_instance.log_commits(repository, ref, after=after, amount=amount, objects=objects, prefixes=prefixes, limit=limit)
         pprint(api_response)
     except lakefs_client.ApiException as e:
         print("Exception when calling RefsApi->log_commits: %s\n" % e)
@@ -334,6 +335,7 @@ Name | Type | Description  | Notes
  **amount** | **int**| how many items to return | [optional] if omitted the server will use the default value of 100
  **objects** | **[str]**| list of paths, each element is a path of a specific object | [optional]
  **prefixes** | **[str]**| list of paths, each element is a path of a prefix | [optional]
+ **limit** | **bool**| limit the number of items in return to amount. no more indication to search if number of items reach the mount. | [optional]
 
 ### Return type
 

--- a/clients/python/lakefs_client/api/refs_api.py
+++ b/clients/python/lakefs_client/api/refs_api.py
@@ -597,7 +597,7 @@ class RefsApi(object):
             amount (int): how many items to return. [optional] if omitted the server will use the default value of 100
             objects ([str]): list of paths, each element is a path of a specific object. [optional]
             prefixes ([str]): list of paths, each element is a path of a prefix. [optional]
-            limit (bool): limit the number of items in return to amount. no more indication to search if number of items reach the mount.. [optional]
+            limit (bool): limit the number of items in return to 'amount'. Without further indication on actual number of items.. [optional]
             _return_http_data_only (bool): response data without head status
                 code and headers. Default is True.
             _preload_content (bool): if False, the urllib3.HTTPResponse object

--- a/clients/python/lakefs_client/api/refs_api.py
+++ b/clients/python/lakefs_client/api/refs_api.py
@@ -225,6 +225,7 @@ class RefsApi(object):
                     'amount',
                     'objects',
                     'prefixes',
+                    'limit',
                 ],
                 'required': [
                     'repository',
@@ -261,6 +262,8 @@ class RefsApi(object):
                         ([str],),
                     'prefixes':
                         ([str],),
+                    'limit':
+                        (bool,),
                 },
                 'attribute_map': {
                     'repository': 'repository',
@@ -269,6 +272,7 @@ class RefsApi(object):
                     'amount': 'amount',
                     'objects': 'objects',
                     'prefixes': 'prefixes',
+                    'limit': 'limit',
                 },
                 'location_map': {
                     'repository': 'path',
@@ -277,6 +281,7 @@ class RefsApi(object):
                     'amount': 'query',
                     'objects': 'query',
                     'prefixes': 'query',
+                    'limit': 'query',
                 },
                 'collection_format_map': {
                     'objects': 'multi',
@@ -592,6 +597,7 @@ class RefsApi(object):
             amount (int): how many items to return. [optional] if omitted the server will use the default value of 100
             objects ([str]): list of paths, each element is a path of a specific object. [optional]
             prefixes ([str]): list of paths, each element is a path of a prefix. [optional]
+            limit (bool): limit the number of items in return to amount. no more indication to search if number of items reach the mount.. [optional]
             _return_http_data_only (bool): response data without head status
                 code and headers. Default is True.
             _preload_content (bool): if False, the urllib3.HTTPResponse object

--- a/cmd/lakectl/cmd/log.go
+++ b/cmd/lakectl/cmd/log.go
@@ -33,6 +33,7 @@ var logCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		amount := MustInt(cmd.Flags().GetInt("amount"))
 		after := MustString(cmd.Flags().GetString("after"))
+		limit := MustBool(cmd.Flags().GetBool("limit"))
 		objectsList := MustSliceNonEmptyString("objects", MustStringSlice(cmd.Flags().GetStringSlice("objects")))
 		prefixesList := MustSliceNonEmptyString("prefixes", MustStringSlice(cmd.Flags().GetStringSlice("prefixes")))
 
@@ -47,6 +48,7 @@ var logCmd = &cobra.Command{
 		logCommitsParams := &api.LogCommitsParams{
 			After:  api.PaginationAfterPtr(after),
 			Amount: api.PaginationAmountPtr(amountForPagination),
+			Limit:  &limit,
 		}
 		if len(objectsList) > 0 {
 			logCommitsParams.Objects = &objectsList
@@ -85,6 +87,7 @@ var logCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(logCmd)
 	logCmd.Flags().Int("amount", 0, "number of results to return. By default, all results are returned")
+	logCmd.Flags().Bool("limit", false, "limit result just to amount. By default false get has more indication")
 	logCmd.Flags().String("after", "", "show results after this value (used for pagination)")
 	logCmd.Flags().Bool("show-meta-range-id", false, "also show meta range ID")
 	logCmd.Flags().StringSlice("objects", nil, "show results that contains changes to at least one path in that list of objects. Use comma separator to pass all objects together")

--- a/cmd/lakectl/cmd/log.go
+++ b/cmd/lakectl/cmd/log.go
@@ -87,7 +87,7 @@ var logCmd = &cobra.Command{
 func init() {
 	rootCmd.AddCommand(logCmd)
 	logCmd.Flags().Int("amount", 0, "number of results to return. By default, all results are returned")
-	logCmd.Flags().Bool("limit", false, "limit result just to amount. By default false get has more indication")
+	logCmd.Flags().Bool("limit", false, "limit result just to amount. By default, returns whether more items are available.")
 	logCmd.Flags().String("after", "", "show results after this value (used for pagination)")
 	logCmd.Flags().Bool("show-meta-range-id", false, "also show meta range ID")
 	logCmd.Flags().StringSlice("objects", nil, "show results that contains changes to at least one path in that list of objects. Use comma separator to pass all objects together")

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -2168,7 +2168,7 @@ lakectl log <branch uri> [flags]
       --after string         show results after this value (used for pagination)
       --amount int           number of results to return. By default, all results are returned
   -h, --help                 help for log
-      --limit                limit result just to amount. By default false get has more indication
+      --limit                limit result just to amount. By default, returns whether more items are available.
       --objects strings      show results that contains changes to at least one path in that list of objects. Use comma separator to pass all objects together
       --prefixes strings     show results that contains changes to at least one path in that list of prefixes. Use comma separator to pass all prefixes together
       --show-meta-range-id   also show meta range ID

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -2168,6 +2168,7 @@ lakectl log <branch uri> [flags]
       --after string         show results after this value (used for pagination)
       --amount int           number of results to return. By default, all results are returned
   -h, --help                 help for log
+      --limit                limit result just to amount. By default false get has more indication
       --objects strings      show results that contains changes to at least one path in that list of objects. Use comma separator to pass all objects together
       --prefixes strings     show results that contains changes to at least one path in that list of prefixes. Use comma separator to pass all prefixes together
       --show-meta-range-id   also show meta range ID

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -2526,7 +2526,7 @@ func (c *Controller) RestoreRefs(w http.ResponseWriter, r *http.Request, body Re
 	_, _, err = c.Catalog.ListCommits(ctx, repo.Name, repo.DefaultBranch, catalog.LogParams{
 		PathList:      make([]catalog.PathRecord, 0),
 		FromReference: "",
-		Limit:         1,
+		Amount:        1,
 	})
 	if !errors.Is(err, graveler.ErrNotFound) {
 		writeError(w, http.StatusBadRequest, "can only restore into a bare repository")
@@ -2715,7 +2715,8 @@ func (c *Controller) logCommitsHelper(w http.ResponseWriter, r *http.Request, re
 	commitLog, hasMore, err := c.Catalog.ListCommits(ctx, repository, ref, catalog.LogParams{
 		PathList:      resolvePathList(params.Objects, params.Prefixes),
 		FromReference: paginationAfter(params.After),
-		Limit:         paginationAmount(params.Amount),
+		Amount:        paginationAmount(params.Amount),
+		Limit:         swag.BoolValue(params.Limit),
 	})
 	if handleAPIError(w, err) {
 		return

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -21,8 +21,6 @@ import (
 	"text/template"
 	"time"
 
-	"github.com/go-openapi/swag"
-
 	"github.com/go-test/deep"
 	nanoid "github.com/matoous/go-nanoid/v2"
 	"github.com/stretchr/testify/require"
@@ -323,9 +321,10 @@ func testController_LogCommitsHandler(t *testing.T, kvEnabled bool) {
 			_, err = deps.catalog.Commit(ctx, repoID, "main", "commit"+n, "some_user", nil, nil, nil)
 			testutil.MustDo(t, "commit "+p, err)
 		}
+		limit := true
 		resp, err := clt.LogCommitsWithResponse(ctx, repoID, "main", &api.LogCommitsParams{
 			Amount: api.PaginationAmountPtr(commitsLen - 1),
-			Limit:  swag.Bool(true),
+			Limit:  &limit,
 		})
 		verifyResponseOK(t, resp, err)
 

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -21,6 +21,8 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/go-openapi/swag"
+
 	"github.com/go-test/deep"
 	nanoid "github.com/matoous/go-nanoid/v2"
 	"github.com/stretchr/testify/require"
@@ -73,7 +75,7 @@ func onBlock(deps *dependencies, path string) string {
 func testControllerWithKV(t *testing.T, kvEnabled bool) {
 	testController_ListRepositoriesHandler(t, kvEnabled)
 	testController_GetRepoHandler(t, kvEnabled)
-	testController_CommitsGetBranchCommitLogHandler(t, kvEnabled)
+	testController_LogCommitsHandler(t, kvEnabled)
 	testController_CommitsGetBranchCommitLogByPath(t, kvEnabled)
 	testController_GetCommitHandler(t, kvEnabled)
 	testController_CommitHandler(t, kvEnabled)
@@ -268,11 +270,11 @@ func testCommitEntries(t *testing.T, ctx context.Context, cat catalog.Interface,
 	return commit.Reference
 }
 
-func testController_CommitsGetBranchCommitLogHandler(t *testing.T, kvEnabled bool) {
+func testController_LogCommitsHandler(t *testing.T, kvEnabled bool) {
 	clt, deps := setupClientWithAdmin(t, kvEnabled)
 	ctx := context.Background()
 
-	t.Run("get missing branch", func(t *testing.T) {
+	t.Run("missing branch", func(t *testing.T) {
 		_, err := deps.catalog.CreateRepository(ctx, "repo1", onBlock(deps, "ns1"), "main")
 		testutil.Must(t, err)
 
@@ -283,7 +285,7 @@ func testController_CommitsGetBranchCommitLogHandler(t *testing.T, kvEnabled boo
 		}
 	})
 
-	t.Run("get branch log", func(t *testing.T) {
+	t.Run("log", func(t *testing.T) {
 		_, err := deps.catalog.CreateRepository(ctx, "repo2", onBlock(deps, "ns1"), "main")
 		testutil.Must(t, err)
 
@@ -304,6 +306,41 @@ func testController_CommitsGetBranchCommitLogHandler(t *testing.T, kvEnabled boo
 		commitsLog := resp.JSON200.Results
 		if len(commitsLog) != expectedCommits {
 			t.Fatalf("Log %d commits, expected %d", len(commitsLog), expectedCommits)
+		}
+	})
+
+	t.Run("limit", func(t *testing.T) {
+		const repoID = "repo3"
+		_, err := deps.catalog.CreateRepository(ctx, repoID, onBlock(deps, "ns2"), "main")
+		testutil.Must(t, err)
+
+		const commitsLen = 2
+		for i := 0; i < commitsLen; i++ {
+			n := strconv.Itoa(i + 1)
+			p := "foo/bar" + n
+			err := deps.catalog.CreateEntry(ctx, repoID, "main", catalog.DBEntry{Path: p, PhysicalAddress: onBlock(deps, "bar"+n+"addr"), CreationDate: time.Now(), Size: int64(i) + 1, Checksum: "cksum" + n})
+			testutil.MustDo(t, "create entry "+p, err)
+			_, err = deps.catalog.Commit(ctx, repoID, "main", "commit"+n, "some_user", nil, nil, nil)
+			testutil.MustDo(t, "commit "+p, err)
+		}
+		resp, err := clt.LogCommitsWithResponse(ctx, repoID, "main", &api.LogCommitsParams{
+			Amount: api.PaginationAmountPtr(commitsLen - 1),
+			Limit:  swag.Bool(true),
+		})
+		verifyResponseOK(t, resp, err)
+
+		// repo is created with a commit
+		if resp.JSON200 == nil {
+			t.Fatal("LogCommits expected valid response")
+		}
+		commitsLog := resp.JSON200.Results
+		// expect exact number of commits without more
+		const expectedCommits = commitsLen - 1
+		if len(commitsLog) != expectedCommits {
+			t.Fatalf("Log %d commits, expected %d", len(commitsLog), expectedCommits)
+		}
+		if resp.JSON200.Pagination.HasMore {
+			t.Fatalf("Log HasMore %t, expected false", resp.JSON200.Pagination.HasMore)
 		}
 	})
 }

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -1036,7 +1036,10 @@ func (c *Catalog) ListCommits(ctx context.Context, repositoryID string, branch s
 			commit.Parents = append(commit.Parents, parent.String())
 		}
 		commits = append(commits, commit)
-		if len(commits) >= params.Limit+1 {
+		if params.Limit && len(commits) >= params.Amount {
+			break
+		}
+		if len(commits) >= params.Amount+1 {
 			break
 		}
 	}
@@ -1044,9 +1047,9 @@ func (c *Catalog) ListCommits(ctx context.Context, repositoryID string, branch s
 		return nil, false, err
 	}
 	hasMore := false
-	if len(commits) > params.Limit {
+	if len(commits) > params.Amount {
 		hasMore = true
-		commits = commits[:params.Limit]
+		commits = commits[:params.Amount]
 	}
 	return commits, hasMore, nil
 }

--- a/pkg/catalog/interface.go
+++ b/pkg/catalog/interface.go
@@ -33,7 +33,8 @@ type PathRecord struct {
 type LogParams struct {
 	PathList      []PathRecord
 	FromReference string
-	Limit         int
+	Amount        int
+	Limit         bool
 }
 
 type ExpireResult struct {


### PR DESCRIPTION
In cases that 'has more' indicator is not required, passing limit=true to log commit request will enable faster response time.
Cases for searching for a objects or prefix - limit the search to the 'amount' that requested will perform faster and no additional search will be done for 'has more' indication.

Fix #3970