### PR TITLE
Ensure output branch has no uncommitted files before starting

### DIFF
--- a/clients/hadoopfs/src/main/java/io/lakefs/Constants.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/Constants.java
@@ -9,9 +9,10 @@ public class Constants {
     public static final String SECRET_KEY_KEY_SUFFIX = "secret.key";
     public static final String ENDPOINT_KEY_SUFFIX = "endpoint";
     public static final String LIST_AMOUNT_KEY_SUFFIX = "list.amount";
+
     public static final String OC_DELETE_JOB_BRANCH = "committer.delete_job_branch";
     public static final String OC_DELETE_TASK_BRANCH = "committer.delete_task_branch";
-
+    public static final String OC_ENSURE_CLEAN_OUTPUT_BRANCH = "committer.ensure_clean_output_branch";
 
     public static final int DEFAULT_LIST_AMOUNT = 1000;
     public static final String SEPARATOR = "/";

--- a/clients/hadoopfs/src/main/java/io/lakefs/committer/DummyOutputCommitter.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/committer/DummyOutputCommitter.java
@@ -182,6 +182,10 @@ public class DummyOutputCommitter extends FileOutputCommitter {
     public void setupJob(JobContext context) throws IOException {
         if (outputPath == null)
             return;
+        if (conf.getBoolean(Constants.OC_ENSURE_CLEAN_OUTPUT_BRANCH, true) &&
+            hasChanges(outputBranch)) {
+            throw new IOException(String.format("Uncommitted changes on output branch %s, merge will fail", outputBranch));
+        }
         LOG.info("Setup job for {} on {}", outputBranch, jobBranch);
         createBranch(jobBranch, outputBranch);
     }

--- a/clients/hadoopfs/src/main/java/io/lakefs/committer/DummyOutputCommitter.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/committer/DummyOutputCommitter.java
@@ -182,7 +182,7 @@ public class DummyOutputCommitter extends FileOutputCommitter {
     public void setupJob(JobContext context) throws IOException {
         if (outputPath == null)
             return;
-        if (conf.getBoolean(Constants.OC_ENSURE_CLEAN_OUTPUT_BRANCH, true) &&
+        if (FSConfiguration.getBoolean(conf, outputPath.toUri().getScheme(), Constants.OC_ENSURE_CLEAN_OUTPUT_BRANCH, true) &&
             hasChanges(outputBranch)) {
             throw new IOException(String.format("Uncommitted changes on output branch %s, merge will fail", outputBranch));
         }


### PR DESCRIPTION
The merge at the _end_ of the write will fail if there are uncommitted
files.  Don't bother even to start.

This is configurable using `committer.output_branch.ensure_clean`, default
true.

Fixes #4519.