### PR TITLE
lakectl check bad response

### DIFF
--- a/cmd/lakectl/cmd/abuse.go
+++ b/cmd/lakectl/cmd/abuse.go
@@ -191,6 +191,9 @@ var abuseRandomWritesCmd = &cobra.Command{
 		client := getClient()
 		resp, err := client.GetRepositoryWithResponse(cmd.Context(), u.Repository)
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusOK)
+		if resp.JSON200 == nil {
+			Die("Bad response from server", 1)
+		}
 
 		repo := resp.JSON200
 		storagePrefix := repo.StorageNamespace
@@ -249,6 +252,9 @@ var abuseCommitCmd = &cobra.Command{
 		client := getClient()
 		resp, err := client.GetRepositoryWithResponse(cmd.Context(), u.Repository)
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusOK)
+		if resp.JSON200 == nil {
+			Die("Bad response from server", 1)
+		}
 
 		// execute the things!
 		generator.Run(func(input chan string, output chan stress.Result) {
@@ -303,6 +309,9 @@ var abuseCreateBranchesCmd = &cobra.Command{
 					Amount: &amount,
 				})
 				DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusOK)
+				if resp.JSON200 == nil {
+					Die("Bad response from server", 1)
+				}
 
 				for _, ref := range resp.JSON200.Results {
 					if !strings.HasPrefix(ref.Id, branchPrefix) {

--- a/cmd/lakectl/cmd/annotate.go
+++ b/cmd/lakectl/cmd/annotate.go
@@ -35,6 +35,9 @@ var annotateCmd = &cobra.Command{
 		context := cmd.Context()
 		resp, err := client.ListObjectsWithResponse(context, pathURI.Repository, pathURI.Ref, &api.ListObjectsParams{Prefix: &pfx})
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusOK)
+		if resp.JSON200 == nil {
+			Die("Bad response from server", 1)
+		}
 		var listObjectsDelimiter api.PaginationDelimiter
 		if !recursive {
 			listObjectsDelimiter = PathDelimiter
@@ -49,6 +52,9 @@ var annotateCmd = &cobra.Command{
 			}
 			listObjectsResp, err := client.ListObjectsWithResponse(context, pathURI.Repository, pathURI.Ref, params)
 			DieOnErrorOrUnexpectedStatusCode(listObjectsResp, err, http.StatusOK)
+			if resp.JSON200 == nil {
+				Die("Bad response from server", 1)
+			}
 			for _, obj := range listObjectsResp.JSON200.Results {
 				logCommitsParams := &api.LogCommitsParams{
 					Amount: api.PaginationAmountPtr(1),
@@ -61,6 +67,9 @@ var annotateCmd = &cobra.Command{
 				}
 				logCommitsResp, err := client.LogCommitsWithResponse(context, pathURI.Repository, pathURI.Ref, logCommitsParams)
 				DieOnErrorOrUnexpectedStatusCode(logCommitsResp, err, http.StatusOK)
+				if resp.JSON200 == nil {
+					Die("Bad response from server", 1)
+				}
 				data := objectCommitData{
 					Object: obj.Path,
 				}

--- a/cmd/lakectl/cmd/auth.go
+++ b/cmd/lakectl/cmd/auth.go
@@ -65,6 +65,9 @@ var authUsersList = &cobra.Command{
 			Amount: api.PaginationAmountPtr(amount),
 		})
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusOK)
+		if resp.JSON200 == nil {
+			Die("Bad response from server", 1)
+		}
 
 		users := resp.JSON200.Results
 		rows := make([][]interface{}, len(users))
@@ -89,6 +92,9 @@ var authUsersCreate = &cobra.Command{
 			Id: id,
 		})
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusCreated)
+		if resp.JSON201 == nil {
+			Die("Bad response from server", 1)
+		}
 		user := resp.JSON201
 		Write(userCreatedTemplate, user)
 	},
@@ -127,6 +133,9 @@ var authUsersGroupsList = &cobra.Command{
 			Amount: api.PaginationAmountPtr(amount),
 		})
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusOK)
+		if resp.JSON200 == nil {
+			Die("Bad response from server", 1)
+		}
 
 		groups := resp.JSON200.Results
 		rows := make([][]interface{}, len(groups))
