### PR TITLE
S3 block adapter support working with AWS SSE with KMS key ID

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -123,7 +123,9 @@ This reference uses `.` to denote the nesting of values.
 * `blockstore.s3.streaming_chunk_size` `(int : 1048576)` - Object chunk size to buffer before streaming to blockstore (use a lower value for less reliable networks). Minimum is 8192.
 * `blockstore.s3.streaming_chunk_timeout` `(time duration : "60s")` - Per object chunk timeout for blockstore streaming operations (use a larger value for less reliable networks).
 * `blockstore.s3.discover_bucket_region` `(bool : true)` - (Can be turned off if the underlying S3 bucket doesn't support the GetBucketRegion API).
-* `blockstore.s3.skip_verify_certificate_test_only` `(boolean: false)` - Skip certificate verification while connecting to the storage endpoint. Should be used only for testing.
+* `blockstore.s3.skip_verify_certificate_test_only` `(boolean : false)` - Skip certificate verification while connecting to the storage endpoint. Should be used only for testing.
+* `blockstore.s3.server_side_encryption` `(string : )` - Server side encryption format used (Example on AWS using SSE-KMS while passing "aws:kms")
+* `blockstore.s3.server_side_encryption_kms_key_id` `(string : )` - Server side encryption KMS key ID
 * `committed.local_cache` - an object describing the local (on-disk) cache of metadata from
   permanent storage:
   + `committed.local_cache.size_bytes` (`int` : `1073741824`) - bytes for local cache to use on disk.  The cache may use more storage for short periods of time.

--- a/pkg/block/factory/build.go
+++ b/pkg/block/factory/build.go
@@ -108,12 +108,19 @@ func buildS3Adapter(statsCollector stats.Collector, params params.S3) (*s3a.Adap
 	if err != nil {
 		return nil, err
 	}
-	adapter := s3a.NewAdapter(sess,
+	opts := []s3a.AdapterOption{
 		s3a.WithStreamingChunkSize(params.StreamingChunkSize),
 		s3a.WithStreamingChunkTimeout(params.StreamingChunkTimeout),
 		s3a.WithStatsCollector(statsCollector),
 		s3a.WithDiscoverBucketRegion(params.DiscoverBucketRegion),
-	)
+	}
+	if params.ServerSideEncryption != "" {
+		opts = append(opts, s3a.WithServerSideEncryption(params.ServerSideEncryption))
+	}
+	if params.ServerSideEncryptionKmsKeyID != "" {
+		opts = append(opts, s3a.WithServerSideEncryptionKmsKeyID(params.ServerSideEncryptionKmsKeyID))
+	}
+	adapter := s3a.NewAdapter(sess, opts...)
 	logging.Default().WithField("type", "s3").Info("initialized blockstore adapter")
 	return adapter, nil
 }

--- a/pkg/block/params/block.go
+++ b/pkg/block/params/block.go
@@ -28,6 +28,8 @@ type S3 struct {
 	StreamingChunkTimeout         time.Duration
 	DiscoverBucketRegion          bool
 	SkipVerifyCertificateTestOnly bool
+	ServerSideEncryption          string
+	ServerSideEncryptionKmsKeyID  string
 }
 
 type GS struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -229,6 +229,8 @@ func (c *Config) GetBlockAdapterS3Params() (blockparams.S3, error) {
 		StreamingChunkTimeout:         c.values.Blockstore.S3.StreamingChunkTimeout,
 		DiscoverBucketRegion:          c.values.Blockstore.S3.DiscoverBucketRegion,
 		SkipVerifyCertificateTestOnly: c.values.Blockstore.S3.SkipVerifyCertificateTestOnly,
+		ServerSideEncryption:          c.values.Blockstore.S3.ServerSideEncryption,
+		ServerSideEncryptionKmsKeyID:  c.values.Blockstore.S3.ServerSideEncryptionKmsKeyID,
 	}, nil
 }
 

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -163,7 +163,7 @@ type configuration struct {
 			ForcePathStyle                bool          `mapstructure:"force_path_style"`
 			DiscoverBucketRegion          bool          `mapstructure:"discover_bucket_region"`
 			SkipVerifyCertificateTestOnly bool          `mapstructure:"skip_verify_certificate_test_only"`
-			ServerSideEncryption          string        `mapstructure:"server_side_encryption""`
+			ServerSideEncryption          string        `mapstructure:"server_side_encryption"`
 			ServerSideEncryptionKmsKeyID  string        `mapstructure:"server_side_encryption_kms_key_id"`
 		}
 		Azure *struct {

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -163,6 +163,8 @@ type configuration struct {
 			ForcePathStyle                bool          `mapstructure:"force_path_style"`
 			DiscoverBucketRegion          bool          `mapstructure:"discover_bucket_region"`
 			SkipVerifyCertificateTestOnly bool          `mapstructure:"skip_verify_certificate_test_only"`
+			ServerSideEncryption          string        `mapstructure:"server_side_encryption""`
+			ServerSideEncryptionKmsKeyID  string        `mapstructure:"server_side_encryption_kms_key_id"`
 		}
 		Azure *struct {
 			TryTimeout       time.Duration `mapstructure:"try_timeout"`


### PR DESCRIPTION
This PR adds support for working with AWS S3 bucket using a server side encryption (SSE) + KMS (Key Management Service).

The following configuration for S3 blockstore was added

```yaml
blockstore:
  type: s3
  s3:
    server_side_encryption: aws:kms
    server_side_encryption_kms_key_id: arn:aws:kms:...
```

Tested manually by creating a bucket with SSE+KMS, using the same policy described in the associated issue and assumed the role by lakeFS.

Fix #4635