### PR TITLE
KV scan batch size control

### DIFF
--- a/cmd/lakefs/cmd/kv.go
+++ b/cmd/lakefs/cmd/kv.go
@@ -119,7 +119,7 @@ var kvScanCmd = &cobra.Command{
 		}
 		defer kvStore.Close()
 
-		iter, err := kvStore.Scan(ctx, []byte(partitionKey), start)
+		iter, err := kvStore.Scan(ctx, []byte(partitionKey), kv.ScanOptions{KeyStart: start})
 		if err != nil {
 			return fmt.Errorf("scan failed: %w", err)
 		}

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -891,7 +891,7 @@ func (c *Catalog) ListEntries(ctx context.Context, repositoryID string, referenc
 	if err != nil {
 		return nil, false, err
 	}
-	iter, err := c.Store.List(ctx, repository, refToList)
+	iter, err := c.Store.List(ctx, repository, refToList, limit+1)
 	if err != nil {
 		return nil, false, err
 	}

--- a/pkg/catalog/fake_graveler_test.go
+++ b/pkg/catalog/fake_graveler_test.go
@@ -114,14 +114,14 @@ func (g *FakeGraveler) DeleteBatch(ctx context.Context, repository *graveler.Rep
 	return nil
 }
 
-func (g *FakeGraveler) ListStaging(_ context.Context, b *graveler.Branch) (graveler.ValueIterator, error) {
+func (g *FakeGraveler) ListStaging(_ context.Context, b *graveler.Branch, _ int) (graveler.ValueIterator, error) {
 	if g.Err != nil {
 		return nil, g.Err
 	}
 	return g.ListStagingIteratorFactory(b.StagingToken), nil
 }
 
-func (g *FakeGraveler) List(_ context.Context, _ *graveler.RepositoryRecord, _ graveler.Ref) (graveler.ValueIterator, error) {
+func (g *FakeGraveler) List(_ context.Context, _ *graveler.RepositoryRecord, _ graveler.Ref, _ int) (graveler.ValueIterator, error) {
 	if g.Err != nil {
 		return nil, g.Err
 	}

--- a/pkg/catalog/uncommitted_iterator.go
+++ b/pkg/catalog/uncommitted_iterator.go
@@ -39,7 +39,7 @@ func (u *UncommittedIterator) nextStaging() bool {
 		u.entryItr.Close()
 	}
 	u.branch = u.branchItr.Value()
-	vItr, err := u.store.ListStaging(u.ctx, u.branch.Branch)
+	vItr, err := u.store.ListStaging(u.ctx, u.branch.Branch, 0)
 	if err != nil {
 		u.err = err
 		return false

--- a/pkg/graveler/graveler.go
+++ b/pkg/graveler/graveler.go
@@ -390,10 +390,10 @@ type KeyValueStore interface {
 	DeleteBatch(ctx context.Context, repository *RepositoryRecord, branchID BranchID, keys []Key) error
 
 	// List lists values on repository / ref
-	List(ctx context.Context, repository *RepositoryRecord, ref Ref) (ValueIterator, error)
+	List(ctx context.Context, repository *RepositoryRecord, ref Ref, batchSize int) (ValueIterator, error)
 
 	// ListStaging returns ValueIterator for branch staging area. Exposed to be used by catalog in PrepareGCUncommitted
-	ListStaging(ctx context.Context, branch *Branch) (ValueIterator, error)
+	ListStaging(ctx context.Context, branch *Branch, batchSize int) (ValueIterator, error)
 }
 
 type VersionController interface {
@@ -1549,17 +1549,17 @@ func (g *Graveler) deleteUnsafe(ctx context.Context, repository *RepositoryRecor
 }
 
 // ListStaging Exposing listStagingArea to catalog for PrepareGCUncommitted
-func (g *Graveler) ListStaging(ctx context.Context, branch *Branch) (ValueIterator, error) {
-	return g.listStagingArea(ctx, branch)
+func (g *Graveler) ListStaging(ctx context.Context, branch *Branch, batchSize int) (ValueIterator, error) {
+	return g.listStagingArea(ctx, branch, batchSize)
 }
 
 // listStagingArea Returns an iterator which is an aggregation of all changes on all the branch's staging area (staging + sealed)
 // for each key in the staging area it will return the latest update for that key (the value that appears in the newest token)
-func (g *Graveler) listStagingArea(ctx context.Context, b *Branch) (ValueIterator, error) {
+func (g *Graveler) listStagingArea(ctx context.Context, b *Branch, batchSize int) (ValueIterator, error) {
 	if b.StagingToken == "" {
 		return nil, ErrNotFound
 	}
-	it, err := g.StagingManager.List(ctx, b.StagingToken, 1)
+	it, err := g.StagingManager.List(ctx, b.StagingToken, batchSize)
 	if err != nil {
 		return nil, err
 	}
@@ -1568,7 +1568,7 @@ func (g *Graveler) listStagingArea(ctx context.Context, b *Branch) (ValueIterato
 		return it, nil
 	}
 
-	itrs, err := g.listSealedTokens(ctx, b)
+	itrs, err := g.listSealedTokens(ctx, b, batchSize)
 	if err != nil {
 		it.Close()
 		return nil, err
@@ -1577,23 +1577,24 @@ func (g *Graveler) listStagingArea(ctx context.Context, b *Branch) (ValueIterato
 	return NewCombinedIterator(itrs...), nil
 }
 
-func (g *Graveler) listSealedTokens(ctx context.Context, b *Branch) ([]ValueIterator, error) {
-	itrs := make([]ValueIterator, 0, len(b.SealedTokens))
+func (g *Graveler) listSealedTokens(ctx context.Context, b *Branch, batchSize int) ([]ValueIterator, error) {
+	iterators := make([]ValueIterator, 0, len(b.SealedTokens))
 	for _, st := range b.SealedTokens {
-		it, err := g.StagingManager.List(ctx, st, 1)
+		it, err := g.StagingManager.List(ctx, st, batchSize)
 		if err != nil {
-			for _, it = range itrs {
-				it.Close()
+			// close the iterators we managed to open
+			for _, iter := range iterators {
+				iter.Close()
 			}
 			return nil, err
 		}
-		itrs = append(itrs, it)
+		iterators = append(iterators, it)
 	}
-	return itrs, nil
+	return iterators, nil
 }
 
-func (g *Graveler) sealedTokensIterator(ctx context.Context, b *Branch) (ValueIterator, error) {
-	itrs, err := g.listSealedTokens(ctx, b)
+func (g *Graveler) sealedTokensIterator(ctx context.Context, b *Branch, batchSize int) (ValueIterator, error) {
+	itrs, err := g.listSealedTokens(ctx, b, batchSize)
 	if err != nil {
 		return nil, err
 	}
@@ -1605,7 +1606,7 @@ func (g *Graveler) sealedTokensIterator(ctx context.Context, b *Branch) (ValueIt
 	return changes, nil
 }
 
-func (g *Graveler) List(ctx context.Context, repository *RepositoryRecord, ref Ref) (ValueIterator, error) {
+func (g *Graveler) List(ctx context.Context, repository *RepositoryRecord, ref Ref, batchSize int) (ValueIterator, error) {
 	reference, err := g.Dereference(ctx, repository, ref)
 	if err != nil {
 		return nil, err
@@ -1624,7 +1625,7 @@ func (g *Graveler) List(ctx context.Context, repository *RepositoryRecord, ref R
 		return nil, err
 	}
 	if reference.StagingToken != "" {
-		stagingList, err := g.listStagingArea(ctx, reference.BranchRecord.Branch)
+		stagingList, err := g.listStagingArea(ctx, reference.BranchRecord.Branch, batchSize)
 		if err != nil {
 			listing.Close()
 			return nil, err
@@ -1722,7 +1723,7 @@ func (g *Graveler) Commit(ctx context.Context, repository *RepositoryRecord, bra
 			}
 			commit.MetaRangeID = *params.SourceMetaRange
 		} else {
-			changes, err := g.sealedTokensIterator(ctx, branch)
+			changes, err := g.sealedTokensIterator(ctx, branch, 0)
 			if err != nil {
 				return nil, err
 			}
@@ -1872,7 +1873,7 @@ func (g *Graveler) addCommitNoLock(ctx context.Context, repository *RepositoryRe
 }
 
 func (g *Graveler) isStagingEmpty(ctx context.Context, repository *RepositoryRecord, branch *Branch) (bool, error) {
-	itr, err := g.listStagingArea(ctx, branch)
+	itr, err := g.listStagingArea(ctx, branch, 0)
 	if err != nil {
 		return false, err
 	}
@@ -1904,7 +1905,7 @@ func (g *Graveler) isSealedEmpty(ctx context.Context, repository *RepositoryReco
 	if len(branch.SealedTokens) == 0 {
 		return true, nil
 	}
-	itrs, err := g.sealedTokensIterator(ctx, branch)
+	itrs, err := g.sealedTokensIterator(ctx, branch, 0)
 	if err != nil {
 		return false, err
 	}
@@ -2029,7 +2030,7 @@ func (g *Graveler) ResetPrefix(ctx context.Context, repository *RepositoryRecord
 		newSealedTokens = append(newSealedTokens, branch.SealedTokens...)
 
 		// Reset keys by prefix on the new staging token
-		itr, err := g.listStagingArea(ctx, branch)
+		itr, err := g.listStagingArea(ctx, branch, 0)
 		if err != nil {
 			return nil, err
 		}
@@ -2282,7 +2283,7 @@ func (g *Graveler) DiffUncommitted(ctx context.Context, repository *RepositoryRe
 		metaRangeID = commit.MetaRangeID
 	}
 
-	valueIterator, err := g.listStagingArea(ctx, branch)
+	valueIterator, err := g.listStagingArea(ctx, branch, 0)
 	if err != nil {
 		return nil, err
 	}
@@ -2348,7 +2349,7 @@ func (g *Graveler) Diff(ctx context.Context, repository *RepositoryRecord, left,
 		leftValueIterator.Close()
 		return nil, err
 	}
-	stagingIterator, err := g.listStagingArea(ctx, rightBranch)
+	stagingIterator, err := g.listStagingArea(ctx, rightBranch, 0)
 	if err != nil {
 		leftValueIterator.Close()
 		return nil, err

--- a/pkg/graveler/graveler.go
+++ b/pkg/graveler/graveler.go
@@ -1873,7 +1873,7 @@ func (g *Graveler) addCommitNoLock(ctx context.Context, repository *RepositoryRe
 }
 
 func (g *Graveler) isStagingEmpty(ctx context.Context, repository *RepositoryRecord, branch *Branch) (bool, error) {
-	itr, err := g.listStagingArea(ctx, branch, 0)
+	itr, err := g.listStagingArea(ctx, branch, 1)
 	if err != nil {
 		return false, err
 	}
@@ -1905,7 +1905,7 @@ func (g *Graveler) isSealedEmpty(ctx context.Context, repository *RepositoryReco
 	if len(branch.SealedTokens) == 0 {
 		return true, nil
 	}
-	itrs, err := g.sealedTokensIterator(ctx, branch, 0)
+	itrs, err := g.sealedTokensIterator(ctx, branch, 1)
 	if err != nil {
 		return false, err
 	}

--- a/pkg/graveler/graveler_test.go
+++ b/pkg/graveler/graveler_test.go
@@ -185,7 +185,7 @@ func TestGraveler_List(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			listing, err := tt.r.List(ctx, repository, "")
+			listing, err := tt.r.List(ctx, repository, "", 0)
 			if !errors.Is(err, tt.expectedErr) {
 				t.Fatalf("wrong error, expected:%s got:%s", tt.expectedErr, err)
 			}

--- a/pkg/graveler/graveler_test.go
+++ b/pkg/graveler/graveler_test.go
@@ -187,7 +187,7 @@ func TestGraveler_List(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			listing, err := tt.r.List(ctx, repository, "", 0)
 			if !errors.Is(err, tt.expectedErr) {
-				t.Fatalf("wrong error, expected:%s got:%s", tt.expectedErr, err)
+				t.Fatalf("wrong error, expected:%v got:%v", tt.expectedErr, err)
 			}
 			if err != nil {
 				return // err == tt.expectedErr

--- a/pkg/graveler/staging/iterator.go
+++ b/pkg/graveler/staging/iterator.go
@@ -16,8 +16,8 @@ type Iterator struct {
 }
 
 // NewStagingIterator initiates the staging iterator with a batchSize
-func NewStagingIterator(ctx context.Context, store kv.StoreMessage, st graveler.StagingToken) (*Iterator, error) {
-	itr := kv.NewPartitionIterator(ctx, store.Store, (&graveler.StagedEntryData{}).ProtoReflect().Type(), graveler.StagingTokenPartition(st))
+func NewStagingIterator(ctx context.Context, store kv.StoreMessage, st graveler.StagingToken, batchSize int) (*Iterator, error) {
+	itr := kv.NewPartitionIterator(ctx, store.Store, (&graveler.StagedEntryData{}).ProtoReflect().Type(), graveler.StagingTokenPartition(st), batchSize)
 	return &Iterator{
 		ctx:   ctx,
 		store: store,

--- a/pkg/graveler/staging/manager.go
+++ b/pkg/graveler/staging/manager.go
@@ -92,7 +92,6 @@ func (m *Manager) DropKey(ctx context.Context, st graveler.StagingToken, key gra
 	return m.store.DeleteMsg(ctx, graveler.StagingTokenPartition(st), key)
 }
 
-// List TODO niro: Remove batchSize parameter post KV
 // List returns an iterator of staged values on the staging token st
 func (m *Manager) List(ctx context.Context, st graveler.StagingToken, batchSize int) (graveler.ValueIterator, error) {
 	return NewStagingIterator(ctx, m.store, st, batchSize)

--- a/pkg/graveler/staging/manager.go
+++ b/pkg/graveler/staging/manager.go
@@ -94,8 +94,8 @@ func (m *Manager) DropKey(ctx context.Context, st graveler.StagingToken, key gra
 
 // List TODO niro: Remove batchSize parameter post KV
 // List returns an iterator of staged values on the staging token st
-func (m *Manager) List(ctx context.Context, st graveler.StagingToken, _ int) (graveler.ValueIterator, error) {
-	return NewStagingIterator(ctx, m.store, st)
+func (m *Manager) List(ctx context.Context, st graveler.StagingToken, batchSize int) (graveler.ValueIterator, error) {
+	return NewStagingIterator(ctx, m.store, st, batchSize)
 }
 
 func (m *Manager) Drop(ctx context.Context, st graveler.StagingToken) error {
@@ -146,7 +146,7 @@ func (m *Manager) asyncLoop(ctx context.Context) {
 }
 
 func (m *Manager) findAndDrop(ctx context.Context) error {
-	it, err := m.store.Store.Scan(ctx, []byte(graveler.CleanupTokensPartition()), []byte{})
+	it, err := m.store.Store.Scan(ctx, []byte(graveler.CleanupTokensPartition()), kv.ScanOptions{})
 	if err != nil {
 		return err
 	}

--- a/pkg/kv/iterators_test.go
+++ b/pkg/kv/iterators_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 
 	"github.com/golang/mock/gomock"
-	"github.com/treeverse/lakefs/pkg/graveler"
 	"github.com/treeverse/lakefs/pkg/kv"
+	"github.com/treeverse/lakefs/pkg/kv/kvtest"
 	"github.com/treeverse/lakefs/pkg/kv/mock"
 )
 
@@ -19,7 +19,7 @@ func TestPartitionIterator_ClosedBehaviour(t *testing.T) {
 	entIt.EXPECT().Close().Times(1)
 	store.EXPECT().Scan(ctx, gomock.Any(), gomock.Any()).Return(entIt, nil).Times(1)
 
-	it := kv.NewPartitionIterator(ctx, store, (&graveler.StagedEntryData{}).ProtoReflect().Type(), "partitionKey")
+	it := kv.NewPartitionIterator(ctx, store, (&kvtest.TestModel{}).ProtoReflect().Type(), "partitionKey", 0)
 	it.SeekGE([]byte("test"))
 	it.Close()
 
@@ -37,7 +37,7 @@ func TestPartitionIterator_CloseAfterSeekGEFailed(t *testing.T) {
 	entItErr := errors.New("failed to scan")
 	store.EXPECT().Scan(ctx, gomock.Any(), gomock.Any()).Return(entIt, entItErr).Times(1)
 
-	it := kv.NewPartitionIterator(ctx, store, (&graveler.StagedEntryData{}).ProtoReflect().Type(), "partitionKey")
+	it := kv.NewPartitionIterator(ctx, store, (&kvtest.TestModel{}).ProtoReflect().Type(), "partitionKey", 0)
 	it.SeekGE([]byte("test"))
 	it.Close() // verify we don't crash after after SeekGE failed internally with Scan
 }

--- a/pkg/kv/kvtest/iterators.go
+++ b/pkg/kv/kvtest/iterators.go
@@ -43,7 +43,7 @@ func testPartitionIterator(t *testing.T, ms MakeStore) {
 	}
 
 	t.Run("listing all values of partition", func(t *testing.T) {
-		itr := kv.NewPartitionIterator(ctx, store, (&TestModel{}).ProtoReflect().Type(), firstPartitionKey)
+		itr := kv.NewPartitionIterator(ctx, store, (&TestModel{}).ProtoReflect().Type(), firstPartitionKey, 0)
 		if itr == nil {
 			t.Fatalf("failed to create partition iterator")
 		}
@@ -67,7 +67,7 @@ func testPartitionIterator(t *testing.T, ms MakeStore) {
 	})
 
 	t.Run("listing values SeekGE", func(t *testing.T) {
-		itr := kv.NewPartitionIterator(ctx, store, (&TestModel{}).ProtoReflect().Type(), secondPartitionKey)
+		itr := kv.NewPartitionIterator(ctx, store, (&TestModel{}).ProtoReflect().Type(), secondPartitionKey, 0)
 		if itr == nil {
 			t.Fatalf("failed to create partition iterator")
 		}
@@ -92,7 +92,7 @@ func testPartitionIterator(t *testing.T, ms MakeStore) {
 	})
 
 	t.Run("failed SeekGE partition not found", func(t *testing.T) {
-		itr := kv.NewPartitionIterator(ctx, store, (&TestModel{}).ProtoReflect().Type(), "")
+		itr := kv.NewPartitionIterator(ctx, store, (&TestModel{}).ProtoReflect().Type(), "", 0)
 		if itr == nil {
 			t.Fatalf("failed to create partition iterator")
 		}

--- a/pkg/kv/local/iterator.go
+++ b/pkg/kv/local/iterator.go
@@ -19,22 +19,6 @@ type EntriesIterator struct {
 	logger       logging.Logger
 }
 
-func newEntriesIterator(logger logging.Logger, db *badger.DB, partitionKey, start []byte, prefetchSize int) *EntriesIterator {
-	prefix := partitionRange(partitionKey)
-	txn := db.NewTransaction(false)
-	opts := badger.DefaultIteratorOptions
-	opts.PrefetchSize = prefetchSize
-	opts.Prefix = prefix
-	iter := txn.NewIterator(opts)
-	return &EntriesIterator{
-		iter:         iter,
-		partitionKey: partitionKey,
-		start:        composeKey(partitionKey, start),
-		logger:       logger,
-		txn:          txn,
-	}
-}
-
 func (e *EntriesIterator) Next() bool {
 	if e.err != nil {
 		return false

--- a/pkg/kv/local/store_test.go
+++ b/pkg/kv/local/store_test.go
@@ -1,7 +1,6 @@
 package local_test
 
 import (
-	"os"
 	"testing"
 
 	"github.com/treeverse/lakefs/pkg/kv/kvtest"
@@ -10,16 +9,10 @@ import (
 )
 
 func TestLocalKV(t *testing.T) {
-	dir, err := os.MkdirTemp("", "local_kv_testing_*")
-	if err != nil {
-		t.Fatalf("could not created temp: %v", err)
-	}
-	defer os.RemoveAll(dir)
-
 	kvtest.TestDriver(t, local.DriverName, kvparams.KV{
 		Type: local.DriverName,
 		Local: &kvparams.Local{
-			Path:          dir,
+			Path:          t.TempDir(),
 			EnableLogging: true,
 		},
 	})

--- a/pkg/kv/mem/store.go
+++ b/pkg/kv/mem/store.go
@@ -145,11 +145,15 @@ func (s *Store) Delete(_ context.Context, partitionKey, key []byte) error {
 	return nil
 }
 
-func (s *Store) Scan(_ context.Context, partitionKey, start []byte) (kv.EntriesIterator, error) {
+func (s *Store) Scan(_ context.Context, partitionKey []byte, options kv.ScanOptions) (kv.EntriesIterator, error) {
 	if len(partitionKey) == 0 {
 		return nil, kv.ErrMissingPartitionKey
 	}
 
+	start := options.KeyStart
+	if start == nil {
+		start = []byte{}
+	}
 	return &EntriesIterator{
 		store:     s,
 		start:     start,

--- a/pkg/kv/metrics.go
+++ b/pkg/kv/metrics.go
@@ -45,10 +45,10 @@ func (s *StoreMetricsWrapper) Delete(ctx context.Context, partitionKey, key []by
 	return s.Store.Delete(ctx, partitionKey, key)
 }
 
-func (s *StoreMetricsWrapper) Scan(ctx context.Context, partitionKey, start []byte) (EntriesIterator, error) {
+func (s *StoreMetricsWrapper) Scan(ctx context.Context, partitionKey []byte, options ScanOptions) (EntriesIterator, error) {
 	timer := prometheus.NewTimer(requestDuration.WithLabelValues(s.StoreType, "Scan"))
 	defer timer.ObserveDuration()
-	return s.Store.Scan(ctx, partitionKey, start)
+	return s.Store.Scan(ctx, partitionKey, options)
 }
 
 func (s *StoreMetricsWrapper) Close() {

--- a/pkg/kv/scan.go
+++ b/pkg/kv/scan.go
@@ -50,7 +50,9 @@ func ScanPrefix(ctx context.Context, store Store, partitionKey, prefix, after []
 	if len(after) > 0 && string(after) > string(prefix) {
 		start = after
 	}
-	iter, err := store.Scan(ctx, partitionKey, start)
+	iter, err := store.Scan(ctx, partitionKey, ScanOptions{
+		KeyStart: start,
+	})
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kv/store.go
+++ b/pkg/kv/store.go
@@ -60,6 +60,11 @@ type ValueWithPredicate struct {
 	Predicate Predicate
 }
 
+type ScanOptions struct {
+	KeyStart  []byte
+	BatchSize int
+}
+
 type Store interface {
 	// Get returns a result containing the Value and Predicate for the given key, or ErrNotFound if key doesn't exist
 	//   Predicate can be used for SetIf operation
@@ -79,7 +84,9 @@ type Store interface {
 
 	// Scan returns entries that can be read by key order, starting at or after the `start` position
 	// partitionKey is optional, passing it might increase performance.
-	Scan(ctx context.Context, partitionKey, start []byte) (EntriesIterator, error)
+	// 'options' holds additional parameters to limit the number of records
+	//  and set the prefix to scan.
+	Scan(ctx context.Context, partitionKey []byte, options ScanOptions) (EntriesIterator, error)
 
 	// Close access to the database store. After calling Close the instance is unusable.
 	Close()

--- a/pkg/kv/store.go
+++ b/pkg/kv/store.go
@@ -61,7 +61,10 @@ type ValueWithPredicate struct {
 }
 
 type ScanOptions struct {
-	KeyStart  []byte
+	// KeyStart start key to seek the scan
+	KeyStart []byte
+	// BatchSize used by each implementation to perform limited query or fetching of data while scanning.
+	// The 0 value means - use the default by the implementation.
 	BatchSize int
 }
 
@@ -82,10 +85,9 @@ type Store interface {
 	// Delete will delete the key, no error in if key doesn't exist
 	Delete(ctx context.Context, partitionKey, key []byte) error
 
-	// Scan returns entries that can be read by key order, starting at or after the `start` position
+	// Scan returns entries that can be read by key order
 	// partitionKey is optional, passing it might increase performance.
-	// 'options' holds additional parameters to limit the number of records
-	//  and set the prefix to scan.
+	// 'options' holds optional parameters to control the batch size and the key to start the scan with.
 	Scan(ctx context.Context, partitionKey []byte, options ScanOptions) (EntriesIterator, error)
 
 	// Close access to the database store. After calling Close the instance is unusable.

--- a/pkg/kv/store_test.go
+++ b/pkg/kv/store_test.go
@@ -39,7 +39,7 @@ func (m *MockStore) Delete(_ context.Context, _, _ []byte) error {
 	return errNotImplemented
 }
 
-func (m *MockStore) Scan(_ context.Context, _, _ []byte) (kv.EntriesIterator, error) {
+func (m *MockStore) Scan(_ context.Context, _ []byte, _ kv.ScanOptions) (kv.EntriesIterator, error) {
 	return nil, errNotImplemented
 }
 

--- a/pkg/testutil/db.go
+++ b/pkg/testutil/db.go
@@ -256,7 +256,7 @@ func ValidateKV(ctx context.Context, t *testing.T, store kv.Store, entries int) 
 func CleanupKV(ctx context.Context, t *testing.T, store kv.Store) {
 	t.Helper()
 
-	scan, err := store.Scan(ctx, []byte(testPartitionKey), []byte{0})
+	scan, err := store.Scan(ctx, []byte(testPartitionKey), kv.ScanOptions{KeyStart: []byte{0}})
 	MustDo(t, "scan store", err)
 	defer scan.Close()
 


### PR DESCRIPTION
Close #4712

Pass listing in catalog level to the KV driver level.
Listing works with paginations, while KV with iterators.
In this PR the caller can pass recommended batch size to the KV level so the implementation can utilize our resources better and perform faster for specific actions.