### PR TITLE
test: makefile and minor improvements 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,8 +35,6 @@ GOFMT=$(GOCMD)fmt
 
 GOTEST_PARALLELISM=4
 
-GO_TEST_MODULES=$(shell $(GOCMD) list ./... | grep -v 'lakefs/pkg/api/gen/')
-
 LAKEFS_BINARY_NAME=lakefs
 LAKECTL_BINARY_NAME=lakectl
 
@@ -141,14 +139,14 @@ package-python: client-python
 package: package-python
 
 gen-api: ## Run the swagger code generator
-	$(GOGENERATE) ./pkg/api
-	$(GOGENERATE) ./pkg/auth
+	$(GOGENERATE) \
+		./pkg/api \
+		./pkg/auth
 
 .PHONY: gen-code
 gen-code: gen-api ## Run the generator for inline commands
 	$(GOGENERATE) \
 		./pkg/actions \
-		./pkg/auth \
 		./pkg/graveler \
 		./pkg/graveler/committed \
 		./pkg/graveler/sstable \
@@ -170,16 +168,16 @@ esti: ## run esti (system testing)
 test: test-go test-hadoopfs  ## Run tests for the project
 
 test-go: gen-code			# Run parallelism > num_cores: most of our slow tests are *not* CPU-bound.
-	$(GOTEST) -count=1 -coverprofile=cover.out -race -cover -failfast -parallel="$(GOTEST_PARALLELISM)" $(GO_TEST_MODULES)
+	$(GOTEST) -count=1 -coverprofile=cover.out -race -cover -failfast -parallel="$(GOTEST_PARALLELISM)" ./...
 
 test-hadoopfs:
 	cd clients/hadoopfs && mvn test
 
 run-test:  ## Run tests without generating anything (faster if already generated)
-	$(GOTEST) -count=1 -coverprofile=cover.out -race -short -cover -failfast $(GO_TEST_MODULES)
+	$(GOTEST) -count=1 -coverprofile=cover.out -race -short -cover -failfast ./...
 
 fast-test:  ## Run tests without race detector (faster)
-	$(GOTEST) -count=1 -coverprofile=cover.out -short -cover -failfast $(GO_TEST_MODULES)
+	$(GOTEST) -count=1 -coverprofile=cover.out -short -cover -failfast ./...
 
 test-html: test  ## Run tests with HTML for the project
 	$(GOTOOL) cover -html=cover.out

