### PR TITLE
S3 permissions: split into metadata only and data + metadata

### DIFF
--- a/docs/setup/storage/s3.md
+++ b/docs/setup/storage/s3.md
@@ -11,49 +11,100 @@ has_children: false
 # Prepare Your AWS S3 Bucket
 
 1. From the S3 Administration console, choose `Create Bucket`.
-1. Make sure that you:
+2. Make sure that you:
    1. Block public access.
-   1. Disable Object Locking.
-1. lakeFS requires permissions to interact with your bucket. The following is a minimal bucket policy. To add it, go to the `Permissions` tab, and paste it as :
+   2. Disable Object Locking.
 
-   ```json
-   {
-     "Id": "Policy1590051531320",
-     "Version": "2012-10-17",
-     "Statement": [
-       {
-         "Sid": "Stmt1590051522178",
+## Metadata only (minimal permissions)
+
+lakeFS requires permissions to interact with the `_lakefs` namespace under your bucket, in which the metadata
+objects are stored ([learn more](../../understand/versioning-internals.md#constructing-a-consistent-view-of-the-keyspace-ie-a-commit)).  
+The following is a minimal bucket policy. To add it, go to the `Permissions` tab, and paste it as :
+
+```json
+{
+  "Id": "<POLICY_ID>",
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "<STMT_ID>",
+      "Action": [
+         "s3:GetObject",
+         "s3:PutObject",
+         "s3:ListBucket",
+         "s3:GetBucketLocation"
+      ],
+      "Effect": "Allow",
+      "Resource": ["arn:aws:s3:::<STORAGE_NAMESPACE>/_lakefs", "arn:aws:s3:::<STORAGE_NAMESPACE>/_lakefs/*"],
+      "Principal": {
+        "AWS": ["arn:aws:iam::<ACCOUNT_ID>:role/<IAM_ROLE>"]
+      }
+    }
+  ]
+}
+```
+
+Replace `<STORAGE_NAMESPACE>` with your [storage namespace](../../understand/model.md#concepts-unique-to-lakefs) which will be in the form of `<BUCKET_NAME>/<PATH>` (`PATH` can be empty).
+Replace `<ACCOUNT_ID>` and `<IAM_ROLE>` with values relevant to your environment.
+`IAM_ROLE` should be the role assumed by your lakeFS installation.
+
+Alternatively, if you use an AWS user's key-pair to authenticate lakeFS to AWS, change the policy's Principal to be the user:
+
+```json
+ "Principal": {
+   "AWS": ["arn:aws:iam::<ACCOUNT_ID>:user/<IAM_USER>"]
+ }
+```
+
+### Usage
+
+By setting this policy you'll be able to perform only metadata operations through lakeFS, meaning that you'll not be able
+to use lakeFS to upload or download objects.
+This permission is useful if you upload/download objects to/from your bucket using external tools.
+For example, you can use the [lakeFS Hadoop FileSystem Spark integration](../../integrations/spark.md#access-lakefs-using-the-lakefs-specific-hadoop-filesystem) 
+to directly access your S3 bucket while performing metadata operations through lakeFS on the objects in that bucket.
+
+## Data & Metadata (extended permissions)
+
+If you plan to transfer data using lakeFS, you'll need to extend the [minimal permissions](#metadata-only-minimal-permissions)
+with the following policy:
+
+```json
+{
+   "Id": "<POLICY_ID>",
+   "Version": "2012-10-17",
+   "Statement": [
+      {
+         "Sid": "<STMT_ID>",
          "Action": [
             "s3:GetObject",
-            "s3:GetObjectVersion",
             "s3:PutObject",
             "s3:AbortMultipartUpload",
             "s3:ListMultipartUploadParts",
-            "s3:GetBucketVersioning",
             "s3:ListBucket",
             "s3:GetBucketLocation",
-            "s3:ListBucketMultipartUploads",
-            "s3:ListBucketVersions"
+            "s3:ListBucketMultipartUploads"
          ],
          "Effect": "Allow",
-         "Resource": ["arn:aws:s3:::<BUCKET_NAME>", "arn:aws:s3:::<BUCKET_NAME_WITH_PATH_PREFIX>/*"],
+         "Resource": ["arn:aws:s3:::<STORAGE_NAMESPACE>", "arn:aws:s3:::<STORAGE_NAMESPACE>/*"],
          "Principal": {
-           "AWS": ["arn:aws:iam::<ACCOUNT_ID>:role/<IAM_ROLE>"]
+            "AWS": ["arn:aws:iam::<ACCOUNT_ID>:role/<IAM_ROLE>"]
          }
-       }
-     ]
-   }
-   ```
+      }
+   ]
+}
+```
 
