### PR TITLE
Exclude non-existing objects from absolute addresses list

### DIFF
--- a/clients/spark/core/src/main/scala/io/treeverse/clients/ConfigMapper.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/ConfigMapper.scala
@@ -1,0 +1,15 @@
+package io.treeverse.clients
+
+import org.apache.hadoop.conf.Configuration
+import org.apache.spark.broadcast.Broadcast
+
+/** Maps a broadcast object including hadoop configuration values into hadoop configuration.
+ *  @param hcValues
+ */
+class ConfigMapper(val hcValues: Broadcast[Array[(String, String)]]) extends Serializable {
+  @transient lazy val configuration = {
+    val conf = new Configuration()
+    hcValues.value.foreach({ case (k, v) => conf.set(k, v) })
+    conf
+  }
+}

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
@@ -5,7 +5,6 @@ import io.lakefs.clients.api.model.GarbageCollectionPrepareResponse
 import io.treeverse.clients.LakeFSContext._
 import org.apache.hadoop.conf.Configuration
 import org.apache.hadoop.fs._
-import org.apache.spark.broadcast.Broadcast
 import org.apache.spark.sql._
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types.{StringType, StructField, StructType}

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
@@ -19,14 +19,6 @@ import java.time.format.DateTimeFormatter
 import java.time.{LocalDateTime, ZoneOffset}
 import java.util.UUID
 
-class ConfigMapper(val hcValues: Broadcast[Array[(String, String)]]) extends Serializable {
-  @transient lazy val configuration = {
-    val conf = new Configuration()
-    hcValues.value.foreach({ case (k, v) => conf.set(k, v) })
-    conf
-  }
-}
-
 trait RangeGetter extends Serializable {
 
   /** @return all rangeIDs in metarange of commitID on repo.


### PR DESCRIPTION
Fixes #4366

### How was this tested 

- Tested manually in aws and azure on databricks: 1. created an addresses file that includes paths to non-existing objects 2. run backup and restore utility. 