### PR TITLE
fix: loading of duckdb every query

### DIFF
--- a/webui/src/pages/repositories/repository/fileRenderers/data.tsx
+++ b/webui/src/pages/repositories/repository/fileRenderers/data.tsx
@@ -91,7 +91,7 @@ LIMIT 20`
 
         if (!data || data.numRows === 0) {
             content = (
-                <p className={"text-md-center mt-5 mb-5"}>
+                <p className="text-md-center mt-5 mb-5">
                     No rows returned.
                 </p>
             )
@@ -108,7 +108,7 @@ LIMIT 20`
                         <small>{`Showing only the first ${res.numRows.toLocaleString()} rows (out of ${data.numRows.toLocaleString()})`}</small>
                     }
                     <div className="object-viewer-sql-results">
-                        <Table striped bordered hover size={"sm"} responsive={"sm"} className="sticky-table">
+                        <Table striped bordered hover size={"sm"} responsive={"sm"}>
                             <thead className="thead-dark">
                             <tr>
                                 {fields.map((field, i) =>

--- a/webui/src/pages/repositories/repository/fileRenderers/data.tsx
+++ b/webui/src/pages/repositories/repository/fileRenderers/data.tsx
@@ -1,12 +1,14 @@
 import React, {FC, FormEvent, useCallback, useEffect, useRef, useState} from "react";
 import {Error, Loading} from "../../../../lib/components/controls";
-import {withConnection} from "./duckdb";
-import {Table} from "react-bootstrap";
+import {getConnection} from "./duckdb";
+import * as duckdb from '@duckdb/duckdb-wasm';
+import * as arrow from 'apache-arrow';
 import Form from "react-bootstrap/Form";
 import Button from "react-bootstrap/Button";
 import {DatabaseIcon} from "@primer/octicons-react";
 import dayjs from "dayjs";
 import {RendererComponent} from "./types";
+import Table from "react-bootstrap/Table";
 
 
 const MAX_RESULTS_RETURNED = 1000;
@@ -30,7 +32,7 @@ LIMIT 20`
     }
     const [shouldSubmit, setShouldSubmit] = useState<boolean>(true)
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const [data, setData] = useState<any[] | null>(null);
+    const [data, setData] = useState<arrow.Table<any> | null>(null);
     const [error, setError] = useState<string | null>(null)
     const [loading, setLoading] = useState<boolean>(false)
 
@@ -38,79 +40,95 @@ LIMIT 20`
 
     const handleSubmit = useCallback((event: FormEvent<HTMLFormElement>) => {
         event.preventDefault()
-        setShouldSubmit(!shouldSubmit)
+        setShouldSubmit(prev => !prev)
     }, [setShouldSubmit])
 
     useEffect(() => {
-        setLoading(true)
-        withConnection(async conn => {
-            if (!sql || !sql.current) return
-            const results = await conn.query(sql.current.value)
-            const data = results.toArray()
-            setData(data)
+        if (!sql || !sql.current)
+            return
+        const runQuery = async (sql: string) => {
+            setLoading(true)
             setError(null)
+            let conn: duckdb.AsyncDuckDBConnection | null
+            try {
+                conn =  await getConnection()
+            } catch (e) {
+                setData(null)
+                setError(e.toString())
+                setLoading(false)
+                return
+            }
 
-        }).catch(e => {
-            setError(e.toString())
-        }).finally(() => {
-            setLoading(false)
-        })
+            try {
+                const results = await conn.query(sql)
+                setData(results)
+                setError(null)
+            } catch (e) {
+                setError(e.toString())
+                setData(null)
+            } finally {
+                setLoading(false)
+                if (conn !== null)
+                    await conn.close()
+            }
+        }
+        runQuery(sql.current.value).catch(console.error);
     }, [repoId, refId, path, shouldSubmit])
 
-
     let content;
-    let button = (
-        <Button type="submit" variant={"success"} >
-            <DatabaseIcon/>{' '}
-            Execute
+    const button = (
+        <Button type="submit" variant="success" disabled={loading}>
+            <DatabaseIcon /> {" "}
+            { loading ? "Executing..." : "Execute" }
         </Button>
-    )
-    if (loading) {
-        button = (
-            <Button type="submit" variant={"success"} disabled>
-                <DatabaseIcon/>{' '}
-                Executing...
-            </Button>
-        )
-    }
+    );
 
     if (error) {
         content = <Error error={error}/>
     } else if (data === null) {
         content = <DataLoader/>
     } else {
-        if (!data || data.length === 0) {
+
+        if (!data || data.numRows === 0) {
             content = (
                 <p className={"text-md-center mt-5 mb-5"}>
                     No rows returned.
                 </p>
             )
         } else {
-            const totalRows = data.length
+            const fields = data.schema.fields
+            const totalRows = data.numRows
             let res = data;
             if (totalRows > MAX_RESULTS_RETURNED) {
                 res = data.slice(0, MAX_RESULTS_RETURNED)
             }
             content = (
                 <>
-                    {(res.length < data.length) &&
-                        <small>{`Showing only the first ${res.length.toLocaleString()} rows (out of ${data.length.toLocaleString()})`}</small>
+                    {(res.numRows < data.numRows) &&
+                        <small>{`Showing only the first ${res.numRows.toLocaleString()} rows (out of ${data.numRows.toLocaleString()})`}</small>
                     }
                     <div className="object-viewer-sql-results">
                         <Table striped bordered hover size={"sm"} responsive={"sm"} className="sticky-table">
                             <thead className="thead-dark">
                             <tr>
-                                {Object.getOwnPropertyNames(res[0]).map(name =>
-                                    <th key={name}>{name}</th>
+                                {fields.map((field, i) =>
+                                    <th key={i}>
+                                        {field.name}
+                                        <br/>
+                                        <small>{field.type.toString()}</small>
+                                    </th>
                                 )}
                             </tr>
                             </thead>
                             <tbody>
-                            {res.map((row, i) => (
+                            {[...res].map((row, i) => (
                                 <tr key={`row-${i}`}>
-                                    {Object.getOwnPropertyNames(res[0]).map(name => (
-                                        <DataRow key={`row-${i}-${name}`} value={row[name]}/>
-                                    ))}
+                                    {[...row].map((v, j: number) => {
+                                        return (
+                                            <DataRow key={`col-${i}-${j}`} value={v[1]}/>
+                                        )
+
+                                    })}
                                 </tr>
                             ))}
                             </tbody>
@@ -125,7 +143,7 @@ LIMIT 20`
         <div>
             <Form onSubmit={handleSubmit}>
                 <Form.Group className="mb-2 mt-2" controlId="objectQuery">
-                    <Form.Control as="textarea" className="object-viewer-sql-input" rows={5} defaultValue={initialQuery} spellCheck={false} ref={sql} />
+                    <Form.Control as="textarea" className="object-viewer-sql-input" rows={5} defaultValue={initialQuery} spellCheck={false} ref={sql} autoComplete="off"/>
 
                     <Form.Text className="text-muted align-right">
                         Powered by <a href="https://duckdb.org/2021/10/29/duckdb-wasm.html" target="_blank" rel="noreferrer">DuckDB-WASM</a>.
@@ -135,7 +153,7 @@ LIMIT 20`
                 </Form.Group>
                 {button}
             </Form>
-            <div className={"mt-3"}>
+            <div className="mt-3">
                 {content}
             </div>
         </div>

--- a/webui/src/pages/repositories/repository/fileRenderers/data.tsx
+++ b/webui/src/pages/repositories/repository/fileRenderers/data.tsx
@@ -1,8 +1,7 @@
-import React, {FC, FormEvent, useEffect, useRef, useState} from "react";
+import React, {FC, FormEvent, useCallback, useEffect, useRef, useState} from "react";
 import {Error, Loading} from "../../../../lib/components/controls";
 import {withConnection} from "./duckdb";
 import {Table} from "react-bootstrap";
-import Alert from "react-bootstrap/Alert";
 import Form from "react-bootstrap/Form";
 import Button from "react-bootstrap/Button";
 import {DatabaseIcon} from "@primer/octicons-react";
@@ -37,21 +36,23 @@ LIMIT 20`
 
     const sql = useRef<HTMLTextAreaElement>(null);
 
-    const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    const handleSubmit = useCallback((event: FormEvent<HTMLFormElement>) => {
         event.preventDefault()
         setShouldSubmit(!shouldSubmit)
-    }
+    }, [setShouldSubmit])
 
     useEffect(() => {
         setLoading(true)
         withConnection(async conn => {
-            const results = await conn.query(sql.current!.value)
+            if (!sql || !sql.current) return
+            const results = await conn.query(sql.current.value)
             const data = results.toArray()
             setData(data)
             setError(null)
-            setLoading(false)
+
         }).catch(e => {
             setError(e.toString())
+        }).finally(() => {
             setLoading(false)
         })
     }, [repoId, refId, path, shouldSubmit])

--- a/webui/src/pages/repositories/repository/fileRenderers/duckdb.tsx
+++ b/webui/src/pages/repositories/repository/fileRenderers/duckdb.tsx
@@ -5,6 +5,53 @@ import duckdb_wasm_eh from '@duckdb/duckdb-wasm/dist/duckdb-eh.wasm?url';
 import eh_worker from '@duckdb/duckdb-wasm/dist/duckdb-browser-eh.worker.js?url';
 
 
+// based on the replacement rules on the percent-encoding MDN page:
+// https://developer.mozilla.org/en-US/docs/Glossary/Percent-encoding
+// also, I tried doing something nicer with list comprehensions and printf('%x') to convert
+//  from unicode code point to hex - DuckDB didn't seem to evaluate lambdas and list comprehensions
+// when padding a macro to a table function such as read_parquet() or read_csv().
+// so - string replacements it is.
+const URL_ENCODE_MACRO_SQL = `
+CREATE MACRO p_encode(s) AS
+    replace(
+        replace(
+            replace(
+                replace(
+                    replace(
+                        replace(
+                            replace(
+                                replace(
+                                    replace(
+                                        replace(
+                                            replace(
+                                                replace(
+                                                    replace(
+                                                        replace(
+                                                            replace(
+                                                                replace(
+                                                                    replace(
+                                                                        replace(
+                                                                            replace(s, '%', '%25'),
+                                                                            '/', '%2F'),
+                                                                        '?', '%3F'),
+                                                                    '#', '%23'),
+                                                                '[', '%5B'),
+                                                            ']', '%5D'),
+                                                        '@', '%40'),
+                                                    '!', '%21'),
+                                                '$', '%24'),
+                                            '&', '%26'),
+                                        '''', '%27'),
+                                    '(', '%28'),
+                                ')', '%29'),
+                            '+', '%2B'),
+                        ',', '%2C'),
+                    ';', '%3B'),
+                '=','%3D'),
+            ' ', '%20'),
+        ':', '%3A');
+`
+
 
 const MANUAL_BUNDLES: duckdb.DuckDBBundles = {
     mvp: {
@@ -28,18 +75,15 @@ async function getDB(): Promise<duckdb.AsyncDuckDB> {
             throw Error("could not initialize DuckDB")
         }
         _worker = new Worker(bundle.mainWorker);
-        const logger = new duckdb.VoidLogger();
-        const db = new duckdb.AsyncDuckDB(logger, _worker);
+        const db = new duckdb.AsyncDuckDB(new duckdb.VoidLogger(), _worker);
         await db.instantiate(bundle.mainModule, bundle.pthreadWorker);
         const conn = await db.connect()
+        // await conn.query(`SET access_mode = READ_ONLY`)
+        await conn.query(URL_ENCODE_MACRO_SQL)
         await conn.query(`
-            CREATE MACRO lakefs_object(repoId, refId, path) AS 
-            '${document.location.protocol}//${document.location.host}/api/v1/repositories/' || 
-            repoId || 
-            '/refs/' || 
-            refId ||
-            '/objects?path=' ||
-             replace(path, '/', '%2F')
+            CREATE MACRO lakefs_object(repoId, refId, path) AS
+                '${document.location.protocol}//${document.location.host}/api/v1/repositories/' ||
+                p_encode(repoId) || '/refs/' || p_encode(refId) || '/objects?path=' || p_encode(path);
         `)
         await conn.close()
         _db = db
@@ -47,11 +91,8 @@ async function getDB(): Promise<duckdb.AsyncDuckDB> {
     return _db
 }
 
-export async function withConnection(cb: (conn: duckdb.AsyncDuckDBConnection) => void) {
+export async function getConnection(): Promise<duckdb.AsyncDuckDBConnection> {
     // Instantiate the async version of DuckDB-wasm
     const db = await getDB()
-    const conn = await db.connect()
-    const results = await cb(conn)
-    await conn.close()
-    return results
+    return await db.connect()
 }

--- a/webui/src/pages/repositories/repository/fileRenderers/duckdb.tsx
+++ b/webui/src/pages/repositories/repository/fileRenderers/duckdb.tsx
@@ -9,6 +9,7 @@ import eh_worker from '@duckdb/duckdb-wasm/dist/duckdb-browser-eh.worker.js?url'
 // https://developer.mozilla.org/en-US/docs/Glossary/Percent-encoding
 // also, I tried doing something nicer with list comprehensions and printf('%x') to convert
 //  from unicode code point to hex - DuckDB didn't seem to evaluate lambdas and list comprehensions
+// Issue: https://github.com/duckdb/duckdb/issues/5821
 // when padding a macro to a table function such as read_parquet() or read_csv().
 // so - string replacements it is.
 const URL_ENCODE_MACRO_SQL = `

--- a/webui/src/pages/repositories/repository/fileRenderers/duckdb.tsx
+++ b/webui/src/pages/repositories/repository/fileRenderers/duckdb.tsx
@@ -32,22 +32,19 @@ async function getDB(): Promise<duckdb.AsyncDuckDB> {
         const db = new duckdb.AsyncDuckDB(logger, _worker);
         await db.instantiate(bundle.mainModule, bundle.pthreadWorker);
         const conn = await db.connect()
-        await conn.query(`CREATE MACRO lakefs_object(repoId, refId, path) AS '${document.location.protocol}//${document.location.host}/api/v1/repositories/' || repoId || '/refs/' || refId || '/objects?path=' || replace(path, '/', '%2F');`)
+        await conn.query(`
+            CREATE MACRO lakefs_object(repoId, refId, path) AS 
+            '${document.location.protocol}//${document.location.host}/api/v1/repositories/' || 
+            repoId || 
+            '/refs/' || 
+            refId ||
+            '/objects?path=' ||
+             replace(path, '/', '%2F')
+        `)
         await conn.close()
         _db = db
     }
     return _db
-}
-
-async function teardownDB() {
-    if (_db) {
-        await _db.terminate()
-        _db = null
-    }
-    if (_worker) {
-        await _worker.terminate()
-        _worker = null
-    }
 }
 
 export async function withConnection(cb: (conn: duckdb.AsyncDuckDBConnection) => void) {

--- a/webui/src/styles/globals.css
+++ b/webui/src/styles/globals.css
@@ -616,3 +616,20 @@ td .form-group {
 .required-field-label {
   color: red;
 }
+
+/* SQL tables with sticky headers */
+.sticky-table tbody {
+  display:block;
+  height:200px;
+  overflow-y:scroll;
+}
+.sticky-table thead{
+  display:table;
+  width:98.7%;
+  table-layout:fixed;
+}
+.sticky-table tbody tr {
+  display:table;
+  width:100%;
+  table-layout:fixed;
+}

--- a/webui/src/styles/globals.css
+++ b/webui/src/styles/globals.css
@@ -595,8 +595,10 @@ td .form-group {
 }
 .object-viewer-sql-results {
   overflow: auto;
-  font-size: .7rem;
+  font-size: .75rem;
+  max-height: 400px;
 }
+
 .image-container {
   padding: 30px;
 }
@@ -614,21 +616,4 @@ td .form-group {
 
 .required-field-label {
   color: red;
-}
-
-/* SQL tables with sticky headers */
-.sticky-table tbody {
-  display:block;
-  height:350px;
-  overflow-y:scroll;
-}
-.sticky-table thead{
-  display:table;
-  width:98.7%;
-  table-layout:fixed;
-}
-.sticky-table tbody tr {
-  display:table;
-  width:100%;
-  table-layout:fixed;
 }

--- a/webui/src/styles/globals.css
+++ b/webui/src/styles/globals.css
@@ -594,7 +594,6 @@ td .form-group {
   color: #FFFFFF;
 }
 .object-viewer-sql-results {
-  max-height: 350px;
   overflow: auto;
   font-size: .7rem;
 }
@@ -620,7 +619,7 @@ td .form-group {
 /* SQL tables with sticky headers */
 .sticky-table tbody {
   display:block;
-  height:200px;
+  height:350px;
   overflow-y:scroll;
 }
 .sticky-table thead{


### PR DESCRIPTION
Fix the duckDB wasm package being downloaded on every query (as well as a few minor tweaks to the UX of running said queries)