### PR TITLE
Fix spark workflow to use setup-scala v13

### DIFF
--- a/.github/workflows/spark.yaml
+++ b/.github/workflows/spark.yaml
@@ -13,8 +13,10 @@ jobs:
     steps:
       - name: Check-out code
         uses: actions/checkout@v3
+
       - name: Setup Scala
-        uses: olafurpg/setup-scala@v10
+        uses: olafurpg/setup-scala@v13
+
       - name: run tests, validate and package
         working-directory: clients/spark
         run: sbt test scalafmtCheck "scalafix --check" package


### PR DESCRIPTION
Try to resolve the following GitHub workflow warning:

```
[Unit test Spark metadata client](https://github.com/treeverse/lakeFS/actions/runs/3316170109/jobs/5477646274)
Node.js 12 actions are deprecated. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/. Please update the following actions to use Node.js 16: olafurpg/setup-scala
```