### PR TITLE
Fix auth's wildcard Match function

### DIFF
--- a/pkg/auth/wildcard/match.go
+++ b/pkg/auth/wildcard/match.go
@@ -1,53 +1,82 @@
-/*
- * MinIO Cloud Storage, (C) 2015, 2016 MinIO, Inc.
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
 package wildcard
 
-// Match -  finds whether the text matches/satisfies the pattern string.
-// supports  '*' and '?' wildcards in the pattern string.
-// unlike path.Match(), considers a path as a flat name space while matching the pattern.
-// The difference is illustrated in the example here https://play.golang.org/p/Ega9qgD4Qz .
-func Match(pattern, name string) (matched bool) {
-	if pattern == "" {
-		return name == pattern
+import (
+	"unicode/utf8"
+)
+
+// Match reports whether name matches the shell pattern.
+// This is a strip down version of Go's `path.Match` https://pkg.go.dev/path#Match
+func Match(pattern, name string) bool {
+Pattern:
+	for len(pattern) > 0 {
+		var (
+			star  bool
+			chunk string
+		)
+		star, chunk, pattern = scanChunk(pattern)
+		if star && chunk == "" {
+			// Trailing * matches rest of string
+			return true
+		}
+		// Look for match at current position.
+		t, ok := matchChunk(chunk, name)
+		// if we're the last chunk, make sure we've exhausted the name
+		// otherwise we'll give a false result even if we could still match
+		// using the star
+		if ok && (len(t) == 0 || len(pattern) > 0) {
+			name = t
+			continue
+		}
+		if star {
+			// Look for match skipping i+1 bytes.
+			for i := 0; i < len(name); i++ {
+				t, ok := matchChunk(chunk, name[i+1:])
+				if ok {
+					// if we're the last chunk, make sure we exhausted the name
+					if len(pattern) == 0 && len(t) > 0 {
+						continue
+					}
+					name = t
+					continue Pattern
+				}
+			}
+		}
+		return false
 	}
-	if pattern == "*" {
-		return true
-	}
-	// Does extended wildcard '*' and '?' match.
-	return deepMatchRune([]rune(name), []rune(pattern))
+	return len(name) == 0
 }
 
-func deepMatchRune(str, pattern []rune) bool {
-	for len(pattern) > 0 {
-		switch pattern[0] {
-		default:
-			if len(str) == 0 || str[0] != pattern[0] {
-				return false
-			}
-		case '?':
-			if len(str) == 0 {
-				return false
-			}
-		case '*':
-			return deepMatchRune(str, pattern[1:]) ||
-				(len(str) > 0 && deepMatchRune(str[1:], pattern))
-		}
-		str = str[1:]
+// scanChunk gets the next segment of pattern, which is a non-star string
+// possibly preceded by a star.
+func scanChunk(pattern string) (star bool, chunk, rest string) {
+	for len(pattern) > 0 && pattern[0] == '*' {
 		pattern = pattern[1:]
+		star = true
 	}
-	return len(str) == 0 && len(pattern) == 0
+	for i := 1; i < len(pattern); i++ {
+		if pattern[i] == '*' {
+			return star, pattern[0:i], pattern[i:]
+		}
+	}
+	return star, pattern, ""
+}
+
+// matchChunk checks whether chunk matches the beginning of s.
+// If so, it returns the remainder of s (after the match).
+// Chunk is all single-character operators: literals, char classes, and ?.
+func matchChunk(chunk, s string) (rest string, ok bool) {
+	for len(chunk) > 0 {
+		if len(s) == 0 {
+			return "", false
+		}
+		n := 1
+		if chunk[0] == '?' {
+			_, n = utf8.DecodeRuneInString(s)
+		} else if chunk[0] != s[0] {
+			return "", false
+		}
+		s = s[n:]
+		chunk = chunk[1:]
+	}
+	return s, true
 }

--- a/pkg/auth/wildcard/match.go
+++ b/pkg/auth/wildcard/match.go
@@ -6,6 +6,13 @@ import (
 
 // Match reports whether name matches the shell pattern.
 // This is a strip down version of Go's `path.Match` https://pkg.go.dev/path#Match
+// Call a "fixword" a maximal portion of the pattern consisting only of regular characters and ?s.
+// So a fixword has to begin after * or at the beginning of the string, and it has to end before * or at the end of the string.
+// Each fixword matches a fixed length of string. Now a pattern is a list of fixwords separated by *s.
+// Consider a fixword that is not preceded by a *; that's an easy match to find because it can only be at one place.
+// Consider a fixword that is preceded by a *; if it matches at multiple places then it is always safe to match it at
+// the first possible location: either the pattern ends after that fixword in which case there's only one possible location,
+// or the pattern continues with *, in which case that * can "expand" to pick up all characters and the next match of the fixword.
 func Match(pattern, name string) bool {
 Pattern:
 	for len(pattern) > 0 {

--- a/pkg/auth/wildcard/match_test.go
+++ b/pkg/auth/wildcard/match_test.go
@@ -1,0 +1,302 @@
+package wildcard_test
+
+/*
+ * MinIO Cloud Storage, (C) 2015, 2016 MinIO, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import (
+	"testing"
+
+	"github.com/treeverse/lakefs/pkg/auth/wildcard"
+)
+
+// TestMatch - Tests validate the logic of wild card matching.
+// `Match` supports '*' and '?' wildcards.
+// Sample usage: In resource matching for bucket policy validation.
+func TestMatch(t *testing.T) {
+	tests := []struct {
+		pattern string
+		text    string
+		matched bool
+	}{
+		{
+			pattern: "*",
+			text:    "s3:GetObject",
+			matched: true,
+		},
+		{
+			pattern: "",
+			text:    "s3:GetObject",
+			matched: false,
+		},
+		{
+			pattern: "",
+			text:    "",
+			matched: true,
+		},
+		{
+			pattern: "s3:*",
+			text:    "s3:ListMultipartUploadParts",
+			matched: true,
+		},
+		{
+			pattern: "s3:ListBucketMultipartUploads",
+			text:    "s3:ListBucket",
+			matched: false,
+		},
+		{
+			pattern: "s3:ListBucket",
+			text:    "s3:ListBucket",
+			matched: true,
+		},
+		{
+			pattern: "s3:ListBucketMultipartUploads",
+			text:    "s3:ListBucketMultipartUploads",
+			matched: true,
+		},
+		{
+			pattern: "my-bucket/oo*",
+			text:    "my-bucket/oo",
+			matched: true,
+		},
+		{
+			pattern: "my-bucket/In*",
+			text:    "my-bucket/India/Karnataka/",
+			matched: true,
+		},
+		{
+			pattern: "my-bucket/In*",
+			text:    "my-bucket/Karnataka/India/",
+			matched: false,
+		},
+		{
+			pattern: "my-bucket/In*/Ka*/Ban",
+			text:    "my-bucket/India/Karnataka/Ban",
+			matched: true,
+		},
+		{
+			pattern: "my-bucket/In*/Ka*/Ban",
+			text:    "my-bucket/India/Karnataka/Ban/Ban/Ban/Ban/Ban",
+			matched: true,
+		},
+		{
+			pattern: "my-bucket/In*/Ka*/Ban",
+			text:    "my-bucket/India/Karnataka/Area1/Area2/Area3/Ban",
+			matched: true,
+		},
+		{
+			pattern: "my-bucket/In*/Ka*/Ban",
+			text:    "my-bucket/India/State1/State2/Karnataka/Area1/Area2/Area3/Ban",
+			matched: true,
+		},
+		{
+			pattern: "my-bucket/In*/Ka*/Ban",
+			text:    "my-bucket/India/Karnataka/Bangalore",
+			matched: false,
+		},
+		{
+			pattern: "my-bucket/In*/Ka*/Ban*",
+			text:    "my-bucket/India/Karnataka/Bangalore",
+			matched: true,
+		},
+		{
+			pattern: "my-bucket/*",
+			text:    "my-bucket/India",
+			matched: true,
+		},
+		{
+			pattern: "my-bucket/oo*",
+			text:    "my-bucket/odo",
+			matched: false,
+		},
+		{
+			pattern: "my-bucket?/abc*",
+			text:    "mybucket/abc",
+			matched: false,
+		},
+		{
+			pattern: "my-bucket?/abc*",
+			text:    "my-bucket1/abc",
+			matched: true,
+		},
+		{
+			pattern: "my-?-bucket/abc*",
+			text:    "my--bucket/abc",
+			matched: false,
+		},
+		{
+			pattern: "my-?-bucket/abc*",
+			text:    "my-1-bucket/abc",
+			matched: true,
+		},
+		{
+			pattern: "my-?-bucket/abc*",
+			text:    "my-k-bucket/abc",
+			matched: true,
+		},
+		{
+			pattern: "my??bucket/abc*",
+			text:    "mybucket/abc",
+			matched: false,
+		},
+		{
+			pattern: "my??bucket/abc*",
+			text:    "my4abucket/abc",
+			matched: true,
+		},
+		{
+			pattern: "my-bucket?abc*",
+			text:    "my-bucket/abc",
+			matched: true,
+		},
+		{
+			pattern: "my-bucket/abc?efg",
+			text:    "my-bucket/abcdefg",
+			matched: true,
+		},
+		{
+			pattern: "my-bucket/abc?efg",
+			text:    "my-bucket/abc/efg",
+			matched: true,
+		},
+		{
+			pattern: "my-bucket/abc????",
+			text:    "my-bucket/abc",
+			matched: false,
+		},
+		{
+			pattern: "my-bucket/abc????",
+			text:    "my-bucket/abcde",
+			matched: false,
+		},
+		{
+			pattern: "my-bucket/abc????",
+			text:    "my-bucket/abcdefg",
+			matched: true,
+		},
+		{
+			pattern: "my-bucket/abc?",
+			text:    "my-bucket/abc",
+			matched: false,
+		},
+		{
+			pattern: "my-bucket/abc?",
+			text:    "my-bucket/abcd",
+			matched: true,
+		},
+		{
+			pattern: "my-bucket/abc?",
+			text:    "my-bucket/abcde",
+			matched: false,
+		},
+		{
+			pattern: "my-bucket/mnop*?",
+			text:    "my-bucket/mnop",
+			matched: false,
+		},
+		{
+			pattern: "my-bucket/mnop*?",
+			text:    "my-bucket/mnopqrst/mnopqr",
+			matched: true,
+		},
+		{
+			pattern: "my-bucket/mnop*?",
+			text:    "my-bucket/mnopqrst/mnopqrs",
+			matched: true,
+		},
+		{
+			pattern: "my-bucket/mnop*?",
+			text:    "my-bucket/mnop",
+			matched: false,
+		},
+		{
+			pattern: "my-bucket/mnop*?",
+			text:    "my-bucket/mnopq",
+			matched: true,
+		},
+		{
+			pattern: "my-bucket/mnop*?",
+			text:    "my-bucket/mnopqr",
+			matched: true,
+		},
+		{
+			pattern: "my-bucket/mnop*?and",
+			text:    "my-bucket/mnopqand",
+			matched: true,
+		},
+		{
+			pattern: "my-bucket/mnop*?and",
+			text:    "my-bucket/mnopand",
+			matched: false,
+		},
+		{
+			pattern: "my-bucket/mnop*?and",
+			text:    "my-bucket/mnopqand",
+			matched: true,
+		},
+		{
+			pattern: "my-bucket/mnop*?",
+			text:    "my-bucket/mn",
+			matched: false,
+		},
+		{
+			pattern: "my-bucket/mnop*?",
+			text:    "my-bucket/mnopqrst/mnopqrs",
+			matched: true,
+		},
+		{
+			pattern: "my-bucket/mnop*??",
+			text:    "my-bucket/mnopqrst",
+			matched: true,
+		},
+		{
+			pattern: "my-bucket/mnop*qrst",
+			text:    "my-bucket/mnopabcdegqrst",
+			matched: true,
+		},
+		{
+			pattern: "my-bucket/mnop*?and",
+			text:    "my-bucket/mnopqand",
+			matched: true,
+		},
+		{
+			pattern: "my-bucket/mnop*?and",
+			text:    "my-bucket/mnopand",
+			matched: false,
+		},
+		{
+			pattern: "my-bucket/mnop*?and?",
+			text:    "my-bucket/mnopqanda",
+			matched: true,
+		},
+		{
+			pattern: "my-bucket/mnop*?and",
+			text:    "my-bucket/mnopqanda",
+			matched: false,
+		},
+		{
+			pattern: "my-?-bucket/abc*",
+			text:    "my-bucket/mnopqanda",
+			matched: false,
+		},
+	}
+	for i, tt := range tests {
+		actualResult := wildcard.Match(tt.pattern, tt.text)
+		if tt.matched != actualResult {
+			t.Errorf("Match('%s', '%s') [%d] expected=%t, got=%t",
+				tt.pattern, tt.text, i+1, tt.matched, actualResult)
+		}
+	}
+}