-   Replace `<ACCOUNT_ID>`, `<BUCKET_NAME>` and `<IAM_ROLE>` with values relevant to your environment.
-   `IAM_ROLE` should be the role assumed by your lakeFS installation.
+Notice that this time you allow lakeFS to access your storage namespace. This is necessary to upload/download objects to/from
+your underlying bucket namespace.
 
-   Alternatively, if you use an AWS user's key-pair to authenticate lakeFS to AWS, change the policy's Principal to be the user:
+### Usage
 
-   ```json
-    "Principal": {
-      "AWS": ["arn:aws:iam::<ACCOUNT_ID>:user/<IAM_USER>"]
-    }
-   ```
+By setting this bucket policy you'll be able to perform metadata operations as well as to upload/download objects to/from your bucket using lakeFS.
+To upload or download an object to your storage namespace using lakeFS, you can use the [API](../../reference/api.md), the CLI tool
+[`lakectl`](../../reference#lakectl-fs), the [Spark metadata client](../../reference/spark-client.md),
+or the [S3 gateway](../../integrations/spark.md#access-lakefs-using-the-s3a-gateway).
+
+---
 
 You're now ready to [create your first lakeFS repository](../create-repo.md).

--- a/docs/setup/storage/s3.md
+++ b/docs/setup/storage/s3.md
@@ -12,11 +12,11 @@ has_children: false
 
 1. From the S3 Administration console, choose `Create Bucket`.
 2. Make sure that you:
-   1. Block public access.
-   2. Disable Object Locking.
+   1. [Block public access](https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-control-block-public-access.html).
+   2. **Disable** [Object Lock](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock-console.html).
 
-There are two types of S3 bucket permission policies that can be used: the [default](#permission-policy) permission
-policy and the [metadata-only](#metadata-permissions-policy-minimal-permissions) permission policy.
+There are two types of S3 bucket permission policies that can be used: the default [permission
+policy](#permission-policy) and the [metadata-only](#metadata-permissions-policy-minimal-permissions) permission policy.
 Pick the one that best describes your use case and to add it, go to the `Permissions` tab, and paste it.
 
 ## Permission Policy
@@ -77,7 +77,7 @@ Alternatively, if you use an AWS user's key-pair to authenticate lakeFS to AWS, 
 
 ## Metadata Permissions Policy (minimal permissions)
 
-lakeFS requires permissions to interact with the `_lakefs` prefix under your storage namespace, in which the metadata
+lakeFS requires permissions to access the `_lakefs` prefix under your storage namespace, in which the metadata
 objects are stored ([learn more](../../understand/versioning-internals.md#constructing-a-consistent-view-of-the-keyspace-ie-a-commit)).  
 By setting this policy you'll be able to perform only metadata operations through lakeFS, meaning that you'll **not** be able
 to use lakeFS to upload or download objects.

--- a/docs/setup/storage/s3.md
+++ b/docs/setup/storage/s3.md
@@ -15,38 +15,57 @@ has_children: false
    1. Block public access.
    2. Disable Object Locking.
 
-## Metadata only (minimal permissions)
+There are two types of S3 bucket permission policies that can be used: the [default](#permission-policy) permission
+policy and the [metadata-only](#metadata-permissions-policy-minimal-permissions) permission policy.
+Pick the one that best describes your use case and to add it, go to the `Permissions` tab, and paste it.
 
-lakeFS requires permissions to interact with the `_lakefs` namespace under your bucket, in which the metadata
-objects are stored ([learn more](../../understand/versioning-internals.md#constructing-a-consistent-view-of-the-keyspace-ie-a-commit)).  
-The following is a minimal bucket policy. To add it, go to the `Permissions` tab, and paste it as :
+## Permission Policy
+
+By setting this bucket policy you'll be able to perform metadata operations as well as to upload/download objects to/from your bucket using lakeFS.
+To upload or download an object to your storage namespace using lakeFS, you can use the [API](../../reference/api.md), the CLI tool
+[`lakectl`](../../reference#lakectl-fs), the [Spark metadata client](../../reference/spark-client.md),
+or the [S3 gateway](../../integrations/spark.md#access-lakefs-using-the-s3a-gateway).
 
 ```json
 {
-  "Id": "<POLICY_ID>",
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-      "Sid": "<STMT_ID>",
-      "Action": [
-         "s3:GetObject",
-         "s3:PutObject",
-         "s3:ListBucket",
-         "s3:GetBucketLocation"
-      ],
-      "Effect": "Allow",
-      "Resource": ["arn:aws:s3:::<STORAGE_NAMESPACE>/_lakefs", "arn:aws:s3:::<STORAGE_NAMESPACE>/_lakefs/*"],
-      "Principal": {
-        "AWS": ["arn:aws:iam::<ACCOUNT_ID>:role/<IAM_ROLE>"]
+   "Id": "<POLICY_ID>",
+   "Version": "2012-10-17",
+   "Statement": [
+      {
+         "Sid": "<STMT_ID1>",
+         "Action": [
+            "s3:GetObject",
+            "s3:PutObject",
+            "s3:AbortMultipartUpload",
+            "s3:ListMultipartUploadParts"
+         ],
+         "Effect": "Allow",
+         "Resource": ["arn:aws:s3:::<STORAGE_NAMESPACE>/*"],
+         "Principal": {
+            "AWS": ["arn:aws:iam::<ACCOUNT_ID>:role/<IAM_ROLE>"]
+         }
+      },
+      {
+         "Sid": "<STMT_ID2>",
+         "Action": [
+            "s3:ListBucket",
+            "s3:GetBucketLocation",
+            "s3:ListBucketMultipartUploads"
+         ],
+         "Effect": "Allow",
+         "Resource": ["arn:aws:s3:::<BUCKET>"],
+         "Principal": {
+            "AWS": ["arn:aws:iam::<ACCOUNT_ID>:role/<IAM_ROLE>"]
+         }
       }
-    }
-  ]
+   ]
 }
 ```
-
-Replace `<STORAGE_NAMESPACE>` with your [storage namespace](../../understand/model.md#concepts-unique-to-lakefs) which will be in the form of `<BUCKET_NAME>/<PATH>` (`PATH` can be empty).
-Replace `<ACCOUNT_ID>` and `<IAM_ROLE>` with values relevant to your environment.
-`IAM_ROLE` should be the role assumed by your lakeFS installation.
+* Replace `<STORAGE_NAMESPACE>` with your [storage namespace](../../understand/model.md#concepts-unique-to-lakefs) which will be in the form of `<BUCKET_NAME>/<PATH>` (`PATH` can be empty).
+* Replace `<ACCOUNT_ID>` and `<IAM_ROLE>` with values relevant to your environment.
+* Replace `<BUCKET>` with the **bucket** that lakeFS is managing.
+* Replace `<STMT_ID1>`, `<STMT_ID2>` and `<POLICY_ID>` with string IDs of your choice.
+* `IAM_ROLE` should be the role assumed by your lakeFS installation.
 
 Alternatively, if you use an AWS user's key-pair to authenticate lakeFS to AWS, change the policy's Principal to be the user:
 
@@ -56,54 +75,50 @@ Alternatively, if you use an AWS user's key-pair to authenticate lakeFS to AWS, 
  }
 ```
 
-### Usage
+## Metadata Permissions Policy (minimal permissions)
 
-By setting this policy you'll be able to perform only metadata operations through lakeFS, meaning that you'll not be able
+lakeFS requires permissions to interact with the `_lakefs` prefix under your storage namespace, in which the metadata
+objects are stored ([learn more](../../understand/versioning-internals.md#constructing-a-consistent-view-of-the-keyspace-ie-a-commit)).  
+By setting this policy you'll be able to perform only metadata operations through lakeFS, meaning that you'll **not** be able
 to use lakeFS to upload or download objects.
 This permission is useful if you upload/download objects to/from your bucket using external tools.
-For example, you can use the [lakeFS Hadoop FileSystem Spark integration](../../integrations/spark.md#access-lakefs-using-the-lakefs-specific-hadoop-filesystem) 
+For example, you can use the [lakeFS Hadoop FileSystem Spark integration](../../integrations/spark.md#access-lakefs-using-the-lakefs-specific-hadoop-filesystem)
 to directly access your S3 bucket while performing metadata operations through lakeFS on the objects in that bucket.
-
-## Data & Metadata (extended permissions)
-
-If you plan to transfer data using lakeFS, you'll need to extend the [minimal permissions](#metadata-only-minimal-permissions)
-with the following policy:
 
 ```json
 {
-   "Id": "<POLICY_ID>",
-   "Version": "2012-10-17",
-   "Statement": [
-      {
-         "Sid": "<STMT_ID>",
-         "Action": [
-            "s3:GetObject",
-            "s3:PutObject",
-            "s3:AbortMultipartUpload",
-            "s3:ListMultipartUploadParts",
-            "s3:ListBucket",
-            "s3:GetBucketLocation",
-            "s3:ListBucketMultipartUploads"
-         ],
-         "Effect": "Allow",
-         "Resource": ["arn:aws:s3:::<STORAGE_NAMESPACE>", "arn:aws:s3:::<STORAGE_NAMESPACE>/*"],
-         "Principal": {
-            "AWS": ["arn:aws:iam::<ACCOUNT_ID>:role/<IAM_ROLE>"]
-         }
+  "Id": "<POLICY_ID>",
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "<STMT_ID1>",
+      "Action": [
+         "s3:GetObject",
+         "s3:PutObject"
+      ],
+      "Effect": "Allow",
+      "Resource": [
+         "arn:aws:s3:::<STORAGE_NAMESPACE>/_lakefs/*"
+      ],
+      "Principal": {
+        "AWS": ["arn:aws:iam::<ACCOUNT_ID>:role/<IAM_ROLE>"]
       }
-   ]
+    },
+     {
+        "Sid": "<STMT_ID2>",
+        "Action": [
+           "s3:ListBucket",
+           "s3:GetBucketLocation"
+        ],
+        "Effect": "Allow",
+        "Resource": ["arn:aws:s3:::<BUCKET>"],
+        "Principal": {
+           "AWS": ["arn:aws:iam::<ACCOUNT_ID>:role/<IAM_ROLE>"]
+        }
+     }
+  ]
 }
 ```
-
-Notice that this time you allow lakeFS to access your storage namespace. This is necessary to upload/download objects to/from
-your underlying bucket namespace.
-
-### Usage
-
-By setting this bucket policy you'll be able to perform metadata operations as well as to upload/download objects to/from your bucket using lakeFS.
-To upload or download an object to your storage namespace using lakeFS, you can use the [API](../../reference/api.md), the CLI tool
-[`lakectl`](../../reference#lakectl-fs), the [Spark metadata client](../../reference/spark-client.md),
-or the [S3 gateway](../../integrations/spark.md#access-lakefs-using-the-s3a-gateway).
 
 ---
 

--- a/docs/setup/storage/s3.md
+++ b/docs/setup/storage/s3.md
@@ -16,7 +16,7 @@ has_children: false
    2. **Disable** [Object Lock](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock-console.html).
 
 There are two types of S3 bucket permission policies that can be used: the default [permission
-policy](#permission-policy) and the [metadata-only](#metadata-permissions-policy-minimal-permissions) permission policy.
+policy](#permission-policy) and the [metadata-only](#metadata-permissions-policy-advanced) permission policy.
 Pick the one that best describes your use case and to add it, go to the `Permissions` tab, and paste it.
 
 ## Permission Policy
@@ -75,12 +75,21 @@ Alternatively, if you use an AWS user's key-pair to authenticate lakeFS to AWS, 
  }
 ```
 
-## Metadata Permissions Policy (minimal permissions)
+---
+
+You're now ready to [create your first lakeFS repository](../create-repo.md).
+
+---
+
+## Metadata Permissions Policy (advanced)
 
 lakeFS requires permissions to access the `_lakefs` prefix under your storage namespace, in which the metadata
 objects are stored ([learn more](../../understand/versioning-internals.md#constructing-a-consistent-view-of-the-keyspace-ie-a-commit)).  
 By setting this policy you'll be able to perform only metadata operations through lakeFS, meaning that you'll **not** be able
-to use lakeFS to upload or download objects.
+to use lakeFS to upload or download objects. Specifically you won't be able to:
+* Upload objects using the lakeFS GUI
+* Upload objects through Spark using the S3 gateway
+* Run `lakectl fs` commands (unless using the `--direct` flag)
 This permission is useful if you upload/download objects to/from your bucket using external tools.
 For example, you can use the [lakeFS Hadoop FileSystem Spark integration](../../integrations/spark.md#access-lakefs-using-the-lakefs-specific-hadoop-filesystem)
 to directly access your S3 bucket while performing metadata operations through lakeFS on the objects in that bucket.
@@ -119,7 +128,3 @@ to directly access your S3 bucket while performing metadata operations through l
   ]
 }
 ```
-
----
-
-You're now ready to [create your first lakeFS repository](../create-repo.md).

--- a/docs/setup/storage/s3.md
+++ b/docs/setup/storage/s3.md
@@ -32,7 +32,7 @@ or the [S3 gateway](../../integrations/spark.md#access-lakefs-using-the-s3a-gate
    "Version": "2012-10-17",
    "Statement": [
       {
-         "Sid": "<STMT_ID1>",
+         "Sid": "lakeFSObjects",
          "Action": [
             "s3:GetObject",
             "s3:PutObject",
@@ -46,7 +46,7 @@ or the [S3 gateway](../../integrations/spark.md#access-lakefs-using-the-s3a-gate
          }
       },
       {
-         "Sid": "<STMT_ID2>",
+         "Sid": "lakeFSBucket",
          "Action": [
             "s3:ListBucket",
             "s3:GetBucketLocation",
@@ -64,7 +64,7 @@ or the [S3 gateway](../../integrations/spark.md#access-lakefs-using-the-s3a-gate
 * Replace `<STORAGE_NAMESPACE>` with your [storage namespace](../../understand/model.md#concepts-unique-to-lakefs) which will be in the form of `<BUCKET_NAME>/<PATH>` (`PATH` can be empty).
 * Replace `<ACCOUNT_ID>` and `<IAM_ROLE>` with values relevant to your environment.
 * Replace `<BUCKET>` with the **bucket** that lakeFS is managing.
-* Replace `<STMT_ID1>`, `<STMT_ID2>` and `<POLICY_ID>` with string IDs of your choice.
+* Replace `<POLICY_ID>` with a string ID of your choice.
 * `IAM_ROLE` should be the role assumed by your lakeFS installation.
 
 Alternatively, if you use an AWS user's key-pair to authenticate lakeFS to AWS, change the policy's Principal to be the user:
@@ -100,7 +100,7 @@ to directly access your S3 bucket while performing metadata operations through l
   "Version": "2012-10-17",
   "Statement": [
     {
-      "Sid": "<STMT_ID1>",
+      "Sid": "lakeFSObjects",
       "Action": [
          "s3:GetObject",
          "s3:PutObject"
@@ -114,7 +114,7 @@ to directly access your S3 bucket while performing metadata operations through l
       }
     },
      {
-        "Sid": "<STMT_ID2>",
+        "Sid": "lakeFSBucket",
         "Action": [
            "s3:ListBucket",
            "s3:GetBucketLocation"


### PR DESCRIPTION
This PR includes the separation of permissions required for lakeFS to operate in a given environment.
lakeFS doesn't need permissions for accessing the root of the storage namespace if it doesn't handle the actual data, so fewer permissions are required.

## How was this tested?
Manually:
Configured the lakeFS server with the credentials of an unprivileged AWS user (a user without any permitting policy).
1. **Configured a bucket policy for the default permissions.** 
2. Used lakeFS to upload and download files. Then committed.
3. Used lakeFS to upload a file. Not committed.
4. **Configured a bucket policy for the advanced permissions (metadata only).**
5. Tried to upload and download files -> failed.
6. Committed the file from step 3.
7. Created a new branch.
8. Used Spark with lakeFSFS to write to this branch.
9. Committed.
10. Merged the branch to the main branch.

Closes #4304 