### PR TITLE
GC Separation: Add "run_id" to a "mark"'s metadata 

### DIFF
--- a/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
@@ -345,7 +345,7 @@ object GarbageCollector {
                storageNSForSdkClient,
                gcAddressesLocation,
                expiredAddresses,
-               runID,
+               markId,
                region,
                storageType,
                schema
@@ -354,7 +354,7 @@ object GarbageCollector {
     val commitsDF = gc.getCommitsDF(runID, gcCommitsLocation)
     writeReports(storageNSForHadoopFS,
                  gcRules,
-                 runID,
+                 markId,
                  commitsDF,
                  expiredAddresses,
                  removed,
@@ -367,7 +367,7 @@ object GarbageCollector {
   private def writeReports(
       storageNSForHadoopFS: String,
       gcRules: String,
-      runID: String,
+      markId: String,
       commitsDF: DataFrame,
       expiredAddresses: DataFrame,
       removed: DataFrame,
@@ -381,9 +381,9 @@ object GarbageCollector {
     writeJsonSummary(configMapper, reportLogsDst, removed.count(), gcRules, time)
 
     removed
-      .withColumn("run_id", lit(runID))
+      .withColumn(MARK_ID_KEY, lit(markId))
       .write
-      .partitionBy("run_id")
+      .partitionBy(MARK_ID_KEY)
       .mode(SaveMode.Overwrite)
       .parquet(
         concatToGCLogsPrefix(storageNSForHadoopFS, s"deleted_objects/$time/deleted.parquet")

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
@@ -222,8 +222,11 @@ object GarbageCollector {
     val maxCommitIsoDatetime = hc.get(LAKEFS_CONF_DEBUG_GC_MAX_COMMIT_ISO_DATETIME_KEY, "")
     val runIDToReproduce = hc.get(LAKEFS_CONF_DEBUG_GC_REPRODUCE_RUN_ID_KEY, "")
 
-    if(hc.getBoolean(LAKEFS_CONF_DEBUG_GC_NO_DELETE_KEY, false)) {
-      Console.err.printf("The \"%s\" configuration is deprecated. Use \"%s=false\" instead", LAKEFS_CONF_DEBUG_GC_NO_DELETE_KEY, LAKEFS_CONF_GC_DO_SWEEP)
+    if (hc.getBoolean(LAKEFS_CONF_DEBUG_GC_NO_DELETE_KEY, false)) {
+      Console.err.printf("The \"%s\" configuration is deprecated. Use \"%s=false\" instead",
+                         LAKEFS_CONF_DEBUG_GC_NO_DELETE_KEY,
+                         LAKEFS_CONF_GC_DO_SWEEP
+                        )
       System.exit(1)
     }
 

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/LakeFSContext.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/LakeFSContext.scala
@@ -24,10 +24,6 @@ object LakeFSContext {
   val LAKEFS_CONF_GC_NUM_ADDRESS_PARTITIONS = "lakefs.gc.address.num_partitions"
   val LAKEFS_CONF_DEBUG_GC_MAX_COMMIT_ISO_DATETIME_KEY = "lakefs.debug.gc.max_commit_iso_datetime"
   val LAKEFS_CONF_DEBUG_GC_MAX_COMMIT_EPOCH_SECONDS_KEY = "lakefs.debug.gc.max_commit_epoch_seconds"
-  /*
-  TODO(Jonathan): Delete the "LAKEFS_CONF_DEBUG_GC_NO_DELETE_KEY" flag after the mark/sweep feature will be complete
-   */
-  val LAKEFS_CONF_DEBUG_GC_NO_DELETE_KEY = "lakefs.debug.gc.no_delete"
   val LAKEFS_CONF_DEBUG_GC_REPRODUCE_RUN_ID_KEY = "lakefs.debug.gc.reproduce_run_id"
   val LAKEFS_CONF_GC_DO_MARK = "lakefs.gc.do_mark"
   val LAKEFS_CONF_GC_DO_SWEEP = "lakefs.gc.do_sweep"

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/LakeFSContext.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/LakeFSContext.scala
@@ -30,6 +30,7 @@ object LakeFSContext {
   val LAKEFS_CONF_GC_MARK_ID = "lakefs.gc.mark_id"
 
   val MARK_ID_KEY = "mark_id"
+  val RUN_ID_KEY = "run_id"
   val DEFAULT_LAKEFS_CONF_GC_NUM_RANGE_PARTITIONS = 50
   val DEFAULT_LAKEFS_CONF_GC_NUM_ADDRESS_PARTITIONS = 200
 


### PR DESCRIPTION
This is a way to link between a mark to a run_id.

The addresses will be written to:
* `STORAGE_NAMESPACE/_lakefs/retention/gc/addresses/mark_id=MARK_ID/`

The mark's run metadata (such as its associated run id) will be written to:
* `STORAGE_NAMESPACE/_lakefs/retention/gc/addresses/MARK_ID.meta/`
**as JSON**

The deleted objects report summary will be written to:
`STORAGE_NAMESPACE/_lakefs/logs/gc/deleted_objects/DATE/deleted.parquet/mark_id=MARK_ID/run_id=RUN_ID/`

### How was this tested?
Manually 

Closes #4272