### PR TITLE
lakectl autocomplete with repository name

### DIFF
--- a/cmd/lakectl/cmd/abuse.go
+++ b/cmd/lakectl/cmd/abuse.go
@@ -46,10 +46,11 @@ func readLines(path string) (lines []string, err error) {
 }
 
 var abuseRandomReadsCmd = &cobra.Command{
-	Use:    "random-read <source ref uri>",
-	Short:  "Read keys from a file and generate random reads from the source ref for those keys.",
-	Hidden: false,
-	Args:   cobra.ExactArgs(1),
+	Use:               "random-read <source ref uri>",
+	Short:             "Read keys from a file and generate random reads from the source ref for those keys.",
+	Hidden:            false,
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: ValidArgsRepository,
 	Run: func(cmd *cobra.Command, args []string) {
 		u := MustParseRefURI("source ref", args[0])
 		amount := MustInt(cmd.Flags().GetInt("amount"))
@@ -97,10 +98,11 @@ var abuseRandomReadsCmd = &cobra.Command{
 }
 
 var abuseLinkSameObjectCmd = &cobra.Command{
-	Use:    "link-same-object <source ref uri>",
-	Short:  "Link the same object in parallel.",
-	Hidden: false,
-	Args:   cobra.ExactArgs(1),
+	Use:               "link-same-object <source ref uri>",
+	Short:             "Link the same object in parallel.",
+	Hidden:            false,
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: ValidArgsRepository,
 	Run: func(cmd *cobra.Command, args []string) {
 		u := MustParseRefURI("source ref", args[0])
 		amount := MustInt(cmd.Flags().GetInt("amount"))
@@ -164,10 +166,11 @@ var abuseLinkSameObjectCmd = &cobra.Command{
 }
 
 var abuseRandomWritesCmd = &cobra.Command{
-	Use:    "random-write <source branch uri>",
-	Short:  "Generate random writes to the source branch",
-	Hidden: false,
-	Args:   cobra.ExactArgs(1),
+	Use:               "random-write <source branch uri>",
+	Short:             "Generate random writes to the source branch",
+	Hidden:            false,
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: ValidArgsRepository,
 	Run: func(cmd *cobra.Command, args []string) {
 		u := MustParseRefURI("source branch", args[0])
 		amount := MustInt(cmd.Flags().GetInt("amount"))
@@ -221,10 +224,11 @@ var abuseRandomWritesCmd = &cobra.Command{
 }
 
 var abuseCommitCmd = &cobra.Command{
-	Use:    "commit <source ref uri>",
-	Short:  "Commits to the source ref repeatedly",
-	Hidden: false,
-	Args:   cobra.ExactArgs(1),
+	Use:               "commit <source ref uri>",
+	Short:             "Commits to the source ref repeatedly",
+	Hidden:            false,
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: ValidArgsRepository,
 	Run: func(cmd *cobra.Command, args []string) {
 		u := MustParseRefURI("source ref", args[0])
 		amount := MustInt(cmd.Flags().GetInt("amount"))
@@ -272,10 +276,11 @@ var abuseCommitCmd = &cobra.Command{
 }
 
 var abuseCreateBranchesCmd = &cobra.Command{
-	Use:    "create-branches <source ref uri>",
-	Short:  "Create a lot of branches very quickly.",
-	Hidden: false,
-	Args:   cobra.ExactArgs(1),
+	Use:               "create-branches <source ref uri>",
+	Short:             "Create a lot of branches very quickly.",
+	Hidden:            false,
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: ValidArgsRepository,
 	Run: func(cmd *cobra.Command, args []string) {
 		u := MustParseRefURI("source ref", args[0])
 		cleanOnly := MustBool(cmd.Flags().GetBool("clean-only"))
@@ -361,10 +366,11 @@ var abuseCreateBranchesCmd = &cobra.Command{
 }
 
 var abuseListCmd = &cobra.Command{
-	Use:    "list <source ref uri>",
-	Short:  "List from the source ref",
-	Hidden: false,
-	Args:   cobra.ExactArgs(1),
+	Use:               "list <source ref uri>",
+	Short:             "List from the source ref",
+	Hidden:            false,
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: ValidArgsRepository,
 	Run: func(cmd *cobra.Command, args []string) {
 		u := MustParseRefURI("source ref", args[0])
 		amount := MustInt(cmd.Flags().GetInt("amount"))

--- a/cmd/lakectl/cmd/action_validate.go
+++ b/cmd/lakectl/cmd/action_validate.go
@@ -15,9 +15,7 @@ var actionsValidateCmd = &cobra.Command{
 	Short:   "Validate action file",
 	Long:    `Tries to parse the input action file as lakeFS action file`,
 	Example: "lakectl actions validate <path>",
-	Args: cmdutils.ValidationChain(
-		cobra.ExactArgs(actionsValidateRequiredArgs),
-	),
+	Args:    cmdutils.ValidationChain(cobra.ExactArgs(actionsValidateRequiredArgs)),
 	Run: func(cmd *cobra.Command, args []string) {
 		file := args[0]
 		reader := OpenByPath(file)

--- a/cmd/lakectl/cmd/annotate.go
+++ b/cmd/lakectl/cmd/annotate.go
@@ -22,10 +22,11 @@ type objectCommitData struct {
 }
 
 var annotateCmd = &cobra.Command{
-	Use:     "annotate <path uri>",
-	Short:   "List entries under a given path, annotating each with the latest modifying commit",
-	Aliases: []string{"blame"},
-	Args:    cobra.ExactArgs(1),
+	Use:               "annotate <path uri>",
+	Short:             "List entries under a given path, annotating each with the latest modifying commit",
+	Aliases:           []string{"blame"},
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: ValidArgsRepository,
 	Run: func(cmd *cobra.Command, args []string) {
 		pathURI := MustParsePathURI("path", args[0])
 		recursive, _ := cmd.Flags().GetBool("recursive")

--- a/cmd/lakectl/cmd/auth.go
+++ b/cmd/lakectl/cmd/auth.go
@@ -170,7 +170,6 @@ var authUsersPoliciesList = &cobra.Command{
 				ts := time.Unix(*policy.CreationDate, 0).String()
 				rows = append(rows, []interface{}{policy.Id, ts, i, statement.Resource, statement.Effect, strings.Join(statement.Action, ", ")})
 			}
-
 		}
 
 		pagination := resp.JSON200.Pagination
@@ -434,7 +433,6 @@ var authGroupsPoliciesList = &cobra.Command{
 				ts := time.Unix(*policy.CreationDate, 0).String()
 				rows = append(rows, []interface{}{policy.Id, ts, i, statement.Resource, statement.Effect, strings.Join(statement.Action, ", ")})
 			}
-
 		}
 
 		pagination := resp.JSON200.Pagination

--- a/cmd/lakectl/cmd/branch.go
+++ b/cmd/lakectl/cmd/branch.go
@@ -24,10 +24,11 @@ var branchCmd = &cobra.Command{
 }
 
 var branchListCmd = &cobra.Command{
-	Use:     "list <repository uri>",
-	Short:   "List branches in a repository",
-	Example: "lakectl branch list lakefs://<repository>",
-	Args:    cobra.ExactArgs(1),
+	Use:               "list <repository uri>",
+	Short:             "List branches in a repository",
+	Example:           "lakectl branch list lakefs://<repository>",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: ValidArgsRepository,
 	Run: func(cmd *cobra.Command, args []string) {
 		amount := MustInt(cmd.Flags().GetInt("amount"))
 		after := MustString(cmd.Flags().GetString("after"))
@@ -51,10 +52,11 @@ var branchListCmd = &cobra.Command{
 }
 
 var branchCreateCmd = &cobra.Command{
-	Use:     "create <branch uri> -s <source ref uri>",
-	Short:   "Create a new branch in a repository",
-	Example: "lakectl branch create lakefs://example-repo/new-branch -s lakefs://example-repo/main",
-	Args:    cobra.ExactArgs(1),
+	Use:               "create <branch uri> -s <source ref uri>",
+	Short:             "Create a new branch in a repository",
+	Example:           "lakectl branch create lakefs://example-repo/new-branch -s lakefs://example-repo/main",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: ValidArgsRepository,
 	Run: func(cmd *cobra.Command, args []string) {
 		u := MustParseBranchURI("branch", args[0])
 		client := getClient()
@@ -78,10 +80,11 @@ var branchCreateCmd = &cobra.Command{
 }
 
 var branchDeleteCmd = &cobra.Command{
-	Use:     "delete <branch uri>",
-	Short:   "Delete a branch in a repository, along with its uncommitted changes (CAREFUL)",
-	Example: "lakectl branch delete lakefs://example-repo/example-branch",
-	Args:    cobra.ExactArgs(1),
+	Use:               "delete <branch uri>",
+	Short:             "Delete a branch in a repository, along with its uncommitted changes (CAREFUL)",
+	Example:           "lakectl branch delete lakefs://example-repo/example-branch",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: ValidArgsRepository,
 	Run: func(cmd *cobra.Command, args []string) {
 		confirmation, err := Confirm(cmd.Flags(), "Are you sure you want to delete branch")
 		if err != nil || !confirmation {
@@ -105,6 +108,9 @@ var branchRevertCmd = &cobra.Command{
 		      branch revert lakefs://example-repo/example-branch HEAD~1 HEAD~2 HEAD~3
 		      Revert the changes done by the second last commit to the fourth last commit in example-branch`,
 	Args: cobra.MinimumNArgs(branchRevertCmdArgs),
+	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return validRepositoryToComplete(cmd.Context(), toComplete)
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		u := MustParseBranchURI("branch", args[0])
 		Fmt("Branch: %s\n", u.String())
@@ -140,7 +146,8 @@ var branchResetCmd = &cobra.Command{
   1. reset all uncommitted changes - reset lakefs://myrepo/main 
   2. reset uncommitted changes under specific path - reset lakefs://myrepo/main --prefix path
   3. reset uncommitted changes for specific object - reset lakefs://myrepo/main --object path`,
-	Args: cobra.ExactArgs(1),
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: ValidArgsRepository,
 	Run: func(cmd *cobra.Command, args []string) {
 		clt := getClient()
 		u := MustParseBranchURI("branch", args[0])
@@ -187,10 +194,11 @@ var branchResetCmd = &cobra.Command{
 }
 
 var branchShowCmd = &cobra.Command{
-	Use:     "show <branch uri>",
-	Example: "lakectl branch show lakefs://example-repo/example-branch",
-	Short:   "Show branch latest commit reference",
-	Args:    cobra.ExactArgs(1),
+	Use:               "show <branch uri>",
+	Example:           "lakectl branch show lakefs://example-repo/example-branch",
+	Short:             "Show branch latest commit reference",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: ValidArgsRepository,
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getClient()
 		u := MustParseBranchURI("branch", args[0])
@@ -217,6 +225,7 @@ func init() {
 
 	branchCreateCmd.Flags().StringP("source", "s", "", "source branch uri")
 	_ = branchCreateCmd.MarkFlagRequired("source")
+	_ = branchCreateCmd.RegisterFlagCompletionFunc("source", ValidArgsRepository)
 
 	branchResetCmd.Flags().String("prefix", "", "prefix of the objects to be reset")
 	branchResetCmd.Flags().String("object", "", "path to object to be reset")

--- a/cmd/lakectl/cmd/branch_protect.go
+++ b/cmd/lakectl/cmd/branch_protect.go
@@ -17,11 +17,13 @@ var branchProtectCmd = &cobra.Command{
 	Short: "Create and manage branch protection rules",
 	Long:  "Define branch protection rules to prevent direct changes. Changes to protected branches can only be done by merging from other branches.",
 }
+
 var branchProtectListCmd = &cobra.Command{
-	Use:     "list <repo uri>",
-	Short:   "List all branch protection rules",
-	Example: "lakectl branch-protect list lakefs://<repository>",
-	Args:    cobra.ExactArgs(1),
+	Use:               "list <repo uri>",
+	Short:             "List all branch protection rules",
+	Example:           "lakectl branch-protect list lakefs://<repository>",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: ValidArgsRepository,
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getClient()
 		u := MustParseRepoURI("repository", args[0])
@@ -39,11 +41,12 @@ var branchProtectListCmd = &cobra.Command{
 }
 
 var branchProtectAddCmd = &cobra.Command{
-	Use:     "add <repo uri> <pattern>",
-	Short:   "Add a branch protection rule",
-	Long:    "Add a branch protection rule for a given branch name pattern",
-	Example: "lakectl branch-protect add lakefs://<repository> 'stable_*'",
-	Args:    cobra.ExactArgs(branchProtectAddCmdArgs),
+	Use:               "add <repo uri> <pattern>",
+	Short:             "Add a branch protection rule",
+	Long:              "Add a branch protection rule for a given branch name pattern",
+	Example:           "lakectl branch-protect add lakefs://<repository> 'stable_*'",
+	Args:              cobra.ExactArgs(branchProtectAddCmdArgs),
+	ValidArgsFunction: ValidArgsRepository,
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getClient()
 		u := MustParseRepoURI("repository", args[0])
@@ -55,11 +58,12 @@ var branchProtectAddCmd = &cobra.Command{
 }
 
 var branchProtectDeleteCmd = &cobra.Command{
-	Use:     "delete <repo uri> <pattern>",
-	Short:   "Delete a branch protection rule",
-	Long:    "Delete a branch protection rule for a given branch name pattern",
-	Example: "lakectl branch-protect delete lakefs://<repository> stable_*",
-	Args:    cobra.ExactArgs(branchProtectDeleteCmdArgs),
+	Use:               "delete <repo uri> <pattern>",
+	Short:             "Delete a branch protection rule",
+	Long:              "Delete a branch protection rule for a given branch name pattern",
+	Example:           "lakectl branch-protect delete lakefs://<repository> stable_*",
+	Args:              cobra.ExactArgs(branchProtectDeleteCmdArgs),
+	ValidArgsFunction: ValidArgsRepository,
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getClient()
 		u := MustParseRepoURI("repository", args[0])

--- a/cmd/lakectl/cmd/cat_hook_output.go
+++ b/cmd/lakectl/cmd/cat_hook_output.go
@@ -9,11 +9,12 @@ import (
 const catHookOutputRequiredArgs = 3
 
 var catHookOutputCmd = &cobra.Command{
-	Use:     "cat-hook-output",
-	Short:   "Cat actions hook output",
-	Hidden:  true,
-	Example: "lakectl cat-hook-output lakefs://<repository> <run_id> <run_hook_id>",
-	Args:    cobra.ExactArgs(catHookOutputRequiredArgs),
+	Use:               "cat-hook-output",
+	Short:             "Cat actions hook output",
+	Hidden:            true,
+	Example:           "lakectl cat-hook-output lakefs://<repository> <run_id> <run_hook_id>",
+	Args:              cobra.ExactArgs(catHookOutputRequiredArgs),
+	ValidArgsFunction: ValidArgsRepository,
 	Run: func(cmd *cobra.Command, args []string) {
 		u := MustParseRepoURI("repository", args[0])
 		Fmt("Repository: %s\n", u.String())

--- a/cmd/lakectl/cmd/commit.go
+++ b/cmd/lakectl/cmd/commit.go
@@ -30,9 +30,10 @@ Parents: {{.Commit.Parents|join ", "}}
 )
 
 var commitCmd = &cobra.Command{
-	Use:   "commit <branch uri>",
-	Short: "Commit changes on a given branch",
-	Args:  cobra.ExactArgs(1),
+	Use:               "commit <branch uri>",
+	Short:             "Commit changes on a given branch",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: ValidArgsRepository,
 	Run: func(cmd *cobra.Command, args []string) {
 		// validate message
 		kvPairs, err := getKV(cmd, metaFlagName)

--- a/cmd/lakectl/cmd/common_helpers_test.go
+++ b/cmd/lakectl/cmd/common_helpers_test.go
@@ -19,7 +19,7 @@ func TestIsValidAccessKeyID(t *testing.T) {
 		{name: "access key id with extra char", args: args{accessKeyID: "AKIAJ123ZZZZZZZZZZZZQ"}, want: false},
 		{name: "access key id with missing char", args: args{accessKeyID: "AKIAJ1ZZZZZZZZZZZZQ"}, want: false},
 		{name: "access key id with wrong prefix", args: args{accessKeyID: "AKIAM12ZZZZZZZZZZZZQ"}, want: false},
-		{name: "access key id with wrong suffiix", args: args{accessKeyID: "AKIAJ12ZZZZZZZZZZZZA"}, want: false},
+		{name: "access key id with wrong suffix", args: args{accessKeyID: "AKIAJ12ZZZZZZZZZZZZA"}, want: false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/lakectl/cmd/config/config.go
+++ b/cmd/lakectl/cmd/config/config.go
@@ -124,6 +124,7 @@ func (c *Config) GetMetastoreHiveURI() string {
 func (c *Config) GetMetastoreGlueCatalogID() string {
 	return string(c.Values.Metastore.Glue.CatalogID)
 }
+
 func (c *Config) GetMetastoreType() string {
 	return c.Values.Metastore.Type
 }

--- a/cmd/lakectl/cmd/dbt.go
+++ b/cmd/lakectl/cmd/dbt.go
@@ -16,8 +16,10 @@ import (
 	mserrors "github.com/treeverse/lakefs/pkg/metastore/errors"
 )
 
-var schemaRegex = regexp.MustCompile(`schema: (.+)`)
-var materializedSelection = []string{"config.materialized:table", "config.materialized:incremental"}
+var (
+	schemaRegex           = regexp.MustCompile(`schema: (.+)`)
+	materializedSelection = []string{"config.materialized:table", "config.materialized:incremental"}
+)
 
 const (
 	schemaEnvVarName     = "LAKEFS_SCHEMA"
@@ -186,7 +188,7 @@ generate_schema_name.sql
 {%- endmacro %}
 `
 		//nolint:gosec
-		err := ioutil.WriteFile(macroPath, []byte(generateSchemaData), 0644) //nolint: gomnd
+		err := ioutil.WriteFile(macroPath, []byte(generateSchemaData), 0o644) //nolint: gomnd
 		if err != nil {
 			DieErr(err)
 		}

--- a/cmd/lakectl/cmd/dbt_util_test.go
+++ b/cmd/lakectl/cmd/dbt_util_test.go
@@ -36,7 +36,7 @@ func TestDbtDebug(t *testing.T) {
 		schemaRegex *regexp.Regexp
 		executor    DummyCommandExecutor
 	}
-	var schemaRegex = regexp.MustCompile(`schema: (.+)`)
+	schemaRegex := regexp.MustCompile(`schema: (.+)`)
 
 	type dbtDebugTestCase struct {
 		Name       string

--- a/cmd/lakectl/cmd/diff.go
+++ b/cmd/lakectl/cmd/diff.go
@@ -43,6 +43,12 @@ var diffCmd = &cobra.Command{
 	Show changes between the tip of the main and the dev branch, including uncommitted changes on dev.`, twoWayFlagName, twoWayFlagName),
 
 	Args: cobra.RangeArgs(diffCmdMinArgs, diffCmdMaxArgs),
+	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) >= diffCmdMaxArgs {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		return validRepositoryToComplete(cmd.Context(), toComplete)
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getClient()
 		if len(args) == diffCmdMinArgs {

--- a/cmd/lakectl/cmd/fs.go
+++ b/cmd/lakectl/cmd/fs.go
@@ -35,9 +35,10 @@ Human Total Size: {{.Bytes|human_bytes}}
 var quoteEscaper = strings.NewReplacer("\\", "\\\\", `"`, "\\\"")
 
 var fsStatCmd = &cobra.Command{
-	Use:   "stat <path uri>",
-	Short: "View object metadata",
-	Args:  cobra.ExactArgs(1),
+	Use:               "stat <path uri>",
+	Short:             "View object metadata",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: ValidArgsRepository,
 	Run: func(cmd *cobra.Command, args []string) {
 		pathURI := MustParsePathURI("path", args[0])
 		client := getClient()
@@ -57,9 +58,10 @@ const fsLsTemplate = `{{ range $val := . -}}
 `
 
 var fsListCmd = &cobra.Command{
-	Use:   "ls <path uri>",
-	Short: "List entries under a given tree",
-	Args:  cobra.ExactArgs(1),
+	Use:               "ls <path uri>",
+	Short:             "List entries under a given tree",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: ValidArgsRepository,
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getClient()
 		pathURI := MustParsePathURI("path", args[0])
@@ -109,9 +111,10 @@ var fsListCmd = &cobra.Command{
 }
 
 var fsCatCmd = &cobra.Command{
-	Use:   "cat <path uri>",
-	Short: "Dump content of object to stdout",
-	Args:  cobra.ExactArgs(1),
+	Use:               "cat <path uri>",
+	Short:             "Dump content of object to stdout",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: ValidArgsRepository,
 	Run: func(cmd *cobra.Command, args []string) {
 		pathURI := MustParsePathURI("path", args[0])
 		direct, _ := cmd.Flags().GetBool("direct")
@@ -206,9 +209,10 @@ func uploadObject(ctx context.Context, client api.ClientWithResponsesInterface, 
 }
 
 var fsUploadCmd = &cobra.Command{
-	Use:   "upload <path uri>",
-	Short: "Upload a local file to the specified URI",
-	Args:  cobra.ExactArgs(1),
+	Use:               "upload <path uri>",
+	Short:             "Upload a local file to the specified URI",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: ValidArgsRepository,
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getClient()
 		pathURI := MustParsePathURI("path", args[0])
@@ -258,10 +262,11 @@ var fsUploadCmd = &cobra.Command{
 }
 
 var fsStageCmd = &cobra.Command{
-	Use:    "stage <path uri>",
-	Short:  "Stage a reference to an existing object, to be managed in lakeFS",
-	Hidden: true,
-	Args:   cobra.ExactArgs(1),
+	Use:               "stage <path uri>",
+	Short:             "Stage a reference to an existing object, to be managed in lakeFS",
+	Hidden:            true,
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: ValidArgsRepository,
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getClient()
 		pathURI := MustParsePathURI("path", args[0])
@@ -321,9 +326,10 @@ func deleteObject(ctx context.Context, client api.ClientWithResponsesInterface, 
 }
 
 var fsRmCmd = &cobra.Command{
-	Use:   "rm <path uri>",
-	Short: "Delete object",
-	Args:  cobra.ExactArgs(1),
+	Use:               "rm <path uri>",
+	Short:             "Delete object",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: ValidArgsRepository,
 	Run: func(cmd *cobra.Command, args []string) {
 		recursive, _ := cmd.Flags().GetBool("recursive")
 		concurrency := MustInt(cmd.Flags().GetInt("concurrency"))

--- a/cmd/lakectl/cmd/gc.go
+++ b/cmd/lakectl/cmd/gc.go
@@ -73,11 +73,13 @@ Example configuration file:
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusNoContent)
 	},
 }
+
 var gcDeleteConfigCmd = &cobra.Command{
-	Use:     "delete-config",
-	Short:   "Deletes the garbage collection policy for the repository",
-	Example: "lakectl gc delete-config <repository uri>",
-	Args:    cobra.ExactArgs(gcSetConfigCmdArgs),
+	Use:               "delete-config",
+	Short:             "Deletes the garbage collection policy for the repository",
+	Example:           "lakectl gc delete-config <repository uri>",
+	Args:              cobra.ExactArgs(gcSetConfigCmdArgs),
+	ValidArgsFunction: ValidArgsRepository,
 	Run: func(cmd *cobra.Command, args []string) {
 		u := MustParseRepoURI("repository", args[0])
 		client := getClient()
@@ -87,10 +89,11 @@ var gcDeleteConfigCmd = &cobra.Command{
 }
 
 var gcGetConfigCmd = &cobra.Command{
-	Use:     "get-config",
-	Short:   "Show the garbage collection policy for this repository",
-	Example: "lakectl gc get-config <repository uri>",
-	Args:    cobra.ExactArgs(gcSetConfigCmdArgs),
+	Use:               "get-config",
+	Short:             "Show the garbage collection policy for this repository",
+	Example:           "lakectl gc get-config <repository uri>",
+	Args:              cobra.ExactArgs(gcSetConfigCmdArgs),
+	ValidArgsFunction: ValidArgsRepository,
 	Run: func(cmd *cobra.Command, args []string) {
 		u := MustParseRepoURI("repository", args[0])
 		isJSON := MustBool(cmd.Flags().GetBool(jsonFlagName))

--- a/cmd/lakectl/cmd/log.go
+++ b/cmd/lakectl/cmd/log.go
@@ -26,10 +26,11 @@ Merge:         {{ $val.Parents|join ", "|bold }}
 
 // logCmd represents the log command
 var logCmd = &cobra.Command{
-	Use:   "log <branch uri>",
-	Short: "Show log of commits",
-	Long:  "Show log of commits for a given branch",
-	Args:  cobra.ExactArgs(1),
+	Use:               "log <branch uri>",
+	Short:             "Show log of commits",
+	Long:              "Show log of commits for a given branch",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: ValidArgsRepository,
 	Run: func(cmd *cobra.Command, args []string) {
 		amount := MustInt(cmd.Flags().GetInt("amount"))
 		after := MustString(cmd.Flags().GetString("after"))

--- a/cmd/lakectl/cmd/merge.go
+++ b/cmd/lakectl/cmd/merge.go
@@ -16,7 +16,8 @@ const (
 )
 
 type FromTo struct {
-	FromRef, ToRef string
+	FromRef string
+	ToRef   string
 }
 
 // mergeCmd represents the merge command
@@ -25,6 +26,12 @@ var mergeCmd = &cobra.Command{
 	Short: "Merge & commit changes from source branch into destination branch",
 	Long:  "Merge & commit changes from source branch into destination branch",
 	Args:  cobra.RangeArgs(mergeCmdMinArgs, mergeCmdMaxArgs),
+	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) >= mergeCmdMaxArgs {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		return validRepositoryToComplete(cmd.Context(), toComplete)
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getClient()
 		sourceRef := MustParseRefURI("source ref", args[0])
@@ -49,7 +56,10 @@ var mergeCmd = &cobra.Command{
 			Merge  FromTo
 			Result *api.MergeResult
 		}{
-			Merge:  FromTo{FromRef: sourceRef.Ref, ToRef: destinationRef.Ref},
+			Merge: FromTo{
+				FromRef: sourceRef.Ref,
+				ToRef:   destinationRef.Ref,
+			},
 			Result: resp.JSON200,
 		})
 	},

--- a/cmd/lakectl/cmd/refs.go
+++ b/cmd/lakectl/cmd/refs.go
@@ -55,10 +55,11 @@ Since a bare repo is expected, in case of transient failure, delete the reposito
 }
 
 var refsDumpCmd = &cobra.Command{
-	Use:    "refs-dump <repository uri>",
-	Short:  "Dumps refs (branches, commits, tags) to the underlying object store",
-	Hidden: true,
-	Args:   cobra.ExactArgs(1),
+	Use:               "refs-dump <repository uri>",
+	Short:             "Dumps refs (branches, commits, tags) to the underlying object store",
+	Hidden:            true,
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: ValidArgsRepository,
 	Run: func(cmd *cobra.Command, args []string) {
 		repoURI := MustParseRepoURI("repository", args[0])
 		Fmt("Repository: %s\n", repoURI.String())

--- a/cmd/lakectl/cmd/repo.go
+++ b/cmd/lakectl/cmd/repo.go
@@ -46,10 +46,11 @@ var repoListCmd = &cobra.Command{
 // repoCreateCmd represents the create repo command
 // lakectl create lakefs://myrepo s3://my-bucket/
 var repoCreateCmd = &cobra.Command{
-	Use:     "create <repository uri> <storage namespace>",
-	Short:   "Create a new repository",
-	Example: "lakectl repo create lakefs://some-repo-name s3://some-bucket-name",
-	Args:    cobra.ExactArgs(repoCreateCmdArgs),
+	Use:               "create <repository uri> <storage namespace>",
+	Short:             "Create a new repository",
+	Example:           "lakectl repo create lakefs://some-repo-name s3://some-bucket-name",
+	Args:              cobra.ExactArgs(repoCreateCmdArgs),
+	ValidArgsFunction: ValidArgsRepository,
 	Run: func(cmd *cobra.Command, args []string) {
 		clt := getClient()
 		u := MustParseRepoURI("repository", args[0])
@@ -79,11 +80,12 @@ var repoCreateCmd = &cobra.Command{
 // repoCreateBareCmd represents the create repo command
 // lakectl create-bare lakefs://myrepo s3://my-bucket/
 var repoCreateBareCmd = &cobra.Command{
-	Use:     "create-bare <repository uri> <storage namespace>",
-	Short:   "Create a new repository with no initial branch or commit",
-	Example: "lakectl create-bare lakefs://some-repo-name s3://some-bucket-name",
-	Hidden:  true,
-	Args:    cobra.ExactArgs(repoCreateCmdArgs),
+	Use:               "create-bare <repository uri> <storage namespace>",
+	Short:             "Create a new repository with no initial branch or commit",
+	Example:           "lakectl create-bare lakefs://some-repo-name s3://some-bucket-name",
+	Hidden:            true,
+	Args:              cobra.ExactArgs(repoCreateCmdArgs),
+	ValidArgsFunction: ValidArgsRepository,
 	Run: func(cmd *cobra.Command, args []string) {
 		clt := getClient()
 		u := MustParseRepoURI("repository", args[0])
@@ -114,9 +116,10 @@ var repoCreateBareCmd = &cobra.Command{
 // repoDeleteCmd represents the delete repo command
 // lakectl delete lakefs://myrepo
 var repoDeleteCmd = &cobra.Command{
-	Use:   "delete <repository uri>",
-	Short: "Delete existing repository",
-	Args:  cobra.ExactArgs(1),
+	Use:               "delete <repository uri>",
+	Short:             "Delete existing repository",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: ValidArgsRepository,
 	Run: func(cmd *cobra.Command, args []string) {
 		clt := getClient()
 		u := MustParseRepoURI("repository", args[0])

--- a/cmd/lakectl/cmd/repo.go
+++ b/cmd/lakectl/cmd/repo.go
@@ -22,6 +22,10 @@ var repoCmd = &cobra.Command{
 var repoListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List repositories",
+	Args:  cobra.NoArgs,
+	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		amount := MustInt(cmd.Flags().GetInt("amount"))
 		after := MustString(cmd.Flags().GetString("after"))

--- a/cmd/lakectl/cmd/root.go
+++ b/cmd/lakectl/cmd/root.go
@@ -50,8 +50,7 @@ var (
 var rootCmd = &cobra.Command{
 	Use:   "lakectl",
 	Short: "A cli tool to explore manage and work with lakeFS",
-	Long: `lakectl is a CLI tool allowing exploration and manipulation of a lakeFS environment.
-lakeFS is data lake management solution, allowing Git-like semantics over common object stores.`,
+	Long:  `lakectl is a CLI tool allowing exploration and manipulation of a lakeFS environment`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		logging.SetLevel(logLevel)
 		logging.SetOutputFormat(logFormat)

--- a/cmd/lakectl/cmd/root.go
+++ b/cmd/lakectl/cmd/root.go
@@ -50,9 +50,8 @@ var (
 var rootCmd = &cobra.Command{
 	Use:   "lakectl",
 	Short: "A cli tool to explore manage and work with lakeFS",
-	Long: `lakeFS is data lake management solution, allowing Git-like semantics over common object stores
-
-lakectl is a CLI tool allowing exploration and manipulation of a lakeFS environment`,
+	Long: `lakectl is a CLI tool allowing exploration and manipulation of a lakeFS environment.
+lakeFS is data lake management solution, allowing Git-like semantics over common object stores.`,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		logging.SetLevel(logLevel)
 		logging.SetOutputFormat(logFormat)

--- a/cmd/lakectl/cmd/runs_describe.go
+++ b/cmd/lakectl/cmd/runs_describe.go
@@ -18,11 +18,12 @@ const actionTaskResultTemplate = `{{ $r := . }}{{ range $idx, $val := .Hooks }}{
 const runsShowRequiredArgs = 2
 
 var runsDescribeCmd = &cobra.Command{
-	Use:     "describe",
-	Short:   "Describe run results",
-	Long:    `Show information about the run and all the hooks that were executed as part of the run`,
-	Example: "lakectl actions runs describe lakefs://<repository> <run_id>",
-	Args:    cobra.ExactArgs(runsShowRequiredArgs),
+	Use:               "describe",
+	Short:             "Describe run results",
+	Long:              `Show information about the run and all the hooks that were executed as part of the run`,
+	Example:           "lakectl actions runs describe lakefs://<repository> <run_id>",
+	Args:              cobra.ExactArgs(runsShowRequiredArgs),
+	ValidArgsFunction: ValidArgsRepository,
 	Run: func(cmd *cobra.Command, args []string) {
 		amount := MustInt(cmd.Flags().GetInt("amount"))
 		after := MustString(cmd.Flags().GetString("after"))

--- a/cmd/lakectl/cmd/runs_list.go
+++ b/cmd/lakectl/cmd/runs_list.go
@@ -12,11 +12,12 @@ const actionsRunsListTemplate = `{{.ActionsRunsTable | table -}}
 `
 
 var runsListCmd = &cobra.Command{
-	Use:     "list",
-	Short:   "List runs",
-	Long:    `List all runs on a repository optional filter by branch or commit`,
-	Example: "lakectl actions runs list lakefs://<repository> [--branch <branch>] [--commit <commit_id>]",
-	Args:    cobra.ExactArgs(1),
+	Use:               "list",
+	Short:             "List runs",
+	Long:              `List all runs on a repository optional filter by branch or commit`,
+	Example:           "lakectl actions runs list lakefs://<repository> [--branch <branch>] [--commit <commit_id>]",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: ValidArgsRepository,
 	Run: func(cmd *cobra.Command, args []string) {
 		amount := MustInt(cmd.Flags().GetInt("amount"))
 		after := MustString(cmd.Flags().GetString("after"))

--- a/cmd/lakectl/cmd/show.go
+++ b/cmd/lakectl/cmd/show.go
@@ -10,9 +10,10 @@ import (
 
 // showCmd represents the show command
 var showCmd = &cobra.Command{
-	Use:   "show <repository uri>",
-	Short: "See detailed information about an entity by ID (commit, user, etc)",
-	Args:  cobra.ExactArgs(1),
+	Use:               "show <repository uri>",
+	Short:             "See detailed information about an entity by ID (commit, user, etc)",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: ValidArgsRepository,
 	Run: func(cmd *cobra.Command, args []string) {
 		u := MustParseRepoURI("repository", args[0])
 		Fmt("Repository: %s\n", u.String())

--- a/cmd/lakectl/cmd/tag.go
+++ b/cmd/lakectl/cmd/tag.go
@@ -17,10 +17,11 @@ var tagCmd = &cobra.Command{
 }
 
 var tagListCmd = &cobra.Command{
-	Use:     "list <repository uri>",
-	Short:   "List tags in a repository",
-	Example: "lakectl tag list lakefs://<repository>",
-	Args:    cobra.ExactArgs(1),
+	Use:               "list <repository uri>",
+	Short:             "List tags in a repository",
+	Example:           "lakectl tag list lakefs://<repository>",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: ValidArgsRepository,
 	Run: func(cmd *cobra.Command, args []string) {
 		amount := MustInt(cmd.Flags().GetInt("amount"))
 		after := MustString(cmd.Flags().GetString("after"))
@@ -67,6 +68,12 @@ var tagCreateCmd = &cobra.Command{
 	Short:   "Create a new tag in a repository",
 	Example: "lakectl tag create lakefs://example-repo/example-tag lakefs://example-repo/2397cc9a9d04c20a4e5739b42c1dd3d8ba655c0b3a3b974850895a13d8bf9917",
 	Args:    cobra.ExactArgs(tagCreateRequiredArgs),
+	ValidArgsFunction: func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) >= tagCreateRequiredArgs {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		return validRepositoryToComplete(cmd.Context(), toComplete)
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		tagURI := MustParseRefURI("tag uri", args[0])
 		commitURI := MustParseRefURI("commit uri", args[1])
@@ -103,9 +110,10 @@ var tagCreateCmd = &cobra.Command{
 }
 
 var tagDeleteCmd = &cobra.Command{
-	Use:   "delete <tag uri>",
-	Short: "Delete a tag from a repository",
-	Args:  cobra.ExactArgs(1),
+	Use:               "delete <tag uri>",
+	Short:             "Delete a tag from a repository",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: ValidArgsRepository,
 	Run: func(cmd *cobra.Command, args []string) {
 		confirmation, err := Confirm(cmd.Flags(), "Are you sure you want to delete tag")
 		if err != nil || !confirmation {
@@ -122,9 +130,10 @@ var tagDeleteCmd = &cobra.Command{
 }
 
 var tagShowCmd = &cobra.Command{
-	Use:   "show <tag uri>",
-	Short: "Show tag's commit reference",
-	Args:  cobra.ExactArgs(1),
+	Use:               "show <tag uri>",
+	Short:             "Show tag's commit reference",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: ValidArgsRepository,
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getClient()
 		u := MustParseRefURI("tag", args[0])

--- a/cmd/lakectl/cmd/validargs.go
+++ b/cmd/lakectl/cmd/validargs.go
@@ -26,9 +26,8 @@ func validRepositoryToComplete(ctx context.Context, toComplete string) ([]string
 	// extract repository name written so far
 	var prefix api.PaginationPrefix
 	if strings.HasPrefix(toComplete, uriPrefix) {
-		idx := strings.Index(toComplete[len(uriPrefix):], uri.PathSeparator)
-		if idx > 1 {
-			prefix = api.PaginationPrefix(toComplete[len(uriPrefix):idx])
+		if !strings.Contains(toComplete[len(uriPrefix):], uri.PathSeparator) {
+			prefix = api.PaginationPrefix(toComplete[len(uriPrefix):])
 		}
 	}
 

--- a/cmd/lakectl/cmd/validargs.go
+++ b/cmd/lakectl/cmd/validargs.go
@@ -1,0 +1,38 @@
+package cmd
+
+import (
+	"context"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/uri"
+)
+
+func ValidArgsRepository(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	if len(args) != 0 {
+		return nil, cobra.ShellCompDirectiveNoFileComp
+	}
+	return validRepositoryToComplete(cmd.Context(), toComplete)
+}
+
+func validRepositoryToComplete(ctx context.Context, toComplete string) ([]string, cobra.ShellCompDirective) {
+	// do not suggest in case we are passed the repository part
+	prefix := uri.LakeFSSchema + uri.LakeFSSchemaSeparator
+	if strings.HasPrefix(toComplete, prefix) && strings.Contains(toComplete[len(prefix):], uri.PathSeparator) {
+		return nil, cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace
+	}
+
+	// suggest repositories
+	// TODO(barak): smart suggest based on current value
+	clt := getClient()
+	resp, err := clt.ListRepositoriesWithResponse(ctx, &api.ListRepositoriesParams{})
+	if err != nil || resp.JSON200 == nil {
+		return nil, cobra.ShellCompDirectiveError
+	}
+	results := make([]string, 0, len(resp.JSON200.Results))
+	for _, repo := range resp.JSON200.Results {
+		results = append(results, prefix+repo.Id)
+	}
+	return results, cobra.ShellCompDirectiveNoFileComp | cobra.ShellCompDirectiveNoSpace
+}

--- a/docs/reference/commands.md
+++ b/docs/reference/commands.md
@@ -46,8 +46,6 @@ A cli tool to explore manage and work with lakeFS
 #### Synopsis
 {:.no_toc}
 
-lakeFS is data lake management solution, allowing Git-like semantics over common object stores
-
 lakectl is a CLI tool allowing exploration and manipulation of a lakeFS environment
 
 #### Options

--- a/esti/golden/lakectl_help.golden
+++ b/esti/golden/lakectl_help.golden
@@ -1,6 +1,4 @@
-lakeFS is data lake management solution, allowing Git-like semantics over common object stores
-
-lakectl is a CLI tool allowing exploration and manipulation of a lakeFS environment
+lakectl is a CLI tool allowing exploration and manipulation of a lakeFS environment.
 
 Usage:
   lakectl [command]

--- a/esti/golden/lakectl_help.golden
+++ b/esti/golden/lakectl_help.golden
@@ -1,4 +1,4 @@
-lakectl is a CLI tool allowing exploration and manipulation of a lakeFS environment.
+lakectl is a CLI tool allowing exploration and manipulation of a lakeFS environment
 
 Usage:
   lakectl [command]


### PR DESCRIPTION
Enhance the auto-complete with auto complete by listing the current repositories.
This is the first step in enable better user-experience while working from the command line.
Next step will be to enable specific tag/branch/commit and path.

Part of #654
