### PR TITLE
Python client map APIs use dynamically

### DIFF
--- a/clients/python/lakefs_client/client.py
+++ b/clients/python/lakefs_client/client.py
@@ -1,10 +1,11 @@
 from urllib3.util import parse_url, Url
 import sys
 import inspect
-import keyword
 
 import lakefs_client
 import lakefs_client.apis
+
+_API_CLASS_SUFFIX = "api"
 
 class _WrappedApiClient(lakefs_client.ApiClient):
     """ApiClient that fixes some weirdnesses."""
@@ -31,12 +32,11 @@ class LakeFSClient:
                                           header_value=header_value, cookie=cookie, pool_threads=pool_threads)
         for key, value in inspect.getmembers(sys.modules['lakefs_client.apis'], inspect.isclass):
             name = key.lower()
-            if not name.endswith('api'):
+            if not name.endswith(_API_CLASS_SUFFIX):
                 continue
             api_instance = value(self._api)
-            attr_name = name[0:len(name)-3]
-            if attr_name not in keyword.kwlist:
-                setattr(self, attr_name, api_instance)
+            attr_name = name[:-len(_API_CLASS_SUFFIX)]
+            setattr(self, attr_name, api_instance)
             setattr(self, attr_name + '_api', api_instance)
 
     @staticmethod

--- a/clients/python/lakefs_client/client.py
+++ b/clients/python/lakefs_client/client.py
@@ -29,13 +29,12 @@ class LakeFSClient:
             configuration = LakeFSClient._ensure_endpoint(configuration)
         self._api = _WrappedApiClient(configuration=configuration, header_name=header_name,
                                           header_value=header_value, cookie=cookie, pool_threads=pool_threads)
-        # for each api set attribute with instance set with the client
-        for k in inspect.getmembers(sys.modules['lakefs_client.apis'], inspect.isclass):
-            name = k[0].lower()
+        for key, value in inspect.getmembers(sys.modules['lakefs_client.apis'], inspect.isclass):
+            name = key.lower()
             if not name.endswith('api'):
                 continue
+            api_instance = value(self._api)
             attr_name = name[0:len(name)-3]
-            api_instance = k[1](self._api)
             if attr_name not in keyword.kwlist:
                 setattr(self, attr_name, api_instance)
             setattr(self, attr_name + '_api', api_instance)


### PR DESCRIPTION
- Map each existing api to the name of the tag, assign it twice (with and without _api)
- If the attribute match python keyword skip the assignment (example 'import_api' will not be mapped as 'import' because it is a keyword)

Fix: added missing APIs - import, templates and retention
Break: the attribute 'health' will be mapped to 'healthcheck' and 'healthcheck_api'
- [ ] Document the above breaking change in the CHANGELOG

Fix #4604 