### PR TITLE
fix: ingest range content type is wrong

### DIFF
--- a/pkg/catalog/walk_entry_iterator.go
+++ b/pkg/catalog/walk_entry_iterator.go
@@ -78,7 +78,6 @@ func NewWalkEntryIterator(ctx context.Context, walker *store.WalkerWrapper, prep
 						Size:         e.Size,
 						ETag:         e.ETag,
 						AddressType:  Entry_FULL,
-						ContentType:  e.Address,
 					},
 				},
 				Mark: Mark(it.walker.Marker()),


### PR DESCRIPTION
Removed the use of the physical address as the content type, as it's not a valid content type.
Since the walker function has no access to content types (nor does S3 when listing objects, for example), I believe it's better to leave the field empty than put something invalid.

Closes #4906 