### PR TITLE
test delete objects read only user from s3 gateway

### DIFF
--- a/esti/delete_objects_test.go
+++ b/esti/delete_objects_test.go
@@ -81,8 +81,9 @@ func TestDeleteObjects_Viewer(t *testing.T) {
 	require.Equal(t, http.StatusCreated, resCreateCreds.StatusCode(), "CreateCredentials unexpectedly status code")
 
 	// client with viewer user credentials
+	s3Endpoint := aws.StringValue(svc.Config.Endpoint)
 	creds := resCreateCreds.JSON201
-	svcViewer := testutil.SetupTestS3Client(creds.AccessKeyId, creds.SecretAccessKey)
+	svcViewer := testutil.SetupTestS3Client(s3Endpoint, creds.AccessKeyId, creds.SecretAccessKey)
 
 	// delete objects using viewer
 	deleteOut, err := svcViewer.DeleteObjects(&s3.DeleteObjectsInput{

--- a/esti/delete_objects_test.go
+++ b/esti/delete_objects_test.go
@@ -55,6 +55,7 @@ func TestDeleteObjects(t *testing.T) {
 	assert.Len(t, listOut.Contents, 0)
 }
 
+// TestDeleteObjects_Viewer verify we can't delete with read only user
 func TestDeleteObjects_Viewer(t *testing.T) {
 	ctx, _, repo := setupTest(t)
 	defer tearDownTest(repo)

--- a/pkg/testutil/setup.go
+++ b/pkg/testutil/setup.go
@@ -104,19 +104,19 @@ func SetupTestingEnv(params *SetupTestingEnvParams) (logging.Logger, api.ClientW
 		logger.WithError(err).Fatal("could not initialize API client with security provider")
 	}
 
+	s3Endpoint := viper.GetString("s3_endpoint")
 	key := viper.GetString("access_key_id")
 	secret := viper.GetString("secret_access_key")
-	svc := SetupTestS3Client(key, secret)
+	svc := SetupTestS3Client(s3Endpoint, key, secret)
 	return logger, client, svc
 }
 
-func SetupTestS3Client(key, secret string) *s3.S3 {
-	s3Endpoint := viper.GetString("s3_endpoint")
+func SetupTestS3Client(endpoint, key, secret string) *s3.S3 {
 	awsSession := session.Must(session.NewSession())
 	svc := s3.New(awsSession,
 		aws.NewConfig().
 			WithRegion("us-east-1").
-			WithEndpoint(s3Endpoint).
+			WithEndpoint(endpoint).
 			WithDisableSSL(true).
 			WithCredentials(credentials.NewCredentials(
 				&credentials.StaticProvider{


### PR DESCRIPTION
reuse the s3 client configuration the test currently use and just update the credentials to access as viewer.