### PR TITLE
Always run Esti

### DIFF
--- a/.github/workflows/esti.yaml
+++ b/.github/workflows/esti.yaml
@@ -2,11 +2,6 @@ name: Esti
 on:
   pull_request:
   push:
-    paths-ignore:
-      - "*.md"
-      - "docs/**"
-      - "webui/**"
-      - "design/**"
     branches:
       - master
 


### PR DESCRIPTION
Skipping Esti for docs-only PRs does not work: the PR must be pushed by force.  So instead of doing the wrong thing quickly, waste some time and do the right thing.