@@ -162,6 +171,9 @@ var authUsersPoliciesList = &cobra.Command{
 			Effective: &effective,
 		})
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusOK)
+		if resp.JSON200 == nil {
+			Die("Bad response from server", 1)
+		}
 
 		policies := resp.JSON200.Results
 		rows := make([][]interface{}, 0)
@@ -220,11 +232,17 @@ var authUsersCredentialsCreate = &cobra.Command{
 		if id == "" {
 			resp, err := clt.GetCurrentUserWithResponse(cmd.Context())
 			DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusOK)
+			if resp.JSON200 == nil {
+				Die("Bad response from server", 1)
+			}
 			id = resp.JSON200.User.Id
 		}
 
 		resp, err := clt.CreateCredentialsWithResponse(cmd.Context(), id)
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusCreated)
+		if resp.JSON201 == nil {
+			Die("Bad response from server", 1)
+		}
 
 		credentials := resp.JSON201
 		Write(credentialsCreatedTemplate, credentials)
@@ -242,6 +260,9 @@ var authUsersCredentialsDelete = &cobra.Command{
 		if id == "" {
 			resp, err := clt.GetCurrentUserWithResponse(cmd.Context())
 			DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusOK)
+			if resp.JSON200 == nil {
+				Die("Bad response from server", 1)
+			}
 			id = resp.JSON200.User.Id
 		}
 		resp, err := clt.DeleteCredentialsWithResponse(cmd.Context(), id, accessKeyID)
@@ -263,6 +284,9 @@ var authUsersCredentialsList = &cobra.Command{
 		if id == "" {
 			resp, err := clt.GetCurrentUserWithResponse(cmd.Context())
 			DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusOK)
+			if resp.JSON200 == nil {
+				Die("Bad response from server", 1)
+			}
 			id = resp.JSON200.User.Id
 		}
 
@@ -271,6 +295,9 @@ var authUsersCredentialsList = &cobra.Command{
 			Amount: api.PaginationAmountPtr(amount),
 		})
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusOK)
+		if resp.JSON200 == nil {
+			Die("Bad response from server", 1)
+		}
 
 		credentials := resp.JSON200.Results
 		rows := make([][]interface{}, len(credentials))
@@ -303,6 +330,9 @@ var authGroupsList = &cobra.Command{
 			Amount: api.PaginationAmountPtr(amount),
 		})
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusOK)
+		if resp.JSON200 == nil {
+			Die("Bad response from server", 1)
+		}
 
 		groups := resp.JSON200.Results
 		rows := make([][]interface{}, len(groups))
@@ -327,6 +357,9 @@ var authGroupsCreate = &cobra.Command{
 			Id: id,
 		})
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusCreated)
+		if resp.JSON201 == nil {
+			Die("Bad response from server", 1)
+		}
 		group := resp.JSON201
 		Write(groupCreatedTemplate, group)
 	},
@@ -365,6 +398,9 @@ var authGroupsListMembers = &cobra.Command{
 			Amount: api.PaginationAmountPtr(amount),
 		})
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusOK)
+		if resp.JSON200 == nil {
+			Die("Bad response from server", 1)
+		}
 
 		users := resp.JSON200.Results
 		rows := make([][]interface{}, len(users))
@@ -425,6 +461,9 @@ var authGroupsPoliciesList = &cobra.Command{
 			Amount: api.PaginationAmountPtr(amount),
 		})
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusOK)
+		if resp.JSON200 == nil {
+			Die("Bad response from server", 1)
+		}
 
 		policies := resp.JSON200.Results
 		rows := make([][]interface{}, 0)
@@ -490,6 +529,9 @@ var authPoliciesList = &cobra.Command{
 			Amount: api.PaginationAmountPtr(amount),
 		})
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusOK)
+		if resp.JSON200 == nil {
+			Die("Bad response from server", 1)
+		}
 
 		policies := resp.JSON200.Results
 		rows := make([][]interface{}, len(policies))
