### PR TITLE
GC: Parallelize metarange fetching

### DIFF
--- a/clients/spark/core/src/main/scala/io/treeverse/clients/LakeFSContext.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/LakeFSContext.scala
@@ -61,6 +61,7 @@ object LakeFSContext {
   val LAKEFS_CONF_JOB_COMMIT_ID_KEY = "lakefs.job.commit_id"
   val LAKEFS_CONF_JOB_SOURCE_NAME_KEY = "lakefs.job.source_name"
 
+  val LAKEFS_CONF_GC_NUM_COMMIT_PARTITIONS = "lakefs.gc.commit.num_partitions"
   val LAKEFS_CONF_GC_NUM_RANGE_PARTITIONS = "lakefs.gc.range.num_partitions"
   val LAKEFS_CONF_GC_NUM_ADDRESS_PARTITIONS = "lakefs.gc.address.num_partitions"
   val LAKEFS_CONF_DEBUG_GC_MAX_COMMIT_ISO_DATETIME_KEY = "lakefs.debug.gc.max_commit_iso_datetime"
@@ -78,6 +79,7 @@ object LakeFSContext {
   val MARK_ID_KEY = "mark_id"
   val RUN_ID_KEY = "run_id"
   val COMMITS_LOCATION_KEY = "commits_location"
+  val DEFAULT_LAKEFS_CONF_GC_NUM_COMMIT_PARTITIONS = 24
   val DEFAULT_LAKEFS_CONF_GC_NUM_RANGE_PARTITIONS = 50
   val DEFAULT_LAKEFS_CONF_GC_NUM_ADDRESS_PARTITIONS = 200
 

--- a/test/spark/run-gc-test.sh
+++ b/test/spark/run-gc-test.sh
@@ -26,11 +26,13 @@ run_gc_according_to_storage_provider() {
     docker-compose run -v ${CLIENT_JAR}:/client/client.jar -T --no-deps --rm spark-submit bash -c "spark-submit -v --packages org.apache.hadoop:hadoop-azure:3.2.1 --master spark://spark:7077 \
      --class io.treeverse.clients.GarbageCollector ${additional_config_string} -c spark.hadoop.lakefs.api.url=http://docker.lakefs.io:8000/api/v1 -c spark.hadoop.lakefs.api.access_key=\${TESTER_ACCESS_KEY_ID} \
      -c spark.hadoop.lakefs.api.secret_key=\${TESTER_SECRET_ACCESS_KEY} -c spark.hadoop.lakefs.api.connection.timeout_seconds=3 -c spark.hadoop.lakefs.api.read.timeout_seconds=8 -c \
+     -c spark.hadoop.lakefs.gc.commit.num_partitions=2 \
      spark.hadoop.fs.azure.account.key.\${LAKEFS_BLOCKSTORE_AZURE_STORAGE_ACCOUNT}.dfs.core.windows.net=\${LAKEFS_BLOCKSTORE_AZURE_STORAGE_ACCESS_KEY} ${parallelism} /client/client.jar ${repo}"
   else
     docker-compose run -v ${CLIENT_JAR}:/client/client.jar -T --no-deps --rm spark-submit bash -c "spark-submit -v --master spark://spark:7077 --class io.treeverse.clients.GarbageCollector \
      -c spark.hadoop.lakefs.api.url=http://docker.lakefs.io:8000/api/v1 ${additional_config_string} -c spark.hadoop.lakefs.api.access_key=\${TESTER_ACCESS_KEY_ID} \
      -c spark.hadoop.lakefs.api.secret_key=\${TESTER_SECRET_ACCESS_KEY} -c spark.hadoop.fs.s3a.access.key=\${AWS_ACCESS_KEY_ID} -c spark.hadoop.fs.s3a.secret.key=\${AWS_SECRET_ACCESS_KEY} \
+     -c spark.hadoop.lakefs.gc.commit.num_partitions=2 \
      ${parallelism} /client/client.jar ${repo} us-east-1"
   fi
 }

--- a/test/spark/run-gc-test.sh
+++ b/test/spark/run-gc-test.sh
@@ -25,9 +25,9 @@ run_gc_according_to_storage_provider() {
   if [[ ${LAKEFS_BLOCKSTORE_TYPE} == "azure" ]]; then
     docker-compose run -v ${CLIENT_JAR}:/client/client.jar -T --no-deps --rm spark-submit bash -c "spark-submit -v --packages org.apache.hadoop:hadoop-azure:3.2.1 --master spark://spark:7077 \
      --class io.treeverse.clients.GarbageCollector ${additional_config_string} -c spark.hadoop.lakefs.api.url=http://docker.lakefs.io:8000/api/v1 -c spark.hadoop.lakefs.api.access_key=\${TESTER_ACCESS_KEY_ID} \
-     -c spark.hadoop.lakefs.api.secret_key=\${TESTER_SECRET_ACCESS_KEY} -c spark.hadoop.lakefs.api.connection.timeout_seconds=3 -c spark.hadoop.lakefs.api.read.timeout_seconds=8 -c \
+     -c spark.hadoop.lakefs.api.secret_key=\${TESTER_SECRET_ACCESS_KEY} -c spark.hadoop.lakefs.api.connection.timeout_seconds=3 -c spark.hadoop.lakefs.api.read.timeout_seconds=8 \
      -c spark.hadoop.lakefs.gc.commit.num_partitions=2 \
-     spark.hadoop.fs.azure.account.key.\${LAKEFS_BLOCKSTORE_AZURE_STORAGE_ACCOUNT}.dfs.core.windows.net=\${LAKEFS_BLOCKSTORE_AZURE_STORAGE_ACCESS_KEY} ${parallelism} /client/client.jar ${repo}"
+     -c spark.hadoop.fs.azure.account.key.\${LAKEFS_BLOCKSTORE_AZURE_STORAGE_ACCOUNT}.dfs.core.windows.net=\${LAKEFS_BLOCKSTORE_AZURE_STORAGE_ACCESS_KEY} ${parallelism} /client/client.jar ${repo}"
   else
     docker-compose run -v ${CLIENT_JAR}:/client/client.jar -T --no-deps --rm spark-submit bash -c "spark-submit -v --master spark://spark:7077 --class io.treeverse.clients.GarbageCollector \
      -c spark.hadoop.lakefs.api.url=http://docker.lakefs.io:8000/api/v1 ${additional_config_string} -c spark.hadoop.lakefs.api.access_key=\${TESTER_ACCESS_KEY_ID} \


### PR DESCRIPTION
Resolves #4890.

1. Re-partition commit dataset, so that fetching the ranges will be parallelized.
2. ~Make ranges distinct before getting all their addresses.~
3. ~Change flatMap, which seemed to cause parallelization problems, to mapPartitions + flatMap.~

After testing, it seems that (1) gives a significant performance gain (75% faster) on our E2E monitoring. The other ones did not improve speed in my setting - we will test these in the future in other settings.