### PR TITLE
API upload object without using tmp file

### DIFF
--- a/pkg/block/local/adapter.go
+++ b/pkg/block/local/adapter.go
@@ -42,7 +42,7 @@ func WithRemoveEmptyDir(b bool) func(a *Adapter) {
 func NewAdapter(path string, opts ...func(a *Adapter)) (*Adapter, error) {
 	// Clean() the path so that misconfiguration does not allow path traversal.
 	path = filepath.Clean(path)
-	err := os.MkdirAll(path, 0700) //nolint: gomnd
+	err := os.MkdirAll(path, 0o700) //nolint: gomnd
 	if err != nil {
 		return nil, err
 	}
@@ -102,7 +102,7 @@ func (l *Adapter) maybeMkdir(path string, f func(p string) (*os.File, error)) (*
 		return ret, err
 	}
 	d := filepath.Dir(filepath.Clean(path))
-	if err = os.MkdirAll(d, 0750); err != nil { //nolint: gomnd
+	if err = os.MkdirAll(d, 0o750); err != nil { //nolint: gomnd
 		return nil, err
 	}
 	return f(path)
@@ -237,7 +237,7 @@ func (l *Adapter) Get(_ context.Context, obj block.ObjectPointer, _ int64) (read
 	if err != nil {
 		return nil, err
 	}
-	f, err := os.OpenFile(filepath.Clean(p), os.O_RDONLY, 0600) //nolint: gomnd
+	f, err := os.OpenFile(filepath.Clean(p), os.O_RDONLY, 0o600) //nolint: gomnd
 	if os.IsNotExist(err) {
 		return nil, adapter.ErrDataNotFound
 	}
@@ -328,7 +328,7 @@ func (l *Adapter) CreateMultiPartUpload(_ context.Context, obj block.ObjectPoint
 			return nil, err
 		}
 		fullDir := path.Dir(fullPath)
-		err = os.MkdirAll(fullDir, 0750) //nolint: gomnd
+		err = os.MkdirAll(fullDir, 0o750) //nolint: gomnd
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
Fix #4849

Multipart request read content directly to block adapter.
The issue is that the Go implementation uses local temporary file when accessing content size >32MB.
In order to support reading the data directly in this case we stream the request data into the adapter's `Put` request without specify the content size.

To support Put with reader without size (stream), updated the S3 to use of s3manager upload in case the size == -1.
All other adapters ignore the size in the request to upload.

Tested manually with file size ~170MB
