### PR TITLE
UI remove unknown webkit-border from css

### DIFF
--- a/webui/src/styles/ipynb.css
+++ b/webui/src/styles/ipynb.css
@@ -2712,7 +2712,6 @@
     box-shadow: none !important;
     border: none;
     border-bottom-left-radius: 2px;
-    -webkit-border-: 2px;
     border-radius: 2px;
     border-top-right-radius: 0px;
     border-top-left-radius: 0px;


### PR DESCRIPTION
During build:

```Invalid property name '-webkit-border-' at 13579:4.```

It should match one of the webkit css properties - removing as it is currently ignored.