### PR TITLE
Changes the description to docker (vs docker compose) and simplified …

### DIFF
--- a/docs/quickstart/installing.md
+++ b/docs/quickstart/installing.md
@@ -12,7 +12,7 @@ has_children: false
 
 {% include learn_only.html %} 
 
-## Using Docker Compose
+## Using Docker 
 {: .no_toc }
 
 To run a local lakeFS instance using [Docker](https://docs.docker.com/){:target="_blank"}:
@@ -38,37 +38,10 @@ You can try lakeFS:
 
 ## Modifying the local deployment
 
-To modify the local deployment, for example, in order to use your local lakeFS against S3 storage (as opposed to the local storage), you can either:
-1. Pass or expose the variables using this syntax:
-
+To modify the local deployment, for example, in order to use your local lakeFS against S3 storage (as opposed to the local storage), run the command with local parameters:
    ```bash
-   curl https://compose.lakefs.io | LAKEFS_BLOCKSTORE_TYPE=s3 AWS_ACCESS_KEY_ID=YourAccessKeyValue AWS_SECRET_ACCESS_KEY=YourSecretKeyValue docker-compose -f - up
+docker run --pull always -p 8000:8000 -e LAKEFS_BLOCKSTORE_TYPE='s3' -e AWS_ACCESS_KEY_ID='XXX' -e AWS_SECRET_ACCESS_KEY='YYY'  treeverse/lakefs run --local-settings
    ```
-2. Download the configuration file https://compose.lakefs.io, modify it and then run the container with the modified copy:
-
-   ```bash
-   docker-compose -f modified-docker-compose.yml up
-   ```
-
-   For example, to run against S3 instead of local storage, change:
-   ```bash
-   ...
-   - LAKEFS_BLOCKSTORE_TYPE=${LAKEFS_BLOCKSTORE_TYPE:-local}
-   ...
-   - LAKEFS_BLOCKSTORE_S3_CREDENTIALS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID:-}
-   - LAKEFS_BLOCKSTORE_S3_CREDENTIALS_ACCESS_SECRET_KEY=${AWS_SECRET_ACCESS_KEY:-}
-   ...
-   ```
-   To:
-   ```bash
-   ...
-   - LAKEFS_BLOCKSTORE_TYPE=s3
-   ...
-   - LAKEFS_BLOCKSTORE_S3_CREDENTIALS_ACCESS_KEY_ID=###
-   - LAKEFS_BLOCKSTORE_S3_CREDENTIALS_ACCESS_SECRET_KEY=###
-   ...
-   ```
-Note that if you only stop/start the container as opposed to remove the a previous run, lakeFS will try to identify repositories that use different storange namespaces, and prevert running.
 
 ## Next steps
 

--- a/docs/quickstart/installing.md
+++ b/docs/quickstart/installing.md
@@ -40,7 +40,7 @@ You can try lakeFS:
 
 To modify the local deployment, for example, in order to use your local lakeFS against S3 storage (as opposed to the local storage), run the command with local parameters:
    ```bash
-docker run --pull always -p 8000:8000 -e LAKEFS_BLOCKSTORE_TYPE='s3' -e AWS_ACCESS_KEY_ID='XXX' -e AWS_SECRET_ACCESS_KEY='YYY'  treeverse/lakefs run --local-settings
+docker run --pull always -p 8000:8000 -e LAKEFS_BLOCKSTORE_TYPE='s3' -e AWS_ACCESS_KEY_ID='YourAccessKeyValue' -e AWS_SECRET_ACCESS_KEY='YourSecretKeyValue'  treeverse/lakefs run --local-settings
    ```
 
 ## Next steps

--- a/docs/quickstart/installing.md
+++ b/docs/quickstart/installing.md
@@ -42,6 +42,7 @@ To modify the local deployment, for example, in order to use your local lakeFS a
    ```bash
 docker run --pull always -p 8000:8000 -e LAKEFS_BLOCKSTORE_TYPE='s3' -e AWS_ACCESS_KEY_ID='YourAccessKeyValue' -e AWS_SECRET_ACCESS_KEY='YourSecretKeyValue'  treeverse/lakefs run --local-settings
    ```
+Note using the ```bash--local-settings``` flag, metadata is being stored locally in the lakeFS container. Therefore, avoid using this flag for production usages.
 
 ## Next steps
 


### PR DESCRIPTION
Made 2 changes to the local installation documentation:
1.  Changed docker compose to docker. 
2.  Changed the section explaining connecting to S3 to according to the new docker installation suggestion (i.e. without compose)

FIX #4273 