### PR TITLE
Remove KV from Graveler types

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -228,7 +228,7 @@ func New(ctx context.Context, cfg Config) (*Catalog, error) {
 	executor := batch.NewConditionalExecutor(logging.Default())
 	go executor.Run(ctx)
 
-	refManager := ref.NewKVRefManager(ref.ManagerConfig{
+	refManager := ref.NewRefManager(ref.ManagerConfig{
 		Executor:        executor,
 		KvStore:         cfg.KVStore,
 		AddressProvider: ident.NewHexAddressProvider(),
@@ -241,7 +241,7 @@ func New(ctx context.Context, cfg Config) (*Catalog, error) {
 
 	protectedBranchesManager := branch.NewProtectionManager(settingManager)
 	stagingManager := staging.NewManager(ctx, *cfg.KVStore)
-	gStore := graveler.NewKVGraveler(committedManager, stagingManager, refManager, gcManager, protectedBranchesManager)
+	gStore := graveler.NewGraveler(committedManager, stagingManager, refManager, gcManager, protectedBranchesManager)
 
 	// The size of the workPool is determined by the number of workers and the number of desired pending tasks for each worker.
 	workPool := pond.New(sharedWorkers, sharedWorkers*pendingTasksPerWorker, pond.Context(ctx))

--- a/pkg/graveler/branch/protection_manager.go
+++ b/pkg/graveler/branch/protection_manager.go
@@ -28,11 +28,11 @@ var (
 )
 
 type ProtectionManager struct {
-	settingManager *settings.KVManager
+	settingManager *settings.Manager
 	matchers       cache.Cache
 }
 
-func NewProtectionManager(settingManager *settings.KVManager) *ProtectionManager {
+func NewProtectionManager(settingManager *settings.Manager) *ProtectionManager {
 	return &ProtectionManager{settingManager: settingManager, matchers: cache.NewCache(matcherCacheSize, matcherCacheExpiry, cache.NewJitterFn(matcherCacheJitter))}
 }
 

--- a/pkg/graveler/committed/batch_test.go
+++ b/pkg/graveler/committed/batch_test.go
@@ -6,11 +6,10 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/treeverse/lakefs/pkg/graveler"
-
 	"github.com/go-test/deep"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/treeverse/lakefs/pkg/graveler"
 	"github.com/treeverse/lakefs/pkg/graveler/committed"
 )
 

--- a/pkg/graveler/committed/manager_test.go
+++ b/pkg/graveler/committed/manager_test.go
@@ -4,12 +4,10 @@ import (
 	"context"
 	"testing"
 
+	"github.com/golang/mock/gomock"
+	"github.com/stretchr/testify/require"
 	"github.com/treeverse/lakefs/pkg/catalog/testutils"
 	"github.com/treeverse/lakefs/pkg/graveler"
-
-	"github.com/stretchr/testify/require"
-
-	"github.com/golang/mock/gomock"
 	"github.com/treeverse/lakefs/pkg/graveler/committed"
 	"github.com/treeverse/lakefs/pkg/graveler/committed/mock"
 )

--- a/pkg/graveler/committed/range.go
+++ b/pkg/graveler/committed/range.go
@@ -3,7 +3,6 @@ package committed
 import "google.golang.org/protobuf/proto"
 
 // Range represents a range of sorted Keys
-
 type Range struct {
 	ID            ID
 	MinKey        Key

--- a/pkg/graveler/graveler_test.go
+++ b/pkg/graveler/graveler_test.go
@@ -147,7 +147,7 @@ func newGraveler(t *testing.T, committedManager graveler.CommittedManager, stagi
 ) catalog.Store {
 	t.Helper()
 
-	return graveler.NewKVGraveler(committedManager, stagingManager, refManager, gcManager, protectedBranchesManager)
+	return graveler.NewGraveler(committedManager, stagingManager, refManager, gcManager, protectedBranchesManager)
 }
 
 func TestGraveler_List(t *testing.T) {

--- a/pkg/graveler/ref/commit_ordered_iterator.go
+++ b/pkg/graveler/ref/commit_ordered_iterator.go
@@ -7,7 +7,7 @@ import (
 	"github.com/treeverse/lakefs/pkg/kv"
 )
 
-type KVOrderedCommitIterator struct {
+type OrderedCommitIterator struct {
 	ctx                context.Context
 	it                 *kv.PrimaryIterator
 	store              kv.Store
@@ -18,11 +18,11 @@ type KVOrderedCommitIterator struct {
 	firstParents       map[string]bool
 }
 
-// NewKVOrderedCommitIterator returns an iterator over all commits in the given repository.
+// NewOrderedCommitIterator returns an iterator over all commits in the given repository.
 // Ordering is based on the Commit ID value.
 // WithOnlyAncestryLeaves causes the iterator to return only commits which are not the first parent of any other commit.
 // Consider a commit graph where all non-first-parent edges are removed. This graph is a tree, and ancestry leaves are its leaves.
-func NewKVOrderedCommitIterator(ctx context.Context, store *kv.StoreMessage, repo *graveler.RepositoryRecord, onlyAncestryLeaves bool) (*KVOrderedCommitIterator, error) {
+func NewOrderedCommitIterator(ctx context.Context, store *kv.StoreMessage, repo *graveler.RepositoryRecord, onlyAncestryLeaves bool) (*OrderedCommitIterator, error) {
 	repoPath := graveler.RepoPartition(repo)
 	it, err := kv.NewPrimaryIterator(ctx, store.Store, (&graveler.CommitData{}).ProtoReflect().Type(), repoPath,
 		[]byte(graveler.CommitPath("")), kv.IteratorOptionsFrom([]byte("")))
@@ -37,7 +37,7 @@ func NewKVOrderedCommitIterator(ctx context.Context, store *kv.StoreMessage, rep
 			return nil, err
 		}
 	}
-	return &KVOrderedCommitIterator{
+	return &OrderedCommitIterator{
 		ctx:                ctx,
 		it:                 it,
 		store:              store.Store,
@@ -47,7 +47,7 @@ func NewKVOrderedCommitIterator(ctx context.Context, store *kv.StoreMessage, rep
 	}, nil
 }
 
-func (i *KVOrderedCommitIterator) Next() bool {
+func (i *OrderedCommitIterator) Next() bool {
 	if i.Err() != nil || i.it == nil {
 		return false
 	}
@@ -71,7 +71,7 @@ func (i *KVOrderedCommitIterator) Next() bool {
 	return false
 }
 
-func (i *KVOrderedCommitIterator) SeekGE(id graveler.CommitID) {
+func (i *OrderedCommitIterator) SeekGE(id graveler.CommitID) {
 	if i.err != nil {
 		return
 	}
@@ -81,14 +81,14 @@ func (i *KVOrderedCommitIterator) SeekGE(id graveler.CommitID) {
 		[]byte(graveler.CommitPath("")), kv.IteratorOptionsFrom([]byte(graveler.CommitPath(id))))
 }
 
-func (i *KVOrderedCommitIterator) Value() *graveler.CommitRecord {
+func (i *OrderedCommitIterator) Value() *graveler.CommitRecord {
 	if i.Err() != nil {
 		return nil
 	}
 	return i.value
 }
 
-func (i *KVOrderedCommitIterator) Err() error {
+func (i *OrderedCommitIterator) Err() error {
 	if i.err != nil {
 		return i.err
 	}
@@ -98,7 +98,7 @@ func (i *KVOrderedCommitIterator) Err() error {
 	return nil
 }
 
-func (i *KVOrderedCommitIterator) Close() {
+func (i *OrderedCommitIterator) Close() {
 	if i.it != nil {
 		i.it.Close()
 		i.it = nil

--- a/pkg/graveler/ref/commit_ordered_iterator_test.go
+++ b/pkg/graveler/ref/commit_ordered_iterator_test.go
@@ -32,7 +32,7 @@ type testCommit struct {
 	version *int
 }
 
-func TestKVOrderedCommitIterator(t *testing.T) {
+func TestOrderedCommitIterator(t *testing.T) {
 	ctx := context.Background()
 	cases := []struct {
 		Name                   string
@@ -159,7 +159,7 @@ func TestKVOrderedCommitIterator(t *testing.T) {
 					Version: version,
 				})
 			}
-			r, store := testRefManagerWithKVAndAddressProvider(t, newFakeAddressProvider(commits))
+			r, store := testRefManagerWithAddressProvider(t, newFakeAddressProvider(commits))
 			repository, err := r.CreateBareRepository(ctx, graveler.RepositoryID(tst.Name), graveler.Repository{
 				StorageNamespace: "s3://foo",
 				CreationDate:     time.Now(),
@@ -171,9 +171,9 @@ func TestKVOrderedCommitIterator(t *testing.T) {
 				testutil.Must(t, err)
 			}
 
-			iterator, err := ref.NewKVOrderedCommitIterator(ctx, store, repository, false)
+			iterator, err := ref.NewOrderedCommitIterator(ctx, store, repository, false)
 			if err != nil {
-				t.Fatal("create kv ordered commit iterator", err)
+				t.Fatal("create ordered commit iterator", err)
 			}
 			var actualOrderedCommits []string
 			for iterator.Next() {
@@ -188,9 +188,9 @@ func TestKVOrderedCommitIterator(t *testing.T) {
 				t.Errorf("Unexpected ordered commits from iterator. diff=%s", diff)
 			}
 			iterator.Close()
-			iterator, err = ref.NewKVOrderedCommitIterator(ctx, store, repository, true)
+			iterator, err = ref.NewOrderedCommitIterator(ctx, store, repository, true)
 			if err != nil {
-				t.Fatal("create kv ordered commit iterator", err)
+				t.Fatal("create ordered commit iterator", err)
 			}
 			var actualAncestryLeaves []string
 			for iterator.Next() {
@@ -209,7 +209,7 @@ func TestKVOrderedCommitIterator(t *testing.T) {
 	}
 }
 
-func TestKVOrderedCommitIteratorGrid(t *testing.T) {
+func TestOrderedCommitIteratorGrid(t *testing.T) {
 	// Construct the following grid, taken from https://github.com/git/git/blob/master/t/t6600-test-reach.sh
 	//             (10,10)
 	//            /       \
@@ -249,7 +249,7 @@ func TestKVOrderedCommitIteratorGrid(t *testing.T) {
 		}
 	}
 	sort.Strings(expectedCommitIDS)
-	r, store := testRefManagerWithKVAndAddressProvider(t, newFakeAddressProvider(commits))
+	r, store := testRefManagerWithAddressProvider(t, newFakeAddressProvider(commits))
 	ctx := context.Background()
 	repo := graveler.RepositoryRecord{
 		RepositoryID: graveler.RepositoryID("repo"),
@@ -265,9 +265,9 @@ func TestKVOrderedCommitIteratorGrid(t *testing.T) {
 		_, err := r.AddCommit(ctx, repository, *c)
 		testutil.Must(t, err)
 	}
-	iterator, err := ref.NewKVOrderedCommitIterator(ctx, store, &repo, false)
+	iterator, err := ref.NewOrderedCommitIterator(ctx, store, &repo, false)
 	if err != nil {
-		t.Fatal("create kv ordered commit iterator", err)
+		t.Fatal("create ordered commit iterator", err)
 	}
 	var actualOrderedCommits []string
 	for iterator.Next() {
@@ -282,9 +282,9 @@ func TestKVOrderedCommitIteratorGrid(t *testing.T) {
 		t.Errorf("Unexpected ordered commits from iterator. diff=%s", diff)
 	}
 	iterator.Close()
-	iterator, err = ref.NewKVOrderedCommitIterator(ctx, store, &repo, true)
+	iterator, err = ref.NewOrderedCommitIterator(ctx, store, &repo, true)
 	if err != nil {
-		t.Fatal("create kv ordered commit iterator", err)
+		t.Fatal("create ordered commit iterator", err)
 	}
 	var actualAncestryLeaves []string
 	for iterator.Next() {
@@ -301,7 +301,7 @@ func TestKVOrderedCommitIteratorGrid(t *testing.T) {
 	iterator.Close()
 }
 
-func TestKVOrderedCommitIterator_CloseTwice(t *testing.T) {
+func TestOrderedCommitIterator_CloseTwice(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	ctx := context.Background()
 	entIt := mock.NewMockEntriesIterator(ctrl)
@@ -319,16 +319,16 @@ func TestKVOrderedCommitIterator_CloseTwice(t *testing.T) {
 			InstanceUID:      "rid",
 		},
 	}
-	it, err := ref.NewKVOrderedCommitIterator(ctx, &msgStore, repository, false)
+	it, err := ref.NewOrderedCommitIterator(ctx, &msgStore, repository, false)
 	if err != nil {
-		t.Fatal("failed to create kv ordered commit iterator", err)
+		t.Fatal("failed to create ordered commit iterator", err)
 	}
 	it.Close()
 	// calling 'Close()` again to verify the iterator doesn't call the internal iterator close method
 	it.Close()
 }
 
-func TestKVOrderedCommitIterator_NextAfterClose(t *testing.T) {
+func TestOrderedCommitIterator_NextAfterClose(t *testing.T) {
 	ctrl := gomock.NewController(t)
 	ctx := context.Background()
 	entIt := mock.NewMockEntriesIterator(ctrl)
@@ -342,7 +342,7 @@ func TestKVOrderedCommitIterator_NextAfterClose(t *testing.T) {
 			InstanceUID: "rid",
 		},
 	}
-	it, err := ref.NewKVOrderedCommitIterator(ctx, &msgStore, repository, false)
+	it, err := ref.NewOrderedCommitIterator(ctx, &msgStore, repository, false)
 	if err != nil {
 		t.Fatal("failed to create kv ordered commit iterator", err)
 	}

--- a/pkg/graveler/ref/main_test.go
+++ b/pkg/graveler/ref/main_test.go
@@ -42,10 +42,10 @@ func testRefManager(t testing.TB) (graveler.RefManager, *kv.StoreMessage) {
 		RepoCacheConfig:   testRepoCacheConfig,
 		CommitCacheConfig: testCommitCacheConfig,
 	}
-	return ref.NewKVRefManager(cfg), storeMessage
+	return ref.NewRefManager(cfg), storeMessage
 }
 
-func testRefManagerWithKVAndAddressProvider(t testing.TB, addressProvider ident.AddressProvider) (graveler.RefManager, *kv.StoreMessage) {
+func testRefManagerWithAddressProvider(t testing.TB, addressProvider ident.AddressProvider) (graveler.RefManager, *kv.StoreMessage) {
 	t.Helper()
 	ctx := context.Background()
 	kvStore := kvtest.GetStore(ctx, t)
@@ -57,7 +57,7 @@ func testRefManagerWithKVAndAddressProvider(t testing.TB, addressProvider ident.
 		RepoCacheConfig:   testRepoCacheConfig,
 		CommitCacheConfig: testCommitCacheConfig,
 	}
-	return ref.NewKVRefManager(cfg), storeMessage
+	return ref.NewRefManager(cfg), storeMessage
 }
 
 func TestMain(m *testing.M) {

--- a/pkg/graveler/ref/manager.go
+++ b/pkg/graveler/ref/manager.go
@@ -57,7 +57,7 @@ var (
 	}
 )
 
-type KVManager struct {
+type Manager struct {
 	kvStore         *kv.StoreMessage
 	addressProvider ident.AddressProvider
 	batchExecutor   batch.Batcher
@@ -100,10 +100,10 @@ type ManagerConfig struct {
 	CommitCacheConfig *CacheConfig
 }
 
-func NewKVRefManager(cfg ManagerConfig) *KVManager {
+func NewRefManager(cfg ManagerConfig) *Manager {
 	repoCache := newCache(cfg.RepoCacheConfig, DefaultRepositoryCacheConfig)
 	commitCache := newCache(cfg.CommitCacheConfig, DefaultCommitCacheConfig)
-	return &KVManager{
+	return &Manager{
 		kvStore:         cfg.KvStore,
 		addressProvider: cfg.AddressProvider,
 		batchExecutor:   cfg.Executor,
@@ -112,7 +112,7 @@ func NewKVRefManager(cfg ManagerConfig) *KVManager {
 	}
 }
 
-func (m *KVManager) getRepository(ctx context.Context, repositoryID graveler.RepositoryID) (*graveler.RepositoryRecord, error) {
+func (m *Manager) getRepository(ctx context.Context, repositoryID graveler.RepositoryID) (*graveler.RepositoryRecord, error) {
 	data := graveler.RepositoryData{}
 	_, err := m.kvStore.GetMsg(ctx, graveler.RepositoriesPartition(), []byte(graveler.RepoPath(repositoryID)), &data)
 	if err != nil {
@@ -124,7 +124,7 @@ func (m *KVManager) getRepository(ctx context.Context, repositoryID graveler.Rep
 	return graveler.RepoFromProto(&data), nil
 }
 
-func (m *KVManager) getRepositoryBatch(ctx context.Context, repositoryID graveler.RepositoryID) (*graveler.RepositoryRecord, error) {
+func (m *Manager) getRepositoryBatch(ctx context.Context, repositoryID graveler.RepositoryID) (*graveler.RepositoryRecord, error) {
 	key := fmt.Sprintf("GetRepository:%s", repositoryID)
 	repository, err := m.batchExecutor.BatchFor(ctx, key, MaxBatchDelay, batch.BatchFn(func() (interface{}, error) {
 		return m.getRepository(ctx, repositoryID)
@@ -135,7 +135,7 @@ func (m *KVManager) getRepositoryBatch(ctx context.Context, repositoryID gravele
 	return repository.(*graveler.RepositoryRecord), nil
 }
 
-func (m *KVManager) GetRepository(ctx context.Context, repositoryID graveler.RepositoryID) (*graveler.RepositoryRecord, error) {
+func (m *Manager) GetRepository(ctx context.Context, repositoryID graveler.RepositoryID) (*graveler.RepositoryRecord, error) {
 	rec, err := m.repoCache.GetOrSet(repositoryID, func() (interface{}, error) {
 		repo, err := m.getRepositoryBatch(ctx, repositoryID)
 		if err != nil {
@@ -157,7 +157,7 @@ func (m *KVManager) GetRepository(ctx context.Context, repositoryID graveler.Rep
 	return rec.(*graveler.RepositoryRecord), nil
 }
 
-func (m *KVManager) createBareRepository(ctx context.Context, repositoryID graveler.RepositoryID, repository graveler.Repository) (*graveler.RepositoryRecord, error) {
+func (m *Manager) createBareRepository(ctx context.Context, repositoryID graveler.RepositoryID, repository graveler.Repository) (*graveler.RepositoryRecord, error) {
 	repoRecord := &graveler.RepositoryRecord{
 		RepositoryID: repositoryID,
 		Repository:   &repository,
@@ -174,7 +174,7 @@ func (m *KVManager) createBareRepository(ctx context.Context, repositoryID grave
 	return repoRecord, nil
 }
 
-func (m *KVManager) CreateRepository(ctx context.Context, repositoryID graveler.RepositoryID, repository graveler.Repository) (*graveler.RepositoryRecord, error) {
+func (m *Manager) CreateRepository(ctx context.Context, repositoryID graveler.RepositoryID, repository graveler.Repository) (*graveler.RepositoryRecord, error) {
 	firstCommit := graveler.NewCommit()
 	firstCommit.Message = graveler.FirstCommitMsg
 	firstCommit.Generation = 1
@@ -205,20 +205,20 @@ func (m *KVManager) CreateRepository(ctx context.Context, repositoryID graveler.
 	return repo, nil
 }
 
-func (m *KVManager) CreateBareRepository(ctx context.Context, repositoryID graveler.RepositoryID, repository graveler.Repository) (*graveler.RepositoryRecord, error) {
+func (m *Manager) CreateBareRepository(ctx context.Context, repositoryID graveler.RepositoryID, repository graveler.Repository) (*graveler.RepositoryRecord, error) {
 	return m.createBareRepository(ctx, repositoryID, repository)
 }
 
-func (m *KVManager) ListRepositories(ctx context.Context) (graveler.RepositoryIterator, error) {
-	return NewKVRepositoryIterator(ctx, m.kvStore)
+func (m *Manager) ListRepositories(ctx context.Context) (graveler.RepositoryIterator, error) {
+	return NewRepositoryIterator(ctx, m.kvStore)
 }
 
-func (m *KVManager) updateRepoState(ctx context.Context, repo *graveler.RepositoryRecord, state graveler.RepositoryState) error {
+func (m *Manager) updateRepoState(ctx context.Context, repo *graveler.RepositoryRecord, state graveler.RepositoryState) error {
 	repo.State = state
 	return m.kvStore.SetMsg(ctx, graveler.RepositoriesPartition(), []byte(graveler.RepoPath(repo.RepositoryID)), graveler.ProtoFromRepo(repo))
 }
 
-func (m *KVManager) deleteRepositoryBranches(ctx context.Context, repository *graveler.RepositoryRecord) error {
+func (m *Manager) deleteRepositoryBranches(ctx context.Context, repository *graveler.RepositoryRecord) error {
 	itr, err := m.ListBranches(ctx, repository)
 	if err != nil {
 		return err
@@ -234,7 +234,7 @@ func (m *KVManager) deleteRepositoryBranches(ctx context.Context, repository *gr
 	return wg.Wait().ErrorOrNil()
 }
 
-func (m *KVManager) deleteRepositoryTags(ctx context.Context, repository *graveler.RepositoryRecord) error {
+func (m *Manager) deleteRepositoryTags(ctx context.Context, repository *graveler.RepositoryRecord) error {
 	itr, err := m.ListTags(ctx, repository)
 	if err != nil {
 		return err
@@ -250,7 +250,7 @@ func (m *KVManager) deleteRepositoryTags(ctx context.Context, repository *gravel
 	return wg.Wait().ErrorOrNil()
 }
 
-func (m *KVManager) deleteRepositoryCommits(ctx context.Context, repository *graveler.RepositoryRecord) error {
+func (m *Manager) deleteRepositoryCommits(ctx context.Context, repository *graveler.RepositoryRecord) error {
 	itr, err := m.ListCommits(ctx, repository)
 	if err != nil {
 		return err
@@ -266,7 +266,7 @@ func (m *KVManager) deleteRepositoryCommits(ctx context.Context, repository *gra
 	return wg.Wait().ErrorOrNil()
 }
 
-func (m *KVManager) deleteRepository(ctx context.Context, repo *graveler.RepositoryRecord) error {
+func (m *Manager) deleteRepository(ctx context.Context, repo *graveler.RepositoryRecord) error {
 	// ctx := context.Background() TODO (niro): When running this async create a new context and remove ctx from signature
 	var wg multierror.Group
 	wg.Go(func() error {
@@ -287,7 +287,7 @@ func (m *KVManager) deleteRepository(ctx context.Context, repo *graveler.Reposit
 	return m.kvStore.DeleteMsg(ctx, graveler.RepositoriesPartition(), []byte(graveler.RepoPath(repo.RepositoryID)))
 }
 
-func (m *KVManager) DeleteRepository(ctx context.Context, repositoryID graveler.RepositoryID) error {
+func (m *Manager) DeleteRepository(ctx context.Context, repositoryID graveler.RepositoryID) error {
 	repo, err := m.getRepository(ctx, repositoryID)
 	if err != nil {
 		return err
@@ -305,15 +305,15 @@ func (m *KVManager) DeleteRepository(ctx context.Context, repositoryID graveler.
 	return m.deleteRepository(ctx, repo)
 }
 
-func (m *KVManager) ParseRef(ref graveler.Ref) (graveler.RawRef, error) {
+func (m *Manager) ParseRef(ref graveler.Ref) (graveler.RawRef, error) {
 	return ParseRef(ref)
 }
 
-func (m *KVManager) ResolveRawRef(ctx context.Context, repository *graveler.RepositoryRecord, raw graveler.RawRef) (*graveler.ResolvedRef, error) {
+func (m *Manager) ResolveRawRef(ctx context.Context, repository *graveler.RepositoryRecord, raw graveler.RawRef) (*graveler.ResolvedRef, error) {
 	return ResolveRawRef(ctx, m, m.addressProvider, repository, raw)
 }
 
-func (m *KVManager) getBranchWithPredicate(ctx context.Context, repository *graveler.RepositoryRecord, branchID graveler.BranchID) (*graveler.Branch, kv.Predicate, error) {
+func (m *Manager) getBranchWithPredicate(ctx context.Context, repository *graveler.RepositoryRecord, branchID graveler.BranchID) (*graveler.Branch, kv.Predicate, error) {
 	key := fmt.Sprintf("GetBranch:%s:%s", repository.RepositoryID, branchID)
 	type branchPred struct {
 		*graveler.Branch
@@ -338,12 +338,12 @@ func (m *KVManager) getBranchWithPredicate(ctx context.Context, repository *grav
 	return branchWithPred.Branch, branchWithPred.Predicate, nil
 }
 
-func (m *KVManager) GetBranch(ctx context.Context, repository *graveler.RepositoryRecord, branchID graveler.BranchID) (*graveler.Branch, error) {
+func (m *Manager) GetBranch(ctx context.Context, repository *graveler.RepositoryRecord, branchID graveler.BranchID) (*graveler.Branch, error) {
 	branch, _, err := m.getBranchWithPredicate(ctx, repository, branchID)
 	return branch, err
 }
 
-func (m *KVManager) createBranch(ctx context.Context, repositoryPartition string, branchID graveler.BranchID, branch graveler.Branch) error {
+func (m *Manager) createBranch(ctx context.Context, repositoryPartition string, branchID graveler.BranchID, branch graveler.Branch) error {
 	err := m.kvStore.SetMsgIf(ctx, repositoryPartition, []byte(graveler.BranchPath(branchID)), protoFromBranch(branchID, &branch), nil)
 	if errors.Is(err, kv.ErrPredicateFailed) {
 		err = graveler.ErrBranchExists
@@ -351,15 +351,15 @@ func (m *KVManager) createBranch(ctx context.Context, repositoryPartition string
 	return err
 }
 
-func (m *KVManager) CreateBranch(ctx context.Context, repository *graveler.RepositoryRecord, branchID graveler.BranchID, branch graveler.Branch) error {
+func (m *Manager) CreateBranch(ctx context.Context, repository *graveler.RepositoryRecord, branchID graveler.BranchID, branch graveler.Branch) error {
 	return m.createBranch(ctx, graveler.RepoPartition(repository), branchID, branch)
 }
 
-func (m *KVManager) SetBranch(ctx context.Context, repository *graveler.RepositoryRecord, branchID graveler.BranchID, branch graveler.Branch) error {
+func (m *Manager) SetBranch(ctx context.Context, repository *graveler.RepositoryRecord, branchID graveler.BranchID, branch graveler.Branch) error {
 	return m.kvStore.SetMsg(ctx, graveler.RepoPartition(repository), []byte(graveler.BranchPath(branchID)), protoFromBranch(branchID, &branch))
 }
 
-func (m *KVManager) BranchUpdate(ctx context.Context, repository *graveler.RepositoryRecord, branchID graveler.BranchID, f graveler.BranchUpdateFunc) error {
+func (m *Manager) BranchUpdate(ctx context.Context, repository *graveler.RepositoryRecord, branchID graveler.BranchID, f graveler.BranchUpdateFunc) error {
 	b, pred, err := m.getBranchWithPredicate(ctx, repository, branchID)
 	if err != nil {
 		return err
@@ -372,7 +372,7 @@ func (m *KVManager) BranchUpdate(ctx context.Context, repository *graveler.Repos
 	return m.kvStore.SetMsgIf(ctx, graveler.RepoPartition(repository), []byte(graveler.BranchPath(branchID)), protoFromBranch(branchID, newBranch), pred)
 }
 
-func (m *KVManager) DeleteBranch(ctx context.Context, repository *graveler.RepositoryRecord, branchID graveler.BranchID) error {
+func (m *Manager) DeleteBranch(ctx context.Context, repository *graveler.RepositoryRecord, branchID graveler.BranchID) error {
 	_, err := m.GetBranch(ctx, repository, branchID)
 	if err != nil {
 		return err
@@ -380,15 +380,15 @@ func (m *KVManager) DeleteBranch(ctx context.Context, repository *graveler.Repos
 	return m.kvStore.DeleteMsg(ctx, graveler.RepoPartition(repository), []byte(graveler.BranchPath(branchID)))
 }
 
-func (m *KVManager) ListBranches(ctx context.Context, repository *graveler.RepositoryRecord) (graveler.BranchIterator, error) {
+func (m *Manager) ListBranches(ctx context.Context, repository *graveler.RepositoryRecord) (graveler.BranchIterator, error) {
 	return NewBranchSimpleIterator(ctx, m.kvStore, repository)
 }
 
-func (m *KVManager) GCBranchIterator(ctx context.Context, repository *graveler.RepositoryRecord) (graveler.BranchIterator, error) {
+func (m *Manager) GCBranchIterator(ctx context.Context, repository *graveler.RepositoryRecord) (graveler.BranchIterator, error) {
 	return NewBranchByCommitIterator(ctx, m.kvStore, repository)
 }
 
-func (m *KVManager) GetTag(ctx context.Context, repository *graveler.RepositoryRecord, tagID graveler.TagID) (*graveler.CommitID, error) {
+func (m *Manager) GetTag(ctx context.Context, repository *graveler.RepositoryRecord, tagID graveler.TagID) (*graveler.CommitID, error) {
 	key := fmt.Sprintf("GetTag:%s:%s", repository.RepositoryID, tagID)
 	commitID, err := m.batchExecutor.BatchFor(ctx, key, MaxBatchDelay, batch.BatchFn(func() (interface{}, error) {
 		tagKey := graveler.TagPath(tagID)
@@ -409,7 +409,7 @@ func (m *KVManager) GetTag(ctx context.Context, repository *graveler.RepositoryR
 	return commitID.(*graveler.CommitID), nil
 }
 
-func (m *KVManager) CreateTag(ctx context.Context, repository *graveler.RepositoryRecord, tagID graveler.TagID, commitID graveler.CommitID) error {
+func (m *Manager) CreateTag(ctx context.Context, repository *graveler.RepositoryRecord, tagID graveler.TagID, commitID graveler.CommitID) error {
 	t := &graveler.TagData{
 		Id:       tagID.String(),
 		CommitId: commitID.String(),
@@ -425,24 +425,24 @@ func (m *KVManager) CreateTag(ctx context.Context, repository *graveler.Reposito
 	return nil
 }
 
-func (m *KVManager) DeleteTag(ctx context.Context, repository *graveler.RepositoryRecord, tagID graveler.TagID) error {
+func (m *Manager) DeleteTag(ctx context.Context, repository *graveler.RepositoryRecord, tagID graveler.TagID) error {
 	tagKey := graveler.TagPath(tagID)
 	// TODO (issue 3640) align with delete tag DB - return ErrNotFound when tag does not exist
 	return m.kvStore.DeleteMsg(ctx, graveler.RepoPartition(repository), []byte(tagKey))
 }
 
-func (m *KVManager) ListTags(ctx context.Context, repository *graveler.RepositoryRecord) (graveler.TagIterator, error) {
-	return NewKVTagIterator(ctx, m.kvStore, repository)
+func (m *Manager) ListTags(ctx context.Context, repository *graveler.RepositoryRecord) (graveler.TagIterator, error) {
+	return NewTagIterator(ctx, m.kvStore, repository)
 }
 
-func (m *KVManager) GetCommitByPrefix(ctx context.Context, repository *graveler.RepositoryRecord, prefix graveler.CommitID) (*graveler.Commit, error) {
+func (m *Manager) GetCommitByPrefix(ctx context.Context, repository *graveler.RepositoryRecord, prefix graveler.CommitID) (*graveler.Commit, error) {
 	// optimize by get if prefix is not a prefix, but a full length commit id
 	if len(prefix) == commitIDStringLength {
 		return m.GetCommit(ctx, repository, prefix)
 	}
 	key := fmt.Sprintf("GetCommitByPrefix:%s:%s", repository.RepositoryID, prefix)
 	commit, err := m.batchExecutor.BatchFor(ctx, key, MaxBatchDelay, batch.BatchFn(func() (interface{}, error) {
-		it, err := NewKVOrderedCommitIterator(ctx, m.kvStore, repository, false)
+		it, err := NewOrderedCommitIterator(ctx, m.kvStore, repository, false)
 		if err != nil {
 			return nil, err
 		}
@@ -474,7 +474,7 @@ func (m *KVManager) GetCommitByPrefix(ctx context.Context, repository *graveler.
 	return commit.(*graveler.Commit), nil
 }
 
-func (m *KVManager) GetCommit(ctx context.Context, repository *graveler.RepositoryRecord, commitID graveler.CommitID) (*graveler.Commit, error) {
+func (m *Manager) GetCommit(ctx context.Context, repository *graveler.RepositoryRecord, commitID graveler.CommitID) (*graveler.Commit, error) {
 	key := fmt.Sprintf("%s:%s", repository.RepositoryID, commitID)
 	v, err := m.commitCache.GetOrSet(key, func() (v interface{}, err error) {
 		return m.getCommitBatch(ctx, repository, commitID)
@@ -485,7 +485,7 @@ func (m *KVManager) GetCommit(ctx context.Context, repository *graveler.Reposito
 	return v.(*graveler.Commit), nil
 }
 
-func (m *KVManager) getCommitBatch(ctx context.Context, repository *graveler.RepositoryRecord, commitID graveler.CommitID) (*graveler.Commit, error) {
+func (m *Manager) getCommitBatch(ctx context.Context, repository *graveler.RepositoryRecord, commitID graveler.CommitID) (*graveler.Commit, error) {
 	key := fmt.Sprintf("GetCommit:%s:%s", repository.RepositoryID, commitID)
 	commit, err := m.batchExecutor.BatchFor(ctx, key, MaxBatchDelay, batch.BatchFn(func() (interface{}, error) {
 		return m.getCommit(commitID, ctx, repository)
@@ -496,7 +496,7 @@ func (m *KVManager) getCommitBatch(ctx context.Context, repository *graveler.Rep
 	return commit.(*graveler.Commit), nil
 }
 
-func (m *KVManager) getCommit(commitID graveler.CommitID, ctx context.Context, repository *graveler.RepositoryRecord) (interface{}, error) {
+func (m *Manager) getCommit(commitID graveler.CommitID, ctx context.Context, repository *graveler.RepositoryRecord) (interface{}, error) {
 	commitKey := graveler.CommitPath(commitID)
 	c := graveler.CommitData{}
 	_, err := m.kvStore.GetMsg(ctx, graveler.RepoPartition(repository), []byte(commitKey), &c)
@@ -509,7 +509,7 @@ func (m *KVManager) getCommit(commitID graveler.CommitID, ctx context.Context, r
 	return graveler.CommitFromProto(&c), nil
 }
 
-func (m *KVManager) addCommit(ctx context.Context, repoPartition string, commit graveler.Commit) (graveler.CommitID, error) {
+func (m *Manager) addCommit(ctx context.Context, repoPartition string, commit graveler.Commit) (graveler.CommitID, error) {
 	commitID := m.addressProvider.ContentAddress(commit)
 	c := graveler.ProtoFromCommit(graveler.CommitID(commitID), &commit)
 	commitKey := graveler.CommitPath(graveler.CommitID(commitID))
@@ -522,16 +522,16 @@ func (m *KVManager) addCommit(ctx context.Context, repoPartition string, commit 
 	return graveler.CommitID(commitID), nil
 }
 
-func (m *KVManager) AddCommit(ctx context.Context, repository *graveler.RepositoryRecord, commit graveler.Commit) (graveler.CommitID, error) {
+func (m *Manager) AddCommit(ctx context.Context, repository *graveler.RepositoryRecord, commit graveler.Commit) (graveler.CommitID, error) {
 	return m.addCommit(ctx, graveler.RepoPartition(repository), commit)
 }
 
-func (m *KVManager) RemoveCommit(ctx context.Context, repository *graveler.RepositoryRecord, commitID graveler.CommitID) error {
+func (m *Manager) RemoveCommit(ctx context.Context, repository *graveler.RepositoryRecord, commitID graveler.CommitID) error {
 	commitKey := graveler.CommitPath(commitID)
 	return m.kvStore.DeleteMsg(ctx, graveler.RepoPartition(repository), []byte(commitKey))
 }
 
-func (m *KVManager) FindMergeBase(ctx context.Context, repository *graveler.RepositoryRecord, commitIDs ...graveler.CommitID) (*graveler.Commit, error) {
+func (m *Manager) FindMergeBase(ctx context.Context, repository *graveler.RepositoryRecord, commitIDs ...graveler.CommitID) (*graveler.Commit, error) {
 	const allowedCommitsToCompare = 2
 	if len(commitIDs) != allowedCommitsToCompare {
 		return nil, graveler.ErrInvalidMergeBase
@@ -539,16 +539,16 @@ func (m *KVManager) FindMergeBase(ctx context.Context, repository *graveler.Repo
 	return FindMergeBase(ctx, m, repository, commitIDs[0], commitIDs[1])
 }
 
-func (m *KVManager) Log(ctx context.Context, repository *graveler.RepositoryRecord, from graveler.CommitID) (graveler.CommitIterator, error) {
+func (m *Manager) Log(ctx context.Context, repository *graveler.RepositoryRecord, from graveler.CommitID) (graveler.CommitIterator, error) {
 	return NewCommitIterator(ctx, repository, from, m), nil
 }
 
-func (m *KVManager) ListCommits(ctx context.Context, repository *graveler.RepositoryRecord) (graveler.CommitIterator, error) {
-	return NewKVOrderedCommitIterator(ctx, m.kvStore, repository, false)
+func (m *Manager) ListCommits(ctx context.Context, repository *graveler.RepositoryRecord) (graveler.CommitIterator, error) {
+	return NewOrderedCommitIterator(ctx, m.kvStore, repository, false)
 }
 
-func (m *KVManager) GCCommitIterator(ctx context.Context, repository *graveler.RepositoryRecord) (graveler.CommitIterator, error) {
-	return NewKVOrderedCommitIterator(ctx, m.kvStore, repository, true)
+func (m *Manager) GCCommitIterator(ctx context.Context, repository *graveler.RepositoryRecord) (graveler.CommitIterator, error) {
+	return NewOrderedCommitIterator(ctx, m.kvStore, repository, true)
 }
 
 func newCache(cfg *CacheConfig, def *CacheConfig) cache.Cache {

--- a/pkg/graveler/ref/manager_test.go
+++ b/pkg/graveler/ref/manager_test.go
@@ -48,7 +48,7 @@ func TestManager_GetRepositoryCache(t *testing.T) {
 		RepoCacheConfig:   cacheConfig,
 		CommitCacheConfig: cacheConfig,
 	}
-	refManager := ref.NewKVRefManager(cfg)
+	refManager := ref.NewRefManager(cfg)
 	for i := 0; i < calls; i++ {
 		_, err := refManager.GetRepository(ctx, "repo1")
 		if err != nil {
@@ -96,7 +96,7 @@ func TestManager_GetCommitCache(t *testing.T) {
 		RepoCacheConfig:   cacheConfig,
 		CommitCacheConfig: cacheConfig,
 	}
-	refManager := ref.NewKVRefManager(cfg)
+	refManager := ref.NewRefManager(cfg)
 	for i := 0; i < calls; i++ {
 		_, err := refManager.GetCommit(ctx, &graveler.RepositoryRecord{
 			RepositoryID: repoID,
@@ -898,7 +898,7 @@ func TestManager_GetCommitByPrefix(t *testing.T) {
 	identityToFakeIdentity := make(map[string]string)
 
 	provider := &fakeAddressProvider{identityToFakeIdentity: identityToFakeIdentity}
-	r, _ := testRefManagerWithKVAndAddressProvider(t, provider)
+	r, _ := testRefManagerWithAddressProvider(t, provider)
 	ctx := context.Background()
 	repository, err := r.CreateRepository(ctx, "repo1", graveler.Repository{
 		StorageNamespace: "s3://",

--- a/pkg/graveler/ref/repository_iterator_test.go
+++ b/pkg/graveler/ref/repository_iterator_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/treeverse/lakefs/pkg/testutil"
 )
 
-func TestKVRepositoryIterator(t *testing.T) {
+func TestRepositoryIterator(t *testing.T) {
 	r, store := testRefManager(t)
 	repos := []graveler.RepositoryID{"a", "aa", "b", "c", "e", "d", "f"}
 
@@ -30,7 +30,7 @@ func TestKVRepositoryIterator(t *testing.T) {
 	}
 
 	t.Run("listing all repos", func(t *testing.T) {
-		iter, err := ref.NewKVRepositoryIterator(context.Background(), store)
+		iter, err := ref.NewRepositoryIterator(context.Background(), store)
 		require.NoError(t, err)
 		repoIds := make([]graveler.RepositoryID, 0)
 		for iter.Next() {
@@ -48,7 +48,7 @@ func TestKVRepositoryIterator(t *testing.T) {
 	})
 
 	t.Run("listing repos from prefix", func(t *testing.T) {
-		iter, err := ref.NewKVRepositoryIterator(context.Background(), store)
+		iter, err := ref.NewRepositoryIterator(context.Background(), store)
 		require.NoError(t, err)
 		iter.SeekGE("b")
 		repoIds := make([]graveler.RepositoryID, 0)
@@ -67,7 +67,7 @@ func TestKVRepositoryIterator(t *testing.T) {
 	})
 
 	t.Run("listing repos SeekGE", func(t *testing.T) {
-		iter, err := ref.NewKVRepositoryIterator(context.Background(), store)
+		iter, err := ref.NewRepositoryIterator(context.Background(), store)
 		require.NoError(t, err)
 		iter.SeekGE("b")
 		repoIds := make([]graveler.RepositoryID, 0)
@@ -102,7 +102,7 @@ func TestKVRepositoryIterator(t *testing.T) {
 	})
 }
 
-func TestKVRepositoryIterator_CloseTwice(t *testing.T) {
+func TestRepositoryIterator_CloseTwice(t *testing.T) {
 	ctx := context.Background()
 	ctrl := gomock.NewController(t)
 	entIt := mock.NewMockEntriesIterator(ctrl)
@@ -110,16 +110,16 @@ func TestKVRepositoryIterator_CloseTwice(t *testing.T) {
 	store := mock.NewMockStore(ctrl)
 	store.EXPECT().Scan(ctx, gomock.Any(), gomock.Any()).Return(entIt, nil).Times(1)
 	msgStore := kv.StoreMessage{Store: store}
-	it, err := ref.NewKVRepositoryIterator(ctx, &msgStore)
+	it, err := ref.NewRepositoryIterator(ctx, &msgStore)
 	if err != nil {
-		t.Fatal("NewKVRepositoryIterator failed", err)
+		t.Fatal("NewRepositoryIterator failed", err)
 	}
 	it.Close()
 	// Make sure calling Close again do not crash
 	it.Close()
 }
 
-func TestKVRepositoryIterator_NextClosed(t *testing.T) {
+func TestRepositoryIterator_NextClosed(t *testing.T) {
 	ctx := context.Background()
 	ctrl := gomock.NewController(t)
 	entIt := mock.NewMockEntriesIterator(ctrl)
@@ -127,9 +127,9 @@ func TestKVRepositoryIterator_NextClosed(t *testing.T) {
 	store := mock.NewMockStore(ctrl)
 	store.EXPECT().Scan(ctx, gomock.Any(), gomock.Any()).Return(entIt, nil).Times(1)
 	msgStore := kv.StoreMessage{Store: store}
-	it, err := ref.NewKVRepositoryIterator(ctx, &msgStore)
+	it, err := ref.NewRepositoryIterator(ctx, &msgStore)
 	if err != nil {
-		t.Fatal("NewKVRepositoryIterator failed", err)
+		t.Fatal("NewRepositoryIterator failed", err)
 	}
 	it.Close()
 	// Make sure calling Next should not crash

--- a/pkg/graveler/ref/tag_iterator.go
+++ b/pkg/graveler/ref/tag_iterator.go
@@ -7,7 +7,7 @@ import (
 	"github.com/treeverse/lakefs/pkg/kv"
 )
 
-type KVTagIterator struct {
+type TagIterator struct {
 	ctx           context.Context
 	it            kv.MessageIterator
 	err           error
@@ -17,7 +17,7 @@ type KVTagIterator struct {
 	closed        bool
 }
 
-func NewKVTagIterator(ctx context.Context, store *kv.StoreMessage, repo *graveler.RepositoryRecord) (*KVTagIterator, error) {
+func NewTagIterator(ctx context.Context, store *kv.StoreMessage, repo *graveler.RepositoryRecord) (*TagIterator, error) {
 	repoPartition := graveler.RepoPartition(repo)
 	it, err := kv.NewPrimaryIterator(ctx, store.Store, (&graveler.TagData{}).ProtoReflect().Type(),
 		graveler.RepoPartition(repo),
@@ -25,7 +25,7 @@ func NewKVTagIterator(ctx context.Context, store *kv.StoreMessage, repo *gravele
 	if err != nil {
 		return nil, err
 	}
-	return &KVTagIterator{
+	return &TagIterator{
 		ctx:           ctx,
 		it:            it,
 		store:         store.Store,
@@ -34,7 +34,7 @@ func NewKVTagIterator(ctx context.Context, store *kv.StoreMessage, repo *gravele
 	}, nil
 }
 
-func (i *KVTagIterator) Next() bool {
+func (i *TagIterator) Next() bool {
 	if i.Err() != nil || i.closed {
 		return false
 	}
@@ -56,7 +56,7 @@ func (i *KVTagIterator) Next() bool {
 	return true
 }
 
-func (i *KVTagIterator) SeekGE(id graveler.TagID) {
+func (i *TagIterator) SeekGE(id graveler.TagID) {
 	if i.Err() != nil {
 		return
 	}
@@ -70,14 +70,14 @@ func (i *KVTagIterator) SeekGE(id graveler.TagID) {
 	i.closed = err != nil
 }
 
-func (i *KVTagIterator) Value() *graveler.TagRecord {
+func (i *TagIterator) Value() *graveler.TagRecord {
 	if i.Err() != nil {
 		return nil
 	}
 	return i.value
 }
 
-func (i *KVTagIterator) Err() error {
+func (i *TagIterator) Err() error {
 	if i.err != nil {
 		return i.err
 	}
@@ -87,7 +87,7 @@ func (i *KVTagIterator) Err() error {
 	return nil
 }
 
-func (i *KVTagIterator) Close() {
+func (i *TagIterator) Close() {
 	if i.closed {
 		return
 	}

--- a/pkg/graveler/ref/tag_iterator_test.go
+++ b/pkg/graveler/ref/tag_iterator_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/treeverse/lakefs/pkg/testutil"
 )
 
-func TestKVTagIterator(t *testing.T) {
+func TestTagIterator(t *testing.T) {
 	r, kvstore := testRefManager(t)
 	tags := []graveler.TagID{"a", "aa", "b", "c", "e", "d", "f", "g"}
 	ctx := context.Background()
@@ -32,7 +32,7 @@ func TestKVTagIterator(t *testing.T) {
 	}
 
 	t.Run("listing all tags", func(t *testing.T) {
-		iter, err := ref.NewKVTagIterator(ctx, kvstore, repository)
+		iter, err := ref.NewTagIterator(ctx, kvstore, repository)
 		testutil.Must(t, err)
 		ids := make([]graveler.TagID, 0)
 		for iter.Next() {
@@ -50,7 +50,7 @@ func TestKVTagIterator(t *testing.T) {
 	})
 
 	t.Run("listing tags using prefix", func(t *testing.T) {
-		iter, err := ref.NewKVTagIterator(ctx, kvstore, repository)
+		iter, err := ref.NewTagIterator(ctx, kvstore, repository)
 		testutil.Must(t, err)
 		iter.SeekGE("b")
 		ids := make([]graveler.TagID, 0)
@@ -69,7 +69,7 @@ func TestKVTagIterator(t *testing.T) {
 	})
 
 	t.Run("listing tags SeekGE", func(t *testing.T) {
-		iter, err := ref.NewKVTagIterator(ctx, kvstore, repository)
+		iter, err := ref.NewTagIterator(ctx, kvstore, repository)
 		testutil.Must(t, err)
 		iter.SeekGE("b")
 		ids := make([]graveler.TagID, 0)
@@ -103,7 +103,7 @@ func TestKVTagIterator(t *testing.T) {
 	})
 
 	t.Run("empty value SeekGE", func(t *testing.T) {
-		iter, err := ref.NewKVTagIterator(ctx, kvstore, repository)
+		iter, err := ref.NewTagIterator(ctx, kvstore, repository)
 		testutil.Must(t, err)
 		iter.SeekGE("b")
 
@@ -113,7 +113,7 @@ func TestKVTagIterator(t *testing.T) {
 	})
 }
 
-func TestKVTagIterator_CloseTwice(t *testing.T) {
+func TestTagIterator_CloseTwice(t *testing.T) {
 	ctx := context.Background()
 	ctrl := gomock.NewController(t)
 	entIt := mock.NewMockEntriesIterator(ctrl)
@@ -127,16 +127,16 @@ func TestKVTagIterator_CloseTwice(t *testing.T) {
 			InstanceUID: "rid",
 		},
 	}
-	it, err := ref.NewKVTagIterator(ctx, &msgStore, repo)
+	it, err := ref.NewTagIterator(ctx, &msgStore, repo)
 	if err != nil {
-		t.Fatal("TestKVTagIterator failed", err)
+		t.Fatal("TestTagIterator failed", err)
 	}
 	it.Close()
 	// Make sure calling Close again do not crash
 	it.Close()
 }
 
-func TestKVTagIterator_NextClosed(t *testing.T) {
+func TestTagIterator_NextClosed(t *testing.T) {
 	ctx := context.Background()
 	ctrl := gomock.NewController(t)
 	entIt := mock.NewMockEntriesIterator(ctrl)
@@ -150,9 +150,9 @@ func TestKVTagIterator_NextClosed(t *testing.T) {
 			InstanceUID: "rid",
 		},
 	}
-	it, err := ref.NewKVTagIterator(ctx, &msgStore, repo)
+	it, err := ref.NewTagIterator(ctx, &msgStore, repo)
 	if err != nil {
-		t.Fatal("TestKVTagIterator failed", err)
+		t.Fatal("TestTagIterator failed", err)
 	}
 	it.Close()
 	// Make sure calling Next should not crash

--- a/pkg/graveler/settings/manager_test.go
+++ b/pkg/graveler/settings/manager_test.go
@@ -232,7 +232,7 @@ func TestEmpty(t *testing.T) {
 	}
 }
 
-func prepareTest(t *testing.T, ctx context.Context, refCache cache.Cache, branchLockCallback func(context.Context, *graveler.RepositoryRecord, graveler.BranchID, func() (interface{}, error)) (interface{}, error)) (*settings.KVManager, block.Adapter) {
+func prepareTest(t *testing.T, ctx context.Context, refCache cache.Cache, branchLockCallback func(context.Context, *graveler.RepositoryRecord, graveler.BranchID, func() (interface{}, error)) (interface{}, error)) (*settings.Manager, block.Adapter) {
 	ctrl := gomock.NewController(t)
 	refManager := mock.NewMockRefManager(ctrl)
 

--- a/pkg/graveler/testutil/graveler_mock.go
+++ b/pkg/graveler/testutil/graveler_mock.go
@@ -14,7 +14,7 @@ type GravelerTest struct {
 	StagingManager           *mock.MockStagingManager
 	ProtectedBranchesManager *mock.MockProtectedBranchesManager
 	GarbageCollectionManager *mock.MockGarbageCollectionManager
-	Sut                      *graveler.KVGraveler
+	Sut                      *graveler.Graveler
 }
 
 func InitGravelerTest(t *testing.T) *GravelerTest {
@@ -28,7 +28,7 @@ func InitGravelerTest(t *testing.T) *GravelerTest {
 		ProtectedBranchesManager: mock.NewMockProtectedBranchesManager(ctrl),
 	}
 
-	test.Sut = graveler.NewKVGraveler(test.CommittedManager, test.StagingManager, test.RefManager, test.GarbageCollectionManager, test.ProtectedBranchesManager)
+	test.Sut = graveler.NewGraveler(test.CommittedManager, test.StagingManager, test.RefManager, test.GarbageCollectionManager, test.ProtectedBranchesManager)
 
 	return test
 }


### PR DESCRIPTION
Cleanup naming as previously we had KV and DB implementation of these types.

In order to keep the PR small - didn't remove the KV naming from `actions` and `auth`.