### PR TITLE
Concurrent merge improvements

### DIFF
--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -1744,7 +1744,7 @@ func (c *Controller) handleAPIError(ctx context.Context, w http.ResponseWriter, 
 		writeError(w, http.StatusBadRequest, "Already exists")
 
 	case errors.Is(err, graveler.ErrTooManyTries):
-		writeError(w, http.StatusLocked, "Concurrent resource updates, try again later")
+		writeError(w, http.StatusLocked, "Too many attempts, try again later")
 
 	case err != nil:
 		c.Logger.WithContext(ctx).WithError(err).Error("API call returned status internal server error")

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -1743,6 +1743,9 @@ func (c *Controller) handleAPIError(ctx context.Context, w http.ResponseWriter, 
 	case errors.Is(err, db.ErrAlreadyExists):
 		writeError(w, http.StatusBadRequest, "Already exists")
 
+	case errors.Is(err, graveler.ErrTooManyTries):
+		writeError(w, http.StatusLocked, "Concurrent resource updates, try again later")
+
 	case err != nil:
 		c.Logger.WithContext(ctx).WithError(err).Error("API call returned status internal server error")
 		writeError(w, http.StatusInternalServerError, err)

--- a/pkg/graveler/graveler.go
+++ b/pkg/graveler/graveler.go
@@ -29,7 +29,7 @@ const (
 
 	SettingsRelativeKey = "%s/settings/%s.json" // where the settings are saved relative to the storage namespace
 
-	BrnachUpdateMaxInterval = 5
+	BrnachUpdateMaxInterval = 5 * time.Second
 	BranchUpdateMaxTries    = 3
 )
 
@@ -1722,7 +1722,7 @@ func (g *KVGraveler) Commit(ctx context.Context, repository *RepositoryRecord, b
 
 func (g *KVGraveler) retryBranchUpdate(ctx context.Context, repository *RepositoryRecord, branchID BranchID, f BranchUpdateFunc) error {
 	bo := backoff.NewExponentialBackOff()
-	bo.MaxInterval = BrnachUpdateMaxInterval * time.Second
+	bo.MaxInterval = BrnachUpdateMaxInterval
 
 	try := 1
 	err := backoff.Retry(func() error {

--- a/pkg/graveler/graveler.go
+++ b/pkg/graveler/graveler.go
@@ -2179,7 +2179,7 @@ func (g *KVGraveler) Merge(ctx context.Context, repository *RepositoryRecord, de
 	// No retries on any failure during the merge. If the branch changed, it's either that commit is in progress, commit occurred,
 	// or some other branch changing operation. If commit is in-progress, then staging area wasn't empty after we checked so not retrying is ok.
 	// If another commit/merge succeeded, then the user should decide whether to retry the merge.
-	err := g.RefManager.BranchUpdate(ctx, repository, destination, func(branch *Branch) (*Branch, error) {
+	err := g.retryBranchUpdate(ctx, repository, destination, func(branch *Branch) (*Branch, error) {
 		empty, err := g.isSealedEmpty(ctx, repository, branch)
 		if err != nil {
 			return nil, fmt.Errorf("check if staging empty: %w", err)

--- a/pkg/graveler/graveler.go
+++ b/pkg/graveler/graveler.go
@@ -29,6 +29,8 @@ const (
 
 	SettingsRelativeKey = "%s/settings/%s.json" // where the settings are saved relative to the storage namespace
 
+	BrnachUpdateMaxInterval = 5
+	BranchUpdateMaxTries    = 3
 )
 
 // Basic Types
@@ -1719,18 +1721,14 @@ func (g *KVGraveler) Commit(ctx context.Context, repository *RepositoryRecord, b
 }
 
 func (g *KVGraveler) retryBranchUpdate(ctx context.Context, repository *RepositoryRecord, branchID BranchID, f BranchUpdateFunc) error {
-	const (
-		maxInterval = 5
-		setTries    = 3
-	)
 	bo := backoff.NewExponentialBackOff()
-	bo.MaxInterval = maxInterval * time.Second
+	bo.MaxInterval = BrnachUpdateMaxInterval * time.Second
 
 	try := 1
 	err := backoff.Retry(func() error {
 		// TODO(eden) issue 3586 - if the branch commit id hasn't changed, update the fields instead of fail
 		err := g.RefManager.BranchUpdate(ctx, repository, branchID, f)
-		if errors.Is(err, kv.ErrPredicateFailed) && try < setTries {
+		if errors.Is(err, kv.ErrPredicateFailed) && try < BranchUpdateMaxTries {
 			g.log.WithField("try", try).
 				WithField("branchID", branchID).
 				Info("Retrying update branch")
@@ -1742,7 +1740,7 @@ func (g *KVGraveler) retryBranchUpdate(ctx context.Context, repository *Reposito
 		}
 		return nil
 	}, bo)
-	if err != nil && try >= setTries {
+	if err != nil && try >= BranchUpdateMaxTries {
 		return fmt.Errorf("update branch: %w", ErrTooManyTries)
 	}
 	return err

--- a/pkg/graveler/graveler.go
+++ b/pkg/graveler/graveler.go
@@ -30,7 +30,7 @@ const (
 	SettingsRelativeKey = "%s/settings/%s.json" // where the settings are saved relative to the storage namespace
 
 	BrnachUpdateMaxInterval = 5 * time.Second
-	BranchUpdateMaxTries    = 3
+	BranchUpdateMaxTries    = 10
 )
 
 // Basic Types

--- a/pkg/graveler/graveler_v2_test.go
+++ b/pkg/graveler/graveler_v2_test.go
@@ -301,7 +301,7 @@ func TestGravelerMerge(t *testing.T) {
 		test.refManager.EXPECT().BranchUpdate(ctx, repository, branch1ID, gomock.Any()).
 			DoAndReturn(func(_ context.Context, _ *graveler.RepositoryRecord, _ graveler.BranchID, f graveler.BranchUpdateFunc) error {
 				return kv.ErrPredicateFailed
-			}).Times(1)
+			}).Times(graveler.BranchUpdateMaxTries - 1)
 		test.refManager.EXPECT().BranchUpdate(ctx, repository, branch1ID, gomock.Any()).
 			Do(func(_ context.Context, _ *graveler.RepositoryRecord, _ graveler.BranchID, f graveler.BranchUpdateFunc) error {
 				branchTest := &graveler.Branch{StagingToken: stagingToken4, CommitID: commit1ID, SealedTokens: []graveler.StagingToken{stagingToken1, stagingToken2, stagingToken3}}

--- a/pkg/graveler/graveler_v2_test.go
+++ b/pkg/graveler/graveler_v2_test.go
@@ -541,7 +541,7 @@ func TestGravelerCommit(t *testing.T) {
 				return nil
 			}).Times(1)
 
-		test.refManager.EXPECT().BranchUpdate(ctx, repository, branch1ID, gomock.Any()).Times(3).Return(kv.ErrPredicateFailed)
+		test.refManager.EXPECT().BranchUpdate(ctx, repository, branch1ID, gomock.Any()).Times(graveler.BranchUpdateMaxTries).Return(kv.ErrPredicateFailed)
 
 		val, err := test.sut.Commit(ctx, repository, branch1ID, graveler.CommitParams{})
 

--- a/pkg/graveler/graveler_v2_test.go
+++ b/pkg/graveler/graveler_v2_test.go
@@ -6,13 +6,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/treeverse/lakefs/pkg/kv"
-
 	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 	"github.com/treeverse/lakefs/pkg/catalog/testutils"
 	"github.com/treeverse/lakefs/pkg/graveler"
 	"github.com/treeverse/lakefs/pkg/graveler/mock"
+	"github.com/treeverse/lakefs/pkg/kv"
 )
 
 type gravelerTest struct {
@@ -201,13 +200,13 @@ func TestGravelerMerge(t *testing.T) {
 				return nil
 			}).Times(1)
 	}
-	emptyStagingTokenCombo := func(test *gravelerTest) {
-		test.stagingManager.EXPECT().List(ctx, stagingToken1, gomock.Any()).Times(2).Return(testutils.NewFakeValueIterator([]*graveler.ValueRecord{{
+	emptyStagingTokenCombo := func(test *gravelerTest, numReps int) {
+		test.stagingManager.EXPECT().List(ctx, stagingToken1, gomock.Any()).Times(numReps).Return(testutils.NewFakeValueIterator([]*graveler.ValueRecord{{
 			Key:   key1,
 			Value: nil, // tombstone
 		}}), nil)
-		test.stagingManager.EXPECT().List(ctx, stagingToken2, gomock.Any()).Times(2).Return(testutils.NewFakeValueIterator(nil), nil)
-		test.stagingManager.EXPECT().List(ctx, stagingToken3, gomock.Any()).Times(2).Return(testutils.NewFakeValueIterator([]*graveler.ValueRecord{{
+		test.stagingManager.EXPECT().List(ctx, stagingToken2, gomock.Any()).Times(numReps).Return(testutils.NewFakeValueIterator(nil), nil)
+		test.stagingManager.EXPECT().List(ctx, stagingToken3, gomock.Any()).Times(numReps).Return(testutils.NewFakeValueIterator([]*graveler.ValueRecord{{
 			Key:   key1,
 			Value: value1,
 		}}), nil)
@@ -215,7 +214,7 @@ func TestGravelerMerge(t *testing.T) {
 	t.Run("merge successful", func(t *testing.T) {
 		test := initGravelerTest(t)
 		firstUpdateBranch(test)
-		emptyStagingTokenCombo(test)
+		emptyStagingTokenCombo(test, 2)
 		test.refManager.EXPECT().GetCommit(ctx, repository, commit1ID).Times(3).Return(&commit1, nil)
 		test.committedManager.EXPECT().List(ctx, repository.StorageNamespace, mr1ID).Times(2).Return(testutils.NewFakeValueIterator(nil), nil)
 		test.refManager.EXPECT().ParseRef(graveler.Ref(branch2ID)).Times(1).Return(rawRefCommit2, nil)
@@ -280,6 +279,65 @@ func TestGravelerMerge(t *testing.T) {
 
 		require.Equal(t, graveler.ErrConflictFound, err)
 		require.Equal(t, graveler.CommitID(""), val)
+	})
+
+	t.Run("merge successful with branchUpdate retry", func(t *testing.T) {
+		test := initGravelerTest(t)
+		firstUpdateBranch(test)
+		emptyStagingTokenCombo(test, 2)
+		test.refManager.EXPECT().GetCommit(ctx, repository, commit1ID).Times(3).Return(&commit1, nil)
+		test.committedManager.EXPECT().List(ctx, repository.StorageNamespace, mr1ID).Times(2).Return(testutils.NewFakeValueIterator(nil), nil)
+		test.refManager.EXPECT().ParseRef(graveler.Ref(branch2ID)).Times(1).Return(rawRefCommit2, nil)
+		test.refManager.EXPECT().ParseRef(graveler.Ref(branch1ID)).Times(1).Return(rawRefCommit1, nil)
+		test.refManager.EXPECT().ResolveRawRef(ctx, repository, rawRefCommit2).Times(1).Return(&graveler.ResolvedRef{Type: graveler.ReferenceTypeCommit, BranchRecord: graveler.BranchRecord{Branch: &graveler.Branch{CommitID: commit2ID}}}, nil)
+		test.refManager.EXPECT().ResolveRawRef(ctx, repository, rawRefCommit1).Times(1).Return(&graveler.ResolvedRef{Type: graveler.ReferenceTypeCommit, BranchRecord: graveler.BranchRecord{Branch: &graveler.Branch{CommitID: commit1ID}}}, nil)
+		test.refManager.EXPECT().GetCommit(ctx, repository, commit2ID).Times(1).Return(&commit2, nil)
+		test.refManager.EXPECT().FindMergeBase(ctx, repository, commit2ID, commit1ID).Times(1).Return(&commit3, nil)
+		test.committedManager.EXPECT().Merge(ctx, repository.StorageNamespace, mr1ID, mr2ID, mr3ID, graveler.MergeStrategyNone).Times(1).Return(mr4ID, nil)
+		test.refManager.EXPECT().AddCommit(ctx, repository, gomock.Any()).DoAndReturn(func(ctx context.Context, repository *graveler.RepositoryRecord, commit graveler.Commit) (graveler.CommitID, error) {
+			require.Equal(t, mr4ID, commit.MetaRangeID)
+			return commit4ID, nil
+		}).Times(1)
+		test.refManager.EXPECT().BranchUpdate(ctx, repository, branch1ID, gomock.Any()).
+			DoAndReturn(func(_ context.Context, _ *graveler.RepositoryRecord, _ graveler.BranchID, f graveler.BranchUpdateFunc) error {
+				return kv.ErrPredicateFailed
+			}).Times(1)
+		test.refManager.EXPECT().BranchUpdate(ctx, repository, branch1ID, gomock.Any()).
+			Do(func(_ context.Context, _ *graveler.RepositoryRecord, _ graveler.BranchID, f graveler.BranchUpdateFunc) error {
+				branchTest := &graveler.Branch{StagingToken: stagingToken4, CommitID: commit1ID, SealedTokens: []graveler.StagingToken{stagingToken1, stagingToken2, stagingToken3}}
+				updatedBranch, err := f(branchTest)
+				require.NoError(t, err)
+				require.Equal(t, []graveler.StagingToken{}, updatedBranch.SealedTokens)
+				require.NotEmpty(t, updatedBranch.StagingToken)
+				require.Equal(t, commit4ID, updatedBranch.CommitID)
+				return nil
+			}).Times(1)
+		test.stagingManager.EXPECT().DropAsync(ctx, stagingToken1).Times(1)
+		test.stagingManager.EXPECT().DropAsync(ctx, stagingToken2).Times(1)
+		test.stagingManager.EXPECT().DropAsync(ctx, stagingToken3).Times(1)
+
+		val, err := test.sut.Merge(ctx, repository, branch1ID, graveler.Ref(branch2ID), graveler.CommitParams{}, "")
+
+		require.NoError(t, err)
+		require.NotNil(t, val)
+		require.Equal(t, commit4ID, graveler.CommitID(val.Ref()))
+	})
+
+	t.Run("merge fails due to BranchUpdate retries exhaustion", func(t *testing.T) {
+		test := initGravelerTest(t)
+		firstUpdateBranch(test)
+		emptyStagingTokenCombo(test, 1)
+		test.refManager.EXPECT().GetCommit(ctx, repository, commit1ID).Times(1).Return(&commit1, nil)
+		test.committedManager.EXPECT().List(ctx, repository.StorageNamespace, mr1ID).Times(1).Return(testutils.NewFakeValueIterator(nil), nil)
+		test.refManager.EXPECT().BranchUpdate(ctx, repository, branch1ID, gomock.Any()).
+			DoAndReturn(func(_ context.Context, _ *graveler.RepositoryRecord, _ graveler.BranchID, f graveler.BranchUpdateFunc) error {
+				return kv.ErrPredicateFailed
+			}).Times(3)
+
+		val, err := test.sut.Merge(ctx, repository, branch1ID, graveler.Ref(branch2ID), graveler.CommitParams{}, "")
+
+		require.ErrorIs(t, err, graveler.ErrTooManyTries)
+		require.Empty(t, val)
 	})
 }
 

--- a/pkg/graveler/graveler_v2_test.go
+++ b/pkg/graveler/graveler_v2_test.go
@@ -332,7 +332,7 @@ func TestGravelerMerge(t *testing.T) {
 		test.refManager.EXPECT().BranchUpdate(ctx, repository, branch1ID, gomock.Any()).
 			DoAndReturn(func(_ context.Context, _ *graveler.RepositoryRecord, _ graveler.BranchID, f graveler.BranchUpdateFunc) error {
 				return kv.ErrPredicateFailed
-			}).Times(3)
+			}).Times(graveler.BranchUpdateMaxTries)
 
 		val, err := test.sut.Merge(ctx, repository, branch1ID, graveler.Ref(branch2ID), graveler.CommitParams{}, "")
 


### PR DESCRIPTION
Closes #4067 

* Using `retryBranchUpdate` for `graveler.Merge` (instead of `BranchUpdate`)
* `http.StatusLocked` is returned upon exhaustion of retries (see output sample below)
* Unit tests to verify a successful merge with retries, and a failed merge due to too many retries

```
./lakectl merge lakefs://example-repo/source lakefs://example-repo/dest
Source: lakefs://example-repo/source
Destination: lakefs://example-repo/dest
Concurrent resource updates, try again later
423 Locked
```