### PR TITLE
API GetCommit return empty array instead of nil for no parent

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -1035,6 +1035,7 @@ func (c *Catalog) GetCommit(ctx context.Context, repositoryID string, reference 
 		CreationDate: commit.CreationDate,
 		MetaRangeID:  string(commit.MetaRangeID),
 		Metadata:     Metadata(commit.Metadata),
+		Parents:      []string{},
 	}
 	for _, parent := range commit.Parents {
 		catalogCommitLog.Parents = append(catalogCommitLog.Parents, string(parent))


### PR DESCRIPTION
Fix #4829

Added API test to validate the initial commit structure