### PR TITLE
GC+: CommittedDataLister transform address column to relative path

### DIFF
--- a/clients/spark/core/src/main/scala/io/treeverse/gc/CommittedAddressLister.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/gc/CommittedAddressLister.scala
@@ -27,7 +27,9 @@ class NaiveCommittedAddressLister extends CommittedAddressLister {
     // TODO push down a filter to the input format, to filter out absolute addresses!
     df = df
       // TODO (niro): Revert substring after https://github.com/treeverse/lakeFS/issues/4699
-      .select(df("absolute_address"), substring_index(col("absolute_address"), "/", -3) .as("address"))
+      .select(df("absolute_address"),
+              substring_index(col("absolute_address"), "/", -3).as("address")
+             )
       .distinct
     df
   }

--- a/clients/spark/core/src/main/scala/io/treeverse/gc/CommittedAddressLister.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/gc/CommittedAddressLister.scala
@@ -28,7 +28,7 @@ class NaiveCommittedAddressLister extends CommittedAddressLister {
     df = df
       // TODO (niro): Revert substring after https://github.com/treeverse/lakeFS/issues/4699
       .select(df("absolute_address"),
-              substring_index(col("absolute_address"), "/", -3).as("address")
+              substring_index(col("absolute_address"), normalizedStorageNamespace, -1).as("address")
              )
       .distinct
     df

--- a/clients/spark/core/src/main/scala/io/treeverse/gc/CommittedAddressLister.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/gc/CommittedAddressLister.scala
@@ -17,7 +17,7 @@ class NaiveCommittedAddressLister extends CommittedAddressLister {
       normalizedStorageNamespace = "/"
     }
     val params =
-      LakeFSJobParams.forStorageNamespace(s"${normalizedStorageNamespace}",
+      LakeFSJobParams.forStorageNamespace(s"$normalizedStorageNamespace",
                                           UncommittedGarbageCollector.UNCOMMITTED_GC_SOURCE_NAME
                                          )
     var df = LakeFSContext.newDF(spark, params)
@@ -26,7 +26,8 @@ class NaiveCommittedAddressLister extends CommittedAddressLister {
       .withColumn("absolute_address", concat(lit(normalizedStorageNamespace), df("address")))
     // TODO push down a filter to the input format, to filter out absolute addresses!
     df = df
-      .select(df("absolute_address").as("address"))
+      // TODO (niro): Revert substring after https://github.com/treeverse/lakeFS/issues/4699
+      .select(df("absolute_address"), substring_index(col("absolute_address"), "/", -3) .as("address"))
       .distinct
     df
   }


### PR DESCRIPTION
Closes #4698 

Intermediate solution until https://github.com/treeverse/lakeFS/issues/4699 is implemented

Tested manually:

```
+---------------------------------------------------------------------+
|address                                                              |
+---------------------------------------------------------------------+
|s3a://storagenamespace/data/gr7t8hlfcls7ethcf6k0/cdviuglfcls7ethcf6ng|
|s3a://storagenamespace/data/gr7t8hlfcls7ethcf6k0/sdkfjlfkvlkvcbcz    |
+---------------------------------------------------------------------+

+----------------------------------------------+
|address                                       |
+----------------------------------------------+
|data/gr7t8hlfcls7ethcf6k0/cdviuglfcls7ethcf6ng|
|data/gr7t8hlfcls7ethcf6k0/sdkfjlfkvlkvcbcz    |
+----------------------------------------------+
```