### PR TITLE
Add prefix scan to KV implementations

### DIFF
--- a/pkg/cache/cache.go
+++ b/pkg/cache/cache.go
@@ -12,6 +12,9 @@ type SetFn func() (v interface{}, err error)
 
 type Cache interface {
 	GetOrSet(k interface{}, setFn SetFn) (v interface{}, err error)
+
+	Clear(k interface{})
+	Set(k interface{}, v interface{})
 }
 
 type GetSetCache struct {
@@ -43,6 +46,14 @@ func (c *GetSetCache) GetOrSet(k interface{}, setFn SetFn) (v interface{}, err e
 		c.lru.AddEx(k, v, c.baseExpiry+c.jitterFn())
 		return v, nil
 	})
+}
+
+func (c *GetSetCache) Set(k, v interface{}) {
+	c.lru.AddEx(k, v, c.baseExpiry+c.jitterFn())
+}
+
+func (c *GetSetCache) Clear(k interface{}) {
+	c.lru.Remove(k)
 }
 
 func NewJitterFn(jitter time.Duration) JitterFn {

--- a/pkg/cache/no_cache.go
+++ b/pkg/cache/no_cache.go
@@ -7,3 +7,7 @@ type noCache struct{}
 func (m *noCache) GetOrSet(_ interface{}, setFn SetFn) (v interface{}, err error) {
 	return setFn()
 }
+
+func (m *noCache) Set(_ interface{}, _ interface{}) {}
+
+func (m *noCache) Clear(_ interface{}) {}

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -891,7 +891,7 @@ func (c *Catalog) ListEntries(ctx context.Context, repositoryID string, referenc
 	if err != nil {
 		return nil, false, err
 	}
-	iter, err := c.Store.List(ctx, repository, refToList)
+	iter, err := c.Store.ListWithPrefix(ctx, repository, refToList, graveler.Key(prefix))
 	if err != nil {
 		return nil, false, err
 	}

--- a/pkg/catalog/catalog_test.go
+++ b/pkg/catalog/catalog_test.go
@@ -663,7 +663,7 @@ func createPrepareUncommittedTestScenario(t *testing.T, numBranches, numRecords,
 	test.RefManager.EXPECT().ListBranches(gomock.Any(), gomock.Any()).Times(expectedCalls).Return(gUtils.NewFakeBranchIterator(branches), nil)
 
 	for i := 0; i < len(branches); i++ {
-		test.StagingManager.EXPECT().List(gomock.Any(), branches[i].StagingToken, gomock.Any()).AnyTimes().Return(cUtils.NewFakeValueIterator(records[i]), nil)
+		test.StagingManager.EXPECT().List(gomock.Any(), branches[i].StagingToken, nil, gomock.Any()).AnyTimes().Return(cUtils.NewFakeValueIterator(records[i]), nil)
 	}
 	if numRecords*numBranches > 0 {
 		test.GarbageCollectionManager.EXPECT().GetUncommittedLocation(gomock.Any(), gomock.Any()).Times(expectedCalls).DoAndReturn(func(runID string, sn graveler.StorageNamespace) (string, error) {

--- a/pkg/catalog/fake_graveler_test.go
+++ b/pkg/catalog/fake_graveler_test.go
@@ -121,11 +121,19 @@ func (g *FakeGraveler) ListStaging(_ context.Context, b *graveler.Branch) (grave
 	return g.ListStagingIteratorFactory(b.StagingToken), nil
 }
 
-func (g *FakeGraveler) List(_ context.Context, _ *graveler.RepositoryRecord, _ graveler.Ref) (graveler.ValueIterator, error) {
+func (g *FakeGraveler) List(ctx context.Context, rr *graveler.RepositoryRecord, ref graveler.Ref) (graveler.ValueIterator, error) {
+	return g.ListWithPrefix(ctx, rr, ref, nil)
+}
+
+func (g *FakeGraveler) ListWithPrefix(ctx context.Context, rr *graveler.RepositoryRecord, ref graveler.Ref, prefix graveler.Key) (graveler.ValueIterator, error) {
 	if g.Err != nil {
 		return nil, g.Err
 	}
-	return g.ListIteratorFactory(), nil
+	iter := g.ListIteratorFactory()
+	if prefix != nil {
+		iter = graveler.NewFilterPrefixIterator(iter, prefix)
+	}
+	return iter, nil
 }
 
 func (g *FakeGraveler) GetRepository(ctx context.Context, repositoryID graveler.RepositoryID) (*graveler.RepositoryRecord, error) {

--- a/pkg/graveler/graveler.go
+++ b/pkg/graveler/graveler.go
@@ -664,6 +664,17 @@ type RefManager interface {
 	// GetBranch returns the Branch metadata object for the given BranchID
 	GetBranch(ctx context.Context, repository *RepositoryRecord, branchID BranchID) (*Branch, error)
 
+	// GetBranchCached gets cached branch information by branch /
+	// repository id.  Cached information is refreshed by time or by
+	// GetBranch.
+	//
+	// Use it only for speedups not for correctness, as it may return
+	// stale (incorrect) data.  The typical flow is to call
+	// GetBranchCached, perform some actions, and commit using an action
+	// that verifies the branch information used was actually correct.
+	// If that fails, retry.
+	GetBranchCached(ctx context.Context, repository *RepositoryRecord, branchID BranchID) (*Branch, error)
+
 	// CreateBranch creates a branch with the given id and Branch metadata
 	CreateBranch(ctx context.Context, repository *RepositoryRecord, branchID BranchID, branch Branch) error
 
@@ -1433,7 +1444,7 @@ func (g *KVGraveler) Set(ctx context.Context, repository *RepositoryRecord, bran
 func (g *KVGraveler) safeBranchWrite(ctx context.Context, log logging.Logger, repository *RepositoryRecord, branchID BranchID, stagingOperation func(branch *Branch) error) error {
 	var try int
 	for try = 0; try < BranchWriteMaxTries; try++ {
-		branch, err := g.GetBranch(ctx, repository, branchID)
+		branch, err := g.RefManager.GetBranchCached(ctx, repository, branchID)
 		if err != nil {
 			return err
 		}
@@ -1445,7 +1456,7 @@ func (g *KVGraveler) safeBranchWrite(ctx context.Context, log logging.Logger, re
 
 		// Checking if the token has changed.
 		// If it changed, we need to write the changes to the branch's new staging token
-		branch, err = g.GetBranch(ctx, repository, branchID)
+		branch, err = g.RefManager.GetBranch(ctx, repository, branchID)
 		if err != nil {
 			return err
 		}

--- a/pkg/graveler/graveler_v2_test.go
+++ b/pkg/graveler/graveler_v2_test.go
@@ -174,12 +174,12 @@ func TestGravelerMerge(t *testing.T) {
 			}).Times(1)
 	}
 	emptyStagingTokenCombo := func(test *testutil.GravelerTest, numReps int) {
-		test.StagingManager.EXPECT().List(ctx, stagingToken1, gomock.Any()).Times(numReps).Return(testutils.NewFakeValueIterator([]*graveler.ValueRecord{{
+		test.StagingManager.EXPECT().List(ctx, stagingToken1, nil, gomock.Any()).Times(numReps).Return(testutils.NewFakeValueIterator([]*graveler.ValueRecord{{
 			Key:   key1,
 			Value: nil, // tombstone
 		}}), nil)
-		test.StagingManager.EXPECT().List(ctx, stagingToken2, gomock.Any()).Times(numReps).Return(testutils.NewFakeValueIterator(nil), nil)
-		test.StagingManager.EXPECT().List(ctx, stagingToken3, gomock.Any()).Times(numReps).Return(testutils.NewFakeValueIterator([]*graveler.ValueRecord{{
+		test.StagingManager.EXPECT().List(ctx, stagingToken2, nil, gomock.Any()).Times(numReps).Return(testutils.NewFakeValueIterator(nil), nil)
+		test.StagingManager.EXPECT().List(ctx, stagingToken3, nil, gomock.Any()).Times(numReps).Return(testutils.NewFakeValueIterator([]*graveler.ValueRecord{{
 			Key:   key1,
 			Value: value1,
 		}}), nil)
@@ -233,15 +233,15 @@ func TestGravelerMerge(t *testing.T) {
 				return err
 			}).Times(1)
 
-		test.StagingManager.EXPECT().List(ctx, stagingToken1, gomock.Any()).Times(1).Return(testutils.NewFakeValueIterator([]*graveler.ValueRecord{{
+		test.StagingManager.EXPECT().List(ctx, stagingToken1, nil, gomock.Any()).Times(1).Return(testutils.NewFakeValueIterator([]*graveler.ValueRecord{{
 			Key:   key1,
 			Value: nil, // tombstone
 		}}), nil)
-		test.StagingManager.EXPECT().List(ctx, stagingToken2, gomock.Any()).Times(1).Return(testutils.NewFakeValueIterator([]*graveler.ValueRecord{{
+		test.StagingManager.EXPECT().List(ctx, stagingToken2, nil, gomock.Any()).Times(1).Return(testutils.NewFakeValueIterator([]*graveler.ValueRecord{{
 			Key:   key2,
 			Value: value2,
 		}}), nil)
-		test.StagingManager.EXPECT().List(ctx, stagingToken3, gomock.Any()).Times(1).Return(testutils.NewFakeValueIterator([]*graveler.ValueRecord{{
+		test.StagingManager.EXPECT().List(ctx, stagingToken3, nil, gomock.Any()).Times(1).Return(testutils.NewFakeValueIterator([]*graveler.ValueRecord{{
 			Key:   key1,
 			Value: value1,
 		}}), nil)
@@ -329,20 +329,20 @@ func TestGravelerRevert(t *testing.T) {
 			}).Times(1)
 	}
 	emptyStagingTokenCombo := func(test *testutil.GravelerTest, times int) {
-		test.StagingManager.EXPECT().List(ctx, stagingToken1, gomock.Any()).Times(times).Return(testutils.NewFakeValueIterator([]*graveler.ValueRecord{{
+		test.StagingManager.EXPECT().List(ctx, stagingToken1, nil, gomock.Any()).Times(times).Return(testutils.NewFakeValueIterator([]*graveler.ValueRecord{{
 			Key:   key1,
 			Value: nil, // tombstone
 		}}), nil)
-		test.StagingManager.EXPECT().List(ctx, stagingToken2, gomock.Any()).Times(times).Return(testutils.NewFakeValueIterator(nil), nil)
-		test.StagingManager.EXPECT().List(ctx, stagingToken3, gomock.Any()).Times(times).Return(testutils.NewFakeValueIterator([]*graveler.ValueRecord{{
+		test.StagingManager.EXPECT().List(ctx, stagingToken2, nil, gomock.Any()).Times(times).Return(testutils.NewFakeValueIterator(nil), nil)
+		test.StagingManager.EXPECT().List(ctx, stagingToken3, nil, gomock.Any()).Times(times).Return(testutils.NewFakeValueIterator([]*graveler.ValueRecord{{
 			Key:   key1,
 			Value: value1,
 		}}), nil)
 	}
 	dirtyStagingTokenCombo := func(test *testutil.GravelerTest) {
-		test.StagingManager.EXPECT().List(ctx, stagingToken1, gomock.Any()).Times(1).Return(testutils.NewFakeValueIterator(nil), nil)
-		test.StagingManager.EXPECT().List(ctx, stagingToken2, gomock.Any()).Times(1).Return(testutils.NewFakeValueIterator(nil), nil)
-		test.StagingManager.EXPECT().List(ctx, stagingToken3, gomock.Any()).Times(1).Return(testutils.NewFakeValueIterator([]*graveler.ValueRecord{{
+		test.StagingManager.EXPECT().List(ctx, stagingToken1, nil, gomock.Any()).Times(1).Return(testutils.NewFakeValueIterator(nil), nil)
+		test.StagingManager.EXPECT().List(ctx, stagingToken2, nil, gomock.Any()).Times(1).Return(testutils.NewFakeValueIterator(nil), nil)
+		test.StagingManager.EXPECT().List(ctx, stagingToken3, nil, gomock.Any()).Times(1).Return(testutils.NewFakeValueIterator([]*graveler.ValueRecord{{
 			Key:   key1,
 			Value: value1,
 		}}), nil)
@@ -444,9 +444,9 @@ func TestGravelerCommit_v2(t *testing.T) {
 			}).Times(1)
 
 		test.RefManager.EXPECT().GetCommit(ctx, repository, commit1ID).Times(1).Return(&commit1, nil)
-		test.StagingManager.EXPECT().List(ctx, stagingToken1, gomock.Any()).Times(1).Return(testutils.NewFakeValueIterator([]*graveler.ValueRecord{}), nil)
-		test.StagingManager.EXPECT().List(ctx, stagingToken2, gomock.Any()).Times(1).Return(testutils.NewFakeValueIterator([]*graveler.ValueRecord{}), nil)
-		test.StagingManager.EXPECT().List(ctx, stagingToken3, gomock.Any()).Times(1).Return(testutils.NewFakeValueIterator([]*graveler.ValueRecord{}), nil)
+		test.StagingManager.EXPECT().List(ctx, stagingToken1, nil, gomock.Any()).Times(1).Return(testutils.NewFakeValueIterator([]*graveler.ValueRecord{}), nil)
+		test.StagingManager.EXPECT().List(ctx, stagingToken2, nil, gomock.Any()).Times(1).Return(testutils.NewFakeValueIterator([]*graveler.ValueRecord{}), nil)
+		test.StagingManager.EXPECT().List(ctx, stagingToken3, nil, gomock.Any()).Times(1).Return(testutils.NewFakeValueIterator([]*graveler.ValueRecord{}), nil)
 		test.CommittedManager.EXPECT().Commit(ctx, repository.StorageNamespace, mr1ID, gomock.Any()).Times(1).Return(graveler.MetaRangeID(""), graveler.DiffSummary{}, nil)
 		test.RefManager.EXPECT().AddCommit(ctx, repository, gomock.Any()).Return(graveler.CommitID(""), nil)
 		test.StagingManager.EXPECT().DropAsync(ctx, stagingToken1).Return(nil)
@@ -486,9 +486,9 @@ func TestGravelerCommit_v2(t *testing.T) {
 			}).Times(1).Return(graveler.ErrNoChanges)
 
 		test.RefManager.EXPECT().GetCommit(ctx, repository, commit1ID).Times(1).Return(&commit1, nil)
-		test.StagingManager.EXPECT().List(ctx, stagingToken1, gomock.Any()).Times(1).Return(testutils.NewFakeValueIterator([]*graveler.ValueRecord{}), nil)
-		test.StagingManager.EXPECT().List(ctx, stagingToken2, gomock.Any()).Times(1).Return(testutils.NewFakeValueIterator([]*graveler.ValueRecord{}), nil)
-		test.StagingManager.EXPECT().List(ctx, stagingToken3, gomock.Any()).Times(1).Return(testutils.NewFakeValueIterator([]*graveler.ValueRecord{}), nil)
+		test.StagingManager.EXPECT().List(ctx, stagingToken1, nil, gomock.Any()).Times(1).Return(testutils.NewFakeValueIterator([]*graveler.ValueRecord{}), nil)
+		test.StagingManager.EXPECT().List(ctx, stagingToken2, nil, gomock.Any()).Times(1).Return(testutils.NewFakeValueIterator([]*graveler.ValueRecord{}), nil)
+		test.StagingManager.EXPECT().List(ctx, stagingToken3, nil, gomock.Any()).Times(1).Return(testutils.NewFakeValueIterator([]*graveler.ValueRecord{}), nil)
 		test.CommittedManager.EXPECT().Commit(ctx, repository.StorageNamespace, mr1ID, gomock.Any()).Times(1).Return(graveler.MetaRangeID(""), graveler.DiffSummary{}, graveler.ErrNoChanges)
 
 		val, err := test.Sut.Commit(ctx, repository, branch1ID, graveler.CommitParams{})

--- a/pkg/graveler/prefix_iterator.go
+++ b/pkg/graveler/prefix_iterator.go
@@ -1,0 +1,43 @@
+package graveler
+
+import "bytes"
+
+type filterPrefixIterator struct {
+	iter   ValueIterator
+	prefix Key
+}
+
+func NewFilterPrefixIterator(iter ValueIterator, prefix Key) *filterPrefixIterator {
+	iter.SeekGE(prefix)
+	return &filterPrefixIterator{
+		iter:   iter,
+		prefix: prefix,
+	}
+}
+
+func (f *filterPrefixIterator) Next() bool {
+	if ok := f.iter.Next(); !ok {
+		return false
+	}
+	value := f.iter.Value()
+	if !bytes.HasPrefix(value.Key, f.prefix) {
+		return false
+	}
+	return true
+}
+
+func (f *filterPrefixIterator) SeekGE(id Key) {
+	f.iter.SeekGE(id)
+}
+
+func (f *filterPrefixIterator) Value() *ValueRecord {
+	return f.iter.Value()
+}
+
+func (f *filterPrefixIterator) Err() error {
+	return f.iter.Err()
+}
+
+func (f *filterPrefixIterator) Close() {
+	f.iter.Close()
+}

--- a/pkg/graveler/ref/commit_ordered_iterator_test.go
+++ b/pkg/graveler/ref/commit_ordered_iterator_test.go
@@ -307,7 +307,7 @@ func TestKVOrderedCommitIterator_CloseTwice(t *testing.T) {
 	entIt := mock.NewMockEntriesIterator(ctrl)
 	entIt.EXPECT().Close().Times(1)
 	store := mock.NewMockStore(ctrl)
-	store.EXPECT().Scan(ctx, gomock.Any(), gomock.Any()).Return(entIt, nil).Times(1)
+	store.EXPECT().ScanWithPrefix(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(entIt, nil).Times(1)
 	msgStore := kv.StoreMessage{Store: store}
 	repository := &graveler.RepositoryRecord{
 		RepositoryID: "CommitIterClose",
@@ -334,7 +334,7 @@ func TestKVOrderedCommitIterator_NextAfterClose(t *testing.T) {
 	entIt := mock.NewMockEntriesIterator(ctrl)
 	entIt.EXPECT().Close().Times(1)
 	store := mock.NewMockStore(ctrl)
-	store.EXPECT().Scan(ctx, gomock.Any(), gomock.Any()).Return(entIt, nil).Times(1)
+	store.EXPECT().ScanWithPrefix(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(entIt, nil).Times(1)
 	msgStore := kv.StoreMessage{Store: store}
 	repository := &graveler.RepositoryRecord{
 		RepositoryID: "CommitIterClose",

--- a/pkg/graveler/ref/repository_iterator_test.go
+++ b/pkg/graveler/ref/repository_iterator_test.go
@@ -108,7 +108,7 @@ func TestKVRepositoryIterator_CloseTwice(t *testing.T) {
 	entIt := mock.NewMockEntriesIterator(ctrl)
 	entIt.EXPECT().Close().Times(1)
 	store := mock.NewMockStore(ctrl)
-	store.EXPECT().Scan(ctx, gomock.Any(), gomock.Any()).Return(entIt, nil).Times(1)
+	store.EXPECT().ScanWithPrefix(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(entIt, nil).Times(1)
 	msgStore := kv.StoreMessage{Store: store}
 	it, err := ref.NewKVRepositoryIterator(ctx, &msgStore)
 	if err != nil {
@@ -125,7 +125,7 @@ func TestKVRepositoryIterator_NextClosed(t *testing.T) {
 	entIt := mock.NewMockEntriesIterator(ctrl)
 	entIt.EXPECT().Close().Times(1)
 	store := mock.NewMockStore(ctrl)
-	store.EXPECT().Scan(ctx, gomock.Any(), gomock.Any()).Return(entIt, nil).Times(1)
+	store.EXPECT().ScanWithPrefix(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(entIt, nil).Times(1)
 	msgStore := kv.StoreMessage{Store: store}
 	it, err := ref.NewKVRepositoryIterator(ctx, &msgStore)
 	if err != nil {

--- a/pkg/graveler/ref/tag_iterator_test.go
+++ b/pkg/graveler/ref/tag_iterator_test.go
@@ -119,7 +119,7 @@ func TestKVTagIterator_CloseTwice(t *testing.T) {
 	entIt := mock.NewMockEntriesIterator(ctrl)
 	entIt.EXPECT().Close().Times(1)
 	store := mock.NewMockStore(ctrl)
-	store.EXPECT().Scan(ctx, gomock.Any(), gomock.Any()).Return(entIt, nil).Times(1)
+	store.EXPECT().ScanWithPrefix(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(entIt, nil).Times(1)
 	msgStore := kv.StoreMessage{Store: store}
 	repo := &graveler.RepositoryRecord{
 		RepositoryID: "repo",
@@ -142,7 +142,7 @@ func TestKVTagIterator_NextClosed(t *testing.T) {
 	entIt := mock.NewMockEntriesIterator(ctrl)
 	entIt.EXPECT().Close().Times(1)
 	store := mock.NewMockStore(ctrl)
-	store.EXPECT().Scan(ctx, gomock.Any(), gomock.Any()).Return(entIt, nil).Times(1)
+	store.EXPECT().ScanWithPrefix(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(entIt, nil).Times(1)
 	msgStore := kv.StoreMessage{Store: store}
 	repo := &graveler.RepositoryRecord{
 		RepositoryID: "repo",

--- a/pkg/graveler/settings/manager_test.go
+++ b/pkg/graveler/settings/manager_test.go
@@ -46,6 +46,14 @@ func (m *mockCache) GetOrSet(k interface{}, setFn cache.SetFn) (v interface{}, e
 	return val, nil
 }
 
+func (m *mockCache) Set(k interface{}, v interface{}) {
+	m.c[k] = v
+}
+
+func (m *mockCache) Clear(k interface{}) {
+	delete(m.c, k)
+}
+
 func TestSaveAndGet(t *testing.T) {
 	ctx := context.Background()
 	mc := &mockCache{

--- a/pkg/graveler/staging/iterator.go
+++ b/pkg/graveler/staging/iterator.go
@@ -19,10 +19,10 @@ type Iterator struct {
 
 // NewStagingIterator initiates the staging iterator with a batchSize
 func NewStagingIterator(ctx context.Context, store kv.StoreMessage, st graveler.StagingToken, prefix graveler.Key) (*Iterator, error) {
-	itr := kv.NewPartitionIterator(ctx, store.Store, (&graveler.StagedEntryData{}).ProtoReflect().Type(), graveler.StagingTokenPartition(st))
-	if prefix != nil {
-		itr.SeekGE(prefix)
-	}
+	itr := kv.NewPartitionIterator(ctx, store.Store, (&graveler.StagedEntryData{}).ProtoReflect().Type(), graveler.StagingTokenPartition(st), prefix)
+	// if prefix != nil {
+	// 	itr.SeekGE(prefix)
+	// }
 	return &Iterator{
 		ctx:    ctx,
 		store:  store,

--- a/pkg/graveler/staging/manager.go
+++ b/pkg/graveler/staging/manager.go
@@ -94,8 +94,8 @@ func (m *Manager) DropKey(ctx context.Context, st graveler.StagingToken, key gra
 
 // List TODO niro: Remove batchSize parameter post KV
 // List returns an iterator of staged values on the staging token st
-func (m *Manager) List(ctx context.Context, st graveler.StagingToken, _ int) (graveler.ValueIterator, error) {
-	return NewStagingIterator(ctx, m.store, st)
+func (m *Manager) List(ctx context.Context, st graveler.StagingToken, prefix graveler.Key, _ int) (graveler.ValueIterator, error) {
+	return NewStagingIterator(ctx, m.store, st, prefix)
 }
 
 func (m *Manager) Drop(ctx context.Context, st graveler.StagingToken) error {

--- a/pkg/graveler/staging/manager_test.go
+++ b/pkg/graveler/staging/manager_test.go
@@ -114,12 +114,12 @@ func TestDrop(t *testing.T) {
 	if !errors.Is(err, graveler.ErrNotFound) {
 		t.Fatalf("after dropping staging area, expected ErrNotFound in Get. got err=%v, got value=%v", err, v)
 	}
-	it, _ := s.List(ctx, "t1", 0)
+	it, _ := s.List(ctx, "t1", nil, 0)
 	if it.Next() {
 		t.Fatal("expected staging area with token t1 to be empty, got non-empty iterator")
 	}
 	it.Close()
-	it, _ = s.List(ctx, "t2", 0)
+	it, _ = s.List(ctx, "t2", nil, 0)
 	count := 0
 	for it.Next() {
 		if string(it.Value().Data) != fmt.Sprintf("value%d", count) {
@@ -159,7 +159,7 @@ func TestDropAsync(t *testing.T) {
 
 	// wait for async cleanup to end
 	<-ch
-	it, _ := s.List(ctx, "t1", 0)
+	it, _ := s.List(ctx, "t1", nil, 0)
 	if it.Next() {
 		t.Fatal("expected staging area with token t1 to be empty, got non-empty iterator")
 	}
@@ -181,7 +181,7 @@ func TestDropByPrefix(t *testing.T) {
 	_, err = s.Get(ctx, "t1", []byte("key0000"))
 	// key0000 does not start with the deleted prefix - should be returned
 	testutil.Must(t, err)
-	it, _ := s.List(ctx, "t1", 0)
+	it, _ := s.List(ctx, "t1", nil, 0)
 	count := 0
 	for it.Next() {
 		count++
@@ -190,7 +190,7 @@ func TestDropByPrefix(t *testing.T) {
 	if count != numOfValues-1000 {
 		t.Errorf("got unexpected number of results after drop. expected=%d, got=%d", numOfValues-1000, count)
 	}
-	it, _ = s.List(ctx, "t2", 0)
+	it, _ = s.List(ctx, "t2", nil, 0)
 	count = 0
 	for it.Next() {
 		count++
@@ -286,7 +286,7 @@ func TestDropPrefixBytes(t *testing.T) {
 			}
 			err := s.DropByPrefix(ctx, st, tst.prefix)
 			testutil.Must(t, err)
-			it, err := s.List(ctx, st, 0)
+			it, err := s.List(ctx, st, nil, 0)
 			testutil.Must(t, err)
 			count := 0
 			for it.Next() {
@@ -312,7 +312,7 @@ func TestList(t *testing.T) {
 			testutil.Must(t, err)
 		}
 		res := make([]*graveler.ValueRecord, 0, numOfValues)
-		it, _ := s.List(ctx, token, 0)
+		it, _ := s.List(ctx, token, nil, 0)
 		for it.Next() {
 			res = append(res, it.Value())
 		}
@@ -341,7 +341,7 @@ func TestSeek(t *testing.T) {
 		err := s.Set(ctx, "t1", []byte(fmt.Sprintf("key%04d", i)), newTestValue("identity1", "value1"), true)
 		testutil.Must(t, err)
 	}
-	it, _ := s.List(ctx, "t1", 0)
+	it, _ := s.List(ctx, "t1", nil, 0)
 	defer it.Close()
 	if it.SeekGE([]byte("key0050")); !it.Next() {
 		t.Fatal("iterator seek expected to return true, got false")
@@ -383,7 +383,7 @@ func TestNilValue(t *testing.T) {
 	if e != nil {
 		t.Errorf("got unexpected value. expected=nil, got=%s", e)
 	}
-	it, err := s.List(ctx, "t1", 0)
+	it, err := s.List(ctx, "t1", nil, 0)
 	testutil.Must(t, err)
 	defer it.Close()
 	if !it.Next() {
@@ -452,7 +452,7 @@ func TestDeleteAndTombstone(t *testing.T) {
 		if string(e.Identity) != "identity1" {
 			t.Fatalf("got unexpected value identity. expected=%s, got=%s", "identity1", string(e.Identity))
 		}
-		it, err := s.List(ctx, "t1", 0)
+		it, err := s.List(ctx, "t1", nil, 0)
 		testutil.Must(t, err)
 		if !it.Next() {
 			t.Fatalf("expected to get key from list")

--- a/pkg/graveler/testutil/fakes.go
+++ b/pkg/graveler/testutil/fakes.go
@@ -338,6 +338,10 @@ func (m *RefsFake) GetBranch(context.Context, *graveler.RepositoryRecord, gravel
 	return m.Branch, m.Err
 }
 
+func (m *RefsFake) GetBranchCached(context.Context, *graveler.RepositoryRecord, graveler.BranchID) (*graveler.Branch, error) {
+	return m.Branch, m.Err
+}
+
 func (m *RefsFake) SetBranch(context.Context, *graveler.RepositoryRecord, graveler.BranchID, graveler.Branch) error {
 	return nil
 }

--- a/pkg/graveler/testutil/fakes.go
+++ b/pkg/graveler/testutil/fakes.go
@@ -195,14 +195,16 @@ func (s *StagingFake) DropKey(_ context.Context, _ graveler.StagingToken, key gr
 	return nil
 }
 
-func (s *StagingFake) List(_ context.Context, st graveler.StagingToken, _ int) (graveler.ValueIterator, error) {
+func (s *StagingFake) List(_ context.Context, st graveler.StagingToken, prefix graveler.Key, _ int) (graveler.ValueIterator, error) {
 	if s.Err != nil {
 		return nil, s.Err
 	}
 	if s.Values != nil && s.Values[st.String()] != nil {
 		keys := make([]string, 0)
 		for k := range s.Values[st.String()] {
-			keys = append(keys, k)
+			if bytes.HasPrefix([]byte(k), prefix) {
+				keys = append(keys, k)
+			}
 		}
 		sort.Strings(keys)
 		values := make([]graveler.ValueRecord, 0)

--- a/pkg/kv/iterators_test.go
+++ b/pkg/kv/iterators_test.go
@@ -17,9 +17,9 @@ func TestPartitionIterator_ClosedBehaviour(t *testing.T) {
 	store := mock.NewMockStore(ctrl)
 	entIt := mock.NewMockEntriesIterator(ctrl)
 	entIt.EXPECT().Close().Times(1)
-	store.EXPECT().Scan(ctx, gomock.Any(), gomock.Any()).Return(entIt, nil).Times(1)
+	store.EXPECT().ScanWithPrefix(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(entIt, nil).Times(1)
 
-	it := kv.NewPartitionIterator(ctx, store, (&graveler.StagedEntryData{}).ProtoReflect().Type(), "partitionKey")
+	it := kv.NewPartitionIterator(ctx, store, (&graveler.StagedEntryData{}).ProtoReflect().Type(), "partitionKey", nil)
 	it.SeekGE([]byte("test"))
 	it.Close()
 
@@ -35,9 +35,9 @@ func TestPartitionIterator_CloseAfterSeekGEFailed(t *testing.T) {
 	store := mock.NewMockStore(ctrl)
 	var entIt *mock.MockEntriesIterator
 	entItErr := errors.New("failed to scan")
-	store.EXPECT().Scan(ctx, gomock.Any(), gomock.Any()).Return(entIt, entItErr).Times(1)
+	store.EXPECT().ScanWithPrefix(ctx, gomock.Any(), gomock.Any(), gomock.Any()).Return(entIt, entItErr).Times(1)
 
-	it := kv.NewPartitionIterator(ctx, store, (&graveler.StagedEntryData{}).ProtoReflect().Type(), "partitionKey")
+	it := kv.NewPartitionIterator(ctx, store, (&graveler.StagedEntryData{}).ProtoReflect().Type(), "partitionKey", nil)
 	it.SeekGE([]byte("test"))
 	it.Close() // verify we don't crash after after SeekGE failed internally with Scan
 }

--- a/pkg/kv/kvtest/iterators.go
+++ b/pkg/kv/kvtest/iterators.go
@@ -43,7 +43,7 @@ func testPartitionIterator(t *testing.T, ms MakeStore) {
 	}
 
 	t.Run("listing all values of partition", func(t *testing.T) {
-		itr := kv.NewPartitionIterator(ctx, store, (&TestModel{}).ProtoReflect().Type(), firstPartitionKey)
+		itr := kv.NewPartitionIterator(ctx, store, (&TestModel{}).ProtoReflect().Type(), firstPartitionKey, nil)
 		if itr == nil {
 			t.Fatalf("failed to create partition iterator")
 		}
@@ -67,7 +67,7 @@ func testPartitionIterator(t *testing.T, ms MakeStore) {
 	})
 
 	t.Run("listing values SeekGE", func(t *testing.T) {
-		itr := kv.NewPartitionIterator(ctx, store, (&TestModel{}).ProtoReflect().Type(), secondPartitionKey)
+		itr := kv.NewPartitionIterator(ctx, store, (&TestModel{}).ProtoReflect().Type(), secondPartitionKey, nil)
 		if itr == nil {
 			t.Fatalf("failed to create partition iterator")
 		}
@@ -92,7 +92,7 @@ func testPartitionIterator(t *testing.T, ms MakeStore) {
 	})
 
 	t.Run("failed SeekGE partition not found", func(t *testing.T) {
-		itr := kv.NewPartitionIterator(ctx, store, (&TestModel{}).ProtoReflect().Type(), "")
+		itr := kv.NewPartitionIterator(ctx, store, (&TestModel{}).ProtoReflect().Type(), "", nil)
 		if itr == nil {
 			t.Fatalf("failed to create partition iterator")
 		}

--- a/pkg/kv/local/iterator.go
+++ b/pkg/kv/local/iterator.go
@@ -19,12 +19,12 @@ type EntriesIterator struct {
 	logger       logging.Logger
 }
 
-func newEntriesIterator(logger logging.Logger, db *badger.DB, partitionKey, start []byte, prefetchSize int) *EntriesIterator {
-	prefix := partitionRange(partitionKey)
+func newEntriesIterator(logger logging.Logger, db *badger.DB, partitionKey, prefix, start []byte, prefetchSize int) *EntriesIterator {
+	keyPrefix := append(partitionRange(partitionKey), prefix...)
 	txn := db.NewTransaction(false)
 	opts := badger.DefaultIteratorOptions
 	opts.PrefetchSize = prefetchSize
-	opts.Prefix = prefix
+	opts.Prefix = keyPrefix
 	iter := txn.NewIterator(opts)
 	return &EntriesIterator{
 		iter:         iter,

--- a/pkg/kv/local/iterator.go
+++ b/pkg/kv/local/iterator.go
@@ -20,16 +20,15 @@ type EntriesIterator struct {
 }
 
 func newEntriesIterator(logger logging.Logger, db *badger.DB, partitionKey, prefix, start []byte, prefetchSize int) *EntriesIterator {
-	keyPrefix := append(partitionRange(partitionKey), prefix...)
 	txn := db.NewTransaction(false)
 	opts := badger.DefaultIteratorOptions
 	opts.PrefetchSize = prefetchSize
-	opts.Prefix = keyPrefix
+	opts.Prefix = composeKey(partitionKey, prefix)
 	iter := txn.NewIterator(opts)
 	return &EntriesIterator{
 		iter:         iter,
 		partitionKey: partitionKey,
-		start:        composeKey(partitionKey, start),
+		start:        composeKey(partitionKey, append(append(make([]byte, 0), prefix...), start...)),
 		logger:       logger,
 		txn:          txn,
 	}

--- a/pkg/kv/local/store.go
+++ b/pkg/kv/local/store.go
@@ -183,8 +183,13 @@ func (s *Store) Delete(ctx context.Context, partitionKey, key []byte) error {
 }
 
 func (s *Store) Scan(ctx context.Context, partitionKey, start []byte) (kv.EntriesIterator, error) {
+	return s.ScanWithPrefix(ctx, partitionKey, nil, start)
+}
+
+func (s *Store) ScanWithPrefix(ctx context.Context, partitionKey, prefix, start []byte) (kv.EntriesIterator, error) {
 	log := s.logger.WithFields(logging.Fields{
 		"partition_key": string(partitionKey),
+		"prefix":        prefix,
 		"start_key":     string(start),
 		"op":            "scan",
 	}).WithContext(ctx)
@@ -194,7 +199,7 @@ func (s *Store) Scan(ctx context.Context, partitionKey, start []byte) (kv.Entrie
 		return nil, kv.ErrMissingPartitionKey
 	}
 
-	return newEntriesIterator(log, s.db, partitionKey, start, s.prefetchSize), nil
+	return newEntriesIterator(log, s.db, partitionKey, prefix, start, s.prefetchSize), nil
 }
 
 func (s *Store) Close() {

--- a/pkg/kv/mem/store.go
+++ b/pkg/kv/mem/store.go
@@ -155,6 +155,10 @@ func (s *Store) ScanWithPrefix(ctx context.Context, partitionKey, prefix, start 
 		return nil, kv.ErrMissingPartitionKey
 	}
 
+	if start == nil {
+		start = make([]byte, 0)
+	}
+
 	return &EntriesIterator{
 		store:     s,
 		prefix:    prefix,

--- a/pkg/kv/scan.go
+++ b/pkg/kv/scan.go
@@ -46,11 +46,11 @@ func (b *PrefixIterator) Close() {
 // ScanPrefix returns an iterator on store that scan the set of keys that start with prefix
 // after is the full key name for which to start the scan from
 func ScanPrefix(ctx context.Context, store Store, partitionKey, prefix, after []byte) (EntriesIterator, error) {
-	start := prefix
-	if len(after) > 0 && string(after) > string(prefix) {
+	var start []byte
+	if len(after) > 0 && bytes.Compare(after, prefix) > 0 {
 		start = after
 	}
-	iter, err := store.Scan(ctx, partitionKey, start)
+	iter, err := store.ScanWithPrefix(ctx, partitionKey, prefix, start)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kv/store.go
+++ b/pkg/kv/store.go
@@ -81,6 +81,10 @@ type Store interface {
 	// partitionKey is optional, passing it might increase performance.
 	Scan(ctx context.Context, partitionKey, start []byte) (EntriesIterator, error)
 
+	// ScanWithPrefix returns entries that can be read by key order, starting at or after the `start` position
+	// partitionKey is optional, passing it might increase performance.
+	ScanWithPrefix(ctx context.Context, partitionKey, prefix []byte, start []byte) (EntriesIterator, error)
+
 	// Close access to the database store. After calling Close the instance is unusable.
 	Close()
 }

--- a/pkg/kv/store_test.go
+++ b/pkg/kv/store_test.go
@@ -43,6 +43,10 @@ func (m *MockStore) Scan(_ context.Context, _, _ []byte) (kv.EntriesIterator, er
 	return nil, errNotImplemented
 }
 
+func (m *MockStore) ScanWithPrefix(_ context.Context, _, _, _ []byte) (kv.EntriesIterator, error) {
+	return nil, errNotImplemented
+}
+
 func (m *MockStore) Close() {}
 
 func (m *MockDriver) Open(_ context.Context, params kvparams.KV) (kv.Store, error) {


### PR DESCRIPTION
The LakeFSOutputCommitter project was abandoned and I will **not** be continuing to work on this PR.  However it offers a significant speedup (2x) to lakeFSFS with FileOutputCommitter (the Spark default OutputCommitter), and may help with the linked issue.