### PR TITLE
Extended metrics

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -153,9 +153,9 @@ gen-code: go-install ## Run the generator for inline commands
 		./pkg/graveler \
 		./pkg/graveler/committed \
 		./pkg/graveler/sstable \
+		./pkg/kv \
 		./pkg/onboard \
-		./pkg/pyramid \
-	    ./pkg/kv
+		./pkg/pyramid
 
 LD_FLAGS := "-X github.com/treeverse/lakefs/pkg/version.Version=$(VERSION)-$(REVISION)"
 build: gen docs ## Download dependencies and build the default binary

--- a/Makefile
+++ b/Makefile
@@ -229,7 +229,7 @@ checks-validator: lint validate-fmt validate-proto validate-client-python valida
 $(UI_DIR)/node_modules:
 	cd $(UI_DIR) && $(NPM) install
 
-gen-ui:  ## Build UI app
+gen-ui: $(UI_DIR)/node_modules  ## Build UI web app
 	cd $(UI_DIR) && $(NPM) run build
 
 proto: ## Build proto (Protocol Buffers) files

--- a/Makefile
+++ b/Makefile
@@ -117,6 +117,7 @@ client-python: api/swagger.yml  ## Generate SDK for Python client
 		-g python \
 		-t /mnt/clients/python/templates \
 		--package-name lakefs_client \
+		--http-user-agent "lakefs-python-sdk/$(PACKAGE_VERSION)" \
 		--git-user-id treeverse --git-repo-id lakeFS \
 		--additional-properties=infoName=Treeverse,infoEmail=services@treeverse.io,packageName=lakefs_client,packageVersion=$(PACKAGE_VERSION),projectName=lakefs-client,packageUrl=https://github.com/treeverse/lakeFS/tree/master/clients/python \
 		-o /mnt/clients/python
@@ -127,6 +128,7 @@ client-java: api/swagger.yml  ## Generate SDK for Java (and Scala) client
 		-i /mnt/$< \
 		-g java \
 		--invoker-package io.lakefs.clients.api \
+		--http-user-agent "lakefs-java-sdk/$(PACKAGE_VERSION)" \
 		--additional-properties=hideGenerationTimestamp=true,artifactVersion=$(PACKAGE_VERSION),parentArtifactId=lakefs-parent,parentGroupId=io.lakefs,parentVersion=0,groupId=io.lakefs,artifactId='api-client',artifactDescription='lakeFS OpenAPI Java client',artifactUrl=https://lakefs.io,apiPackage=io.lakefs.clients.api,modelPackage=io.lakefs.clients.api.model,mainPackage=io.lakefs.clients.api,developerEmail=services@treeverse.io,developerName='Treeverse lakeFS dev',developerOrganization='lakefs.io',developerOrganizationUrl='https://lakefs.io',licenseName=apache2,licenseUrl=http://www.apache.org/licenses/,scmConnection=scm:git:git@github.com:treeverse/lakeFS.git,scmDeveloperConnection=scm:git:git@github.com:treeverse/lakeFS.git,scmUrl=https://github.com/treeverse/lakeFS \
 		-o /mnt/clients/java
 
@@ -227,11 +229,8 @@ checks-validator: lint validate-fmt validate-proto validate-client-python valida
 $(UI_DIR)/node_modules:
 	cd $(UI_DIR) && $(NPM) install
 
-# UI operations
-ui-build: $(UI_DIR)/node_modules  ## Build UI app
+gen-ui:  ## Build UI app
 	cd $(UI_DIR) && $(NPM) run build
-
-gen-ui: ui-build
 
 proto: ## Build proto (Protocol Buffers) files
 	$(PROTOC) --proto_path=pkg/catalog --go_out=pkg/catalog --go_opt=paths=source_relative catalog.proto

--- a/clients/java/src/main/java/io/lakefs/clients/api/ApiClient.java
+++ b/clients/java/src/main/java/io/lakefs/clients/api/ApiClient.java
@@ -131,7 +131,7 @@ public class ApiClient {
         json = new JSON();
 
         // Set default User-Agent.
-        setUserAgent("OpenAPI-Generator/0.1.0-SNAPSHOT/java");
+        setUserAgent("lakefs-java-sdk/0.1.0-SNAPSHOT");
 
         authentications = new HashMap<String, Authentication>();
     }

--- a/clients/python/lakefs_client/api_client.py
+++ b/clients/python/lakefs_client/api_client.py
@@ -77,7 +77,7 @@ class ApiClient(object):
             self.default_headers[header_name] = header_value
         self.cookie = cookie
         # Set default User-Agent.
-        self.user_agent = 'OpenAPI-Generator/0.1.0-SNAPSHOT/python'
+        self.user_agent = 'lakefs-python-sdk/0.1.0-SNAPSHOT'
 
     def __enter__(self):
         return self

