### PR TITLE
Cache top-level ApiClient not low-level generated api.ApiClient

### DIFF
--- a/clients/spark/core/src/main/scala/io/treeverse/clients/ApiClient.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/ApiClient.scala
@@ -78,7 +78,9 @@ private object ApiClient {
   }
 }
 
-private class ApiClient(
+// Only cached instances of ApiClient can be constructed.  The actual
+// constructor is private.
+class ApiClient private (
     apiUrl: String,
     accessKey: String,
     secretKey: String,

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/ApiClient.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/ApiClient.scala
@@ -45,7 +45,8 @@ private object ApiClient {
     ClientKey(apiUrl, accessKey),
     new Callable[ApiClient] {
       def call() = new ApiClient(apiUrl, accessKey, secretKey, connectionTimeoutSec, readTimeoutSec)
-    })
+    }
+  )
 
   /** Translate uri according to two cases:
    *  If the storage type is s3 then translate the protocol of uri from "standard"-ish "s3" to "s3a", to

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/Exporter.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/Exporter.scala
@@ -185,7 +185,7 @@ object Main {
     val rootLocation =
       if (rawLocation.startsWith(s3Prefix)) "s3a://" + rawLocation.substring(s3Prefix.length)
       else rawLocation
-    val apiClient = new ApiClient(endpoint, accessKey, secretKey)
+    val apiClient = ApiClient.get(endpoint, accessKey, secretKey)
     val exporter = new Exporter(spark, apiClient, conf.repo(), rootLocation)
 
     if (conf.commit_id.isSupplied) {

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
@@ -78,7 +78,7 @@ object GarbageCollector {
       apiConf: APIConfigurations,
       hcValues: Broadcast[ConfMap]
   ): Set[(String, Array[Byte], Array[Byte])] = {
-    val location = new ApiClient(apiConf.apiURL, apiConf.accessKey, apiConf.secretKey)
+    val location = ApiClient.get(apiConf.apiURL, apiConf.accessKey, apiConf.secretKey)
       .getMetaRangeURL(repo, commitID)
     // continue on empty location, empty location is a result of a commit with no metaRangeID (e.g 'Repository created' commit)
     if (location == "") Set()
@@ -119,7 +119,7 @@ object GarbageCollector {
       repo: String,
       hcValues: Broadcast[ConfMap]
   ): Seq[String] = {
-    val location = new ApiClient(apiConf.apiURL, apiConf.accessKey, apiConf.secretKey)
+    val location = ApiClient.get(apiConf.apiURL, apiConf.accessKey, apiConf.secretKey)
       .getRangeURL(repo, rangeID)
     SSTableReader
       .forRange(configurationFromValues(hcValues), location)
@@ -138,7 +138,7 @@ object GarbageCollector {
       ts.getOrElse(0).asInstanceOf[Timestamp].seconds
     }
 
-    val location = new ApiClient(apiConf.apiURL, apiConf.accessKey, apiConf.secretKey)
+    val location = ApiClient.get(apiConf.apiURL, apiConf.accessKey, apiConf.secretKey)
       .getRangeURL(repo, rangeID)
     SSTableReader
       .forRange(configurationFromValues(hcValues), location)
@@ -312,7 +312,7 @@ object GarbageCollector {
     val secretKey = hc.get(LAKEFS_CONF_API_SECRET_KEY_KEY)
     val connectionTimeout = hc.get(LAKEFS_CONF_API_CONNECTION_TIMEOUT)
     val readTimeout = hc.get(LAKEFS_CONF_API_READ_TIMEOUT)
-    val apiClient = new ApiClient(apiURL, accessKey, secretKey, connectionTimeout, readTimeout)
+    val apiClient = ApiClient.get(apiURL, accessKey, secretKey, connectionTimeout, readTimeout)
     val storageType = apiClient.getBlockstoreType()
 
     if (storageType == StorageUtils.StorageTypeS3 && args.length != 2) {

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
@@ -78,7 +78,8 @@ object GarbageCollector {
       apiConf: APIConfigurations,
       hcValues: Broadcast[ConfMap]
   ): Set[(String, Array[Byte], Array[Byte])] = {
-    val location = ApiClient.get(apiConf.apiURL, apiConf.accessKey, apiConf.secretKey)
+    val location = ApiClient
+      .get(apiConf.apiURL, apiConf.accessKey, apiConf.secretKey)
       .getMetaRangeURL(repo, commitID)
     // continue on empty location, empty location is a result of a commit with no metaRangeID (e.g 'Repository created' commit)
     if (location == "") Set()
@@ -119,7 +120,8 @@ object GarbageCollector {
       repo: String,
       hcValues: Broadcast[ConfMap]
   ): Seq[String] = {
-    val location = ApiClient.get(apiConf.apiURL, apiConf.accessKey, apiConf.secretKey)
+    val location = ApiClient
+      .get(apiConf.apiURL, apiConf.accessKey, apiConf.secretKey)
       .getRangeURL(repo, rangeID)
     SSTableReader
       .forRange(configurationFromValues(hcValues), location)
@@ -138,7 +140,8 @@ object GarbageCollector {
       ts.getOrElse(0).asInstanceOf[Timestamp].seconds
     }
 
-    val location = ApiClient.get(apiConf.apiURL, apiConf.accessKey, apiConf.secretKey)
+    val location = ApiClient
+      .get(apiConf.apiURL, apiConf.accessKey, apiConf.secretKey)
       .getRangeURL(repo, rangeID)
     SSTableReader
       .forRange(configurationFromValues(hcValues), location)

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/LakeFSInputFormat.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/LakeFSInputFormat.scala
@@ -100,7 +100,7 @@ class LakeFSInputFormat extends InputFormat[Array[Byte], WithIdentifier[Entry]] 
     val conf = job.getConfiguration
     val repoName = conf.get(LAKEFS_CONF_JOB_REPO_NAME_KEY)
     val commitID = conf.get(LAKEFS_CONF_JOB_COMMIT_ID_KEY)
-    val apiClient = new ApiClient(
+    val apiClient = ApiClient.get(
       conf.get(LAKEFS_CONF_API_URL_KEY),
       conf.get(LAKEFS_CONF_API_ACCESS_KEY_KEY),
       conf.get(LAKEFS_CONF_API_SECRET_KEY_KEY)

--- a/clients/spark/examples/src/main/scala/io/treeverse/clients/examples/Export.scala
+++ b/clients/spark/examples/src/main/scala/io/treeverse/clients/examples/Export.scala
@@ -33,7 +33,7 @@ object Export extends App {
     sc.hadoopConfiguration.set("lakefs.api.access_key", accessKey)
     sc.hadoopConfiguration.set("lakefs.api.secret_key", secretKey)
 
-    val apiClient = new ApiClient(endpoint, accessKey, secretKey)
+    val apiClient = ApiClient.get(endpoint, accessKey, secretKey)
     val exporter = new Exporter(spark, apiClient, repo, rootLocation)
 
     exporter.exportAllFromBranch(branch)


### PR DESCRIPTION
The storage namespace cache is part of the top-level ApiClient.  If we share
only the _generated_ api.ApiClient then the storage namespace cache is much
less useful.