### PR TITLE
Setting kv driver defaults as configuration

### DIFF
--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -7,8 +7,8 @@ import (
 )
 
 const (
-	DatabaseTypeKey     = "database.type"
-	DefaultDatabaseType = "local"
+	DatabaseTypeKey   = "database.type"
+	LocalDatabaseType = "local"
 
 	DatabaseLocalPathKey     = "database.local.path"
 	DefaultDatabaseLocalPath = "~/lakefs/metadata"
@@ -109,8 +109,8 @@ const (
 	LoggingFilesKeepKey     = "logging.files_keep"
 	LoggingAuditLogLevel    = "logging.audit_log_level"
 
-	AuthEncryptSecretKey        = "auth.encrypt.secret_key"            // #nosec
-	DefaultAuthEncryptSecretKey = "THIS_MUST_BE_CHANGED_IN_PRODUCTION" // #nosec
+	AuthEncryptSecretKey      = "auth.encrypt.secret_key"            // #nosec
+	LocalAuthEncryptSecretKey = "THIS_MUST_BE_CHANGED_IN_PRODUCTION" // #nosec
 
 	ActionsEnabledKey = "actions.enabled"
 
@@ -157,8 +157,8 @@ const (
 
 func setDefaults(local bool) {
 	if local {
-		viper.SetDefault(DatabaseTypeKey, DefaultDatabaseType)
-		viper.SetDefault(AuthEncryptSecretKey, DefaultAuthEncryptSecretKey)
+		viper.SetDefault(DatabaseTypeKey, LocalDatabaseType)
+		viper.SetDefault(AuthEncryptSecretKey, LocalAuthEncryptSecretKey)
 	}
 
 	viper.SetDefault(ListenAddressKey, DefaultListenAddr)

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -10,8 +10,29 @@ const (
 	DatabaseTypeKey     = "database.type"
 	DefaultDatabaseType = "local"
 
-	DatabaseKVLocalPath        = "database.local.path"
-	DefaultDatabaseLocalKVPath = "~/lakefs/metadata"
+	DatabaseLocalPathKey     = "database.local.path"
+	DefaultDatabaseLocalPath = "~/lakefs/metadata"
+
+	DatabaseLocalPrefetchSizeKey     = "database.local.prefetch_size"
+	DefaultDatabaseLocalPrefetchSize = 256
+
+	DatabaseDynamodbTableNameKey     = "database.dynamodb.table_name"
+	DefaultDatabaseDynamodbTableName = "kvstore"
+
+	DatabaseDynamodbReadCapacityUnitsKey     = "database.dynamodb.read_capacity_units"
+	DefaultDatabaseDynamodbReadCapacityUnits = 1000
+
+	DatabaseDynamodbWriteCapacityUnitsKey     = "database.dynamodb.write_capacity_units"
+	DefaultDatabaseDynamodbWriteCapacityUnits = 1000
+
+	DatabasePostgresMaxOpenConnectionsKey     = "database.postgres.max_open_connections"
+	DefaultDatabasePostgresMaxOpenConnections = 25
+
+	DatabasePostgresMaxIdleConnectionsKey     = "database.postgres.max_idle_connections"
+	DefaultDatabasePostgresMaxIdleConnections = 25
+
+	PostgresConnectionMaxLifetimeKey     = "database.postgres.connection_max_lifetime"
+	DefaultPostgresConnectionMaxLifetime = "5m"
 
 	BlockstoreTypeKey     = "blockstore.type"
 	DefaultBlockstoreType = "local"
@@ -134,17 +155,10 @@ const (
 	UIEnabledKey = "ui.enabled"
 )
 
-func setDefaultLocalConfig() {
-	viper.SetDefault(DatabaseTypeKey, DefaultDatabaseType)
-	viper.SetDefault(DatabaseKVLocalPath, DefaultDatabaseLocalKVPath)
-	viper.SetDefault(BlockstoreLocalPathKey, DefaultBlockstoreLocalPath)
-	viper.SetDefault(AuthEncryptSecretKey, DefaultAuthEncryptSecretKey)
-	viper.SetDefault(BlockstoreTypeKey, DefaultBlockstoreType)
-}
-
 func setDefaults(local bool) {
 	if local {
-		setDefaultLocalConfig()
+		viper.SetDefault(DatabaseTypeKey, DefaultDatabaseType)
+		viper.SetDefault(AuthEncryptSecretKey, DefaultAuthEncryptSecretKey)
 	}
 
 	viper.SetDefault(ListenAddressKey, DefaultListenAddr)
@@ -206,4 +220,18 @@ func setDefaults(local bool) {
 	viper.SetDefault(LakefsEmailBaseURLKey, DefaultLakefsEmailBaseURL)
 
 	viper.SetDefault(UIEnabledKey, DefaultUIEnabled)
+
+	viper.SetDefault(BlockstoreLocalPathKey, DefaultBlockstoreLocalPath)
+
+	viper.SetDefault(DatabaseLocalPathKey, DefaultDatabaseLocalPath)
+	viper.SetDefault(DatabaseLocalPrefetchSizeKey, DefaultDatabaseLocalPrefetchSize)
+
+	viper.SetDefault(DatabaseDynamodbTableNameKey, DefaultDatabaseDynamodbTableName)
+
+	viper.SetDefault(DatabaseDynamodbReadCapacityUnitsKey, DefaultDatabaseDynamodbReadCapacityUnits)
+	viper.SetDefault(DatabaseDynamodbWriteCapacityUnitsKey, DefaultDatabaseDynamodbWriteCapacityUnits)
+
+	viper.SetDefault(DatabasePostgresMaxOpenConnectionsKey, DefaultDatabasePostgresMaxOpenConnections)
+	viper.SetDefault(DatabasePostgresMaxIdleConnectionsKey, DefaultDatabasePostgresMaxIdleConnections)
+	viper.SetDefault(PostgresConnectionMaxLifetimeKey, DefaultPostgresConnectionMaxLifetime)
 }

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -34,8 +34,8 @@ const (
 	PostgresConnectionMaxLifetimeKey     = "database.postgres.connection_max_lifetime"
 	DefaultPostgresConnectionMaxLifetime = "5m"
 
-	BlockstoreTypeKey     = "blockstore.type"
-	DefaultBlockstoreType = "local"
+	BlockstoreTypeKey   = "blockstore.type"
+	LocalBlockstoreType = "local"
 
 	BlockstoreLocalPathKey     = "blockstore.local.path"
 	DefaultBlockstoreLocalPath = "~/lakefs/data/block"
@@ -159,6 +159,7 @@ func setDefaults(local bool) {
 	if local {
 		viper.SetDefault(DatabaseTypeKey, LocalDatabaseType)
 		viper.SetDefault(AuthEncryptSecretKey, LocalAuthEncryptSecretKey)
+		viper.SetDefault(BlockstoreTypeKey, LocalBlockstoreType)
 	}
 
 	viper.SetDefault(ListenAddressKey, DefaultListenAddr)
@@ -180,7 +181,6 @@ func setDefaults(local bool) {
 	viper.SetDefault(AuthLogoutRedirectURL, DefaultAuthLogoutRedirectURL)
 
 	viper.SetDefault(BlockstoreLocalPathKey, DefaultBlockstoreLocalPath)
-	viper.SetDefault(BlockstoreTypeKey, DefaultBlockstoreType)
 	viper.SetDefault(BlockstoreS3RegionKey, DefaultBlockstoreS3Region)
 	viper.SetDefault(BlockstoreS3StreamingChunkSizeKey, DefaultBlockstoreS3StreamingChunkSize)
 	viper.SetDefault(BlockstoreS3StreamingChunkTimeoutKey, DefaultBlockstoreS3StreamingChunkTimeout)

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -77,7 +77,7 @@ type configuration struct {
 		// DropTables Development flag to delete tables after successful migration to KV
 		DropTables bool `mapstructure:"drop_tables"`
 		// Type Name of the KV Store driver DB implementation which is available according to the kv package Drivers function
-		Type string `mapstructure:"type"`
+		Type string `mapstructure:"type" validate:"required"`
 
 		Local *struct {
 			// Path - Local directory path to store the DB files

--- a/pkg/config/testdata/aws_credentials.yaml
+++ b/pkg/config/testdata/aws_credentials.yaml
@@ -1,4 +1,7 @@
 ---
+database:
+  type: local
+
 auth:
   encrypt:
     secret_key: "required in config"

--- a/pkg/config/testdata/aws_credentials_with_alias.yaml
+++ b/pkg/config/testdata/aws_credentials_with_alias.yaml
@@ -1,4 +1,7 @@
 ---
+database:
+  type: local
+
 auth:
   encrypt:
     secret_key: "required in config"

--- a/pkg/config/testdata/domain_name_prefix.yaml
+++ b/pkg/config/testdata/domain_name_prefix.yaml
@@ -1,4 +1,10 @@
 ---
+database:
+  type: local
+
+blockstore:
+  type: local
+
 gateways:
   s3:
     domain_name:

--- a/pkg/config/testdata/valid_config.yaml
+++ b/pkg/config/testdata/valid_config.yaml
@@ -5,6 +5,7 @@ logging:
   output: "-"
 
 database:
+  type: postgres
   postgres:
     connection_string: test:///dev/null
     max_open_connections: 12

--- a/pkg/config/testdata/valid_custom_badger_config.yaml
+++ b/pkg/config/testdata/valid_custom_badger_config.yaml
@@ -1,4 +1,7 @@
 ---
+database:
+  type: local
+
 logging:
   format: text
   level: NONE

--- a/pkg/config/testdata/valid_gs_adapter_config.yaml
+++ b/pkg/config/testdata/valid_gs_adapter_config.yaml
@@ -1,4 +1,7 @@
 ---
+database:
+  type: local
+
 logging:
   format: text
   level: NONE

--- a/pkg/config/testdata/valid_json_logger_config.yaml
+++ b/pkg/config/testdata/valid_json_logger_config.yaml
@@ -1,4 +1,7 @@
 ---
+database:
+  type: local
+
 logging:
   format: json
   level: DEBUG

--- a/pkg/config/testdata/valid_oidc_config.yaml
+++ b/pkg/config/testdata/valid_oidc_config.yaml
@@ -5,6 +5,7 @@ logging:
   output: "-"
 
 database:
+  type: postgres
   postgres:
     connection_string: test:///dev/null
     max_open_connections: 12

--- a/pkg/config/testdata/valid_s3_adapter_config.yaml
+++ b/pkg/config/testdata/valid_s3_adapter_config.yaml
@@ -1,4 +1,7 @@
 ---
+database:
+  type: local
+
 logging:
   format: text
   level: NONE

--- a/pkg/kv/dynamodb/store.go
+++ b/pkg/kv/dynamodb/store.go
@@ -47,30 +47,11 @@ const (
 	PartitionKey = "PartitionKey"
 	ItemKey      = "ItemKey"
 	ItemValue    = "ItemValue"
-
-	DefaultDynamoDBTableName = "kvstore"
-	// TODO (niro): Which values to use for DynamoDB tables?
-	DefaultDynamoDBReadCapacityUnits  = 1000
-	DefaultDynamoDBWriteCapacityUnits = 1000
 )
 
 //nolint:gochecknoinits
 func init() {
 	kv.Register(DriverName, &Driver{})
-}
-
-func normalizeDBParams(p *kvparams.DynamoDB) {
-	if len(p.TableName) == 0 {
-		p.TableName = DefaultDynamoDBTableName
-	}
-
-	if p.ReadCapacityUnits == 0 {
-		p.ReadCapacityUnits = DefaultDynamoDBReadCapacityUnits
-	}
-
-	if p.WriteCapacityUnits == 0 {
-		p.WriteCapacityUnits = DefaultDynamoDBWriteCapacityUnits
-	}
 }
 
 // Open - opens and returns a KV store over DynamoDB. This function creates the DB session
@@ -81,7 +62,6 @@ func (d *Driver) Open(ctx context.Context, kvParams kvparams.KV) (kv.Store, erro
 		return nil, fmt.Errorf("missing %s settings: %w", DriverName, kv.ErrDriverConfiguration)
 	}
 
-	normalizeDBParams(params)
 	sess, err := session.NewSessionWithOptions(session.Options{
 		SharedConfigState: session.SharedConfigEnable,
 		Profile:           params.AwsProfile,

--- a/pkg/kv/local/driver.go
+++ b/pkg/kv/local/driver.go
@@ -12,9 +12,7 @@ import (
 )
 
 const (
-	DriverName           = "local"
-	DefaultDirectoryPath = "~/lakefs/metadata"
-	DefaultPrefetchSize  = 256
+	DriverName = "local"
 )
 
 var (
@@ -24,21 +22,11 @@ var (
 
 type Driver struct{}
 
-func normalizeDBParams(p *kvparams.Local) {
-	if len(p.Path) == 0 {
-		p.Path = DefaultDirectoryPath
-	}
-	if p.PrefetchSize <= 0 {
-		p.PrefetchSize = DefaultPrefetchSize
-	}
-}
-
 func (d *Driver) Open(ctx context.Context, kvParams kvparams.KV) (kv.Store, error) {
 	params := kvParams.Local
 	if params == nil {
 		return nil, fmt.Errorf("missing %s settings: %w", DriverName, kv.ErrDriverConfiguration)
 	}
-	normalizeDBParams(params)
 
 	driverLock.Lock()
 	defer driverLock.Unlock()

--- a/pkg/kv/params/database.go
+++ b/pkg/kv/params/database.go
@@ -27,7 +27,7 @@ type Postgres struct {
 	MaxOpenConnections    int32
 	MaxIdleConnections    int32
 	ConnectionMaxLifetime time.Duration
-	ScanPageSize          int32
+	ScanPageSize          int
 	Metrics               bool
 }
 

--- a/pkg/kv/postgres/store.go
+++ b/pkg/kv/postgres/store.go
@@ -112,9 +112,15 @@ func newPgxpoolConfig(kvParams kvparams.KV) (*pgxpool.Config, error) {
 	if err != nil {
 		return nil, fmt.Errorf("%w: %s", kv.ErrDriverConfiguration, err)
 	}
-	config.MaxConns = kvParams.Postgres.MaxOpenConnections
-	config.MinConns = kvParams.Postgres.MaxIdleConnections
-	config.MaxConnLifetime = kvParams.Postgres.ConnectionMaxLifetime
+	if kvParams.Postgres.MaxOpenConnections > 0 {
+		config.MaxConns = kvParams.Postgres.MaxOpenConnections
+	}
+	if kvParams.Postgres.MaxIdleConnections > 0 {
+		config.MinConns = kvParams.Postgres.MaxIdleConnections
+	}
+	if kvParams.Postgres.ConnectionMaxLifetime > 0 {
+		config.MaxConnLifetime = kvParams.Postgres.ConnectionMaxLifetime
+	}
 	return config, err
 }
 


### PR DESCRIPTION
Flag local-settings will enable the local storage and local kv, but the values used by each driver will be set by the configuration and not by each driver's configuration normalization.

The block adapter type will be a required field - the user will have to specify it or use "--local-settings" flag to set it as default.

This change will prevent processing of default as part of each driver and simplify the loading process done by our configuration without splining the default values into two more than one place. Having the configuration log the values will reflect the values we use by each driver.

Fix #4565