### PR TITLE
[lakefsfs] Add minimal hookup for OutputCommitter

### DIFF
--- a/clients/hadoopfs/pom.xml
+++ b/clients/hadoopfs/pom.xml
@@ -230,6 +230,16 @@ To export to S3:
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-client</artifactId>
+            <version>2.7.7</version> <!-- The common Hadoop version for Spark 2.4.7 and 3.0.1, which lakeFS supports -->
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-mapreduce-client-jobclient</artifactId>
+            <version>2.7.7</version> <!-- The common Hadoop version for Spark 2.4.7 and 3.0.1, which lakeFS supports -->
+        </dependency>
+        <dependency>
+            <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
             <scope>test</scope>
             <type>test-jar</type>

--- a/clients/hadoopfs/pom.xml
+++ b/clients/hadoopfs/pom.xml
@@ -239,6 +239,12 @@ To export to S3:
             <version>2.7.7</version> <!-- The common Hadoop version for Spark 2.4.7 and 3.0.1, which lakeFS supports -->
         </dependency>
         <dependency>
+            <groupId>org.apache.parquet</groupId>
+            <artifactId> parquet-hadoop </artifactId>
+            <scope>provided</scope>
+            <version>1.12.3</version>
+        </dependency>
+        <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
             <scope>test</scope>

--- a/clients/hadoopfs/src/main/java/io/lakefs/Constants.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/Constants.java
@@ -2,7 +2,7 @@ package io.lakefs;
 
 import org.apache.commons.io.FileUtils;
 
