### PR TITLE
Python lakefs-client library does not have a license

### DIFF
--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -3,6 +3,9 @@ openapi: "3.0.0"
 info:
   description: lakeFS HTTP API
   title: lakeFS API
+  license:
+    name: "Apache 2.0"
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
   version: 0.1.0
 
 servers:

--- a/clients/java/api/openapi.yaml
+++ b/clients/java/api/openapi.yaml
@@ -1,6 +1,9 @@
 openapi: 3.0.0
 info:
   description: lakeFS HTTP API
+  license:
+    name: Apache 2.0
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
   title: lakeFS API
   version: 0.1.0
 servers:

--- a/clients/java/pom.xml
+++ b/clients/java/pom.xml
@@ -22,7 +22,7 @@
     <licenses>
         <license>
             <name>apache2</name>
-            <url>http://www.apache.org/licenses/</url>
+            <url>http://www.apache.org/licenses/LICENSE-2.0.html</url>
             <distribution>repo</distribution>
         </license>
     </licenses>

--- a/clients/python/setup.py
+++ b/clients/python/setup.py
@@ -40,6 +40,7 @@ setup(
     install_requires=REQUIRES,
     packages=find_packages(exclude=["test", "tests"]),
     include_package_data=True,
+    license="Apache 2.0",
     long_description=long_description,
     long_description_content_type='text/markdown'
 )

--- a/docs/assets/js/swagger.yml
+++ b/docs/assets/js/swagger.yml
@@ -3,6 +3,9 @@ openapi: "3.0.0"
 info:
   description: lakeFS HTTP API
   title: lakeFS API
+  license:
+    name: "Apache 2.0"
+    url: http://www.apache.org/licenses/LICENSE-2.0.html
   version: 0.1.0
 
 servers:


### PR DESCRIPTION
Hi,

The lakefs-client Python library is great and works really well as an OpenAPI generated lib. It however does not have a license. We usually check for invalid license types to ensure we can work safely with libraries.

Is the absence of a license intentional?

Thanks!