### PR TITLE
flatMap range contents directly

### DIFF
--- a/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
@@ -117,7 +117,7 @@ object GarbageCollector {
       apiConf: APIConfigurations,
       repo: String,
       hcValues: Broadcast[ConfMap]
-  ): Seq[String] = {
+  ): Iterator[String] = {
     val location = ApiClient
       .get(apiConf)
       .getRangeURL(repo, rangeID)
@@ -125,7 +125,6 @@ object GarbageCollector {
       .forRange(configurationFromValues(hcValues), location)
       .newIterator()
       .map(a => a.message.address)
-      .toSeq
   }
 
   def getEntryTuples(


### PR DESCRIPTION
Don't materialize them in memory, just shove them out to Spark.