@@ -534,6 +576,9 @@ var authPoliciesCreate = &cobra.Command{
 			Statement: doc.Statement,
 		})
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusCreated)
+		if resp.JSON201 == nil {
+			Die("Bad response from server", 1)
+		}
 
 		createdPolicy := resp.JSON201
 		Write(policyCreatedTemplate, struct {
@@ -561,6 +606,9 @@ var authPoliciesShow = &cobra.Command{
 
 		resp, err := clt.GetPolicyWithResponse(cmd.Context(), id)
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusOK)
+		if resp.JSON200 == nil {
+			Die("Bad response from server", 1)
+		}
 
 		policy := *resp.JSON200
 		Write(policyDetailsTemplate, struct {

--- a/cmd/lakectl/cmd/branch.go
+++ b/cmd/lakectl/cmd/branch.go
@@ -39,6 +39,9 @@ var branchListCmd = &cobra.Command{
 			Amount: api.PaginationAmountPtr(amount),
 		})
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusOK)
+		if resp.JSON200 == nil {
+			Die("Bad response from server", 1)
+		}
 
 		refs := resp.JSON200.Results
 		rows := make([][]interface{}, len(refs))
@@ -205,6 +208,9 @@ var branchShowCmd = &cobra.Command{
 		Fmt("Branch: %s\n", u.String())
 		resp, err := client.GetBranchWithResponse(cmd.Context(), u.Repository, u.Ref)
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusOK)
+		if resp.JSON200 == nil {
+			Die("Bad response from server", 1)
+		}
 		branch := resp.JSON200
 		Fmt("%s\n", branch)
 	},

--- a/cmd/lakectl/cmd/branch_protect.go
+++ b/cmd/lakectl/cmd/branch_protect.go
@@ -29,6 +29,9 @@ var branchProtectListCmd = &cobra.Command{
 		u := MustParseRepoURI("repository", args[0])
 		resp, err := client.GetBranchProtectionRulesWithResponse(cmd.Context(), u.Repository)
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusOK)
+		if resp.JSON200 == nil {
+			Die("Bad response from server", 1)
+		}
 		patterns := make([][]interface{}, len(*resp.JSON200))
 		for i, rule := range *resp.JSON200 {
 			patterns[i] = []interface{}{rule.Pattern}

--- a/cmd/lakectl/cmd/commit.go
+++ b/cmd/lakectl/cmd/commit.go
@@ -68,6 +68,9 @@ var commitCmd = &cobra.Command{
 			Date:     datePtr,
 		})
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusCreated)
+		if resp.JSON201 == nil {
+			Die("Bad response from server", 1)
+		}
 
 		commit := resp.JSON201
 		Write(commitCreateTemplate, struct {

--- a/cmd/lakectl/cmd/diff.go
+++ b/cmd/lakectl/cmd/diff.go
@@ -91,6 +91,9 @@ func printDiffBranch(ctx context.Context, client api.ClientWithResponsesInterfac
 			Amount: api.PaginationAmountPtr(int(pageSize)),
 		})
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusOK)
+		if resp.JSON200 == nil {
+			Die("Bad response from server", 1)
+		}
 
 		for _, line := range resp.JSON200.Results {
 			FmtDiff(line, false)
@@ -119,6 +122,9 @@ func printDiffRefs(ctx context.Context, client api.ClientWithResponsesInterface,
 			Type:   diffType,
 		})
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusOK)
+		if resp.JSON200 == nil {
+			Die("Bad response from server", 1)
+		}
 
 		for _, line := range resp.JSON200.Results {
 			FmtDiff(line, true)

--- a/cmd/lakectl/cmd/fs.go
+++ b/cmd/lakectl/cmd/fs.go
@@ -46,9 +46,11 @@ var fsStatCmd = &cobra.Command{
 			Path: *pathURI.Path,
 		})
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusOK)
+		if resp.JSON200 == nil {
+			Die("Bad response from server", 1)
+		}
 
-		stat := resp.JSON200
-		Write(fsStatTemplate, stat)
+		Write(fsStatTemplate, resp.JSON200)
 	},
 }
 
@@ -90,6 +92,9 @@ var fsListCmd = &cobra.Command{
 			}
 			resp, err := client.ListObjectsWithResponse(cmd.Context(), pathURI.Repository, pathURI.Ref, params)
 			DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusOK)
+			if resp.JSON200 == nil {
+				Die("Bad response from server", 1)
+			}
 
 			results := resp.JSON200.Results
 			// trim prefix if non-recursive
@@ -301,6 +306,9 @@ var fsStageCmd = &cobra.Command{
 			Path: *pathURI.Path,
 		}, api.StageObjectJSONRequestBody(obj))
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusCreated)
+		if resp.JSON201 == nil {
+			Die("Bad response from server", 1)
+		}
 
 		Write(fsStatTemplate, resp.JSON201)
 	},
@@ -375,6 +383,9 @@ var fsRmCmd = &cobra.Command{
 			}
 			resp, err := client.ListObjectsWithResponse(cmd.Context(), pathURI.Repository, pathURI.Ref, params)
 			DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusOK)
