### PR TITLE
Store relative path in stage and link physical address

### DIFF
--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -376,7 +376,7 @@ func (c *Controller) LinkPhysicalAddress(w http.ResponseWriter, r *http.Request,
 	}
 
 	writeTime := time.Now()
-	physicalAddress, addressType := physicalAddressFullToRelative(repo.StorageNamespace, StringValue(body.Staging.PhysicalAddress))
+	physicalAddress, addressType := normalizePhysicalAddress(repo.StorageNamespace, StringValue(body.Staging.PhysicalAddress))
 
 	// Because CreateEntry tracks staging on a database with atomic operations,
 	// _ignore_ the staging token here: no harm done even if a race was lost
@@ -420,9 +420,9 @@ func (c *Controller) LinkPhysicalAddress(w http.ResponseWriter, r *http.Request,
 	writeResponse(w, http.StatusOK, response)
 }
 
-// physicalAddressFullToRelative return relative address based on storage namespace if possible. If address doesn't match
+// normalizePhysicalAddress return relative address based on storage namespace if possible. If address doesn't match
 // the storage namespace prefix, the return address type is full.
-func physicalAddressFullToRelative(storageNamespace string, physicalAddress string) (string, catalog.AddressType) {
+func normalizePhysicalAddress(storageNamespace string, physicalAddress string) (string, catalog.AddressType) {
 	prefix := storageNamespace
 	if !strings.HasSuffix(prefix, catalog.DefaultPathDelimiter) {
 		prefix += catalog.DefaultPathDelimiter
@@ -2228,7 +2228,7 @@ func (c *Controller) StageObject(w http.ResponseWriter, r *http.Request, body St
 		writeTime = time.Unix(*body.Mtime, 0)
 	}
 
-	physicalAddress, addressType := physicalAddressFullToRelative(repo.StorageNamespace, body.PhysicalAddress)
+	physicalAddress, addressType := normalizePhysicalAddress(repo.StorageNamespace, body.PhysicalAddress)
 
 	entryBuilder := catalog.NewDBEntryBuilder().
 		CommonLevel(false).

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -376,14 +376,16 @@ func (c *Controller) LinkPhysicalAddress(w http.ResponseWriter, r *http.Request,
 	}
 
 	writeTime := time.Now()
+	physicalAddress, addressType := physicalAddressFullToRelative(repo.StorageNamespace, StringValue(body.Staging.PhysicalAddress))
+
 	// Because CreateEntry tracks staging on a database with atomic operations,
 	// _ignore_ the staging token here: no harm done even if a race was lost
 	// against a commit.
 	entryBuilder := catalog.NewDBEntryBuilder().
 		CommonLevel(false).
 		Path(params.Path).
-		PhysicalAddress(*body.Staging.PhysicalAddress).
-		AddressType(catalog.AddressTypeFull).
+		PhysicalAddress(physicalAddress).
+		AddressType(addressType).
 		CreationDate(writeTime).
 		Size(body.SizeBytes).
 		Checksum(body.Checksum).
@@ -416,6 +418,19 @@ func (c *Controller) LinkPhysicalAddress(w http.ResponseWriter, r *http.Request,
 	}
 
 	writeResponse(w, http.StatusOK, response)
+}
+
+// physicalAddressFullToRelative return relative address based on storage namespace if possible. If address doesn't match
+// the storage namespace prefix, the return address type is full.
+func physicalAddressFullToRelative(storageNamespace string, physicalAddress string) (string, catalog.AddressType) {
+	prefix := storageNamespace
+	if !strings.HasSuffix(prefix, catalog.DefaultPathDelimiter) {
+		prefix += catalog.DefaultPathDelimiter
+	}
+	if strings.HasPrefix(physicalAddress, prefix) {
+		return physicalAddress[len(prefix):], catalog.AddressTypeRelative
+	}
+	return physicalAddress, catalog.AddressTypeFull
 }
 
 func (c *Controller) ListGroups(w http.ResponseWriter, r *http.Request, params ListGroupsParams) {
@@ -2213,11 +2228,13 @@ func (c *Controller) StageObject(w http.ResponseWriter, r *http.Request, body St
 		writeTime = time.Unix(*body.Mtime, 0)
 	}
 
+	physicalAddress, addressType := physicalAddressFullToRelative(repo.StorageNamespace, body.PhysicalAddress)
+
 	entryBuilder := catalog.NewDBEntryBuilder().
 		CommonLevel(false).
 		Path(params.Path).
-		PhysicalAddress(body.PhysicalAddress).
-		AddressType(catalog.AddressTypeFull).
+		PhysicalAddress(physicalAddress).
+		AddressType(addressType).
 		CreationDate(writeTime).
 		Size(body.SizeBytes).
 		Checksum(body.Checksum).

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -2099,14 +2099,19 @@ func TestController_ObjectsStageObjectHandler(t *testing.T) {
 			t.Fatalf("GetPhysicalAddress non 200 response - status code %d", linkResp.StatusCode())
 		}
 		const expectedSizeBytes = 38
-		resp, err := clt.StageObjectWithResponse(ctx, "repo1", "main", &api.StageObjectParams{Path: "foo/bar2"}, api.StageObjectJSONRequestBody{
-			Checksum:        "afb0689fe58b82c5f762991453edbbec",
-			PhysicalAddress: api.StringValue(linkResp.JSON200.PhysicalAddress),
-			SizeBytes:       expectedSizeBytes,
+		resp, err := clt.LinkPhysicalAddressWithResponse(ctx, "repo1", "main", &api.LinkPhysicalAddressParams{
+			Path: "foo/bar2",
+		}, api.LinkPhysicalAddressJSONRequestBody{
+			Checksum:  "afb0689fe58b82c5f762991453edbbec",
+			SizeBytes: expectedSizeBytes,
+			Staging: api.StagingLocation{
+				PhysicalAddress: linkResp.JSON200.PhysicalAddress,
+				Token:           linkResp.JSON200.Token,
+			},
 		})
 		verifyResponseOK(t, resp, err)
 
-		sizeBytes := api.Int64Value(resp.JSON201.SizeBytes)
+		sizeBytes := api.Int64Value(resp.JSON200.SizeBytes)
 		if sizeBytes != expectedSizeBytes {
 			t.Fatalf("expected %d bytes to be written, got back %d", expectedSizeBytes, sizeBytes)
 		}

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -2092,6 +2092,37 @@ func TestController_ObjectsStageObjectHandler(t *testing.T) {
 		}
 	})
 
+	t.Run("stage object in storage ns", func(t *testing.T) {
+		linkResp, err := clt.GetPhysicalAddressWithResponse(ctx, "repo1", "main", &api.GetPhysicalAddressParams{Path: "foo/bar2"})
+		verifyResponseOK(t, linkResp, err)
+		if linkResp.JSON200 == nil {
+			t.Fatalf("GetPhysicalAddress non 200 response - status code %d", linkResp.StatusCode())
+		}
+		const expectedSizeBytes = 38
+		resp, err := clt.StageObjectWithResponse(ctx, "repo1", "main", &api.StageObjectParams{Path: "foo/bar2"}, api.StageObjectJSONRequestBody{
+			Checksum:        "afb0689fe58b82c5f762991453edbbec",
+			PhysicalAddress: api.StringValue(linkResp.JSON200.PhysicalAddress),
+			SizeBytes:       expectedSizeBytes,
+		})
+		verifyResponseOK(t, resp, err)
+
+		sizeBytes := api.Int64Value(resp.JSON201.SizeBytes)
+		if sizeBytes != expectedSizeBytes {
+			t.Fatalf("expected %d bytes to be written, got back %d", expectedSizeBytes, sizeBytes)
+		}
+
+		// get back info
+		statResp, err := clt.StatObjectWithResponse(ctx, "repo1", "main", &api.StatObjectParams{Path: "foo/bar2"})
+		verifyResponseOK(t, statResp, err)
+		if statResp.JSON200 == nil {
+			t.Fatalf("StatObject non 200 - status code %d", statResp.StatusCode())
+		}
+		objectStat := statResp.JSON200
+		if objectStat.PhysicalAddress != api.StringValue(linkResp.JSON200.PhysicalAddress) {
+			t.Fatalf("unexpected physical address: %s", objectStat.PhysicalAddress)
+		}
+	})
+
 	t.Run("upload object missing branch", func(t *testing.T) {
 		resp, err := clt.StageObjectWithResponse(ctx, "repo1", "main1234", &api.StageObjectParams{Path: "foo/bar"},
 			api.StageObjectJSONRequestBody{


### PR DESCRIPTION
Based on repository storage namespace, use relative path to object when data is kept under our managed storage.

Fix #4750