### PR TITLE
Perform fewer API calls for exists

### DIFF
--- a/clients/hadoopfs/pom.xml
+++ b/clients/hadoopfs/pom.xml
@@ -266,11 +266,13 @@ To export to S3:
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-client</artifactId>
             <version>2.7.7</version> <!-- The common Hadoop version for Spark 2.4.7 and 3.0.1, which lakeFS supports -->
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-mapreduce-client-jobclient</artifactId>
             <version>2.7.7</version> <!-- The common Hadoop version for Spark 2.4.7 and 3.0.1, which lakeFS supports -->
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.apache.parquet</groupId>

--- a/clients/hadoopfs/pom.xml
+++ b/clients/hadoopfs/pom.xml
@@ -257,6 +257,13 @@ To export to S3:
         </dependency>
 
         <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-sql_2.12</artifactId>
+            <version>3.0.1</version>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
             <version>${hadoop.version}</version>
@@ -333,7 +340,7 @@ To export to S3:
 	<dependency>
 	  <groupId>com.fasterxml.jackson.core</groupId>
 	  <artifactId>jackson-databind</artifactId>
-	  <version>2.13.4.1</version>
+	  <version>2.10.0</version>
 	  <scope>test</scope>
 	</dependency>
 	<dependency>

--- a/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileSystem.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileSystem.java
@@ -808,31 +808,72 @@ public class LakeFSFileSystem extends FileSystem {
             return isBranchExists(objectLoc.getRepository(), objectLoc.getRef());
         }
 
-        // check if file exists
         ObjectsApi objects = lfsClient.getObjects();
