### PR TITLE
Configurable repository and commit cache

### DIFF
--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -2105,7 +2105,7 @@ func TestController_ObjectsGetObjectHandler(t *testing.T) {
 		}
 		properties := resp.JSON200
 		if properties == nil {
-			t.Errorf("expected to get underlying properties, status code %d", resp.HTTPResponse.StatusCode)
+			t.Fatalf("expected to get underlying properties, status code %d", resp.StatusCode())
 		}
 
 		if api.StringValue(properties.StorageClass) != expensiveString {

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -228,11 +228,14 @@ func New(ctx context.Context, cfg Config) (*Catalog, error) {
 	executor := batch.NewConditionalExecutor(logging.Default())
 	go executor.Run(ctx)
 
-	refManager := ref.NewRefManager(ref.ManagerConfig{
-		Executor:        executor,
-		KvStore:         cfg.KVStore,
-		AddressProvider: ident.NewHexAddressProvider(),
-	})
+	refManager := ref.NewRefManager(
+		ref.ManagerConfig{
+			Executor:              executor,
+			KvStore:               cfg.KVStore,
+			AddressProvider:       ident.NewHexAddressProvider(),
+			RepositoryCacheConfig: cfg.Config.GravelerRepositoryCacheConfig(),
+			CommitCacheConfig:     cfg.Config.GravelerCommitCacheConfig(),
+		})
 	gcManager := retention.NewGarbageCollectionManager(tierFSParams.Adapter, refManager, cfg.Config.GetCommittedBlockStoragePrefix())
 	settingManager := settings.NewManager(refManager, *cfg.KVStore)
 	if cfg.SettingsManagerOption != nil {

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -233,8 +233,8 @@ func New(ctx context.Context, cfg Config) (*Catalog, error) {
 			Executor:              executor,
 			KvStore:               cfg.KVStore,
 			AddressProvider:       ident.NewHexAddressProvider(),
-			RepositoryCacheConfig: cfg.Config.GravelerRepositoryCacheConfig(),
-			CommitCacheConfig:     cfg.Config.GravelerCommitCacheConfig(),
+			RepositoryCacheConfig: cfg.Config.GetGravelerRepositoryCacheConfig(),
+			CommitCacheConfig:     cfg.Config.GetGravelerCommitCacheConfig(),
 		})
 	gcManager := retention.NewGarbageCollectionManager(tierFSParams.Adapter, refManager, cfg.Config.GetCommittedBlockStoragePrefix())
 	settingManager := settings.NewManager(refManager, *cfg.KVStore)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -451,7 +451,7 @@ func (c *Config) GetLoginDuration() time.Duration {
 	return c.values.Auth.LoginDuration
 }
 
-func (c *Config) GravelerRepositoryCacheConfig() ref.CacheConfig {
+func (c *Config) GetGravelerRepositoryCacheConfig() ref.CacheConfig {
 	return ref.CacheConfig{
 		Size:   c.values.Graveler.RepositoryCache.Size,
 		Expiry: c.values.Graveler.RepositoryCache.Expiry,
@@ -459,7 +459,7 @@ func (c *Config) GravelerRepositoryCacheConfig() ref.CacheConfig {
 	}
 }
 
-func (c *Config) GravelerCommitCacheConfig() ref.CacheConfig {
+func (c *Config) GetGravelerCommitCacheConfig() ref.CacheConfig {
 	return ref.CacheConfig{
 		Size:   c.values.Graveler.CommitCache.Size,
 		Expiry: c.values.Graveler.CommitCache.Expiry,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -21,6 +21,7 @@ import (
 	"github.com/treeverse/lakefs/pkg/block"
 	blockparams "github.com/treeverse/lakefs/pkg/block/params"
 	"github.com/treeverse/lakefs/pkg/graveler/committed"
+	"github.com/treeverse/lakefs/pkg/graveler/ref"
 	kvparams "github.com/treeverse/lakefs/pkg/kv/params"
 	"github.com/treeverse/lakefs/pkg/logging"
 	pyramidparams "github.com/treeverse/lakefs/pkg/pyramid/params"
@@ -448,4 +449,20 @@ func (c *Config) GetUIEnabled() bool {
 
 func (c *Config) GetLoginDuration() time.Duration {
 	return c.values.Auth.LoginDuration
+}
+
+func (c *Config) GravelerRepositoryCacheConfig() ref.CacheConfig {
+	return ref.CacheConfig{
+		Size:   c.values.Graveler.RepositoryCache.Size,
+		Expiry: c.values.Graveler.RepositoryCache.Expiry,
+		Jitter: c.values.Graveler.RepositoryCache.Jitter,
+	}
+}
+
+func (c *Config) GravelerCommitCacheConfig() ref.CacheConfig {
+	return ref.CacheConfig{
+		Size:   c.values.Graveler.CommitCache.Size,
+		Expiry: c.values.Graveler.CommitCache.Expiry,
+		Jitter: c.values.Graveler.CommitCache.Jitter,
+	}
 }

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -159,6 +159,19 @@ const (
 	LakefsEmailBaseURLKey      = "email.lakefs_base_url"
 
 	UIEnabledKey = "ui.enabled"
+
+	GravelerRepositoryCacheSizeKey       = "graveler.repository_cache.size"
+	DefaultGravelerRepositoryCacheSize   = 1000
+	GravelerRepositoryCacheExpiryKey     = "graveler.repository_cache.expiry"
+	DefaultGravelerRepositoryCacheExpiry = 5 * time.Second
+	GravelerRepositoryCacheJitterKey     = "graveler.repository_cache.jitter"
+	DefaultGravelerRepositoryCacheJitter = DefaultGravelerRepositoryCacheExpiry / 2
+	GravelerCommitCacheSizeKey           = "graveler.commit_cache.size"
+	DefaultGravelerCommitCacheSize       = 50000
+	GravelerCommitCacheExpiryKey         = "graveler.commit_cache.expiry"
+	DefaultGravelerCommitCacheExpiry     = 30 * time.Second
+	GravelerCommitCacheJitterKey         = "graveler.commit_cache.jitter"
+	DefaultGravelerCommitCacheJitter     = DefaultGravelerCommitCacheExpiry / 2
 )
 
 func setDefaults(local bool) {
@@ -243,4 +256,9 @@ func setDefaults(local bool) {
 	viper.SetDefault(DatabasePostgresMaxOpenConnectionsKey, DefaultDatabasePostgresMaxOpenConnections)
 	viper.SetDefault(DatabasePostgresMaxIdleConnectionsKey, DefaultDatabasePostgresMaxIdleConnections)
 	viper.SetDefault(PostgresConnectionMaxLifetimeKey, DefaultPostgresConnectionMaxLifetime)
+
+	viper.SetDefault(GravelerRepositoryCacheSizeKey, DefaultGravelerRepositoryCacheSize)
+	viper.SetDefault(GravelerRepositoryCacheExpiryKey, DefaultGravelerRepositoryCacheExpiry)
+	viper.SetDefault(GravelerCommitCacheSizeKey, DefaultGravelerCommitCacheSize)
+	viper.SetDefault(GravelerCommitCacheExpiryKey, DefaultGravelerCommitCacheExpiry)
 }

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -165,13 +165,13 @@ const (
 	GravelerRepositoryCacheExpiryKey     = "graveler.repository_cache.expiry"
 	DefaultGravelerRepositoryCacheExpiry = 5 * time.Second
 	GravelerRepositoryCacheJitterKey     = "graveler.repository_cache.jitter"
-	DefaultGravelerRepositoryCacheJitter = DefaultGravelerRepositoryCacheExpiry / 2
+	DefaultGravelerRepositoryCacheJitter = 2 * time.Second
 	GravelerCommitCacheSizeKey           = "graveler.commit_cache.size"
-	DefaultGravelerCommitCacheSize       = 50000
+	DefaultGravelerCommitCacheSize       = 50_000
 	GravelerCommitCacheExpiryKey         = "graveler.commit_cache.expiry"
-	DefaultGravelerCommitCacheExpiry     = 30 * time.Second
+	DefaultGravelerCommitCacheExpiry     = 10 * time.Minute
 	GravelerCommitCacheJitterKey         = "graveler.commit_cache.jitter"
-	DefaultGravelerCommitCacheJitter     = DefaultGravelerCommitCacheExpiry / 2
+	DefaultGravelerCommitCacheJitter     = 2 * time.Second
 )
 
 func setDefaults(local bool) {

--- a/pkg/config/template.go
+++ b/pkg/config/template.go
@@ -198,6 +198,18 @@ type configuration struct {
 			}
 		}
 	}
+	Graveler struct {
+		RepositoryCache struct {
+			Size   int           `mapstructure:"size"`
+			Expiry time.Duration `mapstructure:"expiry"`
+			Jitter time.Duration `mapstructure:"jitter"`
+		} `mapstructure:"repository_cache"`
+		CommitCache struct {
+			Size   int           `mapstructure:"size"`
+			Expiry time.Duration `mapstructure:"expiry"`
+			Jitter time.Duration `mapstructure:"jitter"`
+		} `mapstructure:"commit_cache"`
+	} `mapstructure:"graveler"`
 	Gateways struct {
 		S3 struct {
 			DomainNames Strings `mapstructure:"domain_name"`

--- a/pkg/graveler/ref/main_test.go
+++ b/pkg/graveler/ref/main_test.go
@@ -17,16 +17,14 @@ import (
 )
 
 var (
-	testRepoCacheConfig = &ref.CacheConfig{
-		Size:   ref.DefaultRepositoryCacheSize,
+	testRepoCacheConfig = ref.CacheConfig{
+		Size:   1000,
 		Expiry: 20 * time.Millisecond,
-		Jitter: 0,
 	}
 
-	testCommitCacheConfig = &ref.CacheConfig{
-		Size:   ref.DefaultCommitCacheSize,
+	testCommitCacheConfig = ref.CacheConfig{
+		Size:   5000,
 		Expiry: 20 * time.Millisecond,
-		Jitter: 0,
 	}
 )
 
@@ -36,11 +34,11 @@ func testRefManager(t testing.TB) (graveler.RefManager, *kv.StoreMessage) {
 	kvStore := kvtest.GetStore(ctx, t)
 	storeMessage := &kv.StoreMessage{Store: kvStore}
 	cfg := ref.ManagerConfig{
-		Executor:          batch.NopExecutor(),
-		KvStore:           storeMessage,
-		AddressProvider:   ident.NewHexAddressProvider(),
-		RepoCacheConfig:   testRepoCacheConfig,
-		CommitCacheConfig: testCommitCacheConfig,
+		Executor:              batch.NopExecutor(),
+		KvStore:               storeMessage,
+		AddressProvider:       ident.NewHexAddressProvider(),
+		RepositoryCacheConfig: testRepoCacheConfig,
+		CommitCacheConfig:     testCommitCacheConfig,
 	}
 	return ref.NewRefManager(cfg), storeMessage
 }
@@ -51,11 +49,11 @@ func testRefManagerWithAddressProvider(t testing.TB, addressProvider ident.Addre
 	kvStore := kvtest.GetStore(ctx, t)
 	storeMessage := &kv.StoreMessage{Store: kvStore}
 	cfg := ref.ManagerConfig{
-		Executor:          batch.NopExecutor(),
-		KvStore:           storeMessage,
-		AddressProvider:   addressProvider,
-		RepoCacheConfig:   testRepoCacheConfig,
-		CommitCacheConfig: testCommitCacheConfig,
+		Executor:              batch.NopExecutor(),
+		KvStore:               storeMessage,
+		AddressProvider:       addressProvider,
+		RepositoryCacheConfig: testRepoCacheConfig,
+		CommitCacheConfig:     testCommitCacheConfig,
 	}
 	return ref.NewRefManager(cfg), storeMessage
 }

--- a/pkg/graveler/ref/manager_test.go
+++ b/pkg/graveler/ref/manager_test.go
@@ -36,17 +36,17 @@ func TestManager_GetRepositoryCache(t *testing.T) {
 	storeMessage := &kv.StoreMessage{Store: mockStore}
 	ctx := context.Background()
 	mockStore.EXPECT().Get(ctx, []byte("graveler"), []byte("repos/repo1")).Times(times).Return(&kv.ValueWithPredicate{}, nil)
-	cacheConfig := &ref.CacheConfig{
+	cacheConfig := ref.CacheConfig{
 		Size:   100,
 		Expiry: 20 * time.Millisecond,
 		Jitter: 0,
 	}
 	cfg := ref.ManagerConfig{
-		Executor:          batch.NopExecutor(),
-		KvStore:           storeMessage,
-		AddressProvider:   ident.NewHexAddressProvider(),
-		RepoCacheConfig:   cacheConfig,
-		CommitCacheConfig: cacheConfig,
+		Executor:              batch.NopExecutor(),
+		KvStore:               storeMessage,
+		AddressProvider:       ident.NewHexAddressProvider(),
+		RepositoryCacheConfig: cacheConfig,
+		CommitCacheConfig:     cacheConfig,
 	}
 	refManager := ref.NewRefManager(cfg)
 	for i := 0; i < calls; i++ {
@@ -84,17 +84,16 @@ func TestManager_GetCommitCache(t *testing.T) {
 		Times(times).
 		Return(&kv.ValueWithPredicate{}, nil)
 
-	cacheConfig := &ref.CacheConfig{
+	cacheConfig := ref.CacheConfig{
 		Size:   100,
 		Expiry: 20 * time.Millisecond,
-		Jitter: 0,
 	}
 	cfg := ref.ManagerConfig{
-		Executor:          batch.NopExecutor(),
-		KvStore:           storeMessage,
-		AddressProvider:   ident.NewHexAddressProvider(),
-		RepoCacheConfig:   cacheConfig,
-		CommitCacheConfig: cacheConfig,
+		Executor:              batch.NopExecutor(),
+		KvStore:               storeMessage,
+		AddressProvider:       ident.NewHexAddressProvider(),
+		RepositoryCacheConfig: cacheConfig,
+		CommitCacheConfig:     cacheConfig,
 	}
 	refManager := ref.NewRefManager(cfg)
 	for i := 0; i < calls; i++ {


### PR DESCRIPTION
Close #4637

- Configurable cache size for repository and commit information.
- Increase the size of commit cache from 1k to 50k items.
- Increase the expiry of commit cache from 5sec to 10min.