### PR TITLE
Consistently shade everything as io.lakefs.<client>.shade.*

### DIFF
--- a/clients/hadoopfs/pom.xml
+++ b/clients/hadoopfs/pom.xml
@@ -148,27 +148,27 @@ To export to S3:
                                     <relocations>
                                         <relocation>
                                             <pattern>org.apache.httpcomponents</pattern>
-                                            <shadedPattern>io.lakefs.shaded.apache.httpcomponents</shadedPattern>
+                                            <shadedPattern>io.lakefs.hadoopfs.shade.org.apache.httpcomponents</shadedPattern>
                                         </relocation>
                                         <relocation>
                                             <pattern>okio</pattern>
-                                            <shadedPattern>io.lakefs.shaded.okio</shadedPattern>
+                                            <shadedPattern>io.lakefs.hadoopfs.shade.okio</shadedPattern>
                                         </relocation>
                                         <relocation>
                                             <pattern>okhttp3</pattern>
-                                            <shadedPattern>io.lakefs.shaded.okhttp3</shadedPattern>
+                                            <shadedPattern>io.lakefs.hadoop.shade.okhttp3</shadedPattern>
                                         </relocation>
                                         <relocation>
                                             <pattern>com.google.gson</pattern>
-                                            <shadedPattern>io.lakefs.shaded.gson</shadedPattern>
+                                            <shadedPattern>io.lakefs.hadoop.shade.gson</shadedPattern>
                                         </relocation>
                                         <relocation>
                                             <pattern>io.gsonfire</pattern>
-                                            <shadedPattern>io.lakefs.shaded.gsonfire</shadedPattern>
+                                            <shadedPattern>io.lakefs.hadoop.shade.gsonfire</shadedPattern>
                                         </relocation>
                                         <relocation>
                                             <pattern>io.lakefs.clients.api</pattern>
-                                            <shadedPattern>io.lakefs.shaded.api</shadedPattern>
+                                            <shadedPattern>io.lakefs.hadoop.shade.api</shadedPattern>
                                         </relocation>
                                     </relocations>
                                     <transformers>

--- a/clients/spark/build.sbt
+++ b/clients/spark/build.sbt
@@ -148,6 +148,8 @@ lazy val examples312 = generateExamplesProject(spark312Type).dependsOn(core312)
 lazy val root =
   (project in file(".")).aggregate(core2, core3, core312, examples2, examples3, examples312)
 
+def rename(prefix: String) = ShadeRule.rename(prefix -> "io.lakefs.spark.shade.@0")
+
 // We are using the default sbt assembly merge strategy https://github.com/sbt/sbt-assembly#merge-strategy with a change
 // to the general case: use MergeStrategy.first instead of MergeStrategy.deduplicate.
 lazy val assemblySettings = Seq(
@@ -169,19 +171,18 @@ lazy val assemblySettings = Seq(
     case _ => MergeStrategy.first
   },
   assembly / assemblyShadeRules := Seq(
-    ShadeRule.rename("org.apache.http.**" -> "org.apache.httpShaded@1").inAll,
-    ShadeRule.rename("com.google.protobuf.**" -> "shadeproto.@1").inAll,
-    ShadeRule
-      .rename("com.google.common.**" -> "shadegooglecommon.@1")
+    rename("org.apache.http.**").inAll,
+    rename("com.google.protobuf.**").inAll,
+    rename("com.google.common.**")
       .inLibrary("com.google.guava" % "guava" % "30.1-jre",
                  "com.google.guava" % "failureaccess" % "1.0.1"
                 )
       .inProject,
-    ShadeRule.rename("scala.collection.compat.**" -> "shadecompat.@1").inAll,
-    ShadeRule.rename("okio.**" -> "okio.shaded.@0").inAll,
-    ShadeRule.rename("okhttp3.**" -> "okhttp3.shaded.@0").inAll,
-    ShadeRule.rename("reactor.netty.**" -> "shadereactor.netty.@1").inAll,
-    ShadeRule.rename("reactor.util.**" -> "shadereactor.util.@1").inAll
+    rename("scala.collection.compat.**").inAll,
+    rename("okio.**").inAll,
+    rename("okhttp3.**").inAll,
+    rename("reactor.netty.**").inAll,
+    rename("reactor.util.**").inAll
   )
 )
 

--- a/test/lakefsfs/build.sbt
+++ b/test/lakefsfs/build.sbt
@@ -58,9 +58,9 @@ lazy val root = (project in file("."))
 lazy val assemblySettings = Seq(
   assembly / assemblyMergeStrategy := (_ => MergeStrategy.first),
   assembly / assemblyShadeRules := Seq(
-    ShadeRule.rename("okio.**" -> "okio.shaded.@0").inAll,
-    ShadeRule.rename("okhttp3.**" -> "okhttp3.shaded.@0").inAll,
-    ShadeRule.rename("scala.collection.compat.**" -> "shadecompat.@1").inAll,
+    ShadeRule.rename("okio.**" -> "io.lakefs.test.shade.@0").inAll,
+    ShadeRule.rename("okhttp3.**" -> "io.lakefs.test.shade.@0").inAll,
+    ShadeRule.rename("scala.collection.compat.**" -> "io.lakefs.test.shade.@0").inAll,
   ),
 )
 


### PR DESCRIPTION
Apply a single identical shading naming rule to clients: To shade a library
com.bar.baz in a client foo, use io.lakefs.foo.com.bar.baz.  This:

* Is easy to predict and clear to debug
* Guarantees uniqueness among other packages by using a prefix that we own
* Guarantees uniqueness among our clients by using the client name

Fixes #3823.