+        /*
+         * path "exists" in Hadoop if one of these holds:
+         *
+         *    - path exists on lakeFS (regular file)
+         *    - path + "/" exists (directory marker)
+         *    - path + "/" + <something> exists (a nonempty directory that has no
+         *      directory marker for some reason; perhaps it was not created by
+         *      Spark).
+         */
+
+        String directoryPath = objectLoc.toDirectory().getPath();
+        // List a small number of objects after path.  If either path or
+        // path + "/" + <something> are there, then path exists.  Pick the
+        // number of objects so that it costs about the same to list that
+        // many objects as it does to list 1.
         try {
-            objects.statObject(objectLoc.getRepository(), objectLoc.getRef(), objectLoc.getPath(), false);
-            return true;
+            ObjectStatsList osl = objects.listObjects(objectLoc.getRepository(), objectLoc.getRef(), false, "", 123 /* TODO(ariels): configure! */, "", objectLoc.getPath());
+            List<ObjectStats> l = osl.getResults();
+            if (l.isEmpty()) {
+                // No object with any name that starts with objectLoc.
+                return false;
+            }
+            ObjectStats first = l.get(0);
+            if (first.getPath().equals(objectLoc.getPath())) {
+                // objectLoc itself points at the object, it's a regular object!
+                return true;
+            }
+            for (ObjectStats stat : l) {
+                if (stat.getPath().startsWith(directoryPath)) {
+                    // path exists as a directory containing this object.
+                    // Also handles the case where this object is a directory marker.
+                    return true;
+                }
+                if (stat.getPath().compareTo(directoryPath) > 0) {
+                    // This object is after path + "/" and does not start
+                    // with it: there can be no object under path + "/".
+                    return false;
+                }
+            }
+            if (!osl.getPagination().getHasMore()) {
+                // Scanned all files with prefix path and did not find
+                // anything with path or path + "/".
+                return false;
+            }
         } catch (ApiException e) {
-            if (e.getCode() != HttpStatus.SC_NOT_FOUND) {
-                throw new IOException("statObject", e);
+            if (e.getCode() == HttpStatus.SC_NOT_FOUND) {
+                // Repository or ref do not exist.
+                return false;
+            } else {
+                throw new IOException("exists", e);
             }
         }
 
-        // check if directory marker directory exists
-        try {
-            objects.statObject(objectLoc.getRepository(), objectLoc.getRef(), objectLoc.getPath() + SEPARATOR, false);
-            return true;
-        } catch (ApiException e) {
-            if (e.getCode() != HttpStatus.SC_NOT_FOUND) {
-                throw new IOException("statObject", e);
-            }
-        }
+        // The initial listing did not even reach path+"/".  We know path
+        // does not exist (it would have been first in that listing), so
+        // just check if path+"/" or something below it exist.
 
-        // use listing to check if directory exists
-        ListingIterator iterator = new ListingIterator(path, true, 1);
-        iterator.setRemoveDirectory(false);
-        return iterator.hasNext();
+        try {
+            ObjectStatsList osl = objects.listObjects(objectLoc.getRepository(), objectLoc.getRef(), false, "", 1, "", directoryPath);
+            List<ObjectStats> l = osl.getResults();
+            return ! l.isEmpty();
+        } catch (ApiException e) {
+            // Repo and ref exist!
+            throw new IOException("exists", e);
+        }
     }
 
     private boolean isBranchExists(String repository, String branch) throws IOException {

--- a/clients/hadoopfs/src/main/java/io/lakefs/committer/DummyOutputCommitter.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/committer/DummyOutputCommitter.java
@@ -4,6 +4,7 @@ import io.lakefs.Constants;
 import io.lakefs.FSConfiguration;
 import io.lakefs.LakeFSFileSystem;
 import io.lakefs.LakeFSClient;
+import io.lakefs.utils.Bulk;
 import io.lakefs.utils.ObjectLocation;
 
 import io.lakefs.clients.api.ApiException;
@@ -11,11 +12,11 @@ import io.lakefs.clients.api.BranchesApi;
 import io.lakefs.clients.api.RefsApi;
 import io.lakefs.clients.api.CommitsApi;
 import io.lakefs.clients.api.model.BranchCreation;
+import io.lakefs.clients.api.model.Commit;
 import io.lakefs.clients.api.model.CommitCreation;
 import io.lakefs.clients.api.model.DiffList;
 import io.lakefs.clients.api.model.Merge;
 
-import org.apache.commons.lang.exception.ExceptionUtils; // (for debug prints ONLY)
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.conf.Configuration;
@@ -30,7 +31,7 @@ import org.apache.http.HttpStatus;
 import com.google.common.base.Preconditions;
 import com.google.common.hash.Hashing;
 import com.google.common.hash.HashFunction;
-    
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,6 +49,9 @@ public class DummyOutputCommitter extends FileOutputCommitter {
      * API client connected to the lakeFS server used on the filesystem.
      */
     protected LakeFSClient lakeFSClient = null;
+
+    protected Bulk bulk = null;
+
     /**
      * Repository for files.
      */
@@ -65,20 +69,27 @@ public class DummyOutputCommitter extends FileOutputCommitter {
     protected String jobBranch = null;
 
     /**
-     * Branch for this task.  Deleted if the task fails.  Always defined,
+     * ID for this task, if created with a task context.  Always defined,
      * even if this committer is a noop.
      */
-    protected String taskBranch;
+    protected String taskID = null;
 
     /**
      * Output path (possibly supplied to task).  Defined on a task, null if
      * this committer is a noop.
      */
     protected Path outputPath = null;
+
+    /**
+     * Path for this job: outputPath in the job branch.
+     */
+    protected Path jobPath = null;
+
     /**
      * "Working" path for this task: the same as outputPath, but on
-     * taskBranch rather than on outputBranch.  Defined on a task, null if
-     * this committer is a noop.
+     * jobBranch rather than on outputBranch, and under
+     * _temporary/<TASK_ID>.  Defined on a task, null if this committer is a
+     * noop.
      */
     protected Path workPath = null;
 
@@ -107,8 +118,6 @@ public class DummyOutputCommitter extends FileOutputCommitter {
 
         this.conf = context.getConfiguration();
 
-        JobID id = context.getJobID();
-
         this.jobBranch = pathToBranch(outputPath);
 
         LOG.info("Construct OC: Job branch: {}", jobBranch);
@@ -118,10 +127,12 @@ public class DummyOutputCommitter extends FileOutputCommitter {
             Preconditions.checkArgument(fs instanceof LakeFSFileSystem,
                                         "%s not on a LakeFSFileSystem", outputPath);
             this.lakeFSClient = new LakeFSClient(fs.getScheme(), conf);
+            this.bulk = new Bulk(this.lakeFSClient);
             ObjectLocation outputLocation = ObjectLocation.pathToObjectLocation(null, outputPath);
             this.repository = outputLocation.getRepository();
             this.outputBranch = outputLocation.getRef();
             this.outputPath = fs.makeQualified(outputPath);
+            this.jobPath = changePathBranch(this.outputPath, this.jobBranch);
         }
     }
 
@@ -129,19 +140,19 @@ public class DummyOutputCommitter extends FileOutputCommitter {
         this(outputPath, (JobContext)context);
 
         TaskAttemptID id = context.getTaskAttemptID();
-        // TODO(ariels): s/[^-\w]//g on the branch ID, ensuring all chars
-        // are allowed.  (Some) users might manage to create a bad task
-        // name.
-        this.taskBranch = String.format("%s-%s", this.jobBranch, id.toString());
+        // TODO(ariels): Consider removing weird characters from the task
+        //     ID: users who do not use Spark might manage to create a weird
+        //     task name.
+        this.taskID = id.toString();
 
         if (outputPath != null) {
-            this.workPath = changePathBranch(outputPath, this.taskBranch);
-            LOG.trace("Working path: {}", workPath);
+            this.workPath = new Path(this.jobPath, "_temporary/" + this.taskID + "/");
+            LOG.debug("Working path: {}", this.workPath);
         }
     }
 
     private Path changePathBranch(Path path, String branch) {
-        ObjectLocation loc = ObjectLocation.pathToObjectLocation(null, path);
+        ObjectLocation loc = ObjectLocation.pathToObjectLocation(path);
         loc.setRef(branch);
         return loc.toFSPath();
     }
@@ -240,27 +251,37 @@ public class DummyOutputCommitter extends FileOutputCommitter {
             boolean changes = false;
 
             if (needsSuccessFile()) {
-                Path markerPath = new Path(changePathBranch(outputPath, jobBranch),
-                                           FileOutputCommitter.SUCCEEDED_FILE_NAME);
+                Path markerPath = new Path(jobPath, FileOutputCommitter.SUCCEEDED_FILE_NAME);
                 fs.create(markerPath, true).close();
-
-                CommitsApi commits = lakeFSClient.getCommits();
-                commits.commit(repository, jobBranch, new CommitCreation().message(String.format("Add success marker for job %s", jobContext.getJobID())), null);
             }
+
+            bulk.deletePrefix(ObjectLocation.pathToObjectLocation(null, new Path(jobPath, "_temporary")));
+
+            if (hasChanges(jobBranch)) {
+                CommitsApi commits = lakeFSClient.getCommits();
+                Commit c =
+                    commits.commit(repository, jobBranch,
+                                   new CommitCreation().message(String.format("Add success marker for job %s", jobContext.getJobID())),
+                                   null);
+                LOG.info("Committed {}", c);
+            } else {
+                LOG.info("Nothing to commit to {}", jobBranch);
+            }
+
             if (!hasDiffs(repository, jobBranch, outputBranch)) {
-                LOG.debug("No differences from {} to {}, nothing to merge", jobBranch, outputBranch);
+                LOG.info("No differences from {} to {}, nothing to merge", jobBranch, outputBranch);
                 return;
             }
-            LOG.info("Commit job branch {} to {}", jobBranch, outputBranch);
+            LOG.info("Merge job branch {} into {}", jobBranch, outputBranch);
             RefsApi refs = lakeFSClient.getRefs();
             refs.mergeIntoBranch(repository, jobBranch, outputBranch, new Merge().message("").strategy("source-wins"));
         } catch (ApiException e) {
-            throw new IOException(String.format("commitJob %s failed", jobContext.getJobID()), e);
+            throw new IOException(String.format("commitJob %s failed", jobBranch), e);
         }
         try {
             cleanupJob();
         } catch (IOException e) {
-            LOG.warn("Failed to delete task branch {} after merge (keep going)", taskBranch, e);
+            LOG.warn("Failed to delete job branch {} after merge (keep going)", jobBranch, e);
         }
 
     }
@@ -279,20 +300,7 @@ public class DummyOutputCommitter extends FileOutputCommitter {
     }
 
     @Override
-    public void setupTask(TaskAttemptContext taskContext)
-        throws IOException {
-        if (outputPath == null)
-            return;
-        LOG.info("Setup task for {} on {}", taskBranch, jobBranch);
-        createBranch(jobBranch, outputBranch);
-        createBranch(taskBranch, jobBranch);
-    }
-
-    private void cleanupTask() throws IOException {
-        if (FSConfiguration.getBoolean(conf, outputPath.toUri().getScheme(), Constants.OC_DELETE_TASK_BRANCH, true)) {
-            deleteBranch(taskBranch);
-        }
-    }
+    public void setupTask(TaskAttemptContext taskContext) throws IOException {}
 
     @Override
     public void commitTask(TaskAttemptContext taskContext)
@@ -300,42 +308,16 @@ public class DummyOutputCommitter extends FileOutputCommitter {
         if (outputPath == null)
             return;
         try {
-            if (!hasChanges(taskBranch)) {
-                LOG.debug("Nothing to commit into {} for {}", taskBranch, jobBranch);
-                return;
-            }
-
-            LOG.info("Commit task branch {} and merge to {}", taskBranch, jobBranch);
-            CommitsApi commits = lakeFSClient.getCommits();
-            commits.commit(repository, taskBranch, new CommitCreation().message(String.format("committing Task %s", taskContext.getTaskAttemptID())), null);
-
-            if (!hasDiffs(repository, taskBranch, jobBranch)) {
-                LOG.info("Strange, after committing no differences from {} to {}, nothing to merge", taskBranch, jobBranch);
-                return;
-            }
-            RefsApi refs = lakeFSClient.getRefs();
-            refs.mergeIntoBranch(repository, taskBranch, jobBranch, new Merge().message(""));
+            LOG.info("Move task {} files from {} to {}", taskID, workPath, jobPath);
+            bulk.copyPrefix(ObjectLocation.pathToObjectLocation(workPath),
+                            ObjectLocation.pathToObjectLocation(jobPath));
         } catch (ApiException e) {
             throw new IOException(String.format("commitTask %s failed", taskContext.getTaskAttemptID()), e);
-        }
-        try {
-            cleanupTask();
-        } catch (IOException e) {
-            LOG.warn("Failed to delete task branch {} after merge (keep going)", taskBranch, e);
         }
     }
 
     @Override
-    public void abortTask(TaskAttemptContext taskContext)
-        throws IOException {    // TODO(lynn)
-        if (outputPath == null)
-            return;
-        try {
-            cleanupTask();
-        } catch (IOException e) {
-            LOG.warn("Failed to delete task branch {} while aborting (keep going)", taskBranch, e);
-        }
-    }
+    public void abortTask(TaskAttemptContext taskContext) throws IOException {}
 
     // TODO(lynn): More methods: isRecoverySupported, isCommitJobRepeatable, recoverTask.
 }

--- a/clients/hadoopfs/src/main/java/io/lakefs/committer/LakeFSOutputCommitter.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/committer/LakeFSOutputCommitter.java
@@ -40,8 +40,8 @@ import java.math.BigInteger;
 import java.nio.charset.Charset;
 
 // TODO(ariels): For Hadoop 3, it is enough (and better!) to extend PathOutputCommitter.
-public class DummyOutputCommitter extends FileOutputCommitter {
-    private static final Logger LOG = LoggerFactory.getLogger(DummyOutputCommitter.class);
+public class LakeFSOutputCommitter extends FileOutputCommitter {
+    private static final Logger LOG = LoggerFactory.getLogger(LakeFSOutputCommitter.class);
 
     private static final String branchNamePrefix = "lakeFS-OC";
 
@@ -113,7 +113,7 @@ public class DummyOutputCommitter extends FileOutputCommitter {
         return String.format("%s-%s-%s", branchNamePrefix, digest, pathPrefix);
     }
 
-    public DummyOutputCommitter(Path outputPath, JobContext context) throws IOException {
+    public LakeFSOutputCommitter(Path outputPath, JobContext context) throws IOException {
         super(outputPath, context);
 
         this.conf = context.getConfiguration();
@@ -136,7 +136,7 @@ public class DummyOutputCommitter extends FileOutputCommitter {
         }
     }
 
-    public DummyOutputCommitter(Path outputPath, TaskAttemptContext context) throws IOException {
+    public LakeFSOutputCommitter(Path outputPath, TaskAttemptContext context) throws IOException {
         this(outputPath, (JobContext)context);
 
         TaskAttemptID id = context.getTaskAttemptID();

--- a/clients/hadoopfs/src/main/java/io/lakefs/committer/LakeFSParquetOutputCommitter.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/committer/LakeFSParquetOutputCommitter.java
@@ -9,12 +9,12 @@ import org.apache.parquet.hadoop.util.ContextUtil;
 
 import java.io.IOException;
 
-public class DummyParquetOutputCommitter extends DummyOutputCommitter {
-    public DummyParquetOutputCommitter(Path outputPath, JobContext context) throws IOException {
+public class LakeFSParquetOutputCommitter extends LakeFSOutputCommitter {
+    public LakeFSParquetOutputCommitter(Path outputPath, JobContext context) throws IOException {
         super(outputPath, context);
     }
 
-    public DummyParquetOutputCommitter(Path outputPath, TaskAttemptContext context) throws IOException {
+    public LakeFSParquetOutputCommitter(Path outputPath, TaskAttemptContext context) throws IOException {
         super(outputPath, context);
     }
 

--- a/clients/hadoopfs/src/main/java/io/lakefs/utils/Bulk.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/utils/Bulk.java
@@ -1,0 +1,120 @@
+package io.lakefs.utils;
+
+import io.lakefs.LakeFSClient;
+
+import io.lakefs.clients.api.ApiException;
+import io.lakefs.clients.api.ObjectsApi;
+import io.lakefs.clients.api.model.ObjectStageCreation;
+import io.lakefs.clients.api.model.ObjectStats;
+import io.lakefs.clients.api.model.ObjectStatsList;
+import io.lakefs.clients.api.model.Pagination;
+import io.lakefs.clients.api.model.PathList;
+
+import org.apache.hadoop.fs.Path;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Bulk lakeFS operations.
+ *
+ * TODO(ariels): Some LakeFSFileSystem operations could use these.
+ */
+public class Bulk {
+    private static final Logger LOG = LoggerFactory.getLogger(Bulk.class);
+
+    protected final LakeFSClient lakeFSClient;
+
+    /**
+     * Size of bulks to use.  This is suitable for both listing and bulk
+     * deletion in the lakeFS API.
+     */
+    public static final int BULK_SIZE = 1000;
+
+    public Bulk(LakeFSClient lakeFSClient) {
+        this.lakeFSClient = lakeFSClient;
+    }
+
+    protected void ensureTrailingSlash(ObjectLocation loc) {
+        if (!loc.getPath().endsWith("/")) {
+            loc.setPath(loc.getPath() + "/");
+        }
+    }
+
+    /**
+     * Delete all objects beneath prefixLoc.
+     */
+    public void deletePrefix(ObjectLocation prefixLoc) throws ApiException {
+        ObjectsApi objects = lakeFSClient.getObjects();
+        ensureTrailingSlash(prefixLoc);
+
+        String after = "";
+        for (;;) {              // break within loop
+            ObjectStatsList o =
+                objects.listObjects(prefixLoc.getRepository(), prefixLoc.getRef(), false,
+                                    after, BULK_SIZE, "", prefixLoc.getPath());
+            Pagination page = o.getPagination();
+            after = page.getNextOffset();
+            if (o.getResults().isEmpty()) {
+                break;
+            }
+
+            // TODO(ariels): It may be faster to delete asynchronously using
+            //     BulkDeleter here.
+            PathList p = new PathList();
+            String lastPath = null;
+            for (ObjectStats stats : o.getResults()) {
+                String path = stats.getPath();
+                p.addPathsItem(path);
+                lastPath = path;
+            }
+            // BUG(ariels): Handle pathType??
+            LOG.info("{}/{}: Delete objects range {}..{}",
+                     prefixLoc.getRepository(), prefixLoc.getRef(), p.getPaths().get(0), lastPath);
+            objects.deleteObjects(prefixLoc.getRepository(), prefixLoc.getRef(), p);
+
+            if (!page.getHasMore()) {
+                break;
+            }
+        }
+    }
+
+    public void copyPrefix(ObjectLocation fromLoc, ObjectLocation toLoc) throws ApiException {
+        ObjectsApi objects = lakeFSClient.getObjects();
+        String after = "";
+        ensureTrailingSlash(fromLoc);
+        ensureTrailingSlash(toLoc);
+        Path listBase = new ObjectLocation(fromLoc.getScheme(), fromLoc.getRepository(), fromLoc.getRef()).toFSPath();
+        for (;;) {              // break within loop
+            ObjectStatsList o =
+                objects.listObjects(fromLoc.getRepository(), fromLoc.getRef(), true,
+                                    after, BULK_SIZE, "", fromLoc.getPath());
+            Pagination page = o.getPagination();
+            after = page.getNextOffset();
+
+            for (ObjectStats stats : o.getResults()) {
+                ObjectLocation src = ObjectLocation.pathToObjectLocation(listBase, new Path(stats.getPath()));
+                ObjectLocation dst = src.clone();
+                if (src.getPath().startsWith(fromLoc.getPath())) {
+                    dst.setPath(toLoc.getPath() + src.getPath().substring(fromLoc.getPath().length()));
+                } else {
+                    throw new RuntimeException(String.format("[I] %s does not have expected prefix %s", src, fromLoc));
+                }
+                // BUG(ariels): trace this!
+                LOG.info("{} -> {}", src, dst);
+                // TODO(ariels): Support upcoming copy-on-staging API.
+                ObjectStageCreation stage = new ObjectStageCreation()
+                    .physicalAddress(stats.getPhysicalAddress())
+                    .checksum(stats.getChecksum())
+                    .sizeBytes(stats.getSizeBytes())
+                    .mtime(stats.getMtime())
+                    .metadata(stats.getMetadata())
+                    .contentType(stats.getContentType());
+                objects.stageObject(dst.getRepository(), dst.getRef(), dst.getPath(), stage);
+            }
+            if (!page.getHasMore()) {
+                break;
+            }
+        }
+    }
+}

--- a/clients/hadoopfs/src/main/java/io/lakefs/utils/ObjectLocation.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/utils/ObjectLocation.java
@@ -16,6 +16,7 @@ public class ObjectLocation {
     /**
      * Returns Location with repository, ref and path used by lakeFS based on filesystem path.
      *
+     * @param workingDirectory used if path is local.
      * @param path to extract information from.
      * @return lakeFS Location with repository, ref and path
      */
@@ -23,7 +24,7 @@ public class ObjectLocation {
     static public ObjectLocation pathToObjectLocation(Path workingDirectory, Path path) {
         if (!path.isAbsolute()) {
             if (workingDirectory == null) {
-                throw new IllegalArgumentException("cannot expand local path with null workingDirectory");
+                throw new IllegalArgumentException(String.format("cannot expand local path %s with null workingDirectory", path));
             }
             path = new Path(workingDirectory, path);
         }
@@ -45,8 +46,21 @@ public class ObjectLocation {
         return loc;
     }
 
+    /**
+     * Returns Location with repository, ref and path used by lakeFS based on filesystem path.
+     *
+     * @param path to extract information from.
+     * @return lakeFS Location with repository, ref and path
+     */
+    @Nonnull
+    static public ObjectLocation pathToObjectLocation(Path path) {
+        return pathToObjectLocation(null, path);
+    }
+
     public static String formatPath(String scheme, String repository, String ref, String path) {
-        return String.format("%s://%s/%s/%s", scheme, repository, ref, path);
+        String ret = formatPath(scheme, repository, ref);
+        if (path != null) ret = ret + "/" + path;
+        return ret;
     }
 
 
@@ -76,6 +90,10 @@ public class ObjectLocation {
         this.repository = repository;
         this.ref = ref;
         this.path = path;
+    }
+
+    public ObjectLocation clone() {
+        return new ObjectLocation(scheme, repository, ref, path);
     }
 
     public ObjectLocation getParent() {

--- a/clients/hadoopfs/src/test/java/io/lakefs/LakeFSFileSystemTest.java
+++ b/clients/hadoopfs/src/test/java/io/lakefs/LakeFSFileSystemTest.java
@@ -234,28 +234,54 @@ public class LakeFSFileSystemTest {
     }
 
     @Test
-    public void testExists_Exists() throws ApiException, IOException {
+    public void testExists_ExistsAsObject() throws ApiException, IOException {
         Path p = new Path("lakefs://repo/main/exis.ts");
-        when(objectsApi.statObject("repo", "main", "exis.ts", false))
-            .thenReturn(new ObjectStats());
+        ObjectStats stats = new ObjectStats().path("exis.ts").pathType(PathTypeEnum.OBJECT);
+        when(objectsApi.listObjects(eq("repo"), eq("main"), eq(false), eq(""), any(), eq(""), eq("exis.ts")))
+            .thenReturn(new ObjectStatsList().results(ImmutableList.of(stats)));
         Assert.assertTrue(fs.exists(p));
-
-        Path dirPath = new Path("lakefs://repo/main/dir1/dir2/dir3");
-        when(objectsApi.statObject("repo", "main", "dir1/dir2/dir3/", false))
-                .thenReturn(new ObjectStats());
-        Assert.assertTrue(fs.exists(dirPath));
     }
 
     @Test
-    public void testExists_NotExists() throws ApiException, IOException {
-        Path p = new Path("lakefs://repo/main/doesNotExi.st");
-        when(objectsApi.statObject(any(), any(), any(), any()))
-            .thenThrow(new ApiException(HttpStatus.SC_NOT_FOUND, "no such file"));
-        when(objectsApi.listObjects(any(), any(), any(), any(), any(), any(), any()))
-            .thenReturn(new ObjectStatsList().results(Collections.emptyList()).pagination(new Pagination().hasMore(false)));
+    public void testExists_ExistsAsDirectoryMarker() throws ApiException, IOException {
+        Path p = new Path("lakefs://repo/main/exis.ts");
+        ObjectStats stats = new ObjectStats().path("exis.ts/").pathType(PathTypeEnum.OBJECT);
+        when(objectsApi.listObjects(eq("repo"), eq("main"), eq(false), eq(""), any(), eq(""), eq("exis.ts")))
+            .thenReturn(new ObjectStatsList().results(ImmutableList.of(stats)));
+        Assert.assertTrue(fs.exists(p));
+    }
 
+    @Test
+    public void testExists_ExistsAsDirectoryContents() throws ApiException, IOException {
+        Path p = new Path("lakefs://repo/main/exis.ts");
+        ObjectStats stats = new ObjectStats().path("exis.ts/inside").pathType(PathTypeEnum.OBJECT);
+        when(objectsApi.listObjects(eq("repo"), eq("main"), eq(false), eq(""), any(), eq(""), eq("exis.ts")))
+            .thenReturn(new ObjectStatsList().results(ImmutableList.of(stats)));
+        Assert.assertTrue(fs.exists(p));
+    }
+
+    @Test
+    public void testExists_ExistsAsDirectoryInSecondList() throws ApiException, IOException {
+        // TODO(ariels)
+    }
+
+    @Test
+    public void testExists_NotExistsNoPrefix() throws ApiException, IOException {
+        Path p = new Path("lakefs://repo/main/doesNotExi.st");
+        when(objectsApi.listObjects(any(), any(), any(), any(), any(), any(), any()))
+            .thenReturn(new ObjectStatsList());
         boolean exists = fs.exists(p);
         Assert.assertFalse(exists);
+    }
+
+    @Test
+    public void testExists_NotExistsPrefixWithNoSlash() throws ApiException, IOException {
+        // TODO(ariels)
+    }
+
+    @Test
+    public void testExists_NotExistsPrefixWithNoSlashTwoLists() throws ApiException, IOException {
+        // TODO(ariels)
     }
 
     @Test
@@ -281,8 +307,12 @@ public class LakeFSFileSystemTest {
         when(stagingApi.getPhysicalAddress("repo", "main", "no/place/"))
                 .thenReturn(stagingLocation);
 
+        Path path = new Path("lakefs://repo/main/no/place/file.txt");
+
+        mockDirectoryMarker(ObjectLocation.pathToObjectLocation(null, path.getParent()));
+
         // return true because file found
-        boolean success = fs.delete(new Path("lakefs://repo/main/no/place/file.txt"), false);
+        boolean success = fs.delete(path, false);
         Assert.assertTrue(success);
     }
 
@@ -321,7 +351,11 @@ public class LakeFSFileSystemTest {
                 .thenReturn(srcStats)
                 .thenThrow(noSuchFile);
 
-        boolean success = fs.delete(new Path("lakefs://repo/main/delete/me"), false);
+        Path path = new Path("lakefs://repo/main/delete/me");
+
+        mockDirectoryMarker(ObjectLocation.pathToObjectLocation(null, path.getParent()));
+
+        boolean success = fs.delete(path, false);
         Assert.assertTrue(success);
     }
 
@@ -378,7 +412,11 @@ public class LakeFSFileSystemTest {
         when(objectsApi.deleteObjects("repo", "main", newPathList("delete/sample/file.txt")))
             .thenReturn(new ObjectErrorList());
         // recursive will always end successfully
-        boolean delete = fs.delete(new Path("lakefs://repo/main/delete/sample"), true);
+        Path path = new Path("lakefs://repo/main/delete/sample");
+
+        mockDirectoryMarker(ObjectLocation.pathToObjectLocation(null, path.getParent()));
+
+        boolean delete = fs.delete(path, true);
         Assert.assertTrue(delete);
     }
 
@@ -414,6 +452,10 @@ public class LakeFSFileSystemTest {
             when(objectsApi.deleteObjects(eq("repo"), eq("main"), eq(pl)))
                 .thenReturn(new ObjectErrorList());
         }
+        // Mock parent directory marker creation at end of fs.delete to show
+        // the directory marker exists.
+        ObjectLocation dir = new ObjectLocation("lakefs", "repo", "main", "delete");
+        mockDirectoryMarker(dir);
         // recursive will always end successfully
         boolean delete = fs.delete(new Path("lakefs://repo/main/delete/sample"), true);
         Assert.assertTrue(delete);
@@ -677,6 +719,13 @@ public class LakeFSFileSystemTest {
         fs.append(null, 0, null);
     }
 
+    private void mockDirectoryMarker(ObjectLocation objectLoc) throws ApiException {
+        // Mock parent directory to show the directory marker exists.
+        ObjectStats markerStats = new ObjectStats().path(objectLoc.getPath()).pathType(PathTypeEnum.OBJECT);
+        when(objectsApi.listObjects(eq(objectLoc.getRepository()), eq(objectLoc.getRef()), eq(false), eq(""), any(), eq(""), eq(objectLoc.getPath()))).
+            thenReturn(new ObjectStatsList().results(ImmutableList.of(markerStats)));
+    }
+
     private void mockNonExistingPath(ObjectLocation objectLoc) throws ApiException {
         when(objectsApi.statObject(objectLoc.getRepository(), objectLoc.getRef(), objectLoc.getPath(), false))
                 .thenThrow(new ApiException(HttpStatus.SC_NOT_FOUND, "no such file"));
@@ -795,6 +844,8 @@ public class LakeFSFileSystemTest {
         mockNonExistingPath(dstObjLoc);
         mockNonExistingPath(fs.pathToObjectLocation(dst.getParent()));
 
+        mockDirectoryMarker(fs.pathToObjectLocation(src.getParent()));
+
         boolean renamed = fs.rename(src, dst);
         Assert.assertFalse(renamed);
     }
@@ -808,6 +859,8 @@ public class LakeFSFileSystemTest {
         Path dst = new Path("lakefs://repo/main/existing.dst");
         ObjectLocation dstObjLoc = fs.pathToObjectLocation(dst);
         mockExistingFilePath(dstObjLoc);
+
+        mockDirectoryMarker(fs.pathToObjectLocation(src.getParent()));
 
         boolean success = fs.rename(src, dst);
         Assert.assertTrue(success);
@@ -843,6 +896,8 @@ public class LakeFSFileSystemTest {
         Path dst = new Path("lakefs://repo/main/existing-dir2");
         ObjectLocation dstObjLoc = fs.pathToObjectLocation(dst);
         mockExistingDirPath(dstObjLoc, ImmutableList.of(fileObjLoc));
+
+        mockDirectoryMarker(fs.pathToObjectLocation(src.getParent()));
 
         boolean renamed = fs.rename(src, dst);
         Assert.assertTrue(renamed);
@@ -882,6 +937,8 @@ public class LakeFSFileSystemTest {
         mockExistingDirPath(new ObjectLocation("lakefs", "repo", "main", "existing-dir2/new"), Collections.emptyList());
 
         Path dst = new Path("lakefs://repo/main/existing-dir2/new");
+        mockDirectoryMarker(fs.pathToObjectLocation(srcDir));
+
         boolean renamed = fs.rename(srcDir, dst);
         Assert.assertTrue(renamed);
     }

--- a/clients/hadoopfs/src/test/java/io/lakefs/committer/LakeFSOutputCommitterTest.java
+++ b/clients/hadoopfs/src/test/java/io/lakefs/committer/LakeFSOutputCommitterTest.java
@@ -109,7 +109,7 @@ public class LakeFSOutputCommitterTest {
 
         SparkConf sparkConf = new SparkConf().setMaster("local").setAppName("Spark test")
                 .set("spark.sql.shuffle.partitions", "17")
-                .set("spark.hadoop.mapred.output.committer.class","io.lakefs.committer.DummyOutputCommitter")
+                .set("spark.hadoop.mapred.output.committer.class","io.lakefs.committer.LakeFSOutputCommitter")
                 .set("spark.hadoop.fs.lakefs.impl","io.lakefs.LakeFSFileSystem")
                 .set("fs.lakefs.access.key", "AKIAIOSFODNN7EXAMPLE")
                 .set("fs.lakefs.secret.key", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")

--- a/clients/hadoopfs/src/test/java/io/lakefs/committer/LakeFSOutputCommitterTest.java
+++ b/clients/hadoopfs/src/test/java/io/lakefs/committer/LakeFSOutputCommitterTest.java
@@ -1,0 +1,163 @@
+package io.lakefs;
+
+import io.lakefs.clients.api.*;
+import io.lakefs.clients.api.model.*;
+import io.lakefs.clients.api.model.ObjectStats.PathTypeEnum;
+import io.lakefs.utils.ObjectLocation;
+import io.lakefs.LakeFSClient;
+
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.S3ClientOptions;
+import com.amazonaws.services.s3.model.*;
+import com.aventrix.jnanoid.jnanoid.NanoIdUtils;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import org.apache.commons.io.IOUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileAlreadyExistsException;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.LocatedFileStatus;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.http.HttpStatus;
+
+import org.apache.spark.SparkConf;
+import org.apache.spark.sql.SparkSession;
+import org.apache.spark.sql.Row;
+import org.apache.spark.sql.RowFactory;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.types.*;
+
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.Ignore;
+import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.io.*;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+public class LakeFSOutputCommitterTest {
+    Logger logger = LoggerFactory.getLogger("LakeFSOutputCommitterTest");
+
+    protected AmazonS3 s3Client;
+
+    protected String s3Base;
+    protected String s3Bucket;
+
+    protected SparkSession spark;
+
+    private static final DockerImageName MINIO = DockerImageName.parse("minio/minio:RELEASE.2021-06-07T21-40-51Z");
+    protected static final String S3_ACCESS_KEY_ID = "AKIArootkey";
+    protected static final String S3_SECRET_ACCESS_KEY = "secret/minio/key=";
+
+    @Rule
+    public final GenericContainer s3 = new GenericContainer(MINIO.toString()).
+        withCommand("minio", "server", "/data").
+        withEnv("MINIO_ROOT_USER", S3_ACCESS_KEY_ID).
+        withEnv("MINIO_ROOT_PASSWORD", S3_SECRET_ACCESS_KEY).
+        withEnv("MINIO_DOMAIN", "s3.local.lakefs.io").
+        withEnv("MINIO_UPDATE", "off").
+        withExposedPorts(9000);
+
+
+    @After
+    public void closeSparkSession(){
+        spark.close();
+    }
+
+
+    @Before
+    public void setUp() throws Exception {
+        AWSCredentials creds = new BasicAWSCredentials(S3_ACCESS_KEY_ID, S3_SECRET_ACCESS_KEY);
+
+        ClientConfiguration clientConfiguration = new ClientConfiguration()
+                .withSignerOverride("AWSS3V4SignerType");
+        String s3Endpoint = String.format("http://s3.local.lakefs.io:%d", s3.getMappedPort(9000));
+
+        s3Client = new AmazonS3Client(creds, clientConfiguration);
+
+        S3ClientOptions s3ClientOptions = new S3ClientOptions()
+            .withPathStyleAccess(true);
+        s3Client.setS3ClientOptions(s3ClientOptions);
+        s3Client.setEndpoint(s3Endpoint);
+
+        s3Bucket = "example";
+        s3Base = String.format("s3://%s", s3Bucket);
+        CreateBucketRequest cbr = new CreateBucketRequest(s3Bucket);
+        s3Client.createBucket(cbr);
+
+        SparkConf sparkConf = new SparkConf().setMaster("local").setAppName("Spark test")
+                .set("spark.sql.shuffle.partitions", "17")
+                .set("spark.hadoop.mapred.output.committer.class","io.lakefs.committer.DummyOutputCommitter")
+                .set("spark.hadoop.fs.lakefs.impl","io.lakefs.LakeFSFileSystem")
+                .set("fs.lakefs.access.key", "AKIAIOSFODNN7EXAMPLE")
+                .set("fs.lakefs.secret.key", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
+                .set("fs.lakefs.endpoint", "http://localhost:8000/api/v1")
+                .set("fs.s3a.impl", "org.apache.hadoop.fs.s3a.S3AFileSystem")
+                .set(org.apache.hadoop.fs.s3a.Constants.ACCESS_KEY, S3_ACCESS_KEY_ID)
+                .set(org.apache.hadoop.fs.s3a.Constants.SECRET_KEY, S3_SECRET_ACCESS_KEY)
+                .set(org.apache.hadoop.fs.s3a.Constants.ENDPOINT, s3Endpoint);
+        this.spark = SparkSession.builder().config(sparkConf).getOrCreate();
+    }
+
+    @Ignore
+    @Test
+    public void testWriteTextfile() throws ApiException, IOException {
+        String output = "lakefs://example/main/some_df";
+
+        StructType structType = new StructType().add("A", DataTypes.StringType, false);
+
+        List<Row> nums = ImmutableList.of(
+                RowFactory.create("value1"),
+                RowFactory.create("value2"));
+        Dataset<Row> df = spark.createDataFrame(nums, structType);
+
+        ArrayList<String> failed = new ArrayList<String>();
+
+        // TODO(Lynn): Add relevant file formats
+        List<String> fileFormats = Arrays.asList("text");
+        for (String fileFormat : fileFormats) {
+            try {
+                // save data in selected format
+                String outputPath = String.format("%s.%s", output, fileFormat);
+                logger.info(String.format("writing file in format %s to path %s", fileFormat, outputPath));
+                df.write().format(fileFormat).save(outputPath);
+
+                // read the data we just wrote
+                logger.info(String.format("reading file in format %s", fileFormat));
+                Dataset<Row> df_read = spark.read().format(fileFormat).load(outputPath);
+                Dataset<Row> diff = df.exceptAll(df_read);
+                Assert.assertTrue("all rows written were read", diff.isEmpty());
+                diff = df_read.exceptAll(df);
+                Assert.assertTrue("all rows read were written", diff.isEmpty());
+
+            } catch (Exception e) {
+                logger.error(String.format("Format %s unexpected exception: %s", fileFormat, e));
+                failed.add(fileFormat);
+            }
+        }
+
+        Assert.assertEquals("Failed list is not empty: %s" , 0, failed.size());
+    }
+}

--- a/clients/hadoopfs/src/test/java/io/lakefs/utils/BulkTest.java
+++ b/clients/hadoopfs/src/test/java/io/lakefs/utils/BulkTest.java
@@ -1,0 +1,174 @@
+package io.lakefs.utils;
+
+import io.lakefs.LakeFSClient;
+import io.lakefs.clients.api.ApiException;
+import io.lakefs.clients.api.ObjectsApi;
+import io.lakefs.clients.api.model.ObjectStageCreation;
+import io.lakefs.clients.api.model.ObjectStats;
+import io.lakefs.clients.api.model.ObjectStatsList;
+import io.lakefs.clients.api.model.Pagination;
+import io.lakefs.clients.api.model.PathList;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+
+import org.apache.http.HttpStatus;
+import org.junit.Assert;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.mockito.Answers;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.*;
+
+public class BulkTest {
+    protected Bulk bulk;
+
+    protected LakeFSClient lfsClient;
+    protected ObjectsApi objects;
+
+    protected final String SCHEME = "pondfs";
+    protected final String REPO = "repo";
+    protected final String REF = "one";
+
+    protected final ObjectStats stats1 = new ObjectStats()
+        .path("foo/bar/_temp/task/baz/zoo")
+        .physicalAddress("s3://zoo")
+        .checksum("1")
+        .sizeBytes(11L)
+        .mtime(5432L)
+        .metadata(null)
+        .contentType("text/plain");
+    protected final ObjectStats stats2 = new ObjectStats()
+        .path("foo/bar/_temp/task/quux/boo")
+        .physicalAddress("s3://garden")
+        .checksum("2")
+        .sizeBytes(22L)
+        .mtime(54321L)
+        .metadata(null)
+        .contentType("text/complex");
+    protected final ObjectStats stats3 = new ObjectStats()
+        .path("foo/bar/_temp/task/quux/moo")
+        .physicalAddress("s3://path")
+        .checksum("3")
+        .sizeBytes(33L)
+        .mtime(543210L)
+        .metadata(null)
+        .contentType("x-app/app");
+
+    protected static ObjectStageCreation creationFor(ObjectStats stats) {
+        return new ObjectStageCreation()
+            .physicalAddress(stats.getPhysicalAddress())
+            .checksum(stats.getChecksum())
+            .sizeBytes(stats.getSizeBytes())
+            .mtime(stats.getMtime())
+            .metadata(stats.getMetadata())
+            .contentType(stats.getContentType());
+    }
+
+    @Before
+    public void mockClient() {
+        lfsClient = mock(LakeFSClient.class, Answers.RETURNS_SMART_NULLS);
+        objects = mock(ObjectsApi.class, Answers.RETURNS_SMART_NULLS);
+        when(lfsClient.getObjects()).thenReturn(objects);
+
+        bulk = new Bulk(lfsClient);
+    }
+
+    protected void checkCopyPrefixSingleItemCase(String src, String dst) throws ApiException {
+        when(objects.listObjects(REPO, REF, true, "", Bulk.BULK_SIZE, "", "foo/bar/_temp/task/"))
+            .thenReturn(new ObjectStatsList()
+                        .pagination(new Pagination().hasMore(false).nextOffset("unused"))
+                        .results(ImmutableList.of(stats1)));
+        bulk.copyPrefix(new ObjectLocation(SCHEME, REPO, REF, src),
+                        new ObjectLocation(SCHEME, REPO, REF, dst));
+        verify(objects).stageObject(REPO, REF, "foo/bar/baz/zoo", creationFor(stats1));
+    }
+
+    @Test
+    public void copyPrefix() throws ApiException {
+        checkCopyPrefixSingleItemCase("foo/bar/_temp/task/", "foo/bar/");
+    }
+
+    @Test
+    public void copyPrefixSrcWithoutTrailingSlash() throws ApiException {
+        checkCopyPrefixSingleItemCase("foo/bar/_temp/task", "foo/bar/");
+    }
+
+    @Test
+    public void copyPrefixDstWithoutTrailingSlash() throws ApiException {
+        checkCopyPrefixSingleItemCase("foo/bar/_temp/task/", "foo/bar");
+    }
+
+    @Test
+    public void copyPrefixManyItemsListPaged() throws ApiException {
+        String next1 = stats2.getPath() + "\0";
+        ObjectStatsList osl1 = new ObjectStatsList()
+            .pagination(new Pagination().hasMore(true).nextOffset(next1))
+            .results(ImmutableList.of(stats1, stats2));
+        when(objects.listObjects(REPO, REF, true, "", Bulk.BULK_SIZE, "", "foo/bar/_temp/task/"))
+            .thenReturn(osl1);
+        ObjectStatsList osl2 = new ObjectStatsList()
+            .pagination(new Pagination().hasMore(false).nextOffset("unused"))
+            .results(ImmutableList.of(stats3));
+        when(objects.listObjects(REPO, REF, true, next1, Bulk.BULK_SIZE, "", "foo/bar/_temp/task/"))
+            .thenReturn(osl2);
+        bulk.copyPrefix(new ObjectLocation(SCHEME, REPO, REF, "foo/bar/_temp/task/"),
+                        new ObjectLocation(SCHEME, REPO, REF, "foo/bar/"));
+        verify(objects).stageObject(REPO, REF, "foo/bar/baz/zoo", creationFor(stats1));
+        verify(objects).stageObject(REPO, REF, "foo/bar/quux/boo", creationFor(stats2));
+        verify(objects).stageObject(REPO, REF, "foo/bar/quux/moo", creationFor(stats3));
+    }
+
+    @Test
+    public void deletePrefix() throws ApiException {
+        when(objects.listObjects(REPO, REF, false, "", Bulk.BULK_SIZE, "", "foo/bar/_temp/task/"))
+            .thenReturn(new ObjectStatsList()
+                        .pagination(new Pagination().hasMore(false).nextOffset("unused"))
+                        .results(ImmutableList.of(stats1)));
+        bulk.deletePrefix(new ObjectLocation(SCHEME, REPO, REF, "foo/bar/_temp/task/"));
+        verify(objects).deleteObjects(REPO, REF, new PathList().
+                                      paths(ImmutableList.of(stats1.getPath())));
+    }
+
+    @Test
+    public void deletePrefixWithoutTrailingSlash() throws ApiException {
+        when(objects.listObjects(REPO, REF, false, "", Bulk.BULK_SIZE, "", "foo/bar/_temp/task/"))
+            .thenReturn(new ObjectStatsList()
+                        .pagination(new Pagination().hasMore(false).nextOffset("unused"))
+                        .results(ImmutableList.of(stats1)));
+        bulk.deletePrefix(new ObjectLocation(SCHEME, REPO, REF, "foo/bar/_temp/task"));
+        verify(objects).deleteObjects(REPO, REF, new PathList().
+                                      paths(ImmutableList.of(stats1.getPath())));
+    }
+
+    @Test
+    public void deletePrefixManyItemsListPaged() throws ApiException {
+        String next1 = stats2.getPath() + "\0";
+        ObjectStatsList osl1 = new ObjectStatsList()
+            .pagination(new Pagination().hasMore(true).nextOffset(next1))
+            .results(ImmutableList.of(stats1, stats2));
+        when(objects.listObjects(REPO, REF, false, "", Bulk.BULK_SIZE, "", "foo/bar/_temp/task/"))
+            .thenReturn(osl1);
+        ObjectStatsList osl2 = new ObjectStatsList()
+            .pagination(new Pagination().hasMore(false).nextOffset("unused"))
+            .results(ImmutableList.of(stats3));
+        when(objects.listObjects(REPO, REF, false, next1, Bulk.BULK_SIZE, "", "foo/bar/_temp/task/"))
+            .thenReturn(osl2);
+        bulk.deletePrefix(new ObjectLocation(SCHEME, REPO, REF, "foo/bar/_temp/task/"));
+        verify(objects).deleteObjects(REPO, REF, new PathList().
+                                      paths(ImmutableList.of(stats1.getPath(), stats2.getPath())));
+        verify(objects).deleteObjects(REPO, REF, new PathList().
+                                      paths(ImmutableList.of(stats3.getPath())));
+    }
+}

--- a/docs/integrations/spark.md
+++ b/docs/integrations/spark.md
@@ -370,7 +370,7 @@ On Hadoop 2, configure:
     </property>
 	<property>
 		<name>spark.sql.parquet.output.committer.class</name>
-		<value>io.lakefs.committer.DummyParquetOutputCommitter</value>
+		<value>io.lakefs.committer.LakeFSParquetOutputCommitter</value>
 	</property>
 </configuration>
 ```

--- a/docs/integrations/spark.md
+++ b/docs/integrations/spark.md
@@ -24,15 +24,22 @@ Similarly, properties defining lakeFS credentials should be configured in secure
 not on the command line or inlined in code where they might be exposed.
 {: .note}
 
-## Two-tiered Spark support
-{: .no_toc }
+## Multi-tiered Spark support
 
-There are two ways you can use lakeFS with Spark:
+lakeFS support in Spark has three tiers:
 
-* Using the [S3 gateway](#use-the-s3-gateway): get started quickly!
-* Using the [lakeFS Hadoop FileSystem](#use-the-lakefs-hadoop-filesystem): fully unlock the performance of lakeFS.
+* Access lakeFS using the [S3A gateway](#access-lakefs-using-the-s3a-gateway): quickly get started!
+* Access lakeFS using the [lakeFS-specific Hadoop
+  FileSystem](#access-lakefs-using-the-lakefs-specific-hadoop-filesystem): fully unlock the performance of lakeFS.
+* (**BETA!**) Access lakeFS using lake lakeFS-specific Hadoop FileSystem and
+  write using the [lakeFS Output
+  Committer](#write-using-the-lakefs-output-committer): better integrate into the Spark/Hadoop ecosystem.
 
-## Use the S3 gateway
+Using the S3A gateway is easier to configure and may be more suitable for
+legacy or small-scale applications. Using the lakeFS FileSystem requires a
+somewhat more complex configuration, but offers greatly increased
+performance.  The lakeFS Output Committer add-on to the lakeFS FileSystem is
+in beta.  It provides atomic writes and increases write performance.
 
 lakeFS has an S3-compatible endpoint. Simply point Spark to this endpoint to get started quickly.
 You will access your data using S3-style URIs, e.g. `s3a://example-repo/example-branch/example-table`.
@@ -340,6 +347,15 @@ The data is now created in lakeFS as new changes in your branch. You can now com
 * The FileSystem implementation is tested with the latest Spark 2.X (Hadoop 2) and Spark 3.X (Hadoop 3) Bitnami images.
 
 ## Using the new OutputCommitter
+## Using the lakeFS OutputCommitter
+
+This feature is currently **in beta**.  It provides atomic writes and
+increases write performance.
+
+The lakeFS output committer uses temporary lakeFS branches to hold Hadoop
+working objects.  It merges them back to the output branch when done.  So
+objects appear atomically: it is not possible for another task to see the
+output path with any set of objects except the entire desired output set.
 
 ### Configuration
 
@@ -359,7 +375,28 @@ On Hadoop 2, configure:
 </configuration>
 ```
 
-(You can also set a default output committer using mapred.output.committer.class and possibly setting mapred.mapper.new-api=false.)
+#### Additional options
+
+* If you need to use Hadoop with the older mapred API rather than the
+  mapreduce API, you might set a default output committer using
+  `mapred.output.committer.class`, and possibly setting
+  `mapred.mapper.new-api=false`.
+* The lakeFS output committer adds a `_SUCCESS` file to the output path,
+  much like FileOutputCommitter and other Hadoop output committers.  You
+  might not require this file, for instance by waiting for a merge to occur
+  to the output branch.  Control its generation using the
+  `spark.hadoop.fs.lakefs.committer.marksuccessfuljobs` option:
+  * If `auto` (the default), copy whatever FileOutputCommitter is configured
+    to do using
+    `spark.hadoop.mapreduce.fileoutputcommitter.marksuccessfuljobs`.  That
+    option itself defaults to `true`, so by default the lakeFS output
+    committer writes the file.
+  * If `false`, do _not_ write the file.
+  * If `true` or otherwise, write the file.
+* By default the temporary job branch and the temporary tasks branches are
+  deleted.  Configure `committer.delete_job_branch` and/or
+  `committer.delete_task_branch` to `false` to prevent this deletion.  This
+  may be useful for debugging.
 
 ## Case Study: SimilarWeb
 


### PR DESCRIPTION
Make the "does not exist" path faster: with this change it typically takes 1 listObjects() API call instead of 1 statObject and 2 listObjects.  This is surprisingly *common*.  The trivial "exists" path now requires 1 listObject instead of 1 statObject call, which is more expensive.