### PR TITLE
Fix: remove unused diff_type from diffRefs operation

### DIFF
--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -2563,10 +2563,6 @@ paths:
         name: type
         schema:
           type: string
-      - in: query
-        name: diff_type
-        schema:
-          type: string
           enum: [two_dot, three_dot]
           default: three_dot
 

--- a/clients/java/api/openapi.yaml
+++ b/clients/java/api/openapi.yaml
@@ -2792,13 +2792,6 @@ paths:
         name: type
         required: false
         schema:
-          type: string
-        style: form
-      - explode: true
-        in: query
-        name: diff_type
-        required: false
-        schema:
           default: three_dot
           enum:
           - two_dot

--- a/clients/java/docs/RefsApi.md
+++ b/clients/java/docs/RefsApi.md
@@ -13,7 +13,7 @@ Method | HTTP request | Description
 
 <a name="diffRefs"></a>
 # **diffRefs**
-> DiffList diffRefs(repository, leftRef, rightRef, after, amount, prefix, delimiter, type, diffType)
+> DiffList diffRefs(repository, leftRef, rightRef, after, amount, prefix, delimiter, type)
 
 diff references
 
@@ -61,10 +61,9 @@ public class Example {
     Integer amount = 100; // Integer | how many items to return
     String prefix = "prefix_example"; // String | return items prefixed with this value
     String delimiter = "delimiter_example"; // String | delimiter used to group common prefixes by
-    String type = "type_example"; // String | 
-    String diffType = "two_dot"; // String | 
+    String type = "two_dot"; // String | 
     try {
-      DiffList result = apiInstance.diffRefs(repository, leftRef, rightRef, after, amount, prefix, delimiter, type, diffType);
+      DiffList result = apiInstance.diffRefs(repository, leftRef, rightRef, after, amount, prefix, delimiter, type);
       System.out.println(result);
     } catch (ApiException e) {
       System.err.println("Exception when calling RefsApi#diffRefs");
@@ -88,8 +87,7 @@ Name | Type | Description  | Notes
  **amount** | **Integer**| how many items to return | [optional] [default to 100]
  **prefix** | **String**| return items prefixed with this value | [optional]
  **delimiter** | **String**| delimiter used to group common prefixes by | [optional]
- **type** | **String**|  | [optional]
- **diffType** | **String**|  | [optional] [default to three_dot] [enum: two_dot, three_dot]
+ **type** | **String**|  | [optional] [default to three_dot] [enum: two_dot, three_dot]
 
 ### Return type
 

--- a/clients/java/src/main/java/io/lakefs/clients/api/RefsApi.java
+++ b/clients/java/src/main/java/io/lakefs/clients/api/RefsApi.java
@@ -68,8 +68,7 @@ public class RefsApi {
      * @param amount how many items to return (optional, default to 100)
      * @param prefix return items prefixed with this value (optional)
      * @param delimiter delimiter used to group common prefixes by (optional)
-     * @param type  (optional)
-     * @param diffType  (optional, default to three_dot)
+     * @param type  (optional, default to three_dot)
      * @param _callback Callback for upload/download progress
      * @return Call to execute
      * @throws ApiException If fail to serialize the request body object
@@ -82,7 +81,7 @@ public class RefsApi {
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call diffRefsCall(String repository, String leftRef, String rightRef, String after, Integer amount, String prefix, String delimiter, String type, String diffType, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call diffRefsCall(String repository, String leftRef, String rightRef, String after, Integer amount, String prefix, String delimiter, String type, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -117,10 +116,6 @@ public class RefsApi {
             localVarQueryParams.addAll(localVarApiClient.parameterToPair("type", type));
         }
 
-        if (diffType != null) {
-            localVarQueryParams.addAll(localVarApiClient.parameterToPair("diff_type", diffType));
-        }
-
         final String[] localVarAccepts = {
             "application/json"
         };
@@ -140,7 +135,7 @@ public class RefsApi {
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call diffRefsValidateBeforeCall(String repository, String leftRef, String rightRef, String after, Integer amount, String prefix, String delimiter, String type, String diffType, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call diffRefsValidateBeforeCall(String repository, String leftRef, String rightRef, String after, Integer amount, String prefix, String delimiter, String type, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'repository' is set
         if (repository == null) {
@@ -158,7 +153,7 @@ public class RefsApi {
         }
         
 
-        okhttp3.Call localVarCall = diffRefsCall(repository, leftRef, rightRef, after, amount, prefix, delimiter, type, diffType, _callback);
+        okhttp3.Call localVarCall = diffRefsCall(repository, leftRef, rightRef, after, amount, prefix, delimiter, type, _callback);
         return localVarCall;
 
     }
@@ -173,8 +168,7 @@ public class RefsApi {
      * @param amount how many items to return (optional, default to 100)
      * @param prefix return items prefixed with this value (optional)
      * @param delimiter delimiter used to group common prefixes by (optional)
-     * @param type  (optional)
-     * @param diffType  (optional, default to three_dot)
+     * @param type  (optional, default to three_dot)
      * @return DiffList
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -186,8 +180,8 @@ public class RefsApi {
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
      */
-    public DiffList diffRefs(String repository, String leftRef, String rightRef, String after, Integer amount, String prefix, String delimiter, String type, String diffType) throws ApiException {
-        ApiResponse<DiffList> localVarResp = diffRefsWithHttpInfo(repository, leftRef, rightRef, after, amount, prefix, delimiter, type, diffType);
+    public DiffList diffRefs(String repository, String leftRef, String rightRef, String after, Integer amount, String prefix, String delimiter, String type) throws ApiException {
+        ApiResponse<DiffList> localVarResp = diffRefsWithHttpInfo(repository, leftRef, rightRef, after, amount, prefix, delimiter, type);
         return localVarResp.getData();
     }
 
@@ -201,8 +195,7 @@ public class RefsApi {
      * @param amount how many items to return (optional, default to 100)
      * @param prefix return items prefixed with this value (optional)
      * @param delimiter delimiter used to group common prefixes by (optional)
-     * @param type  (optional)
-     * @param diffType  (optional, default to three_dot)
+     * @param type  (optional, default to three_dot)
      * @return ApiResponse&lt;DiffList&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
@@ -214,8 +207,8 @@ public class RefsApi {
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<DiffList> diffRefsWithHttpInfo(String repository, String leftRef, String rightRef, String after, Integer amount, String prefix, String delimiter, String type, String diffType) throws ApiException {
-        okhttp3.Call localVarCall = diffRefsValidateBeforeCall(repository, leftRef, rightRef, after, amount, prefix, delimiter, type, diffType, null);
+    public ApiResponse<DiffList> diffRefsWithHttpInfo(String repository, String leftRef, String rightRef, String after, Integer amount, String prefix, String delimiter, String type) throws ApiException {
+        okhttp3.Call localVarCall = diffRefsValidateBeforeCall(repository, leftRef, rightRef, after, amount, prefix, delimiter, type, null);
         Type localVarReturnType = new TypeToken<DiffList>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
@@ -230,8 +223,7 @@ public class RefsApi {
      * @param amount how many items to return (optional, default to 100)
      * @param prefix return items prefixed with this value (optional)
      * @param delimiter delimiter used to group common prefixes by (optional)
-     * @param type  (optional)
-     * @param diffType  (optional, default to three_dot)
+     * @param type  (optional, default to three_dot)
      * @param _callback The callback to be executed when the API call finishes
      * @return The request call
      * @throws ApiException If fail to process the API call, e.g. serializing the request body object
@@ -244,9 +236,9 @@ public class RefsApi {
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call diffRefsAsync(String repository, String leftRef, String rightRef, String after, Integer amount, String prefix, String delimiter, String type, String diffType, final ApiCallback<DiffList> _callback) throws ApiException {
+    public okhttp3.Call diffRefsAsync(String repository, String leftRef, String rightRef, String after, Integer amount, String prefix, String delimiter, String type, final ApiCallback<DiffList> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = diffRefsValidateBeforeCall(repository, leftRef, rightRef, after, amount, prefix, delimiter, type, diffType, _callback);
+        okhttp3.Call localVarCall = diffRefsValidateBeforeCall(repository, leftRef, rightRef, after, amount, prefix, delimiter, type, _callback);
         Type localVarReturnType = new TypeToken<DiffList>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;

--- a/clients/java/src/test/java/io/lakefs/clients/api/RefsApiTest.java
+++ b/clients/java/src/test/java/io/lakefs/clients/api/RefsApiTest.java
@@ -55,8 +55,7 @@ public class RefsApiTest {
         String prefix = null;
         String delimiter = null;
         String type = null;
-        String diffType = null;
-                DiffList response = api.diffRefs(repository, leftRef, rightRef, after, amount, prefix, delimiter, type, diffType);
+                DiffList response = api.diffRefs(repository, leftRef, rightRef, after, amount, prefix, delimiter, type);
         // TODO: test validations
     }
     

--- a/clients/python/docs/RefsApi.md
+++ b/clients/python/docs/RefsApi.md
@@ -75,8 +75,7 @@ with lakefs_client.ApiClient(configuration) as api_client:
     amount = 100 # int | how many items to return (optional) if omitted the server will use the default value of 100
     prefix = "prefix_example" # str | return items prefixed with this value (optional)
     delimiter = "delimiter_example" # str | delimiter used to group common prefixes by (optional)
-    type = "type_example" # str |  (optional)
-    diff_type = "three_dot" # str |  (optional) if omitted the server will use the default value of "three_dot"
+    type = "three_dot" # str |  (optional) if omitted the server will use the default value of "three_dot"
 
     # example passing only required values which don't have defaults set
     try:
@@ -90,7 +89,7 @@ with lakefs_client.ApiClient(configuration) as api_client:
     # and optional values
     try:
         # diff references
-        api_response = api_instance.diff_refs(repository, left_ref, right_ref, after=after, amount=amount, prefix=prefix, delimiter=delimiter, type=type, diff_type=diff_type)
+        api_response = api_instance.diff_refs(repository, left_ref, right_ref, after=after, amount=amount, prefix=prefix, delimiter=delimiter, type=type)
         pprint(api_response)
     except lakefs_client.ApiException as e:
         print("Exception when calling RefsApi->diff_refs: %s\n" % e)
@@ -108,8 +107,7 @@ Name | Type | Description  | Notes
  **amount** | **int**| how many items to return | [optional] if omitted the server will use the default value of 100
  **prefix** | **str**| return items prefixed with this value | [optional]
  **delimiter** | **str**| delimiter used to group common prefixes by | [optional]
- **type** | **str**|  | [optional]
- **diff_type** | **str**|  | [optional] if omitted the server will use the default value of "three_dot"
+ **type** | **str**|  | [optional] if omitted the server will use the default value of "three_dot"
 
 ### Return type
 

--- a/clients/python/lakefs_client/api/refs_api.py
+++ b/clients/python/lakefs_client/api/refs_api.py
@@ -65,7 +65,6 @@ class RefsApi(object):
                     'prefix',
                     'delimiter',
                     'type',
-                    'diff_type',
                 ],
                 'required': [
                     'repository',
@@ -75,7 +74,7 @@ class RefsApi(object):
                 'nullable': [
                 ],
                 'enum': [
-                    'diff_type',
+                    'type',
                 ],
                 'validation': [
                     'amount',
@@ -90,7 +89,7 @@ class RefsApi(object):
                     },
                 },
                 'allowed_values': {
-                    ('diff_type',): {
+                    ('type',): {
 
                         "TWO_DOT": "two_dot",
                         "THREE_DOT": "three_dot"
@@ -113,8 +112,6 @@ class RefsApi(object):
                         (str,),
                     'type':
                         (str,),
-                    'diff_type':
-                        (str,),
                 },
                 'attribute_map': {
                     'repository': 'repository',
@@ -125,7 +122,6 @@ class RefsApi(object):
                     'prefix': 'prefix',
                     'delimiter': 'delimiter',
                     'type': 'type',
-                    'diff_type': 'diff_type',
                 },
                 'location_map': {
                     'repository': 'path',
@@ -136,7 +132,6 @@ class RefsApi(object):
                     'prefix': 'query',
                     'delimiter': 'query',
                     'type': 'query',
-                    'diff_type': 'query',
                 },
                 'collection_format_map': {
                 }
@@ -455,8 +450,7 @@ class RefsApi(object):
             amount (int): how many items to return. [optional] if omitted the server will use the default value of 100
             prefix (str): return items prefixed with this value. [optional]
             delimiter (str): delimiter used to group common prefixes by. [optional]
-            type (str): [optional]
-            diff_type (str): [optional] if omitted the server will use the default value of "three_dot"
+            type (str): [optional] if omitted the server will use the default value of "three_dot"
             _return_http_data_only (bool): response data without head status
                 code and headers. Default is True.
             _preload_content (bool): if False, the urllib3.HTTPResponse object

--- a/docs/assets/js/swagger.yml
+++ b/docs/assets/js/swagger.yml
@@ -1532,6 +1532,8 @@ paths:
           $ref: "#/components/responses/ValidationError"
         401:
           $ref: "#/components/responses/Unauthorized"
+        404:
+          $ref: "#/components/responses/NotFound"
         default:
           $ref: "#/components/responses/ServerError"
     delete:
@@ -2559,10 +2561,6 @@ paths:
       - $ref: "#/components/parameters/PaginationDelimiter"
       - in: query
         name: type
-        schema:
-          type: string
-      - in: query
-        name: diff_type
         schema:
           type: string
           enum: [two_dot, three_dot]


### PR DESCRIPTION
The current code uses 'type' to control which diff type we like to perform.

Fix #4461