### PR TITLE
GC Separation: Add flags and replace "run_id" with "mark_id" in addresses

### DIFF
--- a/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
@@ -345,7 +345,7 @@ object GarbageCollector {
                storageNSForSdkClient,
                gcAddressesLocation,
                expiredAddresses,
-               runID,
+               markId,
                region,
                storageType,
                schema
@@ -354,7 +354,7 @@ object GarbageCollector {
     val commitsDF = gc.getCommitsDF(runID, gcCommitsLocation)
     writeReports(storageNSForHadoopFS,
                  gcRules,
-                 runID,
+                 markId,
                  commitsDF,
                  expiredAddresses,
                  removed,
@@ -367,7 +367,7 @@ object GarbageCollector {
   private def writeReports(
       storageNSForHadoopFS: String,
       gcRules: String,
-      runID: String,
+      markId: String,
       commitsDF: DataFrame,
       expiredAddresses: DataFrame,
       removed: DataFrame,
@@ -381,9 +381,9 @@ object GarbageCollector {
     writeJsonSummary(configMapper, reportLogsDst, removed.count(), gcRules, time)
 
     removed
-      .withColumn("run_id", lit(runID))
+      .withColumn(MARK_ID_KEY, lit(markId))
       .write
-      .partitionBy("run_id")
+      .partitionBy(MARK_ID_KEY)
       .mode(SaveMode.Overwrite)
       .parquet(
         concatToGCLogsPrefix(storageNSForHadoopFS, s"deleted_objects/$time/deleted.parquet")

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
@@ -222,6 +222,14 @@ object GarbageCollector {
     val maxCommitIsoDatetime = hc.get(LAKEFS_CONF_DEBUG_GC_MAX_COMMIT_ISO_DATETIME_KEY, "")
     val runIDToReproduce = hc.get(LAKEFS_CONF_DEBUG_GC_REPRODUCE_RUN_ID_KEY, "")
 
+    if (hc.getBoolean(LAKEFS_CONF_DEBUG_GC_NO_DELETE_KEY, false)) {
+      Console.err.printf("The \"%s\" configuration is deprecated. Use \"%s=false\" instead",
+                         LAKEFS_CONF_DEBUG_GC_NO_DELETE_KEY,
+                         LAKEFS_CONF_GC_DO_SWEEP
+                        )
+      System.exit(1)
+    }
+
     val markId = hc.get(LAKEFS_CONF_GC_MARK_ID, UUID.randomUUID().toString)
     val shouldMark = hc.getBoolean(LAKEFS_CONF_GC_DO_MARK, true)
     val shouldSweep = hc.getBoolean(LAKEFS_CONF_GC_DO_SWEEP, true)
@@ -337,10 +345,8 @@ object GarbageCollector {
     }
 
     val schema = StructType(Array(StructField("addresses", StringType, nullable = false)))
-    val removed =
-      if (hc.getBoolean(LAKEFS_CONF_DEBUG_GC_NO_DELETE_KEY, false)) {
-        spark.createDataFrame(spark.sparkContext.emptyRDD[Row], schema)
-      } else
+    val removed = {
+      if (shouldSweep) {
         remove(configMapper,
                storageNSForSdkClient,
                gcAddressesLocation,
@@ -350,6 +356,10 @@ object GarbageCollector {
                storageType,
                schema
               )
+      } else {
+        spark.createDataFrame(spark.sparkContext.emptyRDD[Row], schema)
+      }
+    }
 
     val commitsDF = gc.getCommitsDF(runID, gcCommitsLocation)
     writeReports(storageNSForHadoopFS,

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
@@ -227,7 +227,7 @@ object GarbageCollector {
     val shouldSweep = hc.getBoolean(LAKEFS_CONF_GC_DO_SWEEP, true)
 
     if (!shouldMark && !shouldSweep) {
-      Console.out.println("Mark and sweep disabled. Exiting...")
+      Console.out.println("Nothing to do, must specify at least one of mark, sweep. Exiting...")
       System.exit(0)
     }
 

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
@@ -15,8 +15,8 @@ import org.json4s._
 import org.json4s.native.JsonMethods._
 
 import java.net.URI
-import java.time.{LocalDateTime, ZoneOffset}
 import java.time.format.DateTimeFormatter
+import java.time.{LocalDateTime, ZoneOffset}
 import java.util.UUID
 import scala.collection.JavaConverters._
 
@@ -92,10 +92,10 @@ trait S3ClientBuilder extends Serializable {
   def build(hc: Configuration, bucket: String, region: String, numRetries: Int): AmazonS3
 }
 
-class GarbageCollector(val rangeGetter: RangeGetter, configMap: ConfigMapper) extends Serializable {
+class GarbageCollector(val rangeGetter: RangeGetter) extends Serializable {
   @transient lazy val spark = SparkSession.active
 
-  def getCommitsDF(runID: String, commitDFLocation: String): Dataset[Row] = {
+  def getCommitsDF(commitDFLocation: String): Dataset[Row] = {
     spark.read
       .option("header", value = true)
       .option("inferSchema", value = true)
@@ -180,7 +180,7 @@ class GarbageCollector(val rangeGetter: RangeGetter, configMap: ConfigMapper) ex
   ): Dataset[String] = {
     import spark.implicits._
 
-    val commitsDF = getCommitsDF(runID, commitDFLocation)
+    val commitsDF = getCommitsDF(commitDFLocation)
 
     val keepCommitsDF = commitsDF.where("!expired").select("commit_id").as[String]
     val expiredCommitsDF = commitsDF.where("expired").select("commit_id").as[String]
@@ -211,6 +211,19 @@ object GarbageCollector {
   def getHadoopConfigMapper(hc: Configuration, prefixes: String*): ConfigMapper =
     new ConfigMapper(spark.sparkContext.broadcast(getHadoopConfigurationValues(hc, prefixes: _*)))
 
+  private def validateArgsByStorageType(storageType: String, args: Array[String]) = {
+    if (storageType == StorageUtils.StorageTypeS3 && args.length != 2) {
+      Console.err.println(
+        "Usage: ... <repo_name> <region>"
+      )
+      System.exit(1)
+    } else if (storageType == StorageUtils.StorageTypeAzure && args.length != 1) {
+      Console.err.println(
+        "Usage: ... <repo_name>"
+      )
+    }
+  }
+
   def main(args: Array[String]) {
     val hc = spark.sparkContext.hadoopConfiguration
 
@@ -220,7 +233,6 @@ object GarbageCollector {
     val connectionTimeout = hc.get(LAKEFS_CONF_API_CONNECTION_TIMEOUT_SEC_KEY)
     val readTimeout = hc.get(LAKEFS_CONF_API_READ_TIMEOUT_SEC_KEY)
     val maxCommitIsoDatetime = hc.get(LAKEFS_CONF_DEBUG_GC_MAX_COMMIT_ISO_DATETIME_KEY, "")
-    val runIDToReproduce = hc.get(LAKEFS_CONF_DEBUG_GC_REPRODUCE_RUN_ID_KEY, "")
 
     if (hc.getBoolean(LAKEFS_CONF_DEBUG_GC_NO_DELETE_KEY, false)) {
       Console.err.printf("The \"%s\" configuration is deprecated. Use \"%s=false\" instead",
@@ -230,14 +242,19 @@ object GarbageCollector {
       System.exit(1)
     }
 
-    val markID = hc.get(LAKEFS_CONF_GC_MARK_ID, UUID.randomUUID().toString)
     val shouldMark = hc.getBoolean(LAKEFS_CONF_GC_DO_MARK, true)
     val shouldSweep = hc.getBoolean(LAKEFS_CONF_GC_DO_SWEEP, true)
 
     if (!shouldMark && !shouldSweep) {
       Console.out.println("Nothing to do, must specify at least one of mark, sweep. Exiting...")
       System.exit(0)
+    } else if (!shouldMark && hc.get(LAKEFS_CONF_GC_MARK_ID, "").isEmpty) {
+      Console.out.printf("Please provide a mark ID (%s) for sweep-only mode. Exiting...\n",
+                         LAKEFS_CONF_GC_MARK_ID
+                        )
+      System.exit(2)
     }
+    val markID = hc.get(LAKEFS_CONF_GC_MARK_ID, UUID.randomUUID().toString)
 
     if (!maxCommitIsoDatetime.isEmpty) {
       hc.setLong(
@@ -253,28 +270,9 @@ object GarbageCollector {
     val apiClient = ApiClient.get(apiConf)
     val storageType = apiClient.getBlockstoreType()
 
-    if (storageType == StorageUtils.StorageTypeS3 && args.length != 2) {
-      Console.err.println(
-        "Usage: ... <repo_name> <region>"
-      )
-      System.exit(1)
-    } else if (storageType == StorageUtils.StorageTypeAzure && args.length != 1) {
-      Console.err.println(
-        "Usage: ... <repo_name>"
-      )
-    }
+    validateArgsByStorageType(storageType, args)
 
     val repo = args(0)
-    val region = if (args.length == 2) args(1) else null
-    val previousRunID =
-      "" //args(2) // TODO(Guys): get previous runID from arguments or from storage
-
-    // Spark operators will need to generate configured FileSystems to read
-    // ranges and metaranges.  They will not have a JobContext to let them
-    // do that.  Transmit (all) Hadoop filesystem configuration values to
-    // let them generate a (close-enough) Hadoop configuration to build the
-    // needed FileSystems.
-    val hcValues = spark.sparkContext.broadcast(getHadoopConfigurationValues(hc, "fs.", "lakefs."))
 
     val gcRules: String =
       try {
@@ -286,10 +284,97 @@ object GarbageCollector {
           // Exiting with a failure status code because users should not really run gc on repos without GC rules.
           sys.exit(2)
       }
+    // Spark operators will need to generate configured FileSystems to read
+    // ranges and metaranges.  They will not have a JobContext to let them
+    // do that.  Transmit (all) Hadoop filesystem configuration values to
+    // let them generate a (close-enough) Hadoop configuration to build the
+    // needed FileSystems.
+    val hcValues = spark.sparkContext.broadcast(getHadoopConfigurationValues(hc, "fs.", "lakefs."))
+    val configMapper = new ConfigMapper(hcValues)
+    val gc = new GarbageCollector(new LakeFSRangeGetter(apiConf, configMapper))
     var storageNSForHadoopFS = apiClient.getStorageNamespace(repo, StorageClientType.HadoopFS)
     if (!storageNSForHadoopFS.endsWith("/")) {
       storageNSForHadoopFS += "/"
     }
+
+    var gcAddressesLocation = ""
+    var gcCommitsLocation = ""
+    var runID = ""
+    var expiredAddresses: DataFrame = null
+    if (shouldMark) {
+      val markInfo =
+        markAddresses(gc, apiClient, repo, hc, storageType, apiURL, markID, storageNSForHadoopFS)
+      gcAddressesLocation = markInfo._1
+      gcCommitsLocation = markInfo._2
+      expiredAddresses = markInfo._3
+      runID = markInfo._4
+    }
+
+    val schema = StructType(Array(StructField("addresses", StringType, nullable = false)))
+    val removed = {
+      if (shouldSweep) {
+        if (gcAddressesLocation.isEmpty) {
+          gcAddressesLocation = getAddressesLocation(storageNSForHadoopFS)
+        }
+        if (expiredAddresses == null) {
+          expiredAddresses = readExpiredAddresses(gcAddressesLocation, markID)
+        }
+        val region = if (args.length == 2) args(1) else null
+        // The remove operation uses an SDK client to directly access the underlying storage, and therefore does not need
+        // a translated storage namespace that triggers processing by Hadoop FileSystems.
+        var storageNSForSdkClient = apiClient.getStorageNamespace(repo, StorageClientType.SDKClient)
+        if (!storageNSForSdkClient.endsWith("/")) {
+          storageNSForSdkClient += "/"
+        }
+
+        remove(configMapper,
+               storageNSForSdkClient,
+               gcAddressesLocation,
+               expiredAddresses,
+               markID,
+               region,
+               storageType,
+               schema
+              )
+      } else {
+        spark.createDataFrame(spark.sparkContext.emptyRDD[Row], schema)
+      }
+    }
+
+    if (!shouldMark) {
+      val runIDAndCommitsLocation = populateRunIDAndCommitsLocation(markID, gcAddressesLocation)
+      runID = runIDAndCommitsLocation(0)
+      gcCommitsLocation = runIDAndCommitsLocation(1)
+    }
+
+    val commitsDF = gc.getCommitsDF(gcCommitsLocation)
+    writeReports(storageNSForHadoopFS,
+                 gcRules,
+                 runID,
+                 markID,
+                 commitsDF,
+                 expiredAddresses,
+                 removed,
+                 configMapper
+                )
+
+    spark.close()
+  }
+
+  private def markAddresses(
+      gc: GarbageCollector,
+      apiClient: ApiClient,
+      repo: String,
+      hc: Configuration,
+      storageType: String,
+      apiURL: String,
+      markID: String,
+      storageNSForHadoopFS: String
+  ): (String, String, DataFrame, String) = {
+    val runIDToReproduce = hc.get(LAKEFS_CONF_DEBUG_GC_REPRODUCE_RUN_ID_KEY, "")
+    val previousRunID =
+      "" //args(2) // TODO(Guys): get previous runID from arguments or from storage
+
     var prepareResult: GarbageCollectionPrepareResponse = null
     var runID = ""
     var gcCommitsLocation = ""
@@ -314,9 +399,6 @@ object GarbageCollector {
     }
     println("apiURL: " + apiURL)
 
-    val configMapper = new ConfigMapper(hcValues)
-    val gc = new GarbageCollector(new LakeFSRangeGetter(apiConf, configMapper), configMapper)
-
     val numRangePartitions =
       hc.getInt(LAKEFS_CONF_GC_NUM_RANGE_PARTITIONS, DEFAULT_LAKEFS_CONF_GC_NUM_RANGE_PARTITIONS)
     val numAddressPartitions = hc.getInt(LAKEFS_CONF_GC_NUM_ADDRESS_PARTITIONS,
@@ -334,54 +416,24 @@ object GarbageCollector {
       .mode(SaveMode.Overwrite)
       .parquet(gcAddressesLocation)
 
-    writeAddressesMarkMetadata(runID, markID, gcAddressesLocation)
+    writeAddressesMarkMetadata(runID, markID, gcAddressesLocation, gcCommitsLocation)
 
     println("Expired addresses:")
     expiredAddresses.show()
+    (gcAddressesLocation, gcCommitsLocation, expiredAddresses, runID)
+  }
 
-    // The remove operation uses an SDK client to directly access the underlying storage, and therefore does not need
-    // a translated storage namespace that triggers processing by Hadoop FileSystems.
-    var storageNSForSdkClient = apiClient.getStorageNamespace(repo, StorageClientType.SDKClient)
-    if (!storageNSForSdkClient.endsWith("/")) {
-      storageNSForSdkClient += "/"
-    }
-
-    val schema = StructType(Array(StructField("addresses", StringType, nullable = false)))
-    val removed = {
-      if (shouldSweep) {
-        remove(configMapper,
-               storageNSForSdkClient,
-               gcAddressesLocation,
-               expiredAddresses,
-               markID,
-               region,
-               storageType,
-               schema
-              )
-      } else {
-        spark.createDataFrame(spark.sparkContext.emptyRDD[Row], schema)
-      }
-    }
-
-    val commitsDF = gc.getCommitsDF(runID, gcCommitsLocation)
-    writeReports(storageNSForHadoopFS,
-                 gcAddressesLocation,
-                 gcRules,
-                 markID,
-                 commitsDF,
-                 expiredAddresses,
-                 removed,
-                 configMapper
-                )
-
-    spark.close()
+  private def readExpiredAddresses(addressesLocation: String, markID: String): DataFrame = {
+    spark.read
+      .parquet(s"$addressesLocation/$MARK_ID_KEY=$markID")
+      .withColumn(MARK_ID_KEY, lit(markID))
   }
 
   private def writeReports(
       storageNSForHadoopFS: String,
-      gcAddressesLocation: String,
       gcRules: String,
-      markId: String,
+      runID: String,
+      markID: String,
       commitsDF: DataFrame,
       expiredAddresses: DataFrame,
       removed: DataFrame,
@@ -389,23 +441,13 @@ object GarbageCollector {
   ) = {
     val reportLogsDst = concatToGCLogsPrefix(storageNSForHadoopFS, "summary")
     val reportExpiredDst = concatToGCLogsPrefix(storageNSForHadoopFS, "expired_addresses")
-    val addressesMarkMetadataLocation = getMetadataMarkLocation(markId, gcAddressesLocation)
-    val addressesMarkMetadataDF = spark.read.json(addressesMarkMetadataLocation)
     val time = DateTimeFormatter.ISO_INSTANT.format(java.time.Clock.systemUTC.instant())
     writeParquetReport(commitsDF, reportLogsDst, time, "commits.parquet")
     writeParquetReport(expiredAddresses, reportExpiredDst, time)
     writeJsonSummary(configMapper, reportLogsDst, removed.count(), gcRules, time)
 
-    import spark.implicits._
-    val metadataArray = addressesMarkMetadataDF
-      .select(RUN_ID_KEY)
-      .map(_.getString(0))
-      .collect
-
-    val runID = metadataArray(0)
-
     removed
-      .withColumn(MARK_ID_KEY, lit(markId))
+      .withColumn(MARK_ID_KEY, lit(markID))
       .withColumn(RUN_ID_KEY, lit(runID))
       .write
       .partitionBy(MARK_ID_KEY, RUN_ID_KEY)
@@ -475,9 +517,35 @@ object GarbageCollector {
     s"$gcAddressesLocation/$markId.meta"
   }
 
-  private def generateMarkMetadataDataframe(runId: String): DataFrame = {
-    val metadata = List(runId).map(Tuple1(_))
-    val fields = Array(StructField(RUN_ID_KEY, StringType, nullable = false))
+  private def getMarkMetadata(markId: String, gcAddressesLocation: String): DataFrame = {
+    val addressesMarkMetadataLocation = getMetadataMarkLocation(markId, gcAddressesLocation)
+    spark.read.json(addressesMarkMetadataLocation)
+  }
+
+  private def populateRunIDAndCommitsLocation(
+      markID: String,
+      gcAddressesLocation: String
+  ): Array[String] = {
+    import spark.implicits._
+    val markMetadataDF = getMarkMetadata(markID, gcAddressesLocation)
+    markMetadataDF
+      .select(RUN_ID_KEY, COMMITS_LOCATION_KEY)
+      .map(row => {
+        var arr = Array[String]()
+        for (i <- 0 until row.length) {
+          arr = arr :+ row.getString(i)
+        }
+        arr
+      })
+      .first()
+  }
+
+  private def generateMarkMetadataDataframe(runId: String, commitsLocation: String): DataFrame = {
+    val metadata = Seq((runId, commitsLocation))
+    val fields = Array(
+      StructField(RUN_ID_KEY, StringType, nullable = false),
+      StructField(COMMITS_LOCATION_KEY, StringType, nullable = false)
+    )
     val schema = StructType(fields)
     spark.createDataFrame(metadata).toDF(schema.fieldNames: _*)
   }
@@ -485,11 +553,17 @@ object GarbageCollector {
   private def writeAddressesMarkMetadata(
       runID: String,
       markId: String,
-      gcAddressesLocation: String
+      gcAddressesLocation: String,
+      gcCommitsLocation: String
   ) = {
-    generateMarkMetadataDataframe(runID).write
+    generateMarkMetadataDataframe(runID, gcCommitsLocation).write
       .mode(SaveMode.Overwrite)
       .json(getMetadataMarkLocation(markId, gcAddressesLocation))
+  }
+
+  private def getAddressesLocation(storageNSForHadoopFS: String): String = {
+    // TODO(jonathan): the server should generate this path
+    s"${storageNSForHadoopFS.stripSuffix("/")}/_lakefs/retention/gc/addresses/"
   }
 
   private def writeParquetReport(

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/LakeFSContext.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/LakeFSContext.scala
@@ -24,14 +24,11 @@ object LakeFSContext {
   val LAKEFS_CONF_GC_NUM_ADDRESS_PARTITIONS = "lakefs.gc.address.num_partitions"
   val LAKEFS_CONF_DEBUG_GC_MAX_COMMIT_ISO_DATETIME_KEY = "lakefs.debug.gc.max_commit_iso_datetime"
   val LAKEFS_CONF_DEBUG_GC_MAX_COMMIT_EPOCH_SECONDS_KEY = "lakefs.debug.gc.max_commit_epoch_seconds"
-  /*
-  TODO(Jonathan): Delete the "LAKEFS_CONF_DEBUG_GC_NO_DELETE_KEY" flag after the mark/sweep feature will be complete
-   */
-  val LAKEFS_CONF_DEBUG_GC_NO_DELETE_KEY = "lakefs.debug.gc.no_delete"
   val LAKEFS_CONF_DEBUG_GC_REPRODUCE_RUN_ID_KEY = "lakefs.debug.gc.reproduce_run_id"
   val LAKEFS_CONF_GC_DO_MARK = "lakefs.gc.do_mark"
   val LAKEFS_CONF_GC_DO_SWEEP = "lakefs.gc.do_sweep"
   val LAKEFS_CONF_GC_MARK_ID = "lakefs.gc.mark_id"
+  val LAKEFS_CONF_DEBUG_GC_NO_DELETE_KEY = "lakefs.debug.gc.no_delete"
 
   val MARK_ID_KEY = "mark_id"
   val DEFAULT_LAKEFS_CONF_GC_NUM_RANGE_PARTITIONS = 50

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/LakeFSContext.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/LakeFSContext.scala
@@ -31,6 +31,7 @@ object LakeFSContext {
   val LAKEFS_CONF_DEBUG_GC_NO_DELETE_KEY = "lakefs.debug.gc.no_delete"
 
   val MARK_ID_KEY = "mark_id"
+  val RUN_ID_KEY = "run_id"
   val DEFAULT_LAKEFS_CONF_GC_NUM_RANGE_PARTITIONS = 50
   val DEFAULT_LAKEFS_CONF_GC_NUM_ADDRESS_PARTITIONS = 200
 

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/LakeFSContext.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/LakeFSContext.scala
@@ -24,9 +24,16 @@ object LakeFSContext {
   val LAKEFS_CONF_GC_NUM_ADDRESS_PARTITIONS = "lakefs.gc.address.num_partitions"
   val LAKEFS_CONF_DEBUG_GC_MAX_COMMIT_ISO_DATETIME_KEY = "lakefs.debug.gc.max_commit_iso_datetime"
   val LAKEFS_CONF_DEBUG_GC_MAX_COMMIT_EPOCH_SECONDS_KEY = "lakefs.debug.gc.max_commit_epoch_seconds"
+  /*
+  TODO(Jonathan): Delete the "LAKEFS_CONF_DEBUG_GC_NO_DELETE_KEY" flag after the mark/sweep feature will be complete
+   */
   val LAKEFS_CONF_DEBUG_GC_NO_DELETE_KEY = "lakefs.debug.gc.no_delete"
   val LAKEFS_CONF_DEBUG_GC_REPRODUCE_RUN_ID_KEY = "lakefs.debug.gc.reproduce_run_id"
+  val LAKEFS_CONF_GC_DO_MARK = "lakefs.gc.do_mark"
+  val LAKEFS_CONF_GC_DO_SWEEP = "lakefs.gc.do_sweep"
+  val LAKEFS_CONF_GC_MARK_ID = "lakefs.gc.mark_id"
 
+  val MARK_ID_KEY = "mark_id"
   val DEFAULT_LAKEFS_CONF_GC_NUM_RANGE_PARTITIONS = 50
   val DEFAULT_LAKEFS_CONF_GC_NUM_ADDRESS_PARTITIONS = 200
 

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/LakeFSContext.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/LakeFSContext.scala
@@ -32,6 +32,7 @@ object LakeFSContext {
 
   val MARK_ID_KEY = "mark_id"
   val RUN_ID_KEY = "run_id"
+  val COMMITS_LOCATION_KEY = "commits_location"
   val DEFAULT_LAKEFS_CONF_GC_NUM_RANGE_PARTITIONS = 50
   val DEFAULT_LAKEFS_CONF_GC_NUM_ADDRESS_PARTITIONS = 200
 


### PR DESCRIPTION
1. Add the GC separation flags.
2. Exit if both mark and sweep are disabled.
3. Change "run_id" to "mark_id" when computing the partition for addresses.

Closes https://github.com/treeverse/lakeFS/issues/4255