### PR TITLE
Adding template support to python client build

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -111,10 +111,11 @@ go-install: go-mod-download ## Install dependencies
 client-python: api/swagger.yml  ## Generate SDK for Python client
 	# remove the build folder as it also holds lakefs_client folder which keeps because we skip it during find
 	rm -rf clients/python/build; cd clients/python && \
-		find . -depth -name lakefs_client -prune -o ! \( -name client.py -or -name Gemfile -or -name Gemfile.lock -or -name _config.yml -or -name .openapi-generator-ignore \) -delete
+		find . -depth -name lakefs_client -prune -o ! \( -name client.py -or -name Gemfile -or -name Gemfile.lock -or -name _config.yml -or -name .openapi-generator-ignore -or -name templates -or -name setup.mustache \) -delete
 	$(OPENAPI_GENERATOR) generate \
 		-i /mnt/$< \
 		-g python \
+		-t /mnt/clients/python/templates \
 		--package-name lakefs_client \
 		--git-user-id treeverse --git-repo-id lakeFS \
 		--additional-properties=infoName=Treeverse,infoEmail=services@treeverse.io,packageName=lakefs_client,packageVersion=$(PACKAGE_VERSION),projectName=lakefs-client,packageUrl=https://github.com/treeverse/lakeFS/tree/master/clients/python \

--- a/clients/python/.openapi-generator-ignore
+++ b/clients/python/.openapi-generator-ignore
@@ -29,3 +29,4 @@ lakefs_client/client.py
 Gemfile.lock
 Gemfile
 _config.yml
+templates

--- a/clients/python/templates/setup.mustache
+++ b/clients/python/templates/setup.mustache
@@ -1,0 +1,51 @@
+{{>partial_header}}
+
+from setuptools import setup, find_packages  # noqa: H301
+
+NAME = "{{{projectName}}}"
+VERSION = "{{packageVersion}}"
+{{#apiInfo}}
+{{#apis}}
+{{#-last}}
+# To install the library, run the following
+#
+# python setup.py install
+#
+# prerequisite: setuptools
+# http://pypi.python.org/pypi/setuptools
+
+REQUIRES = [
+  "urllib3 >= 1.25.3",
+  "python-dateutil",
+{{#asyncio}}
+  "aiohttp >= 3.0.0",
+{{/asyncio}}
+{{#tornado}}
+  "tornado>=4.2,<5",
+{{/tornado}}
+{{#hasHttpSignatureMethods}}
+  "pem>=19.3.0",
+  "pycryptodome>=3.9.0",
+{{/hasHttpSignatureMethods}}
+]
+
+setup(
+    name=NAME,
+    version=VERSION,
+    description="{{appName}}",
+    author="{{infoName}}{{^infoName}}OpenAPI Generator community{{/infoName}}",
+    author_email="{{infoEmail}}{{^infoEmail}}team@openapitools.org{{/infoEmail}}",
+    url="{{packageUrl}}",
+    keywords=["OpenAPI", "OpenAPI-Generator", "{{{appName}}}"],
+    python_requires=">=3.6",
+    install_requires=REQUIRES,
+    packages=find_packages(exclude=["test", "tests"]),
+    include_package_data=True,
+    {{#licenseInfo}}license="{{.}}",
+    {{/licenseInfo}}long_description="""\
+    {{appDescription}}  # noqa: E501
+    """
+)
+{{/-last}}
+{{/apis}}
+{{/apiInfo}}


### PR DESCRIPTION
Adding `setup.mustache` and configuring `Makefile` to use it and to not delete it.
Done to allow to override of the `long_description` field to allow fix of #2344 


We should consider upgrading our OpenAPI Generator!!