### PR TITLE
added jupyter notebook password in everything bagel docker-compose.yaml

### DIFF
--- a/deployments/compose/docker-compose.yml
+++ b/deployments/compose/docker-compose.yml
@@ -208,6 +208,7 @@ services:
     entrypoint: dbt
 
   notebook:
+    # To login to jupyter notebook, use password:lakefs
     build: jupyter
     container_name: notebook
     ports:


### PR DESCRIPTION
evrything bagel docker-compose.yaml doesn't include password for jupyter notebook service. Added the password as a comment. 

@nopcoder should we rather remove the password altogether?