### PR TITLE
Add byte range support to OpenAPI (server, spec and generated clients)

### DIFF
--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -2669,6 +2669,15 @@ paths:
         - objects
       operationId: getObject
       summary: get object content
+      parameters:
+        - in: header
+          name: Range
+          description: Byte range to retrieve
+          example: "bytes=0-1023"
+          required: false
+          schema:
+            type: string
+            pattern: '^bytes=((\d*-\d*,? ?)+)$'
       responses:
         200:
           description: object content
@@ -2682,6 +2691,31 @@ paths:
               schema:
                 type: integer
                 format: int64
+            Last-Modified:
+              schema:
+                type: string
+            ETag:
+              schema:
+                type: string
+            Content-Disposition:
+              schema:
+                type: string
+        206:
+          description: partial object content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+          headers:
+            Content-Length:
+              schema:
+                type: integer
+                format: int64
+            Content-Range:
+              schema:
+                type: string
+                pattern: '^bytes=((\d*-\d*,? ?)+)$'
             Last-Modified:
               schema:
                 type: string

--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -2737,6 +2737,12 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+        416:
+          description: Requested Range Not Satisfiable
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
 
   /repositories/{repository}/branches/{branch}/staging/backing:
     parameters:

--- a/clients/java/api/openapi.yaml
+++ b/clients/java/api/openapi.yaml
@@ -2910,6 +2910,16 @@ paths:
         schema:
           type: string
         style: form
+      - description: Byte range to retrieve
+        example: bytes=0-1023
+        explode: false
+        in: header
+        name: Range
+        required: false
+        schema:
+          pattern: ^bytes=((\d*-\d*,? ?)+)$
+          type: string
+        style: simple
       responses:
         "200":
           content:
@@ -2924,6 +2934,41 @@ paths:
               schema:
                 format: int64
                 type: integer
+              style: simple
+            Last-Modified:
+              explode: false
+              schema:
+                type: string
+              style: simple
+            ETag:
+              explode: false
+              schema:
+                type: string
+              style: simple
+            Content-Disposition:
+              explode: false
+              schema:
+                type: string
+              style: simple
+        "206":
+          content:
+            application/octet-stream:
+              schema:
+                format: binary
+                type: string
+          description: partial object content
+          headers:
+            Content-Length:
+              explode: false
+              schema:
+                format: int64
+                type: integer
+              style: simple
+            Content-Range:
+              explode: false
+              schema:
+                pattern: ^bytes=((\d*-\d*,? ?)+)$
+                type: string
               style: simple
             Last-Modified:
               explode: false

--- a/clients/java/api/openapi.yaml
+++ b/clients/java/api/openapi.yaml
@@ -3009,6 +3009,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: object expired
+        "416":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Requested Range Not Satisfiable
       summary: get object content
       tags:
       - objects

--- a/clients/java/docs/ObjectsApi.md
+++ b/clients/java/docs/ObjectsApi.md
@@ -193,7 +193,7 @@ Name | Type | Description  | Notes
 
 <a name="getObject"></a>
 # **getObject**
-> File getObject(repository, ref, path)
+> File getObject(repository, ref, path, range)
 
 get object content
 
