### PR TITLE
GC Separation: Enable "mark only" mode

### DIFF
--- a/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
@@ -222,6 +222,11 @@ object GarbageCollector {
     val maxCommitIsoDatetime = hc.get(LAKEFS_CONF_DEBUG_GC_MAX_COMMIT_ISO_DATETIME_KEY, "")
     val runIDToReproduce = hc.get(LAKEFS_CONF_DEBUG_GC_REPRODUCE_RUN_ID_KEY, "")
 
+    if(hc.getBoolean(LAKEFS_CONF_DEBUG_GC_NO_DELETE_KEY, false)) {
+      Console.err.printf("The \"%s\" configuration is deprecated. Use \"%s=false\" instead", LAKEFS_CONF_DEBUG_GC_NO_DELETE_KEY, LAKEFS_CONF_GC_DO_SWEEP)
+      System.exit(1)
+    }
+
     val markId = hc.get(LAKEFS_CONF_GC_MARK_ID, UUID.randomUUID().toString)
     val shouldMark = hc.getBoolean(LAKEFS_CONF_GC_DO_MARK, true)
     val shouldSweep = hc.getBoolean(LAKEFS_CONF_GC_DO_SWEEP, true)

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
@@ -340,14 +340,14 @@ object GarbageCollector {
     val removed = {
       if (shouldSweep) {
         remove(configMapper,
-          storageNSForSdkClient,
-          gcAddressesLocation,
-          expiredAddresses,
-          markId,
-          region,
-          storageType,
-          schema
-        )
+               storageNSForSdkClient,
+               gcAddressesLocation,
+               expiredAddresses,
+               markId,
+               region,
+               storageType,
+               schema
+              )
       } else {
         spark.createDataFrame(spark.sparkContext.emptyRDD[Row], schema)
       }

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
@@ -222,8 +222,11 @@ object GarbageCollector {
     val maxCommitIsoDatetime = hc.get(LAKEFS_CONF_DEBUG_GC_MAX_COMMIT_ISO_DATETIME_KEY, "")
     val runIDToReproduce = hc.get(LAKEFS_CONF_DEBUG_GC_REPRODUCE_RUN_ID_KEY, "")
 
-    if(hc.getBoolean(LAKEFS_CONF_DEBUG_GC_NO_DELETE_KEY, false)) {
-      Console.err.printf("The \"%s\" configuration is deprecated. Use \"%s=false\" instead", LAKEFS_CONF_DEBUG_GC_NO_DELETE_KEY, LAKEFS_CONF_GC_DO_SWEEP)
+    if (hc.getBoolean(LAKEFS_CONF_DEBUG_GC_NO_DELETE_KEY, false)) {
+      Console.err.printf("The \"%s\" configuration is deprecated. Use \"%s=false\" instead",
+                         LAKEFS_CONF_DEBUG_GC_NO_DELETE_KEY,
+                         LAKEFS_CONF_GC_DO_SWEEP
+                        )
       System.exit(1)
     }
 

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/LakeFSContext.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/LakeFSContext.scala
@@ -24,10 +24,6 @@ object LakeFSContext {
   val LAKEFS_CONF_GC_NUM_ADDRESS_PARTITIONS = "lakefs.gc.address.num_partitions"
   val LAKEFS_CONF_DEBUG_GC_MAX_COMMIT_ISO_DATETIME_KEY = "lakefs.debug.gc.max_commit_iso_datetime"
   val LAKEFS_CONF_DEBUG_GC_MAX_COMMIT_EPOCH_SECONDS_KEY = "lakefs.debug.gc.max_commit_epoch_seconds"
-  /*
-  TODO(Jonathan): Delete the "LAKEFS_CONF_DEBUG_GC_NO_DELETE_KEY" flag after the mark/sweep feature will be complete
-   */
-  val LAKEFS_CONF_DEBUG_GC_NO_DELETE_KEY = "lakefs.debug.gc.no_delete"
   val LAKEFS_CONF_DEBUG_GC_REPRODUCE_RUN_ID_KEY = "lakefs.debug.gc.reproduce_run_id"
   val LAKEFS_CONF_GC_DO_MARK = "lakefs.gc.do_mark"
   val LAKEFS_CONF_GC_DO_SWEEP = "lakefs.gc.do_sweep"

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/LakeFSContext.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/LakeFSContext.scala
@@ -28,6 +28,7 @@ object LakeFSContext {
   val LAKEFS_CONF_GC_DO_MARK = "lakefs.gc.do_mark"
   val LAKEFS_CONF_GC_DO_SWEEP = "lakefs.gc.do_sweep"
   val LAKEFS_CONF_GC_MARK_ID = "lakefs.gc.mark_id"
+  val LAKEFS_CONF_DEBUG_GC_NO_DELETE_KEY = "lakefs.debug.gc.no_delete"
 
   val MARK_ID_KEY = "mark_id"
   val DEFAULT_LAKEFS_CONF_GC_NUM_RANGE_PARTITIONS = 50


### PR DESCRIPTION
This PR includes the option to only mark the addresses to be deleted without actually deleting them.
Basically, this is "dry mode"...

Closes #4272 