### PR TITLE
Change using lakeFS to Data Lifecycle Management #4368

### DIFF
--- a/docs/data_lifecycle_management/ci.md
+++ b/docs/data_lifecycle_management/ci.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: During Deployment
-parent: Using lakeFS
+parent: Data Lifecycle Management
 description: lakeFS enables to continuously test newly ingested data to ensure data quality requirements are met
 nav_order: 35
 ---

--- a/docs/data_lifecycle_management/data-devenv.md
+++ b/docs/data_lifecycle_management/data-devenv.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: In Test
-parent: Using lakeFS
+parent: Data Lifecycle Management
 description: lakeFS enables a safe test environment on your data lake without the need to copy or mock data
 nav_order: 25
 ---

--- a/docs/data_lifecycle_management/index.md
+++ b/docs/data_lifecycle_management/index.md
@@ -1,0 +1,10 @@
+---
+layout: default
+title: Data Lifecycle Management
+description: Learn how lakeFS enables data lifecycle managment.
+nav_order: 25
+has_children: true
+redirect_from:
+    - ../branching/recommendations.html
+    - ../using_lakefs.html
+---

--- a/docs/data_lifecycle_management/production.md
+++ b/docs/data_lifecycle_management/production.md
@@ -1,7 +1,7 @@
 ---
 layout: default
 title: In Production
-parent: Using lakeFS
+parent: Data Lifecycle Management
 description: lakeFS helps recover from errors and find root case in production.
 nav_order: 55
 ---

--- a/docs/using_lakefs/index.md
+++ b/docs/using_lakefs/index.md
@@ -1,9 +1,0 @@
----
-layout: default
-title: Using lakeFS
-description: Explore example of how other companies are using lakeFS for safe experimentation and CI/CD for data.
-nav_order: 25
-has_children: true
-redirect_from:
-    - ../branching/recommendations.html
----


### PR DESCRIPTION
Renamed using lakefs to data lifecycle management, including referencing link to make sure not to break any existing link. using_lakefs now directs to this section



Change using lakeFS to Data Lifecycle Management #4368