### PR TITLE
s3 block adapter: enable skip verify certificate of storage endpoint

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -116,7 +116,7 @@ This reference uses `.` to denote the nesting of values.
 * `blockstore.s3.streaming_chunk_size` `(int : 1048576)` - Object chunk size to buffer before streaming to blockstore (use a lower value for less reliable networks). Minimum is 8192.
 * `blockstore.s3.streaming_chunk_timeout` `(time duration : "60s")` - Per object chunk timeout for blockstore streaming operations (use a larger value for less reliable networks).
 * `blockstore.s3.discover_bucket_region` `(boolean : true)` - (Can be turned off if the underlying S3 bucket doesn't support the GetBucketRegion API).
-* `blockstore.s3.skip_verify_certificate` `(boolean: false)` - Skip certificate verification while connecting to the storage endpoint.
+* `blockstore.s3.skip_verify_certificate_test_only` `(boolean: false)` - Skip certificate verification while connecting to the storage endpoint. Should be used only for testing.
 * `committed.local_cache` - an object describing the local (on-disk) cache of metadata from
   permanent storage:
   + `committed.local_cache.size_bytes` (`int` : `1073741824`) - bytes for local cache to use on disk.  The cache may use more storage for short periods of time.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -116,6 +116,7 @@ This reference uses `.` to denote the nesting of values.
 * `blockstore.s3.streaming_chunk_size` `(int : 1048576)` - Object chunk size to buffer before streaming to blockstore (use a lower value for less reliable networks). Minimum is 8192.
 * `blockstore.s3.streaming_chunk_timeout` `(time duration : "60s")` - Per object chunk timeout for blockstore streaming operations (use a larger value for less reliable networks).
 * `blockstore.s3.discover_bucket_region` `(boolean : true)` - (Can be turned off if the underlying S3 bucket doesn't support the GetBucketRegion API).
+* `blockstore.s3.skip_verify_certificate` `(boolean: false)` - Skip certificate verification while connecting to the storage endpoint.
 * `committed.local_cache` - an object describing the local (on-disk) cache of metadata from
   permanent storage:
   + `committed.local_cache.size_bytes` (`int` : `1073741824`) - bytes for local cache to use on disk.  The cache may use more storage for short periods of time.

--- a/pkg/block/factory/build.go
+++ b/pkg/block/factory/build.go
@@ -2,8 +2,10 @@ package factory
 
 import (
 	"context"
+	"crypto/tls"
 	"errors"
 	"fmt"
+	"net/http"
 
 	"cloud.google.com/go/storage"
 	"github.com/Azure/azure-pipeline-go/pipeline"
@@ -85,8 +87,15 @@ func buildLocalAdapter(params params.Local) (*local.Adapter, error) {
 	return adapter, nil
 }
 
-func BuildS3Client(params *aws.Config) (*session.Session, error) {
-	sess, err := session.NewSession(params)
+func BuildS3Client(params *aws.Config, skipVerifyCertificate bool) (*session.Session, error) {
+	client := http.DefaultClient
+	if skipVerifyCertificate {
+		tr := &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
+		}
+		client = &http.Client{Transport: tr}
+	}
+	sess, err := session.NewSession(params, aws.NewConfig().WithHTTPClient(client))
 	if err != nil {
 		return nil, err
 	}
@@ -95,7 +104,7 @@ func BuildS3Client(params *aws.Config) (*session.Session, error) {
 }
 
 func buildS3Adapter(statsCollector stats.Collector, params params.S3) (*s3a.Adapter, error) {
-	sess, err := BuildS3Client(params.AwsConfig)
+	sess, err := BuildS3Client(params.AwsConfig, params.SkipVerifyCertificate)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/block/factory/build.go
+++ b/pkg/block/factory/build.go
@@ -87,9 +87,9 @@ func buildLocalAdapter(params params.Local) (*local.Adapter, error) {
 	return adapter, nil
 }
 
-func BuildS3Client(params *aws.Config, skipVerifyCertificate bool) (*session.Session, error) {
+func BuildS3Client(params *aws.Config, skipVerifyCertificateTestOnly bool) (*session.Session, error) {
 	client := http.DefaultClient
-	if skipVerifyCertificate {
+	if skipVerifyCertificateTestOnly {
 		tr := &http.Transport{
 			TLSClientConfig: &tls.Config{InsecureSkipVerify: true}, //nolint:gosec
 		}
@@ -104,7 +104,7 @@ func BuildS3Client(params *aws.Config, skipVerifyCertificate bool) (*session.Ses
 }
 
 func buildS3Adapter(statsCollector stats.Collector, params params.S3) (*s3a.Adapter, error) {
-	sess, err := BuildS3Client(params.AwsConfig, params.SkipVerifyCertificate)
+	sess, err := BuildS3Client(params.AwsConfig, params.SkipVerifyCertificateTestOnly)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/block/params/block.go
+++ b/pkg/block/params/block.go
@@ -27,6 +27,7 @@ type S3 struct {
 	StreamingChunkSize    int
 	StreamingChunkTimeout time.Duration
 	DiscoverBucketRegion  bool
+	SkipVerifyCertificate bool
 }
 
 type GS struct {

--- a/pkg/block/params/block.go
+++ b/pkg/block/params/block.go
@@ -23,11 +23,11 @@ type Local struct {
 }
 
 type S3 struct {
-	AwsConfig             *aws.Config
-	StreamingChunkSize    int
-	StreamingChunkTimeout time.Duration
-	DiscoverBucketRegion  bool
-	SkipVerifyCertificate bool
+	AwsConfig                     *aws.Config
+	StreamingChunkSize            int
+	StreamingChunkTimeout         time.Duration
+	DiscoverBucketRegion          bool
+	SkipVerifyCertificateTestOnly bool
 }
 
 type GS struct {

--- a/pkg/block/s3/adapter.go
+++ b/pkg/block/s3/adapter.go
@@ -99,7 +99,7 @@ func WithDiscoverBucketRegion(b bool) func(a *Adapter) {
 func NewAdapter(awsSession *session.Session, opts ...func(a *Adapter)) *Adapter {
 	a := &Adapter{
 		clients:               NewClientCache(awsSession),
-		httpClient:            http.DefaultClient,
+		httpClient:            awsSession.Config.HTTPClient,
 		streamingChunkSize:    DefaultStreamingChunkSize,
 		streamingChunkTimeout: DefaultStreamingChunkTimeout,
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -388,6 +388,7 @@ func (c *Config) GetBlockAdapterS3Params() (blockparams.S3, error) {
 		StreamingChunkSize:    c.values.Blockstore.S3.StreamingChunkSize,
 		StreamingChunkTimeout: c.values.Blockstore.S3.StreamingChunkTimeout,
 		DiscoverBucketRegion:  c.values.Blockstore.S3.DiscoverBucketRegion,
+		SkipVerifyCertificate: c.values.Blockstore.S3.SkipVerifyCertificate,
 	}, nil
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -384,11 +384,11 @@ func (c *Config) GetBlockAdapterS3Params() (blockparams.S3, error) {
 	cfg := c.GetAwsConfig()
 
 	return blockparams.S3{
-		AwsConfig:             cfg,
-		StreamingChunkSize:    c.values.Blockstore.S3.StreamingChunkSize,
-		StreamingChunkTimeout: c.values.Blockstore.S3.StreamingChunkTimeout,
-		DiscoverBucketRegion:  c.values.Blockstore.S3.DiscoverBucketRegion,
-		SkipVerifyCertificate: c.values.Blockstore.S3.SkipVerifyCertificate,
+		AwsConfig:                     cfg,
+		StreamingChunkSize:            c.values.Blockstore.S3.StreamingChunkSize,
+		StreamingChunkTimeout:         c.values.Blockstore.S3.StreamingChunkTimeout,
+		DiscoverBucketRegion:          c.values.Blockstore.S3.DiscoverBucketRegion,
+		SkipVerifyCertificateTestOnly: c.values.Blockstore.S3.SkipVerifyCertificateTestOnly,
 	}, nil
 }
 

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -149,15 +149,15 @@ type configuration struct {
 			Path string
 		}
 		S3 *struct {
-			S3AuthInfo            `mapstructure:",squash"`
-			Region                string
-			Endpoint              string
-			StreamingChunkSize    int           `mapstructure:"streaming_chunk_size"`
-			StreamingChunkTimeout time.Duration `mapstructure:"streaming_chunk_timeout"`
-			MaxRetries            int           `mapstructure:"max_retries"`
-			ForcePathStyle        bool          `mapstructure:"force_path_style"`
-			DiscoverBucketRegion  bool          `mapstructure:"discover_bucket_region"`
-			SkipVerifyCertificate bool          `mapstructure:"skip_verify_certificate"`
+			S3AuthInfo                    `mapstructure:",squash"`
+			Region                        string
+			Endpoint                      string
+			StreamingChunkSize            int           `mapstructure:"streaming_chunk_size"`
+			StreamingChunkTimeout         time.Duration `mapstructure:"streaming_chunk_timeout"`
+			MaxRetries                    int           `mapstructure:"max_retries"`
+			ForcePathStyle                bool          `mapstructure:"force_path_style"`
+			DiscoverBucketRegion          bool          `mapstructure:"discover_bucket_region"`
+			SkipVerifyCertificateTestOnly bool          `mapstructure:"skip_verify_certificate_test_only"`
 		}
 		Azure *struct {
 			TryTimeout       time.Duration `mapstructure:"try_timeout"`

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -157,6 +157,7 @@ type configuration struct {
 			MaxRetries            int           `mapstructure:"max_retries"`
 			ForcePathStyle        bool          `mapstructure:"force_path_style"`
 			DiscoverBucketRegion  bool          `mapstructure:"discover_bucket_region"`
+			SkipVerifyCertificate bool          `mapstructure:"skip_verify_certificate"`
 		}
 		Azure *struct {
 			TryTimeout       time.Duration `mapstructure:"try_timeout"`

--- a/pkg/ingest/store/factory.go
+++ b/pkg/ingest/store/factory.go
@@ -99,7 +99,7 @@ func (f *walkerFactory) buildS3Walker(opts WalkerOptions) (*s3Walker, error) {
 		if err != nil {
 			return nil, err
 		}
-		sess, err = factory.BuildS3Client(s3params.AwsConfig)
+		sess, err = factory.BuildS3Client(s3params.AwsConfig, s3params.SkipVerifyCertificate)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/ingest/store/factory.go
+++ b/pkg/ingest/store/factory.go
@@ -99,7 +99,7 @@ func (f *walkerFactory) buildS3Walker(opts WalkerOptions) (*s3Walker, error) {
 		if err != nil {
 			return nil, err
 		}
-		sess, err = factory.BuildS3Client(s3params.AwsConfig, s3params.SkipVerifyCertificate)
+		sess, err = factory.BuildS3Client(s3params.AwsConfig, s3params.SkipVerifyCertificateTestOnly)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Fix #4153