+			if resp.JSON200 == nil {
+				Die("Bad response from server", 1)
+			}
 
 			results := resp.JSON200.Results
 			for i := range results {

--- a/cmd/lakectl/cmd/gc.go
+++ b/cmd/lakectl/cmd/gc.go
@@ -100,6 +100,9 @@ var gcGetConfigCmd = &cobra.Command{
 		client := getClient()
 		resp, err := client.GetGarbageCollectionRulesWithResponse(cmd.Context(), u.Repository)
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusOK)
+		if resp.JSON200 == nil {
+			Die("Bad response from server", 1)
+		}
 		if isJSON {
 			Write("{{ . | json }}", resp.JSON200)
 		} else {

--- a/cmd/lakectl/cmd/gc.go
+++ b/cmd/lakectl/cmd/gc.go
@@ -83,7 +83,7 @@ var gcDeleteConfigCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		u := MustParseRepoURI("repository", args[0])
 		client := getClient()
-		resp, err := client.DeleteGarbageCollectionRules(cmd.Context(), u.Repository)
+		resp, err := client.DeleteGarbageCollectionRulesWithResponse(cmd.Context(), u.Repository)
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusNoContent)
 	},
 }

--- a/cmd/lakectl/cmd/ingest.go
+++ b/cmd/lakectl/cmd/ingest.go
@@ -26,9 +26,11 @@ type stageRequest struct {
 func stageWorker(ctx context.Context, client api.ClientWithResponsesInterface, wg *sync.WaitGroup, requests <-chan *stageRequest, responses chan<- *api.StageObjectResponse) {
 	defer wg.Done()
 	for req := range requests {
-		resp, err := client.StageObjectWithResponse(
-			ctx, req.repository, req.branch, req.params, req.body)
+		resp, err := client.StageObjectWithResponse(ctx, req.repository, req.branch, req.params, req.body)
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusCreated)
+		if resp.JSON201 == nil {
+			Die("Bad response from server", 1)
+		}
 		responses <- resp
 	}
 }

--- a/cmd/lakectl/cmd/log.go
+++ b/cmd/lakectl/cmd/log.go
@@ -60,6 +60,9 @@ var logCmd = &cobra.Command{
 		for pagination.HasMore {
 			resp, err := client.LogCommitsWithResponse(cmd.Context(), branchURI.Repository, branchURI.Ref, logCommitsParams)
 			DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusOK)
+			if resp.JSON200 == nil {
+				Die("Bad response from server", 1)
+			}
 			pagination = resp.JSON200.Pagination
 			logCommitsParams.After = api.PaginationAfterPtr(pagination.NextOffset)
 			data := struct {

--- a/cmd/lakectl/cmd/merge.go
+++ b/cmd/lakectl/cmd/merge.go
@@ -51,6 +51,9 @@ var mergeCmd = &cobra.Command{
 			Die("Conflict found.", 1)
 		}
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusOK)
+		if resp.JSON200 == nil {
+			Die("Bad response from server", 1)
+		}
 
 		Write(mergeCreateTemplate, struct {
 			Merge  FromTo

--- a/cmd/lakectl/cmd/metastore.go
+++ b/cmd/lakectl/cmd/metastore.go
@@ -288,6 +288,9 @@ var createSymlinkCmd = &cobra.Command{
 			DieErr(err)
 		}
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusCreated)
+		if resp.JSON201 == nil {
+			Die("Bad response from server", 1)
+		}
 		location := resp.JSON201.Location
 
 		err = metastore.CopyOrMergeToSymlink(cmd.Context(), fromClient, toClient, fromDB, fromTable, toDB, toTable, location, cfg.GetFixSparkPlaceholder())

--- a/cmd/lakectl/cmd/refs.go
+++ b/cmd/lakectl/cmd/refs.go
@@ -9,11 +9,11 @@ import (
 	"github.com/treeverse/lakefs/pkg/api"
 )
 
-var metadataDumpTemplate = `
+const metadataDumpTemplate = `
 {{ .Response | json }}
 `
 
-var refsRestoreSuccess = `
+const refsRestoreSuccess = `
 {{ "All references restored successfully!" | green }}
 `
 
@@ -66,6 +66,9 @@ var refsDumpCmd = &cobra.Command{
 		client := getClient()
 		resp, err := client.DumpRefsWithResponse(cmd.Context(), repoURI.Repository)
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusCreated)
+		if resp.JSON201 == nil {
+			Die("Bad response from server", 1)
+		}
 
 		Write(metadataDumpTemplate, struct {
 			Response interface{}

--- a/cmd/lakectl/cmd/repo.go
+++ b/cmd/lakectl/cmd/repo.go
@@ -74,6 +74,9 @@ var repoCreateCmd = &cobra.Command{
 				DefaultBranch:    &defaultBranch,
 			})
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusCreated)
+		if resp.JSON201 == nil {
+			Die("Bad response from server", 1)
+		}
 		repo := resp.JSON201
 		Fmt("Repository '%s' created:\nstorage namespace: %s\ndefault branch: %s\ntimestamp: %d\n",
 			repo.Id, repo.StorageNamespace, repo.DefaultBranch, repo.CreationDate)
@@ -106,6 +109,9 @@ var repoCreateBareCmd = &cobra.Command{
 			StorageNamespace: args[1],
 		})
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusCreated)
+		if resp.JSON201 == nil {
+			Die("Bad response from server", 1)
+		}
 		repo := resp.JSON201
 		Fmt("Repository '%s' created:\nstorage namespace: %s\ndefault branch: %s\ntimestamp: %d\n",
 			repo.Id, repo.StorageNamespace, repo.DefaultBranch, repo.CreationDate)