### PR DESCRIPTION
Address performance and malicious usage.
Fix #1996 

Added unit test code from MinIO for testing the functionality.

Used the following modified benchmark code supplied by @arielshaqed to test code for malicious usage:

```go
package wildcard

import (
	"strings"
	"testing"
)

func BenchmarkMatch(b *testing.B) {
	const pattern = "a*b*c*z"
	str := strings.Repeat("a", 1000) + strings.Repeat("b", 1000) + strings.Repeat("c", 1000)
	for i := 0; i < b.N; i++ {
		if Match(pattern, str) {
			b.Errorf("Expecteded '%s' NOT to match '%s'", str, pattern)
		}
	}
}

func BenchmarkMatchDuh(b *testing.B) {
	const pattern = "a*a*a*z"
	str := strings.Repeat("a", 2000)
	for i := 0; i < b.N; i++ {
		if Match(pattern, str) {
			b.Errorf("Expecteded '%s' NOT to match '%s'", str, pattern)
		}
	}
}
```

Test results of current implementation:
```
BenchmarkMatch-10                      1        4474831292 ns/op
BenchmarkMatchDuh-10                   1        11981327834 ns/op
```

Test results of the new implementation:
```
BenchmarkMatch-10                 176950              6804 ns/op
BenchmarkMatchDuh-10              264994              4511 ns/op
```