### PR TITLE
Skip integration test TestDeleteObject_Viewer

### DIFF
--- a/esti/delete_objects_test.go
+++ b/esti/delete_objects_test.go
@@ -56,6 +56,7 @@ func TestDeleteObjects(t *testing.T) {
 }
 
 func TestDeleteObjects_Viewer(t *testing.T) {
+	t.SkipNow()
 	ctx, _, repo := setupTest(t)
 	defer tearDownTest(repo)
 


### PR DESCRIPTION
Skip the test until code fix.
The test works locally but not on the our github testing actions.