### PR TITLE
Make a working OutputCommitter

### DIFF
--- a/clients/hadoopfs/src/main/java/io/lakefs/LakeFSClient.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/LakeFSClient.java
@@ -31,7 +31,7 @@ public class LakeFSClient {
             throw new IOException("Missing lakeFS secret key");
         }
 
-        ApiClient apiClient = io.lakefs.clients.api.Configuration.getDefaultApiClient();
+        ApiClient apiClient = new ApiClient();
         String endpoint = FSConfiguration.get(conf, scheme, Constants.ENDPOINT_KEY_SUFFIX, Constants.DEFAULT_CLIENT_ENDPOINT);
         if (endpoint.endsWith(Constants.SEPARATOR)) {
             endpoint = endpoint.substring(0, endpoint.length() - 1);
@@ -41,6 +41,10 @@ public class LakeFSClient {
         HttpBasicAuth basicAuth = (HttpBasicAuth) apiClient.getAuthentication(BASIC_AUTH);
         basicAuth.setUsername(accessKey);
         basicAuth.setPassword(secretKey);
+
+        // BUG(ariels): Configurable timeouts!
+        apiClient.setConnectTimeout(15000 /* msec */);
+        apiClient.setReadTimeout(15000 /* msec */);
 
         this.objects = new ObjectsApi(apiClient);
         this.staging = new StagingApi(apiClient);

--- a/clients/hadoopfs/src/main/java/io/lakefs/committer/DummyOutputCommitter.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/committer/DummyOutputCommitter.java
@@ -166,7 +166,7 @@ public class DummyOutputCommitter extends FileOutputCommitter {
             CommitsApi commits = lakeFSClient.getCommits();
             commits.commit(repository, jobBranch, new CommitCreation().message(String.format("commiting Job %s", jobContext.getJobID())), null);
             RefsApi refs = lakeFSClient.getRefs();
-            refs.mergeIntoBranch(repository, jobBranch, outputBranch, new Merge().message(""));
+            refs.mergeIntoBranch(repository, jobBranch, outputBranch, new Merge().message("").strategy("source-wins"));
         } catch (ApiException e) {
             throw new IOException(String.format("commitJob %s failed", jobContext.getJobID()), e);
         }

--- a/clients/hadoopfs/src/main/java/io/lakefs/committer/DummyOutputCommitter.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/committer/DummyOutputCommitter.java
@@ -96,7 +96,7 @@ public class DummyOutputCommitter extends FileOutputCommitter {
         // TODO(ariels): Use a more compact encoding (base-36?)
         String digest = hash.hashString(path, utf8).toString();
         String pathPrefix = path.length() > 128 ? path.substring(0, 128) : path;
-        pathPrefix = pathPrefix.replaceAll("[^-_a-zA-Z0-9]", "-")
+        pathPrefix = pathPrefix.replaceAll("[^-_a-zA-Z0-9]", "-");
         return String.format("%s-%s-%s", branchNamePrefix, digest, pathPrefix);
     }
 

--- a/clients/hadoopfs/src/main/java/io/lakefs/committer/DummyOutputCommitter.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/committer/DummyOutputCommitter.java
@@ -39,6 +39,7 @@ import java.nio.charset.Charset;
 public class DummyOutputCommitter extends FileOutputCommitter {
     private static final Logger LOG = LoggerFactory.getLogger(DummyOutputCommitter.class);
 
+    private static final String branchNamePrefix = "lakeFS-OC-";
 
     /**
      * API client connected to the lakeFS server used on the filesystem.
@@ -95,7 +96,8 @@ public class DummyOutputCommitter extends FileOutputCommitter {
         // TODO(ariels): Use a more compact encoding (base-36?)
         String digest = hash.hashString(path, utf8).toString();
         String pathPrefix = path.length() > 128 ? path.substring(0, 128) : path;
-        return digest + "-" + pathPrefix.replaceAll("[^-_a-zA-Z0-9]", "-");
+        pathPrefix = pathPrefix.replaceAll("[^-_a-zA-Z0-9]", "-")
+        return String.format("%s-%s-%s", branchNamePrefix, digest, pathPrefix);
     }
 
     public DummyOutputCommitter(Path outputPath, JobContext context) throws IOException {


### PR DESCRIPTION
Tested by writing a 3-partition dataframe as text and as Parquet, nothing comprehensive.

* Use `outputPath` as "job" branch name for writing output.

  **Why?** Spark `FileFormatWriter` writes using _two_ JobIDs: it calls `setupJob`/`commitJob` on the first and `setupTask`/`commitTask` on the second.  So if we name the work branch by "its" JobID we will write all objects to the second and then try to merge the first.  That does not work.  Instead, use `outputPath` which is shared between them as the base for the branch.

  **How?** `outputPath` itself cannot be used as a branch name -- at the very least it will contain slashes.  Instead, use its SHA-256 as the branch name; to make it readable, append some prefix of the branch name with all non-alphanumerics replaced by `-`s.

  **What else?** This _will not work_ in the multiwriter case, because all writers will share the same working branch.
* Clean up DEBUG prints/logs.
* Merging:
  - Use merge strategy to merge back
  - Avoid empty commit/merge API errors: only commit or merge when there are diffs.
* Use timeouts in client.