--- a/cmd/lakectl/cmd/repo.go
+++ b/cmd/lakectl/cmd/repo.go
@@ -36,6 +36,9 @@ var repoListCmd = &cobra.Command{
 			Amount: api.PaginationAmountPtr(amount),
 		})
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusOK)
+		if resp.JSON200 == nil {
+			Die("Bad response from server", 1)
+		}
 		repos := resp.JSON200.Results
 		rows := make([][]interface{}, len(repos))
 		for i, repo := range repos {
@@ -63,19 +66,15 @@ var repoCreateCmd = &cobra.Command{
 		if err != nil {
 			DieErr(err)
 		}
-		respCreateRepo, err := clt.CreateRepositoryWithResponse(cmd.Context(),
+		resp, err := clt.CreateRepositoryWithResponse(cmd.Context(),
 			&api.CreateRepositoryParams{},
 			api.CreateRepositoryJSONRequestBody{
 				Name:             u.Repository,
 				StorageNamespace: args[1],
 				DefaultBranch:    &defaultBranch,
 			})
-		DieOnErrorOrUnexpectedStatusCode(respCreateRepo, err, http.StatusCreated)
-
-		respGetRepo, err := clt.GetRepositoryWithResponse(cmd.Context(), u.Repository)
-		DieOnErrorOrUnexpectedStatusCode(respGetRepo, err, http.StatusOK)
-
-		repo := respGetRepo.JSON200
+		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusCreated)
+		repo := resp.JSON201
 		Fmt("Repository '%s' created:\nstorage namespace: %s\ndefault branch: %s\ntimestamp: %d\n",
 			repo.Id, repo.StorageNamespace, repo.DefaultBranch, repo.CreationDate)
 	},
@@ -99,19 +98,15 @@ var repoCreateBareCmd = &cobra.Command{
 			DieErr(err)
 		}
 		bareRepo := true
-		respCreateRepo, err := clt.CreateRepositoryWithResponse(cmd.Context(), &api.CreateRepositoryParams{
+		resp, err := clt.CreateRepositoryWithResponse(cmd.Context(), &api.CreateRepositoryParams{
 			Bare: &bareRepo,
 		}, api.CreateRepositoryJSONRequestBody{
 			DefaultBranch:    &defaultBranch,
 			Name:             u.Repository,
 			StorageNamespace: args[1],
 		})
-		DieOnErrorOrUnexpectedStatusCode(respCreateRepo, err, http.StatusCreated)
-
-		respGetRepo, err := clt.GetRepositoryWithResponse(cmd.Context(), u.Repository)
-		DieOnErrorOrUnexpectedStatusCode(respGetRepo, err, http.StatusOK)
-
-		repo := respGetRepo.JSON200
+		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusCreated)
+		repo := resp.JSON201
 		Fmt("Repository '%s' created:\nstorage namespace: %s\ndefault branch: %s\ntimestamp: %d\n",
 			repo.Id, repo.StorageNamespace, repo.DefaultBranch, repo.CreationDate)
 	},

--- a/cmd/lakectl/cmd/runs_describe.go
+++ b/cmd/lakectl/cmd/runs_describe.go
@@ -39,6 +39,9 @@ var runsDescribeCmd = &cobra.Command{
 		// run result information
 		runsRes, err := client.GetRunWithResponse(ctx, u.Repository, runID)
 		DieOnErrorOrUnexpectedStatusCode(runsRes, err, http.StatusOK)
+		if runsRes.JSON200 == nil {
+			Die("Bad response from server", 1)
+		}
 
 		runResult := runsRes.JSON200
 		Write(actionRunResultTemplate, convertRunResultTable(runResult))
@@ -53,6 +56,9 @@ var runsDescribeCmd = &cobra.Command{
 				Amount: api.PaginationAmountPtr(amountForPagination),
 			})
 			DieOnErrorOrUnexpectedStatusCode(runHooksRes, err, http.StatusOK)
+			if runHooksRes.JSON200 == nil {
+				Die("Bad response from server", 1)
+			}
 			pagination = runHooksRes.JSON200.Pagination
 			data := struct {
 				Hooks      []api.HookRun

--- a/cmd/lakectl/cmd/runs_list.go
+++ b/cmd/lakectl/cmd/runs_list.go
@@ -48,6 +48,9 @@ var runsListCmd = &cobra.Command{
 			Commit: optionalCommit,
 		})
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusOK)
+		if resp.JSON200 == nil {
+			Die("Bad response from server", 1)
+		}
 
 		results := resp.JSON200.Results
 		rows := make([][]interface{}, len(results))