--- a/cmd/lakectl/cmd/root.go
+++ b/cmd/lakectl/cmd/root.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"io"
@@ -121,8 +122,12 @@ func getClient() *api.ClientWithResponses {
 
 	client, err := api.NewClientWithResponses(
 		serverEndpoint,
-		api.WithRequestEditorFn(basicAuthProvider.Intercept),
 		api.WithHTTPClient(httpClient),
+		api.WithRequestEditorFn(basicAuthProvider.Intercept),
+		api.WithRequestEditorFn(func(ctx context.Context, req *http.Request) error {
+			req.Header.Set("User-Agent", "lakectl/"+version.Version)
+			return nil
+		}),
 	)
 	if err != nil {
 		Die(fmt.Sprintf("could not initialize API client: %s", err), 1)

--- a/cmd/lakefs/cmd/import.go
+++ b/cmd/lakefs/cmd/import.go
@@ -102,7 +102,7 @@ func runImport(cmd *cobra.Command, args []string) (statusCode int) {
 		return 1
 	}
 
-	bufferedCollector := stats.NewBufferedCollector(cfg.GetFixedInstallationID(), cfg)
+	bufferedCollector := stats.NewBufferedCollector(cfg.GetFixedInstallationID(), cfg, stats.WithLogger(logger))
 	defer bufferedCollector.Close()
 	bufferedCollector.SetRuntimeCollector(blockStore.RuntimeStats)
 

--- a/cmd/lakefs/cmd/run.go
+++ b/cmd/lakefs/cmd/run.go
@@ -167,8 +167,10 @@ var runCmd = &cobra.Command{
 			logger.WithField("adapter_type", blockstoreType).
 				Error("Block adapter NOT SUPPORTED for production use")
 		}
+
 		metadata := stats.NewMetadata(ctx, logger, blockstoreType, authMetadataManager, cloudMetadataProvider)
-		bufferedCollector := stats.NewBufferedCollector(metadata.InstallationID, cfg)
+		bufferedCollector := stats.NewBufferedCollector(metadata.InstallationID, cfg, stats.WithLogger(logger))
+
 		// init block store
 		blockStore, err := factory.BuildBlockAdapter(ctx, bufferedCollector, cfg)
 		if err != nil {

--- a/cmd/lakefs/cmd/run.go
+++ b/cmd/lakefs/cmd/run.go
@@ -313,7 +313,7 @@ var runCmd = &cobra.Command{
 		bufferedCollector.Run(ctx)
 		defer bufferedCollector.Close()
 
-		bufferedCollector.CollectEvent("global", "run")
+		bufferedCollector.CollectEvent(stats.Event{Class: "global", Name: "run"})
 
 		logging.Default().WithField("listen_address", cfg.GetListenAddress()).Info("starting HTTP server")
 		server := &http.Server{

--- a/cmd/lakefs/cmd/setup.go
+++ b/cmd/lakefs/cmd/setup.go
@@ -88,12 +88,12 @@ var setupCmd = &cobra.Command{
 		}
 
 		ctx, cancelFn := context.WithCancel(ctx)
-		stats := stats.NewBufferedCollector(metadata.InstallationID, cfg)
-		stats.Run(ctx)
-		defer stats.Close()
+		collector := stats.NewBufferedCollector(metadata.InstallationID, cfg)
+		collector.Run(ctx)
+		defer collector.Close()
 
-		stats.CollectMetadata(metadata)
-		stats.CollectEvent("global", "init")
+		collector.CollectMetadata(metadata)
+		collector.CollectEvent(stats.Event{Class: "global", Name: "init"})
 
 		fmt.Printf("credentials:\n  access_key_id: %s\n  secret_access_key: %s\n",
 			credentials.AccessKeyID, credentials.SecretAccessKey)

--- a/cmd/lakefs/cmd/superuser.go
+++ b/cmd/lakefs/cmd/superuser.go
@@ -71,12 +71,12 @@ var superuserCmd = &cobra.Command{
 		}
 
 		ctx, cancelFn := context.WithCancel(ctx)
-		stats := stats.NewBufferedCollector(metadata.InstallationID, cfg)
-		stats.Run(ctx)
-		defer stats.Close()
+		collector := stats.NewBufferedCollector(metadata.InstallationID, cfg)
+		collector.Run(ctx)
+		defer collector.Close()
 
-		stats.CollectMetadata(metadata)
-		stats.CollectEvent("global", "superuser")
+		collector.CollectMetadata(metadata)
+		collector.CollectEvent(stats.Event{Class: "global", Name: "superuser"})
 
 		fmt.Printf("credentials:\n  access_key_id: %s\n  secret_access_key: %s\n",
 			credentials.AccessKeyID, credentials.SecretAccessKey)

--- a/cmd/lakefs/cmd/superuser.go
+++ b/cmd/lakefs/cmd/superuser.go
@@ -71,7 +71,7 @@ var superuserCmd = &cobra.Command{
 		}
 
 		ctx, cancelFn := context.WithCancel(ctx)
-		collector := stats.NewBufferedCollector(metadata.InstallationID, cfg)
+		collector := stats.NewBufferedCollector(metadata.InstallationID, cfg, stats.WithLogger(logger))
 		collector.Run(ctx)
 		defer collector.Close()
 

--- a/pkg/actions/service.go
+++ b/pkg/actions/service.go
@@ -300,7 +300,7 @@ func (s *StoreService) runTasks(ctx context.Context, record graveler.HookRecord,
 				task.Err = task.Hook.Run(ctx, record, &buf)
 				task.EndTime = time.Now().UTC()
 
-				s.stats.CollectEvent("actions_service", string(record.EventType))
+				s.stats.CollectEvent(stats.Event{Class: "actions_service", Name: string(record.EventType)})
 
 				if task.Err != nil {
 					_, _ = fmt.Fprintf(&buf, "Error: %s\n", task.Err)

--- a/pkg/actions/service_test.go
+++ b/pkg/actions/service_test.go
@@ -42,9 +42,10 @@ func NewActionStatsMockCollector() ActionStatsMockCollector {
 	}
 }
 
-func (c *ActionStatsMockCollector) CollectEvent(_, action string) {
-	c.Hits[action]++
+func (c *ActionStatsMockCollector) CollectEvent(ev stats.Event) {
+	c.Hits[ev.Name]++
 }
+
 func (c *ActionStatsMockCollector) CollectMetadata(_ *stats.Metadata) {}
 func (c *ActionStatsMockCollector) SetInstallationID(_ string)        {}
 func (c *ActionStatsMockCollector) Close()                            {}

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -102,7 +102,7 @@ func (c *Controller) GetAuthCapabilities(w http.ResponseWriter, _ *http.Request)
 
 func (c *Controller) DeleteObjects(w http.ResponseWriter, r *http.Request, body DeleteObjectsJSONRequestBody, repository string, branch string) {
 	ctx := r.Context()
-	c.LogAction(ctx, "delete_objects", r.UserAgent(), repository, branch, "")
+	c.LogAction(ctx, "delete_objects", r, repository, branch, "")
 
 	// limit check
 	if len(body.Paths) > DefaultMaxDeleteObjects {
@@ -242,7 +242,7 @@ func (c *Controller) GetPhysicalAddress(w http.ResponseWriter, r *http.Request, 
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "generate_physical_address", r.UserAgent(), repository, branch, "")
+	c.LogAction(ctx, "generate_physical_address", r, repository, branch, "")
 
 	repo, err := c.Catalog.GetRepository(ctx, repository)
 	if errors.Is(err, catalog.ErrNotFound) {
@@ -299,7 +299,7 @@ func (c *Controller) LinkPhysicalAddress(w http.ResponseWriter, r *http.Request,
 	}
 
 	ctx := r.Context()
-	c.LogAction(ctx, "stage_object", r.UserAgent(), repository, branch, "")
+	c.LogAction(ctx, "stage_object", r, repository, branch, "")
 
 	repo, err := c.Catalog.GetRepository(ctx, repository)
 	if errors.Is(err, catalog.ErrNotFound) {
@@ -380,7 +380,7 @@ func (c *Controller) ListGroups(w http.ResponseWriter, r *http.Request, params L
 	}
 
 	ctx := r.Context()
-	c.LogAction(ctx, "list_groups", r.UserAgent(), "", "", "")
+	c.LogAction(ctx, "list_groups", r, "", "", "")
 	groups, paginator, err := c.Auth.ListGroups(ctx, &model.PaginationParams{
 		After:  paginationAfter(params.After),
 		Prefix: paginationPrefix(params.Prefix),
@@ -418,7 +418,7 @@ func (c *Controller) CreateGroup(w http.ResponseWriter, r *http.Request, body Cr
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "create_group", r.UserAgent(), "", "", "")
+	c.LogAction(ctx, "create_group", r, "", "", "")
 
 	g := &model.Group{
 		CreatedAt:   time.Now().UTC(),
@@ -446,7 +446,7 @@ func (c *Controller) DeleteGroup(w http.ResponseWriter, r *http.Request, groupID
 	}
 
 	ctx := r.Context()
-	c.LogAction(ctx, "delete_group", r.UserAgent(), "", "", "")
+	c.LogAction(ctx, "delete_group", r, "", "", "")
 	err := c.Auth.DeleteGroup(ctx, groupID)
 	if errors.Is(err, auth.ErrNotFound) {
 		writeError(w, http.StatusNotFound, "group not found")
@@ -468,7 +468,7 @@ func (c *Controller) GetGroup(w http.ResponseWriter, r *http.Request, groupID st
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "get_group", r.UserAgent(), "", "", "")
+	c.LogAction(ctx, "get_group", r, "", "", "")
 	g, err := c.Auth.GetGroup(ctx, groupID)
 	if errors.Is(err, auth.ErrNotFound) {
 		writeError(w, http.StatusNotFound, "group not found")
@@ -495,7 +495,7 @@ func (c *Controller) ListGroupMembers(w http.ResponseWriter, r *http.Request, gr
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "list_group_users", r.UserAgent(), "", "", "")
+	c.LogAction(ctx, "list_group_users", r, "", "", "")
 	users, paginator, err := c.Auth.ListGroupUsers(ctx, groupID, &model.PaginationParams{
 		After:  paginationAfter(params.After),
 		Prefix: paginationPrefix(params.Prefix),
@@ -534,7 +534,7 @@ func (c *Controller) DeleteGroupMembership(w http.ResponseWriter, r *http.Reques
 	}
 
 	ctx := r.Context()
-	c.LogAction(ctx, "remove_user_from_group", r.UserAgent(), "", "", "")
+	c.LogAction(ctx, "remove_user_from_group", r, "", "", "")
 	err := c.Auth.RemoveUserFromGroup(ctx, userID, groupID)
 	if c.handleAPIError(ctx, w, err) {
 		return
@@ -552,7 +552,7 @@ func (c *Controller) AddGroupMembership(w http.ResponseWriter, r *http.Request, 
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "add_user_to_group", r.UserAgent(), "", "", "")
+	c.LogAction(ctx, "add_user_to_group", r, "", "", "")
 	err := c.Auth.AddUserToGroup(ctx, userID, groupID)
 	if c.handleAPIError(ctx, w, err) {
 		return
@@ -571,7 +571,7 @@ func (c *Controller) ListGroupPolicies(w http.ResponseWriter, r *http.Request, g
 	}
 
 	ctx := r.Context()
-	c.LogAction(ctx, "list_group_policies", r.UserAgent(), "", "", "")
+	c.LogAction(ctx, "list_group_policies", r, "", "", "")
 	policies, paginator, err := c.Auth.ListGroupPolicies(ctx, groupID, &model.PaginationParams{
 		After:  paginationAfter(params.After),
 		Prefix: paginationPrefix(params.Prefix),
@@ -623,7 +623,7 @@ func (c *Controller) DetachPolicyFromGroup(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "detach_policy_from_group", r.UserAgent(), "", "", "")
+	c.LogAction(ctx, "detach_policy_from_group", r, "", "", "")
 	err := c.Auth.DetachPolicyFromGroup(ctx, policyID, groupID)
 	if c.handleAPIError(ctx, w, err) {
 		return
@@ -642,7 +642,7 @@ func (c *Controller) AttachPolicyToGroup(w http.ResponseWriter, r *http.Request,
 	}
 
 	ctx := r.Context()
-	c.LogAction(ctx, "attach_policy_to_group", r.UserAgent(), "", "", "")
+	c.LogAction(ctx, "attach_policy_to_group", r, "", "", "")
 	err := c.Auth.AttachPolicyToGroup(ctx, policyID, groupID)
 	if c.handleAPIError(ctx, w, err) {
 		return
@@ -661,7 +661,7 @@ func (c *Controller) ListPolicies(w http.ResponseWriter, r *http.Request, params
 	}
 
 	ctx := r.Context()
-	c.LogAction(ctx, "list_policies", r.UserAgent(), "", "", "")
+	c.LogAction(ctx, "list_policies", r, "", "", "")
 	policies, paginator, err := c.Auth.ListPolicies(ctx, &model.PaginationParams{
 		After:  paginationAfter(params.After),
 		Prefix: paginationPrefix(params.Prefix),
@@ -695,7 +695,7 @@ func (c *Controller) CreatePolicy(w http.ResponseWriter, r *http.Request, body C
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "create_policy", r.UserAgent(), "", "", "")
+	c.LogAction(ctx, "create_policy", r, "", "", "")
 
 	stmts := make(model.Statements, len(body.Statement))
 	for i, apiStatement := range body.Statement {
@@ -730,7 +730,7 @@ func (c *Controller) DeletePolicy(w http.ResponseWriter, r *http.Request, policy
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "delete_policy", r.UserAgent(), "", "", "")
+	c.LogAction(ctx, "delete_policy", r, "", "", "")
 	err := c.Auth.DeletePolicy(ctx, policyID)
 	if errors.Is(err, auth.ErrNotFound) {
 		writeError(w, http.StatusNotFound, "policy not found")
@@ -752,7 +752,7 @@ func (c *Controller) GetPolicy(w http.ResponseWriter, r *http.Request, policyID 
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "get_policy", r.UserAgent(), "", "", "")
+	c.LogAction(ctx, "get_policy", r, "", "", "")
 	p, err := c.Auth.GetPolicy(ctx, policyID)
 	if errors.Is(err, auth.ErrNotFound) {
 		writeError(w, http.StatusNotFound, "policy not found")
@@ -776,7 +776,7 @@ func (c *Controller) UpdatePolicy(w http.ResponseWriter, r *http.Request, body U
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "update_policy", r.UserAgent(), "", "", "")
+	c.LogAction(ctx, "update_policy", r, "", "", "")
 
 	stmts := make(model.Statements, len(body.Statement))
 	for i, apiStatement := range body.Statement {
@@ -810,7 +810,7 @@ func (c *Controller) ListUsers(w http.ResponseWriter, r *http.Request, params Li
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "list_users", r.UserAgent(), "", "", "")
+	c.LogAction(ctx, "list_users", r, "", "", "")
 	users, paginator, err := c.Auth.ListUsers(ctx, &model.PaginationParams{
 		After:  paginationAfter(params.After),
 		Prefix: paginationPrefix(params.Prefix),
@@ -867,7 +867,7 @@ func (c *Controller) CreateUser(w http.ResponseWriter, r *http.Request, body Cre
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "create_user", r.UserAgent(), "", "", "")
+	c.LogAction(ctx, "create_user", r, "", "", "")
 	if invite {
 		err := c.Auth.InviteUser(ctx, *parsedEmail)
 		if c.handleAPIError(ctx, w, err) {
@@ -908,7 +908,7 @@ func (c *Controller) DeleteUser(w http.ResponseWriter, r *http.Request, userID s
 	}
 
 	ctx := r.Context()
-	c.LogAction(ctx, "delete_user", r.UserAgent(), "", "", "")
+	c.LogAction(ctx, "delete_user", r, "", "", "")
 	err := c.Auth.DeleteUser(ctx, userID)
 	if errors.Is(err, auth.ErrNotFound) {
 		writeError(w, http.StatusNotFound, "user not found")
@@ -930,7 +930,7 @@ func (c *Controller) GetUser(w http.ResponseWriter, r *http.Request, userID stri
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "get_user", r.UserAgent(), "", "", "")
+	c.LogAction(ctx, "get_user", r, "", "", "")
 	u, err := c.Auth.GetUser(ctx, userID)
 	if errors.Is(err, auth.ErrNotFound) {
 		writeError(w, http.StatusNotFound, "user not found")
@@ -956,7 +956,7 @@ func (c *Controller) ListUserCredentials(w http.ResponseWriter, r *http.Request,
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "list_user_credentials", r.UserAgent(), "", "", "")
+	c.LogAction(ctx, "list_user_credentials", r, "", "", "")
 	credentials, paginator, err := c.Auth.ListUserCredentials(ctx, userID, &model.PaginationParams{
 		After:  paginationAfter(params.After),
 		Prefix: paginationPrefix(params.Prefix),
@@ -993,7 +993,7 @@ func (c *Controller) CreateCredentials(w http.ResponseWriter, r *http.Request, u
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "create_credentials", r.UserAgent(), "", "", "")
+	c.LogAction(ctx, "create_credentials", r, "", "", "")
 	credentials, err := c.Auth.CreateCredentials(ctx, userID)
 	if c.handleAPIError(ctx, w, err) {
 		return
@@ -1017,7 +1017,7 @@ func (c *Controller) DeleteCredentials(w http.ResponseWriter, r *http.Request, u
 	}
 
 	ctx := r.Context()
-	c.LogAction(ctx, "delete_credentials", r.UserAgent(), "", "", "")
+	c.LogAction(ctx, "delete_credentials", r, "", "", "")
 	err := c.Auth.DeleteCredentials(ctx, userID, accessKeyID)
 	if errors.Is(err, auth.ErrNotFound) {
 		writeError(w, http.StatusNotFound, "credentials not found")
@@ -1039,7 +1039,7 @@ func (c *Controller) GetCredentials(w http.ResponseWriter, r *http.Request, user
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "get_credentials_for_user", r.UserAgent(), "", "", "")
+	c.LogAction(ctx, "get_credentials_for_user", r, "", "", "")
 	credentials, err := c.Auth.GetCredentialsForUser(ctx, userID, accessKeyID)
 	if errors.Is(err, auth.ErrNotFound) {
 		writeError(w, http.StatusNotFound, "credentials not found")
@@ -1066,7 +1066,7 @@ func (c *Controller) ListUserGroups(w http.ResponseWriter, r *http.Request, user
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "list_user_groups", r.UserAgent(), "", "", "")
+	c.LogAction(ctx, "list_user_groups", r, "", "", "")
 	groups, paginator, err := c.Auth.ListUserGroups(ctx, userID, &model.PaginationParams{
 		After:  paginationAfter(params.After),
 		Prefix: paginationPrefix(params.Prefix),
@@ -1105,7 +1105,7 @@ func (c *Controller) ListUserPolicies(w http.ResponseWriter, r *http.Request, us
 	}
 
 	ctx := r.Context()
-	c.LogAction(ctx, "list_user_policies", r.UserAgent(), "", "", "")
+	c.LogAction(ctx, "list_user_policies", r, "", "", "")
 	var listPolicies func(ctx context.Context, username string, params *model.PaginationParams) ([]*model.Policy, *model.Paginator, error)
 	if params.Effective != nil && *params.Effective {
 		listPolicies = c.Auth.ListEffectivePolicies
@@ -1145,7 +1145,7 @@ func (c *Controller) DetachPolicyFromUser(w http.ResponseWriter, r *http.Request
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "detach_policy_from_user", r.UserAgent(), "", "", "")
+	c.LogAction(ctx, "detach_policy_from_user", r, "", "", "")
 	err := c.Auth.DetachPolicyFromUser(ctx, policyID, userID)
 	if c.handleAPIError(ctx, w, err) {
 		return
@@ -1164,7 +1164,7 @@ func (c *Controller) AttachPolicyToUser(w http.ResponseWriter, r *http.Request, 
 	}
 
 	ctx := r.Context()
-	c.LogAction(ctx, "attach_policy_to_user", r.UserAgent(), "", "", "")
+	c.LogAction(ctx, "attach_policy_to_user", r, "", "", "")
 	err := c.Auth.AttachPolicyToUser(ctx, policyID, userID)
 	if c.handleAPIError(ctx, w, err) {
 		return
@@ -1205,7 +1205,7 @@ func (c *Controller) ListRepositories(w http.ResponseWriter, r *http.Request, pa
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "list_repos", r.UserAgent(), "", "", "")
+	c.LogAction(ctx, "list_repos", r, "", "", "")
 
 	repos, hasMore, err := c.Catalog.ListRepositories(ctx, paginationAmount(params.Amount), paginationPrefix(params.Prefix), paginationAfter(params.After))
 	if err != nil {
@@ -1251,7 +1251,7 @@ func (c *Controller) CreateRepository(w http.ResponseWriter, r *http.Request, bo
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "create_repo", r.UserAgent(), body.Name, "", "")
+	c.LogAction(ctx, "create_repo", r, body.Name, "", "")
 
 	defaultBranch := StringValue(body.DefaultBranch)
 	if defaultBranch == "" {
@@ -1355,7 +1355,7 @@ func (c *Controller) DeleteRepository(w http.ResponseWriter, r *http.Request, re
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "delete_repo", r.UserAgent(), repository, "", "")
+	c.LogAction(ctx, "delete_repo", r, repository, "", "")
 	err := c.Catalog.DeleteRepository(ctx, repository)
 	if c.handleAPIError(ctx, w, err) {
 		return
@@ -1373,7 +1373,7 @@ func (c *Controller) GetRepository(w http.ResponseWriter, r *http.Request, repos
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "get_repo", r.UserAgent(), repository, "", "")
+	c.LogAction(ctx, "get_repo", r, repository, "", "")
 	repo, err := c.Catalog.GetRepository(ctx, repository)
 	switch {
 	case err == nil:
@@ -1407,7 +1407,7 @@ func (c *Controller) ListRepositoryRuns(w http.ResponseWriter, r *http.Request, 
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "actions_repository_runs", r.UserAgent(), repository, "", "")
+	c.LogAction(ctx, "actions_repository_runs", r, repository, "", "")
 
 	_, err := c.Catalog.GetRepository(ctx, repository)
 	if c.handleAPIError(ctx, w, err) {
@@ -1475,7 +1475,7 @@ func (c *Controller) GetRun(w http.ResponseWriter, r *http.Request, repository s
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "actions_get_run", r.UserAgent(), repository, "", "")
+	c.LogAction(ctx, "actions_get_run", r, repository, "", "")
 	_, err := c.Catalog.GetRepository(ctx, repository)
 	if c.handleAPIError(ctx, w, err) {
 		return
@@ -1514,7 +1514,7 @@ func (c *Controller) ListRunHooks(w http.ResponseWriter, r *http.Request, reposi
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "actions_list_run_hooks", r.UserAgent(), repository, "", "")
+	c.LogAction(ctx, "actions_list_run_hooks", r, repository, "", "")
 
 	repo, err := c.Catalog.GetRepository(ctx, repository)
 	if c.handleAPIError(ctx, w, err) {
@@ -1579,7 +1579,7 @@ func (c *Controller) GetRunHookOutput(w http.ResponseWriter, r *http.Request, re
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "actions_run_hook_output", r.UserAgent(), repository, "", "")
+	c.LogAction(ctx, "actions_run_hook_output", r, repository, "", "")
 
 	repo, err := c.Catalog.GetRepository(ctx, repository)
 	if c.handleAPIError(ctx, w, err) {
@@ -1627,7 +1627,7 @@ func (c *Controller) ListBranches(w http.ResponseWriter, r *http.Request, reposi
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "list_branches", r.UserAgent(), repository, "", "")
+	c.LogAction(ctx, "list_branches", r, repository, "", "")
 
 	res, hasMore, err := c.Catalog.ListBranches(ctx, repository, paginationPrefix(params.Prefix), paginationAmount(params.Amount), paginationAfter(params.After))
 	if c.handleAPIError(ctx, w, err) {
@@ -1658,7 +1658,7 @@ func (c *Controller) CreateBranch(w http.ResponseWriter, r *http.Request, body C
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "create_branch", r.UserAgent(), repository, body.Name, "")
+	c.LogAction(ctx, "create_branch", r, repository, body.Name, "")
 	commitLog, err := c.Catalog.CreateBranch(ctx, repository, body.Name, body.Source)
 	if c.handleAPIError(ctx, w, err) {
 		return
@@ -1677,7 +1677,7 @@ func (c *Controller) DeleteBranch(w http.ResponseWriter, r *http.Request, reposi
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "delete_branch", r.UserAgent(), repository, branch, "")
+	c.LogAction(ctx, "delete_branch", r, repository, branch, "")
 	err := c.Catalog.DeleteBranch(ctx, repository, branch)
 	if c.handleAPIError(ctx, w, err) {
 		return
@@ -1695,7 +1695,7 @@ func (c *Controller) GetBranch(w http.ResponseWriter, r *http.Request, repositor
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "get_branch", r.UserAgent(), repository, branch, "")
+	c.LogAction(ctx, "get_branch", r, repository, branch, "")
 	reference, err := c.Catalog.GetBranchReference(ctx, repository, branch)
 	if c.handleAPIError(ctx, w, err) {
 		return
@@ -1768,7 +1768,7 @@ func (c *Controller) ResetBranch(w http.ResponseWriter, r *http.Request, body Re
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "reset_branch", r.UserAgent(), repository, branch, "")
+	c.LogAction(ctx, "reset_branch", r, repository, branch, "")
 
 	var err error
 	switch body.Type {
@@ -1809,7 +1809,7 @@ func (c *Controller) IngestRange(w http.ResponseWriter, r *http.Request, body In
 	}
 
 	ctx := r.Context()
-	c.LogAction(ctx, "ingest_range", r.UserAgent(), repository, "", "")
+	c.LogAction(ctx, "ingest_range", r, repository, "", "")
 
 	contToken := swag.StringValue(body.ContinuationToken)
 	info, mark, err := c.Catalog.WriteRange(r.Context(), repository, body.FromSourceURI, body.Prepend, body.After, contToken)
@@ -1844,7 +1844,7 @@ func (c *Controller) CreateMetaRange(w http.ResponseWriter, r *http.Request, bod
 	}
 
 	ctx := r.Context()
-	c.LogAction(ctx, "create_metarange", r.UserAgent(), repository, "", "")
+	c.LogAction(ctx, "create_metarange", r, repository, "", "")
 
 	ranges := make([]*graveler.RangeInfo, 0, len(body.Ranges))
 	for _, r := range body.Ranges {
@@ -1875,7 +1875,7 @@ func (c *Controller) Commit(w http.ResponseWriter, r *http.Request, body CommitJ
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "create_commit", r.UserAgent(), repository, branch, "")
+	c.LogAction(ctx, "create_commit", r, repository, branch, "")
 	user, ok := ctx.Value(UserContextKey).(*model.User)
 	if !ok {
 		writeError(w, http.StatusUnauthorized, "missing user")
@@ -1924,7 +1924,7 @@ func (c *Controller) DiffBranch(w http.ResponseWriter, r *http.Request, reposito
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "diff_workspace", r.UserAgent(), repository, branch, "")
+	c.LogAction(ctx, "diff_workspace", r, repository, branch, "")
 
 	diff, hasMore, err := c.Catalog.DiffUncommitted(
 		ctx,
@@ -1972,7 +1972,7 @@ func (c *Controller) DeleteObject(w http.ResponseWriter, r *http.Request, reposi
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "delete_object", r.UserAgent(), repository, branch, "")
+	c.LogAction(ctx, "delete_object", r, repository, branch, "")
 
 	err := c.Catalog.DeleteEntry(ctx, repository, branch, params.Path)
 	if c.handleAPIError(ctx, w, err) {
@@ -1991,7 +1991,7 @@ func (c *Controller) UploadObject(w http.ResponseWriter, r *http.Request, reposi
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "put_object", r.UserAgent(), repository, branch, "")
+	c.LogAction(ctx, "put_object", r, repository, branch, "")
 
 	repo, err := c.Catalog.GetRepository(ctx, repository)
 	if c.handleAPIError(ctx, w, err) {
@@ -2106,7 +2106,7 @@ func (c *Controller) StageObject(w http.ResponseWriter, r *http.Request, body St
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "stage_object", r.UserAgent(), repository, branch, "")
+	c.LogAction(ctx, "stage_object", r, repository, branch, "")
 
 	repo, err := c.Catalog.GetRepository(ctx, repository)
 	if c.handleAPIError(ctx, w, err) {
@@ -2174,7 +2174,7 @@ func (c *Controller) RevertBranch(w http.ResponseWriter, r *http.Request, body R
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "revert_branch", r.UserAgent(), repository, branch, "")
+	c.LogAction(ctx, "revert_branch", r, repository, branch, "")
 	user, ok := ctx.Value(UserContextKey).(*model.User)
 	if !ok {
 		writeError(w, http.StatusUnauthorized, "user not found")
@@ -2202,7 +2202,7 @@ func (c *Controller) GetCommit(w http.ResponseWriter, r *http.Request, repositor
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "get_commit", r.UserAgent(), repository, commitID, "")
+	c.LogAction(ctx, "get_commit", r, repository, commitID, "")
 	commit, err := c.Catalog.GetCommit(ctx, repository, commitID)
 	if errors.Is(err, catalog.ErrRepositoryNotFound) {
 		writeError(w, http.StatusNotFound, "repository not found")
@@ -2304,7 +2304,7 @@ func (c *Controller) PrepareGarbageCollectionCommits(w http.ResponseWriter, r *h
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "prepare_garbage_collection_commits", r.UserAgent(), repository, "", "")
+	c.LogAction(ctx, "prepare_garbage_collection_commits", r, repository, "", "")
 	gcRUnMetadata, err := c.Catalog.PrepareExpiredCommits(ctx, repository, swag.StringValue(body.PreviousRunId))
 	if c.handleAPIError(ctx, w, err) {
 		return
@@ -2396,7 +2396,7 @@ func (c *Controller) GetMetaRange(w http.ResponseWriter, r *http.Request, reposi
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "metadata_get_metarange", r.UserAgent(), repository, "", "")
+	c.LogAction(ctx, "metadata_get_metarange", r, repository, "", "")
 
 	metarange, err := c.Catalog.GetMetaRange(ctx, repository, metaRange)
 	if c.handleAPIError(ctx, w, err) {
@@ -2431,7 +2431,7 @@ func (c *Controller) GetRange(w http.ResponseWriter, r *http.Request, repository
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "metadata_get_range", r.UserAgent(), repository, "", "")
+	c.LogAction(ctx, "metadata_get_range", r, repository, "", "")
 
 	rng, err := c.Catalog.GetRange(ctx, repository, pRange)
 	if c.handleAPIError(ctx, w, err) {
@@ -2471,7 +2471,7 @@ func (c *Controller) DumpRefs(w http.ResponseWriter, r *http.Request, repository
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "dump_repository_refs", r.UserAgent(), repository, "", "")
+	c.LogAction(ctx, "dump_repository_refs", r, repository, "", "")
 
 	repo, err := c.Catalog.GetRepository(ctx, repository)
 	if c.handleAPIError(ctx, w, err) {
@@ -2543,7 +2543,7 @@ func (c *Controller) RestoreRefs(w http.ResponseWriter, r *http.Request, body Re
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "restore_repository_refs", r.UserAgent(), repository, "", "")
+	c.LogAction(ctx, "restore_repository_refs", r, repository, "", "")
 
 	repo, err := c.Catalog.GetRepository(ctx, repository)
 	if c.handleAPIError(ctx, w, err) {
@@ -2588,7 +2588,7 @@ func (c *Controller) CreateSymlinkFile(w http.ResponseWriter, r *http.Request, r
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "create_symlink", r.UserAgent(), repository, branch, "")
+	c.LogAction(ctx, "create_symlink", r, repository, branch, "")
 
 	// read repo
 	repo, err := c.Catalog.GetRepository(ctx, repository)
@@ -2676,7 +2676,7 @@ func (c *Controller) DiffRefs(w http.ResponseWriter, r *http.Request, repository
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "diff_refs", r.UserAgent(), repository, rightRef, leftRef)
+	c.LogAction(ctx, "diff_refs", r, repository, rightRef, leftRef)
 	diffFunc := c.Catalog.Compare // default diff type is three-dot
 	if params.Type != nil && *params.Type == "two_dot" {
 		diffFunc = c.Catalog.Diff
@@ -2737,7 +2737,7 @@ func (c *Controller) logCommitsHelper(w http.ResponseWriter, r *http.Request, re
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "get_branch_commit_log", r.UserAgent(), repository, ref, "")
+	c.LogAction(ctx, "get_branch_commit_log", r, repository, ref, "")
 
 	// get commit log
 	commitLog, hasMore, err := c.Catalog.ListCommits(ctx, repository, ref, catalog.LogParams{
@@ -2783,7 +2783,7 @@ func (c *Controller) GetObject(w http.ResponseWriter, r *http.Request, repositor
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "get_object", r.UserAgent(), repository, ref, "")
+	c.LogAction(ctx, "get_object", r, repository, ref, "")
 
 	repo, err := c.Catalog.GetRepository(ctx, repository)
 	if c.handleAPIError(ctx, w, err) {
@@ -2839,7 +2839,7 @@ func (c *Controller) ListObjects(w http.ResponseWriter, r *http.Request, reposit
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "list_objects", r.UserAgent(), repository, ref, "")
+	c.LogAction(ctx, "list_objects", r, repository, ref, "")
 
 	res, hasMore, err := c.Catalog.ListEntries(
 		ctx,
@@ -2917,7 +2917,7 @@ func (c *Controller) StatObject(w http.ResponseWriter, r *http.Request, reposito
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "stat_object", r.UserAgent(), repository, ref, "")
+	c.LogAction(ctx, "stat_object", r, repository, ref, "")
 
 	repo, err := c.Catalog.GetRepository(ctx, repository)
 	if c.handleAPIError(ctx, w, err) {
@@ -2963,7 +2963,7 @@ func (c *Controller) GetUnderlyingProperties(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "object_underlying_properties", r.UserAgent(), repository, ref, "")
+	c.LogAction(ctx, "object_underlying_properties", r, repository, ref, "")
 
 	// read repo
 	repo, err := c.Catalog.GetRepository(ctx, repository)
@@ -2999,7 +2999,7 @@ func (c *Controller) MergeIntoBranch(w http.ResponseWriter, r *http.Request, bod
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "merge_branches", r.UserAgent(), repository, destinationBranch, sourceRef)
+	c.LogAction(ctx, "merge_branches", r, repository, destinationBranch, sourceRef)
 	user, ok := ctx.Value(UserContextKey).(*model.User)
 	if !ok {
 		writeError(w, http.StatusUnauthorized, "user not found")
@@ -3042,7 +3042,7 @@ func (c *Controller) ListTags(w http.ResponseWriter, r *http.Request, repository
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "list_tags", r.UserAgent(), repository, "", "")
+	c.LogAction(ctx, "list_tags", r, repository, "", "")
 
 	res, hasMore, err := c.Catalog.ListTags(ctx, repository, paginationPrefix(params.Prefix), paginationAmount(params.Amount), paginationAfter(params.After))
 	if c.handleAPIError(ctx, w, err) {
@@ -3073,7 +3073,7 @@ func (c *Controller) CreateTag(w http.ResponseWriter, r *http.Request, body Crea
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "create_tag", r.UserAgent(), repository, body.Id, "")
+	c.LogAction(ctx, "create_tag", r, repository, body.Id, "")
 
 	commitID, err := c.Catalog.CreateTag(ctx, repository, body.Id, body.Ref)
 	if c.handleAPIError(ctx, w, err) {
@@ -3096,7 +3096,7 @@ func (c *Controller) DeleteTag(w http.ResponseWriter, r *http.Request, repositor
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "delete_tag", r.UserAgent(), repository, tag, "")
+	c.LogAction(ctx, "delete_tag", r, repository, tag, "")
 	err := c.Catalog.DeleteTag(ctx, repository, tag)
 	if c.handleAPIError(ctx, w, err) {
 		return
@@ -3114,7 +3114,7 @@ func (c *Controller) GetTag(w http.ResponseWriter, r *http.Request, repository s
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "get_tag", r.UserAgent(), repository, tag, "")
+	c.LogAction(ctx, "get_tag", r, repository, tag, "")
 	reference, err := c.Catalog.GetTag(ctx, repository, tag)
 	if c.handleAPIError(ctx, w, err) {
 		return
@@ -3190,7 +3190,7 @@ func (c *Controller) Setup(w http.ResponseWriter, r *http.Request, body SetupJSO
 	meta := stats.NewMetadata(ctx, c.Logger, c.BlockAdapter.BlockstoreType(), c.MetadataManager, c.CloudMetadataProvider)
 	c.Collector.SetInstallationID(meta.InstallationID)
 	c.Collector.CollectMetadata(meta)
-	c.Collector.CollectEvent(stats.Event{Class: "global", Name: "init", UserID: body.Username, Client: r.UserAgent()})
+	c.Collector.CollectEvent(stats.Event{Class: "global", Name: "init", UserID: body.Username, Client: httputil.GetRequestLakeFSClient(r)})
 
 	response := CredentialsWithSecret{
 		AccessKeyId:     cred.AccessKeyID,
@@ -3311,7 +3311,7 @@ func (c *Controller) ExpandTemplate(w http.ResponseWriter, r *http.Request, temp
 		}
 	}
 
-	c.LogAction(ctx, "expand_template", r.UserAgent(), "", "", "")
+	c.LogAction(ctx, "expand_template", r, "", "", "")
 	err := c.Templater.Expand(ctx, w, u, templateLocation, p.Params.AdditionalProperties)
 	if err != nil {
 		c.Logger.WithError(err).WithField("location", templateLocation).Error("Template expansion failed")
@@ -3521,14 +3521,15 @@ func NewController(
 	}
 }
 
-func (c *Controller) LogAction(ctx context.Context, action, ua, repository, ref, sourceRef string) {
+func (c *Controller) LogAction(ctx context.Context, action string, r *http.Request, repository, ref, sourceRef string) {
+	client := httputil.GetRequestLakeFSClient(r)
 	ev := stats.Event{
 		Class:      "api_server",
 		Name:       action,
 		Repository: repository,
 		Ref:        ref,
 		SourceRef:  sourceRef,
-		Client:     ua,
+		Client:     client,
 	}
 	user, ok := ctx.Value(UserContextKey).(*model.User)
 	if ok {
@@ -3541,6 +3542,7 @@ func (c *Controller) LogAction(ctx context.Context, action, ua, repository, ref,
 		"ref":        ev.Ref,
 		"source_ref": ev.SourceRef,
 		"user_id":    ev.UserID,
+		"client":     ev.Client,
 	}).Debug("performing API action")
 	c.Collector.CollectEvent(ev)
 }

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -102,7 +102,7 @@ func (c *Controller) GetAuthCapabilities(w http.ResponseWriter, _ *http.Request)
 
 func (c *Controller) DeleteObjects(w http.ResponseWriter, r *http.Request, body DeleteObjectsJSONRequestBody, repository string, branch string) {
 	ctx := r.Context()
-	c.LogAction(ctx, "delete_objects")
+	c.LogAction(ctx, "delete_objects", r.UserAgent(), repository, branch, "")
 
 	// limit check
 	if len(body.Paths) > DefaultMaxDeleteObjects {
@@ -242,7 +242,7 @@ func (c *Controller) GetPhysicalAddress(w http.ResponseWriter, r *http.Request, 
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "generate_physical_address")
+	c.LogAction(ctx, "generate_physical_address", r.UserAgent(), repository, branch, "")
 
 	repo, err := c.Catalog.GetRepository(ctx, repository)
 	if errors.Is(err, catalog.ErrNotFound) {
@@ -299,7 +299,7 @@ func (c *Controller) LinkPhysicalAddress(w http.ResponseWriter, r *http.Request,
 	}
 
 	ctx := r.Context()
-	c.LogAction(ctx, "stage_object")
+	c.LogAction(ctx, "stage_object", r.UserAgent(), repository, branch, "")
 
 	repo, err := c.Catalog.GetRepository(ctx, repository)
 	if errors.Is(err, catalog.ErrNotFound) {
@@ -380,7 +380,7 @@ func (c *Controller) ListGroups(w http.ResponseWriter, r *http.Request, params L
 	}
 
 	ctx := r.Context()
-	c.LogAction(ctx, "list_groups")
+	c.LogAction(ctx, "list_groups", r.UserAgent(), "", "", "")
 	groups, paginator, err := c.Auth.ListGroups(ctx, &model.PaginationParams{
 		After:  paginationAfter(params.After),
 		Prefix: paginationPrefix(params.Prefix),
@@ -418,7 +418,7 @@ func (c *Controller) CreateGroup(w http.ResponseWriter, r *http.Request, body Cr
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "create_group")
+	c.LogAction(ctx, "create_group", r.UserAgent(), "", "", "")
 
 	g := &model.Group{
 		CreatedAt:   time.Now().UTC(),
@@ -446,7 +446,7 @@ func (c *Controller) DeleteGroup(w http.ResponseWriter, r *http.Request, groupID
 	}
 
 	ctx := r.Context()
-	c.LogAction(ctx, "delete_group")
+	c.LogAction(ctx, "delete_group", r.UserAgent(), "", "", "")
 	err := c.Auth.DeleteGroup(ctx, groupID)
 	if errors.Is(err, auth.ErrNotFound) {
 		writeError(w, http.StatusNotFound, "group not found")
@@ -468,7 +468,7 @@ func (c *Controller) GetGroup(w http.ResponseWriter, r *http.Request, groupID st
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "get_group")
+	c.LogAction(ctx, "get_group", r.UserAgent(), "", "", "")
 	g, err := c.Auth.GetGroup(ctx, groupID)
 	if errors.Is(err, auth.ErrNotFound) {
 		writeError(w, http.StatusNotFound, "group not found")
@@ -495,7 +495,7 @@ func (c *Controller) ListGroupMembers(w http.ResponseWriter, r *http.Request, gr
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "list_group_users")
+	c.LogAction(ctx, "list_group_users", r.UserAgent(), "", "", "")
 	users, paginator, err := c.Auth.ListGroupUsers(ctx, groupID, &model.PaginationParams{
 		After:  paginationAfter(params.After),
 		Prefix: paginationPrefix(params.Prefix),
@@ -534,7 +534,7 @@ func (c *Controller) DeleteGroupMembership(w http.ResponseWriter, r *http.Reques
 	}
 
 	ctx := r.Context()
-	c.LogAction(ctx, "remove_user_from_group")
+	c.LogAction(ctx, "remove_user_from_group", r.UserAgent(), "", "", "")
 	err := c.Auth.RemoveUserFromGroup(ctx, userID, groupID)
 	if c.handleAPIError(ctx, w, err) {
 		return
@@ -552,7 +552,7 @@ func (c *Controller) AddGroupMembership(w http.ResponseWriter, r *http.Request, 
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "add_user_to_group")
+	c.LogAction(ctx, "add_user_to_group", r.UserAgent(), "", "", "")
 	err := c.Auth.AddUserToGroup(ctx, userID, groupID)
 	if c.handleAPIError(ctx, w, err) {
 		return
@@ -571,7 +571,7 @@ func (c *Controller) ListGroupPolicies(w http.ResponseWriter, r *http.Request, g
 	}
 
 	ctx := r.Context()
-	c.LogAction(ctx, "list_group_policies")
+	c.LogAction(ctx, "list_group_policies", r.UserAgent(), "", "", "")
 	policies, paginator, err := c.Auth.ListGroupPolicies(ctx, groupID, &model.PaginationParams{
 		After:  paginationAfter(params.After),
 		Prefix: paginationPrefix(params.Prefix),
@@ -623,7 +623,7 @@ func (c *Controller) DetachPolicyFromGroup(w http.ResponseWriter, r *http.Reques
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "detach_policy_from_group")
+	c.LogAction(ctx, "detach_policy_from_group", r.UserAgent(), "", "", "")
 	err := c.Auth.DetachPolicyFromGroup(ctx, policyID, groupID)
 	if c.handleAPIError(ctx, w, err) {
 		return
@@ -642,7 +642,7 @@ func (c *Controller) AttachPolicyToGroup(w http.ResponseWriter, r *http.Request,
 	}
 
 	ctx := r.Context()
-	c.LogAction(ctx, "attach_policy_to_group")
+	c.LogAction(ctx, "attach_policy_to_group", r.UserAgent(), "", "", "")
 	err := c.Auth.AttachPolicyToGroup(ctx, policyID, groupID)
 	if c.handleAPIError(ctx, w, err) {
 		return
@@ -661,7 +661,7 @@ func (c *Controller) ListPolicies(w http.ResponseWriter, r *http.Request, params
 	}
 
 	ctx := r.Context()
-	c.LogAction(ctx, "list_policies")
+	c.LogAction(ctx, "list_policies", r.UserAgent(), "", "", "")
 	policies, paginator, err := c.Auth.ListPolicies(ctx, &model.PaginationParams{
 		After:  paginationAfter(params.After),
 		Prefix: paginationPrefix(params.Prefix),
@@ -695,7 +695,7 @@ func (c *Controller) CreatePolicy(w http.ResponseWriter, r *http.Request, body C
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "create_policy")
+	c.LogAction(ctx, "create_policy", r.UserAgent(), "", "", "")
 
 	stmts := make(model.Statements, len(body.Statement))
 	for i, apiStatement := range body.Statement {
@@ -730,7 +730,7 @@ func (c *Controller) DeletePolicy(w http.ResponseWriter, r *http.Request, policy
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "delete_policy")
+	c.LogAction(ctx, "delete_policy", r.UserAgent(), "", "", "")
 	err := c.Auth.DeletePolicy(ctx, policyID)
 	if errors.Is(err, auth.ErrNotFound) {
 		writeError(w, http.StatusNotFound, "policy not found")
@@ -752,7 +752,7 @@ func (c *Controller) GetPolicy(w http.ResponseWriter, r *http.Request, policyID 
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "get_policy")
+	c.LogAction(ctx, "get_policy", r.UserAgent(), "", "", "")
 	p, err := c.Auth.GetPolicy(ctx, policyID)
 	if errors.Is(err, auth.ErrNotFound) {
 		writeError(w, http.StatusNotFound, "policy not found")
@@ -776,7 +776,7 @@ func (c *Controller) UpdatePolicy(w http.ResponseWriter, r *http.Request, body U
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "update_policy")
+	c.LogAction(ctx, "update_policy", r.UserAgent(), "", "", "")
 
 	stmts := make(model.Statements, len(body.Statement))
 	for i, apiStatement := range body.Statement {
@@ -810,7 +810,7 @@ func (c *Controller) ListUsers(w http.ResponseWriter, r *http.Request, params Li
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "list_users")
+	c.LogAction(ctx, "list_users", r.UserAgent(), "", "", "")
 	users, paginator, err := c.Auth.ListUsers(ctx, &model.PaginationParams{
 		After:  paginationAfter(params.After),
 		Prefix: paginationPrefix(params.Prefix),
@@ -867,7 +867,7 @@ func (c *Controller) CreateUser(w http.ResponseWriter, r *http.Request, body Cre
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "create_user")
+	c.LogAction(ctx, "create_user", r.UserAgent(), "", "", "")
 	if invite {
 		err := c.Auth.InviteUser(ctx, *parsedEmail)
 		if c.handleAPIError(ctx, w, err) {
@@ -908,7 +908,7 @@ func (c *Controller) DeleteUser(w http.ResponseWriter, r *http.Request, userID s
 	}
 
 	ctx := r.Context()
-	c.LogAction(ctx, "delete_user")
+	c.LogAction(ctx, "delete_user", r.UserAgent(), "", "", "")
 	err := c.Auth.DeleteUser(ctx, userID)
 	if errors.Is(err, auth.ErrNotFound) {
 		writeError(w, http.StatusNotFound, "user not found")
@@ -930,7 +930,7 @@ func (c *Controller) GetUser(w http.ResponseWriter, r *http.Request, userID stri
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "get_user")
+	c.LogAction(ctx, "get_user", r.UserAgent(), "", "", "")
 	u, err := c.Auth.GetUser(ctx, userID)
 	if errors.Is(err, auth.ErrNotFound) {
 		writeError(w, http.StatusNotFound, "user not found")
@@ -956,7 +956,7 @@ func (c *Controller) ListUserCredentials(w http.ResponseWriter, r *http.Request,
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "list_user_credentials")
+	c.LogAction(ctx, "list_user_credentials", r.UserAgent(), "", "", "")
 	credentials, paginator, err := c.Auth.ListUserCredentials(ctx, userID, &model.PaginationParams{
 		After:  paginationAfter(params.After),
 		Prefix: paginationPrefix(params.Prefix),
@@ -993,7 +993,7 @@ func (c *Controller) CreateCredentials(w http.ResponseWriter, r *http.Request, u
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "create_credentials")
+	c.LogAction(ctx, "create_credentials", r.UserAgent(), "", "", "")
 	credentials, err := c.Auth.CreateCredentials(ctx, userID)
 	if c.handleAPIError(ctx, w, err) {
 		return
@@ -1017,7 +1017,7 @@ func (c *Controller) DeleteCredentials(w http.ResponseWriter, r *http.Request, u
 	}
 
 	ctx := r.Context()
-	c.LogAction(ctx, "delete_credentials")
+	c.LogAction(ctx, "delete_credentials", r.UserAgent(), "", "", "")
 	err := c.Auth.DeleteCredentials(ctx, userID, accessKeyID)
 	if errors.Is(err, auth.ErrNotFound) {
 		writeError(w, http.StatusNotFound, "credentials not found")
@@ -1039,7 +1039,7 @@ func (c *Controller) GetCredentials(w http.ResponseWriter, r *http.Request, user
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "get_credentials_for_user")
+	c.LogAction(ctx, "get_credentials_for_user", r.UserAgent(), "", "", "")
 	credentials, err := c.Auth.GetCredentialsForUser(ctx, userID, accessKeyID)
 	if errors.Is(err, auth.ErrNotFound) {
 		writeError(w, http.StatusNotFound, "credentials not found")
@@ -1066,7 +1066,7 @@ func (c *Controller) ListUserGroups(w http.ResponseWriter, r *http.Request, user
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "list_user_groups")
+	c.LogAction(ctx, "list_user_groups", r.UserAgent(), "", "", "")
 	groups, paginator, err := c.Auth.ListUserGroups(ctx, userID, &model.PaginationParams{
 		After:  paginationAfter(params.After),
 		Prefix: paginationPrefix(params.Prefix),
@@ -1105,7 +1105,7 @@ func (c *Controller) ListUserPolicies(w http.ResponseWriter, r *http.Request, us
 	}
 
 	ctx := r.Context()
-	c.LogAction(ctx, "list_user_policies")
+	c.LogAction(ctx, "list_user_policies", r.UserAgent(), "", "", "")
 	var listPolicies func(ctx context.Context, username string, params *model.PaginationParams) ([]*model.Policy, *model.Paginator, error)
 	if params.Effective != nil && *params.Effective {
 		listPolicies = c.Auth.ListEffectivePolicies
@@ -1145,7 +1145,7 @@ func (c *Controller) DetachPolicyFromUser(w http.ResponseWriter, r *http.Request
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "detach_policy_from_user")
+	c.LogAction(ctx, "detach_policy_from_user", r.UserAgent(), "", "", "")
 	err := c.Auth.DetachPolicyFromUser(ctx, policyID, userID)
 	if c.handleAPIError(ctx, w, err) {
 		return
@@ -1164,7 +1164,7 @@ func (c *Controller) AttachPolicyToUser(w http.ResponseWriter, r *http.Request, 
 	}
 
 	ctx := r.Context()
-	c.LogAction(ctx, "attach_policy_to_user")
+	c.LogAction(ctx, "attach_policy_to_user", r.UserAgent(), "", "", "")
 	err := c.Auth.AttachPolicyToUser(ctx, policyID, userID)
 	if c.handleAPIError(ctx, w, err) {
 		return
@@ -1205,7 +1205,7 @@ func (c *Controller) ListRepositories(w http.ResponseWriter, r *http.Request, pa
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "list_repos")
+	c.LogAction(ctx, "list_repos", r.UserAgent(), "", "", "")
 
 	repos, hasMore, err := c.Catalog.ListRepositories(ctx, paginationAmount(params.Amount), paginationPrefix(params.Prefix), paginationAfter(params.After))
 	if err != nil {
@@ -1251,7 +1251,7 @@ func (c *Controller) CreateRepository(w http.ResponseWriter, r *http.Request, bo
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "create_repo")
+	c.LogAction(ctx, "create_repo", r.UserAgent(), body.Name, "", "")
 
 	defaultBranch := StringValue(body.DefaultBranch)
 	if defaultBranch == "" {
@@ -1355,7 +1355,7 @@ func (c *Controller) DeleteRepository(w http.ResponseWriter, r *http.Request, re
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "delete_repo")
+	c.LogAction(ctx, "delete_repo", r.UserAgent(), repository, "", "")
 	err := c.Catalog.DeleteRepository(ctx, repository)
 	if c.handleAPIError(ctx, w, err) {
 		return
@@ -1373,7 +1373,7 @@ func (c *Controller) GetRepository(w http.ResponseWriter, r *http.Request, repos
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "get_repo")
+	c.LogAction(ctx, "get_repo", r.UserAgent(), repository, "", "")
 	repo, err := c.Catalog.GetRepository(ctx, repository)
 	switch {
 	case err == nil:
@@ -1407,7 +1407,7 @@ func (c *Controller) ListRepositoryRuns(w http.ResponseWriter, r *http.Request, 
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "actions_repository_runs")
+	c.LogAction(ctx, "actions_repository_runs", r.UserAgent(), repository, "", "")
 
 	_, err := c.Catalog.GetRepository(ctx, repository)
 	if c.handleAPIError(ctx, w, err) {
@@ -1475,7 +1475,7 @@ func (c *Controller) GetRun(w http.ResponseWriter, r *http.Request, repository s
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "actions_get_run")
+	c.LogAction(ctx, "actions_get_run", r.UserAgent(), repository, "", "")
 	_, err := c.Catalog.GetRepository(ctx, repository)
 	if c.handleAPIError(ctx, w, err) {
 		return
@@ -1514,7 +1514,7 @@ func (c *Controller) ListRunHooks(w http.ResponseWriter, r *http.Request, reposi
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "actions_list_run_hooks")
+	c.LogAction(ctx, "actions_list_run_hooks", r.UserAgent(), repository, "", "")
 
 	repo, err := c.Catalog.GetRepository(ctx, repository)
 	if c.handleAPIError(ctx, w, err) {
@@ -1579,7 +1579,7 @@ func (c *Controller) GetRunHookOutput(w http.ResponseWriter, r *http.Request, re
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "actions_run_hook_output")
+	c.LogAction(ctx, "actions_run_hook_output", r.UserAgent(), repository, "", "")
 
 	repo, err := c.Catalog.GetRepository(ctx, repository)
 	if c.handleAPIError(ctx, w, err) {
@@ -1627,7 +1627,7 @@ func (c *Controller) ListBranches(w http.ResponseWriter, r *http.Request, reposi
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "list_branches")
+	c.LogAction(ctx, "list_branches", r.UserAgent(), repository, "", "")
 
 	res, hasMore, err := c.Catalog.ListBranches(ctx, repository, paginationPrefix(params.Prefix), paginationAmount(params.Amount), paginationAfter(params.After))
 	if c.handleAPIError(ctx, w, err) {
@@ -1658,7 +1658,7 @@ func (c *Controller) CreateBranch(w http.ResponseWriter, r *http.Request, body C
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "create_branch")
+	c.LogAction(ctx, "create_branch", r.UserAgent(), repository, body.Name, "")
 	commitLog, err := c.Catalog.CreateBranch(ctx, repository, body.Name, body.Source)
 	if c.handleAPIError(ctx, w, err) {
 		return
@@ -1677,7 +1677,7 @@ func (c *Controller) DeleteBranch(w http.ResponseWriter, r *http.Request, reposi
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "delete_branch")
+	c.LogAction(ctx, "delete_branch", r.UserAgent(), repository, branch, "")
 	err := c.Catalog.DeleteBranch(ctx, repository, branch)
 	if c.handleAPIError(ctx, w, err) {
 		return
@@ -1695,7 +1695,7 @@ func (c *Controller) GetBranch(w http.ResponseWriter, r *http.Request, repositor
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "get_branch")
+	c.LogAction(ctx, "get_branch", r.UserAgent(), repository, branch, "")
 	reference, err := c.Catalog.GetBranchReference(ctx, repository, branch)
 	if c.handleAPIError(ctx, w, err) {
 		return
@@ -1768,7 +1768,7 @@ func (c *Controller) ResetBranch(w http.ResponseWriter, r *http.Request, body Re
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "reset_branch")
+	c.LogAction(ctx, "reset_branch", r.UserAgent(), repository, branch, "")
 
 	var err error
 	switch body.Type {
@@ -1809,7 +1809,7 @@ func (c *Controller) IngestRange(w http.ResponseWriter, r *http.Request, body In
 	}
 
 	ctx := r.Context()
-	c.LogAction(ctx, "ingest_range")
+	c.LogAction(ctx, "ingest_range", r.UserAgent(), repository, "", "")
 
 	contToken := swag.StringValue(body.ContinuationToken)
 	info, mark, err := c.Catalog.WriteRange(r.Context(), repository, body.FromSourceURI, body.Prepend, body.After, contToken)
@@ -1844,7 +1844,7 @@ func (c *Controller) CreateMetaRange(w http.ResponseWriter, r *http.Request, bod
 	}
 
 	ctx := r.Context()
-	c.LogAction(ctx, "create_metarange")
+	c.LogAction(ctx, "create_metarange", r.UserAgent(), repository, "", "")
 
 	ranges := make([]*graveler.RangeInfo, 0, len(body.Ranges))
 	for _, r := range body.Ranges {
@@ -1875,7 +1875,7 @@ func (c *Controller) Commit(w http.ResponseWriter, r *http.Request, body CommitJ
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "create_commit")
+	c.LogAction(ctx, "create_commit", r.UserAgent(), repository, branch, "")
 	user, ok := ctx.Value(UserContextKey).(*model.User)
 	if !ok {
 		writeError(w, http.StatusUnauthorized, "missing user")
@@ -1924,7 +1924,7 @@ func (c *Controller) DiffBranch(w http.ResponseWriter, r *http.Request, reposito
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "diff_workspace")
+	c.LogAction(ctx, "diff_workspace", r.UserAgent(), repository, branch, "")
 
 	diff, hasMore, err := c.Catalog.DiffUncommitted(
 		ctx,
@@ -1972,7 +1972,7 @@ func (c *Controller) DeleteObject(w http.ResponseWriter, r *http.Request, reposi
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "delete_object")
+	c.LogAction(ctx, "delete_object", r.UserAgent(), repository, branch, "")
 
 	err := c.Catalog.DeleteEntry(ctx, repository, branch, params.Path)
 	if c.handleAPIError(ctx, w, err) {
@@ -1991,7 +1991,7 @@ func (c *Controller) UploadObject(w http.ResponseWriter, r *http.Request, reposi
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "put_object")
+	c.LogAction(ctx, "put_object", r.UserAgent(), repository, branch, "")
 
 	repo, err := c.Catalog.GetRepository(ctx, repository)
 	if c.handleAPIError(ctx, w, err) {
@@ -2106,7 +2106,7 @@ func (c *Controller) StageObject(w http.ResponseWriter, r *http.Request, body St
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "stage_object")
+	c.LogAction(ctx, "stage_object", r.UserAgent(), repository, branch, "")
 
 	repo, err := c.Catalog.GetRepository(ctx, repository)
 	if c.handleAPIError(ctx, w, err) {
@@ -2174,7 +2174,7 @@ func (c *Controller) RevertBranch(w http.ResponseWriter, r *http.Request, body R
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "revert_branch")
+	c.LogAction(ctx, "revert_branch", r.UserAgent(), repository, branch, "")
 	user, ok := ctx.Value(UserContextKey).(*model.User)
 	if !ok {
 		writeError(w, http.StatusUnauthorized, "user not found")
@@ -2202,7 +2202,7 @@ func (c *Controller) GetCommit(w http.ResponseWriter, r *http.Request, repositor
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "get_commit")
+	c.LogAction(ctx, "get_commit", r.UserAgent(), repository, commitID, "")
 	commit, err := c.Catalog.GetCommit(ctx, repository, commitID)
 	if errors.Is(err, catalog.ErrRepositoryNotFound) {
 		writeError(w, http.StatusNotFound, "repository not found")
@@ -2304,7 +2304,7 @@ func (c *Controller) PrepareGarbageCollectionCommits(w http.ResponseWriter, r *h
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "prepare_garbage_collection_commits")
+	c.LogAction(ctx, "prepare_garbage_collection_commits", r.UserAgent(), repository, "", "")
 	gcRUnMetadata, err := c.Catalog.PrepareExpiredCommits(ctx, repository, swag.StringValue(body.PreviousRunId))
 	if c.handleAPIError(ctx, w, err) {
 		return
@@ -2396,7 +2396,7 @@ func (c *Controller) GetMetaRange(w http.ResponseWriter, r *http.Request, reposi
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "metadata_get_metarange")
+	c.LogAction(ctx, "metadata_get_metarange", r.UserAgent(), repository, "", "")
 
 	metarange, err := c.Catalog.GetMetaRange(ctx, repository, metaRange)
 	if c.handleAPIError(ctx, w, err) {
@@ -2431,7 +2431,7 @@ func (c *Controller) GetRange(w http.ResponseWriter, r *http.Request, repository
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "metadata_get_range")
+	c.LogAction(ctx, "metadata_get_range", r.UserAgent(), repository, "", "")
 
 	rng, err := c.Catalog.GetRange(ctx, repository, pRange)
 	if c.handleAPIError(ctx, w, err) {
@@ -2471,7 +2471,7 @@ func (c *Controller) DumpRefs(w http.ResponseWriter, r *http.Request, repository
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "dump_repository_refs")
+	c.LogAction(ctx, "dump_repository_refs", r.UserAgent(), repository, "", "")
 
 	repo, err := c.Catalog.GetRepository(ctx, repository)
 	if c.handleAPIError(ctx, w, err) {
@@ -2543,7 +2543,7 @@ func (c *Controller) RestoreRefs(w http.ResponseWriter, r *http.Request, body Re
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "restore_repository_refs")
+	c.LogAction(ctx, "restore_repository_refs", r.UserAgent(), repository, "", "")
 
 	repo, err := c.Catalog.GetRepository(ctx, repository)
 	if c.handleAPIError(ctx, w, err) {
@@ -2588,7 +2588,7 @@ func (c *Controller) CreateSymlinkFile(w http.ResponseWriter, r *http.Request, r
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "create_symlink")
+	c.LogAction(ctx, "create_symlink", r.UserAgent(), repository, branch, "")
 
 	// read repo
 	repo, err := c.Catalog.GetRepository(ctx, repository)
@@ -2676,7 +2676,7 @@ func (c *Controller) DiffRefs(w http.ResponseWriter, r *http.Request, repository
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "diff_refs")
+	c.LogAction(ctx, "diff_refs", r.UserAgent(), repository, rightRef, leftRef)
 	diffFunc := c.Catalog.Compare // default diff type is three-dot
 	if params.Type != nil && *params.Type == "two_dot" {
 		diffFunc = c.Catalog.Diff
@@ -2737,7 +2737,7 @@ func (c *Controller) logCommitsHelper(w http.ResponseWriter, r *http.Request, re
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "get_branch_commit_log")
+	c.LogAction(ctx, "get_branch_commit_log", r.UserAgent(), repository, ref, "")
 
 	// get commit log
 	commitLog, hasMore, err := c.Catalog.ListCommits(ctx, repository, ref, catalog.LogParams{
@@ -2783,7 +2783,7 @@ func (c *Controller) GetObject(w http.ResponseWriter, r *http.Request, repositor
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "get_object")
+	c.LogAction(ctx, "get_object", r.UserAgent(), repository, ref, "")
 
 	repo, err := c.Catalog.GetRepository(ctx, repository)
 	if c.handleAPIError(ctx, w, err) {
@@ -2839,7 +2839,7 @@ func (c *Controller) ListObjects(w http.ResponseWriter, r *http.Request, reposit
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "list_objects")
+	c.LogAction(ctx, "list_objects", r.UserAgent(), repository, ref, "")
 
 	res, hasMore, err := c.Catalog.ListEntries(
 		ctx,
@@ -2917,7 +2917,7 @@ func (c *Controller) StatObject(w http.ResponseWriter, r *http.Request, reposito
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "stat_object")
+	c.LogAction(ctx, "stat_object", r.UserAgent(), repository, ref, "")
 
 	repo, err := c.Catalog.GetRepository(ctx, repository)
 	if c.handleAPIError(ctx, w, err) {
@@ -2963,7 +2963,7 @@ func (c *Controller) GetUnderlyingProperties(w http.ResponseWriter, r *http.Requ
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "object_underlying_properties")
+	c.LogAction(ctx, "object_underlying_properties", r.UserAgent(), repository, ref, "")
 
 	// read repo
 	repo, err := c.Catalog.GetRepository(ctx, repository)
@@ -2999,7 +2999,7 @@ func (c *Controller) MergeIntoBranch(w http.ResponseWriter, r *http.Request, bod
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "merge_branches")
+	c.LogAction(ctx, "merge_branches", r.UserAgent(), repository, destinationBranch, sourceRef)
 	user, ok := ctx.Value(UserContextKey).(*model.User)
 	if !ok {
 		writeError(w, http.StatusUnauthorized, "user not found")
@@ -3042,7 +3042,7 @@ func (c *Controller) ListTags(w http.ResponseWriter, r *http.Request, repository
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "list_tags")
+	c.LogAction(ctx, "list_tags", r.UserAgent(), repository, "", "")
 
 	res, hasMore, err := c.Catalog.ListTags(ctx, repository, paginationPrefix(params.Prefix), paginationAmount(params.Amount), paginationAfter(params.After))
 	if c.handleAPIError(ctx, w, err) {
@@ -3073,7 +3073,7 @@ func (c *Controller) CreateTag(w http.ResponseWriter, r *http.Request, body Crea
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "create_tag")
+	c.LogAction(ctx, "create_tag", r.UserAgent(), repository, body.Id, "")
 
 	commitID, err := c.Catalog.CreateTag(ctx, repository, body.Id, body.Ref)
 	if c.handleAPIError(ctx, w, err) {
@@ -3096,7 +3096,7 @@ func (c *Controller) DeleteTag(w http.ResponseWriter, r *http.Request, repositor
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "delete_tag")
+	c.LogAction(ctx, "delete_tag", r.UserAgent(), repository, tag, "")
 	err := c.Catalog.DeleteTag(ctx, repository, tag)
 	if c.handleAPIError(ctx, w, err) {
 		return
@@ -3114,7 +3114,7 @@ func (c *Controller) GetTag(w http.ResponseWriter, r *http.Request, repository s
 		return
 	}
 	ctx := r.Context()
-	c.LogAction(ctx, "get_tag")
+	c.LogAction(ctx, "get_tag", r.UserAgent(), repository, tag, "")
 	reference, err := c.Catalog.GetTag(ctx, repository, tag)
 	if c.handleAPIError(ctx, w, err) {
 		return
@@ -3190,7 +3190,7 @@ func (c *Controller) Setup(w http.ResponseWriter, r *http.Request, body SetupJSO
 	meta := stats.NewMetadata(ctx, c.Logger, c.BlockAdapter.BlockstoreType(), c.MetadataManager, c.CloudMetadataProvider)
 	c.Collector.SetInstallationID(meta.InstallationID)
 	c.Collector.CollectMetadata(meta)
-	c.Collector.CollectEvent("global", "init")
+	c.Collector.CollectEvent(stats.Event{Class: "global", Name: "init", UserID: body.Username, Client: r.UserAgent()})
 
 	response := CredentialsWithSecret{
 		AccessKeyId:     cred.AccessKeyID,
@@ -3311,7 +3311,7 @@ func (c *Controller) ExpandTemplate(w http.ResponseWriter, r *http.Request, temp
 		}
 	}
 
-	c.LogAction(ctx, "expand_template")
+	c.LogAction(ctx, "expand_template", r.UserAgent(), "", "", "")
 	err := c.Templater.Expand(ctx, w, u, templateLocation, p.Params.AdditionalProperties)
 	if err != nil {
 		c.Logger.WithError(err).WithField("location", templateLocation).Error("Template expansion failed")
@@ -3521,12 +3521,28 @@ func NewController(
 	}
 }
 
-func (c *Controller) LogAction(ctx context.Context, action string) {
-	c.Logger.WithContext(ctx).
-		WithField("action", action).
-		WithField("message_type", "action").
-		Debug("performing API action")
-	c.Collector.CollectEvent("api_server", action)
+func (c *Controller) LogAction(ctx context.Context, action, ua, repository, ref, sourceRef string) {
+	ev := stats.Event{
+		Class:      "api_server",
+		Name:       action,
+		Repository: repository,
+		Ref:        ref,
+		SourceRef:  sourceRef,
+		Client:     ua,
+	}
+	user, ok := ctx.Value(UserContextKey).(*model.User)
+	if ok {
+		ev.UserID = user.Username
+	}
+	c.Logger.WithContext(ctx).WithFields(logging.Fields{
+		"class":      ev.Class,
+		"name":       ev.Name,
+		"repository": ev.Repository,
+		"ref":        ev.Ref,
+		"source_ref": ev.SourceRef,
+		"user_id":    ev.UserID,
+	}).Debug("performing API action")
+	c.Collector.CollectEvent(ev)
 }
 
 func paginationFor(hasMore bool, results interface{}, fieldName string) Pagination {

--- a/pkg/api/serve_test.go
+++ b/pkg/api/serve_test.go
@@ -47,13 +47,13 @@ type dependencies struct {
 
 // memCollector in-memory collector stores events and metadata sent
 type memCollector struct {
-	Events         []*stats.MetadataEntry
+	Events         []*stats.Event
 	Metadata       []*stats.Metadata
 	InstallationID string
 }
 
-func (m *memCollector) CollectEvent(class, action string) {
-	m.Events = append(m.Events, &stats.MetadataEntry{Name: class, Value: action})
+func (m *memCollector) CollectEvent(ev stats.Event) {
+	m.Events = append(m.Events, &ev)
 }
 
 func (m *memCollector) CollectMetadata(metadata *stats.Metadata) {

--- a/pkg/block/s3/client_cache.go
+++ b/pkg/block/s3/client_cache.go
@@ -15,8 +15,10 @@ import (
 	"github.com/treeverse/lakefs/pkg/stats"
 )
 
-type clientFactory func(awsSession *session.Session, cfgs ...*aws.Config) s3iface.S3API
-type s3RegionGetter func(ctx context.Context, sess *session.Session, bucket string) (string, error)
+type (
+	clientFactory  func(awsSession *session.Session, cfgs ...*aws.Config) s3iface.S3API
+	s3RegionGetter func(ctx context.Context, sess *session.Session, bucket string) (string, error)
+)
 
 type ClientCache struct {
 	regionToS3Client sync.Map
@@ -84,7 +86,10 @@ func (c *ClientCache) Get(ctx context.Context, bucket string) s3iface.S3API {
 		svc := c.clientFactory(c.awsSession, &aws.Config{Region: swag.String(region)})
 		c.regionToS3Client.Store(region, svc)
 		if c.collector != nil {
-			c.collector.CollectEvent("s3_block_adapter", fmt.Sprintf("created_aws_client_%s", region))
+			c.collector.CollectEvent(stats.Event{
+				Class: "s3_block_adapter",
+				Name:  fmt.Sprintf("created_aws_client_%s", region),
+			})
 		}
 		return svc
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -307,6 +307,10 @@ func (c *Config) GetStatsFlushInterval() time.Duration {
 	return c.values.Stats.FlushInterval
 }
 
+func (c *Config) GetStatsExtended() bool {
+	return c.values.Stats.Extended
+}
+
 func (c *Config) GetEmailParams() (email.Params, error) {
 	return email.Params{
 		SMTPHost:           c.values.Email.SMTPHost,

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -202,9 +202,10 @@ type configuration struct {
 		}
 	}
 	Stats struct {
-		Enabled       bool
-		Address       string
+		Enabled       bool          `mapstructure:"enabled"`
+		Address       string        `mapstructure:"address"`
 		FlushInterval time.Duration `mapstructure:"flush_interval"`
+		Extended      bool          `mapstructure:"extended"`
 	}
 	Installation struct {
 		FixedID string `mapstructure:"fixed_id"`

--- a/pkg/gateway/middleware.go
+++ b/pkg/gateway/middleware.go
@@ -19,6 +19,7 @@ import (
 	"github.com/treeverse/lakefs/pkg/httputil"
 	"github.com/treeverse/lakefs/pkg/logging"
 	"github.com/treeverse/lakefs/pkg/permissions"
+	"github.com/treeverse/lakefs/pkg/stats"
 )
 
 func AuthenticationHandler(authService auth.GatewayService, next http.Handler) http.Handler {
@@ -102,6 +103,7 @@ func stripPort(host string) string {
 func EnrichWithOperation(sc *ServerContext, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()
+		ua := req.UserAgent()
 		o := &operations.Operation{
 			Region:            sc.region,
 			FQDN:              getBareDomain(stripPort(req.Host), sc.bareDomains),
@@ -109,12 +111,24 @@ func EnrichWithOperation(sc *ServerContext, next http.Handler) http.Handler {
 			MultipartsTracker: sc.multipartsTracker,
 			BlockStore:        sc.blockStore,
 			Auth:              sc.authService,
-			Incr: func(action string) {
+			Incr: func(action, userID, repository, ref string) {
 				logging.FromContext(ctx).
-					WithField("action", action).
-					WithField("message_type", "action").
+					WithFields(logging.Fields{
+						"action":       action,
+						"message_type": "action",
+						"repository":   repository,
+						"ref":          ref,
+						"user_id":      userID,
+					}).
 					Debug("performing S3 action")
-				sc.stats.CollectEvent("s3_gateway", action)
+				sc.stats.CollectEvent(stats.Event{
+					Class:      "s3_gateway",
+					Name:       action,
+					Repository: repository,
+					Ref:        ref,
+					UserID:     userID,
+					Client:     ua,
+				})
 			},
 		}
 		next.ServeHTTP(w, req.WithContext(context.WithValue(ctx, ContextKeyOperation, o)))
@@ -148,7 +162,8 @@ func EnrichWithRepositoryOrFallback(c catalog.Interface, authService auth.Gatewa
 			authResp, authErr := authService.Authorize(ctx, &auth.AuthorizationRequest{
 				Username: username,
 				RequiredPermissions: permissions.Node{
-					Permission: permissions.Permission{Action: permissions.ListRepositoriesAction, Resource: "*"}},
+					Permission: permissions.Permission{Action: permissions.ListRepositoriesAction, Resource: "*"},
+				},
 			})
 			if authErr != nil || authResp.Error != nil || !authResp.Allowed {
 				_ = o.EncodeError(w, req, gatewayerrors.ErrAccessDenied.ToAPIErr())
@@ -202,7 +217,7 @@ func OperationLookupHandler(next http.Handler) http.Handler {
 	})
 }
 
-// memberFold returns true if a is equal case-folded to a member of bs.
+// memberFold returns true if 'a' is equal case-folded to a member of bs.
 func memberFold(a string, bs []string) bool {
 	for _, b := range bs {
 		if strings.EqualFold(a, b) {

--- a/pkg/gateway/middleware.go
+++ b/pkg/gateway/middleware.go
@@ -103,7 +103,7 @@ func stripPort(host string) string {
 func EnrichWithOperation(sc *ServerContext, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()
-		ua := req.UserAgent()
+		client := httputil.GetRequestLakeFSClient(req)
 		o := &operations.Operation{
 			Region:            sc.region,
 			FQDN:              getBareDomain(stripPort(req.Host), sc.bareDomains),
@@ -127,7 +127,7 @@ func EnrichWithOperation(sc *ServerContext, next http.Handler) http.Handler {
 					Repository: repository,
 					Ref:        ref,
 					UserID:     userID,
-					Client:     ua,
+					Client:     client,
 				})
 			},
 		}

--- a/pkg/gateway/operations/base.go
+++ b/pkg/gateway/operations/base.go
@@ -38,7 +38,7 @@ const (
 	OperationIDOperationNotFound    OperationID = "not_found"
 )
 
-type ActionIncr func(string)
+type ActionIncr func(action, repository, ref, userID string)
 
 type Operation struct {
 	OperationID       OperationID

--- a/pkg/gateway/operations/deleteobject.go
+++ b/pkg/gateway/operations/deleteobject.go
@@ -18,12 +18,13 @@ func (controller *DeleteObject) RequiredPermissions(_ *http.Request, repoID, _, 
 	return permissions.Node{
 		Permission: permissions.Permission{
 			Action:   permissions.DeleteObjectAction,
-			Resource: permissions.ObjectArn(repoID, path)},
+			Resource: permissions.ObjectArn(repoID, path),
+		},
 	}, nil
 }
 
 func (controller *DeleteObject) HandleAbortMultipartUpload(w http.ResponseWriter, req *http.Request, o *PathOperation) {
-	o.Incr("abort_mpu")
+	o.Incr("abort_mpu", o.Principal, o.Repository.Name, o.Reference)
 	query := req.URL.Query()
 	uploadID := query.Get(QueryParamUploadID)
 	req = req.WithContext(logging.AddFields(req.Context(), logging.Fields{logging.UploadIDFieldKey: uploadID}))
@@ -46,7 +47,7 @@ func (controller *DeleteObject) Handle(w http.ResponseWriter, req *http.Request,
 		return
 	}
 
-	o.Incr("delete_object")
+	o.Incr("delete_object", o.Principal, o.Repository.Name, o.Reference)
 	lg := o.Log(req).WithField("key", o.Path)
 	err := o.Catalog.DeleteEntry(req.Context(), o.Repository.Name, o.Reference, o.Path)
 	switch {

--- a/pkg/gateway/operations/deleteobjects.go
+++ b/pkg/gateway/operations/deleteobjects.go
@@ -27,7 +27,7 @@ func (controller *DeleteObjects) RequiredPermissions(_ *http.Request, _ string) 
 }
 
 func (controller *DeleteObjects) Handle(w http.ResponseWriter, req *http.Request, o *RepoOperation) {
-	o.Incr("delete_objects")
+	o.Incr("delete_objects", o.Principal, o.Repository.Name, "")
 	decodedXML := &serde.Delete{}
 	err := DecodeXMLBody(req.Body, decodedXML)
 	if err != nil {

--- a/pkg/gateway/operations/getobject.go
+++ b/pkg/gateway/operations/getobject.go
@@ -22,12 +22,13 @@ func (controller *GetObject) RequiredPermissions(_ *http.Request, repoID, _, pat
 	return permissions.Node{
 		Permission: permissions.Permission{
 			Action:   permissions.ReadObjectAction,
-			Resource: permissions.ObjectArn(repoID, path)},
+			Resource: permissions.ObjectArn(repoID, path),
+		},
 	}, nil
 }
 
 func (controller *GetObject) Handle(w http.ResponseWriter, req *http.Request, o *PathOperation) {
-	o.Incr("get_object")
+	o.Incr("get_object", o.Principal, o.Repository.Name, o.Reference)
 	query := req.URL.Query()
 	if _, exists := query["versioning"]; exists {
 		o.EncodeResponse(w, req, serde.VersioningConfiguration{}, http.StatusOK)

--- a/pkg/gateway/operations/headbucket.go
+++ b/pkg/gateway/operations/headbucket.go
@@ -12,11 +12,12 @@ func (controller *HeadBucket) RequiredPermissions(_ *http.Request, repoID string
 	return permissions.Node{
 		Permission: permissions.Permission{
 			Action:   permissions.ReadRepositoryAction,
-			Resource: permissions.RepoArn(repoID)},
+			Resource: permissions.RepoArn(repoID),
+		},
 	}, nil
 }
 
 func (controller *HeadBucket) Handle(w http.ResponseWriter, _ *http.Request, o *RepoOperation) {
-	o.Incr("get_repo")
+	o.Incr("get_repo", o.Principal, o.Repository.Name, "")
 	w.WriteHeader(http.StatusOK)
 }

--- a/pkg/gateway/operations/headobject.go
+++ b/pkg/gateway/operations/headobject.go
@@ -18,12 +18,13 @@ func (controller *HeadObject) RequiredPermissions(_ *http.Request, repoID, _, pa
 	return permissions.Node{
 		Permission: permissions.Permission{
 			Action:   permissions.ReadObjectAction,
-			Resource: permissions.ObjectArn(repoID, path)},
+			Resource: permissions.ObjectArn(repoID, path),
+		},
 	}, nil
 }
 
 func (controller *HeadObject) Handle(w http.ResponseWriter, req *http.Request, o *PathOperation) {
-	o.Incr("stat_object")
+	o.Incr("stat_object", o.Principal, o.Repository.Name, o.Reference)
 	entry, err := o.Catalog.GetEntry(req.Context(), o.Repository.Name, o.Reference, o.Path, catalog.GetEntryParams{ReturnExpired: true})
 	if errors.Is(err, catalog.ErrNotFound) || errors.Is(err, graveler.ErrNotFound) {
 		// TODO: create distinction between missing repo & missing key

--- a/pkg/gateway/operations/listbuckets.go
+++ b/pkg/gateway/operations/listbuckets.go
@@ -15,12 +15,13 @@ func (controller *ListBuckets) RequiredPermissions(_ *http.Request) (permissions
 	return permissions.Node{
 		Permission: permissions.Permission{
 			Action:   permissions.ListRepositoriesAction,
-			Resource: "*"},
+			Resource: "*",
+		},
 	}, nil
 }
 
 func (controller *ListBuckets) Handle(w http.ResponseWriter, req *http.Request, o *AuthorizedOperation) {
-	o.Incr("list_repos")
+	o.Incr("list_repos", o.Principal, "", "")
 	repos, _, err := o.Catalog.ListRepositories(req.Context(), -1, "", "")
 	if err != nil {
 		_ = o.EncodeError(w, req, errors.Codes.ToAPIErr(errors.ErrInternalError))

--- a/pkg/gateway/operations/listobjects.go
+++ b/pkg/gateway/operations/listobjects.go
@@ -30,7 +30,8 @@ func (controller *ListObjects) RequiredPermissions(req *http.Request, repoID str
 		return permissions.Node{
 			Permission: permissions.Permission{
 				Action:   permissions.ListBranchesAction,
-				Resource: permissions.RepoArn(repoID)},
+				Resource: permissions.RepoArn(repoID),
+			},
 		}, nil
 	}
 
@@ -38,7 +39,8 @@ func (controller *ListObjects) RequiredPermissions(req *http.Request, repoID str
 	return permissions.Node{
 		Permission: permissions.Permission{
 			Action:   permissions.ListObjectsAction,
-			Resource: permissions.RepoArn(repoID)},
+			Resource: permissions.RepoArn(repoID),
+		},
 	}, nil
 }
 
@@ -348,7 +350,7 @@ func (controller *ListObjects) ListV1(w http.ResponseWriter, req *http.Request, 
 }
 
 func (controller *ListObjects) Handle(w http.ResponseWriter, req *http.Request, o *RepoOperation) {
-	o.Incr("list_objects")
+	o.Incr("list_objects", o.Principal, o.Repository.Name, "")
 	// parse request parameters
 	// GET /example?list-type=2&prefix=main%2F&delimiter=%2F&encoding-type=url HTTP/1.1
 

--- a/pkg/gateway/operations/postobject.go
+++ b/pkg/gateway/operations/postobject.go
@@ -33,12 +33,13 @@ func (controller *PostObject) RequiredPermissions(_ *http.Request, repoID, _, pa
 	return permissions.Node{
 		Permission: permissions.Permission{
 			Action:   permissions.WriteObjectAction,
-			Resource: permissions.ObjectArn(repoID, path)},
+			Resource: permissions.ObjectArn(repoID, path),
+		},
 	}, nil
 }
 
 func (controller *PostObject) HandleCreateMultipartUpload(w http.ResponseWriter, req *http.Request, o *PathOperation) {
-	o.Incr("create_mpu")
+	o.Incr("create_mpu", o.Principal, o.Repository.Name, o.Reference)
 	branchExists, err := o.Catalog.BranchExists(req.Context(), o.Repository.Name, o.Reference)
 	if err != nil {
 		o.Log(req).WithError(err).Error("could not check if branch exists")
@@ -83,7 +84,7 @@ func (controller *PostObject) HandleCreateMultipartUpload(w http.ResponseWriter,
 }
 
 func (controller *PostObject) HandleCompleteMultipartUpload(w http.ResponseWriter, req *http.Request, o *PathOperation) {
-	o.Incr("complete_mpu")
+	o.Incr("complete_mpu", o.Principal, o.Repository.Name, o.Reference)
 	uploadID := req.URL.Query().Get(CompleteMultipartUploadQueryParam)
 	req = req.WithContext(logging.AddFields(req.Context(), logging.Fields{logging.UploadIDFieldKey: uploadID}))
 	multiPart, err := o.MultipartsTracker.Get(req.Context(), uploadID)

--- a/pkg/gateway/operations/putbucket.go
+++ b/pkg/gateway/operations/putbucket.go
@@ -19,12 +19,13 @@ func (controller *PutBucket) RequiredPermissions(_ *http.Request, repoID string)
 			// create-bucket, even if we only want to receive
 			// 409.
 			Action:   permissions.CreateRepositoryAction,
-			Resource: permissions.RepoArn(repoID)},
+			Resource: permissions.RepoArn(repoID),
+		},
 	}, nil
 }
 
 func (controller *PutBucket) Handle(w http.ResponseWriter, req *http.Request, o *RepoOperation) {
-	o.Incr("put_repo")
+	o.Incr("put_repo", o.Principal, o.Repository.Name, "")
 	if o.Repository == nil {
 		// No repo, would have to create it, but not enough
 		// information -- so not supported.

--- a/pkg/gateway/operations/putobject.go
+++ b/pkg/gateway/operations/putobject.go
@@ -37,7 +37,8 @@ func (controller *PutObject) RequiredPermissions(req *http.Request, repoID, _, d
 		return permissions.Node{
 			Permission: permissions.Permission{
 				Action:   permissions.WriteObjectAction,
-				Resource: permissions.ObjectArn(repoID, destPath)},
+				Resource: permissions.ObjectArn(repoID, destPath),
+			},
 		}, nil
 	}
 	// this is a copy operation
@@ -53,13 +54,17 @@ func (controller *PutObject) RequiredPermissions(req *http.Request, repoID, _, d
 			{
 				Permission: permissions.Permission{
 					Action:   permissions.WriteObjectAction,
-					Resource: permissions.ObjectArn(repoID, destPath)},
+					Resource: permissions.ObjectArn(repoID, destPath),
+				},
 			},
 			{
 				Permission: permissions.Permission{
 					Action:   permissions.ReadObjectAction,
-					Resource: permissions.ObjectArn(p.Repo, p.Path)},
-			}}}, nil
+					Resource: permissions.ObjectArn(p.Repo, p.Path),
+				},
+			},
+		},
+	}, nil
 }
 
 // extractEntryFromCopyReq: get metadata from source file
@@ -132,7 +137,7 @@ func getPathFromSource(copySource string) (path.ResolvedAbsolutePath, error) {
 }
 
 func handleCopy(w http.ResponseWriter, req *http.Request, o *PathOperation, copySource string) {
-	o.Incr("copy_object")
+	o.Incr("copy_object", o.Principal, o.Repository.Name, o.Reference)
 	p, err := getPathFromSource(copySource)
 	if err != nil {
 		o.Log(req).WithError(err).Error("could not parse copy source path")
@@ -168,7 +173,7 @@ func handleCopy(w http.ResponseWriter, req *http.Request, o *PathOperation, copy
 }
 
 func handleUploadPart(w http.ResponseWriter, req *http.Request, o *PathOperation) {
-	o.Incr("put_mpu_part")
+	o.Incr("put_mpu_part", o.Principal, o.Repository.Name, o.Reference)
 	query := req.URL.Query()
 	uploadID := query.Get(QueryParamUploadID)
 	partNumberStr := query.Get(QueryParamPartNumber)
@@ -296,7 +301,7 @@ func (controller *PutObject) Handle(w http.ResponseWriter, req *http.Request, o 
 }
 
 func handlePut(w http.ResponseWriter, req *http.Request, o *PathOperation) {
-	o.Incr("put_object")
+	o.Incr("put_object", o.Principal, o.Repository.Name, o.Reference)
 	storageClass := StorageClassFromHeader(req.Header)
 	opts := block.PutOpts{StorageClass: storageClass}
 	blob, err := upload.WriteBlob(req.Context(), o.BlockStore, o.Repository.StorageNamespace, req.Body, req.ContentLength, opts)

--- a/pkg/graveler/sstable/writer.go
+++ b/pkg/graveler/sstable/writer.go
@@ -162,7 +162,7 @@ func (dw *DiskWriter) Close() (*committed.WriteResult, error) {
 	}, nil
 }
 
-// ShouldBreakAtKey returns true if should break range after the given key
+// ShouldBreakAtKey returns true if it should break range after the given key
 func (dw *DiskWriter) ShouldBreakAtKey(key graveler.Key, params *committed.Params) bool {
 	approximateSize := dw.GetApproximateSize()
 	if approximateSize < params.MinRangeSizeBytes {

--- a/pkg/httputil/client.go
+++ b/pkg/httputil/client.go
@@ -1,0 +1,13 @@
+package httputil
+
+import "net/http"
+
+// GetRequestLakeFSClient get lakeFS client identifier from request.
+//   It extracts the data from X-Lakefs-Client header and fallback to the user-agent
+func GetRequestLakeFSClient(r *http.Request) string {
+	id := r.Header.Get("X-Lakefs-Client")
+	if id == "" {
+		id = r.UserAgent()
+	}
+	return id
+}

--- a/pkg/loadtest/loader.go
+++ b/pkg/loadtest/loader.go
@@ -19,6 +19,7 @@ import (
 	"github.com/treeverse/lakefs/pkg/api"
 	"github.com/treeverse/lakefs/pkg/auth/model"
 	"github.com/treeverse/lakefs/pkg/logging"
+	"github.com/treeverse/lakefs/pkg/version"
 )
 
 type Loader struct {
@@ -137,6 +138,10 @@ func (t *Loader) getClient() (api.ClientWithResponsesInterface, error) {
 	apiClient, err := api.NewClientWithResponses(
 		serverEndpoint,
 		api.WithRequestEditorFn(basicAuthProvider.Intercept),
+		api.WithRequestEditorFn(func(ctx context.Context, req *http.Request) error {
+			req.Header.Set("User-Agent", "lakefs-loadtest/"+version.Version)
+			return nil
+		}),
 	)
 	if err != nil {
 		return nil, ErrCreateClient

--- a/pkg/stats/collector.go
+++ b/pkg/stats/collector.go
@@ -2,13 +2,13 @@ package stats
 
 import (
 	"context"
-	"encoding/hex"
-	"hash/fnv"
+	"fmt"
 	"strings"
 	"sync"
 	"sync/atomic"
 	"time"
 
+	"github.com/cespare/xxhash/v2"
 	"github.com/google/uuid"
 	"github.com/treeverse/lakefs/pkg/config"
 	"github.com/treeverse/lakefs/pkg/logging"
@@ -368,6 +368,6 @@ func HashMetricValue(s string) string {
 	if s == "" {
 		return s
 	}
-	v := fnv.New64().Sum([]byte(s))
-	return hex.EncodeToString(v)
+	v := xxhash.Sum64String(s)
+	return fmt.Sprintf("%02x", v)
 }

--- a/pkg/stats/collector.go
+++ b/pkg/stats/collector.go
@@ -2,7 +2,8 @@ package stats
 
 import (
 	"context"
-	"fmt"
+	"encoding/hex"
+	"hash/fnv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -15,16 +16,16 @@ import (
 )
 
 const (
-	collectorEventBufferSize = 1024 * 1024
-	flushInterval            = time.Second * 600
-	sendTimeout              = time.Second * 5
+	collectorEventBufferSize = 8 * 1024
+	flushInterval            = 10 * time.Minute
+	sendTimeout              = 5 * time.Second
 
 	// heartbeatInterval is the interval between 2 heartbeat events.
 	heartbeatInterval = 60 * time.Minute
 )
 
 type Collector interface {
-	CollectEvent(class, action string)
+	CollectEvent(ev Event)
 	CollectMetadata(accountMetadata *Metadata)
 	SetInstallationID(installationID string)
 
@@ -32,9 +33,38 @@ type Collector interface {
 	Close()
 }
 
+type Event struct {
+	Class      string `json:"class"`
+	Name       string `json:"name"`
+	Repository string `json:"repository"`
+	Ref        string `json:"ref"`
+	SourceRef  string `json:"source_ref"`
+	Client     string `json:"client"`
+	UserID     string `json:"user_id"`
+}
+
+// ClearExtended clear values of *all* extended fields
+func (e Event) ClearExtended() Event {
+	e.Repository = ""
+	e.Ref = ""
+	e.SourceRef = ""
+	e.UserID = ""
+	e.Client = ""
+	return e
+}
+
+// HashExtended hash the values of extended fields with sensitive information
+func (e Event) HashExtended() Event {
+	e.Repository = HashMetricValue(e.Repository)
+	e.Ref = HashMetricValue(e.Ref)
+	e.SourceRef = HashMetricValue(e.SourceRef)
+	e.UserID = HashMetricValue(e.UserID)
+	// e.Client - no need to hash the client value
+	return e
+}
+
 type Metric struct {
-	Class string `json:"class"`
-	Name  string `json:"name"`
+	Event
 	Value uint64 `json:"value"`
 }
 
@@ -45,16 +75,7 @@ type InputEvent struct {
 	Metrics        []Metric `json:"metrics"`
 }
 
-type primaryKey struct {
-	class  string
-	action string
-}
-
-func (p primaryKey) String() string {
-	return fmt.Sprintf("%s/%s", p.class, p.action)
-}
-
-type keyIndex map[primaryKey]uint64
+type keyIndex map[Event]uint64
 
 type FlushTicker interface {
 	Stop()
@@ -75,7 +96,7 @@ func (t *TimeTicker) Tick() <-chan time.Time {
 
 type BufferedCollector struct {
 	cache            keyIndex
-	writes           chan primaryKey
+	writes           chan Event
 	sender           Sender
 	sendTimeout      time.Duration
 	flushTicker      FlushTicker
@@ -84,19 +105,19 @@ type BufferedCollector struct {
 	processID        string
 	runtimeCollector func() map[string]string
 	runtimeStats     map[string]string
-
-	pendingWrites   sync.WaitGroup
-	pendingRequests sync.WaitGroup
-	ctxCancelled    int32
-	done            chan bool
-	runCalled       int32
+	pendingWrites    sync.WaitGroup
+	pendingRequests  sync.WaitGroup
+	ctxCancelled     int32
+	done             chan bool
+	runCalled        int32
+	extended         bool
 }
 
 type BufferedCollectorOpts func(s *BufferedCollector)
 
 func WithWriteBufferSize(bufferSize int) BufferedCollectorOpts {
 	return func(s *BufferedCollector) {
-		s.writes = make(chan primaryKey, bufferSize)
+		s.writes = make(chan Event, bufferSize)
 	}
 }
 
@@ -124,36 +145,55 @@ func WithSendTimeout(d time.Duration) BufferedCollectorOpts {
 	}
 }
 
+func WithExtended(b bool) BufferedCollectorOpts {
+	return func(s *BufferedCollector) {
+		s.extended = b
+	}
+}
+
 func NewBufferedCollector(installationID string, c *config.Config, opts ...BufferedCollectorOpts) *BufferedCollector {
-	processID, moreOpts := getBufferedCollectorArgs(c)
-	opts = append(opts, moreOpts...)
+	statsEnabled := true
+	flushDuration := flushInterval
+	extended := false
+	if c != nil {
+		statsEnabled = c.GetStatsEnabled() && !strings.HasPrefix(version.Version, version.UnreleasedVersion)
+		flushDuration = c.GetStatsFlushInterval()
+		extended = c.GetStatsExtended()
+	}
 	s := &BufferedCollector{
 		cache:           make(keyIndex),
-		writes:          make(chan primaryKey, collectorEventBufferSize),
-		sender:          NewDummySender(),
-		sendTimeout:     sendTimeout,
+		writes:          make(chan Event, collectorEventBufferSize),
 		runtimeStats:    map[string]string{},
-		flushTicker:     &TimeTicker{ticker: time.NewTicker(flushInterval)},
+		flushTicker:     &TimeTicker{ticker: time.NewTicker(flushDuration)},
 		heartbeatTicker: &TimeTicker{ticker: time.NewTicker(heartbeatInterval)},
 		installationID:  installationID,
-		processID:       processID,
+		processID:       uuid.Must(uuid.NewUUID()).String(),
 		pendingWrites:   sync.WaitGroup{},
 		pendingRequests: sync.WaitGroup{},
 		ctxCancelled:    0,
 		done:            make(chan bool),
 		runCalled:       0,
+		sendTimeout:     sendTimeout,
+		extended:        extended,
 	}
 	for _, opt := range opts {
 		opt(s)
 	}
-
+	if s.sender == nil {
+		if statsEnabled {
+			s.sender = NewHTTPSender(c.GetStatsAddress(), s.sendTimeout, time.Now)
+		} else {
+			s.sender = &dummySender{Log: logging.Default().WithField("service", "dummy_stats_collector")}
+		}
+	}
 	return s
 }
+
 func (s *BufferedCollector) getInstallationID() string {
 	return s.installationID
 }
 
-func (s *BufferedCollector) incr(k primaryKey) {
+func (s *BufferedCollector) incr(k Event) {
 	s.cache[k]++
 }
 
@@ -164,9 +204,7 @@ func (s *BufferedCollector) send(metrics []Metric) {
 		if len(metrics) == 0 {
 			return
 		}
-		ctx, cancel := context.WithTimeout(context.Background(), s.sendTimeout)
-		defer cancel()
-		err := s.sender.SendEvent(ctx, s.getInstallationID(), s.processID, metrics)
+		err := s.sender.SendEvent(context.Background(), s.getInstallationID(), s.processID, metrics)
 		if err != nil {
 			logging.Default().
 				WithError(err).
@@ -176,17 +214,20 @@ func (s *BufferedCollector) send(metrics []Metric) {
 	}()
 }
 
-func (s *BufferedCollector) CollectEvent(class, action string) {
+func (s *BufferedCollector) CollectEvent(ev Event) {
 	if s.isCtxCancelled() {
 		return
 	}
 	s.pendingWrites.Add(1)
 	defer s.pendingWrites.Done()
 
-	s.writes <- primaryKey{
-		class:  class,
-		action: action,
+	// hash or clear extended fields on the event
+	if s.extended {
+		ev = ev.HashExtended()
+	} else {
+		ev = ev.ClearExtended()
 	}
+	s.writes <- ev
 }
 
 func (s *BufferedCollector) isCtxCancelled() bool {
@@ -201,9 +242,9 @@ func (s *BufferedCollector) Run(ctx context.Context) {
 			case w := <-s.writes: // collect events
 				s.incr(w)
 			case <-s.heartbeatTicker.Tick():
-				s.incr(primaryKey{
-					class:  "global",
-					action: "heartbeat",
+				s.incr(Event{
+					Class: "global",
+					Name:  "heartbeat",
 				})
 			case <-s.flushTicker.Tick(): // every N seconds, send the collected events
 				s.handleRuntimeStats()
@@ -250,8 +291,7 @@ func makeMetrics(counters keyIndex) []Metric {
 	i := 0
 	for k, v := range counters {
 		metrics[i] = Metric{
-			Class: k.class,
-			Name:  k.action,
+			Event: k,
 			Value: v,
 		}
 		i++
@@ -324,19 +364,10 @@ func (s *BufferedCollector) sendRuntimeStats() {
 	}()
 }
 
-func getBufferedCollectorArgs(c *config.Config) (processID string, opts []BufferedCollectorOpts) {
-	if c == nil {
-		return "", nil
+func HashMetricValue(s string) string {
+	if s == "" {
+		return s
 	}
-	var sender Sender
-	if c.GetStatsEnabled() && !strings.HasPrefix(version.Version, version.UnreleasedVersion) {
-		sender = NewHTTPSender(c.GetStatsAddress(), time.Now)
-	} else {
-		sender = NewDummySender()
-	}
-	return uuid.Must(uuid.NewUUID()).String(),
-		[]BufferedCollectorOpts{
-			WithSender(sender),
-			WithFlushInterval(c.GetStatsFlushInterval()),
-		}
+	v := fnv.New64().Sum([]byte(s))
+	return hex.EncodeToString(v)
 }

--- a/pkg/stats/collector.go
+++ b/pkg/stats/collector.go
@@ -36,11 +36,11 @@ type Collector interface {
 type Event struct {
 	Class      string `json:"class"`
 	Name       string `json:"name"`
-	Repository string `json:"repository"`
-	Ref        string `json:"ref"`
-	SourceRef  string `json:"source_ref"`
-	Client     string `json:"client"`
-	UserID     string `json:"user_id"`
+	Repository string `json:"repository,omitempty"`
+	Ref        string `json:"ref,omitempty"`
+	SourceRef  string `json:"source_ref,omitempty"`
+	UserID     string `json:"user_id,omitempty"`
+	Client     string `json:"client,omitempty"`
 }
 
 // ClearExtended clear values of *all* extended fields
@@ -179,7 +179,6 @@ func NewBufferedCollector(installationID string, c *config.Config, opts ...Buffe
 		pendingRequests: sync.WaitGroup{},
 		ctxCancelled:    0,
 		done:            make(chan bool),
-		runCalled:       0,
 		sendTimeout:     sendTimeout,
 		extended:        extended,
 		log:             logging.Default(),
@@ -245,6 +244,9 @@ func (s *BufferedCollector) isCtxCancelled() bool {
 }
 
 func (s *BufferedCollector) Run(ctx context.Context) {
+	if atomic.LoadInt32(&s.runCalled) != 0 {
+		return
+	}
 	atomic.StoreInt32(&s.runCalled, 1)
 	go func() {
 		for {

--- a/pkg/stats/nullcollector.go
+++ b/pkg/stats/nullcollector.go
@@ -4,7 +4,7 @@ type NullCollector struct{}
 
 func (m *NullCollector) CollectMetadata(_ *Metadata) {}
 
-func (m *NullCollector) CollectEvent(_, _ string) {}
+func (m *NullCollector) CollectEvent(_ Event) {}
 
 func (m *NullCollector) SetInstallationID(_ string) {}
 

--- a/pkg/stats/sender.go
+++ b/pkg/stats/sender.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/davecgh/go-spew/spew"
 	"github.com/treeverse/lakefs/pkg/logging"
 )
 
@@ -108,7 +107,7 @@ func (s *dummySender) SendEvent(_ context.Context, installationID, processID str
 	s.Log.WithFields(logging.Fields{
 		"installation_id": installationID,
 		"process_id":      processID,
-		"metrics":         spew.Sdump(metrics),
+		"metrics":         fmt.Sprintf("%+v", metrics),
 	}).Trace("dummy sender received metrics")
 	return nil
 }
@@ -118,7 +117,7 @@ func (s *dummySender) UpdateMetadata(_ context.Context, m Metadata) error {
 		return nil
 	}
 	s.Log.WithFields(logging.Fields{
-		"metadata": spew.Sdump(m),
+		"metadata": fmt.Sprintf("%+v", m),
 	}).Trace("dummy sender received metadata")
 	return nil
 }

--- a/pkg/stats/sender.go
+++ b/pkg/stats/sender.go
@@ -47,7 +47,7 @@ func (s *HTTPSender) UpdateMetadata(ctx context.Context, m Metadata) error {
 	if len(m.InstallationID) == 0 {
 		return ErrNoInstallationID
 	}
-	serialized, err := json.MarshalIndent(m, "", "  ")
+	serialized, err := json.Marshal(m)
 	if err != nil {
 		return fmt.Errorf("failed to serialize account metadata: %w", err)
 	}
@@ -74,7 +74,7 @@ func (s *HTTPSender) SendEvent(ctx context.Context, installationID, processID st
 		Time:           s.timeFunc().Format(time.RFC3339),
 		Metrics:        metrics,
 	}
-	serialized, err := json.MarshalIndent(event, "", "  ")
+	serialized, err := json.Marshal(event)
 	if err != nil {
 		return fmt.Errorf("could not serialize event: %s: %w", err, ErrSendError)
 	}

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -41,6 +41,7 @@
         "@types/validator": "^13.7.7",
         "@typescript-eslint/eslint-plugin": "^5.38.0",
         "@typescript-eslint/parser": "^5.38.0",
+        "@rollup/plugin-replace": "^4.0.0",
         "@vitejs/plugin-react-refresh": "^1.3.1",
         "babel-eslint": "^10.1.0",
         "eslint-plugin-react": "^7.23.2",
@@ -1761,6 +1762,42 @@
         "react": ">=16.8.0"
       }
     },
+    "node_modules/@rollup/plugin-replace": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-4.0.0.tgz",
+      "integrity": "sha512-+rumQFiaNac9y64OHtkHGmdjm7us9bo1PlbgQfdihQtuNxzjpaB064HbRnewUOggLQxVCCyINfStkgmBeQpv1g==",
+      "dev": true,
+      "dependencies": {
+        "@rollup/pluginutils": "^3.1.0",
+        "magic-string": "^0.25.7"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0 || ^2.0.0"
+      }
+    },
+    "node_modules/@rollup/plugin-replace/node_modules/@rollup/pluginutils": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+      "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "0.0.39",
+        "estree-walker": "^1.0.1",
+        "picomatch": "^2.2.2"
+      },
+      "engines": {
+        "node": ">= 8.0.0"
+      },
+      "peerDependencies": {
+        "rollup": "^1.20.0||^2.0.0"
+      }
+    },
+    "node_modules/@rollup/plugin-replace/node_modules/estree-walker": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+      "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+      "dev": true
+    },
     "node_modules/@rollup/pluginutils": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.1.0.tgz",
@@ -1892,6 +1929,12 @@
       "dependencies": {
         "@types/ms": "*"
       }
+    },
+    "node_modules/@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "dev": true
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.5",
@@ -7140,6 +7183,15 @@
         "node": ">=10"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+      "dev": true,
+      "dependencies": {
+        "sourcemap-codec": "^1.4.8"
+      }
+    },
     "node_modules/make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -9558,6 +9610,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "dev": true
     },
     "node_modules/space-separated-tokens": {
       "version": "1.1.5",
@@ -12142,6 +12200,35 @@
         "lodash-es": "^4.17.20"
       }
     },
+    "@rollup/plugin-replace": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@rollup/plugin-replace/-/plugin-replace-4.0.0.tgz",
+      "integrity": "sha512-+rumQFiaNac9y64OHtkHGmdjm7us9bo1PlbgQfdihQtuNxzjpaB064HbRnewUOggLQxVCCyINfStkgmBeQpv1g==",
+      "dev": true,
+      "requires": {
+        "@rollup/pluginutils": "^3.1.0",
+        "magic-string": "^0.25.7"
+      },
+      "dependencies": {
+        "@rollup/pluginutils": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-3.1.0.tgz",
+          "integrity": "sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==",
+          "dev": true,
+          "requires": {
+            "@types/estree": "0.0.39",
+            "estree-walker": "^1.0.1",
+            "picomatch": "^2.2.2"
+          }
+        },
+        "estree-walker": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-1.0.1.tgz",
+          "integrity": "sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==",
+          "dev": true
+        }
+      }
+    },
     "@rollup/pluginutils": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/@rollup/pluginutils/-/pluginutils-4.1.0.tgz",
@@ -12266,6 +12353,12 @@
       "requires": {
         "@types/ms": "*"
       }
+    },
+    "@types/estree": {
+      "version": "0.0.39",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-0.0.39.tgz",
+      "integrity": "sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==",
+      "dev": true
     },
     "@types/graceful-fs": {
       "version": "4.1.5",
@@ -16112,6 +16205,15 @@
         "yallist": "^4.0.0"
       }
     },
+    "magic-string": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+      "dev": true,
+      "requires": {
+        "sourcemap-codec": "^1.4.8"
+      }
+    },
     "make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -17806,6 +17908,12 @@
           "dev": true
         }
       }
+    },
+    "sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "dev": true
     },
     "space-separated-tokens": {
       "version": "1.1.5",

--- a/webui/package.json
+++ b/webui/package.json
@@ -42,6 +42,7 @@
     "@types/validator": "^13.7.7",
     "@typescript-eslint/eslint-plugin": "^5.38.0",
     "@typescript-eslint/parser": "^5.38.0",
+    "@rollup/plugin-replace": "^4.0.0",
     "@vitejs/plugin-react-refresh": "^1.3.1",
     "babel-eslint": "^10.1.0",
     "eslint-plugin-react": "^7.23.2",

--- a/webui/src/lib/api/index.js
+++ b/webui/src/lib/api/index.js
@@ -55,6 +55,7 @@ export const extractError = async (response) => {
 export const defaultAPIHeaders = {
     "Accept": "application/json",
     "Content-Type": "application/json",
+    "User-Agent": "lakefs-webui/__buildVersion",
 }
 
 const authenticationError = "error authenticating request"

--- a/webui/src/lib/api/index.js
+++ b/webui/src/lib/api/index.js
@@ -32,10 +32,6 @@ export const linkToPath = (repoId, branchId, path) => {
     return `${API_ENDPOINT}/repositories/${repoId}/refs/${branchId}/objects?${query}`;
 };
 
-const json =(data) => {
-    return JSON.stringify(data, null, "");
-};
-
 const qs = (queryParts) => {
     const parts = Object.keys(queryParts).map(key => [key, queryParts[key]]);
     return new URLSearchParams(parts).toString();
@@ -55,8 +51,8 @@ export const extractError = async (response) => {
 export const defaultAPIHeaders = {
     "Accept": "application/json",
     "Content-Type": "application/json",
-    "User-Agent": "lakefs-webui/__buildVersion",
-}
+    "X-Lakefs-Client": "lakefs-webui/__buildVersion",
+};
 
 const authenticationError = "error authenticating request"
 
@@ -78,7 +74,7 @@ const apiRequest = async (uri, requestData = {}, additionalHeaders = {}) => {
     }
 
     return response;
-}
+};
 
 // helper errors
 export class NotFoundError extends Error {
@@ -144,7 +140,7 @@ class Auth {
         const response = await fetch(`${API_ENDPOINT}/auth/password`, {
             headers: new Headers(defaultAPIHeaders),
             method: 'POST',
-            body: json({token: token, newPassword: newPassword, email: email})
+            body: JSON.stringify({token: token, newPassword: newPassword, email: email})
         });
 
         if (response.status === 401) {
@@ -159,7 +155,7 @@ class Auth {
         const response = await fetch(`${API_ENDPOINT}/auth/password/forgot`, {
             headers: new Headers(defaultAPIHeaders),
             method: 'POST',
-            body: json({email: email})
+            body: JSON.stringify({email: email})
         });
 
         if (response.status === 400) {
@@ -174,7 +170,7 @@ class Auth {
         const response = await fetch(`${API_ENDPOINT}/auth/login`, {
             headers: new Headers(defaultAPIHeaders),
             method: 'POST',
-            body: json({access_key_id: accessKeyId, secret_access_key: secretAccessKey})
+            body: JSON.stringify({access_key_id: accessKeyId, secret_access_key: secretAccessKey})
         });
 
         if (response.status === 401) {
@@ -220,7 +216,7 @@ class Auth {
 
     async createUser(userId, inviteUser = false) {
         const response = await apiRequest(`/auth/users`,
-            {method: 'POST', body: json({id: userId, invite_user: inviteUser})});
+            {method: 'POST', body: JSON.stringify({id: userId, invite_user: inviteUser})});
         if (response.status !== 201) {
             throw new Error(await extractError(response));
         }
@@ -295,7 +291,7 @@ class Auth {
     }
 
     async createGroup(groupId) {
-        const response = await apiRequest(`/auth/groups`, {method: 'POST',  body: json({id: groupId})});
+        const response = await apiRequest(`/auth/groups`, {method: 'POST',  body: JSON.stringify({id: groupId})});
         if (response.status !== 201) {
             throw new Error(await extractError(response));
         }
@@ -315,7 +311,7 @@ class Auth {
         const policy = {id: policyId, ...JSON.parse(policyDocument)};
         const response = await apiRequest(`/auth/policies`, {
             method: 'POST',
-            body: json(policy)
+            body: JSON.stringify(policy)
         });
         if (response.status !== 201) {
             throw new Error(await extractError(response));
@@ -327,7 +323,7 @@ class Auth {
         const policy = {id: policyId, ...JSON.parse(policyDocument)};
         const response = await apiRequest(`/auth/policies/${encodeURIComponent(policyId)}`, {
             method: 'PUT',
-            body: json(policy)
+            body: JSON.stringify(policy)
         });
         if (response.status !== 200) {
             throw new Error(await extractError(response));
@@ -463,7 +459,7 @@ class Repositories {
     async create(repo) {
         const response = await apiRequest('/repositories', {
             method: 'POST',
-            body: json(repo),
+            body: JSON.stringify(repo),
         });
         if (response.status !== 201) {
             throw new Error(await extractError(response));
@@ -496,7 +492,7 @@ class Branches {
     async create(repoId, name, source) {
         const response = await apiRequest(`/repositories/${encodeURIComponent(repoId)}/branches`, {
             method: 'POST',
-            body: json({name, source}),
+            body: JSON.stringify({name, source}),
         });
         if (response.status !== 201) {
             throw new Error(await extractError(response));
@@ -516,7 +512,7 @@ class Branches {
     async revert(repoId, branch, options) {
         const response = await apiRequest(`/repositories/${encodeURIComponent(repoId)}/branches/${encodeURIComponent(branch)}`, {
             method: 'PUT',
-            body: json(options),
+            body: JSON.stringify(options),
         });
         if (response.status !== 204) {
             throw new Error(await extractError(response));
@@ -557,7 +553,7 @@ class Tags {
     async create(repoId, id, ref) {
         const response = await apiRequest(`/repositories/${encodeURIComponent(repoId)}/tags`, {
             method: 'POST',
-            body: json({id, ref}),
+            body: JSON.stringify({id, ref}),
         });
         if (response.status !== 201) {
             throw new Error(await extractError(response));
@@ -676,7 +672,7 @@ class Commits {
         const response = await apiRequest(parsedURL, {
 
             method: 'POST',
-            body: json({message, metadata}),
+            body: JSON.stringify({message, metadata}),
         });
 
         if (response.status !== 201) {
@@ -709,7 +705,7 @@ class Refs {
     async merge(repoId, sourceBranch, destinationBranch, strategy="") {
         const response = await apiRequest(`/repositories/${encodeURIComponent(repoId)}/refs/${encodeURIComponent(sourceBranch)}/merge/${encodeURIComponent(destinationBranch)}`, {
             method: 'POST',
-            body: json({strategy})
+            body: JSON.stringify({strategy})
         });
 
         let resp;
@@ -899,7 +895,7 @@ class Ranges {
     async createRange(repoID, fromSourceURI, after, prepend, continuation_token="") {
         const response = await apiRequest(`/repositories/${repoID}/branches/ranges`, {
             method: 'POST',
-            body: json({fromSourceURI, after, prepend, continuation_token}),
+            body: JSON.stringify({fromSourceURI, after, prepend, continuation_token}),
         });
         if (response.status !== 201) {
             throw new Error(await extractError(response));
@@ -912,7 +908,7 @@ class MetaRanges {
     async createMetaRange(repoID, ranges) {
         const response = await apiRequest(`/repositories/${repoID}/branches/metaranges`, {
             method: 'POST',
-            body: json({ranges}),
+            body: JSON.stringify({ranges}),
         });
         if (response.status !== 201) {
             throw new Error(await extractError(response));

--- a/webui/src/lib/components/navbar.jsx
+++ b/webui/src/lib/components/navbar.jsx
@@ -1,19 +1,17 @@
 import React from "react";
-import Navbar from 'react-bootstrap/Navbar';
-import Nav from 'react-bootstrap/Nav';
-import NavDropdown from 'react-bootstrap/NavDropdown';
 import useUser from '../hooks/user'
 import {auth, config} from "../api";
 import {useRouter} from "../hooks/router";
 import {Link} from "./nav";
 import {useAPI} from "../hooks/api";
+import {Navbar, Nav, NavDropdown} from "react-bootstrap";
 
 const NavUserInfo = () => {
     const { user, loading, error } = useUser();
     const { response: versionResponse, loading: versionLoading, error: versionError } = useAPI(() => {
         return config.getLakeFSVersion()
     }, [])
-    if (loading)  return <Navbar.Text>Loading...</Navbar.Text>;
+    if (loading) return <Navbar.Text>Loading...</Navbar.Text>;
     if (!user || !!error) return (<></>);
     return (
         <Navbar.Collapse className="justify-content-end">
@@ -25,10 +23,14 @@ const NavUserInfo = () => {
                     }}>
                     Logout
                 </NavDropdown.Item>
-                {!versionLoading && !versionError && <><NavDropdown.Divider/>
+                <NavDropdown.Divider/>
+                {!versionLoading && !versionError && <>
                 <NavDropdown.Item disabled={true}>
                     <small>lakeFS {versionResponse.version}</small>
                 </NavDropdown.Item></>}
+                <NavDropdown.Item disabled={true}>
+                    <small>Web UI __buildVersion</small>
+                </NavDropdown.Item>
                 {!versionLoading && !versionError && versionResponse.upgrade_recommended && <>
                     <NavDropdown.Item href={versionResponse.upgrade_url}>
                         <small>upgrade recommended</small>

--- a/webui/vite.config.js
+++ b/webui/vite.config.js
@@ -1,11 +1,18 @@
 import reactRefresh from '@vitejs/plugin-react-refresh';
 import eslintPlugin from 'vite-plugin-eslint';
-
+import replace from '@rollup/plugin-replace';
 
 // https://vitejs.dev/config/
 export default ({ command }) => {
   const baseConfig = {
     plugins: [
+      replace({
+          preventAssignment: true,
+          include: ['src/**/*.jsx', 'src/**/*.js'],
+          values: {
+            __buildVersion: process.env.VERSION || 'dev',
+          }
+      }),
       reactRefresh(),
       eslintPlugin({
         include: ['src/**/*.jsx', 'src/**/*.js', 'src/**/*.ts', 'src/**/*.tsx']


### PR DESCRIPTION
- default is off.
- sends client user-agent as id, repository, ref, source ref and username.
- all extended values are hashed, except client id.
- lakectl, webui and sdk now include specific user-agent with build time version information.

Close #4265
