### PR TITLE
unit test and esti test to verify fix for 3975

### DIFF
--- a/esti/commit_test.go
+++ b/esti/commit_test.go
@@ -3,6 +3,7 @@ package esti
 import (
 	"context"
 	"fmt"
+	"net/http"
 	"sync"
 	"testing"
 
@@ -134,6 +135,47 @@ func TestCommitInMixedOrder(t *testing.T) {
 			require.NoError(t, err, "failed to commit second set of changes")
 			require.NoErrorf(t, verifyResponse(commitResp.HTTPResponse, commitResp.Body),
 				"failed to commit second set of changes repo %s branch %s", repo, mainBranch)
+		})
+	}
+}
+
+// Verify panic fix when committing with nil tombstone over KV
+func TestCommitWithTombstone(t *testing.T) {
+	for _, direct := range testDirectDataAccess {
+		name := "indirect"
+		if direct {
+			name = "direct"
+		}
+		t.Run(name, func(t *testing.T) {
+			ctx, _, repo := setupTest(t)
+
+			origObjPathLow := "objb.txt"
+			origObjPathHigh := "objc.txt"
+			uploadFileRandomData(ctx, t, repo, mainBranch, origObjPathLow, direct)
+			uploadFileRandomData(ctx, t, repo, mainBranch, origObjPathHigh, direct)
+			commitResp, err := client.CommitWithResponse(ctx, repo, mainBranch, &api.CommitParams{}, api.CommitJSONRequestBody{
+				Message: "First commit",
+			})
+			require.NoError(t, err, "failed to commit changes")
+			require.NoErrorf(t, verifyResponse(commitResp.HTTPResponse, commitResp.Body),
+				"failed to commit changes repo %s branch %s", repo, mainBranch)
+
+			tombstoneObjPath := "obja.txt"
+			newObjPath := "objd.txt"
+			uploadFileRandomData(ctx, t, repo, mainBranch, tombstoneObjPath, direct)
+			uploadFileRandomData(ctx, t, repo, mainBranch, newObjPath, direct)
+
+			// Turning tombstoneObjPath to tombstone
+			resp, err := client.DeleteObjectWithResponse(ctx, repo, mainBranch, &api.DeleteObjectParams{Path: tombstoneObjPath})
+			require.NoError(t, err, "failed to delete object")
+			require.Equal(t, http.StatusNoContent, resp.StatusCode())
+
+			commitResp, err = client.CommitWithResponse(ctx, repo, mainBranch, &api.CommitParams{}, api.CommitJSONRequestBody{
+				Message: "Commit with tombstone",
+			})
+			require.NoError(t, err, "failed to commit changes")
+			require.NoErrorf(t, verifyResponse(commitResp.HTTPResponse, commitResp.Body),
+				"failed to commit changes repo %s branch %s", repo, mainBranch)
 		})
 	}
 }


### PR DESCRIPTION
Closes #3979 

Creating an initial commit adding 2 onjects outside of the existing range - 1 before and 1 after, and deleting the object before the range, creating a tombstone.
This used to generate panic, as reported in #3975 and fixed by #3976

2 tests verify the above scenarion - `graveler` level unit test and an `Esti` system test