### PR TITLE
Delete objects as part of Graveler

### DIFF
--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -2960,8 +2960,6 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/ObjectErrorList"
-        204:
-          description: all requested objects successfully deleted
         401:
           $ref: "#/components/responses/Unauthorized"
         404:

--- a/clients/java/api/openapi.yaml
+++ b/clients/java/api/openapi.yaml
@@ -3436,8 +3436,6 @@ paths:
               schema:
                 $ref: '#/components/schemas/ObjectErrorList'
           description: Delete objects response
-        "204":
-          description: all requested objects successfully deleted
         "401":
           content:
             application/json:

--- a/clients/java/docs/ObjectsApi.md
+++ b/clients/java/docs/ObjectsApi.md
@@ -187,7 +187,6 @@ Name | Type | Description  | Notes
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 **200** | Delete objects response |  -  |
-**204** | all requested objects successfully deleted |  -  |
 **401** | Unauthorized |  -  |
 **404** | Resource Not Found |  -  |
 **0** | Internal Server Error |  -  |

--- a/clients/java/src/main/java/io/lakefs/clients/api/ObjectsApi.java
+++ b/clients/java/src/main/java/io/lakefs/clients/api/ObjectsApi.java
@@ -216,7 +216,6 @@ public class ObjectsApi {
      <table summary="Response Details" border="1">
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 200 </td><td> Delete objects response </td><td>  -  </td></tr>
-        <tr><td> 204 </td><td> all requested objects successfully deleted </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Resource Not Found </td><td>  -  </td></tr>
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
@@ -290,7 +289,6 @@ public class ObjectsApi {
      <table summary="Response Details" border="1">
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 200 </td><td> Delete objects response </td><td>  -  </td></tr>
-        <tr><td> 204 </td><td> all requested objects successfully deleted </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Resource Not Found </td><td>  -  </td></tr>
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
@@ -313,7 +311,6 @@ public class ObjectsApi {
      <table summary="Response Details" border="1">
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 200 </td><td> Delete objects response </td><td>  -  </td></tr>
-        <tr><td> 204 </td><td> all requested objects successfully deleted </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Resource Not Found </td><td>  -  </td></tr>
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
@@ -338,7 +335,6 @@ public class ObjectsApi {
      <table summary="Response Details" border="1">
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 200 </td><td> Delete objects response </td><td>  -  </td></tr>
-        <tr><td> 204 </td><td> all requested objects successfully deleted </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Resource Not Found </td><td>  -  </td></tr>
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>

--- a/clients/python/docs/ObjectsApi.md
+++ b/clients/python/docs/ObjectsApi.md
@@ -219,7 +219,6 @@ Name | Type | Description  | Notes
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 **200** | Delete objects response |  -  |
-**204** | all requested objects successfully deleted |  -  |
 **401** | Unauthorized |  -  |
 **404** | Resource Not Found |  -  |
 **0** | Internal Server Error |  -  |

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -21,6 +21,8 @@ import (
 	"text/template"
 	"time"
 
+	"github.com/davecgh/go-spew/spew"
+
 	"github.com/go-test/deep"
 	nanoid "github.com/matoous/go-nanoid/v2"
 	"github.com/stretchr/testify/require"
@@ -1814,8 +1816,11 @@ func TestController_ObjectsDeleteObjectHandler(t *testing.T) {
 		// delete objects
 		delResp, err := clt.DeleteObjectsWithResponse(ctx, repo, branch, api.DeleteObjectsJSONRequestBody{Paths: paths})
 		verifyResponseOK(t, delResp, err)
-		if delResp.StatusCode() != http.StatusNoContent {
-			t.Errorf("DeleteObjects should return 204 (no content) for successful delete, got %d", delResp.StatusCode())
+		if delResp.JSON200 == nil {
+			t.Errorf("DeleteObjects should return 200 for successful delete, got status code %d", delResp.StatusCode())
+		}
+		if len(delResp.JSON200.Errors) > 0 {
+			t.Errorf("DeleteObjects (round 2) should have no errors, got %v", delResp.JSON200.Errors)
 		}
 
 		// check objects no longer there
@@ -1829,6 +1834,16 @@ func TestController_ObjectsDeleteObjectHandler(t *testing.T) {
 			if statResp.JSON404 == nil {
 				t.Fatalf("expected file to be gone now for '%s'", p)
 			}
+		}
+
+		// delete objects again - make sure we do not fail or get any error
+		delResp2, err := clt.DeleteObjectsWithResponse(ctx, repo, branch, api.DeleteObjectsJSONRequestBody{Paths: paths})
+		verifyResponseOK(t, delResp2, err)
+		if delResp2.JSON200 == nil {
+			t.Errorf("DeleteObjects (round 2) should return 200 for successful delete, got status code %d", delResp2.StatusCode())
+		}
+		if len(delResp2.JSON200.Errors) > 0 {
+			t.Errorf("DeleteObjects (round 2) should have no errors, got %s", spew.Sdump(delResp2.JSON200.Errors))
 		}
 	})
 

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -22,7 +22,6 @@ import (
 	"time"
 
 	"github.com/davecgh/go-spew/spew"
-
 	"github.com/go-test/deep"
 	nanoid "github.com/matoous/go-nanoid/v2"
 	"github.com/stretchr/testify/require"

--- a/pkg/catalog/fake_graveler_test.go
+++ b/pkg/catalog/fake_graveler_test.go
@@ -106,7 +106,11 @@ func (g *FakeGraveler) Set(_ context.Context, repository *graveler.RepositoryRec
 }
 
 func (g *FakeGraveler) Delete(ctx context.Context, repository *graveler.RepositoryRecord, branchID graveler.BranchID, key graveler.Key) error {
-	panic("implement me")
+	return nil
+}
+
+func (g *FakeGraveler) DeleteBatch(ctx context.Context, repository *graveler.RepositoryRecord, branchID graveler.BranchID, keys []graveler.Key) error {
+	return nil
 }
 
 func (g *FakeGraveler) List(_ context.Context, _ *graveler.RepositoryRecord, _ graveler.Ref) (graveler.ValueIterator, error) {

--- a/pkg/catalog/interface.go
+++ b/pkg/catalog/interface.go
@@ -98,6 +98,7 @@ type Interface interface {
 	GetEntry(ctx context.Context, repository, reference string, path string, params GetEntryParams) (*DBEntry, error)
 	CreateEntry(ctx context.Context, repository, branch string, entry DBEntry, writeConditions ...graveler.WriteConditionOption) error
 	DeleteEntry(ctx context.Context, repository, branch string, path string) error
+	DeleteEntries(ctx context.Context, repository, branch string, paths []string) error
 	ListEntries(ctx context.Context, repository, reference string, prefix, after string, delimiter string, limit int) ([]*DBEntry, bool, error)
 	ResetEntry(ctx context.Context, repository, branch string, path string) error
 	ResetEntries(ctx context.Context, repository, branch string, prefix string) error

--- a/pkg/gateway/operations/deleteobjects.go
+++ b/pkg/gateway/operations/deleteobjects.go
@@ -31,8 +31,6 @@ func (controller *DeleteObjects) Handle(w http.ResponseWriter, req *http.Request
 		return
 	}
 
-	// TODO(barak): limit request size to DefaultMaxDeleteObjects
-
 	// delete all the files and collect responses
 	var (
 		errs      []serde.DeleteError
@@ -61,7 +59,8 @@ func (controller *DeleteObjects) Handle(w http.ResponseWriter, req *http.Request
 				Permission: permissions.Permission{
 					Action:   permissions.DeleteObjectAction,
 					Resource: permissions.ObjectArn(o.Repository.Name, resolvedPath.Path),
-				}},
+				},
+			},
 		})
 		if err != nil || !authResp.Allowed {
 			errs = append(errs, serde.DeleteError{

--- a/pkg/gateway/operations/deleteobjects.go
+++ b/pkg/gateway/operations/deleteobjects.go
@@ -1,6 +1,7 @@
 package operations
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"net/http"
@@ -11,6 +12,7 @@ import (
 	"github.com/treeverse/lakefs/pkg/gateway/path"
 	"github.com/treeverse/lakefs/pkg/gateway/serde"
 	"github.com/treeverse/lakefs/pkg/graveler"
+	"github.com/treeverse/lakefs/pkg/logging"
 	"github.com/treeverse/lakefs/pkg/permissions"
 )
 
@@ -28,9 +30,20 @@ func (controller *DeleteObjects) Handle(w http.ResponseWriter, req *http.Request
 		_ = o.EncodeError(w, req, gerrors.Codes.ToAPIErr(gerrors.ErrBadRequest))
 		return
 	}
+
+	// TODO(barak): limit request size to DefaultMaxDeleteObjects
+
 	// delete all the files and collect responses
-	errs := make([]serde.DeleteError, 0)
-	responses := make([]serde.Deleted, 0)
+	var (
+		errs      []serde.DeleteError
+		responses []serde.Deleted
+	)
+	// arrays of keys/path to delete, left after authorization check
+	var (
+		keysToDelete  []string
+		pathsToDelete []string
+		refsToDelete  []string
+	)
 	for _, obj := range decodedXML.Object {
 		resolvedPath, err := path.ResolvePath(obj.Key)
 		if err != nil {
@@ -56,43 +69,107 @@ func (controller *DeleteObjects) Handle(w http.ResponseWriter, req *http.Request
 				Key:     obj.Key,
 				Message: "Access Denied",
 			})
+			continue
 		}
 
-		lg := o.Log(req).WithField("key", obj.Key)
-		err = o.Catalog.DeleteEntry(req.Context(), o.Repository.Name, resolvedPath.Ref, resolvedPath.Path)
-		switch {
-		case errors.Is(err, catalog.ErrNotFound),
-			errors.Is(err, graveler.ErrNotFound):
-			lg.Debug("tried to delete a non-existent object (OK)")
-		case errors.Is(err, graveler.ErrWriteToProtectedBranch):
-			_ = o.EncodeError(w, req, gerrors.Codes.ToAPIErr(gerrors.ErrWriteToProtectedBranch))
-		case errors.Is(err, catalog.ErrPathRequiredValue):
-			// issue #1706 - https://github.com/treeverse/lakeFS/issues/1706
-			// Spark trying to delete the path "main/", which we map to branch "main" with an empty path.
-			// Spark expects it to succeed (not deleting anything is a success), instead of returning an error.
-			lg.Debug("tried to delete with an empty branch")
-		case err != nil:
-			lg.WithError(err).Error("failed deleting object")
-			errs = append(errs, serde.DeleteError{
-				Code:    "ErrDeletingKey",
-				Key:     obj.Key,
-				Message: fmt.Sprintf("error deleting object: %s", err),
-			})
-			continue
-		default:
-			lg.Debug("object set for deletion")
-		}
-		if !decodedXML.Quiet {
-			responses = append(responses, serde.Deleted{Key: obj.Key})
+		keysToDelete = append(keysToDelete, obj.Key)
+		refsToDelete = append(refsToDelete, resolvedPath.Ref)
+		pathsToDelete = append(pathsToDelete, resolvedPath.Path)
+	}
+	if len(pathsToDelete) == 0 {
+		// construct response
+		resp := serde.DeleteResult{Deleted: responses, Error: errs}
+		o.EncodeResponse(w, req, resp, http.StatusOK)
+		return
+	}
+
+	// batch delete - if all paths to delete are same ref
+	canBatch := true
+	for i := 1; i < len(refsToDelete); i++ {
+		if refsToDelete[0] != refsToDelete[i] {
+			canBatch = false
+			break
 		}
 	}
-	// construct response
-	resp := serde.DeleteResult{}
+
+	var resp serde.DeleteResult
+	if canBatch {
+		// batch - call batch delete and translate error/responses
+		resp = controller.batchDelete(req.Context(), o.Log(req), o, decodedXML.Quiet, refsToDelete[0], keysToDelete, pathsToDelete)
+	} else {
+		// non batch - call delete for each key
+		resp = controller.nonBatchDelete(req.Context(), o.Log(req), o, decodedXML.Quiet, keysToDelete, refsToDelete, pathsToDelete)
+	}
+
+	// construct response - concat what we had so far with delete results
 	if len(errs) > 0 {
-		resp.Error = errs
+		resp.Error = append(errs, resp.Error...)
 	}
-	if !decodedXML.Quiet && len(responses) > 0 {
-		resp.Deleted = responses
+	if len(responses) > 0 {
+		resp.Deleted = append(responses, resp.Deleted...)
 	}
 	o.EncodeResponse(w, req, resp, http.StatusOK)
+}
+
+func (controller *DeleteObjects) nonBatchDelete(ctx context.Context, log logging.Logger, o *RepoOperation, quiet bool, keysToDelete []string, refsToDelete []string, pathsToDelete []string) serde.DeleteResult {
+	var result serde.DeleteResult
+	for i, key := range keysToDelete {
+		err := o.Catalog.DeleteEntry(ctx, o.Repository.Name, refsToDelete[i], pathsToDelete[i])
+		updateDeleteResult(&result, quiet, log, key, err)
+	}
+	return result
+}
+
+func (controller *DeleteObjects) batchDelete(ctx context.Context, log logging.Logger, o *RepoOperation, quiet bool, ref string, keysToDelete []string, pathsToDelete []string) serde.DeleteResult {
+	var result serde.DeleteResult
+	batchErr := o.Catalog.DeleteEntries(ctx, o.Repository.Name, ref, pathsToDelete)
+	deleteErrs := graveler.NewMapDeleteErrors(batchErr)
+	for _, key := range keysToDelete {
+		// err will set to the specific error if possible, fallback to the batch delete error
+		err := deleteErrs[key]
+		if err == nil {
+			err = batchErr
+		}
+		updateDeleteResult(&result, quiet, log, key, err)
+	}
+	return result
+}
+
+// updateDeleteResult check the error and update the 'result' with error or delete response for 'key'
+func updateDeleteResult(result *serde.DeleteResult, quiet bool, log logging.Logger, key string, err error) {
+	deleteError := checkForDeleteError(log, key, err)
+	if deleteError != nil {
+		result.Error = append(result.Error, *deleteError)
+	} else if !quiet {
+		result.Deleted = append(result.Deleted, serde.Deleted{Key: key})
+	}
+}
+
+func checkForDeleteError(log logging.Logger, key string, err error) *serde.DeleteError {
+	switch {
+	case errors.Is(err, catalog.ErrNotFound), errors.Is(err, graveler.ErrNotFound):
+		log.Debug("tried to delete a non-existent object (OK)")
+	case errors.Is(err, graveler.ErrWriteToProtectedBranch):
+		apiErr := gerrors.Codes.ToAPIErr(gerrors.ErrWriteToProtectedBranch)
+		return &serde.DeleteError{
+			Code:    apiErr.Code,
+			Key:     key,
+			Message: fmt.Sprintf("error deleting object: %s", apiErr.Description),
+		}
+	case errors.Is(err, catalog.ErrPathRequiredValue):
+		// issue #1706 - https://github.com/treeverse/lakeFS/issues/1706
+		// Spark trying to delete the path "main/", which we map to branch "main" with an empty path.
+		// Spark expects it to succeed (not deleting anything is a success), instead of returning an error.
+		log.WithField("key", key).Debug("tried to delete with an empty branch")
+	case err != nil:
+		log.WithField("key", key).WithError(err).Error("failed deleting object")
+		return &serde.DeleteError{
+			Code:    "ErrDeletingKey",
+			Key:     key,
+			Message: fmt.Sprintf("error deleting object: %s", err),
+		}
+	default:
+		log.WithField("key", key).Debug("object set for deletion")
+	}
+	return nil
 }

--- a/pkg/graveler/errors.go
+++ b/pkg/graveler/errors.go
@@ -8,8 +8,7 @@ import (
 )
 
 var (
-	// Base error for "user-visible" errors, which should not be wrapped with internal
-	// debug info.
+	// ErrUserVisible is base error for "user-visible" errors, which should not be wrapped with internal debug info.
 	ErrUserVisible = errors.New("")
 
 	// TODO(ariels): Wrap with ErrUserVisible once db is gone.
@@ -88,4 +87,18 @@ func (e *HookAbortError) Error() string {
 
 func (e *HookAbortError) Unwrap() error {
 	return e.Err
+}
+
+// DeleteError single delete error used by DeleteBatch's multierror.Error to report each key that failed
+type DeleteError struct {
+	Key Key
+	Err error
+}
+
+func (d *DeleteError) Error() string {
+	return fmt.Sprintf("%s: %s", d.Key, d.Err.Error())
+}
+
+func (d *DeleteError) Unwrap() error {
+	return d.Err
 }

--- a/pkg/graveler/graveler.go
+++ b/pkg/graveler/graveler.go
@@ -1468,7 +1468,7 @@ func (g *KVGraveler) DeleteBatch(ctx context.Context, repository *RepositoryReco
 		return ErrWriteToProtectedBranch
 	}
 	if len(keys) > DeleteKeysMaxSize {
-		return fmt.Errorf("%w keys length passsed %d", ErrInvalidValue, DeleteKeysMaxSize)
+		return fmt.Errorf("keys length (%d) passed the maximum allowed(%d): %w", len(keys), DeleteKeysMaxSize, ErrInvalidValue)
 	}
 	var m *multierror.Error
 	err = g.safeBranchWrite(ctx, g.log.WithField("operation", "delete_keys"),


### PR DESCRIPTION
Optimize multiple object delete operation as part of gateway and open-api, by adding DeleteBatch operation that will perform the multiple delete as part of Graveler.

Notes:
- That this changes removed the 204 status code from delete objects api, in case of successful or any error it will return 200 and the objects error list will include the specific error

Fix #4203