--- a/cmd/lakefs-loadtest/cmd/run.go
+++ b/cmd/lakefs-loadtest/cmd/run.go
@@ -57,12 +57,14 @@ var runCmd = &cobra.Command{
 			RepoName:         repoName,
 			StorageNamespace: storageNamespace,
 			KeepRepo:         isKeep,
-			Credentials: model.Credential{BaseCredential: model.BaseCredential{
-				AccessKeyID:     viper.GetString(ConfigAccessKeyID),
-				SecretAccessKey: viper.GetString(ConfigSecretAccessKey),
-			},
+			Credentials: model.Credential{
+				BaseCredential: model.BaseCredential{
+					AccessKeyID:     viper.GetString(ConfigAccessKeyID),
+					SecretAccessKey: viper.GetString(ConfigSecretAccessKey),
+				},
 			},
 			ServerAddress: viper.GetString(ConfigServerEndpointURL),
+			ShowProgress:  true,
 		}
 		loader := loadtest.NewLoader(testConfig)
 		err = loader.Run()

--- a/pkg/gateway/sig/sig_test.go
+++ b/pkg/gateway/sig/sig_test.go
@@ -34,19 +34,19 @@ func makeRequest(t *testing.T, headers map[string]string, query map[string]strin
 }
 
 func TestIsAWSSignedRequest(t *testing.T) {
-	type KV map[string]string
+	t.Parallel()
 	cases := []struct {
 		Name    string
 		Want    bool
 		Headers map[string]string
 		Query   map[string]string
 	}{
-		{"no sig", false, nil, nil},
-		{"non aws auth header", false, KV{"Authorization": "Basic dXNlcjpwYXNzd29yZA=="}, nil},
-		{"v2 auth header", true, KV{"Authorization": "AWS wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"}, nil},
-		{"v2 auth query param", true, nil, KV{"AWSAccessKeyId": "bPxRfiCYEXAMPLEKEY"}},
-		{"v4 auth header", true, KV{"Authorization": "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/iam/aws4_request, SignedHeaders=content-type;host;x-amz-date, Signature=5d672d79c15b13162d9279b0855cfba6789a8edb4c82c400e06b5924a6f2b5d7"}, nil},
-		{"v4 auth query param", true, nil, KV{"X-Amz-Credential": "bPxRfiCYEXAMPLEKEY"}},
+		{Name: "no sig", Want: false},
+		{Name: "non aws auth header", Want: false, Headers: map[string]string{"Authorization": "Basic dXNlcjpwYXNzd29yZA=="}},
+		{Name: "v2 auth header", Want: true, Headers: map[string]string{"Authorization": "AWS wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"}},
+		{Name: "v2 auth query param", Want: true, Query: map[string]string{"AWSAccessKeyId": "bPxRfiCYEXAMPLEKEY"}},
+		{Name: "v4 auth header", Want: true, Headers: map[string]string{"Authorization": "AWS4-HMAC-SHA256 Credential=AKIDEXAMPLE/20150830/us-east-1/iam/aws4_request, SignedHeaders=content-type;host;x-amz-date, Signature=5d672d79c15b13162d9279b0855cfba6789a8edb4c82c400e06b5924a6f2b5d7"}},
+		{Name: "v4 auth query param", Want: true, Query: map[string]string{"X-Amz-Credential": "bPxRfiCYEXAMPLEKEY"}},
 	}
 
 	for _, tc := range cases {
@@ -156,8 +156,9 @@ var signatures = []SignCase{
 }
 
 func TestAWSSigVerify(t *testing.T) {
+	t.Parallel()
 	const (
-		numRounds  = 1000
+		numRounds  = 100
 		seed       = 20210913
 		pathLength = 900
 		bucket     = "my-bucket"

--- a/pkg/loadtest/loader.go
+++ b/pkg/loadtest/loader.go
@@ -40,7 +40,7 @@ type Config struct {
 	KeepRepo         bool
 	Credentials      model.Credential
 	ServerAddress    string
-	NoProgress       bool
+	ShowProgress     bool
 }
 
 var (
@@ -70,7 +70,7 @@ func (t *Loader) Run() error {
 		return err
 	}
 	stopCh := make(chan struct{})
-	if !t.Config.NoProgress {
+	if t.Config.ShowProgress {
 		progressBar(t.Config.Duration)
 	}
 	out := new(SimpleScenario).Play(t.Config.ServerAddress, repoName, stopCh)

--- a/pkg/loadtest/loader.go
+++ b/pkg/loadtest/loader.go
@@ -40,6 +40,7 @@ type Config struct {
 	KeepRepo         bool
 	Credentials      model.Credential
 	ServerAddress    string
+	NoProgress       bool
 }
 
 var (
@@ -69,7 +70,9 @@ func (t *Loader) Run() error {
 		return err
 	}
 	stopCh := make(chan struct{})
-	progressBar(t.Config.Duration)
+	if !t.Config.NoProgress {
+		progressBar(t.Config.Duration)
+	}
 	out := new(SimpleScenario).Play(t.Config.ServerAddress, repoName, stopCh)
 	errs := t.streamRequests(out)
 	hasErrors := t.doAttack()

--- a/pkg/loadtest/local_load_test.go
+++ b/pkg/loadtest/local_load_test.go
@@ -57,9 +57,6 @@ func TestLocalLoad(t *testing.T) {
 		blockstoreType = "mem"
 	}
 
-	storeMessage = &kv.StoreMessage{Store: kvStore}
-	viper.Set("database.kv_enabled", true)
-
 	blockAdapter := testutil.NewBlockAdapterByType(t, blockstoreType)
 	c, err := catalog.New(ctx, catalog.Config{
 		Config:  conf,
@@ -71,7 +68,7 @@ func TestLocalLoad(t *testing.T) {
 	outputWriter := catalog.NewActionsOutputWriter(c.BlockAdapter)
 
 	// wire actions
-	actionsService := actions.NewService(ctx, actions.NewActionsKVStore(kv.StoreMessage{Store: kvStore}), source, outputWriter, &actions.DecreasingIDGenerator{}, &stats.NullCollector{}, true)
+	actionsService := actions.NewService(ctx, actions.NewActionsKVStore(*storeMessage), source, outputWriter, &actions.DecreasingIDGenerator{}, &stats.NullCollector{}, true)
 	c.SetHooksHandler(actionsService)
 
 	credentials, err := auth.SetupAdminUser(ctx, authService, superuser)

--- a/pkg/loadtest/local_load_test.go
+++ b/pkg/loadtest/local_load_test.go
@@ -122,7 +122,7 @@ func TestLocalLoad(t *testing.T) {
 		Credentials:      *credentials,
 		ServerAddress:    ts.URL,
 		StorageNamespace: "mem://local/test/",
-		NoProgress:       !testing.Verbose(),
+		ShowProgress:     testing.Verbose(),
 	}
 	loader := NewLoader(testConfig)
 	err = loader.Run()

--- a/pkg/loadtest/local_load_test.go
+++ b/pkg/loadtest/local_load_test.go
@@ -28,33 +28,10 @@ import (
 	"github.com/treeverse/lakefs/pkg/version"
 )
 
-type getActionsService func(t *testing.T, ctx context.Context, source actions.Source, writer actions.OutputWriter, stats stats.Collector, runHooks bool) actions.Service
-
-func GetKVActionsService(t *testing.T, ctx context.Context, source actions.Source, writer actions.OutputWriter, stats stats.Collector, runHooks bool) actions.Service {
-	t.Helper()
-	kvStore := kvtest.GetStore(ctx, t)
-	return actions.NewService(ctx, actions.NewActionsKVStore(kv.StoreMessage{Store: kvStore}), source, writer, &actions.DecreasingIDGenerator{}, stats, runHooks)
-}
-
-func GetKVAuthService(t *testing.T, ctx context.Context) auth.Service {
-	t.Helper()
-	kvStore := kvtest.GetStore(ctx, t)
-	storeMessage := &kv.StoreMessage{Store: kvStore}
-	return auth.NewKVAuthService(storeMessage, crypt.NewSecretStore([]byte("some secret")), nil, authparams.ServiceCache{}, logging.Default().WithField("service", "auth"))
-}
-
-func GetKVMetadataManager(t *testing.T, ctx context.Context, installationID, kvType string) auth.MetadataManager {
-	t.Helper()
-	kvStore := kvtest.GetStore(ctx, t)
-	return auth.NewKVMetadataManager("local_load_test", installationID, kvType, kvStore)
-}
-
 func TestLocalLoad(t *testing.T) {
 	if testing.Short() {
 		t.Skip("Skipping loadtest tests in short mode")
 	}
-
-	var storeMessage *kv.StoreMessage
 
 	// Only once
 	ctx := context.Background()
@@ -63,22 +40,6 @@ func TestLocalLoad(t *testing.T) {
 	conf, err := config.NewConfig()
 	testutil.MustDo(t, "config", err)
 
-	tests := []struct {
-		name           string
-		actionsService getActionsService
-		authService    auth.Service
-		meta           auth.MetadataManager
-		kvEnabled      bool
-	}{
-		{
-			name:           "KV service test",
-			actionsService: GetKVActionsService,
-			authService:    GetKVAuthService(t, ctx),
-			meta:           GetKVMetadataManager(t, ctx, conf.GetFixedInstallationID(), conf.GetDatabaseType()),
-			kvEnabled:      true,
-		},
-	}
-
 	superuser := &authmodel.SuperuserConfiguration{
 		User: authmodel.User{
 			CreatedAt: time.Now(),
@@ -86,87 +47,86 @@ func TestLocalLoad(t *testing.T) {
 		},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			blockstoreType, _ := os.LookupEnv(testutil.EnvKeyUseBlockAdapter)
-			if blockstoreType == "" {
-				blockstoreType = "mem"
-			}
+	kvStore := kvtest.GetStore(ctx, t)
+	storeMessage := &kv.StoreMessage{Store: kvStore}
+	authService := auth.NewKVAuthService(storeMessage, crypt.NewSecretStore([]byte("some secret")), nil, authparams.ServiceCache{}, logging.Default().WithField("service", "auth"))
+	meta := auth.NewKVMetadataManager("local_load_test", conf.GetFixedInstallationID(), conf.GetDatabaseType(), kvStore)
 
-			if tt.kvEnabled {
-				kvStore := kvtest.GetStore(ctx, t)
-				storeMessage = &kv.StoreMessage{Store: kvStore}
-				viper.Set("database.kv_enabled", true)
-			}
+	blockstoreType := os.Getenv(testutil.EnvKeyUseBlockAdapter)
+	if blockstoreType == "" {
+		blockstoreType = "mem"
+	}
 
-			blockAdapter := testutil.NewBlockAdapterByType(t, blockstoreType)
-			c, err := catalog.New(ctx, catalog.Config{
-				Config:  conf,
-				KVStore: storeMessage,
-			})
-			testutil.MustDo(t, "build catalog", err)
+	storeMessage = &kv.StoreMessage{Store: kvStore}
+	viper.Set("database.kv_enabled", true)
 
-			source := catalog.NewActionsSource(c)
-			outputWriter := catalog.NewActionsOutputWriter(c.BlockAdapter)
+	blockAdapter := testutil.NewBlockAdapterByType(t, blockstoreType)
+	c, err := catalog.New(ctx, catalog.Config{
+		Config:  conf,
+		KVStore: storeMessage,
+	})
+	testutil.MustDo(t, "build catalog", err)
 
-			// wire actions
-			actionsService := tt.actionsService(t, ctx, source, outputWriter, &stats.NullCollector{}, true)
-			c.SetHooksHandler(actionsService)
+	source := catalog.NewActionsSource(c)
+	outputWriter := catalog.NewActionsOutputWriter(c.BlockAdapter)
 
-			credentials, err := auth.SetupAdminUser(ctx, tt.authService, superuser)
-			testutil.Must(t, err)
+	// wire actions
+	actionsService := actions.NewService(ctx, actions.NewActionsKVStore(kv.StoreMessage{Store: kvStore}), source, outputWriter, &actions.DecreasingIDGenerator{}, &stats.NullCollector{}, true)
+	c.SetHooksHandler(actionsService)
 
-			authenticator := auth.NewBuiltinAuthenticator(tt.authService)
-			kvParams, err := conf.GetKVParams()
-			testutil.Must(t, err)
-			migrator := kv.NewDatabaseMigrator(kvParams)
-			t.Cleanup(func() {
-				_ = c.Close()
-			})
-			auditChecker := version.NewDefaultAuditChecker(conf.GetSecurityAuditCheckURL(), "")
-			emailParams, _ := conf.GetEmailParams()
-			emailer, err := email.NewEmailer(emailParams)
-			testutil.Must(t, err)
-			handler := api.Serve(
-				conf,
-				c,
-				authenticator,
-				authenticator,
-				tt.authService,
-				blockAdapter,
-				tt.meta,
-				migrator,
-				&stats.NullCollector{},
-				nil,
-				actionsService,
-				auditChecker,
-				logging.Default(),
-				emailer,
-				nil,
-				nil,
-				nil,
-				nil,
-				nil,
-				upload.DefaultPathProvider,
-			)
+	credentials, err := auth.SetupAdminUser(ctx, authService, superuser)
+	testutil.Must(t, err)
 
-			ts := httptest.NewServer(handler)
-			defer ts.Close()
+	authenticator := auth.NewBuiltinAuthenticator(authService)
+	kvParams, err := conf.GetKVParams()
+	testutil.Must(t, err)
+	migrator := kv.NewDatabaseMigrator(kvParams)
+	t.Cleanup(func() {
+		_ = c.Close()
+	})
+	auditChecker := version.NewDefaultAuditChecker(conf.GetSecurityAuditCheckURL(), "")
+	emailParams, _ := conf.GetEmailParams()
+	emailer, err := email.NewEmailer(emailParams)
+	testutil.Must(t, err)
+	handler := api.Serve(
+		conf,
+		c,
+		authenticator,
+		authenticator,
+		authService,
+		blockAdapter,
+		meta,
+		migrator,
+		&stats.NullCollector{},
+		nil,
+		actionsService,
+		auditChecker,
+		logging.Default(),
+		emailer,
+		nil,
+		nil,
+		nil,
+		nil,
+		nil,
+		upload.DefaultPathProvider,
+	)
 
-			testConfig := Config{
-				FreqPerSecond:    6,
-				Duration:         10 * time.Second,
-				MaxWorkers:       math.MaxInt64,
-				KeepRepo:         false,
-				Credentials:      *credentials,
-				ServerAddress:    ts.URL,
-				StorageNamespace: "mem://local/test/",
-			}
-			loader := NewLoader(testConfig)
-			err = loader.Run()
-			if err != nil {
-				t.Fatalf("Got error on test: %s", err)
-			}
-		})
+	ts := httptest.NewServer(handler)
+	defer ts.Close()
+
+	testConfig := Config{
+		FreqPerSecond:    6,
+		Duration:         5 * time.Second,
+		MaxWorkers:       math.MaxInt64,
+		KeepRepo:         false,
+		Credentials:      *credentials,
+		ServerAddress:    ts.URL,
+		StorageNamespace: "mem://local/test/",
+		NoProgress:       !testing.Verbose(),
+	}
+	loader := NewLoader(testConfig)
+	err = loader.Run()
+	if err != nil {
+		t.Fatalf("Got error on test: %s", err)
 	}
 }


### PR DESCRIPTION
- Makefile: go generate auth package once
- Makefile: remove GO_TEST_MODULES not required anymore
- Test AWS SigVerify: run parallel, reduce number of iterations
- Load test: reduce total load test time, optional progress bar, code cleanup