### PR TITLE
Use go run for go:generate instead of download tools by makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ docs: docs/assets/js/swagger.yml
 docs-serve: ### Serve local docs
 	cd docs; bundle exec jekyll serve
 
-gen-docs: go-install ## Generate CLI docs automatically
+gen-docs: ## Generate CLI docs automatically
 	$(GOCMD) run cmd/lakectl/main.go docs > docs/reference/commands.md
 
 gen-metastore: ## Run Metastore Code generation
@@ -102,8 +102,6 @@ go-mod-download: ## Download module dependencies
 	$(GOCMD) mod download
 
 go-install: go-mod-download ## Install dependencies
-	$(GOCMD) install github.com/deepmap/oapi-codegen/cmd/oapi-codegen
-	$(GOCMD) install github.com/golang/mock/mockgen
 	$(GOCMD) install github.com/golangci/golangci-lint/cmd/golangci-lint
 	$(GOCMD) install google.golang.org/protobuf/cmd/protoc-gen-go
 
@@ -141,12 +139,12 @@ package-python: client-python
 
 package: package-python
 
-gen-api: go-install ## Run the swagger code generator
+gen-api: ## Run the swagger code generator
 	$(GOGENERATE) ./pkg/api
 	$(GOGENERATE) ./pkg/auth
 
 .PHONY: gen-code
-gen-code: go-install ## Run the generator for inline commands
+gen-code: gen-api ## Run the generator for inline commands
 	$(GOGENERATE) \
 		./pkg/actions \
 		./pkg/auth \
@@ -231,7 +229,7 @@ $(UI_DIR)/node_modules:
 gen-ui: $(UI_DIR)/node_modules  ## Build UI web app
 	cd $(UI_DIR) && $(NPM) run build
 
-proto: ## Build proto (Protocol Buffers) files
+proto: go-install ## Build proto (Protocol Buffers) files
 	$(PROTOC) --proto_path=pkg/catalog --go_out=pkg/catalog --go_opt=paths=source_relative catalog.proto
 	$(PROTOC) --proto_path=pkg/graveler/committed --go_out=pkg/graveler/committed --go_opt=paths=source_relative committed.proto
 	$(PROTOC) --proto_path=pkg/graveler --go_out=pkg/graveler --go_opt=paths=source_relative graveler.proto
@@ -254,4 +252,4 @@ help:  ## Show Help menu
 	@grep -E '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) | sort | awk 'BEGIN {FS = ":.*?## "}; {printf "\033[36m%-30s\033[0m %s\n", $$1, $$2}'
 
 # helpers
-gen: gen-api gen-ui gen-code clients gen-docs
+gen: gen-ui gen-code clients gen-docs

--- a/go.mod
+++ b/go.mod
@@ -243,8 +243,6 @@ require (
 	github.com/kulti/thelper v0.6.3 // indirect
 	github.com/kunwardeep/paralleltest v1.0.6 // indirect
 	github.com/kyoh86/exportloopref v0.1.8 // indirect
-	github.com/labstack/echo/v4 v4.2.1 // indirect
-	github.com/labstack/gommon v0.3.0 // indirect
 	github.com/lunixbochs/vtclean v1.0.0 // indirect
 	github.com/magiconair/properties v1.8.6 // indirect
 	github.com/mailru/easyjson v0.7.6 // indirect
@@ -302,8 +300,6 @@ require (
 	github.com/ultraware/funlen v0.0.3 // indirect
 	github.com/ultraware/whitespace v0.0.5 // indirect
 	github.com/uudashr/gocognit v1.0.6 // indirect
-	github.com/valyala/bytebufferpool v1.0.0 // indirect
-	github.com/valyala/fasttemplate v1.2.1 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20190905194746-02993c407bfb // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect

--- a/pkg/actions/service.go
+++ b/pkg/actions/service.go
@@ -1,6 +1,6 @@
 package actions
 
-//go:generate mockgen -package=mock -destination=mock/mock_actions.go github.com/treeverse/lakefs/pkg/actions Source,OutputWriter
+//go:generate go run github.com/golang/mock/mockgen@v1.6.0 -package=mock -destination=mock/mock_actions.go github.com/treeverse/lakefs/pkg/actions Source,OutputWriter
 
 import (
 	"bytes"

--- a/pkg/auth/service.go
+++ b/pkg/auth/service.go
@@ -1,6 +1,6 @@
 package auth
 
-//go:generate go run github.com/deepmap/oapi-codegen/cmd/oapi-codegen@v1.5.6 -package auth -generate "types,client"  -o client.gen.go ../../api/authorization.yml
+//go:generate go run github.com/deepmap/oapi-codegen/cmd/oapi-codegen@v1.5.6 -package auth -generate "types,client" -o client.gen.go ../../api/authorization.yml
 //go:generate go run github.com/golang/mock/mockgen@v1.6.0 -package=mock -destination=mock/mock_auth_client.go github.com/treeverse/lakefs/pkg/auth ClientWithResponsesInterface
 
 import (

--- a/pkg/graveler/committed/batch_write_closer.go
+++ b/pkg/graveler/committed/batch_write_closer.go
@@ -1,6 +1,6 @@
 package committed
 
-//go:generate mockgen -source=batch_write_closer.go -destination=mock/batch_write_closer.go -package=mock
+//go:generate go run github.com/golang/mock/mockgen@v1.6.0 -source=batch_write_closer.go -destination=mock/batch_write_closer.go -package=mock
 
 // BatchWriterCloser collects Range writers and handles the asynchronous
 // flushing and closing of the writers.

--- a/pkg/graveler/graveler.go
+++ b/pkg/graveler/graveler.go
@@ -18,7 +18,7 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-//go:generate mockgen -source=graveler.go -destination=mock/graveler.go -package=mock
+//go:generate go run github.com/golang/mock/mockgen@v1.6.0 -source=graveler.go -destination=mock/graveler.go -package=mock
 
 const (
 	MergeStrategySrcWins  = "source-wins"

--- a/pkg/kv/store.go
+++ b/pkg/kv/store.go
@@ -1,6 +1,6 @@
 package kv
 
-//go:generate mockgen -source=store.go -destination=mock/store.go -package=mock
+//go:generate go run github.com/golang/mock/mockgen@v1.6.0 -source=store.go -destination=mock/store.go -package=mock
 
 import (
 	"context"

--- a/pkg/pyramid/pyramid.go
+++ b/pkg/pyramid/pyramid.go
@@ -1,6 +1,6 @@
 package pyramid
 
-//go:generate mockgen -source=pyramid.go -destination=mock/pyramid.go -package=mock
+//go:generate go run github.com/golang/mock/mockgen@v1.6.0 -source=pyramid.go -destination=mock/pyramid.go -package=mock
 
 import (
 	"context"

--- a/tools.go
+++ b/tools.go
@@ -3,8 +3,6 @@
 package tools
 
 import (
-	_ "github.com/deepmap/oapi-codegen/cmd/oapi-codegen"
-	_ "github.com/golang/mock/mockgen"
 	_ "github.com/golangci/golangci-lint/cmd/golangci-lint"
 	_ "google.golang.org/protobuf/cmd/protoc-gen-go"
 )


### PR DESCRIPTION
Remove download part of build process when using mockgen and oapi-gen to build code using go:generate.
By using `go run` the tool will be downloaded and cache once.
