### PR TITLE
Docs: add merge section to reference

### DIFF
--- a/docs/reference/merge.md
+++ b/docs/reference/merge.md
@@ -1,0 +1,62 @@
+---
+layout: default
+title: Merging Reference
+description: Using lakeFS, you can merge different commits and references into a branch. The purpose of this document is to explain how to use this feature.
+parent: Reference
+has_children: false
+---
+
+# Merge
+
+lakeFS allows merging a _merge source_ (a commit/reference) into a _merge destination_ (a **branch**). 
+
+## How it works?
+
+lakeFS first finds the [merge base](https://git-scm.com/docs/git-merge-base#_description) the nearest common parent of the two commits.
+It can now perform a _three-way merge_, by examining the presence and identity of files in each commit. In the table
+below, "A", "B" and "C" are possible file contents, "X" is a missing file, and "conflict"
+(which only appears as a result) is a merge failure.
+
+| **In base** | **In source** | **In destination** | **Result** | **Comment**                                    |
+|:-----------:|:-------------:|:------------------:|:----------:|:-----------------------------------------------|
+|      A      |       A       |         A          |     A      | Unchanged file                                 |
+|      A      |       B       |         B          |     B      | Files changed on both sides in same way        |
+|      A      |       B       |         C          |  conflict  | Files changed on both sides differently        |
+|      A      |       A       |         B          |     B      | File changed only on one branch                |
+|      A      |       B       |         A          |     B      | File changed only on one branch                |
+|      A      |       X       |         X          |     X      | Files deleted on both sides                    |
+|      A      |       B       |         X          |  conflict  | File changed on one side, deleted on the other |
+|      A      |       X       |         B          |  conflict  | File changed on one side, deleted on the other |
+|      A      |       A       |         X          |     X      | File deleted on one side                       |
+|      A      |       X       |         A          |     X      | File deleted on one side                       |
+
+## Merging Strategies
+
+The [API](./api.md) and [`lakectl`](./commands.md#lakectl-merge) allow passing an optional `strategy` flag with the following values:
+
+### `source-wins`
+
+In case of a conflict, merge will pick the source objects.
+
+#### Example
+
+```bash
+lakectl merge lakefs://example-repo/validated-data lakefs://example-repo/production --strategy source-wins
+```
+When a merge conflict arise, the conflicting objects in the `validated-data` branch will be chosen and found in `production`.
+
+### `dest-wins`
+
+In case of a conflict, merge will pick the destination objects.
+
+#### Example
+
+```bash
+lakectl merge lakefs://example-repo/validated-data lakefs://example-repo/production --strategy dest-wins
+```
+When a merge conflict arise, the conflicting objects in the `production` branch will be chosen and found in `validated-data`. The `production` branch will not be affected by object changes from `validated-data` conflicted objects.
+
+The strategy will affect all conflicting objects in the merge if it is set. At the moment, it is not possible to treat conflicts individually.
+
+As a format-agnostic system, lakeFS currently merges by complete files. Format-specific and
+other user-defined merge strategies for handling conflicts are on the roadmap.

--- a/docs/reference/merge.md
+++ b/docs/reference/merge.md
@@ -56,7 +56,7 @@ lakectl merge lakefs://example-repo/validated-data lakefs://example-repo/product
 ```
 When a merge conflict arises, the conflicting objects in the `production` branch will be chosen to end up in `validated-data`. The `production` branch will not be affected by object changes from `validated-data` conflicting objects.
 
-The strategy will affect all conflicting objects in the merge if it is set. At the moment, it is not possible to treat conflicts individually.
+The strategy will affect all conflicting objects in the merge if it is set. Currently it is not possible to treat conflicts individually.
 
 As a format-agnostic system, lakeFS currently merges by complete files. Format-specific and
 other user-defined merge strategies for handling conflicts are on the roadmap.

--- a/docs/reference/merge.md
+++ b/docs/reference/merge.md
@@ -8,7 +8,7 @@ has_children: false
 
 # Merge
 
-lakeFS allows merging a _merge source_ (a commit/reference) into a _merge destination_ (a **branch**). 
+The merge operation in lakeFS is similar to Git. It incorporates changes from a _merge source_ (a commit/reference) into a _merge destination_ (a **branch**). 
 
 ## How does it work?
 

--- a/docs/reference/merge.md
+++ b/docs/reference/merge.md
@@ -54,7 +54,7 @@ In case of a conflict, merge will pick the destination objects.
 ```bash
 lakectl merge lakefs://example-repo/validated-data lakefs://example-repo/production --strategy dest-wins
 ```
-When a merge conflict arise, the conflicting objects in the `production` branch will be chosen and found in `validated-data`. The `production` branch will not be affected by object changes from `validated-data` conflicted objects.
+When a merge conflict arises, the conflicting objects in the `production` branch will be chosen to end up in `validated-data`. The `production` branch will not be affected by object changes from `validated-data` conflicting objects.
 
 The strategy will affect all conflicting objects in the merge if it is set. At the moment, it is not possible to treat conflicts individually.
 

--- a/docs/reference/merge.md
+++ b/docs/reference/merge.md
@@ -30,7 +30,7 @@ below, "A", "B" and "C" are possible file contents, "X" is a missing file, and "
 |      A      |       A       |         X          |     X      | File deleted on one side                       |
 |      A      |       X       |         A          |     X      | File deleted on one side                       |
 
-## Merging Strategies
+## Merge Strategies
 
 The [API](./api.md) and [`lakectl`](./commands.md#lakectl-merge) allow passing an optional `strategy` flag with the following values:
 

--- a/docs/reference/merge.md
+++ b/docs/reference/merge.md
@@ -12,7 +12,7 @@ lakeFS allows merging a _merge source_ (a commit/reference) into a _merge destin
 
 ## How does it work?
 
-lakeFS first finds the [merge base](https://git-scm.com/docs/git-merge-base#_description) the nearest common parent of the two commits.
+lakeFS first finds the [merge base](https://git-scm.com/docs/git-merge-base#_description): the nearest common ancestor of the two commits.
 It can now perform a _three-way merge_, by examining the presence and identity of files in each commit. In the table
 below, "A", "B" and "C" are possible file contents, "X" is a missing file, and "conflict"
 (which only appears as a result) is a merge failure.

--- a/docs/reference/merge.md
+++ b/docs/reference/merge.md
@@ -10,7 +10,7 @@ has_children: false
 
 lakeFS allows merging a _merge source_ (a commit/reference) into a _merge destination_ (a **branch**). 
 
-## How it works?
+## How does it work?
 
 lakeFS first finds the [merge base](https://git-scm.com/docs/git-merge-base#_description) the nearest common parent of the two commits.
 It can now perform a _three-way merge_, by examining the presence and identity of files in each commit. In the table

--- a/docs/reference/merge.md
+++ b/docs/reference/merge.md
@@ -43,7 +43,7 @@ In case of a conflict, merge will pick the source objects.
 ```bash
 lakectl merge lakefs://example-repo/validated-data lakefs://example-repo/production --strategy source-wins
 ```
-When a merge conflict arise, the conflicting objects in the `validated-data` branch will be chosen and found in `production`.
+When a merge conflict arises, the conflicting objects in the `validated-data` branch will be chosen to end up in `production`.
 
 ### `dest-wins`
 

--- a/docs/understand/model.md
+++ b/docs/understand/model.md
@@ -79,7 +79,7 @@ parent of each commit. Histories go back in time.
 _Merging_ is the way to integrate changes from a branch into another branch.
 The result of a merge is a new commit, with the destination as the first parent and the source as the second.
 
-To learn more about how merging works in lakeFS, see [versioning internals](./versioning-internals.md#merging-changes-to-data)
+To learn more about how merging works in lakeFS, see the [merge reference](../reference/merge.md)
 {: .note }
 
 

--- a/docs/understand/versioning-internals.md
+++ b/docs/understand/versioning-internals.md
@@ -98,34 +98,3 @@ Both these types of metadata are not only mutable, but also require strong consi
 Luckily, this is also much smaller set of metadata compared to the committed metadata.
 
 References and uncommitted metadata are currently stored on a key-value store (See [supported databases](../reference/configuration.md)) for consistency guarantees.
-
-## Merging changes to data
-
-lakeFS allows merging a _merge source_ (a commit) into a _merge destination_ (another commit).
-
-lakeFS first finds the [merge base](https://git-scm.com/docs/git-merge-base#_description) the nearest common parent of the two commits.
-It can now perform a _three-way merge_, by examining the presence and identity of files in each commit. In the table
-below, "A", "B" and "C" are possible file contents, "X" is a missing file, and "conflict"
-(which only appears as a result) is a merge failure.
-
-| **In base** | **In source** | **In destination** | **Result** | **Comment**                                    |
-| :---:       | :---:         | :---:              | :---:      | :---                                           |
-| A           | A             | A                  | A          | Unchanged file                                 |
-| A           | B             | B                  | B          | Files changed on both sides in same way        |
-| A           | B             | C                  | conflict   | Files changed on both sides differently        |
-| A           | A             | B                  | B          | File changed only on one branch                |
-| A           | B             | A                  | B          | File changed only on one branch                |
-| A           | X             | X                  | X          | Files deleted on both sides                    |
-| A           | B             | X                  | conflict   | File changed on one side, deleted on the other |
-| A           | X             | B                  | conflict   | File changed on one side, deleted on the other |
-| A           | A             | X                  | X          | File deleted on one side                       |
-| A           | X             | A                  | X          | File deleted on one side                       |
-
-The API and lakectl allow passing an optional `strategy` flag with the following values: 
-- dest-wins - in case of a conflict, merge will pick the destination object.
-- source-wins - in case of a conflict, merge will pick the source object.
-If the strategy is set, it will affect all the objects in the merge, there is currently no way to treat each conflict differently.
-
-As a format-agnostic system, lakeFS currently merges by complete files. Format-specific and
-other user-defined merge strategies for handling conflicts are on the roadmap.
-


### PR DESCRIPTION
Add a Merge section under reference.
Move the description of merging to it. 
On that page add a "Merge Strategies" section with an example for each strategy.

Closes #4306 