### PR TITLE
Fix deprecated use of io/ioutil package

### DIFF
--- a/cmd/lakectl/cmd/dbt.go
+++ b/cmd/lakectl/cmd/dbt.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -188,7 +187,7 @@ generate_schema_name.sql
 {%- endmacro %}
 `
 		//nolint:gosec
-		err := ioutil.WriteFile(macroPath, []byte(generateSchemaData), 0o644) //nolint: gomnd
+		err := os.WriteFile(macroPath, []byte(generateSchemaData), 0o644) //nolint: gomnd
 		if err != nil {
 			DieErr(err)
 		}

--- a/cmd/lakectl/cmd/dbt_util.go
+++ b/cmd/lakectl/cmd/dbt_util.go
@@ -5,7 +5,6 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"path"
@@ -28,7 +27,7 @@ var errSchemaExtraction = fmt.Errorf("failed extracting schema from dbt debug me
 
 func ValidateGenerateSchemaMacro(projectRoot, macrosDirName, generateSchemaFileName, schemaIdentifier string) error {
 	p := path.Join(projectRoot, macrosDirName, generateSchemaFileName)
-	data, err := ioutil.ReadFile(p)
+	data, err := os.ReadFile(p)
 	if err != nil {
 		return err
 	}

--- a/cmd/lakectl/cmd/dbt_util_test.go
+++ b/cmd/lakectl/cmd/dbt_util_test.go
@@ -143,8 +143,8 @@ func TestDbtLsToJson(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
 			dbtResources, err := cmd.DBTLsToJSON(tt.Args.ProjectRoot, tt.Args.ResourceType, tt.Args.SelectValues, tt.Args.Executor.ExecuteCommand)
-			if (err != nil) && !errors.As(err, &tt.ErrType) {
-				t.Errorf("DBTLsToJSON() error = %v, expected ErrType: %v", err, tt.ErrType)
+			if err != nil && reflect.TypeOf(err) != reflect.TypeOf(tt.ErrType) {
+				t.Errorf("DBTLsToJSON() error type=%T, expected type=%T", err, tt.ErrType)
 				return
 			}
 			if !reflect.DeepEqual(dbtResources, tt.DbtResources) {

--- a/esti/lakectl_util.go
+++ b/esti/lakectl_util.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"os/exec"
 	"regexp"
@@ -151,7 +150,7 @@ func runCmdAndVerifyWithFile(t *testing.T, cmd, goldenFile string, expectFail, i
 	if *update {
 		updateGoldenFile(t, cmd, isTerminal, goldenFile, vars)
 	} else {
-		content, err := ioutil.ReadFile(goldenFile)
+		content, err := os.ReadFile(goldenFile)
 		if err != nil {
 			t.Fatal("Failed to read ", goldenFile, err)
 		}
@@ -166,7 +165,7 @@ func updateGoldenFile(t *testing.T, cmd string, isTerminal bool, goldenFile stri
 	s := sanitize(string(result), vars)
 	s, err := embedVariables(s, vars)
 	require.NoError(t, err, "Variable embed failed - %s", err)
-	err = ioutil.WriteFile(goldenFile, []byte(s), 0o600) //nolint: gomnd
+	err = os.WriteFile(goldenFile, []byte(s), 0o600) //nolint: gomnd
 	require.NoError(t, err, "Failed to write file %s", goldenFile)
 }
 

--- a/pkg/graveler/settings/manager_test.go
+++ b/pkg/graveler/settings/manager_test.go
@@ -214,14 +214,14 @@ func TestEmpty(t *testing.T) {
 	}
 	// when using Update on an unset key, the update function gets an empty setting object to operate on
 	err = m.Update(ctx, repository, "settingKey", emptySettings, func(setting proto.Message) (proto.Message, error) {
-		newSettings := *setting.(*settings.ExampleSettings)
+		newSettings := proto.Clone(setting).(*settings.ExampleSettings)
 
 		if newSettings.ExampleMap == nil {
 			newSettings.ExampleMap = make(map[string]int32)
 		}
 		newSettings.ExampleInt++
 		newSettings.ExampleMap["boo"]++
-		return &newSettings, nil
+		return newSettings, nil
 	})
 	testutil.Must(t, err)
 	gotSettings, err := m.Get(ctx, repository, "settingKey", emptySettings)

--- a/pkg/ident/ident.go
+++ b/pkg/ident/ident.go
@@ -47,6 +47,7 @@ const (
 )
 
 // linter is angry because h can be an io.Writer, but we explicitly want a Hash here.
+//
 //nolint:interfacer
 func marshalType(h hash.Hash, addressType AddressType) {
 	_, _ = h.Write([]byte{byte(addressType)})

--- a/pkg/logging/logger_test.go
+++ b/pkg/logging/logger_test.go
@@ -2,7 +2,6 @@ package logging
 
 import (
 	"io"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -41,7 +40,7 @@ func TestSetOutputs(t *testing.T) {
 			t.Fatal("Failed to write to log output with two outputs", err)
 		}
 
-		log1Content, err := ioutil.ReadFile(log1)
+		log1Content, err := os.ReadFile(log1)
 		if err != nil {
 			t.Fatal("Failed to read log1 content", err)
 		}
@@ -49,7 +48,7 @@ func TestSetOutputs(t *testing.T) {
 			t.Fatalf("Log1 content '%s', is not as expected: '%s'", string(log1Content), content)
 		}
 
-		log2Content, err := ioutil.ReadFile(log2)
+		log2Content, err := os.ReadFile(log2)
 		if err != nil {
 			t.Fatal("Failed to read log1 content", err)
 		}

--- a/templates/content.go
+++ b/templates/content.go
@@ -3,5 +3,6 @@ package templates
 import "embed"
 
 // Content embeds templates content folder
+//
 //go:embed content
 var Content embed.FS

--- a/webui/content.go
+++ b/webui/content.go
@@ -3,5 +3,6 @@ package webui
 import "embed"
 
 // Content embeds web ui dist folder
+//
 //go:embed dist
 var Content embed.FS


### PR DESCRIPTION
Update code not to use deprecated `io/ioutil`.
+ Additional code format.

Required in order to move to Go >1.17