### PR TITLE
Garbage Collector- validate that the written report DataFrame isn't empty

### DIFF
--- a/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
@@ -1,27 +1,24 @@
 package io.treeverse.clients
 
-import io.treeverse.clients.LakeFSContext._
-import org.apache.hadoop.fs._
-import org.apache.hadoop.conf.Configuration
-import org.apache.spark.{HashPartitioner, Partitioner}
-import org.apache.spark.broadcast.Broadcast
-import org.apache.spark.sql.functions._
-import org.apache.spark.sql._
 import com.amazonaws.services.s3.AmazonS3
+import io.lakefs.clients.api.model.GarbageCollectionPrepareResponse
+import io.treeverse.clients.LakeFSContext._
+import org.apache.hadoop.conf.Configuration
+import org.apache.hadoop.fs._
+import org.apache.spark.broadcast.Broadcast
+import org.apache.spark.sql._
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types.{StringType, StructField, StructType}
+import org.apache.spark.{HashPartitioner, Partitioner}
+import org.json4s.JsonDSL._
+import org.json4s._
+import org.json4s.native.JsonMethods._
 
 import java.net.URI
-import collection.JavaConverters._
+import java.time.{LocalDateTime, ZoneOffset}
 import java.time.format.DateTimeFormatter
-import org.json4s.native.JsonMethods._
-import org.json4s._
-import org.json4s.JsonDSL._
-
-import java.time.LocalDateTime
-import java.time.ZoneOffset
-import io.lakefs.clients.api.model.GarbageCollectionPrepareResponse
-import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
-
 import java.util.UUID
+import scala.collection.JavaConverters._
 
 class ConfigMapper(val hcValues: Broadcast[Array[(String, String)]]) extends Serializable {
   @transient lazy val configuration = {

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
@@ -326,7 +326,7 @@ object GarbageCollector {
       storageNSForSdkClient += "/"
     }
 
-    val schema = StructType(Array(StructField("addresses", StringType, nullable = true)))
+    val schema = StructType(Array(StructField("addresses", StringType, nullable = false)))
     val removed =
       if (hc.getBoolean(LAKEFS_CONF_DEBUG_GC_NO_DELETE_KEY, false)) {
         spark.createDataFrame(spark.sparkContext.emptyRDD[Row], schema)


### PR DESCRIPTION
Check that the written DataFrame is not empty before writing it, so that it won't throw an exception.


### How was this tested?
I ran the GC in dry-run mode against a repo with ~850K objects to be deleted. It used to fail on that repo but now it finishes successfully.

Fixes #4238