### PR TITLE
Create success file when done

### DIFF
--- a/clients/hadoopfs/src/main/java/io/lakefs/Constants.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/Constants.java
@@ -13,6 +13,7 @@ public class Constants {
     public static final String OC_DELETE_JOB_BRANCH = "committer.delete_job_branch";
     public static final String OC_DELETE_TASK_BRANCH = "committer.delete_task_branch";
     public static final String OC_ENSURE_CLEAN_OUTPUT_BRANCH = "committer.ensure_clean_output_branch";
+    public static final String OC_SUCCESSFUL_JOB_OUTPUT_DIR_MARKER = "committer.marksuccessfuljobs";
 
     public static final int DEFAULT_LIST_AMOUNT = 1000;
     public static final String SEPARATOR = "/";

--- a/clients/hadoopfs/src/main/java/io/lakefs/committer/DummyOutputCommitter.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/committer/DummyOutputCommitter.java
@@ -226,7 +226,10 @@ public class DummyOutputCommitter extends FileOutputCommitter {
         if (markSuccessfulJobs.equals("auto")) {
             return conf.getBoolean(FileOutputCommitter.SUCCESSFUL_JOB_OUTPUT_DIR_MARKER, true);
         }
-        return Boolean.parseBoolean(markSuccessfulJobs);
+        if (markSuccessfulJobs.equalsIgnoreCase("false")) {
+            return false;
+        }
+        return true;
     }
 
     @Override

--- a/clients/hadoopfs/src/main/java/io/lakefs/committer/DummyOutputCommitter.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/committer/DummyOutputCommitter.java
@@ -83,6 +83,7 @@ public class DummyOutputCommitter extends FileOutputCommitter {
     protected Path workPath = null;
 
     protected Configuration conf;
+    protected FileSystem fs;
 
     private static HashFunction hash = Hashing.sha256();
     private static Charset utf8 = Charset.forName("utf8");
@@ -113,7 +114,7 @@ public class DummyOutputCommitter extends FileOutputCommitter {
         LOG.info("Construct OC: Job branch: {}", jobBranch);
 
         if (outputPath != null) {
-            FileSystem fs = outputPath.getFileSystem(conf);
+            fs = outputPath.getFileSystem(conf);
             Preconditions.checkArgument(fs instanceof LakeFSFileSystem,
                                         "%s not on a LakeFSFileSystem", outputPath);
             this.lakeFSClient = new LakeFSClient(fs.getScheme(), conf);
@@ -134,11 +135,15 @@ public class DummyOutputCommitter extends FileOutputCommitter {
         this.taskBranch = String.format("%s-%s", this.jobBranch, id.toString());
 
         if (outputPath != null) {
-            ObjectLocation loc = ObjectLocation.pathToObjectLocation(null, outputPath);
-            loc.setRef(this.taskBranch);
-            this.workPath = loc.toFSPath();
+            this.workPath = changePathBranch(outputPath, this.taskBranch);
             LOG.trace("Working path: {}", workPath);
         }
+    }
+
+    private Path changePathBranch(Path path, String branch) {
+        ObjectLocation loc = ObjectLocation.pathToObjectLocation(null, path);
+        loc.setRef(branch);
+        return loc.toFSPath();
     }
 
     private boolean createBranch(String branch, String base) throws IOException {
@@ -216,11 +221,29 @@ public class DummyOutputCommitter extends FileOutputCommitter {
         }
     }
 
+    private boolean needsSuccessFile() {
+        String markSuccessfulJobs = FSConfiguration.get(conf, outputPath.toUri().getScheme(), Constants.OC_SUCCESSFUL_JOB_OUTPUT_DIR_MARKER, "auto");
+        if (markSuccessfulJobs.equals("auto")) {
+            return conf.getBoolean(FileOutputCommitter.SUCCESSFUL_JOB_OUTPUT_DIR_MARKER, true);
+        }
+        return Boolean.parseBoolean(markSuccessfulJobs);
+    }
+
     @Override
     public void commitJob(JobContext jobContext) throws IOException {
         if (outputPath == null)
             return;
         try {
+            boolean changes = false;
+
+            if (needsSuccessFile()) {
+                Path markerPath = new Path(changePathBranch(outputPath, jobBranch),
+                                           FileOutputCommitter.SUCCEEDED_FILE_NAME);
+                fs.create(markerPath, true).close();
+
+                CommitsApi commits = lakeFSClient.getCommits();
+                commits.commit(repository, jobBranch, new CommitCreation().message(String.format("Add success marker for job %s", jobContext.getJobID())), null);
+            }
             if (!hasDiffs(repository, jobBranch, outputBranch)) {
                 LOG.debug("No differences from {} to {}, nothing to merge", jobBranch, outputBranch);
                 return;


### PR DESCRIPTION
Create an object named _SUCCESS in the output path.  This is controlled by
option `lakefs.fs.committer.marksuccessfuljobs`, with these values:

* "true": Create success file.
* "false": Don't create the file.
* "auto" (the default): Do whatever FileOutputCommitter would do, by reading
   its option `mapreduce.fileoutputcommitter.marksuccessfuljobs` (default
   `true`).

So: by default it creates _SUCCESS or whatever FileOutputCommitter is
configured to do.  And it can be set explicitly.

Fixes #4520.