### PR TITLE
Update and create policy use the user's provided ID

### DIFF
--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -775,6 +775,12 @@ func (c *Controller) UpdatePolicy(w http.ResponseWriter, r *http.Request, body U
 	}) {
 		return
 	}
+	// verify requested policy match the policy document id
+	if policyID != body.Id {
+		writeError(w, http.StatusBadRequest, "can't update policy id")
+		return
+	}
+
 	ctx := r.Context()
 	c.LogAction(ctx, "update_policy", r, "", "", "")
 

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -2528,3 +2528,94 @@ func TestController_ExpandTemplate(t *testing.T) {
 		}
 	})
 }
+
+func TestController_UpdatePolicy(t *testing.T) {
+	clt, _ := setupClientWithAdmin(t)
+	ctx := context.Background()
+
+	// test policy
+	now := api.Int64Ptr(time.Now().Unix())
+	const existingPolicyID = "TestUpdatePolicy"
+	response, err := clt.CreatePolicyWithResponse(ctx, api.CreatePolicyJSONRequestBody{
+		CreationDate: now,
+		Id:           existingPolicyID,
+		Statement: []api.Statement{
+			{
+				Action: []string{
+					"fs:Read*",
+					"fs:List*",
+				},
+				Effect:   "deny",
+				Resource: "*",
+			},
+		},
+	})
+	testutil.Must(t, err)
+	if response.JSON201 == nil {
+		t.Fatal("Failed to create test policy", response.Status())
+	}
+
+	t.Run("unknown", func(t *testing.T) {
+		t.Skip("until we fix create/update policy")
+		const policyID = "UnknownPolicy"
+		updatePolicyResponse, err := clt.UpdatePolicyWithResponse(ctx, policyID, api.UpdatePolicyJSONRequestBody{
+			CreationDate: now,
+			Id:           policyID,
+			Statement: []api.Statement{
+				{
+					Action: []string{
+						"fs:Read*",
+						"fs:List*",
+					},
+					Effect:   "allow",
+					Resource: "*",
+				},
+			},
+		})
+		testutil.Must(t, err)
+		if updatePolicyResponse.JSON404 == nil {
+			t.Errorf("Update unknown policy should fail with 404: %s", updatePolicyResponse.Status())
+		}
+	})
+
+	t.Run("change_effect", func(t *testing.T) {
+		updatePolicyResponse, err := clt.UpdatePolicyWithResponse(ctx, existingPolicyID, api.UpdatePolicyJSONRequestBody{
+			CreationDate: now,
+			Id:           existingPolicyID,
+			Statement: []api.Statement{
+				{
+					Action: []string{
+						"fs:Read*",
+						"fs:List*",
+					},
+					Effect:   "allow",
+					Resource: "*",
+				},
+			},
+		})
+		testutil.Must(t, err)
+		if updatePolicyResponse.JSON200 == nil {
+			t.Errorf("Update policy failed: %s", updatePolicyResponse.Status())
+		}
+	})
+
+	t.Run("change_policy_id", func(t *testing.T) {
+		updatePolicyResponse, err := clt.UpdatePolicyWithResponse(ctx, "SomethingElse", api.UpdatePolicyJSONRequestBody{
+			CreationDate: now,
+			Id:           existingPolicyID,
+			Statement: []api.Statement{
+				{
+					Action: []string{
+						"fs:Read*",
+					},
+					Effect:   "allow",
+					Resource: "*",
+				},
+			},
+		})
+		testutil.Must(t, err)
+		if updatePolicyResponse.JSON400 == nil {
+			t.Errorf("Update policy with different id should fail with 400: %s", updatePolicyResponse.Status())
+		}
+	})
+}

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -2556,7 +2556,6 @@ func TestController_UpdatePolicy(t *testing.T) {
 	}
 
 	t.Run("unknown", func(t *testing.T) {
-		t.Skip("until we fix create/update policy")
 		const policyID = "UnknownPolicy"
 		updatePolicyResponse, err := clt.UpdatePolicyWithResponse(ctx, policyID, api.UpdatePolicyJSONRequestBody{
 			CreationDate: now,

--- a/webui/src/lib/api/index.js
+++ b/webui/src/lib/api/index.js
@@ -309,7 +309,8 @@ class Auth {
     }
 
     async createPolicy(policyId, policyDocument) {
-        const policy = {id: policyId, ...JSON.parse(policyDocument)};
+        // keep id after policy document to override the id the user entered
+        const policy = {...JSON.parse(policyDocument), id: policyId};
         const response = await apiRequest(`/auth/policies`, {
             method: 'POST',
             body: JSON.stringify(policy)
@@ -321,7 +322,7 @@ class Auth {
     }
 
     async editPolicy(policyId, policyDocument) {
-        const policy = {id: policyId, ...JSON.parse(policyDocument)};
+        const policy = {...JSON.parse(policyDocument), id: policyId};
         const response = await apiRequest(`/auth/policies/${encodeURIComponent(policyId)}`, {
             method: 'PUT',
             body: JSON.stringify(policy)


### PR DESCRIPTION
- update policy api can return not found
- update policy api should match id with policy's id

Fix #4358