### PR TITLE
Perform fewer API calls for exists

### DIFF
--- a/clients/hadoopfs/src/main/java/io/lakefs/Constants.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/Constants.java
@@ -2,7 +2,7 @@ package io.lakefs;
 
 import org.apache.commons.io.FileUtils;
 
-class Constants {
+public class Constants {
     public static final String DEFAULT_SCHEME = "lakefs";
     public static final String DEFAULT_CLIENT_ENDPOINT = "http://localhost:8000/api/v1";
     public static final String ACCESS_KEY_KEY_SUFFIX = "access.key";

--- a/clients/hadoopfs/src/main/java/io/lakefs/FileSystemTracer.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/FileSystemTracer.java
@@ -1,5 +1,8 @@
 package io.lakefs;
 
+import io.lakefs.utils.ObjectLocation;
+import io.lakefs.utils.StringUtils;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.*;
 import org.apache.hadoop.fs.permission.FsPermission;

--- a/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileSystem.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileSystem.java
@@ -3,6 +3,8 @@ package io.lakefs;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import io.lakefs.clients.api.*;
 import io.lakefs.clients.api.model.*;
+import io.lakefs.utils.ObjectLocation;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.*;
 import org.apache.hadoop.fs.permission.FsPermission;
@@ -853,25 +855,7 @@ public class LakeFSFileSystem extends FileSystem {
      */
     @Nonnull
     public ObjectLocation pathToObjectLocation(Path path) {
-        if (!path.isAbsolute()) {
-            path = new Path(this.workingDirectory, path);
-        }
-
-        URI uri = path.toUri();
-        ObjectLocation loc = new ObjectLocation();
-        loc.setScheme(uri.getScheme());
-        loc.setRepository(uri.getHost());
-        // extract ref and rest of the path after removing the '/' prefix
-        String s = StringUtils.trimLeadingSlash(uri.getPath());
-        int i = s.indexOf(Constants.SEPARATOR);
-        if (i == -1) {
-            loc.setRef(s);
-            loc.setPath("");
-        } else {
-            loc.setRef(s.substring(0, i));
-            loc.setPath(s.substring(i + 1));
-        }
-        return loc;
+        return ObjectLocation.pathToObjectLocation(this.workingDirectory, path);
     }
 
     class ListingIterator implements RemoteIterator<LakeFSFileStatus> {

--- a/clients/hadoopfs/src/main/java/io/lakefs/LinkOnCloseOutputStream.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/LinkOnCloseOutputStream.java
@@ -1,6 +1,7 @@
 package io.lakefs;
 
 import io.lakefs.clients.api.model.StagingLocation;
+import io.lakefs.utils.ObjectLocation;
 import org.apache.hadoop.fs.Path;
 
 import java.io.IOException;

--- a/clients/hadoopfs/src/main/java/io/lakefs/utils/ObjectLocation.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/utils/ObjectLocation.java
@@ -1,15 +1,66 @@
-package io.lakefs;
+package io.lakefs.utils;
+
+import io.lakefs.Constants;
 
 import org.apache.hadoop.fs.Path;
 
-class ObjectLocation {
+import javax.annotation.Nonnull;
+import java.net.URI;
+
+public class ObjectLocation {
     private String scheme;
     private String repository;
     private String ref;
     private String path;
 
+    /**
+     * Returns Location with repository, ref and path used by lakeFS based on filesystem path.
+     *
+     * @param workingDirectory used if path is local.
+     * @param path to extract information from.
+     * @return lakeFS Location with repository, ref and path
+     */
+    @Nonnull
+    static public ObjectLocation pathToObjectLocation(Path workingDirectory, Path path) {
+        if (!path.isAbsolute()) {
+            if (workingDirectory == null) {
+                throw new IllegalArgumentException(String.format("cannot expand local path %s with null workingDirectory", path));
+            }
+            path = new Path(workingDirectory, path);
+        }
+
+        URI uri = path.toUri();
+        ObjectLocation loc = new ObjectLocation();
+        loc.setScheme(uri.getScheme());
+        loc.setRepository(uri.getHost());
+        // extract ref and rest of the path after removing the '/' prefix
+        String s = StringUtils.trimLeadingSlash(uri.getPath());
+        int i = s.indexOf(Constants.SEPARATOR);
+        if (i == -1) {
+            loc.setRef(s);
+            loc.setPath("");
+        } else {
+            loc.setRef(s.substring(0, i));
+            loc.setPath(s.substring(i + 1));
+        }
+        return loc;
+    }
+
+    /**
+     * Returns Location with repository, ref and path used by lakeFS based on filesystem path.
+     *
+     * @param path to extract information from.
+     * @return lakeFS Location with repository, ref and path
+     */
+    @Nonnull
+    static public ObjectLocation pathToObjectLocation(Path path) {
+        return pathToObjectLocation(null, path);
+    }
+
     public static String formatPath(String scheme, String repository, String ref, String path) {
-        return String.format("%s://%s/%s/%s", scheme, repository, ref, path);
+        String ret = formatPath(scheme, repository, ref);
+        if (path != null) ret = ret + "/" + path;
+        return ret;
     }
 
 
@@ -39,6 +90,10 @@ class ObjectLocation {
         this.repository = repository;
         this.ref = ref;
         this.path = path;
+    }
+
+    public ObjectLocation clone() {
+        return new ObjectLocation(scheme, repository, ref, path);
     }
 
     public ObjectLocation getParent() {
@@ -119,5 +174,9 @@ class ObjectLocation {
 
     public ObjectLocation toDirectory() {
         return new ObjectLocation(scheme, repository, ref, StringUtils.addLeadingSlash(path));
+    }
+
+    public Path toFSPath() {
+        return new Path(this.toString());
     }
 }

--- a/clients/hadoopfs/src/main/java/io/lakefs/utils/StringUtils.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/utils/StringUtils.java
@@ -1,15 +1,17 @@
-package io.lakefs;
+package io.lakefs.utils;
+
+import io.lakefs.Constants;
 
 public final class StringUtils {
 
-    static String trimLeadingSlash(String s) {
+    public static String trimLeadingSlash(String s) {
         if (s.startsWith(Constants.SEPARATOR)) {
             return s.substring(1);
         }
         return s;
     }
 
-    static String addLeadingSlash(String s) {
+    public static String addLeadingSlash(String s) {
         return s.isEmpty() || s.endsWith(Constants.SEPARATOR) ? s : s + Constants.SEPARATOR;
     }
 }

--- a/clients/hadoopfs/src/test/java/io/lakefs/LakeFSFileSystemTest.java
+++ b/clients/hadoopfs/src/test/java/io/lakefs/LakeFSFileSystemTest.java
@@ -234,28 +234,54 @@ public class LakeFSFileSystemTest {
     }
 
     @Test
-    public void testExists_Exists() throws ApiException, IOException {
+    public void testExists_ExistsAsObject() throws ApiException, IOException {
         Path p = new Path("lakefs://repo/main/exis.ts");
-        when(objectsApi.statObject("repo", "main", "exis.ts", false))
-            .thenReturn(new ObjectStats());
+        ObjectStats stats = new ObjectStats().path("exis.ts").pathType(PathTypeEnum.OBJECT);
+        when(objectsApi.listObjects(eq("repo"), eq("main"), eq(false), eq(""), any(), eq(""), eq("exis.ts")))
+            .thenReturn(new ObjectStatsList().results(ImmutableList.of(stats)));
         Assert.assertTrue(fs.exists(p));
-
-        Path dirPath = new Path("lakefs://repo/main/dir1/dir2/dir3");
-        when(objectsApi.statObject("repo", "main", "dir1/dir2/dir3/", false))
-                .thenReturn(new ObjectStats());
-        Assert.assertTrue(fs.exists(dirPath));
     }
 
     @Test
-    public void testExists_NotExists() throws ApiException, IOException {
-        Path p = new Path("lakefs://repo/main/doesNotExi.st");
-        when(objectsApi.statObject(any(), any(), any(), any()))
-            .thenThrow(new ApiException(HttpStatus.SC_NOT_FOUND, "no such file"));
-        when(objectsApi.listObjects(any(), any(), any(), any(), any(), any(), any()))
-            .thenReturn(new ObjectStatsList().results(Collections.emptyList()).pagination(new Pagination().hasMore(false)));
+    public void testExists_ExistsAsDirectoryMarker() throws ApiException, IOException {
+        Path p = new Path("lakefs://repo/main/exis.ts");
+        ObjectStats stats = new ObjectStats().path("exis.ts/").pathType(PathTypeEnum.OBJECT);
+        when(objectsApi.listObjects(eq("repo"), eq("main"), eq(false), eq(""), any(), eq(""), eq("exis.ts")))
+            .thenReturn(new ObjectStatsList().results(ImmutableList.of(stats)));
+        Assert.assertTrue(fs.exists(p));
+    }
 
+    @Test
+    public void testExists_ExistsAsDirectoryContents() throws ApiException, IOException {
+        Path p = new Path("lakefs://repo/main/exis.ts");
+        ObjectStats stats = new ObjectStats().path("exis.ts/inside").pathType(PathTypeEnum.OBJECT);
+        when(objectsApi.listObjects(eq("repo"), eq("main"), eq(false), eq(""), any(), eq(""), eq("exis.ts")))
+            .thenReturn(new ObjectStatsList().results(ImmutableList.of(stats)));
+        Assert.assertTrue(fs.exists(p));
+    }
+
+    @Test
+    public void testExists_ExistsAsDirectoryInSecondList() throws ApiException, IOException {
+        // TODO(ariels)
+    }
+
+    @Test
+    public void testExists_NotExistsNoPrefix() throws ApiException, IOException {
+        Path p = new Path("lakefs://repo/main/doesNotExi.st");
+        when(objectsApi.listObjects(any(), any(), any(), any(), any(), any(), any()))
+            .thenReturn(new ObjectStatsList());
         boolean exists = fs.exists(p);
         Assert.assertFalse(exists);
+    }
+
+    @Test
+    public void testExists_NotExistsPrefixWithNoSlash() throws ApiException, IOException {
+        // TODO(ariels)
+    }
+
+    @Test
+    public void testExists_NotExistsPrefixWithNoSlashTwoLists() throws ApiException, IOException {
+        // TODO(ariels)
     }
 
     @Test
@@ -281,8 +307,12 @@ public class LakeFSFileSystemTest {
         when(stagingApi.getPhysicalAddress("repo", "main", "no/place/"))
                 .thenReturn(stagingLocation);
 
+        Path path = new Path("lakefs://repo/main/no/place/file.txt");
+
+        mockDirectoryMarker(ObjectLocation.pathToObjectLocation(null, path.getParent()));
+
         // return true because file found
-        boolean success = fs.delete(new Path("lakefs://repo/main/no/place/file.txt"), false);
+        boolean success = fs.delete(path, false);
         Assert.assertTrue(success);
     }
 
@@ -321,7 +351,11 @@ public class LakeFSFileSystemTest {
                 .thenReturn(srcStats)
                 .thenThrow(noSuchFile);
 
-        boolean success = fs.delete(new Path("lakefs://repo/main/delete/me"), false);
+        Path path = new Path("lakefs://repo/main/delete/me");
+
+        mockDirectoryMarker(ObjectLocation.pathToObjectLocation(null, path.getParent()));
+
+        boolean success = fs.delete(path, false);
         Assert.assertTrue(success);
     }
 
@@ -378,7 +412,11 @@ public class LakeFSFileSystemTest {
         when(objectsApi.deleteObjects("repo", "main", newPathList("delete/sample/file.txt")))
             .thenReturn(new ObjectErrorList());
         // recursive will always end successfully
-        boolean delete = fs.delete(new Path("lakefs://repo/main/delete/sample"), true);
+        Path path = new Path("lakefs://repo/main/delete/sample");
+
+        mockDirectoryMarker(ObjectLocation.pathToObjectLocation(null, path.getParent()));
+
+        boolean delete = fs.delete(path, true);
         Assert.assertTrue(delete);
     }
 
@@ -414,6 +452,10 @@ public class LakeFSFileSystemTest {
             when(objectsApi.deleteObjects(eq("repo"), eq("main"), eq(pl)))
                 .thenReturn(new ObjectErrorList());
         }
+        // Mock parent directory marker creation at end of fs.delete to show
+        // the directory marker exists.
+        ObjectLocation dir = new ObjectLocation("lakefs", "repo", "main", "delete");
+        mockDirectoryMarker(dir);
         // recursive will always end successfully
         boolean delete = fs.delete(new Path("lakefs://repo/main/delete/sample"), true);
         Assert.assertTrue(delete);
@@ -677,6 +719,13 @@ public class LakeFSFileSystemTest {
         fs.append(null, 0, null);
     }
 
+    private void mockDirectoryMarker(ObjectLocation objectLoc) throws ApiException {
+        // Mock parent directory to show the directory marker exists.
+        ObjectStats markerStats = new ObjectStats().path(objectLoc.getPath()).pathType(PathTypeEnum.OBJECT);
+        when(objectsApi.listObjects(eq(objectLoc.getRepository()), eq(objectLoc.getRef()), eq(false), eq(""), any(), eq(""), eq(objectLoc.getPath()))).
+            thenReturn(new ObjectStatsList().results(ImmutableList.of(markerStats)));
+    }
+
     private void mockNonExistingPath(ObjectLocation objectLoc) throws ApiException {
         when(objectsApi.statObject(objectLoc.getRepository(), objectLoc.getRef(), objectLoc.getPath(), false))
                 .thenThrow(new ApiException(HttpStatus.SC_NOT_FOUND, "no such file"));
@@ -795,6 +844,8 @@ public class LakeFSFileSystemTest {
         mockNonExistingPath(dstObjLoc);
         mockNonExistingPath(fs.pathToObjectLocation(dst.getParent()));
 
+        mockDirectoryMarker(fs.pathToObjectLocation(src.getParent()));
+
         boolean renamed = fs.rename(src, dst);
         Assert.assertFalse(renamed);
     }
@@ -808,6 +859,8 @@ public class LakeFSFileSystemTest {
         Path dst = new Path("lakefs://repo/main/existing.dst");
         ObjectLocation dstObjLoc = fs.pathToObjectLocation(dst);
         mockExistingFilePath(dstObjLoc);
+
+        mockDirectoryMarker(fs.pathToObjectLocation(src.getParent()));
 
         boolean success = fs.rename(src, dst);
         Assert.assertTrue(success);
@@ -843,6 +896,8 @@ public class LakeFSFileSystemTest {
         Path dst = new Path("lakefs://repo/main/existing-dir2");
         ObjectLocation dstObjLoc = fs.pathToObjectLocation(dst);
         mockExistingDirPath(dstObjLoc, ImmutableList.of(fileObjLoc));
+
+        mockDirectoryMarker(fs.pathToObjectLocation(src.getParent()));
 
         boolean renamed = fs.rename(src, dst);
         Assert.assertTrue(renamed);
@@ -882,6 +937,8 @@ public class LakeFSFileSystemTest {
         mockExistingDirPath(new ObjectLocation("lakefs", "repo", "main", "existing-dir2/new"), Collections.emptyList());
 
         Path dst = new Path("lakefs://repo/main/existing-dir2/new");
+        mockDirectoryMarker(fs.pathToObjectLocation(srcDir));
+
         boolean renamed = fs.rename(srcDir, dst);
         Assert.assertTrue(renamed);
     }

--- a/clients/hadoopfs/src/test/java/io/lakefs/LakeFSFileSystemTest.java
+++ b/clients/hadoopfs/src/test/java/io/lakefs/LakeFSFileSystemTest.java
@@ -1,5 +1,10 @@
 package io.lakefs;
 
+import io.lakefs.clients.api.*;
+import io.lakefs.clients.api.model.*;
+import io.lakefs.clients.api.model.ObjectStats.PathTypeEnum;
+import io.lakefs.utils.ObjectLocation;
+
 import com.amazonaws.ClientConfiguration;
 import com.amazonaws.auth.AWSCredentials;
 import com.amazonaws.auth.BasicAWSCredentials;
@@ -10,9 +15,6 @@ import com.amazonaws.services.s3.model.*;
 import com.aventrix.jnanoid.jnanoid.NanoIdUtils;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
-import io.lakefs.clients.api.*;
-import io.lakefs.clients.api.model.*;
-import io.lakefs.clients.api.model.ObjectStats.PathTypeEnum;
 import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileAlreadyExistsException;


### PR DESCRIPTION
Make the "does not exist" path faster: with this change it typically takes 1
listObjects() API call instead of 1 statObject and 2 listObjects.  This is
surprisingly *common*.

However... The trivial "exists" path now requires 1 listObject instead of 1
statObject call.  This is slightly more expensive, so this change will help
a lot more once we finish #4734.  (I _did_ test it as faster with #4792, but then
we deprioritized that work in ecosystem team.)