### PR TITLE
Remove useless code from leftAntiJoinAddresses

### DIFF
--- a/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
@@ -167,8 +167,6 @@ object GarbageCollector {
       repo: String,
       hcValues: Broadcast[ConfMap]
   ): Set[(String, String, Boolean, Long)] = {
-    distinctEntryTuples(leftRangeIDs, apiConf, repo, hcValues)
-
     val leftTuples = distinctEntryTuples(leftRangeIDs, apiConf, repo, hcValues)
     val rightTuples = distinctEntryTuples(rightRangeIDs, apiConf, repo, hcValues)
     leftTuples -- rightTuples


### PR DESCRIPTION
This was mistakenly added in 378fd9e4ce76ed86541fe420e2a3df7a94087ce7 (by @arielshaqed 🤕 🤦🏽‍♂️) and does _nothing_.