-class Constants {
+public class Constants {
     public static final String DEFAULT_SCHEME = "lakefs";
     public static final String DEFAULT_CLIENT_ENDPOINT = "http://localhost:8000/api/v1";
     public static final String ACCESS_KEY_KEY_SUFFIX = "access.key";

--- a/clients/hadoopfs/src/main/java/io/lakefs/FileSystemTracer.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/FileSystemTracer.java
@@ -1,5 +1,8 @@
 package io.lakefs;
 
+import io.lakefs.utils.ObjectLocation;
+import io.lakefs.utils.StringUtils;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.*;
 import org.apache.hadoop.fs.permission.FsPermission;

--- a/clients/hadoopfs/src/main/java/io/lakefs/LinkOnCloseOutputStream.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/LinkOnCloseOutputStream.java
@@ -1,6 +1,8 @@
 package io.lakefs;
 
 import io.lakefs.clients.api.model.StagingLocation;
+import io.lakefs.utils.ObjectLocation;
+
 import org.apache.hadoop.fs.Path;
 
 import java.io.IOException;

--- a/clients/hadoopfs/src/main/java/io/lakefs/committer/DummyOutputCommitter.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/committer/DummyOutputCommitter.java
@@ -23,11 +23,11 @@ import java.io.IOException;
 public class DummyOutputCommitter extends FileOutputCommitter {
     private static final Logger LOG = LoggerFactory.getLogger(DummyOutputCommitter.class);
 
-    private String branch = null;
-    private String outputBranch = null;
-    private Path outputPath = null;
-    private String workBranch;
-    private Path workPath;
+    protected String branch = null;
+    protected String outputBranch = null;
+    protected Path outputPath = null;
+    protected String workBranch;
+    protected Path workPath;
 
     public DummyOutputCommitter(Path outputPath, JobContext context) throws IOException {
         super(outputPath, context);

--- a/clients/hadoopfs/src/main/java/io/lakefs/committer/DummyOutputCommitter.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/committer/DummyOutputCommitter.java
@@ -23,11 +23,10 @@ import java.io.IOException;
 public class DummyOutputCommitter extends FileOutputCommitter {
     private static final Logger LOG = LoggerFactory.getLogger(DummyOutputCommitter.class);
 
-    protected String branch = null;
     protected String outputBranch = null;
     protected Path outputPath = null;
-    protected String workBranch;
-    protected Path workPath;
+    protected String workBranch = null;
+    protected Path workPath = null;
 
     public DummyOutputCommitter(Path outputPath, JobContext context) throws IOException {
         super(outputPath, context);
@@ -50,14 +49,15 @@ public class DummyOutputCommitter extends FileOutputCommitter {
         // TODO(ariels): s/[^-\w]//g on the branch ID, ensuring all chars
         // are allowed.  (Some) users might manage to create a bad task
         // name.
-        this.branch = id.toString();
-        Preconditions.checkNotNull(outputPath, "missing outputPath");
-        createBranch(branch, outputBranch);
+        this.workBranch = id.toString();
+        if (outputPath != null) {
+            createBranch(workBranch, outputBranch);
 
-        ObjectLocation loc = ObjectLocation.pathToObjectLocation(null,outputPath);
-        loc.setRef(this.branch);
-        this.workPath = loc.toFSPath();
-        System.out.printf("TODO: Working path: %s\n", workPath);
+            ObjectLocation loc = ObjectLocation.pathToObjectLocation(null, outputPath);
+            loc.setRef(this.workBranch);
+            this.workPath = loc.toFSPath();
+            System.out.printf("TODO: Working path: %s\n", workPath);
+        }
     }
 
     private void createBranch(String branch, String base) { // TODO(lynn)
@@ -69,19 +69,30 @@ public class DummyOutputCommitter extends FileOutputCommitter {
 
     @Override
     public Path getWorkPath() {
-        System.out.printf("Get working path for %s -> %s\n%s\n", branch, workPath,
+        System.out.printf("Get working path for %s -> %s\n%s\n", workBranch, workPath,
                           ExceptionUtils.getStackTrace(new Throwable()));
         return workPath;
     }
 
     @Override
+    public void setupJob(JobContext context) throws IOException { // TODO(lynn)
+        if (outputPath == null)
+            return;
+        System.out.printf("TODO: Setup job on %s\n", workBranch);
+    }
+
+    @Override
     public void commitJob(JobContext jobContext) throws IOException { // TODO(lynn)
-        System.out.printf("TODO: Commit branch %s to %s\n", branch, outputBranch);
+        if (outputPath == null)
+            return;
+        System.out.printf("TODO: Commit branch %s to %s\n", workBranch, outputBranch);
     }
 
     @Override
     public void abortJob(JobContext jobContext, JobStatus.State status) throws IOException { // TODO(lynn)
-        System.out.printf("TODO: Delete(?) branch %s\n", branch);
+        if (outputPath == null)
+            return;
+        System.out.printf("TODO: Delete(?) branch %s\n", workBranch);
     }
 
     @Override
@@ -93,18 +104,24 @@ public class DummyOutputCommitter extends FileOutputCommitter {
     @Override
     public void setupTask(TaskAttemptContext taskContext)
         throws IOException {    // TODO(lynn)
-        System.out.printf("TODO: Setup task on %s\n", branch);
+        if (outputPath == null)
+            return;
+        System.out.printf("TODO: Setup task on %s\n", workBranch);
     }
 
     @Override
     public void commitTask(TaskAttemptContext taskContext)
         throws IOException {    // TODO(lynn)
-        System.out.printf("TODO: Commit task %s\n", branch);
+        if (outputPath == null)
+            return;
+        System.out.printf("TODO: Commit task %s\n", workBranch);
     }
 
     public void abortTask(TaskAttemptContext taskContext)
         throws IOException {    // TODO(lynn)
-        System.out.printf("TODO: Commit task %s\n", branch);
+        if (outputPath == null)
+            return;
+        System.out.printf("TODO: Commit task %s\n", workBranch);
     }
 
     // TODO(lynn): More methods: isRecoverySupported, isCommitJobRepeatable, recoverTask.

--- a/clients/hadoopfs/src/main/java/io/lakefs/committer/DummyOutputCommitter.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/committer/DummyOutputCommitter.java
@@ -1,0 +1,111 @@
+package io.lakefs.committer;
+
+import io.lakefs.LakeFSFileSystem;
+import io.lakefs.utils.ObjectLocation;
+
+import org.apache.commons.lang.exception.ExceptionUtils; // (for debug prints ONLY)
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.JobStatus;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.hadoop.mapreduce.TaskAttemptID;
+import org.apache.hadoop.mapreduce.lib.output.FileOutputCommitter;
+
+import com.google.common.base.Preconditions;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+// TODO(ariels): For Hadoop 3, it is enough (and better!) to extend PathOutputCommitter.
+public class DummyOutputCommitter extends FileOutputCommitter {
+    private static final Logger LOG = LoggerFactory.getLogger(DummyOutputCommitter.class);
+
+    private String branch = null;
+    private String outputBranch = null;
+    private Path outputPath = null;
+    private String workBranch;
+    private Path workPath;
+
+    public DummyOutputCommitter(Path outputPath, JobContext context) throws IOException {
+        super(outputPath, context);
+        // TODO(lynn): Create lakeFS API client.
+
+        if (outputPath != null) {
+            FileSystem fs = outputPath.getFileSystem(context.getConfiguration());
+            Preconditions.checkArgument(fs instanceof LakeFSFileSystem,
+                                        "%s not on a LakeFSFileSystem", outputPath);
+            ObjectLocation outputLocation = ObjectLocation.pathToObjectLocation(null, outputPath);
+            this.outputBranch = outputLocation.getRef();
+            this.outputPath = fs.makeQualified(outputPath);
+        }
+    }
+
+    public DummyOutputCommitter(Path outputPath, TaskAttemptContext context) throws IOException {
+        this(outputPath, (JobContext)context);
+
+        TaskAttemptID id = context.getTaskAttemptID();
+        // TODO(ariels): s/[^-\w]//g on the branch ID, ensuring all chars
+        // are allowed.  (Some) users might manage to create a bad task
+        // name.
+        this.branch = id.toString();
+        Preconditions.checkNotNull(outputPath, "missing outputPath");
+        createBranch(branch, outputBranch);
+
+        ObjectLocation loc = ObjectLocation.pathToObjectLocation(null,outputPath);
+        loc.setRef(this.branch);
+        this.workPath = loc.toFSPath();
+        System.out.printf("TODO: Working path: %s\n", workPath);
+    }
+
+    private void createBranch(String branch, String base) { // TODO(lynn)
+        System.out.printf("TODO: Create branch %s from %s\n", branch, base);
+    }
+
+    // TODO(ariels): Need to override getJobAttemptPath,
+    // getPendingJobAttemptPath (which is *static*, what do we do???!?)
+
+    @Override
+    public Path getWorkPath() {
+        System.out.printf("Get working path for %s -> %s\n%s\n", branch, workPath,
+                          ExceptionUtils.getStackTrace(new Throwable()));
+        return workPath;
+    }
+
+    @Override
+    public void commitJob(JobContext jobContext) throws IOException { // TODO(lynn)
+        System.out.printf("TODO: Commit branch %s to %s\n", branch, outputBranch);
+    }
+
+    @Override
+    public void abortJob(JobContext jobContext, JobStatus.State status) throws IOException { // TODO(lynn)
+        System.out.printf("TODO: Delete(?) branch %s\n", branch);
+    }
+
+    @Override
+    public boolean needsTaskCommit(TaskAttemptContext taskContext)
+        throws IOException {    // TODO(lynn)
+        return true;
+    }
+
+    @Override
+    public void setupTask(TaskAttemptContext taskContext)
+        throws IOException {    // TODO(lynn)
+        System.out.printf("TODO: Setup task on %s\n", branch);
+    }
+
+    @Override
+    public void commitTask(TaskAttemptContext taskContext)
+        throws IOException {    // TODO(lynn)
+        System.out.printf("TODO: Commit task %s\n", branch);
+    }
+
+    public void abortTask(TaskAttemptContext taskContext)
+        throws IOException {    // TODO(lynn)
+        System.out.printf("TODO: Commit task %s\n", branch);
+    }
+
+    // TODO(lynn): More methods: isRecoverySupported, isCommitJobRepeatable, recoverTask.
+}

--- a/clients/hadoopfs/src/main/java/io/lakefs/committer/DummyParquetOutputCommitter.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/committer/DummyParquetOutputCommitter.java
@@ -1,0 +1,26 @@
+package io.lakefs.committer;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.mapreduce.JobContext;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+import org.apache.parquet.hadoop.ParquetOutputCommitter;
+import org.apache.parquet.hadoop.util.ContextUtil;
+
+import java.io.IOException;
+
+public class DummyParquetOutputCommitter extends DummyOutputCommitter {
+    public DummyParquetOutputCommitter(Path outputPath, JobContext context) throws IOException {
+        super(outputPath, context);
+    }
+
+    public DummyParquetOutputCommitter(Path outputPath, TaskAttemptContext context) throws IOException {
+        super(outputPath, context);
+    }
+
+    public void commitJob(JobContext jobContext) throws IOException {
+        super.commitJob(jobContext);
+        Configuration configuration = ContextUtil.getConfiguration(jobContext);
+        ParquetOutputCommitter.writeMetaDataFile(configuration, outputPath);
+    }
+}

--- a/clients/hadoopfs/src/main/java/io/lakefs/utils/ObjectLocation.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/utils/ObjectLocation.java
@@ -1,12 +1,49 @@
-package io.lakefs;
+package io.lakefs.utils;
+
+import io.lakefs.Constants;
 
 import org.apache.hadoop.fs.Path;
 
-class ObjectLocation {
+import javax.annotation.Nonnull;
+import java.net.URI;
+
+public class ObjectLocation {
     private String scheme;
     private String repository;
     private String ref;
     private String path;
+
+    /**
+     * Returns Location with repository, ref and path used by lakeFS based on filesystem path.
+     *
+     * @param path to extract information from.
+     * @return lakeFS Location with repository, ref and path
+     */
+    @Nonnull
+    static public ObjectLocation pathToObjectLocation(Path workingDirectory, Path path) {
+        if (!path.isAbsolute()) {
+            if (workingDirectory == null) {
+                throw new IllegalArgumentException("cannot expand local path with null workingDirectory");
+            }
+            path = new Path(workingDirectory, path);
+        }
+
+        URI uri = path.toUri();
+        ObjectLocation loc = new ObjectLocation();
+        loc.setScheme(uri.getScheme());
+        loc.setRepository(uri.getHost());
+        // extract ref and rest of the path after removing the '/' prefix
+        String s = StringUtils.trimLeadingSlash(uri.getPath());
+        int i = s.indexOf(Constants.SEPARATOR);
+        if (i == -1) {
+            loc.setRef(s);
+            loc.setPath("");
+        } else {
+            loc.setRef(s.substring(0, i));
+            loc.setPath(s.substring(i + 1));
+        }
+        return loc;
+    }
 
     public static String formatPath(String scheme, String repository, String ref, String path) {
         return String.format("%s://%s/%s/%s", scheme, repository, ref, path);

--- a/clients/hadoopfs/src/main/java/io/lakefs/utils/ObjectLocation.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/utils/ObjectLocation.java
@@ -157,4 +157,8 @@ public class ObjectLocation {
     public ObjectLocation toDirectory() {
         return new ObjectLocation(scheme, repository, ref, StringUtils.addLeadingSlash(path));
     }
+
+    public Path toFSPath() {
+        return new Path(this.toString());
+    }
 }

--- a/clients/hadoopfs/src/main/java/io/lakefs/utils/StringUtils.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/utils/StringUtils.java
@@ -1,15 +1,16 @@
-package io.lakefs;
+package io.lakefs.utils;
+
+import io.lakefs.Constants;
 
 public final class StringUtils {
-
-    static String trimLeadingSlash(String s) {
+    public static String trimLeadingSlash(String s) {
         if (s.startsWith(Constants.SEPARATOR)) {
             return s.substring(1);
         }
         return s;
     }
 
-    static String addLeadingSlash(String s) {
+    public static String addLeadingSlash(String s) {
         return s.isEmpty() || s.endsWith(Constants.SEPARATOR) ? s : s + Constants.SEPARATOR;
     }
 }

--- a/clients/hadoopfs/src/test/java/io/lakefs/LakeFSFileSystemTest.java
+++ b/clients/hadoopfs/src/test/java/io/lakefs/LakeFSFileSystemTest.java
@@ -1,5 +1,10 @@
 package io.lakefs;
 
+import io.lakefs.clients.api.*;
+import io.lakefs.clients.api.model.*;
+import io.lakefs.clients.api.model.ObjectStats.PathTypeEnum;
+import io.lakefs.utils.ObjectLocation;
+
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.BasicAWSCredentials;
@@ -10,9 +15,6 @@ import com.amazonaws.services.s3.model.*;
 import com.aventrix.jnanoid.jnanoid.NanoIdUtils;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import io.lakefs.clients.api.*;
-import io.lakefs.clients.api.model.*;
-import io.lakefs.clients.api.model.ObjectStats.PathTypeEnum;
 import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileAlreadyExistsException;

--- a/docs/integrations/spark.md
+++ b/docs/integrations/spark.md
@@ -369,6 +369,24 @@ df.write.partitionBy("example-column").parquet(s"lakefs://${repo}/${branch}/outp
 
 The data is now created in lakeFS as new changes in your branch. You can now commit these changes or revert them.
 
+## Using the new OutputCommitter
+
+### Configuration
+
+On Hadoop 2, configure:
+
+```xml
+<?xml version="1.0"?>
+<configuration>
+    <property>
+        <name>spark.sql.sources.outputCommitterClass</name>
+        <value>io.lakefs.committer.LakeFSOutputCommitter</value>
+    </property>
+</configuration>
+```
+
+(You can also set a default output committer using mapred.output.committer.class and possibly setting mapred.mapper.new-api=false.)
+
 ## Case Study: SimilarWeb
 
 See how SimilarWeb is using lakeFS with Spark to [manage algorithm changes in data pipelines](https://grdoron.medium.com/a-smarter-way-to-manage-algorithm-changes-in-data-pipelines-with-lakefs-a4e284f8c756).

--- a/docs/integrations/spark.md
+++ b/docs/integrations/spark.md
@@ -382,6 +382,10 @@ On Hadoop 2, configure:
         <name>spark.sql.sources.outputCommitterClass</name>
         <value>io.lakefs.committer.LakeFSOutputCommitter</value>
     </property>
+	<property>
+		<name>spark.sql.parquet.output.committer.class</name>
+		<value>io.lakefs.committer.DummyParquetOutputCommitter</value>
+	</property>
 </configuration>
 ```
 


### PR DESCRIPTION
Includes configuration options.

Tested with Spark 2.4.8 / Hadoop 2.7 by _manually_ running
```shell
SPARK_HOME=$HOME/stuff/spark-2.4.8-bin-hadoop2.7 \
	  spark-shell --jars ./target/hadoop-lakefs-assembly-0.1.0.jar \
	    -c spark.hadoop.mapred.mapper.new-api=false \
	    -c spark.hadoop.spark.sql.sources.outputCommitterClass=io.lakefs.committer.DummyOutputCommitter \
	    -c spark.hadoop.fs.lakefs.impl=io.lakefs.LakeFSFileSystem \
	    -c spark.hadoop.fs.lakefs.endpoint=https://.../api/v1/ \
	    -c spark.hadoop.fs.lakefs.access.key=AKIALFS... \
	    -c spark.hadoop.fs.lakefs.secret.key=shhh \
	    -c spark.hadoop.fs.s3a.access.key=AKIAS3... \
	    -c spark.hadoop.fs.s3a.secret.key=shhhhh
```

and then
```scala
sc.parallelize(1 to 100).toDF.map(_.toString).write.text("lakefs://test-1/main/dummy-oc/out.txt")
```

That doesn't work (because this DummyOutputCommitter can never actually _write_ anything) but it does show relevant debug prints along the way, including the "get working path" backtrace that looks like:
```
Get working path for attempt_20221009091525_0000_m_000010_10 -> lakefs://test-1/attempt_20221009091525_0000_m_000010_10/dummy-oc/out.txt
java.lang.Throwable
        at io.lakefs.committer.DummyOutputCommitter.getWorkPath(DummyOutputCommitter.java:72)
        at org.apache.spark.internal.io.HadoopMapReduceCommitProtocol.newTaskTempFile(HadoopMapReduceCommitProtocol.scala:115)
        at org.apache.spark.sql.execution.datasources.SingleDirectoryDataWriter.newOutputWriter(FileFormatDataWriter.scala:115)
        at org.apache.spark.sql.execution.datasources.SingleDirectoryDataWriter.<init>(FileFormatDataWriter.scala:108)
        at org.apache.spark.sql.execution.datasources.FileFormatWriter$.org$apache$spark$sql$execution$datasources$FileFormatWriter$$executeTask(FileFormatWriter.scala:240)
        at org.apache.spark.sql.execution.datasources.FileFormatWriter$$anonfun$write$1.apply(FileFormatWriter.scala:174)
        at org.apache.spark.sql.execution.datasources.FileFormatWriter$$anonfun$write$1.apply(FileFormatWriter.scala:173)
        at org.apache.spark.scheduler.ResultTask.runTask(ResultTask.scala:90)
        at org.apache.spark.scheduler.Task.run(Task.scala:123)
        at org.apache.spark.executor.Executor$TaskRunner$$anonfun$10.apply(Executor.scala:411)
        at org.apache.spark.util.Utils$.tryWithSafeFinally(Utils.scala:1360)
        at org.apache.spark.executor.Executor$TaskRunner.run(Executor.scala:417)
        at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
        at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
        at java.base/java.lang.Thread.run(Thread.java:829)
```
and means that we got well into the Hadoop writing process.

Fixes #4310.