### PR TITLE
Correctly prefix "after" params in lakeFS auth service

### DIFF
--- a/pkg/auth/service.go
+++ b/pkg/auth/service.go
@@ -131,13 +131,21 @@ type Service interface {
 
 func (s *KVAuthService) ListKVPaged(ctx context.Context, protoType protoreflect.MessageType, params *model.PaginationParams, prefix []byte, secondary bool) ([]proto.Message, *model.Paginator, error) {
 	var (
-		it  kv.MessageIterator
-		err error
+		it    kv.MessageIterator
+		err   error
+		after []byte
 	)
+	if params.After != "" {
+		after = make([]byte, len(prefix)+len(params.After))
+
+		l := copy(after, prefix)
+		l = copy(after[l:], params.After)
+	}
+
 	if secondary {
-		it, err = kv.NewSecondaryIterator(ctx, s.store.Store, protoType, model.PartitionKey, prefix, []byte(params.After))
+		it, err = kv.NewSecondaryIterator(ctx, s.store.Store, protoType, model.PartitionKey, prefix, after)
 	} else {
-		it, err = kv.NewPrimaryIterator(ctx, s.store.Store, protoType, model.PartitionKey, prefix, kv.IteratorOptionsAfter([]byte(params.After)))
+		it, err = kv.NewPrimaryIterator(ctx, s.store.Store, protoType, model.PartitionKey, prefix, kv.IteratorOptionsAfter(after))
 	}
 	if err != nil {
 		return nil, nil, fmt.Errorf("scan prefix(%s): %w", prefix, err)
@@ -156,7 +164,7 @@ func (s *KVAuthService) ListKVPaged(ctx context.Context, protoType protoreflect.
 		value := entry.Value
 		entries = append(entries, value)
 		if len(entries) == amount {
-			p.NextPageToken = string(entry.Key)
+			p.NextPageToken = strings.TrimPrefix(string(entry.Key), params.Prefix)
 			break
 		}
 	}
@@ -328,7 +336,7 @@ func (s *KVAuthService) GetUserByExternalID(ctx context.Context, externalID stri
 
 func (s *KVAuthService) ListUsers(ctx context.Context, params *model.PaginationParams) ([]*model.User, *model.Paginator, error) {
 	var user model.UserData
-	usersKey := model.UserPath("")
+	usersKey := model.UserPath(params.Prefix)
 
 	msgs, paginator, err := s.ListKVPaged(ctx, (&user).ProtoReflect().Type(), params, usersKey, false)
 	if msgs == nil {
@@ -339,7 +347,7 @@ func (s *KVAuthService) ListUsers(ctx context.Context, params *model.PaginationP
 
 func (s *KVAuthService) ListUserCredentials(ctx context.Context, username string, params *model.PaginationParams) ([]*model.Credential, *model.Paginator, error) {
 	var credential model.CredentialData
-	credentialsKey := model.CredentialPath(username, "")
+	credentialsKey := model.CredentialPath(username, params.Prefix)
 
 	msgs, paginator, err := s.ListKVPaged(ctx, (&credential).ProtoReflect().Type(), params, credentialsKey, false)
 	if msgs == nil {
@@ -390,7 +398,7 @@ func (s *KVAuthService) DetachPolicyFromUser(ctx context.Context, policyDisplayN
 
 func (s *KVAuthService) ListUserPolicies(ctx context.Context, username string, params *model.PaginationParams) ([]*model.Policy, *model.Paginator, error) {
 	var policy model.PolicyData
-	userPolicyKey := model.UserPolicyPath(username, "")
+	userPolicyKey := model.UserPolicyPath(username, params.Prefix)
 
 	msgs, paginator, err := s.ListKVPaged(ctx, (&policy).ProtoReflect().Type(), params, userPolicyKey, true)
 	if msgs == nil {
@@ -507,7 +515,7 @@ func ListEffectivePolicies(ctx context.Context, username string, params *model.P
 
 func (s *KVAuthService) ListGroupPolicies(ctx context.Context, groupDisplayName string, params *model.PaginationParams) ([]*model.Policy, *model.Paginator, error) {
 	var policy model.PolicyData
-	groupPolicyKey := model.GroupPolicyPath(groupDisplayName, "")
+	groupPolicyKey := model.GroupPolicyPath(groupDisplayName, params.Prefix)
 
 	msgs, paginator, err := s.ListKVPaged(ctx, (&policy).ProtoReflect().Type(), params, groupPolicyKey, true)
 	if msgs == nil {
@@ -597,7 +605,7 @@ func (s *KVAuthService) GetGroup(ctx context.Context, groupDisplayName string) (
 
 func (s *KVAuthService) ListGroups(ctx context.Context, params *model.PaginationParams) ([]*model.Group, *model.Paginator, error) {
 	var group model.GroupData
-	groupKey := model.GroupPath("")
+	groupKey := model.GroupPath(params.Prefix)
 
 	msgs, paginator, err := s.ListKVPaged(ctx, (&group).ProtoReflect().Type(), params, groupKey, false)
 	if msgs == nil {
@@ -690,7 +698,7 @@ func (s *KVAuthService) ListGroupUsers(ctx context.Context, groupDisplayName str
 		return nil, nil, err
 	}
 	var policy model.UserData
-	userGroupKey := model.GroupUserPath(groupDisplayName, "")
+	userGroupKey := model.GroupUserPath(groupDisplayName, params.Prefix)
 
 	msgs, paginator, err := s.ListKVPaged(ctx, (&policy).ProtoReflect().Type(), params, userGroupKey, true)
 	if msgs == nil {
@@ -791,7 +799,7 @@ func (s *KVAuthService) DeletePolicy(ctx context.Context, policyDisplayName stri
 
 func (s *KVAuthService) ListPolicies(ctx context.Context, params *model.PaginationParams) ([]*model.Policy, *model.Paginator, error) {
 	var policy model.PolicyData
-	policyKey := model.PolicyPath("")
+	policyKey := model.PolicyPath(params.Prefix)
 
 	msgs, paginator, err := s.ListKVPaged(ctx, (&policy).ProtoReflect().Type(), params, policyKey, false)
 	if msgs == nil {

--- a/pkg/auth/service.go
+++ b/pkg/auth/service.go
@@ -139,7 +139,7 @@ func (s *KVAuthService) ListKVPaged(ctx context.Context, protoType protoreflect.
 		after = make([]byte, len(prefix)+len(params.After))
 
 		l := copy(after, prefix)
-		l = copy(after[l:], params.After)
+		_ = copy(after[l:], params.After)
 	}
 
 	if secondary {

--- a/pkg/auth/service.go
+++ b/pkg/auth/service.go
@@ -141,7 +141,6 @@ func (s *KVAuthService) ListKVPaged(ctx context.Context, protoType protoreflect.
 		l := copy(after, prefix)
 		_ = copy(after[l:], params.After)
 	}
-
 	if secondary {
 		it, err = kv.NewSecondaryIterator(ctx, s.store.Store, protoType, model.PartitionKey, prefix, after)
 	} else {
@@ -164,7 +163,7 @@ func (s *KVAuthService) ListKVPaged(ctx context.Context, protoType protoreflect.
 		value := entry.Value
 		entries = append(entries, value)
 		if len(entries) == amount {
-			p.NextPageToken = strings.TrimPrefix(string(entry.Key), params.Prefix)
+			p.NextPageToken = strings.TrimPrefix(string(entry.Key), string(prefix))
 			break
 		}
 	}

--- a/pkg/auth/service_test.go
+++ b/pkg/auth/service_test.go
@@ -104,7 +104,7 @@ func TestKVAuthService_ListUsers_PagedWithPrefix(t *testing.T) {
 		}
 	}
 
-	sizes := []int{10, 3, 2, 1}
+	sizes := []int{10, 3, 2}
 	prefixes := []string{"b", "ba", "bar", "f", "foo", "foob", "foobar"}
 	for _, size := range sizes {
 		for _, p := range prefixes {

--- a/pkg/auth/service_test.go
+++ b/pkg/auth/service_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -85,6 +86,57 @@ func userWithPolicies(t testing.TB, s auth.Service, policies []*model.Policy) st
 	}
 
 	return userName
+}
+
+func TestKVAuthService_ListUsers_PagedWithPrefix(t *testing.T) {
+	ctx := context.Background()
+	kvStore := kvtest.GetStore(ctx, t)
+	storeMessage := &kv.StoreMessage{Store: kvStore}
+	s := auth.NewKVAuthService(storeMessage, crypt.NewSecretStore(someSecret), nil, authparams.ServiceCache{
+		Enabled: false,
+	}, logging.Default())
+
+	users := []string{"bar", "barn", "baz", "foo", "foobar", "foobaz"}
+	for _, u := range users {
+		user := model.User{Username: u}
+		if _, err := s.CreateUser(ctx, &user); err != nil {
+			t.Fatalf("create user: %s", err)
+		}
+	}
+
+	sizes := []int{10, 3, 2, 1}
+	prefixes := []string{"b", "ba", "bar", "f", "foo", "foob", "foobar"}
+	for _, size := range sizes {
+		for _, p := range prefixes {
+			t.Run(fmt.Sprintf("Size:%d;Prefix:%s", size, p), func(t *testing.T) {
+				// Only count the correct number of entries were
+				// returned; values are tested below.
+				got := 0
+				after := ""
+				for {
+					value, paginator, err := s.ListUsers(ctx, &model.PaginationParams{Amount: size, Prefix: p, After: after})
+					if err != nil {
+						t.Fatal(err)
+					}
+					got += len(value)
+					after = paginator.NextPageToken
+					if after == "" {
+						break
+					}
+				}
+				// Verify got the right number of users
+				count := 0
+				for _, u := range users {
+					if strings.HasPrefix(u, p) {
+						count++
+					}
+				}
+				if got != count {
+					t.Errorf("Got %d users when expecting %d", got, count)
+				}
+			})
+		}
+	}
 }
 
 func TestKVAuthService_ListPaged(t *testing.T) {


### PR DESCRIPTION
Contains tests _only_ for users-by-prefix.  Might be useful to test for everything-by-prefix, each call is subtly different.