### PR TITLE
Remove gitleaks while running tests

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -31,8 +31,6 @@ jobs:
         run: make checks-validator
         env:
           GOLANGCI_LINT_FLAGS: --out-format github-actions
-      - name: gitLeaks
-        uses: zricethezav/gitleaks-action@v1.5.0
 
   test-go:
     name: Run Go tests
@@ -86,10 +84,4 @@ jobs:
             ${{ runner.os }}-
 
       - name: Run tests
-        run: |
-          make test-go
-      # - name: Publish coverage
-      #   uses: codecov/codecov-action@v1
-      #   with:
-      #     files: ./cover.out,api/cover.out
-      #     fail_ci_if_error: false
+        run: make test-go


### PR DESCRIPTION
GitHub scans public repositories for secrets. Git pre-commit hook will do a better job in preventing secrets into the repository.