### PR TITLE
Fix broken Everything Bagel (pin lakefs image version)

### DIFF
--- a/deployments/compose/docker-compose.yml
+++ b/deployments/compose/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 services:
 
   lakefs-setup:
-    image: treeverse/lakefs:latest
+    image: treeverse/lakefs:0.70.6
     container_name: lakefs-setup
     depends_on:
       - postgres
@@ -36,7 +36,7 @@ services:
     entrypoint: ["minio", "server", "/data", "--console-address", ":9001"]
 
   lakefs:
-    image: treeverse/lakefs:latest
+    image: treeverse/lakefs:0.70.6
     container_name: lakefs
     ports:
       - "8000:8000"


### PR DESCRIPTION
ref: #4182

This change pins the lakefs docker image used in Everything Bagel so that it continues to work. 

The 0.80 version of the image expects different environment variables (`LAKEFS_DATABASE_TYPE` / `LAKEFS_DATABASE_POSTGRES_CONNECTION_STRING`) which is a subsequent issue to fix assuming Everything Bagel is to keep track with the latest release. 