### PR TITLE
Use Docker BuildKit in Esti

### DIFF
--- a/.github/workflows/esti.yaml
+++ b/.github/workflows/esti.yaml
@@ -85,6 +85,8 @@ jobs:
     runs-on: ubuntu-latest-16-cores
     outputs:
       tag: ${{ steps.version.outputs.tag }}
+    env:
+      DOCKER_BUILDKIT: 1
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
This may improve build times by being better able to use existing Docker caches.