--- a/cmd/lakectl/cmd/show.go
+++ b/cmd/lakectl/cmd/show.go
@@ -41,6 +41,9 @@ var showCmd = &cobra.Command{
 			client := getClient()
 			resp, err := client.GetCommitWithResponse(cmd.Context(), u.Repository, identifier)
 			DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusOK)
+			if resp.JSON200 == nil {
+				Die("Bad response from server", 1)
+			}
 
 			commit := resp.JSON200
 			showMetaRangeID, _ := cmd.Flags().GetBool("show-meta-range-id")

--- a/cmd/lakectl/cmd/tag.go
+++ b/cmd/lakectl/cmd/tag.go
@@ -35,6 +35,9 @@ var tagListCmd = &cobra.Command{
 			Amount: api.PaginationAmountPtr(amount),
 		})
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusOK)
+		if resp.JSON200 == nil {
+			Die("Bad response from server", 1)
+		}
 
 		refs := resp.JSON200.Results
 		rows := make([][]interface{}, len(refs))
@@ -91,6 +94,9 @@ var tagCreateCmd = &cobra.Command{
 			// checking validity of the commitRef before deleting the old one
 			res, err := client.GetCommitWithResponse(ctx, tagURI.Repository, commitURI.Ref)
 			DieOnErrorOrUnexpectedStatusCode(res, err, http.StatusOK)
+			if res.JSON200 == nil {
+				Die("Bad response from server", 1)
+			}
 
 			resp, err := client.DeleteTagWithResponse(ctx, tagURI.Repository, tagURI.Ref)
 			if err != nil && (resp == nil || resp.JSON404 == nil) {
@@ -103,6 +109,9 @@ var tagCreateCmd = &cobra.Command{
 			Ref: commitURI.Ref,
 		})
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusCreated)
+		if resp.JSON201 == nil {
+			Die("Bad response from server", 1)
+		}
 
 		commitID := *resp.JSON201
 		Fmt("Created tag '%s' (%s)\n", tagURI.Ref, commitID)
@@ -142,6 +151,9 @@ var tagShowCmd = &cobra.Command{
 		ctx := cmd.Context()
 		resp, err := client.GetTagWithResponse(ctx, u.Repository, u.Ref)
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusOK)
+		if resp.JSON200 == nil {
+			Die("Bad response from server", 1)
+		}
 		Fmt("%s %s", resp.JSON200.Id, resp.JSON200.CommitId)
 	},
 }


### PR DESCRIPTION
In case where the server returns the right status code, but we fail to parse the response or identify the right content type. The request should fail with an error message.

- Create repository bare response code fix (based on [a different PR](https://github.com/treeverse/lakeFS/pull/4336) will merge after)
- Create repository (with and without bare) skip get repository - create returns all the required data.

Fix #3696