### PR TITLE
Support MinIO

### DIFF
--- a/clients/spark/core/src/main/hadoop2/scala/io/treeverse/clients/conditional/S3ClientBuilder.scala
+++ b/clients/spark/core/src/main/hadoop2/scala/io/treeverse/clients/conditional/S3ClientBuilder.scala
@@ -14,6 +14,7 @@ object S3ClientBuilder extends io.treeverse.clients.S3ClientBuilder {
     import org.apache.hadoop.fs.s3a.Constants
 
     val configuration = new ClientConfiguration().withMaxErrorRetry(numRetries)
+    val s3Endpoint = hc.get(Constants.ENDPOINT)
 
     val credentialsProvider =
       if (hc.get(Constants.ACCESS_KEY) != null) {
@@ -29,9 +30,13 @@ object S3ClientBuilder extends io.treeverse.clients.S3ClientBuilder {
         )
       } else None
 
+    val builder = AmazonS3ClientBuilder.standard()
+      .withPathStyleAccessEnabled(hc.getBoolean("fs.s3a.path.style.access", true))
+
     createAndValidateS3Client(configuration,
                               credentialsProvider,
-                              AmazonS3ClientBuilder.standard(),
+                              builder,
+                              s3Endpoint,
                               region,
                               bucket
                              )

--- a/clients/spark/core/src/main/hadoop3/scala/io/treeverse/clients/conditional/S3ClientBuilder.scala
+++ b/clients/spark/core/src/main/hadoop3/scala/io/treeverse/clients/conditional/S3ClientBuilder.scala
@@ -15,6 +15,7 @@ object S3ClientBuilder extends io.treeverse.clients.S3ClientBuilder {
     import com.amazonaws.auth.{BasicAWSCredentials, AWSStaticCredentialsProvider}
 
     val configuration = new ClientConfiguration().withMaxErrorRetry(numRetries)
+    val s3Endpoint = hc.get(Constants.ENDPOINT)
 
     // TODO(ariels): Support different per-bucket configuration methods.
     //     Possibly pre-generate a FileSystem to access the desired bucket,
@@ -37,9 +38,13 @@ object S3ClientBuilder extends io.treeverse.clients.S3ClientBuilder {
         )
       } else None
 
+    val builder = AmazonS3ClientBuilder.standard()
+      .withPathStyleAccessEnabled(hc.getBoolean("fs.s3a.path.style.access", true))
+
     createAndValidateS3Client(configuration,
                               credentialsProvider,
-                              AmazonS3ClientBuilder.standard(),
+                              builder,
+                              s3Endpoint,
                               region,
                               bucket
                              )

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/StorageUtils.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/StorageUtils.scala
@@ -1,6 +1,7 @@
 package io.treeverse.clients
 
 import com.amazonaws.auth.AWSCredentialsProvider
+import com.amazonaws.client.builder.AwsClientBuilder
 import com.amazonaws.services.s3.model.{HeadBucketRequest, Region}
 import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
 import com.amazonaws.{AmazonServiceException, ClientConfiguration}
@@ -71,6 +72,7 @@ object StorageUtils {
         configuration: ClientConfiguration,
         credentialsProvider: Option[AWSCredentialsProvider],
         awsS3ClientBuilder: AmazonS3ClientBuilder,
+        endpoint: String,
         region: String,
         bucket: String
     ): AmazonS3 = {
@@ -79,7 +81,7 @@ object StorageUtils {
       require(bucket.nonEmpty)
 
       var client =
-        initializeS3Client(configuration, credentialsProvider, awsS3ClientBuilder, region)
+        initializeS3Client(configuration, credentialsProvider, awsS3ClientBuilder, endpoint, region)
 
       if (!validateClientAndBucketRegionsMatch(client, bucket)) {
         val bucketRegion = getAWSS3Region(client, bucket)
@@ -89,6 +91,7 @@ object StorageUtils {
         client = initializeS3Client(configuration,
                                     credentialsProvider,
                                     AmazonS3ClientBuilder.standard(),
+                                    endpoint,
                                     bucketRegion
                                    )
       }
@@ -99,11 +102,13 @@ object StorageUtils {
         configuration: ClientConfiguration,
         credentialsProvider: Option[AWSCredentialsProvider],
         awsS3ClientBuilder: AmazonS3ClientBuilder,
+        endpoint: String,
         region: String
     ): AmazonS3 = {
       val builder = awsS3ClientBuilder
         .withClientConfiguration(configuration)
-        .withRegion(region)
+        .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(endpoint, region))
+
       val builderWithCredentials = credentialsProvider match {
         case Some(cp) => builder.withCredentials(cp)
         case None     => builder

--- a/clients/spark/core/src/test/scala/io/treeverse/clients/StorageUtilsSpec.scala
+++ b/clients/spark/core/src/test/scala/io/treeverse/clients/StorageUtilsSpec.scala
@@ -26,6 +26,7 @@ class StorageUtilsSpec extends AnyFunSpec with BeforeAndAfter with MockitoSugar 
   private var server: MockWebServer = null
   private var clientConfiguration: ClientConfiguration = null
 
+  private val ENDPOINT = "http://s3.example.net"
   private val US_STANDARD = "US"
   private val US_WEST_2 = "us-west-2"
   private val BUCKET_NAME = "bucket"
@@ -49,6 +50,7 @@ class StorageUtilsSpec extends AnyFunSpec with BeforeAndAfter with MockitoSugar 
         clientConfiguration,
         Some(credentialsProvider),
         awsS3ClientBuilder,
+        ENDPOINT,
         US_WEST_2,
         BUCKET_NAME
       )
@@ -208,6 +210,7 @@ class StorageUtilsSpec extends AnyFunSpec with BeforeAndAfter with MockitoSugar 
       clientConfiguration,
       Some(credentialsProvider),
       awsS3ClientBuilder,
+      ENDPOINT,
       US_STANDARD,
       BUCKET_NAME
     )


### PR DESCRIPTION
hard as fixing, so this PR does the latter.

Most of the code already works, of course.  But GC creates its own S3
client.  It is _not_ the same as the S3A client and these differences
were significant:

* S3 endpoint needs to be configured.  Otherwise, the client accesses
  the wrong "S3".
* For most MinIO installations the client needs to be configured with
  path style.  Otherwise it will attempt host style access by default
  and time out in some cases such as when running in Docker.

  Note that this cannot be configured on Hadoop versions before 2.8.0
  so users will need to use a suitable build to GC on Spark 2.4.7.  A
  mitigating factor is that this is _anyway_ needed to use Spark with
  MinIO -- regardless of GC or indeed lakeFS!

With these in place I was able to GC using the Spark 3.1.2 / Hadoop 3
build.

Fixes #4795.  I will split testing on MinIO in Esti off of that issue
for separate work.