### PR TITLE
KV scan ensure we use batch size while iterate

### DIFF
--- a/pkg/kv/dynamodb/store.go
+++ b/pkg/kv/dynamodb/store.go
@@ -106,7 +106,7 @@ func isTableExist(ctx context.Context, svc *dynamodb.DynamoDB, table string) (bo
 		TableName: aws.String(table),
 	})
 	if err != nil {
-		if asErr, ok := err.(awserr.Error); ok && asErr.Code() == dynamodb.ErrCodeResourceNotFoundException {
+		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == dynamodb.ErrCodeResourceNotFoundException {
 			return false, nil
 		}
 		return false, err
@@ -329,12 +329,8 @@ func (s *Store) Scan(ctx context.Context, partitionKey []byte, options kv.ScanOp
 	// limit set to the minimum 'params.ScanLimit' and 'options.BatchSize', unless 0 (not set)
 	limit := s.params.ScanLimit
 	batchSize := int64(options.BatchSize)
-	if batchSize > 0 {
-		if limit == 0 {
-			limit = batchSize
-		} else if batchSize < limit {
-			limit = batchSize
-		}
+	if batchSize != 0 && limit != 0 && batchSize < limit {
+		limit = batchSize
 	}
 
 	// format key and attribute expressions

--- a/pkg/kv/dynamodb/store.go
+++ b/pkg/kv/dynamodb/store.go
@@ -31,7 +31,6 @@ type EntriesIterator struct {
 	store                     *Store
 	queryResult               *dynamodb.QueryOutput
 	currEntryIdx              int64
-	partitionKey              []byte
 	keyConditionExpression    string
 	expressionAttributeValues map[string]*dynamodb.AttributeValue
 	limit                     int64

--- a/pkg/kv/dynamodb/store.go
+++ b/pkg/kv/dynamodb/store.go
@@ -25,14 +25,16 @@ type Store struct {
 }
 
 type EntriesIterator struct {
-	scanCtx      context.Context
-	entry        *kv.Entry
-	err          error
-	store        *Store
-	queryResult  *dynamodb.QueryOutput
-	currEntryIdx int
-	partKey      []byte
-	startKey     []byte
+	scanCtx                   context.Context
+	entry                     *kv.Entry
+	err                       error
+	store                     *Store
+	queryResult               *dynamodb.QueryOutput
+	currEntryIdx              int64
+	partitionKey              []byte
+	keyConditionExpression    string
+	expressionAttributeValues map[string]*dynamodb.AttributeValue
+	limit                     int64
 }
 
 type DynKVItem struct {
@@ -105,7 +107,7 @@ func isTableExist(ctx context.Context, svc *dynamodb.DynamoDB, table string) (bo
 		TableName: aws.String(table),
 	})
 	if err != nil {
-		if aerr, ok := err.(awserr.Error); ok && aerr.Code() == dynamodb.ErrCodeResourceNotFoundException {
+		if asErr, ok := err.(awserr.Error); ok && asErr.Code() == dynamodb.ErrCodeResourceNotFoundException {
 			return false, nil
 		}
 		return false, err
@@ -321,23 +323,28 @@ func (s *Store) Delete(ctx context.Context, partitionKey, key []byte) error {
 }
 
 func (s *Store) Scan(ctx context.Context, partitionKey []byte, options kv.ScanOptions) (kv.EntriesIterator, error) {
-	internalIter, err := s.scanInternal(ctx, partitionKey, options, nil)
-	if err != nil {
-		return nil, err
-	}
-	return internalIter, nil
-}
-
-func (s *Store) scanInternal(ctx context.Context, partitionKey []byte, options kv.ScanOptions, exclusiveStartKey map[string]*dynamodb.AttributeValue) (*EntriesIterator, error) {
 	if len(partitionKey) == 0 {
 		return nil, kv.ErrMissingPartitionKey
 	}
-	keyConditionExpression := PartitionKey + " = :partitionkey"
+
+	// limit set to the minimum 'params.ScanLimit' and 'options.BatchSize', unless 0 (not set)
+	limit := s.params.ScanLimit
+	batchSize := int64(options.BatchSize)
+	if batchSize > 0 {
+		if limit == 0 {
+			limit = batchSize
+		} else if batchSize < limit {
+			limit = batchSize
+		}
+	}
+
+	// format key and attribute expressions
 	expressionAttributeValues := map[string]*dynamodb.AttributeValue{
 		":partitionkey": {
 			B: partitionKey,
 		},
 	}
+	keyConditionExpression := PartitionKey + " = :partitionkey"
 	if len(options.KeyStart) > 0 {
 		keyConditionExpression += " AND " + ItemKey + " >= :fromkey"
 		expressionAttributeValues[":fromkey"] = &dynamodb.AttributeValue{
@@ -345,6 +352,26 @@ func (s *Store) scanInternal(ctx context.Context, partitionKey []byte, options k
 		}
 	}
 
+	queryResult, err := s.scanInternal(ctx, keyConditionExpression, expressionAttributeValues, limit, nil)
+	if err != nil {
+		return nil, err
+	}
+	it := &EntriesIterator{
+		scanCtx:                   ctx,
+		store:                     s,
+		keyConditionExpression:    keyConditionExpression,
+		expressionAttributeValues: expressionAttributeValues,
+		limit:                     limit,
+		queryResult:               queryResult,
+	}
+	return it, nil
+}
+
+func (s *Store) scanInternal(ctx context.Context, keyConditionExpression string,
+	expressionAttributeValues map[string]*dynamodb.AttributeValue,
+	limit int64,
+	exclusiveStartKey map[string]*dynamodb.AttributeValue,
+) (*dynamodb.QueryOutput, error) {
 	queryInput := &dynamodb.QueryInput{
 		TableName:                 aws.String(s.params.TableName),
 		KeyConditionExpression:    aws.String(keyConditionExpression),
@@ -354,17 +381,8 @@ func (s *Store) scanInternal(ctx context.Context, partitionKey []byte, options k
 		ExclusiveStartKey:         exclusiveStartKey,
 		ReturnConsumedCapacity:    aws.String(dynamodb.ReturnConsumedCapacityTotal),
 	}
-	// scan limit set to the minimum 'params.ScanLimit' and 'options.BatchSize', unless 0 (not set)
-	scanLimit := int(s.params.ScanLimit)
-	if options.BatchSize > 0 {
-		if scanLimit == 0 {
-			scanLimit = options.BatchSize
-		} else if options.BatchSize < scanLimit {
-			scanLimit = options.BatchSize
-		}
-	}
-	if scanLimit != 0 {
-		queryInput.SetLimit(int64(scanLimit))
+	if limit != 0 {
+		queryInput.SetLimit(limit)
 	}
 
 	start := time.Now()
@@ -377,15 +395,7 @@ func (s *Store) scanInternal(ctx context.Context, partitionKey []byte, options k
 	}
 	dynamoConsumedCapacity.WithLabelValues(operation).Add(*queryOutput.ConsumedCapacity.CapacityUnits)
 
-	return &EntriesIterator{
-		scanCtx:      ctx,
-		store:        s,
-		partKey:      partitionKey,
-		startKey:     options.KeyStart,
-		queryResult:  queryOutput,
-		currEntryIdx: 0,
-		err:          nil,
-	}, nil
+	return queryOutput, nil
 }
 
 func handleClientError(err error) error {
@@ -411,16 +421,16 @@ func (e *EntriesIterator) Next() bool {
 		return false
 	}
 
-	for e.currEntryIdx == int(*e.queryResult.Count) {
+	for e.currEntryIdx == aws.Int64Value(e.queryResult.Count) {
 		if e.queryResult.LastEvaluatedKey == nil {
 			return false
 		}
-		tmpEntriesIter, err := e.store.scanInternal(e.scanCtx, e.partKey, kv.ScanOptions{KeyStart: e.startKey}, e.queryResult.LastEvaluatedKey)
+		queryResult, err := e.store.scanInternal(e.scanCtx, e.keyConditionExpression, e.expressionAttributeValues, e.limit, e.queryResult.LastEvaluatedKey)
 		if err != nil {
 			e.err = fmt.Errorf("scan paging: %w", err)
 			return false
 		}
-		e.queryResult = tmpEntriesIter.queryResult
+		e.queryResult = queryResult
 		e.currEntryIdx = 0
 	}
 

--- a/pkg/kv/local/store.go
+++ b/pkg/kv/local/store.go
@@ -198,7 +198,7 @@ func (s *Store) Scan(ctx context.Context, partitionKey []byte, options kv.ScanOp
 	txn := s.db.NewTransaction(false)
 	opts := badger.DefaultIteratorOptions
 	opts.PrefetchSize = s.prefetchSize
-	if options.BatchSize > 0 && options.BatchSize < s.prefetchSize {
+	if options.BatchSize != 0 && opts.PrefetchSize != 0 && options.BatchSize < opts.PrefetchSize {
 		opts.PrefetchSize = options.BatchSize
 	}
 	if opts.PrefetchSize > 0 {

--- a/pkg/kv/postgres/store.go
+++ b/pkg/kv/postgres/store.go
@@ -27,11 +27,11 @@ type Store struct {
 
 type EntriesIterator struct {
 	ctx          context.Context
+	store        *Store
 	entries      []kv.Entry
+	limit        int
 	currEntryIdx int
 	err          error
-	store        *Store
-	options      kv.ScanOptions
 }
 
 const (
@@ -88,7 +88,7 @@ func (d *Driver) Open(ctx context.Context, kvParams kvparams.KV) (kv.Store, erro
 		return nil, fmt.Errorf("%w: %s", kv.ErrSetupFailed, err)
 	}
 
-	// register collector to publish pgxpool stats as metrics
+	// register collector to publish pgx's pool stats as metrics
 	var collector prometheus.Collector
 	if params.Metrics {
 		collector = pgxpoolprometheus.NewCollector(pool, map[string]string{"db_name": params.TableName})
@@ -280,28 +280,39 @@ func (s *Store) Scan(ctx context.Context, partitionKey []byte, options kv.ScanOp
 		return nil, kv.ErrMissingPartitionKey
 	}
 
-	// normalize batch size to be the minimum between ScanPageSize and ScanOptions
-	if options.BatchSize == 0 || s.Params.ScanPageSize < options.BatchSize {
-		options.BatchSize = s.Params.ScanPageSize
+	// limit based on the minimum between ScanPageSize and ScanOptions batch size
+	limit := s.Params.ScanPageSize
+	if options.BatchSize != 0 && s.Params.ScanPageSize != 0 && options.BatchSize < s.Params.ScanPageSize {
+		limit = options.BatchSize
 	}
 
-	return s.scanInternal(ctx, partitionKey, options, true)
+	entries, err := s.scanInternal(ctx, partitionKey, options.KeyStart, limit, true)
+	if err != nil {
+		return nil, err
+	}
+	return &EntriesIterator{
+		ctx:          ctx,
+		store:        s,
+		entries:      entries,
+		limit:        limit,
+		currEntryIdx: -1,
+	}, nil
 }
 
-func (s *Store) scanInternal(ctx context.Context, partitionKey []byte, options kv.ScanOptions, includeStart bool) (*EntriesIterator, error) {
+func (s *Store) scanInternal(ctx context.Context, partitionKey []byte, keyStart []byte, limit int, includeStart bool) ([]kv.Entry, error) {
 	var (
 		rows pgx.Rows
 		err  error
 	)
 
-	if options.KeyStart == nil {
-		rows, err = s.Pool.Query(ctx, `SELECT partition_key,key,value FROM `+s.Params.SanitizedTableName+` WHERE partition_key=$1 ORDER BY key LIMIT $2`, partitionKey, options.BatchSize)
+	if keyStart == nil {
+		rows, err = s.Pool.Query(ctx, `SELECT partition_key,key,value FROM `+s.Params.SanitizedTableName+` WHERE partition_key=$1 ORDER BY key LIMIT $2`, partitionKey, limit)
 	} else {
 		compareOp := ">="
 		if !includeStart {
 			compareOp = ">"
 		}
-		rows, err = s.Pool.Query(ctx, `SELECT partition_key,key,value FROM `+s.Params.SanitizedTableName+` WHERE partition_key=$1 AND key `+compareOp+` $2 ORDER BY key LIMIT $3`, partitionKey, options.KeyStart, options.BatchSize)
+		rows, err = s.Pool.Query(ctx, `SELECT partition_key,key,value FROM `+s.Params.SanitizedTableName+` WHERE partition_key=$1 AND key `+compareOp+` $2 ORDER BY key LIMIT $3`, partitionKey, keyStart, limit)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("postgres scan: %w", err)
@@ -313,14 +324,7 @@ func (s *Store) scanInternal(ctx context.Context, partitionKey []byte, options k
 	if err != nil {
 		return nil, fmt.Errorf("scanning all entries: %w", err)
 	}
-
-	return &EntriesIterator{
-		ctx:          ctx,
-		entries:      entries,
-		currEntryIdx: -1,
-		store:        s,
-		options:      options,
-	}, nil
+	return entries, nil
 }
 
 func (s *Store) Close() {
@@ -344,15 +348,15 @@ func (e *EntriesIterator) Next() bool {
 		}
 		partitionKey := e.entries[e.currEntryIdx-1].PartitionKey
 		key := e.entries[e.currEntryIdx-1].Key
-		tmpIter, err := e.store.scanInternal(e.ctx, partitionKey, kv.ScanOptions{KeyStart: key, BatchSize: e.options.BatchSize}, false)
+		entries, err := e.store.scanInternal(e.ctx, partitionKey, key, e.limit, false)
 		if err != nil {
 			e.err = fmt.Errorf("scan paging: %w", err)
 			return false
 		}
-		if len(tmpIter.entries) == 0 {
+		if len(entries) == 0 {
 			return false
 		}
-		e.entries = tmpIter.entries
+		e.entries = entries
 		e.currEntryIdx = 0
 	}
 	return true


### PR DESCRIPTION
- kv dynamodb store internal scan loop parameters instead of re-calc.
- kv postgres calculate limit one and reuse by passing scan options to the iterator.
- delete unused code in db.go.