### PR TITLE
fix the markdown files exclusion

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,7 +5,7 @@ on:
       - master
   pull_request:
     paths-ignore:
-      - "*.md"
+      - "**.md"
       - "docs/**"
       - "design/**"
 jobs:


### PR DESCRIPTION
Go tests are running for markdown files by accident.
In order to avoid running tests for files ending with `.md`, we should exclude `**.md` and not `*.md`

See GitHub's documentation [here](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#example-including-paths)

Closes https://github.com/treeverse/lakeFS/issues/4551