### PR TITLE
Use temporary workdir on job branch and copy out to commit task

### DIFF
--- a/clients/hadoopfs/src/main/java/io/lakefs/committer/LakeFSOutputCommitter.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/committer/LakeFSOutputCommitter.java
@@ -259,10 +259,10 @@ public class LakeFSOutputCommitter extends FileOutputCommitter {
 
             if (hasChanges(jobBranch)) {
                 CommitsApi commits = lakeFSClient.getCommits();
+                CommitCreation commitCreation = new CommitCreation()
+                    .message(String.format("Add results of job %s", jobContext.getJobID()));
                 Commit c =
-                    commits.commit(repository, jobBranch,
-                                   new CommitCreation().message(String.format("Add success marker for job %s", jobContext.getJobID())),
-                                   null);
+                    commits.commit(repository, jobBranch, commitCreation, null);
                 LOG.info("Committed {}", c);
             } else {
                 LOG.info("Nothing to commit to {}", jobBranch);
@@ -274,7 +274,10 @@ public class LakeFSOutputCommitter extends FileOutputCommitter {
             }
             LOG.info("Merge job branch {} into {}", jobBranch, outputBranch);
             RefsApi refs = lakeFSClient.getRefs();
-            refs.mergeIntoBranch(repository, jobBranch, outputBranch, new Merge().message("").strategy("source-wins"));
+            Merge merge = new Merge()
+                .message(String.format("Commit job %s", jobContext.getJobID()))
+                .strategy("source-wins");
+            refs.mergeIntoBranch(repository, jobBranch, outputBranch, merge);
         } catch (ApiException e) {
             throw new IOException(String.format("commitJob %s failed", jobBranch), e);
         }

--- a/clients/hadoopfs/src/main/java/io/lakefs/committer/LakeFSOutputCommitter.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/committer/LakeFSOutputCommitter.java
@@ -4,6 +4,7 @@ import io.lakefs.Constants;
 import io.lakefs.FSConfiguration;
 import io.lakefs.LakeFSFileSystem;
 import io.lakefs.LakeFSClient;
+import io.lakefs.utils.Bulk;
 import io.lakefs.utils.ObjectLocation;
 
 import io.lakefs.clients.api.ApiException;
@@ -11,11 +12,11 @@ import io.lakefs.clients.api.BranchesApi;
 import io.lakefs.clients.api.RefsApi;
 import io.lakefs.clients.api.CommitsApi;
 import io.lakefs.clients.api.model.BranchCreation;
+import io.lakefs.clients.api.model.Commit;
 import io.lakefs.clients.api.model.CommitCreation;
 import io.lakefs.clients.api.model.DiffList;
 import io.lakefs.clients.api.model.Merge;
 
-import org.apache.commons.lang.exception.ExceptionUtils; // (for debug prints ONLY)
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.conf.Configuration;
@@ -30,7 +31,7 @@ import org.apache.http.HttpStatus;
 import com.google.common.base.Preconditions;
 import com.google.common.hash.Hashing;
 import com.google.common.hash.HashFunction;
-    
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,6 +49,9 @@ public class LakeFSOutputCommitter extends FileOutputCommitter {
      * API client connected to the lakeFS server used on the filesystem.
      */
     protected LakeFSClient lakeFSClient = null;
+
+    protected Bulk bulk = null;
+
     /**
      * Repository for files.
      */
@@ -65,20 +69,27 @@ public class LakeFSOutputCommitter extends FileOutputCommitter {
     protected String jobBranch = null;
 
     /**
-     * Branch for this task.  Deleted if the task fails.  Always defined,
+     * ID for this task, if created with a task context.  Always defined,
      * even if this committer is a noop.
      */
-    protected String taskBranch;
+    protected String taskID = null;
 
     /**
      * Output path (possibly supplied to task).  Defined on a task, null if
      * this committer is a noop.
      */
     protected Path outputPath = null;
+
+    /**
+     * Path for this job: outputPath in the job branch.
+     */
+    protected Path jobPath = null;
+
     /**
      * "Working" path for this task: the same as outputPath, but on
-     * taskBranch rather than on outputBranch.  Defined on a task, null if
-     * this committer is a noop.
+     * jobBranch rather than on outputBranch, and under
+     * _temporary/<TASK_ID>.  Defined on a task, null if this committer is a
+     * noop.
      */
     protected Path workPath = null;
 
@@ -107,8 +118,6 @@ public class LakeFSOutputCommitter extends FileOutputCommitter {
 
         this.conf = context.getConfiguration();
 
-        JobID id = context.getJobID();
-
         this.jobBranch = pathToBranch(outputPath);
 
         LOG.info("Construct OC: Job branch: {}", jobBranch);
@@ -118,10 +127,12 @@ public class LakeFSOutputCommitter extends FileOutputCommitter {
             Preconditions.checkArgument(fs instanceof LakeFSFileSystem,
                                         "%s not on a LakeFSFileSystem", outputPath);
             this.lakeFSClient = new LakeFSClient(fs.getScheme(), conf);
+            this.bulk = new Bulk(this.lakeFSClient);
             ObjectLocation outputLocation = ObjectLocation.pathToObjectLocation(null, outputPath);
             this.repository = outputLocation.getRepository();
             this.outputBranch = outputLocation.getRef();
             this.outputPath = fs.makeQualified(outputPath);
+            this.jobPath = changePathBranch(this.outputPath, this.jobBranch);
         }
     }
 
@@ -129,19 +140,19 @@ public class LakeFSOutputCommitter extends FileOutputCommitter {
         this(outputPath, (JobContext)context);
 
         TaskAttemptID id = context.getTaskAttemptID();
-        // TODO(ariels): s/[^-\w]//g on the branch ID, ensuring all chars
-        // are allowed.  (Some) users might manage to create a bad task
-        // name.
-        this.taskBranch = String.format("%s-%s", this.jobBranch, id.toString());
+        // TODO(ariels): Consider removing weird characters from the task
+        //     ID: users who do not use Spark might manage to create a weird
+        //     task name.
+        this.taskID = id.toString();
 
         if (outputPath != null) {
-            this.workPath = changePathBranch(outputPath, this.taskBranch);
-            LOG.trace("Working path: {}", workPath);
+            this.workPath = new Path(this.jobPath, "_temporary/" + this.taskID + "/");
+            LOG.debug("Working path: {}", this.workPath);
         }
     }
 
     private Path changePathBranch(Path path, String branch) {
-        ObjectLocation loc = ObjectLocation.pathToObjectLocation(null, path);
+        ObjectLocation loc = ObjectLocation.pathToObjectLocation(path);
         loc.setRef(branch);
         return loc.toFSPath();
     }
@@ -240,27 +251,37 @@ public class LakeFSOutputCommitter extends FileOutputCommitter {
             boolean changes = false;
 
             if (needsSuccessFile()) {
-                Path markerPath = new Path(changePathBranch(outputPath, jobBranch),
-                                           FileOutputCommitter.SUCCEEDED_FILE_NAME);
+                Path markerPath = new Path(jobPath, FileOutputCommitter.SUCCEEDED_FILE_NAME);
                 fs.create(markerPath, true).close();
-
-                CommitsApi commits = lakeFSClient.getCommits();
-                commits.commit(repository, jobBranch, new CommitCreation().message(String.format("Add success marker for job %s", jobContext.getJobID())), null);
             }
+
+            bulk.deletePrefix(ObjectLocation.pathToObjectLocation(null, new Path(jobPath, "_temporary")));
+
+            if (hasChanges(jobBranch)) {
+                CommitsApi commits = lakeFSClient.getCommits();
+                Commit c =
+                    commits.commit(repository, jobBranch,
+                                   new CommitCreation().message(String.format("Add success marker for job %s", jobContext.getJobID())),
+                                   null);
+                LOG.info("Committed {}", c);
+            } else {
+                LOG.info("Nothing to commit to {}", jobBranch);
+            }
+
             if (!hasDiffs(repository, jobBranch, outputBranch)) {
-                LOG.debug("No differences from {} to {}, nothing to merge", jobBranch, outputBranch);
+                LOG.info("No differences from {} to {}, nothing to merge", jobBranch, outputBranch);
                 return;
             }
-            LOG.info("Commit job branch {} to {}", jobBranch, outputBranch);
+            LOG.info("Merge job branch {} into {}", jobBranch, outputBranch);
             RefsApi refs = lakeFSClient.getRefs();
             refs.mergeIntoBranch(repository, jobBranch, outputBranch, new Merge().message("").strategy("source-wins"));
         } catch (ApiException e) {
-            throw new IOException(String.format("commitJob %s failed", jobContext.getJobID()), e);
+            throw new IOException(String.format("commitJob %s failed", jobBranch), e);
         }
         try {
             cleanupJob();
         } catch (IOException e) {
-            LOG.warn("Failed to delete task branch {} after merge (keep going)", taskBranch, e);
+            LOG.warn("Failed to delete job branch {} after merge (keep going)", jobBranch, e);
         }
 
     }
@@ -279,20 +300,7 @@ public class LakeFSOutputCommitter extends FileOutputCommitter {
     }
 
     @Override
-    public void setupTask(TaskAttemptContext taskContext)
-        throws IOException {
-        if (outputPath == null)
-            return;
-        LOG.info("Setup task for {} on {}", taskBranch, jobBranch);
-        createBranch(jobBranch, outputBranch);
-        createBranch(taskBranch, jobBranch);
-    }
-
-    private void cleanupTask() throws IOException {
-        if (FSConfiguration.getBoolean(conf, outputPath.toUri().getScheme(), Constants.OC_DELETE_TASK_BRANCH, true)) {
-            deleteBranch(taskBranch);
-        }
-    }
+    public void setupTask(TaskAttemptContext taskContext) throws IOException {}
 
     @Override
     public void commitTask(TaskAttemptContext taskContext)
@@ -300,42 +308,16 @@ public class LakeFSOutputCommitter extends FileOutputCommitter {
         if (outputPath == null)
             return;
         try {
-            if (!hasChanges(taskBranch)) {
-                LOG.debug("Nothing to commit into {} for {}", taskBranch, jobBranch);
-                return;
-            }
-
-            LOG.info("Commit task branch {} and merge to {}", taskBranch, jobBranch);
-            CommitsApi commits = lakeFSClient.getCommits();
-            commits.commit(repository, taskBranch, new CommitCreation().message(String.format("committing Task %s", taskContext.getTaskAttemptID())), null);
-
-            if (!hasDiffs(repository, taskBranch, jobBranch)) {
-                LOG.info("Strange, after committing no differences from {} to {}, nothing to merge", taskBranch, jobBranch);
-                return;
-            }
-            RefsApi refs = lakeFSClient.getRefs();
-            refs.mergeIntoBranch(repository, taskBranch, jobBranch, new Merge().message(""));
+            LOG.info("Move task {} files from {} to {}", taskID, workPath, jobPath);
+            bulk.copyPrefix(ObjectLocation.pathToObjectLocation(workPath),
+                            ObjectLocation.pathToObjectLocation(jobPath));
         } catch (ApiException e) {
             throw new IOException(String.format("commitTask %s failed", taskContext.getTaskAttemptID()), e);
-        }
-        try {
-            cleanupTask();
-        } catch (IOException e) {
-            LOG.warn("Failed to delete task branch {} after merge (keep going)", taskBranch, e);
         }
     }
 
     @Override
-    public void abortTask(TaskAttemptContext taskContext)
-        throws IOException {    // TODO(lynn)
-        if (outputPath == null)
-            return;
-        try {
-            cleanupTask();
-        } catch (IOException e) {
-            LOG.warn("Failed to delete task branch {} while aborting (keep going)", taskBranch, e);
-        }
-    }
+    public void abortTask(TaskAttemptContext taskContext) throws IOException {}
 
     // TODO(lynn): More methods: isRecoverySupported, isCommitJobRepeatable, recoverTask.
 }

--- a/clients/hadoopfs/src/main/java/io/lakefs/utils/Bulk.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/utils/Bulk.java
@@ -1,0 +1,120 @@
+package io.lakefs.utils;
+
+import io.lakefs.LakeFSClient;
+
+import io.lakefs.clients.api.ApiException;
+import io.lakefs.clients.api.ObjectsApi;
+import io.lakefs.clients.api.model.ObjectStageCreation;
+import io.lakefs.clients.api.model.ObjectStats;
+import io.lakefs.clients.api.model.ObjectStatsList;
+import io.lakefs.clients.api.model.Pagination;
+import io.lakefs.clients.api.model.PathList;
+
+import org.apache.hadoop.fs.Path;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Bulk lakeFS operations.
+ *
+ * TODO(ariels): Some LakeFSFileSystem operations could use these.
+ */
+public class Bulk {
+    private static final Logger LOG = LoggerFactory.getLogger(Bulk.class);
+
+    protected final LakeFSClient lakeFSClient;
+
+    /**
+     * Size of bulks to use.  This is suitable for both listing and bulk
+     * deletion in the lakeFS API.
+     */
+    public static final int BULK_SIZE = 1000;
+
+    public Bulk(LakeFSClient lakeFSClient) {
+        this.lakeFSClient = lakeFSClient;
+    }
+
+    protected void ensureTrailingSlash(ObjectLocation loc) {
+        if (!loc.getPath().endsWith("/")) {
+            loc.setPath(loc.getPath() + "/");
+        }
+    }
+
+    /**
+     * Delete all objects beneath prefixLoc.
+     */
+    public void deletePrefix(ObjectLocation prefixLoc) throws ApiException {
+        ObjectsApi objects = lakeFSClient.getObjects();
+        ensureTrailingSlash(prefixLoc);
+
+        String after = "";
+        for (;;) {              // break within loop
+            ObjectStatsList o =
+                objects.listObjects(prefixLoc.getRepository(), prefixLoc.getRef(), false,
+                                    after, BULK_SIZE, "", prefixLoc.getPath());
+            Pagination page = o.getPagination();
+            after = page.getNextOffset();
+            if (o.getResults().isEmpty()) {
+                break;
+            }
+
+            // TODO(ariels): It may be faster to delete asynchronously using
+            //     BulkDeleter here.
+            PathList p = new PathList();
+            String lastPath = null;
+            for (ObjectStats stats : o.getResults()) {
+                String path = stats.getPath();
+                p.addPathsItem(path);
+                lastPath = path;
+            }
+            // BUG(ariels): Handle pathType??
+            LOG.info("{}/{}: Delete objects range {}..{}",
+                     prefixLoc.getRepository(), prefixLoc.getRef(), p.getPaths().get(0), lastPath);
+            objects.deleteObjects(prefixLoc.getRepository(), prefixLoc.getRef(), p);
+
+            if (!page.getHasMore()) {
+                break;
+            }
+        }
+    }
+
+    public void copyPrefix(ObjectLocation fromLoc, ObjectLocation toLoc) throws ApiException {
+        ObjectsApi objects = lakeFSClient.getObjects();
+        String after = "";
+        ensureTrailingSlash(fromLoc);
+        ensureTrailingSlash(toLoc);
+        Path listBase = new ObjectLocation(fromLoc.getScheme(), fromLoc.getRepository(), fromLoc.getRef()).toFSPath();
+        for (;;) {              // break within loop
+            ObjectStatsList o =
+                objects.listObjects(fromLoc.getRepository(), fromLoc.getRef(), true,
+                                    after, BULK_SIZE, "", fromLoc.getPath());
+            Pagination page = o.getPagination();
+            after = page.getNextOffset();
+
+            for (ObjectStats stats : o.getResults()) {
+                ObjectLocation src = ObjectLocation.pathToObjectLocation(listBase, new Path(stats.getPath()));
+                ObjectLocation dst = src.clone();
+                if (src.getPath().startsWith(fromLoc.getPath())) {
+                    dst.setPath(toLoc.getPath() + src.getPath().substring(fromLoc.getPath().length()));
+                } else {
+                    throw new RuntimeException(String.format("[I] %s does not have expected prefix %s", src, fromLoc));
+                }
+                // BUG(ariels): trace this!
+                LOG.info("{} -> {}", src, dst);
+                // TODO(ariels): Support upcoming copy-on-staging API.
+                ObjectStageCreation stage = new ObjectStageCreation()
+                    .physicalAddress(stats.getPhysicalAddress())
+                    .checksum(stats.getChecksum())
+                    .sizeBytes(stats.getSizeBytes())
+                    .mtime(stats.getMtime())
+                    .metadata(stats.getMetadata())
+                    .contentType(stats.getContentType());
+                objects.stageObject(dst.getRepository(), dst.getRef(), dst.getPath(), stage);
+            }
+            if (!page.getHasMore()) {
+                break;
+            }
+        }
+    }
+}

--- a/clients/hadoopfs/src/main/java/io/lakefs/utils/ObjectLocation.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/utils/ObjectLocation.java
@@ -16,6 +16,7 @@ public class ObjectLocation {
     /**
      * Returns Location with repository, ref and path used by lakeFS based on filesystem path.
      *
+     * @param workingDirectory used if path is local.
      * @param path to extract information from.
      * @return lakeFS Location with repository, ref and path
      */
@@ -23,7 +24,7 @@ public class ObjectLocation {
     static public ObjectLocation pathToObjectLocation(Path workingDirectory, Path path) {
         if (!path.isAbsolute()) {
             if (workingDirectory == null) {
-                throw new IllegalArgumentException("cannot expand local path with null workingDirectory");
+                throw new IllegalArgumentException(String.format("cannot expand local path %s with null workingDirectory", path));
             }
             path = new Path(workingDirectory, path);
         }
@@ -45,8 +46,21 @@ public class ObjectLocation {
         return loc;
     }
 
+    /**
+     * Returns Location with repository, ref and path used by lakeFS based on filesystem path.
+     *
+     * @param path to extract information from.
+     * @return lakeFS Location with repository, ref and path
+     */
+    @Nonnull
+    static public ObjectLocation pathToObjectLocation(Path path) {
+        return pathToObjectLocation(null, path);
+    }
+
     public static String formatPath(String scheme, String repository, String ref, String path) {
-        return String.format("%s://%s/%s/%s", scheme, repository, ref, path);
+        String ret = formatPath(scheme, repository, ref);
+        if (path != null) ret = ret + "/" + path;
+        return ret;
     }
 
 
@@ -76,6 +90,10 @@ public class ObjectLocation {
         this.repository = repository;
         this.ref = ref;
         this.path = path;
+    }
+
+    public ObjectLocation clone() {
+        return new ObjectLocation(scheme, repository, ref, path);
     }
 
     public ObjectLocation getParent() {

--- a/clients/hadoopfs/src/test/java/io/lakefs/utils/BulkTest.java
+++ b/clients/hadoopfs/src/test/java/io/lakefs/utils/BulkTest.java
@@ -1,0 +1,174 @@
+package io.lakefs.utils;
+
+import io.lakefs.LakeFSClient;
+import io.lakefs.clients.api.ApiException;
+import io.lakefs.clients.api.ObjectsApi;
+import io.lakefs.clients.api.model.ObjectStageCreation;
+import io.lakefs.clients.api.model.ObjectStats;
+import io.lakefs.clients.api.model.ObjectStatsList;
+import io.lakefs.clients.api.model.Pagination;
+import io.lakefs.clients.api.model.PathList;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+
+import org.apache.http.HttpStatus;
+import org.junit.Assert;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+public class BulkTest {
+    protected Bulk bulk;
+
+    protected LakeFSClient lfsClient;
+    protected ObjectsApi objects;
+
+    protected final String SCHEME = "pondfs";
+    protected final String REPO = "repo";
+    protected final String REF = "one";
+
+    protected final ObjectStats stats1 = new ObjectStats()
+        .path("foo/bar/_temp/task/baz/zoo")
+        .physicalAddress("s3://zoo")
+        .checksum("1")
+        .sizeBytes(11L)
+        .mtime(5432L)
+        .metadata(null)
+        .contentType("text/plain");
+    protected final ObjectStats stats2 = new ObjectStats()
+        .path("foo/bar/_temp/task/quux/boo")
+        .physicalAddress("s3://garden")
+        .checksum("2")
+        .sizeBytes(22L)
+        .mtime(54321L)
+        .metadata(null)
+        .contentType("text/complex");
+    protected final ObjectStats stats3 = new ObjectStats()
+        .path("foo/bar/_temp/task/quux/moo")
+        .physicalAddress("s3://path")
+        .checksum("3")
+        .sizeBytes(33L)
+        .mtime(543210L)
+        .metadata(null)
+        .contentType("x-app/app");
+
+    protected static ObjectStageCreation creationFor(ObjectStats stats) {
+        return new ObjectStageCreation()
+            .physicalAddress(stats.getPhysicalAddress())
+            .checksum(stats.getChecksum())
+            .sizeBytes(stats.getSizeBytes())
+            .mtime(stats.getMtime())
+            .metadata(stats.getMetadata())
+            .contentType(stats.getContentType());
+    }
+
+    @Before
+    public void mockClient() {
+        lfsClient = mock(LakeFSClient.class, Answers.RETURNS_SMART_NULLS);
+        objects = mock(ObjectsApi.class, Answers.RETURNS_SMART_NULLS);
+        when(lfsClient.getObjects()).thenReturn(objects);
+
+        bulk = new Bulk(lfsClient);
+    }
+
+    protected void checkCopyPrefixSingleItemCase(String src, String dst) throws ApiException {
+        when(objects.listObjects(REPO, REF, true, "", Bulk.BULK_SIZE, "", "foo/bar/_temp/task/"))
+            .thenReturn(new ObjectStatsList()
+                        .pagination(new Pagination().hasMore(false).nextOffset("unused"))
+                        .results(ImmutableList.of(stats1)));
+        bulk.copyPrefix(new ObjectLocation(SCHEME, REPO, REF, src),
+                        new ObjectLocation(SCHEME, REPO, REF, dst));
+        verify(objects).stageObject(REPO, REF, "foo/bar/baz/zoo", creationFor(stats1));
+    }
+
+    @Test
+    public void copyPrefix() throws ApiException {
+        checkCopyPrefixSingleItemCase("foo/bar/_temp/task/", "foo/bar/");
+    }
+
+    @Test
+    public void copyPrefixSrcWithoutTrailingSlash() throws ApiException {
+        checkCopyPrefixSingleItemCase("foo/bar/_temp/task", "foo/bar/");
+    }
+
+    @Test
+    public void copyPrefixDstWithoutTrailingSlash() throws ApiException {
+        checkCopyPrefixSingleItemCase("foo/bar/_temp/task/", "foo/bar");
+    }
+
+    @Test
+    public void copyPrefixManyItemsListPaged() throws ApiException {
+        String next1 = stats2.getPath() + "\0";
+        ObjectStatsList osl1 = new ObjectStatsList()
+            .pagination(new Pagination().hasMore(true).nextOffset(next1))
+            .results(ImmutableList.of(stats1, stats2));
+        when(objects.listObjects(REPO, REF, true, "", Bulk.BULK_SIZE, "", "foo/bar/_temp/task/"))
+            .thenReturn(osl1);
+        ObjectStatsList osl2 = new ObjectStatsList()
+            .pagination(new Pagination().hasMore(false).nextOffset("unused"))
+            .results(ImmutableList.of(stats3));
+        when(objects.listObjects(REPO, REF, true, next1, Bulk.BULK_SIZE, "", "foo/bar/_temp/task/"))
+            .thenReturn(osl2);
+        bulk.copyPrefix(new ObjectLocation(SCHEME, REPO, REF, "foo/bar/_temp/task/"),
+                        new ObjectLocation(SCHEME, REPO, REF, "foo/bar/"));
+        verify(objects).stageObject(REPO, REF, "foo/bar/baz/zoo", creationFor(stats1));
+        verify(objects).stageObject(REPO, REF, "foo/bar/quux/boo", creationFor(stats2));
+        verify(objects).stageObject(REPO, REF, "foo/bar/quux/moo", creationFor(stats3));
+    }
+
+    @Test
+    public void deletePrefix() throws ApiException {
+        when(objects.listObjects(REPO, REF, false, "", Bulk.BULK_SIZE, "", "foo/bar/_temp/task/"))
+            .thenReturn(new ObjectStatsList()
+                        .pagination(new Pagination().hasMore(false).nextOffset("unused"))
+                        .results(ImmutableList.of(stats1)));
+        bulk.deletePrefix(new ObjectLocation(SCHEME, REPO, REF, "foo/bar/_temp/task/"));
+        verify(objects).deleteObjects(REPO, REF, new PathList().
+                                      paths(ImmutableList.of(stats1.getPath())));
+    }
+
+    @Test
+    public void deletePrefixWithoutTrailingSlash() throws ApiException {
+        when(objects.listObjects(REPO, REF, false, "", Bulk.BULK_SIZE, "", "foo/bar/_temp/task/"))
+            .thenReturn(new ObjectStatsList()
+                        .pagination(new Pagination().hasMore(false).nextOffset("unused"))
+                        .results(ImmutableList.of(stats1)));
+        bulk.deletePrefix(new ObjectLocation(SCHEME, REPO, REF, "foo/bar/_temp/task"));
+        verify(objects).deleteObjects(REPO, REF, new PathList().
+                                      paths(ImmutableList.of(stats1.getPath())));
+    }
+
+    @Test
+    public void deletePrefixManyItemsListPaged() throws ApiException {
+        String next1 = stats2.getPath() + "\0";
+        ObjectStatsList osl1 = new ObjectStatsList()
+            .pagination(new Pagination().hasMore(true).nextOffset(next1))
+            .results(ImmutableList.of(stats1, stats2));
+        when(objects.listObjects(REPO, REF, false, "", Bulk.BULK_SIZE, "", "foo/bar/_temp/task/"))
+            .thenReturn(osl1);
+        ObjectStatsList osl2 = new ObjectStatsList()
+            .pagination(new Pagination().hasMore(false).nextOffset("unused"))
+            .results(ImmutableList.of(stats3));
+        when(objects.listObjects(REPO, REF, false, next1, Bulk.BULK_SIZE, "", "foo/bar/_temp/task/"))
+            .thenReturn(osl2);
+        bulk.deletePrefix(new ObjectLocation(SCHEME, REPO, REF, "foo/bar/_temp/task/"));
+        verify(objects).deleteObjects(REPO, REF, new PathList().
+                                      paths(ImmutableList.of(stats1.getPath(), stats2.getPath())));
+        verify(objects).deleteObjects(REPO, REF, new PathList().
+                                      paths(ImmutableList.of(stats3.getPath())));
+    }
+}


### PR DESCRIPTION
Summary of flow:

* setupJob creates a job branch.

  Use the output path for job branch not the job ID on the context, as some
  Spark writers call setupJob on *one* job context and then run all tasks
  on *another* job context.
* setupTask does nothing!
* Tasks write to workDir `_temporary/<task_id>` on the job branch in the
  outputPath location.
* commitTask lists and copies files up from workDir to the intended
  location.
* commitJob deletes `_temporary/`, creates _SUCCESS if requested, commits
  and merges to output.

Tested manually with 4000 partitions.  It takes ~22 minutes to write 4000
(small!) partitions on a cloud (staging) deployment.