### PR TITLE
Esti system test run without using script

### DIFF
--- a/.github/actions/bootstrap-test-lakefs/action.yaml
+++ b/.github/actions/bootstrap-test-lakefs/action.yaml
@@ -16,7 +16,7 @@ runs:
   using: "composite"
   steps:
     - name: Retrieve generated code
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: generated-code
         path: /tmp/

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,6 +31,8 @@ jobs:
         run: make checks-validator
         env:
           GOLANGCI_LINT_FLAGS: --out-format github-actions
+      - name: gitLeaks
+        uses: zricethezav/gitleaks-action@v1.5.0
 
   test-go:
     name: Run Go tests

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -32,7 +32,7 @@ jobs:
         env:
           GOLANGCI_LINT_FLAGS: --out-format github-actions
       - name: gitLeaks
-        uses: zricethezav/gitleaks-action@v1.5.0
+        uses: gitleaks/gitleaks-action@v2
 
   test-go:
     name: Run Go tests

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,8 +31,6 @@ jobs:
         run: make checks-validator
         env:
           GOLANGCI_LINT_FLAGS: --out-format github-actions
-      - name: gitLeaks
-        uses: gitleaks/gitleaks-action@v2
 
   test-go:
     name: Run Go tests

--- a/esti/lakectl_util_test.go
+++ b/esti/lakectl_util_test.go
@@ -6,19 +6,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// Utilities tests
-func TestRunShellCommand(t *testing.T) {
-	checkTerminal := "if [ -t 1 ] ; then echo -n terminal; else echo -n pipe; fi"
-
-	output, err := runShellCommand(t, checkTerminal, true)
-	require.NoError(t, err, "Failed to run shell command in terminal context")
-	require.Equal(t, "terminal", string(output), "terminal was not detected properly")
-
-	output, err = runShellCommand(t, checkTerminal, false)
-	require.NoError(t, err, "Failed to run shell command out of terminal context")
-	require.Equal(t, "pipe", string(output), "pipe was not detected properly")
-}
-
 func TestExpandVariables(t *testing.T) {
 	type test struct {
 		// In is the input string to expand.

--- a/esti/lakectl_util_test.go
+++ b/esti/lakectl_util_test.go
@@ -10,11 +10,11 @@ import (
 func TestRunShellCommand(t *testing.T) {
 	checkTerminal := "if [ -t 1 ] ; then echo -n terminal; else echo -n pipe; fi"
 
-	output, err := runShellCommand(checkTerminal, true)
+	output, err := runShellCommand(t, checkTerminal, true)
 	require.NoError(t, err, "Failed to run shell command in terminal context")
 	require.Equal(t, "terminal", string(output), "terminal was not detected properly")
 
-	output, err = runShellCommand(checkTerminal, false)
+	output, err = runShellCommand(t, checkTerminal, false)
 	require.NoError(t, err, "Failed to run shell command out of terminal context")
 	require.Equal(t, "pipe", string(output), "pipe was not detected properly")
 }


### PR DESCRIPTION
Replace the use if `script` to capture the terminal output with the lakectl terminal output environment variable.