### PR TITLE
Fix: Auth update policy

### DIFF
--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -712,7 +712,7 @@ func (c *Controller) CreatePolicy(w http.ResponseWriter, r *http.Request, body C
 		Statement:   stmts,
 	}
 
-	err := c.Auth.WritePolicy(ctx, p)
+	err := c.Auth.WritePolicy(ctx, p, false)
 	if c.handleAPIError(ctx, w, err) {
 		return
 	}
@@ -792,7 +792,7 @@ func (c *Controller) UpdatePolicy(w http.ResponseWriter, r *http.Request, body U
 		DisplayName: policyID,
 		Statement:   stmts,
 	}
-	err := c.Auth.WritePolicy(ctx, p)
+	err := c.Auth.WritePolicy(ctx, p, true)
 	if c.handleAPIError(ctx, w, err) {
 		return
 	}

--- a/pkg/auth/setup.go
+++ b/pkg/auth/setup.go
@@ -29,7 +29,7 @@ func createGroups(ctx context.Context, authService Service, groups []*model.Grou
 
 func createPolicies(ctx context.Context, authService Service, policies []*model.Policy) error {
 	for _, policy := range policies {
-		err := authService.WritePolicy(ctx, policy)
+		err := authService.WritePolicy(ctx, policy, false)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Closes #4354

The current fix: https://github.com/treeverse/lakeFS/pull/4321 introduces a new problem where writing a new policy with an already existing policy ID will override the existing policy without warning.
Suggested solution is to differentiate between update and create flows