### PR TITLE
remove jitter for security event and add anonymized installation id

### DIFF
--- a/cmd/lakefs/cmd/run.go
+++ b/cmd/lakefs/cmd/run.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"math/rand"
 	"net"
 	"net/http"
 	"net/url"
@@ -212,13 +211,10 @@ var runCmd = &cobra.Command{
 		}
 		controllerAuthenticator := append(middlewareAuthenticator, auth.NewEmailAuthenticator(authService))
 
-		auditChecker := version.NewDefaultAuditChecker(cfg.GetSecurityAuditCheckURL())
+		auditChecker := version.NewDefaultAuditChecker(cfg.GetSecurityAuditCheckURL(), metadata.InstallationID)
 		defer auditChecker.Close()
 		if version.Version != version.UnreleasedVersion {
-			const maxSecondsToJitter = 12 * 60 * 60                                // 12h in seconds
-			jitter := time.Duration(rand.Int63n(maxSecondsToJitter)) * time.Second //nolint:gosec
-			interval := cfg.GetSecurityAuditCheckInterval() + jitter
-			auditChecker.StartPeriodicCheck(ctx, interval, logger)
+			auditChecker.StartPeriodicCheck(ctx, cfg.GetSecurityAuditCheckInterval(), logger)
 		}
 
 		allowForeign, err := cmd.Flags().GetBool(mismatchedReposFlagName)

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -168,7 +168,7 @@ This reference uses `.` to denote the nesting of values.
 * `gateways.s3.region` `(string : "us-east-1")` - AWS region we're pretending to be in, it should match the region configuration used in AWS SDK clients
 * `gateways.s3.fallback_url` `(string)` - If specified, requests with a non-existing repository will be forwarded to this URL. This can be useful for using lakeFS side-by-side with S3, with the URL pointing at an [S3Proxy](https://github.com/gaul/s3proxy) instance.
 * `stats.enabled` `(bool : true)` - Whether to periodically collect anonymous usage statistics
-* `security.audit_check_interval` `(duration : 12h)` - Duration in which we check for security audit.
+* `security.audit_check_interval` `(duration : 24h)` - Duration in which we check for security audit.
 * `ui.enable` `(bool: true)` - Whether to server the embedded UI from the binary  
 {: .ref-list }
 

--- a/pkg/api/serve_test.go
+++ b/pkg/api/serve_test.go
@@ -130,7 +130,7 @@ func setupHandlerWithWalkerFactory(t testing.TB, factory catalog.WalkerFactory) 
 		_ = c.Close()
 	})
 
-	auditChecker := version.NewDefaultAuditChecker(cfg.GetSecurityAuditCheckURL())
+	auditChecker := version.NewDefaultAuditChecker(cfg.GetSecurityAuditCheckURL(), "")
 	emailParams, _ := cfg.GetEmailParams()
 	emailer, err := email.NewEmailer(emailParams)
 	tmpl := templater.NewService(templates.Content, cfg, authService)

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -120,7 +120,7 @@ const (
 	StatsFlushIntervalKey = "stats.flush_interval"
 
 	SecurityAuditCheckIntervalKey     = "security.audit_check_interval"
-	DefaultSecurityAuditCheckInterval = 12 * time.Hour
+	DefaultSecurityAuditCheckInterval = 24 * time.Hour
 
 	SecurityAuditCheckURLKey     = "security.audit_check_url"
 	DefaultSecurityAuditCheckURL = "https://audit.lakefs.io/audit"

--- a/pkg/loadtest/local_load_test.go
+++ b/pkg/loadtest/local_load_test.go
@@ -120,7 +120,7 @@ func TestLocalLoad(t *testing.T) {
 			t.Cleanup(func() {
 				_ = c.Close()
 			})
-			auditChecker := version.NewDefaultAuditChecker(conf.GetSecurityAuditCheckURL())
+			auditChecker := version.NewDefaultAuditChecker(conf.GetSecurityAuditCheckURL(), "")
 			emailParams, _ := conf.GetEmailParams()
 			emailer, err := email.NewEmailer(emailParams)
 			testutil.Must(t, err)

--- a/pkg/version/audit.go
+++ b/pkg/version/audit.go
@@ -53,7 +53,10 @@ func NewDefaultAuditChecker(checkURL, installationID string) *AuditChecker {
 }
 
 func NewAuditChecker(checkURL, version, installationID string) *AuditChecker {
-	anonymizedInstallationID := fmt.Sprintf("%x", md5.Sum([]byte(installationID))) // #nosec
+	var anonymizedInstallationID string
+	if installationID != "" {
+		anonymizedInstallationID = fmt.Sprintf("%x", md5.Sum([]byte(installationID))) // #nosec
+	}
 	ac := &AuditChecker{
 		CheckURL: checkURL,
 		Client: http.Client{

--- a/pkg/version/audit.go
+++ b/pkg/version/audit.go
@@ -43,7 +43,7 @@ type AuditChecker struct {
 	CheckURL                 string
 	Client                   http.Client
 	Version                  string
-	AnonymizedInstallationId string
+	AnonymizedInstallationID string
 	periodicResponse         atomic.Value
 	ticker                   *time.Ticker
 }
@@ -53,14 +53,14 @@ func NewDefaultAuditChecker(checkURL, installationID string) *AuditChecker {
 }
 
 func NewAuditChecker(checkURL, version, installationID string) *AuditChecker {
-	anonymizedInstallationId := fmt.Sprintf("%x", md5.Sum([]byte(installationID)))
+	anonymizedInstallationID := fmt.Sprintf("%x", md5.Sum([]byte(installationID))) // #nosec
 	ac := &AuditChecker{
 		CheckURL: checkURL,
 		Client: http.Client{
 			Timeout: auditCheckTimeout,
 		},
 		Version:                  version,
-		AnonymizedInstallationId: anonymizedInstallationId,
+		AnonymizedInstallationID: anonymizedInstallationID,
 	}
 	// initial value for last check - empty value
 	ac.periodicResponse.Store(auditPeriodicResponse{})
@@ -77,7 +77,7 @@ func (a *AuditChecker) Check(ctx context.Context) (*AuditResponse, error) {
 	}
 	q := req.URL.Query()
 	q.Add("version", a.Version)
-	q.Add("anonymized_installation_id", a.AnonymizedInstallationId)
+	q.Add("anonymized_installation_id", a.AnonymizedInstallationID)
 	req.URL.RawQuery = q.Encode()
 
 	resp, err := a.Client.Do(req)


### PR DESCRIPTION
Closes #4181 

Changes the security event to run a on fixed interval and increased the default from 12 hours to 24 hours.
Added anonymized installation_id.