### PR TITLE
Refactor lakefs_export script output

### DIFF
--- a/.github/workflows/esti.yaml
+++ b/.github/workflows/esti.yaml
@@ -788,8 +788,8 @@ jobs:
       - name: Test rclone export
         env:
           EXPORT_LOCATION: s3://esti-system-testing/${{ github.run_number }}-rclone-export-dest/${{ steps.unique.outputs.value }}
-          S3_ACCESS_KEY: ${{ secrets.ESTI_AWS_ACCESS_KEY_ID }}
-          S3_SECRET_KEY: ${{ secrets.ESTI_AWS_SECRET_ACCESS_KEY }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.ESTI_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.ESTI_AWS_SECRET_ACCESS_KEY }}
         working-directory: test/rclone_export
         run: ./run-test.sh
 

--- a/docs/howto/export.md
+++ b/docs/howto/export.md
@@ -198,12 +198,16 @@ Using this method, you can export data from lakeFS to S3 using the export option
 You will need to add the relevant environment variables.
 The complete `docker run` command would look like:
 
-```shell 
+```shell
 docker run \
--e LAKEFS_ACCESS_KEY=XXX -e LAKEFS_SECRET_KEY=YYY -e LAKEFS_ENDPOINT=https://<LAKEFS_ENDPOINT>/ \
--e S3_ACCESS_KEY=XXX -e S3_SECRET_KEY=YYY \
--it treeverse/lakefs-rclone-export:latest example-repo s3://destination-bucket/prefix/ --branch="example-branch"
-``` 
+    -e LAKEFS_ACCESS_KEY_ID=XXX -e LAKEFS_SECRET_ACCESS_KEY=YYY \
+	-e LAKEFS_ENDPOINT=https://<LAKEFS_ENDPOINT>/ \
+	-e AWS_ACCESS_KEY_ID=XXX -e AWS_SECRET_ACCESS_KEY=YYY \
+	treeverse/lakefs-rclone-export:latest \
+		example-repo \
+		s3://destination-bucket/prefix/ \
+		--branch="example-branch"
+```
 
 **Note:** This feature uses [rclone](https://rclone.org/){: target="_blank"},
 and specifically [rclone sync](https://rclone.org/commands/rclone_sync/){: target="_blank"}. This can change the destination path, therefore the s3 destination location must be designated to lakeFS export.

--- a/test/rclone_export/docker-compose.yaml
+++ b/test/rclone_export/docker-compose.yaml
@@ -32,7 +32,6 @@ services:
       - LAKEFS_ENDPOINT=http://lakefs:8000
     entrypoint: ["/app/wait-for", "postgres:5432", "--", "/app/lakefs", "run"]
 
-
   lakefs-export:
     image: "${REPO:-treeverse}/lakefs-rclone-export:${EXPORT_TAG:-latest}"
     depends_on:
@@ -41,13 +40,13 @@ services:
     profiles: ["client"]
     environment:
       - LAKEFS_ENDPOINT=http://lakefs:8000
-      - S3_ACCESS_KEY
-      - S3_SECRET_KEY
+      - AWS_ACCESS_KEY_ID
+      - AWS_SECRET_ACCESS_KEY
       - EXPORT_LOCATION
       - LAKECTL_CREDENTIALS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
       - LAKECTL_CREDENTIALS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-      - LAKEFS_ACCESS_KEY=AKIAIOSFODNN7EXAMPLE
-      - LAKEFS_SECRET_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+      - LAKEFS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
+      - LAKEFS_SECRET_ACCESS_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
 
 
 


### PR DESCRIPTION
* **Change environment variables used to configure lakefs_export.**  We now use the same environment variables as elsewhere:
  - For accessing S3: AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY
  - For accessing lakeFS: LAKEFS_ACCESS_KEY_ID, LAKEFS_SECRET_ACCESS_KEY
* lakefs_export now avoids most temporary files
* Don't read entire "rclone check" output into memory
* Detect "rclone check" success/failure directly rather than via error
  output, and correctly detects more failures.

This is part of #4841 but obviously not a fix for it.