### PR TITLE
API delete will not return object not found

### DIFF
--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -3094,7 +3094,7 @@ paths:
       tags:
         - objects
       operationId: deleteObject
-      summary: delete object
+      summary: delete object. Missing objects will not return a NotFound error.
       responses:
         204:
           description: object deleted successfully
@@ -3121,7 +3121,7 @@ paths:
       tags:
         - objects
       operationId: deleteObjects
-      summary: delete objects
+      summary: delete objects. Missing objects will not return a NotFound error.
       requestBody:
         required: true
         content:

--- a/clients/java/README.md
+++ b/clients/java/README.md
@@ -187,8 +187,8 @@ Class | Method | HTTP request | Description
 *MetadataApi* | [**createSymlinkFile**](docs/MetadataApi.md#createSymlinkFile) | **POST** /repositories/{repository}/refs/{branch}/symlink | creates symlink files corresponding to the given directory
 *MetadataApi* | [**getMetaRange**](docs/MetadataApi.md#getMetaRange) | **GET** /repositories/{repository}/metadata/meta_range/{meta_range} | return URI to a meta-range file
 *MetadataApi* | [**getRange**](docs/MetadataApi.md#getRange) | **GET** /repositories/{repository}/metadata/range/{range} | return URI to a range file
-*ObjectsApi* | [**deleteObject**](docs/ObjectsApi.md#deleteObject) | **DELETE** /repositories/{repository}/branches/{branch}/objects | delete object
-*ObjectsApi* | [**deleteObjects**](docs/ObjectsApi.md#deleteObjects) | **POST** /repositories/{repository}/branches/{branch}/objects/delete | delete objects
+*ObjectsApi* | [**deleteObject**](docs/ObjectsApi.md#deleteObject) | **DELETE** /repositories/{repository}/branches/{branch}/objects | delete object. Missing objects will not return a NotFound error.
+*ObjectsApi* | [**deleteObjects**](docs/ObjectsApi.md#deleteObjects) | **POST** /repositories/{repository}/branches/{branch}/objects/delete | delete objects. Missing objects will not return a NotFound error.
 *ObjectsApi* | [**getObject**](docs/ObjectsApi.md#getObject) | **GET** /repositories/{repository}/refs/{ref}/objects | get object content
 *ObjectsApi* | [**getUnderlyingProperties**](docs/ObjectsApi.md#getUnderlyingProperties) | **GET** /repositories/{repository}/refs/{ref}/objects/underlyingProperties | get object properties on underlying storage
 *ObjectsApi* | [**headObject**](docs/ObjectsApi.md#headObject) | **HEAD** /repositories/{repository}/refs/{ref}/objects | check if object exists

--- a/clients/java/api/openapi.yaml
+++ b/clients/java/api/openapi.yaml
@@ -3434,7 +3434,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: Internal Server Error
-      summary: delete object
+      summary: delete object. Missing objects will not return a NotFound error.
       tags:
       - objects
       x-accepts: application/json
@@ -3650,7 +3650,7 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: Internal Server Error
-      summary: delete objects
+      summary: delete objects. Missing objects will not return a NotFound error.
       tags:
       - objects
       x-contentType: application/json

--- a/clients/java/docs/ObjectsApi.md
+++ b/clients/java/docs/ObjectsApi.md
@@ -4,8 +4,8 @@ All URIs are relative to *http://localhost/api/v1*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**deleteObject**](ObjectsApi.md#deleteObject) | **DELETE** /repositories/{repository}/branches/{branch}/objects | delete object
-[**deleteObjects**](ObjectsApi.md#deleteObjects) | **POST** /repositories/{repository}/branches/{branch}/objects/delete | delete objects
+[**deleteObject**](ObjectsApi.md#deleteObject) | **DELETE** /repositories/{repository}/branches/{branch}/objects | delete object. Missing objects will not return a NotFound error.
+[**deleteObjects**](ObjectsApi.md#deleteObjects) | **POST** /repositories/{repository}/branches/{branch}/objects/delete | delete objects. Missing objects will not return a NotFound error.
 [**getObject**](ObjectsApi.md#getObject) | **GET** /repositories/{repository}/refs/{ref}/objects | get object content
 [**getUnderlyingProperties**](ObjectsApi.md#getUnderlyingProperties) | **GET** /repositories/{repository}/refs/{ref}/objects/underlyingProperties | get object properties on underlying storage
 [**headObject**](ObjectsApi.md#headObject) | **HEAD** /repositories/{repository}/refs/{ref}/objects | check if object exists
@@ -19,7 +19,7 @@ Method | HTTP request | Description
 # **deleteObject**
 > deleteObject(repository, branch, path)
 
-delete object
+delete object. Missing objects will not return a NotFound error.
 
 ### Example
 ```java
@@ -107,7 +107,7 @@ null (empty response body)
 # **deleteObjects**
 > ObjectErrorList deleteObjects(repository, branch, pathList)
 
-delete objects
+delete objects. Missing objects will not return a NotFound error.
 
 ### Example
 ```java

--- a/clients/java/src/main/java/io/lakefs/clients/api/ObjectsApi.java
+++ b/clients/java/src/main/java/io/lakefs/clients/api/ObjectsApi.java
@@ -139,7 +139,7 @@ public class ObjectsApi {
     }
 
     /**
-     * delete object
+     * delete object. Missing objects will not return a NotFound error.
      * 
      * @param repository  (required)
      * @param branch  (required)
@@ -159,7 +159,7 @@ public class ObjectsApi {
     }
 
     /**
-     * delete object
+     * delete object. Missing objects will not return a NotFound error.
      * 
      * @param repository  (required)
      * @param branch  (required)
@@ -181,7 +181,7 @@ public class ObjectsApi {
     }
 
     /**
-     * delete object (asynchronously)
+     * delete object. Missing objects will not return a NotFound error. (asynchronously)
      * 
      * @param repository  (required)
      * @param branch  (required)
@@ -278,7 +278,7 @@ public class ObjectsApi {
     }
 
     /**
-     * delete objects
+     * delete objects. Missing objects will not return a NotFound error.
      * 
      * @param repository  (required)
      * @param branch  (required)
@@ -300,7 +300,7 @@ public class ObjectsApi {
     }
 
     /**
-     * delete objects
+     * delete objects. Missing objects will not return a NotFound error.
      * 
      * @param repository  (required)
      * @param branch  (required)
@@ -323,7 +323,7 @@ public class ObjectsApi {
     }
 
     /**
-     * delete objects (asynchronously)
+     * delete objects. Missing objects will not return a NotFound error. (asynchronously)
      * 
      * @param repository  (required)
      * @param branch  (required)

--- a/clients/java/src/test/java/io/lakefs/clients/api/ObjectsApiTest.java
+++ b/clients/java/src/test/java/io/lakefs/clients/api/ObjectsApiTest.java
@@ -40,7 +40,7 @@ public class ObjectsApiTest {
 
     
     /**
-     * delete object
+     * delete object. Missing objects will not return a NotFound error.
      *
      * 
      *
@@ -57,7 +57,7 @@ public class ObjectsApiTest {
     }
     
     /**
-     * delete objects
+     * delete objects. Missing objects will not return a NotFound error.
      *
      * 
      *

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -168,8 +168,8 @@ Class | Method | HTTP request | Description
 *MetadataApi* | [**create_symlink_file**](docs/MetadataApi.md#create_symlink_file) | **POST** /repositories/{repository}/refs/{branch}/symlink | creates symlink files corresponding to the given directory
 *MetadataApi* | [**get_meta_range**](docs/MetadataApi.md#get_meta_range) | **GET** /repositories/{repository}/metadata/meta_range/{meta_range} | return URI to a meta-range file
 *MetadataApi* | [**get_range**](docs/MetadataApi.md#get_range) | **GET** /repositories/{repository}/metadata/range/{range} | return URI to a range file
-*ObjectsApi* | [**delete_object**](docs/ObjectsApi.md#delete_object) | **DELETE** /repositories/{repository}/branches/{branch}/objects | delete object
-*ObjectsApi* | [**delete_objects**](docs/ObjectsApi.md#delete_objects) | **POST** /repositories/{repository}/branches/{branch}/objects/delete | delete objects
+*ObjectsApi* | [**delete_object**](docs/ObjectsApi.md#delete_object) | **DELETE** /repositories/{repository}/branches/{branch}/objects | delete object. Missing objects will not return a NotFound error.
+*ObjectsApi* | [**delete_objects**](docs/ObjectsApi.md#delete_objects) | **POST** /repositories/{repository}/branches/{branch}/objects/delete | delete objects. Missing objects will not return a NotFound error.
 *ObjectsApi* | [**get_object**](docs/ObjectsApi.md#get_object) | **GET** /repositories/{repository}/refs/{ref}/objects | get object content
 *ObjectsApi* | [**get_underlying_properties**](docs/ObjectsApi.md#get_underlying_properties) | **GET** /repositories/{repository}/refs/{ref}/objects/underlyingProperties | get object properties on underlying storage
 *ObjectsApi* | [**head_object**](docs/ObjectsApi.md#head_object) | **HEAD** /repositories/{repository}/refs/{ref}/objects | check if object exists

--- a/clients/python/docs/ObjectsApi.md
+++ b/clients/python/docs/ObjectsApi.md
@@ -4,8 +4,8 @@ All URIs are relative to *http://localhost/api/v1*
 
 Method | HTTP request | Description
 ------------- | ------------- | -------------
-[**delete_object**](ObjectsApi.md#delete_object) | **DELETE** /repositories/{repository}/branches/{branch}/objects | delete object
-[**delete_objects**](ObjectsApi.md#delete_objects) | **POST** /repositories/{repository}/branches/{branch}/objects/delete | delete objects
+[**delete_object**](ObjectsApi.md#delete_object) | **DELETE** /repositories/{repository}/branches/{branch}/objects | delete object. Missing objects will not return a NotFound error.
+[**delete_objects**](ObjectsApi.md#delete_objects) | **POST** /repositories/{repository}/branches/{branch}/objects/delete | delete objects. Missing objects will not return a NotFound error.
 [**get_object**](ObjectsApi.md#get_object) | **GET** /repositories/{repository}/refs/{ref}/objects | get object content
 [**get_underlying_properties**](ObjectsApi.md#get_underlying_properties) | **GET** /repositories/{repository}/refs/{ref}/objects/underlyingProperties | get object properties on underlying storage
 [**head_object**](ObjectsApi.md#head_object) | **HEAD** /repositories/{repository}/refs/{ref}/objects | check if object exists
@@ -18,7 +18,7 @@ Method | HTTP request | Description
 # **delete_object**
 > delete_object(repository, branch, path)
 
-delete object
+delete object. Missing objects will not return a NotFound error.
 
 ### Example
 
@@ -77,7 +77,7 @@ with lakefs_client.ApiClient(configuration) as api_client:
 
     # example passing only required values which don't have defaults set
     try:
-        # delete object
+        # delete object. Missing objects will not return a NotFound error.
         api_instance.delete_object(repository, branch, path)
     except lakefs_client.ApiException as e:
         print("Exception when calling ObjectsApi->delete_object: %s\n" % e)
@@ -120,7 +120,7 @@ void (empty response body)
 # **delete_objects**
 > ObjectErrorList delete_objects(repository, branch, path_list)
 
-delete objects
+delete objects. Missing objects will not return a NotFound error.
 
 ### Example
 
@@ -185,7 +185,7 @@ with lakefs_client.ApiClient(configuration) as api_client:
 
     # example passing only required values which don't have defaults set
     try:
-        # delete objects
+        # delete objects. Missing objects will not return a NotFound error.
         api_response = api_instance.delete_objects(repository, branch, path_list)
         pprint(api_response)
     except lakefs_client.ApiException as e:

--- a/clients/python/lakefs_client/api/objects_api.py
+++ b/clients/python/lakefs_client/api/objects_api.py
@@ -729,7 +729,7 @@ class ObjectsApi(object):
         path,
         **kwargs
     ):
-        """delete object  # noqa: E501
+        """delete object. Missing objects will not return a NotFound error.  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
@@ -802,7 +802,7 @@ class ObjectsApi(object):
         path_list,
         **kwargs
     ):
-        """delete objects  # noqa: E501
+        """delete objects. Missing objects will not return a NotFound error.  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True

--- a/clients/python/test/test_objects_api.py
+++ b/clients/python/test/test_objects_api.py
@@ -27,14 +27,14 @@ class TestObjectsApi(unittest.TestCase):
     def test_delete_object(self):
         """Test case for delete_object
 
-        delete object  # noqa: E501
+        delete object. Missing objects will not return a NotFound error.  # noqa: E501
         """
         pass
 
     def test_delete_objects(self):
         """Test case for delete_objects
 
-        delete objects  # noqa: E501
+        delete objects. Missing objects will not return a NotFound error.  # noqa: E501
         """
         pass
 

--- a/docs/assets/js/swagger.yml
+++ b/docs/assets/js/swagger.yml
@@ -3094,7 +3094,7 @@ paths:
       tags:
         - objects
       operationId: deleteObject
-      summary: delete object
+      summary: delete object. Missing objects will not return a NotFound error.
       responses:
         204:
           description: object deleted successfully
@@ -3121,7 +3121,7 @@ paths:
       tags:
         - objects
       operationId: deleteObjects
-      summary: delete objects
+      summary: delete objects. Missing objects will not return a NotFound error.
       requestBody:
         required: true
         content:

--- a/pkg/graveler/graveler.go
+++ b/pkg/graveler/graveler.go
@@ -1451,7 +1451,7 @@ func (g *Graveler) safeBranchWrite(ctx context.Context, log logging.Logger, repo
 			"try":               try + 1,
 			"branch_token_pre":  branchPreOp.StagingToken,
 			"branch_token_post": branchPostOp.StagingToken,
-		}).Info("Retrying Set")
+		}).Debug("Retrying Set")
 	}
 	if try == BranchWriteMaxTries {
 		return fmt.Errorf("safe branch write: %w", ErrTooManyTries)

--- a/pkg/graveler/graveler_test.go
+++ b/pkg/graveler/graveler_test.go
@@ -1670,7 +1670,7 @@ func TestGravelerDelete(t *testing.T) {
 				},
 			},
 			args:        args{key: []byte("key1")},
-			expectedErr: graveler.ErrNotFound,
+			expectedErr: nil,
 		},
 		{
 			name: "exists only in staging - commits",
@@ -1711,7 +1711,7 @@ func TestGravelerDelete(t *testing.T) {
 				},
 			},
 			args:        args{},
-			expectedErr: graveler.ErrNotFound,
+			expectedErr: nil,
 		},
 	}
 	for _, tt := range tests {


### PR DESCRIPTION
**Change in API `delete object`**

On the following cases the API will not return NotFound error:

- when tombstone found on stage
- when object not found on branch commit

Fix #4798