### PR TITLE
[GC] Changed url parser of Azure to catch path without blob

### DIFF
--- a/clients/spark/core/src/main/scala/io/treeverse/clients/ApiClient.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/ApiClient.scala
@@ -71,7 +71,11 @@ private object ApiClient {
        *  extract the storage account, container and blob path, and use them in abfs url
        */
       val storageAccountName = StorageUtils.AzureBlob.uriToStorageAccountName(uri)
-      val Array(_, container, blobPath) = uri.getPath.split("/", 3)
+      val (container, blobPath) = uri.getPath.split("/", 3) match {
+        case Array(a, b, c) => (b, c)
+        case Array(a, b)    => (b, "")
+        case _              => throw new IllegalArgumentException
+      }
       return new URI(
         s"abfs://${container}@${storageAccountName}.dfs.core.windows.net/${blobPath}"
       )

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/ApiClient.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/ApiClient.scala
@@ -74,7 +74,10 @@ private object ApiClient {
       val (container: String, blobPath: String) = uri.getPath.split("/", 3) match {
         case Array(a, b, c) => (b, c)
         case Array(a, b)    => (b, "")
-        case _              => throw new IllegalArgumentException(s"Expected https://host/container or https://host/container/path in ${uri.toString}")
+        case _ =>
+          throw new IllegalArgumentException(
+            s"Expected https://host/container or https://host/container/path in ${uri.toString}"
+          )
       }
       return new URI(
         s"abfs://${container}@${storageAccountName}.dfs.core.windows.net/${blobPath}"
@@ -145,7 +148,7 @@ class ApiClient private (conf: APIConfigurations) {
           .normalize()
           .toString
       case StorageClientType.SDKClient => repo.getStorageNamespace
-      case _                           => throw new IllegalArgumentException("Unknown storage type ${key.storageClientType}")
+      case _ => throw new IllegalArgumentException("Unknown storage type ${key.storageClientType}")
     }
     storageNamespace
   }

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/ApiClient.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/ApiClient.scala
@@ -71,10 +71,10 @@ private object ApiClient {
        *  extract the storage account, container and blob path, and use them in abfs url
        */
       val storageAccountName = StorageUtils.AzureBlob.uriToStorageAccountName(uri)
-      val (container, blobPath) = uri.getPath.split("/", 3) match {
+      val (container: String, blobPath: String) = uri.getPath.split("/", 3) match {
         case Array(a, b, c) => (b, c)
         case Array(a, b)    => (b, "")
-        case _              => throw new IllegalArgumentException
+        case _              => throw new IllegalArgumentException(s"Expected https://host/container or https://host/container/path in ${uri.toString}")
       }
       return new URI(
         s"abfs://${container}@${storageAccountName}.dfs.core.windows.net/${blobPath}"
@@ -145,7 +145,7 @@ class ApiClient private (conf: APIConfigurations) {
           .normalize()
           .toString
       case StorageClientType.SDKClient => repo.getStorageNamespace
-      case _                           => throw new IllegalArgumentException
+      case _                           => throw new IllegalArgumentException("Unknown storage type ${key.storageClientType}")
     }
     storageNamespace
   }


### PR DESCRIPTION
close #4072

Change the url parser of Azure to correctly parse storage namespace of the form `https://{stAccount}.blob.core.windows.net/{container}`