### PR TITLE
Propagate Esti failure from runner.sh

### DIFF
--- a/esti/scripts/runner.sh
+++ b/esti/scripts/runner.sh
@@ -62,6 +62,7 @@ run_all() {
 
   run_tests "$@"
   RUN_RESULT=$?
+  return $RUN_RESULT		# restore failure (the previous line succeeds in sh)
 }
 
 # Get the options


### PR DESCRIPTION
Fix a sh weirdness: when we save the Esti exit status partway through, that
saving zeroes `$?` and now the script thinks that it succeeded.

Tested by seeing that `make system-tests` now fails when a test fails.

Fixes #4443.