### PR TITLE
GC Separation: Enable "sweep only" mode

### DIFF
--- a/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
@@ -345,7 +345,7 @@ object GarbageCollector {
                storageNSForSdkClient,
                gcAddressesLocation,
                expiredAddresses,
-               runID,
+               markId,
                region,
                storageType,
                schema
@@ -354,7 +354,7 @@ object GarbageCollector {
     val commitsDF = gc.getCommitsDF(runID, gcCommitsLocation)
     writeReports(storageNSForHadoopFS,
                  gcRules,
-                 runID,
+                 markId,
                  commitsDF,
                  expiredAddresses,
                  removed,
@@ -367,7 +367,7 @@ object GarbageCollector {
   private def writeReports(
       storageNSForHadoopFS: String,
       gcRules: String,
-      runID: String,
+      markId: String,
       commitsDF: DataFrame,
       expiredAddresses: DataFrame,
       removed: DataFrame,
@@ -381,9 +381,9 @@ object GarbageCollector {
     writeJsonSummary(configMapper, reportLogsDst, removed.count(), gcRules, time)
 
     removed
-      .withColumn("run_id", lit(runID))
+      .withColumn(MARK_ID_KEY, lit(markId))
       .write
-      .partitionBy("run_id")
+      .partitionBy(MARK_ID_KEY)
       .mode(SaveMode.Overwrite)
       .parquet(
         concatToGCLogsPrefix(storageNSForHadoopFS, s"deleted_objects/$time/deleted.parquet")

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
@@ -211,7 +211,7 @@ object GarbageCollector {
   def getHadoopConfigMapper(hc: Configuration, prefixes: String*): ConfigMapper =
     new ConfigMapper(spark.sparkContext.broadcast(getHadoopConfigurationValues(hc, prefixes: _*)))
 
-  private def validateStorageType(storageType: String, args: Array[String]) = {
+  private def validateArgsByStorageType(storageType: String, args: Array[String]) = {
     if (storageType == StorageUtils.StorageTypeS3 && args.length != 2) {
       Console.err.println(
         "Usage: ... <repo_name> <region>"
@@ -270,7 +270,7 @@ object GarbageCollector {
     val apiClient = ApiClient.get(apiConf)
     val storageType = apiClient.getBlockstoreType()
 
-    validateStorageType(storageType, args)
+    validateArgsByStorageType(storageType, args)
 
     val repo = args(0)
 

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
@@ -222,8 +222,11 @@ object GarbageCollector {
     val maxCommitIsoDatetime = hc.get(LAKEFS_CONF_DEBUG_GC_MAX_COMMIT_ISO_DATETIME_KEY, "")
     val runIDToReproduce = hc.get(LAKEFS_CONF_DEBUG_GC_REPRODUCE_RUN_ID_KEY, "")
 
-    if(hc.getBoolean(LAKEFS_CONF_DEBUG_GC_NO_DELETE_KEY, false)) {
-      Console.err.printf("The \"%s\" configuration is deprecated. Use \"%s=false\" instead", LAKEFS_CONF_DEBUG_GC_NO_DELETE_KEY, LAKEFS_CONF_GC_DO_SWEEP)
+    if (hc.getBoolean(LAKEFS_CONF_DEBUG_GC_NO_DELETE_KEY, false)) {
+      Console.err.printf("The \"%s\" configuration is deprecated. Use \"%s=false\" instead",
+                         LAKEFS_CONF_DEBUG_GC_NO_DELETE_KEY,
+                         LAKEFS_CONF_GC_DO_SWEEP
+                        )
       System.exit(1)
     }
 

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/LakeFSContext.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/LakeFSContext.scala
@@ -24,10 +24,6 @@ object LakeFSContext {
   val LAKEFS_CONF_GC_NUM_ADDRESS_PARTITIONS = "lakefs.gc.address.num_partitions"
   val LAKEFS_CONF_DEBUG_GC_MAX_COMMIT_ISO_DATETIME_KEY = "lakefs.debug.gc.max_commit_iso_datetime"
   val LAKEFS_CONF_DEBUG_GC_MAX_COMMIT_EPOCH_SECONDS_KEY = "lakefs.debug.gc.max_commit_epoch_seconds"
-  /*
-  TODO(Jonathan): Delete the "LAKEFS_CONF_DEBUG_GC_NO_DELETE_KEY" flag after the mark/sweep feature will be complete
-   */
-  val LAKEFS_CONF_DEBUG_GC_NO_DELETE_KEY = "lakefs.debug.gc.no_delete"
   val LAKEFS_CONF_DEBUG_GC_REPRODUCE_RUN_ID_KEY = "lakefs.debug.gc.reproduce_run_id"
   val LAKEFS_CONF_GC_DO_MARK = "lakefs.gc.do_mark"
   val LAKEFS_CONF_GC_DO_SWEEP = "lakefs.gc.do_sweep"

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/LakeFSContext.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/LakeFSContext.scala
@@ -30,6 +30,7 @@ object LakeFSContext {
   val LAKEFS_CONF_GC_MARK_ID = "lakefs.gc.mark_id"
 
   val MARK_ID_KEY = "mark_id"
+  val RUN_ID_KEY = "run_id"
   val DEFAULT_LAKEFS_CONF_GC_NUM_RANGE_PARTITIONS = 50
   val DEFAULT_LAKEFS_CONF_GC_NUM_ADDRESS_PARTITIONS = 200
 

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/LakeFSContext.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/LakeFSContext.scala
@@ -32,6 +32,7 @@ object LakeFSContext {
 
   val MARK_ID_KEY = "mark_id"
   val RUN_ID_KEY = "run_id"
+  val COMMITS_LOCATION_KEY = "commits_location"
   val DEFAULT_LAKEFS_CONF_GC_NUM_RANGE_PARTITIONS = 50
   val DEFAULT_LAKEFS_CONF_GC_NUM_ADDRESS_PARTITIONS = 200
 


### PR DESCRIPTION
This PR includes the changes needed to implement the "Sweep-only" mode, that is, given a "mark ID", GC will delete all of the objects according to a previous run addresses output.
* If no mark ID is given, GC will fail, i.e. running GC and providing `spark.hadoop.lakefs.gc.do_mark=false` and **not** providing a `spark.hadoop.lakefs.gc.mark_id=...` value:
![Screen Shot 2022-09-29 at 16 57 23](https://user-images.githubusercontent.com/96974219/193086480-eb28b7e6-db69-49b1-8fa6-7faa3a771786.png)

After a "mark-only" mode, with `MY_MARK` as the mark ID, we'll result in the following:
![Screen Shot 2022-09-29 at 18 01 52](https://user-images.githubusercontent.com/96974219/193086386-be837073-276a-4215-828f-f6569f334003.png)

After running GC in a "sweep-only", with `MY_MARK` as the mark ID, the summary will show that the deleted objects were:
![Screen Shot 2022-09-29 at 18 56 47](https://user-images.githubusercontent.com/96974219/193086933-f7e05df1-2b2c-4dfb-b8f3-8e317cf2bb01.png)

This PR is presenting the option of using one of the steps of the GC (sweep or mark) without the other. **However, GC can also be run the same way we did before**. The only difference is that a mark ID will be generated for the mark step (if we didn't provide one) and the paths of the addresses will change to `.../_lakefs/retention/gc/addresses/mark_id=<mark id>/`, a mark metadata will be written to `.../_lakefs/retention/gc/addresses/<mark id>.meta/`, and the report of deleted objects would be found at `.../_lakefs/logs/gc/deleted_objects/<utc date>/deleted.parquet/mark_id=<mark id>/run_id=<run id>/`

Closes #4275