@@ -237,8 +237,9 @@ public class Example {
     String repository = "repository_example"; // String | 
     String ref = "ref_example"; // String | a reference (could be either a branch or a commit ID)
     String path = "path_example"; // String | relative to the ref
+    String range = "bytes=0-1023"; // String | Byte range to retrieve
     try {
-      File result = apiInstance.getObject(repository, ref, path);
+      File result = apiInstance.getObject(repository, ref, path, range);
       System.out.println(result);
     } catch (ApiException e) {
       System.err.println("Exception when calling ObjectsApi#getObject");
@@ -258,6 +259,7 @@ Name | Type | Description  | Notes
  **repository** | **String**|  |
  **ref** | **String**| a reference (could be either a branch or a commit ID) |
  **path** | **String**| relative to the ref |
+ **range** | **String**| Byte range to retrieve | [optional]
 
 ### Return type
 
@@ -276,6 +278,7 @@ Name | Type | Description  | Notes
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 **200** | object content |  * Content-Length -  <br>  * Last-Modified -  <br>  * ETag -  <br>  * Content-Disposition -  <br>  |
+**206** | partial object content |  * Content-Length -  <br>  * Content-Range -  <br>  * Last-Modified -  <br>  * ETag -  <br>  * Content-Disposition -  <br>  |
 **401** | Unauthorized |  -  |
 **404** | Resource Not Found |  -  |
 **410** | object expired |  -  |

--- a/clients/java/docs/ObjectsApi.md
+++ b/clients/java/docs/ObjectsApi.md
@@ -282,6 +282,7 @@ Name | Type | Description  | Notes
 **401** | Unauthorized |  -  |
 **404** | Resource Not Found |  -  |
 **410** | object expired |  -  |
+**416** | Requested Range Not Satisfiable |  -  |
 **0** | Internal Server Error |  -  |
 
 <a name="getUnderlyingProperties"></a>

--- a/clients/java/src/main/java/io/lakefs/clients/api/ObjectsApi.java
+++ b/clients/java/src/main/java/io/lakefs/clients/api/ObjectsApi.java
@@ -352,6 +352,7 @@ public class ObjectsApi {
      * @param repository  (required)
      * @param ref a reference (could be either a branch or a commit ID) (required)
      * @param path relative to the ref (required)
+     * @param range Byte range to retrieve (optional)
      * @param _callback Callback for upload/download progress
      * @return Call to execute
      * @throws ApiException If fail to serialize the request body object
@@ -359,13 +360,14 @@ public class ObjectsApi {
      <table summary="Response Details" border="1">
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 200 </td><td> object content </td><td>  * Content-Length -  <br>  * Last-Modified -  <br>  * ETag -  <br>  * Content-Disposition -  <br>  </td></tr>
+        <tr><td> 206 </td><td> partial object content </td><td>  * Content-Length -  <br>  * Content-Range -  <br>  * Last-Modified -  <br>  * ETag -  <br>  * Content-Disposition -  <br>  </td></tr>
         <tr><td> 401 </td><td> Unauthorized </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Resource Not Found </td><td>  -  </td></tr>
         <tr><td> 410 </td><td> object expired </td><td>  -  </td></tr>
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call getObjectCall(String repository, String ref, String path, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call getObjectCall(String repository, String ref, String path, String range, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -381,6 +383,10 @@ public class ObjectsApi {
 
         if (path != null) {
             localVarQueryParams.addAll(localVarApiClient.parameterToPair("path", path));
+        }
+
+        if (range != null) {
+            localVarHeaderParams.put("Range", localVarApiClient.parameterToString(range));
         }
 
         final String[] localVarAccepts = {
@@ -402,7 +408,7 @@ public class ObjectsApi {
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call getObjectValidateBeforeCall(String repository, String ref, String path, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call getObjectValidateBeforeCall(String repository, String ref, String path, String range, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'repository' is set
         if (repository == null) {
@@ -420,7 +426,7 @@ public class ObjectsApi {
         }
         
 
-        okhttp3.Call localVarCall = getObjectCall(repository, ref, path, _callback);
+        okhttp3.Call localVarCall = getObjectCall(repository, ref, path, range, _callback);
         return localVarCall;
 
     }
@@ -431,20 +437,22 @@ public class ObjectsApi {
      * @param repository  (required)
      * @param ref a reference (could be either a branch or a commit ID) (required)
      * @param path relative to the ref (required)
+     * @param range Byte range to retrieve (optional)
      * @return File
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
      <table summary="Response Details" border="1">
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 200 </td><td> object content </td><td>  * Content-Length -  <br>  * Last-Modified -  <br>  * ETag -  <br>  * Content-Disposition -  <br>  </td></tr>
+        <tr><td> 206 </td><td> partial object content </td><td>  * Content-Length -  <br>  * Content-Range -  <br>  * Last-Modified -  <br>  * ETag -  <br>  * Content-Disposition -  <br>  </td></tr>
         <tr><td> 401 </td><td> Unauthorized </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Resource Not Found </td><td>  -  </td></tr>
         <tr><td> 410 </td><td> object expired </td><td>  -  </td></tr>
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
      */
-    public File getObject(String repository, String ref, String path) throws ApiException {
-        ApiResponse<File> localVarResp = getObjectWithHttpInfo(repository, ref, path);
+    public File getObject(String repository, String ref, String path, String range) throws ApiException {
+        ApiResponse<File> localVarResp = getObjectWithHttpInfo(repository, ref, path, range);
         return localVarResp.getData();
     }
 
@@ -454,20 +462,22 @@ public class ObjectsApi {
      * @param repository  (required)
      * @param ref a reference (could be either a branch or a commit ID) (required)
      * @param path relative to the ref (required)
+     * @param range Byte range to retrieve (optional)
      * @return ApiResponse&lt;File&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
      * @http.response.details
      <table summary="Response Details" border="1">
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 200 </td><td> object content </td><td>  * Content-Length -  <br>  * Last-Modified -  <br>  * ETag -  <br>  * Content-Disposition -  <br>  </td></tr>
+        <tr><td> 206 </td><td> partial object content </td><td>  * Content-Length -  <br>  * Content-Range -  <br>  * Last-Modified -  <br>  * ETag -  <br>  * Content-Disposition -  <br>  </td></tr>
         <tr><td> 401 </td><td> Unauthorized </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Resource Not Found </td><td>  -  </td></tr>
         <tr><td> 410 </td><td> object expired </td><td>  -  </td></tr>
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<File> getObjectWithHttpInfo(String repository, String ref, String path) throws ApiException {
-        okhttp3.Call localVarCall = getObjectValidateBeforeCall(repository, ref, path, null);
+    public ApiResponse<File> getObjectWithHttpInfo(String repository, String ref, String path, String range) throws ApiException {
+        okhttp3.Call localVarCall = getObjectValidateBeforeCall(repository, ref, path, range, null);
         Type localVarReturnType = new TypeToken<File>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
@@ -478,6 +488,7 @@ public class ObjectsApi {
      * @param repository  (required)
      * @param ref a reference (could be either a branch or a commit ID) (required)
      * @param path relative to the ref (required)
+     * @param range Byte range to retrieve (optional)
      * @param _callback The callback to be executed when the API call finishes
      * @return The request call
      * @throws ApiException If fail to process the API call, e.g. serializing the request body object
@@ -485,15 +496,16 @@ public class ObjectsApi {
      <table summary="Response Details" border="1">
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 200 </td><td> object content </td><td>  * Content-Length -  <br>  * Last-Modified -  <br>  * ETag -  <br>  * Content-Disposition -  <br>  </td></tr>
+        <tr><td> 206 </td><td> partial object content </td><td>  * Content-Length -  <br>  * Content-Range -  <br>  * Last-Modified -  <br>  * ETag -  <br>  * Content-Disposition -  <br>  </td></tr>
         <tr><td> 401 </td><td> Unauthorized </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Resource Not Found </td><td>  -  </td></tr>
         <tr><td> 410 </td><td> object expired </td><td>  -  </td></tr>
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call getObjectAsync(String repository, String ref, String path, final ApiCallback<File> _callback) throws ApiException {
+    public okhttp3.Call getObjectAsync(String repository, String ref, String path, String range, final ApiCallback<File> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = getObjectValidateBeforeCall(repository, ref, path, _callback);
+        okhttp3.Call localVarCall = getObjectValidateBeforeCall(repository, ref, path, range, _callback);
         Type localVarReturnType = new TypeToken<File>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;

--- a/clients/java/src/main/java/io/lakefs/clients/api/ObjectsApi.java
+++ b/clients/java/src/main/java/io/lakefs/clients/api/ObjectsApi.java
@@ -364,6 +364,7 @@ public class ObjectsApi {
         <tr><td> 401 </td><td> Unauthorized </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Resource Not Found </td><td>  -  </td></tr>
         <tr><td> 410 </td><td> object expired </td><td>  -  </td></tr>
+        <tr><td> 416 </td><td> Requested Range Not Satisfiable </td><td>  -  </td></tr>
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
      */
@@ -448,6 +449,7 @@ public class ObjectsApi {
         <tr><td> 401 </td><td> Unauthorized </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Resource Not Found </td><td>  -  </td></tr>
         <tr><td> 410 </td><td> object expired </td><td>  -  </td></tr>
+        <tr><td> 416 </td><td> Requested Range Not Satisfiable </td><td>  -  </td></tr>
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
      */
@@ -473,6 +475,7 @@ public class ObjectsApi {
         <tr><td> 401 </td><td> Unauthorized </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Resource Not Found </td><td>  -  </td></tr>
         <tr><td> 410 </td><td> object expired </td><td>  -  </td></tr>
+        <tr><td> 416 </td><td> Requested Range Not Satisfiable </td><td>  -  </td></tr>
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
      */
@@ -500,6 +503,7 @@ public class ObjectsApi {
         <tr><td> 401 </td><td> Unauthorized </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Resource Not Found </td><td>  -  </td></tr>
         <tr><td> 410 </td><td> object expired </td><td>  -  </td></tr>
+        <tr><td> 416 </td><td> Requested Range Not Satisfiable </td><td>  -  </td></tr>
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
      */

--- a/clients/java/src/test/java/io/lakefs/clients/api/ObjectsApiTest.java
+++ b/clients/java/src/test/java/io/lakefs/clients/api/ObjectsApiTest.java
@@ -86,7 +86,8 @@ public class ObjectsApiTest {
         String repository = null;
         String ref = null;
         String path = null;
-                File response = api.getObject(repository, ref, path);
+        String range = null;
+                File response = api.getObject(repository, ref, path, range);
         // TODO: test validations
     }
     

--- a/clients/python/docs/ObjectsApi.md
+++ b/clients/python/docs/ObjectsApi.md
@@ -284,11 +284,21 @@ with lakefs_client.ApiClient(configuration) as api_client:
     repository = "repository_example" # str | 
     ref = "ref_example" # str | a reference (could be either a branch or a commit ID)
     path = "path_example" # str | relative to the ref
+    range = "bytes=0-1023" # str | Byte range to retrieve (optional)
 
     # example passing only required values which don't have defaults set
     try:
         # get object content
         api_response = api_instance.get_object(repository, ref, path)
+        pprint(api_response)
+    except lakefs_client.ApiException as e:
+        print("Exception when calling ObjectsApi->get_object: %s\n" % e)
+
+    # example passing only required values which don't have defaults set
+    # and optional values
+    try:
+        # get object content
+        api_response = api_instance.get_object(repository, ref, path, range=range)
         pprint(api_response)
     except lakefs_client.ApiException as e:
         print("Exception when calling ObjectsApi->get_object: %s\n" % e)
@@ -302,6 +312,7 @@ Name | Type | Description  | Notes
  **repository** | **str**|  |
  **ref** | **str**| a reference (could be either a branch or a commit ID) |
  **path** | **str**| relative to the ref |
+ **range** | **str**| Byte range to retrieve | [optional]
 
 ### Return type
 
@@ -322,6 +333,7 @@ Name | Type | Description  | Notes
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 **200** | object content |  * Content-Length -  <br>  * Last-Modified -  <br>  * ETag -  <br>  * Content-Disposition -  <br>  |
+**206** | partial object content |  * Content-Length -  <br>  * Content-Range -  <br>  * Last-Modified -  <br>  * ETag -  <br>  * Content-Disposition -  <br>  |
 **401** | Unauthorized |  -  |
 **404** | Resource Not Found |  -  |
 **410** | object expired |  -  |

--- a/clients/python/docs/ObjectsApi.md
+++ b/clients/python/docs/ObjectsApi.md
@@ -337,6 +337,7 @@ Name | Type | Description  | Notes
 **401** | Unauthorized |  -  |
 **404** | Resource Not Found |  -  |
 **410** | object expired |  -  |
+**416** | Requested Range Not Satisfiable |  -  |
 **0** | Internal Server Error |  -  |
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)

--- a/clients/python/lakefs_client/api/objects_api.py
+++ b/clients/python/lakefs_client/api/objects_api.py
@@ -194,6 +194,7 @@ class ObjectsApi(object):
                     'repository',
                     'ref',
                     'path',
+                    'range',
                 ],
                 'required': [
                     'repository',
@@ -205,10 +206,17 @@ class ObjectsApi(object):
                 'enum': [
                 ],
                 'validation': [
+                    'range',
                 ]
             },
             root_map={
                 'validations': {
+                    ('range',): {
+
+                        'regex': {
+                            'pattern': r'^bytes=((\d*-\d*,? ?)+)$',  # noqa: E501
+                        },
+                    },
                 },
                 'allowed_values': {
                 },
@@ -219,16 +227,20 @@ class ObjectsApi(object):
                         (str,),
                     'path':
                         (str,),
+                    'range':
+                        (str,),
                 },
                 'attribute_map': {
                     'repository': 'repository',
                     'ref': 'ref',
                     'path': 'path',
+                    'range': 'Range',
                 },
                 'location_map': {
                     'repository': 'path',
                     'ref': 'path',
                     'path': 'query',
+                    'range': 'header',
                 },
                 'collection_format_map': {
                 }
@@ -801,6 +813,7 @@ class ObjectsApi(object):
             path (str): relative to the ref
 
         Keyword Args:
+            range (str): Byte range to retrieve. [optional]
             _return_http_data_only (bool): response data without head status
                 code and headers. Default is True.
             _preload_content (bool): if False, the urllib3.HTTPResponse object

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -2888,7 +2888,7 @@ func (c *Controller) GetObject(w http.ResponseWriter, r *http.Request, repositor
 	if params.Range != nil {
 		rng, err := httputil.ParseRange(*params.Range, entry.Size)
 		if err != nil {
-			writeError(w, http.StatusBadRequest, "invalid byte range")
+			writeError(w, http.StatusRequestedRangeNotSatisfiable, "Requested Range Not Satisfiable")
 			return
 		}
 		reader, err = c.BlockAdapter.GetRange(ctx, pointer, rng.StartOffset, rng.EndOffset)

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -2881,14 +2881,35 @@ func (c *Controller) GetObject(w http.ResponseWriter, r *http.Request, repositor
 	}
 
 	// setup response
-	reader, err := c.BlockAdapter.Get(ctx, block.ObjectPointer{StorageNamespace: repo.StorageNamespace, Identifier: entry.PhysicalAddress}, entry.Size)
-	if c.handleAPIError(ctx, w, err) {
-		return
+	var reader io.ReadCloser
+
+	// handle partial response if byte range supplied
+	if params.Range != nil {
+		rng, err := httputil.ParseRange(*params.Range, entry.Size)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, "invalid byte range")
+		}
+		reader, err = c.BlockAdapter.GetRange(ctx, block.ObjectPointer{StorageNamespace: repo.StorageNamespace, Identifier: entry.PhysicalAddress}, rng.StartOffset, rng.EndOffset)
+		if c.handleAPIError(ctx, w, err) {
+			return
+		}
+		defer func() {
+			_ = reader.Close()
+		}()
+		w.WriteHeader(http.StatusPartialContent)
+		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", rng.StartOffset, rng.EndOffset, entry.Size))
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", rng.EndOffset-rng.StartOffset+1))
+	} else {
+		reader, err = c.BlockAdapter.Get(ctx, block.ObjectPointer{StorageNamespace: repo.StorageNamespace, Identifier: entry.PhysicalAddress}, entry.Size)
+		if c.handleAPIError(ctx, w, err) {
+			return
+		}
+		defer func() {
+			_ = reader.Close()
+		}()
+		w.Header().Set("Content-Length", fmt.Sprint(entry.Size))
 	}
-	defer func() {
-		_ = reader.Close()
-	}()
-	w.Header().Set("Content-Length", fmt.Sprint(entry.Size))
+
 	etag := httputil.ETag(entry.Checksum)
 	w.Header().Set("ETag", etag)
 	lastModified := httputil.HeaderTimestamp(entry.CreationDate)

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -2882,14 +2882,16 @@ func (c *Controller) GetObject(w http.ResponseWriter, r *http.Request, repositor
 
 	// setup response
 	var reader io.ReadCloser
+	pointer := block.ObjectPointer{StorageNamespace: repo.StorageNamespace, Identifier: entry.PhysicalAddress}
 
 	// handle partial response if byte range supplied
 	if params.Range != nil {
 		rng, err := httputil.ParseRange(*params.Range, entry.Size)
 		if err != nil {
 			writeError(w, http.StatusBadRequest, "invalid byte range")
+			return
 		}
-		reader, err = c.BlockAdapter.GetRange(ctx, block.ObjectPointer{StorageNamespace: repo.StorageNamespace, Identifier: entry.PhysicalAddress}, rng.StartOffset, rng.EndOffset)
+		reader, err = c.BlockAdapter.GetRange(ctx, pointer, rng.StartOffset, rng.EndOffset)
 		if c.handleAPIError(ctx, w, err) {
 			return
 		}
@@ -2900,7 +2902,7 @@ func (c *Controller) GetObject(w http.ResponseWriter, r *http.Request, repositor
 		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", rng.StartOffset, rng.EndOffset, entry.Size))
 		w.Header().Set("Content-Length", fmt.Sprintf("%d", rng.EndOffset-rng.StartOffset+1))
 	} else {
-		reader, err = c.BlockAdapter.Get(ctx, block.ObjectPointer{StorageNamespace: repo.StorageNamespace, Identifier: entry.PhysicalAddress}, entry.Size)
+		reader, err = c.BlockAdapter.Get(ctx, pointer, entry.Size)
 		if c.handleAPIError(ctx, w, err) {
 			return
 		}

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -1932,20 +1932,20 @@ func TestController_ObjectsGetObjectHandler(t *testing.T) {
 			t.Fatal(err)
 		}
 		if resp.HTTPResponse.StatusCode != http.StatusOK {
-			t.Fatalf("GetObject() status code %d, expected %d", resp.HTTPResponse.StatusCode, http.StatusOK)
+			t.Errorf("GetObject() status code %d, expected %d", resp.HTTPResponse.StatusCode, http.StatusOK)
 		}
 
 		if resp.HTTPResponse.ContentLength != 37 {
-			t.Fatalf("expected 37 bytes in content length, got back %d", resp.HTTPResponse.ContentLength)
+			t.Errorf("expected 37 bytes in content length, got back %d", resp.HTTPResponse.ContentLength)
 		}
 		etag := resp.HTTPResponse.Header.Get("ETag")
 		if etag != `"3c4838fe975c762ee97cf39fbbe566f1"` {
-			t.Fatalf("got unexpected etag: %s", etag)
+			t.Errorf("got unexpected etag: %s", etag)
 		}
 
 		body := string(resp.Body)
 		if body != "this is file content made up of bytes" {
-			t.Fatalf("got unexpected body: '%s'", body)
+			t.Errorf("got unexpected body: '%s'", body)
 		}
 	})
 
@@ -1959,21 +1959,21 @@ func TestController_ObjectsGetObjectHandler(t *testing.T) {
 			t.Fatal(err)
 		}
 		if resp.HTTPResponse.StatusCode != http.StatusPartialContent {
-			t.Fatalf("GetObject() status code %d, expected %d", resp.HTTPResponse.StatusCode, http.StatusPartialContent)
+			t.Errorf("GetObject() status code %d, expected %d", resp.HTTPResponse.StatusCode, http.StatusPartialContent)
 		}
 
 		if resp.HTTPResponse.ContentLength != 10 {
-			t.Fatalf("expected 10 bytes in content length, got back %d", resp.HTTPResponse.ContentLength)
+			t.Errorf("expected 10 bytes in content length, got back %d", resp.HTTPResponse.ContentLength)
 		}
 
 		etag := resp.HTTPResponse.Header.Get("ETag")
 		if etag != `"3c4838fe975c762ee97cf39fbbe566f1"` {
-			t.Fatalf("got unexpected etag: %s", etag)
+			t.Errorf("got unexpected etag: %s", etag)
 		}
 
 		body := string(resp.Body)
 		if body != "this is fi" {
-			t.Fatalf("got unexpected body: '%s'", body)
+			t.Errorf("got unexpected body: '%s'", body)
 		}
 	})
 
@@ -1987,18 +1987,18 @@ func TestController_ObjectsGetObjectHandler(t *testing.T) {
 			t.Fatal(err)
 		}
 		if resp.HTTPResponse.StatusCode != http.StatusRequestedRangeNotSatisfiable {
-			t.Fatalf("GetObject() status code %d, expected %d", resp.HTTPResponse.StatusCode, http.StatusRequestedRangeNotSatisfiable)
+			t.Errorf("GetObject() status code %d, expected %d", resp.HTTPResponse.StatusCode, http.StatusRequestedRangeNotSatisfiable)
 		}
 	})
 
 	t.Run("get properties", func(t *testing.T) {
 		resp, err := clt.GetUnderlyingPropertiesWithResponse(ctx, "repo1", "main", &api.GetUnderlyingPropertiesParams{Path: "foo/bar"})
 		if err != nil {
-			t.Fatalf("expected to get underlying properties, got %v", err)
+			t.Errorf("expected to get underlying properties, got %v", err)
 		}
 		properties := resp.JSON200
 		if properties == nil {
-			t.Fatalf("expected to get underlying properties, status code %d", resp.HTTPResponse.StatusCode)
+			t.Errorf("expected to get underlying properties, status code %d", resp.HTTPResponse.StatusCode)
 		}
 
 		if api.StringValue(properties.StorageClass) != expensiveString {

--- a/pkg/gateway/operations/getobject.go
+++ b/pkg/gateway/operations/getobject.go
@@ -10,7 +10,6 @@ import (
 	"github.com/treeverse/lakefs/pkg/block"
 	"github.com/treeverse/lakefs/pkg/catalog"
 	gatewayerrors "github.com/treeverse/lakefs/pkg/gateway/errors"
-	ghttp "github.com/treeverse/lakefs/pkg/gateway/http"
 	"github.com/treeverse/lakefs/pkg/gateway/serde"
 	"github.com/treeverse/lakefs/pkg/graveler"
 	"github.com/treeverse/lakefs/pkg/httputil"
@@ -71,11 +70,11 @@ func (controller *GetObject) Handle(w http.ResponseWriter, req *http.Request, o 
 	// range query
 	var expected int64
 	var data io.ReadCloser
-	var rng ghttp.Range
+	var rng httputil.Range
 	// range query
 	rangeSpec := req.Header.Get("Range")
 	if len(rangeSpec) > 0 {
-		rng, err = ghttp.ParseRange(rangeSpec, entry.Size)
+		rng, err = httputil.ParseRange(rangeSpec, entry.Size)
 		if err != nil {
 			o.Log(req).WithError(err).WithField("range", rangeSpec).Debug("invalid range spec")
 		}

--- a/pkg/gateway/operations/putobject.go
+++ b/pkg/gateway/operations/putobject.go
@@ -11,7 +11,6 @@ import (
 	"github.com/treeverse/lakefs/pkg/block"
 	"github.com/treeverse/lakefs/pkg/catalog"
 	gatewayErrors "github.com/treeverse/lakefs/pkg/gateway/errors"
-	ghttp "github.com/treeverse/lakefs/pkg/gateway/http"
 	"github.com/treeverse/lakefs/pkg/gateway/path"
 	"github.com/treeverse/lakefs/pkg/gateway/serde"
 	"github.com/treeverse/lakefs/pkg/graveler"
@@ -222,7 +221,7 @@ func handleUploadPart(w http.ResponseWriter, req *http.Request, o *PathOperation
 		var resp *block.UploadPartResponse
 		if rang := req.Header.Get(CopySourceRangeHeader); rang != "" {
 			// if this is a copy part with a byte range:
-			parsedRange, parseErr := ghttp.ParseRange(rang, ent.Size)
+			parsedRange, parseErr := httputil.ParseRange(rang, ent.Size)
 			if parseErr != nil {
 				// invalid range will silently fallback to copying the entire object. ¯\_(ツ)_/¯
 				resp, err = o.BlockStore.UploadCopyPart(req.Context(), src, dst, uploadID, partNumber)

--- a/pkg/httputil/range.go
+++ b/pkg/httputil/range.go
@@ -1,4 +1,4 @@
-package http
+package httputil
 
 import (
 	"fmt"

--- a/pkg/httputil/range_test.go
+++ b/pkg/httputil/range_test.go
@@ -2,8 +2,9 @@ package httputil_test
 
 import (
 	"fmt"
-	"github.com/treeverse/lakefs/pkg/httputil"
 	"testing"
+
+	"github.com/treeverse/lakefs/pkg/httputil"
 )
 
 func TestParseRange(t *testing.T) {

--- a/pkg/httputil/range_test.go
+++ b/pkg/httputil/range_test.go
@@ -1,10 +1,9 @@
-package http_test
+package httputil_test
 
 import (
 	"fmt"
+	"github.com/treeverse/lakefs/pkg/httputil"
 	"testing"
-
-	"github.com/treeverse/lakefs/pkg/gateway/http"
 )
 
 func TestParseRange(t *testing.T) {
@@ -33,7 +32,7 @@ func TestParseRange(t *testing.T) {
 
 	for _, c := range cases {
 		t.Run(fmt.Sprintf("%s_length_%d", c.Spec, c.Length), func(t *testing.T) {
-			r, err := http.ParseRange(c.Spec, int64(c.Length))
+			r, err := httputil.ParseRange(c.Spec, int64(c.Length))
 			if (err != nil) != c.ExpectedError {
 				t.Fatalf("got err=%s, expected error %t", err, c.ExpectedError)
 			}


### PR DESCRIPTION
Context: trying to read parquet footer from Pandas using the Python SDK, I discovered I can't read the Parquet footer since the API does not support byte ranges