### PR TITLE
Don't batch GetCommit calls during merges

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -1559,6 +1559,10 @@ func (c *Catalog) Merge(ctx context.Context, repositoryID string, destinationBra
 	}); err != nil {
 		return "", err
 	}
+
+	// disabling batching for this flow. See #3935 for more details
+	ctx = context.WithValue(ctx, batch.SkipBatchContextKey, struct{}{})
+
 	repository, err := c.getRepository(ctx, repositoryID)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
During a merge, prevent batching GetCommit calls when there is a cache miss.

FindMergeBase performs one GetCommit call per commit traversed.  This is currently performed in series, so any batching immediate slows it down.