### PR TITLE
Improve how we handle kv iterator interface

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,8 @@ clean:
 		pkg/auth/client.gen.go \
 		pkg/graveler/sstable/mock \
 	    pkg/graveler/committed/mock \
-	    pkg/graveler/mock
+	    pkg/graveler/mock \
+	    pkg/kv/mock
 
 check-licenses: check-licenses-go-mod check-licenses-npm
 
@@ -144,13 +145,14 @@ gen-api: go-install ## Run the swagger code generator
 .PHONY: gen-code
 gen-code: go-install ## Run the generator for inline commands
 	$(GOGENERATE) \
-		./pkg/graveler/sstable \
-		./pkg/graveler/committed \
-		./pkg/graveler \
-		./pkg/pyramid \
-		./pkg/onboard \
 		./pkg/actions \
-		./pkg/auth
+		./pkg/auth \
+		./pkg/graveler \
+		./pkg/graveler/committed \
+		./pkg/graveler/sstable \
+		./pkg/onboard \
+		./pkg/pyramid \
+	    ./pkg/kv
 
 LD_FLAGS := "-X github.com/treeverse/lakefs/pkg/version.Version=$(VERSION)-$(REVISION)"
 build: gen docs ## Download dependencies and build the default binary

--- a/pkg/actions/kv_run_results_iterator.go
+++ b/pkg/actions/kv_run_results_iterator.go
@@ -45,14 +45,11 @@ func NewKVRunResultIterator(ctx context.Context, store kv.StoreMessage, reposito
 	var it kv.MessageIterator
 	if secondary {
 		it, err = kv.NewSecondaryIterator(ctx, store.Store, (&RunResultData{}).ProtoReflect().Type(), PartitionKey, []byte(prefix), []byte(after))
-		if err != nil {
-			return nil, err
-		}
 	} else {
 		it, err = kv.NewPrimaryIterator(ctx, store.Store, (&RunResultData{}).ProtoReflect().Type(), PartitionKey, []byte(prefix), kv.IteratorOptionsAfter([]byte(after)))
-		if err != nil {
-			return nil, err
-		}
+	}
+	if err != nil {
+		return nil, err
 	}
 
 	return &KVRunResultIterator{
@@ -85,10 +82,10 @@ func (i *KVRunResultIterator) Value() *RunResult {
 }
 
 func (i *KVRunResultIterator) Err() error {
-	if i.err == nil {
-		return i.it.Err()
+	if i.err != nil {
+		return i.err
 	}
-	return i.err
+	return i.it.Err()
 }
 
 func (i *KVRunResultIterator) Close() {

--- a/pkg/graveler/ref/commit_ordered_iterator.go
+++ b/pkg/graveler/ref/commit_ordered_iterator.go
@@ -18,30 +18,6 @@ type KVOrderedCommitIterator struct {
 	firstParents       map[string]bool
 }
 
-// getAllFirstParents returns a set of all commits that are not a first parent of other commit in the given repository.
-func getAllFirstParents(ctx context.Context, store *kv.StoreMessage, repo *graveler.RepositoryRecord) (map[string]bool, error) {
-	it, err := kv.NewPrimaryIterator(ctx, store.Store, (&graveler.CommitData{}).ProtoReflect().Type(),
-		graveler.RepoPartition(repo),
-		[]byte(graveler.CommitPath("")), kv.IteratorOptionsFrom([]byte("")))
-	if err != nil {
-		return nil, err
-	}
-	defer it.Close()
-	firstParents := make(map[string]bool)
-	for it.Next() {
-		entry := it.Entry()
-		commit := entry.Value.(*graveler.CommitData)
-		if len(commit.Parents) > 0 {
-			if graveler.CommitVersion(commit.Version) < graveler.CommitVersionParentSwitch && len(commit.Parents) > 1 {
-				firstParents[commit.Parents[1]] = true
-			} else {
-				firstParents[commit.Parents[0]] = true
-			}
-		}
-	}
-	return firstParents, nil
-}
-
 // NewKVOrderedCommitIterator returns an iterator over all commits in the given repository.
 // Ordering is based on the Commit ID value.
 // WithOnlyAncestryLeaves causes the iterator to return only commits which are not the first parent of any other commit.
@@ -113,14 +89,42 @@ func (i *KVOrderedCommitIterator) Value() *graveler.CommitRecord {
 }
 
 func (i *KVOrderedCommitIterator) Err() error {
-	if i.err == nil {
+	if i.err != nil {
+		return i.err
+	}
+	if i.it != nil {
 		return i.it.Err()
 	}
-	return i.err
+	return nil
 }
 
 func (i *KVOrderedCommitIterator) Close() {
 	if i.it != nil {
 		i.it.Close()
+		i.it = nil
 	}
+}
+
+// getAllFirstParents returns a set of all commits that are not a first parent of other commit in the given repository.
+func getAllFirstParents(ctx context.Context, store *kv.StoreMessage, repo *graveler.RepositoryRecord) (map[string]bool, error) {
+	it, err := kv.NewPrimaryIterator(ctx, store.Store, (&graveler.CommitData{}).ProtoReflect().Type(),
+		graveler.RepoPartition(repo),
+		[]byte(graveler.CommitPath("")), kv.IteratorOptionsFrom([]byte("")))
+	if err != nil {
+		return nil, err
+	}
+	defer it.Close()
+	firstParents := make(map[string]bool)
+	for it.Next() {
+		entry := it.Entry()
+		commit := entry.Value.(*graveler.CommitData)
+		if len(commit.Parents) > 0 {
+			if graveler.CommitVersion(commit.Version) < graveler.CommitVersionParentSwitch && len(commit.Parents) > 1 {
+				firstParents[commit.Parents[1]] = true
+			} else {
+				firstParents[commit.Parents[0]] = true
+			}
+		}
+	}
+	return firstParents, nil
 }

--- a/pkg/graveler/ref/commit_ordered_iterator.go
+++ b/pkg/graveler/ref/commit_ordered_iterator.go
@@ -48,7 +48,7 @@ func NewKVOrderedCommitIterator(ctx context.Context, store *kv.StoreMessage, rep
 }
 
 func (i *KVOrderedCommitIterator) Next() bool {
-	if i.Err() != nil {
+	if i.Err() != nil || i.it == nil {
 		return false
 	}
 	for i.it.Next() {

--- a/pkg/graveler/ref/commit_ordered_iterator_test.go
+++ b/pkg/graveler/ref/commit_ordered_iterator_test.go
@@ -8,16 +8,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/treeverse/lakefs/pkg/kv"
-
-	"github.com/treeverse/lakefs/pkg/kv/mock"
-
-	"github.com/golang/mock/gomock"
-
 	"github.com/go-openapi/swag"
 	"github.com/go-test/deep"
+	"github.com/golang/mock/gomock"
 	"github.com/treeverse/lakefs/pkg/graveler"
 	"github.com/treeverse/lakefs/pkg/graveler/ref"
+	"github.com/treeverse/lakefs/pkg/kv"
+	"github.com/treeverse/lakefs/pkg/kv/mock"
 	"github.com/treeverse/lakefs/pkg/testutil"
 )
 
@@ -37,112 +34,113 @@ type testCommit struct {
 
 func TestDBOrderedCommitIterator(t *testing.T) {
 	ctx := context.Background()
-	var (
-		cases = []struct {
-			Name                   string
-			Commits                []*testCommit
-			expectedCommits        []string
-			expectedAncestryLeaves []string
-		}{
-			{
-				Name: "two_ancestries",
-				Commits: []*testCommit{
-					{id: "e0", parents: []string{}},
-					{id: "c1", parents: []string{"e0"}},
-					{id: "b2", parents: []string{"e0"}},
-					{id: "d3", parents: []string{"c1"}},
-					{id: "e4", parents: []string{"b2"}},
-					{id: "f5", parents: []string{"d3"}},
-					{id: "a6", parents: []string{"e4"}},
-					{id: "c7", parents: []string{"f5"}}},
-				expectedCommits:        []string{"a6", "b2", "c1", "c7", "d3", "e0", "e4", "f5"},
-				expectedAncestryLeaves: []string{"a6", "c7"},
+	cases := []struct {
+		Name                   string
+		Commits                []*testCommit
+		expectedCommits        []string
+		expectedAncestryLeaves []string
+	}{
+		{
+			Name: "two_ancestries",
+			Commits: []*testCommit{
+				{id: "e0", parents: []string{}},
+				{id: "c1", parents: []string{"e0"}},
+				{id: "b2", parents: []string{"e0"}},
+				{id: "d3", parents: []string{"c1"}},
+				{id: "e4", parents: []string{"b2"}},
+				{id: "f5", parents: []string{"d3"}},
+				{id: "a6", parents: []string{"e4"}},
+				{id: "c7", parents: []string{"f5"}},
 			},
-			{
-				Name: "with_merge",
-				Commits: []*testCommit{
-					{id: "e0", parents: []string{}},
-					{id: "c1", parents: []string{"e0"}},
-					{id: "b2", parents: []string{"e0"}},
-					{id: "d3", parents: []string{"c1"}},
-					{id: "e4", parents: []string{"b2"}},
-					{id: "f5", parents: []string{"d3"}},
-					{id: "a6", parents: []string{"e4"}},
-					{id: "c7", parents: []string{"f5", "a6"}}},
-				expectedCommits:        []string{"a6", "b2", "c1", "c7", "d3", "e0", "e4", "f5"},
-				expectedAncestryLeaves: []string{"a6", "c7"},
+			expectedCommits:        []string{"a6", "b2", "c1", "c7", "d3", "e0", "e4", "f5"},
+			expectedAncestryLeaves: []string{"a6", "c7"},
+		},
+		{
+			Name: "with_merge",
+			Commits: []*testCommit{
+				{id: "e0", parents: []string{}},
+				{id: "c1", parents: []string{"e0"}},
+				{id: "b2", parents: []string{"e0"}},
+				{id: "d3", parents: []string{"c1"}},
+				{id: "e4", parents: []string{"b2"}},
+				{id: "f5", parents: []string{"d3"}},
+				{id: "a6", parents: []string{"e4"}},
+				{id: "c7", parents: []string{"f5", "a6"}},
 			},
-			{
-				Name: "with_merge_old_version",
-				Commits: []*testCommit{
-					{id: "e0", parents: []string{}},
-					{id: "c1", parents: []string{"e0"}},
-					{id: "b2", parents: []string{"e0"}},
-					{id: "d3", parents: []string{"c1"}},
-					{id: "e4", parents: []string{"b2"}},
-					{id: "f5", parents: []string{"d3"}},
-					{id: "a6", parents: []string{"e4"}},
-					{id: "c7", parents: []string{"f5", "a6"}, version: swag.Int(int(graveler.CommitVersionInitial))}},
-				expectedCommits:        []string{"a6", "b2", "c1", "c7", "d3", "e0", "e4", "f5"},
-				expectedAncestryLeaves: []string{"c7", "f5"},
+			expectedCommits:        []string{"a6", "b2", "c1", "c7", "d3", "e0", "e4", "f5"},
+			expectedAncestryLeaves: []string{"a6", "c7"},
+		},
+		{
+			Name: "with_merge_old_version",
+			Commits: []*testCommit{
+				{id: "e0", parents: []string{}},
+				{id: "c1", parents: []string{"e0"}},
+				{id: "b2", parents: []string{"e0"}},
+				{id: "d3", parents: []string{"c1"}},
+				{id: "e4", parents: []string{"b2"}},
+				{id: "f5", parents: []string{"d3"}},
+				{id: "a6", parents: []string{"e4"}},
+				{id: "c7", parents: []string{"f5", "a6"}, version: swag.Int(int(graveler.CommitVersionInitial))},
 			},
-			{
-				Name: "criss_cross_merge",
-				Commits: []*testCommit{
-					{id: "e0", parents: []string{}},
-					{id: "c1", parents: []string{"e0"}},
-					{id: "b2", parents: []string{"e0"}},
-					{id: "d3", parents: []string{"c1", "b2"}},
-					{id: "a4", parents: []string{"c1", "b2"}},
-					{id: "c5", parents: []string{"d3"}},
-					{id: "f6", parents: []string{"a4"}},
-				},
-				expectedCommits:        []string{"a4", "b2", "c1", "c5", "d3", "e0", "f6"},
-				expectedAncestryLeaves: []string{"b2", "c5", "f6"},
+			expectedCommits:        []string{"a6", "b2", "c1", "c7", "d3", "e0", "e4", "f5"},
+			expectedAncestryLeaves: []string{"c7", "f5"},
+		},
+		{
+			Name: "criss_cross_merge",
+			Commits: []*testCommit{
+				{id: "e0", parents: []string{}},
+				{id: "c1", parents: []string{"e0"}},
+				{id: "b2", parents: []string{"e0"}},
+				{id: "d3", parents: []string{"c1", "b2"}},
+				{id: "a4", parents: []string{"c1", "b2"}},
+				{id: "c5", parents: []string{"d3"}},
+				{id: "f6", parents: []string{"a4"}},
 			},
-			{
-				Name: "merges_in_history",
-				// from git core tests:
-				// E---D---C---B---A
-				// \"-_         \   \
-				//  \  `---------G   \
-				//   \                \
-				//    F----------------H
-				Commits: []*testCommit{
-					{id: "e", parents: []string{}},
-					{id: "d", parents: []string{"e"}},
-					{id: "f", parents: []string{"e"}},
-					{id: "c", parents: []string{"d"}},
-					{id: "b", parents: []string{"c"}},
-					{id: "a", parents: []string{"b"}},
-					{id: "g", parents: []string{"b", "e"}},
-					{id: "h", parents: []string{"a", "f"}},
-				},
-				expectedCommits:        []string{"a", "b", "c", "d", "e", "f", "g", "h"},
-				expectedAncestryLeaves: []string{"f", "g", "h"},
+			expectedCommits:        []string{"a4", "b2", "c1", "c5", "d3", "e0", "f6"},
+			expectedAncestryLeaves: []string{"b2", "c5", "f6"},
+		},
+		{
+			Name: "merges_in_history",
+			// from git core tests:
+			// E---D---C---B---A
+			// \"-_         \   \
+			//  \  `---------G   \
+			//   \                \
+			//    F----------------H
+			Commits: []*testCommit{
+				{id: "e", parents: []string{}},
+				{id: "d", parents: []string{"e"}},
+				{id: "f", parents: []string{"e"}},
+				{id: "c", parents: []string{"d"}},
+				{id: "b", parents: []string{"c"}},
+				{id: "a", parents: []string{"b"}},
+				{id: "g", parents: []string{"b", "e"}},
+				{id: "h", parents: []string{"a", "f"}},
 			},
-			{
-				Name: "merge_to_and_from_main",
-				// E---D----C---B------A
-				//  \      /     \    /
-				//   F----G---H---I--J
-				Commits: []*testCommit{
-					{id: "e", parents: []string{}},
-					{id: "d", parents: []string{"e"}},
-					{id: "f", parents: []string{"e"}},
-					{id: "g", parents: []string{"f"}},
-					{id: "c", parents: []string{"d", "g"}},
-					{id: "b", parents: []string{"c"}},
-					{id: "h", parents: []string{"g"}},
-					{id: "i", parents: []string{"h", "b"}},
-					{id: "j", parents: []string{"i"}},
-					{id: "a", parents: []string{"b", "j"}},
-				},
-				expectedCommits:        []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"},
-				expectedAncestryLeaves: []string{"a", "j"},
+			expectedCommits:        []string{"a", "b", "c", "d", "e", "f", "g", "h"},
+			expectedAncestryLeaves: []string{"f", "g", "h"},
+		},
+		{
+			Name: "merge_to_and_from_main",
+			// E---D----C---B------A
+			//  \      /     \    /
+			//   F----G---H---I--J
+			Commits: []*testCommit{
+				{id: "e", parents: []string{}},
+				{id: "d", parents: []string{"e"}},
+				{id: "f", parents: []string{"e"}},
+				{id: "g", parents: []string{"f"}},
+				{id: "c", parents: []string{"d", "g"}},
+				{id: "b", parents: []string{"c"}},
+				{id: "h", parents: []string{"g"}},
+				{id: "i", parents: []string{"h", "b"}},
+				{id: "j", parents: []string{"i"}},
+				{id: "a", parents: []string{"b", "j"}},
 			},
-		}
-	)
+			expectedCommits:        []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"},
+			expectedAncestryLeaves: []string{"a", "j"},
+		},
+	}
 	for _, tst := range cases {
 		t.Run(tst.Name, func(t *testing.T) {
 			var commits []*graveler.Commit
@@ -298,117 +296,117 @@ func TestDBOrderedCommitIteratorGrid(t *testing.T) {
 		t.Errorf("Unexpected ancestry leaves from iterator. diff=%s", diff)
 	}
 	iterator.Close()
-
 }
 
 func TestKVOrderedCommitIterator(t *testing.T) {
 	ctx := context.Background()
-	var (
-		cases = []struct {
-			Name                   string
-			Commits                []*testCommit
-			expectedCommits        []string
-			expectedAncestryLeaves []string
-		}{
-			{
-				Name: "two_ancestries",
-				Commits: []*testCommit{
-					{id: "e0", parents: []string{}},
-					{id: "c1", parents: []string{"e0"}},
-					{id: "b2", parents: []string{"e0"}},
-					{id: "d3", parents: []string{"c1"}},
-					{id: "e4", parents: []string{"b2"}},
-					{id: "f5", parents: []string{"d3"}},
-					{id: "a6", parents: []string{"e4"}},
-					{id: "c7", parents: []string{"f5"}}},
-				expectedCommits:        []string{"a6", "b2", "c1", "c7", "d3", "e0", "e4", "f5"},
-				expectedAncestryLeaves: []string{"a6", "c7"},
+	cases := []struct {
+		Name                   string
+		Commits                []*testCommit
+		expectedCommits        []string
+		expectedAncestryLeaves []string
+	}{
+		{
+			Name: "two_ancestries",
+			Commits: []*testCommit{
+				{id: "e0", parents: []string{}},
+				{id: "c1", parents: []string{"e0"}},
+				{id: "b2", parents: []string{"e0"}},
+				{id: "d3", parents: []string{"c1"}},
+				{id: "e4", parents: []string{"b2"}},
+				{id: "f5", parents: []string{"d3"}},
+				{id: "a6", parents: []string{"e4"}},
+				{id: "c7", parents: []string{"f5"}},
 			},
-			{
-				Name: "with_merge",
-				Commits: []*testCommit{
-					{id: "e0", parents: []string{}},
-					{id: "c1", parents: []string{"e0"}},
-					{id: "b2", parents: []string{"e0"}},
-					{id: "d3", parents: []string{"c1"}},
-					{id: "e4", parents: []string{"b2"}},
-					{id: "f5", parents: []string{"d3"}},
-					{id: "a6", parents: []string{"e4"}},
-					{id: "c7", parents: []string{"f5", "a6"}}},
-				expectedCommits:        []string{"a6", "b2", "c1", "c7", "d3", "e0", "e4", "f5"},
-				expectedAncestryLeaves: []string{"a6", "c7"},
+			expectedCommits:        []string{"a6", "b2", "c1", "c7", "d3", "e0", "e4", "f5"},
+			expectedAncestryLeaves: []string{"a6", "c7"},
+		},
+		{
+			Name: "with_merge",
+			Commits: []*testCommit{
+				{id: "e0", parents: []string{}},
+				{id: "c1", parents: []string{"e0"}},
+				{id: "b2", parents: []string{"e0"}},
+				{id: "d3", parents: []string{"c1"}},
+				{id: "e4", parents: []string{"b2"}},
+				{id: "f5", parents: []string{"d3"}},
+				{id: "a6", parents: []string{"e4"}},
+				{id: "c7", parents: []string{"f5", "a6"}},
 			},
-			{
-				Name: "with_merge_old_version",
-				Commits: []*testCommit{
-					{id: "e0", parents: []string{}},
-					{id: "c1", parents: []string{"e0"}},
-					{id: "b2", parents: []string{"e0"}},
-					{id: "d3", parents: []string{"c1"}},
-					{id: "e4", parents: []string{"b2"}},
-					{id: "f5", parents: []string{"d3"}},
-					{id: "a6", parents: []string{"e4"}},
-					{id: "c7", parents: []string{"f5", "a6"}, version: swag.Int(int(graveler.CommitVersionInitial))}},
-				expectedCommits:        []string{"a6", "b2", "c1", "c7", "d3", "e0", "e4", "f5"},
-				expectedAncestryLeaves: []string{"c7", "f5"},
+			expectedCommits:        []string{"a6", "b2", "c1", "c7", "d3", "e0", "e4", "f5"},
+			expectedAncestryLeaves: []string{"a6", "c7"},
+		},
+		{
+			Name: "with_merge_old_version",
+			Commits: []*testCommit{
+				{id: "e0", parents: []string{}},
+				{id: "c1", parents: []string{"e0"}},
+				{id: "b2", parents: []string{"e0"}},
+				{id: "d3", parents: []string{"c1"}},
+				{id: "e4", parents: []string{"b2"}},
+				{id: "f5", parents: []string{"d3"}},
+				{id: "a6", parents: []string{"e4"}},
+				{id: "c7", parents: []string{"f5", "a6"}, version: swag.Int(int(graveler.CommitVersionInitial))},
 			},
-			{
-				Name: "criss_cross_merge",
-				Commits: []*testCommit{
-					{id: "e0", parents: []string{}},
-					{id: "c1", parents: []string{"e0"}},
-					{id: "b2", parents: []string{"e0"}},
-					{id: "d3", parents: []string{"c1", "b2"}},
-					{id: "a4", parents: []string{"c1", "b2"}},
-					{id: "c5", parents: []string{"d3"}},
-					{id: "f6", parents: []string{"a4"}},
-				},
-				expectedCommits:        []string{"a4", "b2", "c1", "c5", "d3", "e0", "f6"},
-				expectedAncestryLeaves: []string{"b2", "c5", "f6"},
+			expectedCommits:        []string{"a6", "b2", "c1", "c7", "d3", "e0", "e4", "f5"},
+			expectedAncestryLeaves: []string{"c7", "f5"},
+		},
+		{
+			Name: "criss_cross_merge",
+			Commits: []*testCommit{
+				{id: "e0", parents: []string{}},
+				{id: "c1", parents: []string{"e0"}},
+				{id: "b2", parents: []string{"e0"}},
+				{id: "d3", parents: []string{"c1", "b2"}},
+				{id: "a4", parents: []string{"c1", "b2"}},
+				{id: "c5", parents: []string{"d3"}},
+				{id: "f6", parents: []string{"a4"}},
 			},
-			{
-				Name: "merges_in_history",
-				// from git core tests:
-				// E---D---C---B---A
-				// \"-_         \   \
-				//  \  `---------G   \
-				//   \                \
-				//    F----------------H
-				Commits: []*testCommit{
-					{id: "e", parents: []string{}},
-					{id: "d", parents: []string{"e"}},
-					{id: "f", parents: []string{"e"}},
-					{id: "c", parents: []string{"d"}},
-					{id: "b", parents: []string{"c"}},
-					{id: "a", parents: []string{"b"}},
-					{id: "g", parents: []string{"b", "e"}},
-					{id: "h", parents: []string{"a", "f"}},
-				},
-				expectedCommits:        []string{"a", "b", "c", "d", "e", "f", "g", "h"},
-				expectedAncestryLeaves: []string{"f", "g", "h"},
+			expectedCommits:        []string{"a4", "b2", "c1", "c5", "d3", "e0", "f6"},
+			expectedAncestryLeaves: []string{"b2", "c5", "f6"},
+		},
+		{
+			Name: "merges_in_history",
+			// from git core tests:
+			// E---D---C---B---A
+			// \"-_         \   \
+			//  \  `---------G   \
+			//   \                \
+			//    F----------------H
+			Commits: []*testCommit{
+				{id: "e", parents: []string{}},
+				{id: "d", parents: []string{"e"}},
+				{id: "f", parents: []string{"e"}},
+				{id: "c", parents: []string{"d"}},
+				{id: "b", parents: []string{"c"}},
+				{id: "a", parents: []string{"b"}},
+				{id: "g", parents: []string{"b", "e"}},
+				{id: "h", parents: []string{"a", "f"}},
 			},
-			{
-				Name: "merge_to_and_from_main",
-				// E---D----C---B------A
-				//  \      /     \    /
-				//   F----G---H---I--J
-				Commits: []*testCommit{
-					{id: "e", parents: []string{}},
-					{id: "d", parents: []string{"e"}},
-					{id: "f", parents: []string{"e"}},
-					{id: "g", parents: []string{"f"}},
-					{id: "c", parents: []string{"d", "g"}},
-					{id: "b", parents: []string{"c"}},
-					{id: "h", parents: []string{"g"}},
-					{id: "i", parents: []string{"h", "b"}},
-					{id: "j", parents: []string{"i"}},
-					{id: "a", parents: []string{"b", "j"}},
-				},
-				expectedCommits:        []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"},
-				expectedAncestryLeaves: []string{"a", "j"},
+			expectedCommits:        []string{"a", "b", "c", "d", "e", "f", "g", "h"},
+			expectedAncestryLeaves: []string{"f", "g", "h"},
+		},
+		{
+			Name: "merge_to_and_from_main",
+			// E---D----C---B------A
+			//  \      /     \    /
+			//   F----G---H---I--J
+			Commits: []*testCommit{
+				{id: "e", parents: []string{}},
+				{id: "d", parents: []string{"e"}},
+				{id: "f", parents: []string{"e"}},
+				{id: "g", parents: []string{"f"}},
+				{id: "c", parents: []string{"d", "g"}},
+				{id: "b", parents: []string{"c"}},
+				{id: "h", parents: []string{"g"}},
+				{id: "i", parents: []string{"h", "b"}},
+				{id: "j", parents: []string{"i"}},
+				{id: "a", parents: []string{"b", "j"}},
 			},
-		}
-	)
+			expectedCommits:        []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j"},
+			expectedAncestryLeaves: []string{"a", "j"},
+		},
+	}
 	for _, tst := range cases {
 		t.Run(tst.Name, func(t *testing.T) {
 			var commits []*graveler.Commit
@@ -567,7 +565,6 @@ func TestKVOrderedCommitIteratorGrid(t *testing.T) {
 		t.Errorf("Unexpected ancestry leaves from iterator. diff=%s", diff)
 	}
 	iterator.Close()
-
 }
 
 func TestKVOrderedCommitIterator_CloseTwice(t *testing.T) {

--- a/pkg/graveler/ref/merge_base_finder_test.go
+++ b/pkg/graveler/ref/merge_base_finder_test.go
@@ -15,8 +15,6 @@ type MockCommitGetter struct {
 	visited    map[graveler.CommitID]int
 }
 
-var repository = &graveler.RepositoryRecord{RepositoryID: "ref-test-repo"}
-
 func (g *MockCommitGetter) GetCommit(_ context.Context, _ *graveler.RepositoryRecord, commitID graveler.CommitID) (*graveler.Commit, error) {
 	if commit, ok := g.byCommitID[commitID]; ok {
 		g.visited[commitID] += 1
@@ -233,7 +231,7 @@ func TestFindMergeBase(t *testing.T) {
 			// Verifying the fix introduced with https://github.com/treeverse/lakeFS/pull/2968. The following commits tree
 			// will generate multiple accesses to commit 'b' as it is a parent commit for both 'd' and 'c' and per BFS algo,
 			// it will be reached via both paths before ROOT is reached from L.
-			// The abovementioned fix eliminates that
+			// The above-mentioned fix eliminates that
 			Left:  "l",
 			Right: "r",
 			Getter: func() *MockCommitGetter {
@@ -321,6 +319,7 @@ func TestFindMergeBase(t *testing.T) {
 			Expected: []string{"ab"},
 		},
 	}
+	repository := &graveler.RepositoryRecord{RepositoryID: "ref-test-repo"}
 	for _, cas := range cases {
 		t.Run(cas.Name, func(t *testing.T) {
 			getter := cas.Getter()
@@ -373,6 +372,7 @@ func TestGrid(t *testing.T) {
 			kv[graveler.CommitID(fmt.Sprintf("%d-%d", i, j))] = grid[i][j]
 		}
 	}
+	repository := &graveler.RepositoryRecord{RepositoryID: "ref-test-repo"}
 	getter := newReader(kv)
 	c, err := ref.FindMergeBase(context.Background(), getter, repository, "7-4", "5-6")
 	testutil.Must(t, err)

--- a/pkg/graveler/ref/repository_iterator_test.go
+++ b/pkg/graveler/ref/repository_iterator_test.go
@@ -5,14 +5,13 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/mock/gomock"
-	"github.com/treeverse/lakefs/pkg/kv"
-	"github.com/treeverse/lakefs/pkg/kv/mock"
-
 	"github.com/go-test/deep"
+	"github.com/golang/mock/gomock"
 	"github.com/stretchr/testify/require"
 	"github.com/treeverse/lakefs/pkg/graveler"
 	"github.com/treeverse/lakefs/pkg/graveler/ref"
+	"github.com/treeverse/lakefs/pkg/kv"
+	"github.com/treeverse/lakefs/pkg/kv/mock"
 	"github.com/treeverse/lakefs/pkg/testutil"
 )
 

--- a/pkg/graveler/ref/tag_iterator_test.go
+++ b/pkg/graveler/ref/tag_iterator_test.go
@@ -5,6 +5,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/golang/mock/gomock"
+	"github.com/treeverse/lakefs/pkg/kv"
+	"github.com/treeverse/lakefs/pkg/kv/mock"
+
 	"github.com/go-test/deep"
 	"github.com/treeverse/lakefs/pkg/graveler"
 	"github.com/treeverse/lakefs/pkg/graveler/ref"
@@ -208,4 +212,50 @@ func TestKVTagIterator(t *testing.T) {
 			t.Fatalf("expected nil value after seekGE")
 		}
 	})
+}
+
+func TestKVTagIterator_CloseTwice(t *testing.T) {
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	entIt := mock.NewMockEntriesIterator(ctrl)
+	entIt.EXPECT().Close().Times(1)
+	store := mock.NewMockStore(ctrl)
+	store.EXPECT().Scan(ctx, gomock.Any(), gomock.Any()).Return(entIt, nil).Times(1)
+	msgStore := kv.StoreMessage{Store: store}
+	repo := &graveler.RepositoryRecord{
+		RepositoryID: "repo",
+		Repository: &graveler.Repository{
+			InstanceUID: "rid",
+		},
+	}
+	it, err := ref.NewKVTagIterator(ctx, &msgStore, repo)
+	if err != nil {
+		t.Fatal("TestKVTagIterator failed", err)
+	}
+	it.Close()
+	// Make sure calling Close again do not crash
+	it.Close()
+}
+
+func TestKVTagIterator_NextClosed(t *testing.T) {
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	entIt := mock.NewMockEntriesIterator(ctrl)
+	entIt.EXPECT().Close().Times(1)
+	store := mock.NewMockStore(ctrl)
+	store.EXPECT().Scan(ctx, gomock.Any(), gomock.Any()).Return(entIt, nil).Times(1)
+	msgStore := kv.StoreMessage{Store: store}
+	repo := &graveler.RepositoryRecord{
+		RepositoryID: "repo",
+		Repository: &graveler.Repository{
+			InstanceUID: "rid",
+		},
+	}
+	it, err := ref.NewKVTagIterator(ctx, &msgStore, repo)
+	if err != nil {
+		t.Fatal("TestKVTagIterator failed", err)
+	}
+	it.Close()
+	// Make sure calling Next should not crash
+	it.Next()
 }

--- a/pkg/graveler/ref/tag_iterator_test.go
+++ b/pkg/graveler/ref/tag_iterator_test.go
@@ -5,13 +5,12 @@ import (
 	"testing"
 	"time"
 
-	"github.com/golang/mock/gomock"
-	"github.com/treeverse/lakefs/pkg/kv"
-	"github.com/treeverse/lakefs/pkg/kv/mock"
-
 	"github.com/go-test/deep"
+	"github.com/golang/mock/gomock"
 	"github.com/treeverse/lakefs/pkg/graveler"
 	"github.com/treeverse/lakefs/pkg/graveler/ref"
+	"github.com/treeverse/lakefs/pkg/kv"
+	"github.com/treeverse/lakefs/pkg/kv/mock"
 	"github.com/treeverse/lakefs/pkg/testutil"
 )
 

--- a/pkg/kv/iterators.go
+++ b/pkg/kv/iterators.go
@@ -312,7 +312,7 @@ func (p *PartitionIterator) Err() error {
 	if p.err != nil {
 		return p.err
 	}
-	if p.itr != nil {
+	if !p.itrClosed {
 		return p.itr.Err()
 	}
 	return nil

--- a/pkg/kv/iterators_test.go
+++ b/pkg/kv/iterators_test.go
@@ -39,5 +39,5 @@ func TestPartitionIterator_CloseAfterSeekGEFailed(t *testing.T) {
 
 	it := kv.NewPartitionIterator(ctx, store, (&graveler.StagedEntryData{}).ProtoReflect().Type(), "partitionKey")
 	it.SeekGE([]byte("test"))
-	it.Close() // verify we don't crash after see failedcx
+	it.Close() // verify we don't crash after after SeekGE failed internally with Scan
 }

--- a/pkg/kv/iterators_test.go
+++ b/pkg/kv/iterators_test.go
@@ -1,0 +1,29 @@
+package kv_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/treeverse/lakefs/pkg/graveler"
+	"github.com/treeverse/lakefs/pkg/kv"
+	"github.com/treeverse/lakefs/pkg/kv/mock"
+)
+
+func TestPartitionIterator_ClosedBehaviour(t *testing.T) {
+	ctx := context.Background()
+	ctrl := gomock.NewController(t)
+	store := mock.NewMockStore(ctrl)
+	entIt := mock.NewMockEntriesIterator(ctrl)
+	entIt.EXPECT().Close().Times(1)
+	store.EXPECT().Scan(ctx, gomock.Any(), gomock.Any()).Return(entIt, nil).Times(1)
+
+	it := kv.NewPartitionIterator(ctx, store, (&graveler.StagedEntryData{}).ProtoReflect().Type(), "partitionKey")
+	it.SeekGE([]byte("test"))
+	it.Close()
+
+	err := it.Err() // verify we don't crash or call underlying iterator after we Close()
+	if err != nil {
+		t.Fatal("Err() on closed iterator", err)
+	}
+}

--- a/pkg/kv/kvtest/store.go
+++ b/pkg/kv/kvtest/store.go
@@ -462,12 +462,9 @@ func testStoreMissingArgument(t *testing.T, ms MakeStore) {
 	t.Run("Scan", func(t *testing.T) {
 		start := uniqueKey("test-missing-argument")
 		for _, pk := range [][]byte{nil, {}} {
-			it, err := store.Scan(ctx, pk, start)
+			_, err := store.Scan(ctx, pk, start)
 			if !errors.Is(err, kv.ErrMissingPartitionKey) {
-				t.Errorf("Scan using empty partition key - err=%v, expected %s", err, kv.ErrMissingPartitionKey)
-			}
-			if it != nil {
-				t.Errorf("Scan using empty partition key - expected nil iterator: %s", it)
+				t.Fatalf("Scan using empty partition key - err=%v, expected %s", err, kv.ErrMissingPartitionKey)
 			}
 		}
 	})

--- a/pkg/kv/store.go
+++ b/pkg/kv/store.go
@@ -1,5 +1,7 @@
 package kv
 
+//go:generate mockgen -source=store.go -destination=mock/store.go -package=mock
+
 import (
 	"context"
 	"errors"


### PR DESCRIPTION
- Align how repository iterator use of MessageIterator handle when it is closed
- Align how tag iterator use of MessageIterator handle when it is closed
- kv/PartitionIterator Err should check itr closed flag and not interface
- Remove interface compare in store test

Close #4164