### PR TITLE
GC Separation: Minor refactor

### DIFF
--- a/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
@@ -224,9 +224,8 @@ object GarbageCollector {
     }
   }
 
-  /**
-   * This function validates that at least one of the mark or sweep flags is true, and that if only sweep is true, then a mark ID is provided.
-   * If 'lakefs.debug.gc.no_delete' is passed or if the above is not true, the function will stop the execution of the GC and exit.
+  /** This function validates that at least one of the mark or sweep flags is true, and that if only sweep is true, then a mark ID is provided.
+   *  If 'lakefs.debug.gc.no_delete' is passed or if the above is not true, the function will stop the execution of the GC and exit.
    */
   private def validateRunModeConfigs(
       noDeleteFlag: Boolean,
@@ -266,7 +265,11 @@ object GarbageCollector {
     val shouldMark = hc.getBoolean(LAKEFS_CONF_GC_DO_MARK, true)
     val shouldSweep = hc.getBoolean(LAKEFS_CONF_GC_DO_SWEEP, true)
 
-    validateRunModeConfigs(hc.getBoolean(LAKEFS_CONF_DEBUG_GC_NO_DELETE_KEY, false), shouldMark, shouldSweep, hc.get(LAKEFS_CONF_GC_MARK_ID, ""))
+    validateRunModeConfigs(hc.getBoolean(LAKEFS_CONF_DEBUG_GC_NO_DELETE_KEY, false),
+                           shouldMark,
+                           shouldSweep,
+                           hc.get(LAKEFS_CONF_GC_MARK_ID, "")
+                          )
 
     val markID = hc.get(LAKEFS_CONF_GC_MARK_ID, UUID.randomUUID().toString)
 

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
@@ -224,12 +224,16 @@ object GarbageCollector {
     }
   }
 
-  private def validateRunModeConfigs(hc: Configuration, shouldMark: Boolean, shouldSweep: Boolean): Unit = {
+  private def validateRunModeConfigs(
+      hc: Configuration,
+      shouldMark: Boolean,
+      shouldSweep: Boolean
+  ): Unit = {
     if (hc.getBoolean(LAKEFS_CONF_DEBUG_GC_NO_DELETE_KEY, false)) {
       Console.err.printf("The \"%s\" configuration is deprecated. Use \"%s=false\" instead",
-        LAKEFS_CONF_DEBUG_GC_NO_DELETE_KEY,
-        LAKEFS_CONF_GC_DO_SWEEP
-      )
+                         LAKEFS_CONF_DEBUG_GC_NO_DELETE_KEY,
+                         LAKEFS_CONF_GC_DO_SWEEP
+                        )
       System.exit(1)
     }
 
@@ -238,8 +242,8 @@ object GarbageCollector {
       System.exit(2)
     } else if (!shouldMark && hc.get(LAKEFS_CONF_GC_MARK_ID, "").isEmpty) { // Sweep-only mode but no mark ID to sweep
       Console.out.printf("Please provide a mark ID (%s) for sweep-only mode. Exiting...\n",
-        LAKEFS_CONF_GC_MARK_ID
-      )
+                         LAKEFS_CONF_GC_MARK_ID
+                        )
       System.exit(2)
     }
   }
@@ -346,7 +350,7 @@ object GarbageCollector {
         spark.createDataFrame(spark.sparkContext.emptyRDD[Row], schema)
       }
     }
-    
+
 //    It is necessary to fetch the run ID and commit location if we did not mark in this run (sweep-only mode).
     if (!shouldMark) {
       val runIDAndCommitsLocation = populateRunIDAndCommitsLocation(markID, gcAddressesLocation)

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
@@ -224,12 +224,17 @@ object GarbageCollector {
     }
   }
 
+  /**
+   * This function validates that at least one of the mark or sweep flags is true, and that if only sweep is true, then a mark ID is provided.
+   * If 'lakefs.debug.gc.no_delete' is passed or if the above is not true, the function will stop the execution of the GC and exit.
+   */
   private def validateRunModeConfigs(
-      hc: Configuration,
+      noDeleteFlag: Boolean,
       shouldMark: Boolean,
-      shouldSweep: Boolean
+      shouldSweep: Boolean,
+      markID: String
   ): Unit = {
-    if (hc.getBoolean(LAKEFS_CONF_DEBUG_GC_NO_DELETE_KEY, false)) {
+    if (noDeleteFlag) {
       Console.err.printf("The \"%s\" configuration is deprecated. Use \"%s=false\" instead",
                          LAKEFS_CONF_DEBUG_GC_NO_DELETE_KEY,
                          LAKEFS_CONF_GC_DO_SWEEP
@@ -240,7 +245,7 @@ object GarbageCollector {
     if (!shouldMark && !shouldSweep) {
       Console.out.println("Nothing to do, must specify at least one of mark, sweep. Exiting...")
       System.exit(2)
-    } else if (!shouldMark && hc.get(LAKEFS_CONF_GC_MARK_ID, "").isEmpty) { // Sweep-only mode but no mark ID to sweep
+    } else if (!shouldMark && markID.isEmpty) { // Sweep-only mode but no mark ID to sweep
       Console.out.printf("Please provide a mark ID (%s) for sweep-only mode. Exiting...\n",
                          LAKEFS_CONF_GC_MARK_ID
                         )
@@ -261,7 +266,7 @@ object GarbageCollector {
     val shouldMark = hc.getBoolean(LAKEFS_CONF_GC_DO_MARK, true)
     val shouldSweep = hc.getBoolean(LAKEFS_CONF_GC_DO_SWEEP, true)
 
-    validateRunModeConfigs(hc, shouldMark, shouldSweep)
+    validateRunModeConfigs(hc.getBoolean(LAKEFS_CONF_DEBUG_GC_NO_DELETE_KEY, false), shouldMark, shouldSweep, hc.get(LAKEFS_CONF_GC_MARK_ID, ""))
 
     val markID = hc.get(LAKEFS_CONF_GC_MARK_ID, UUID.randomUUID().toString)
 

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
@@ -346,9 +346,8 @@ object GarbageCollector {
         spark.createDataFrame(spark.sparkContext.emptyRDD[Row], schema)
       }
     }
-
-    // If we didn't mark in this run (sweep-only mode) we should fetch the run ID and commit location according to the
-    // provided mark ID.
+    
+//    It is necessary to fetch the run ID and commit location if we did not mark in this run (sweep-only mode).
     if (!shouldMark) {
       val runIDAndCommitsLocation = populateRunIDAndCommitsLocation(markID, gcAddressesLocation)
       runID = runIDAndCommitsLocation(0)

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
@@ -235,7 +235,7 @@ object GarbageCollector {
 
     if (!shouldMark && !shouldSweep) {
       Console.out.println("Nothing to do, must specify at least one of mark, sweep. Exiting...")
-      System.exit(0)
+      System.exit(2)
     } else if (!shouldMark && hc.get(LAKEFS_CONF_GC_MARK_ID, "").isEmpty) { // Sweep-only mode but no mark ID to sweep
       Console.out.printf("Please provide a mark ID (%s) for sweep-only mode. Exiting...\n",
         LAKEFS_CONF_GC_MARK_ID


### PR DESCRIPTION
1. Makes things a bit more readable.
2. If both `do_mark` and `do_sweep` are `false`, the exit code is not 0.
3. Add a few explanation comments.

Closes #4272 