### PR TITLE
Cache branch information while safe branch write

### DIFF
--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -198,7 +198,7 @@ func TestController_GetRepoHandler(t *testing.T) {
 	})
 
 	t.Run("use same storage namespace twice", func(t *testing.T) {
-		name := testUniqueRepoName()
+		name := testUniqueRepoName(t)
 		resp, err := clt.CreateRepositoryWithResponse(ctx, &api.CreateRepositoryParams{}, api.CreateRepositoryJSONRequestBody{
 			Name:             name,
 			StorageNamespace: onBlock(deps, name),
@@ -332,7 +332,7 @@ func TestController_LogCommitsParallelHandler(t *testing.T) {
 	clt, deps := setupClientWithAdmin(t)
 	ctx := context.Background()
 
-	repo := testUniqueRepoName()
+	repo := testUniqueRepoName(t)
 	_, err := deps.catalog.CreateRepository(ctx, repo, onBlock(deps, repo), "main")
 	testutil.Must(t, err)
 
@@ -382,7 +382,7 @@ func TestController_LogCommitsPredefinedData(t *testing.T) {
 	ctx := context.Background()
 
 	// prepare test data
-	repo := testUniqueRepoName()
+	repo := testUniqueRepoName(t)
 	_, err := deps.catalog.CreateRepository(ctx, repo, onBlock(deps, repo), "main")
 	testutil.Must(t, err)
 	const prefix = "foo/bar"
@@ -765,7 +765,7 @@ func TestController_CommitHandler(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("commit non-existent commit", func(t *testing.T) {
-		repo := testUniqueRepoName()
+		repo := testUniqueRepoName(t)
 		resp, err := clt.CommitWithResponse(ctx, repo, "main", &api.CommitParams{}, api.CommitJSONRequestBody{
 			Message: "some message",
 		})
@@ -780,7 +780,7 @@ func TestController_CommitHandler(t *testing.T) {
 	})
 
 	t.Run("commit success", func(t *testing.T) {
-		repo := testUniqueRepoName()
+		repo := testUniqueRepoName(t)
 		_, err := deps.catalog.CreateRepository(ctx, repo, onBlock(deps, repo), "main")
 		testutil.MustDo(t, fmt.Sprintf("create repo %s", repo), err)
 		testutil.MustDo(t, fmt.Sprintf("commit bar on %s", repo), deps.catalog.CreateEntry(ctx, repo, "main", catalog.DBEntry{Path: "foo/bar", PhysicalAddress: "pa", CreationDate: time.Now(), Size: 666, Checksum: "cs", Metadata: nil}))
@@ -791,7 +791,7 @@ func TestController_CommitHandler(t *testing.T) {
 	})
 
 	t.Run("commit success with source metarange", func(t *testing.T) {
-		repo := testUniqueRepoName()
+		repo := testUniqueRepoName(t)
 		_, err := deps.catalog.CreateRepository(ctx, repo, onBlock(deps, repo), "main")
 		testutil.MustDo(t, fmt.Sprintf("create repo %s", repo), err)
 
@@ -810,7 +810,7 @@ func TestController_CommitHandler(t *testing.T) {
 	})
 
 	t.Run("commit failure with source metarange and dirty branch", func(t *testing.T) {
-		repo := testUniqueRepoName()
+		repo := testUniqueRepoName(t)
 		_, err := deps.catalog.CreateRepository(ctx, repo, onBlock(deps, repo), "main")
 		testutil.MustDo(t, fmt.Sprintf("create repo %s", repo), err)
 
@@ -835,7 +835,7 @@ func TestController_CommitHandler(t *testing.T) {
 	})
 
 	t.Run("commit failure empty branch", func(t *testing.T) {
-		repo := testUniqueRepoName()
+		repo := testUniqueRepoName(t)
 		_, err := deps.catalog.CreateRepository(ctx, repo, onBlock(deps, repo), "main")
 		testutil.MustDo(t, fmt.Sprintf("create repo %s", repo), err)
 
@@ -853,7 +853,7 @@ func TestController_CommitHandler(t *testing.T) {
 	})
 
 	t.Run("commit success - with creation date", func(t *testing.T) {
-		repo := testUniqueRepoName()
+		repo := testUniqueRepoName(t)
 		_, err := deps.catalog.CreateRepository(ctx, repo, onBlock(deps, repo), "main")
 		testutil.MustDo(t, fmt.Sprintf("create repo %s", repo), err)
 		testutil.MustDo(t, fmt.Sprintf("commit bar on %s", repo), deps.catalog.CreateEntry(ctx, repo, "main", catalog.DBEntry{Path: "foo/bar", PhysicalAddress: "pa", CreationDate: time.Now(), Size: 666, Checksum: "cs", Metadata: nil}))
@@ -956,7 +956,7 @@ func TestController_DeleteRepositoryHandler(t *testing.T) {
 	ctx := context.Background()
 
 	t.Run("delete repo success", func(t *testing.T) {
-		repo := testUniqueRepoName()
+		repo := testUniqueRepoName(t)
 		_, err := deps.catalog.CreateRepository(ctx, repo, onBlock(deps, "foo1"), "main")
 		testutil.Must(t, err)
 
@@ -972,7 +972,7 @@ func TestController_DeleteRepositoryHandler(t *testing.T) {
 	})
 
 	t.Run("delete repo doesnt exist", func(t *testing.T) {
-		repo := testUniqueRepoName()
+		repo := testUniqueRepoName(t)
 		resp, err := clt.DeleteRepositoryWithResponse(ctx, repo)
 		testutil.Must(t, err)
 		if resp.StatusCode() == http.StatusOK {
@@ -1716,7 +1716,7 @@ func TestController_IngestRangeHandler(t *testing.T) {
 func TestController_WriteMetaRangeHandler(t *testing.T) {
 	ctx := context.Background()
 	clt, deps := setupClientWithAdmin(t)
-	repo := testUniqueRepoName()
+	repo := testUniqueRepoName(t)
 	// setup test data
 	_, err := deps.catalog.CreateRepository(ctx, repo, onBlock(deps, repo), "main")
 	testutil.Must(t, err)
@@ -2861,7 +2861,7 @@ func TestController_MergeIntoExplicitBranch(t *testing.T) {
 	ctx := context.Background()
 
 	// setup env
-	repo := testUniqueRepoName()
+	repo := testUniqueRepoName(t)
 	_, err := deps.catalog.CreateRepository(ctx, repo, onBlock(deps, repo), "main")
 	testutil.Must(t, err)
 	_, err = deps.catalog.CreateBranch(ctx, repo, "branch1", "main")
@@ -2896,7 +2896,7 @@ func TestController_MergeDirtyBranch(t *testing.T) {
 	ctx := context.Background()
 
 	// setup env
-	repo := testUniqueRepoName()
+	repo := testUniqueRepoName(t)
 	_, err := deps.catalog.CreateRepository(ctx, repo, onBlock(deps, repo), "main")
 	testutil.Must(t, err)
 	err = deps.catalog.CreateEntry(ctx, repo, "main", catalog.DBEntry{Path: "foo/bar1", PhysicalAddress: "bar1addr", CreationDate: time.Now(), Size: 1, Checksum: "cksum1"})
@@ -2920,7 +2920,7 @@ func TestController_CreateTag(t *testing.T) {
 	clt, deps := setupClientWithAdmin(t)
 	ctx := context.Background()
 	// setup env
-	repo := testUniqueRepoName()
+	repo := testUniqueRepoName(t)
 	_, err := deps.catalog.CreateRepository(ctx, repo, onBlock(deps, repo), "main")
 	testutil.Must(t, err)
 	testutil.MustDo(t, "create entry bar1", deps.catalog.CreateEntry(ctx, repo, "main", catalog.DBEntry{Path: "foo/bar1", PhysicalAddress: "bar1addr", CreationDate: time.Now(), Size: 1, Checksum: "cksum1"}))
@@ -3030,15 +3030,23 @@ func TestController_CreateTag(t *testing.T) {
 	})
 }
 
-func testUniqueRepoName() string {
-	return "repo-" + nanoid.MustGenerate("abcdef1234567890", 8)
+func testUniqueRepoName(t testing.TB) string {
+	var prefix string
+	if t == nil {
+		prefix = "repo"
+	} else {
+		// convert test name to repo as prefix (limited in length
+		prefix = strings.ReplaceAll(strings.ToLower(t.Name()), "_", "-")[:52]
+	}
+	uniqueID := nanoid.MustGenerate("abcdef1234567890", 8)
+	return prefix + "-" + uniqueID
 }
 
 func TestController_Revert(t *testing.T) {
 	clt, deps := setupClientWithAdmin(t)
 	ctx := context.Background()
 	// setup env
-	repo := testUniqueRepoName()
+	repo := testUniqueRepoName(t)
 	_, err := deps.catalog.CreateRepository(ctx, repo, onBlock(deps, repo), "main")
 	testutil.Must(t, err)
 	testutil.MustDo(t, "create entry bar1", deps.catalog.CreateEntry(ctx, repo, "main", catalog.DBEntry{Path: "foo/bar1", PhysicalAddress: "bar1addr", CreationDate: time.Now(), Size: 1, Checksum: "cksum1"}))
@@ -3086,7 +3094,7 @@ func TestController_Revert(t *testing.T) {
 	})
 
 	t.Run("revert_no_parent", func(t *testing.T) {
-		repo := testUniqueRepoName()
+		repo := testUniqueRepoName(t)
 		// setup data - repo with one object committed
 		_, err := deps.catalog.CreateRepository(ctx, repo, onBlock(deps, repo), "main")
 		testutil.Must(t, err)
@@ -3118,7 +3126,7 @@ func TestController_RevertConflict(t *testing.T) {
 	clt, deps := setupClientWithAdmin(t)
 	ctx := context.Background()
 	// setup env
-	repo := testUniqueRepoName()
+	repo := testUniqueRepoName(t)
 	_, err := deps.catalog.CreateRepository(ctx, repo, onBlock(deps, repo), "main")
 	testutil.Must(t, err)
 	testutil.MustDo(t, "create entry bar1", deps.catalog.CreateEntry(ctx, repo, "main", catalog.DBEntry{Path: "foo/bar1", PhysicalAddress: "bar1addr", CreationDate: time.Now(), Size: 1, Checksum: "cksum1"}))
@@ -3368,7 +3376,7 @@ func TestController_PrepareGarbageCollectionUncommitted(t *testing.T) {
 	})
 
 	t.Run("repository_not_exists", func(t *testing.T) {
-		repo := testUniqueRepoName()
+		repo := testUniqueRepoName(t)
 		resp, err := clt.PrepareGarbageCollectionUncommittedWithResponse(ctx, repo, api.PrepareGarbageCollectionUncommittedJSONRequestBody{})
 		if err != nil {
 			t.Fatalf("PrepareGarbageCollectionUncommittedWithResponse failed: %s", err)
@@ -3379,7 +3387,7 @@ func TestController_PrepareGarbageCollectionUncommitted(t *testing.T) {
 	})
 
 	t.Run("uncommitted", func(t *testing.T) {
-		repo := testUniqueRepoName()
+		repo := testUniqueRepoName(t)
 		_, err := deps.catalog.CreateRepository(ctx, repo, onBlock(deps, repo), "main")
 		testutil.Must(t, err)
 		const items = 3
@@ -3403,7 +3411,7 @@ func TestController_PrepareGarbageCollectionUncommitted(t *testing.T) {
 	})
 
 	t.Run("committed", func(t *testing.T) {
-		repo := testUniqueRepoName()
+		repo := testUniqueRepoName(t)
 		_, err := deps.catalog.CreateRepository(ctx, repo, onBlock(deps, repo), "main")
 		testutil.Must(t, err)
 		const items = 3

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -332,12 +332,14 @@ func TestController_LogCommitsParallelHandler(t *testing.T) {
 	clt, deps := setupClientWithAdmin(t)
 	ctx := context.Background()
 
-	repo := "repo-log-commits-parallel"
+	repo := testUniqueRepoName()
 	_, err := deps.catalog.CreateRepository(ctx, repo, onBlock(deps, repo), "main")
 	testutil.Must(t, err)
 
-	commits := 100
-	const prefix = "foo/bar"
+	const (
+		commits = 100
+		prefix  = "foo/bar"
+	)
 	commitsToLook := map[string]*catalog.CommitLog{}
 	for i := 0; i < commits; i++ {
 		n := strconv.Itoa(i + 1)

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -3031,12 +3031,18 @@ func TestController_CreateTag(t *testing.T) {
 }
 
 func testUniqueRepoName(t testing.TB) string {
-	var prefix string
-	if t == nil {
-		prefix = "repo"
-	} else {
-		// convert test name to repo as prefix (limited in length
-		prefix = strings.ReplaceAll(strings.ToLower(t.Name()), "_", "-")[:52]
+	prefix := "repo"
+	if t != nil {
+		testName := t.Name()
+		if len(testName) > 0 {
+			// cleanup test name from invalid characters + trim if needed
+			replacer := strings.NewReplacer("_", "-", "/", "-")
+			prefix = replacer.Replace(strings.ToLower(testName))
+			const maxPrefixLen = 52
+			if len(prefix) > maxPrefixLen {
+				prefix = prefix[:maxPrefixLen]
+			}
+		}
 	}
 	uniqueID := nanoid.MustGenerate("abcdef1234567890", 8)
 	return prefix + "-" + uniqueID

--- a/pkg/cache/no_cache.go
+++ b/pkg/cache/no_cache.go
@@ -7,3 +7,7 @@ type noCache struct{}
 func (m *noCache) GetOrSet(_ interface{}, setFn SetFn) (v interface{}, err error) {
 	return setFn()
 }
+
+func (m *noCache) Set(_, _ interface{}) {}
+
+func (m *noCache) Clear(_ interface{}) {}

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -235,6 +235,7 @@ func New(ctx context.Context, cfg Config) (*Catalog, error) {
 			AddressProvider:       ident.NewHexAddressProvider(),
 			RepositoryCacheConfig: ref.CacheConfig(cfg.Config.Graveler.RepositoryCache),
 			CommitCacheConfig:     ref.CacheConfig(cfg.Config.Graveler.CommitCache),
+			BranchCacheConfig:     ref.CacheConfig(cfg.Config.Graveler.BranchCache),
 		})
 	gcManager := retention.NewGarbageCollectionManager(tierFSParams.Adapter, refManager, cfg.Config.Committed.BlockStoragePrefix)
 	settingManager := settings.NewManager(refManager, *cfg.KVStore)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -243,6 +243,11 @@ type Config struct {
 			Expiry time.Duration `mapstructure:"expiry"`
 			Jitter time.Duration `mapstructure:"jitter"`
 		} `mapstructure:"commit_cache"`
+		BranchCache struct {
+			Size   int           `mapstructure:"size"`
+			Expiry time.Duration `mapstructure:"expiry"`
+			Jitter time.Duration `mapstructure:"jitter"`
+		} `mapstructure:"branch_cache"`
 	} `mapstructure:"graveler"`
 	Gateways struct {
 		S3 struct {

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -175,6 +175,12 @@ const (
 	DefaultGravelerCommitCacheExpiry     = 10 * time.Minute
 	GravelerCommitCacheJitterKey         = "graveler.commit_cache.jitter"
 	DefaultGravelerCommitCacheJitter     = 2 * time.Second
+	GravelerBranchCacheSizeKey           = "graveler.branch_cache.size"
+	DefaultGravelerBranchCacheSize       = 10_000
+	GravelerBranchCacheExpiryKey         = "graveler.commit_cache.expiry"
+	DefaultGravelerBranchCacheExpiry     = 10 * time.Minute
+	GravelerBranchCacheJitterKey         = "graveler.commit_cache.jitter"
+	DefaultGravelerBranchCacheJitter     = 2 * time.Second
 )
 
 func setDefaults(local bool) {

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -170,13 +170,13 @@ const (
 	GravelerRepositoryCacheJitterKey     = "graveler.repository_cache.jitter"
 	DefaultGravelerRepositoryCacheJitter = 2 * time.Second
 	GravelerCommitCacheSizeKey           = "graveler.commit_cache.size"
-	DefaultGravelerCommitCacheSize       = 50_000
+	DefaultGravelerCommitCacheSize       = 60_000
 	GravelerCommitCacheExpiryKey         = "graveler.commit_cache.expiry"
 	DefaultGravelerCommitCacheExpiry     = 10 * time.Minute
 	GravelerCommitCacheJitterKey         = "graveler.commit_cache.jitter"
 	DefaultGravelerCommitCacheJitter     = 2 * time.Second
 	GravelerBranchCacheSizeKey           = "graveler.branch_cache.size"
-	DefaultGravelerBranchCacheSize       = 10_000
+	DefaultGravelerBranchCacheSize       = 500
 	GravelerBranchCacheExpiryKey         = "graveler.commit_cache.expiry"
 	DefaultGravelerBranchCacheExpiry     = 10 * time.Minute
 	GravelerBranchCacheJitterKey         = "graveler.commit_cache.jitter"

--- a/pkg/graveler/graveler_test.go
+++ b/pkg/graveler/graveler_test.go
@@ -382,7 +382,7 @@ func TestGravelerSet_Advanced(t *testing.T) {
 		stagingMgr := &testutil.StagingFake{
 			UpdateErr: ErrGravelerUpdate,
 		}
-		refMgr.EXPECT().GetBranch(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(&graveler.Branch{}, nil)
+		refMgr.EXPECT().GetBranchCached(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(&graveler.Branch{}, nil)
 		refExpectCommitNotFound()
 		store := newGraveler(t, committedMgr, stagingMgr, refMgr, nil, testutil.NewProtectedBranchesManagerFake())
 		err := store.Set(ctx, repository, "branch-1", newSetVal.Key, *newSetVal.Value, graveler.IfAbsent(true))
@@ -391,7 +391,7 @@ func TestGravelerSet_Advanced(t *testing.T) {
 	})
 
 	t.Run("branch deleted after update", func(t *testing.T) {
-		refMgr.EXPECT().GetBranch(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(&graveler.Branch{}, nil)
+		refMgr.EXPECT().GetBranchCached(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(&graveler.Branch{}, nil)
 		refExpectCommitNotFound()
 		refMgr.EXPECT().GetBranch(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(nil, graveler.ErrNotFound)
 		stagingMgr := &testutil.StagingFake{}
@@ -403,13 +403,13 @@ func TestGravelerSet_Advanced(t *testing.T) {
 
 	t.Run("branch token changed after update - one retry", func(t *testing.T) {
 		// Test safeBranchWrite retries when token changed after update a single time and then succeeds
-		refMgr.EXPECT().GetBranch(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(&graveler.Branch{}, nil)
+		refMgr.EXPECT().GetBranchCached(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(&graveler.Branch{}, nil)
 		refExpectCommitNotFound()
 		refMgr.EXPECT().GetBranch(gomock.Any(), gomock.Any(), gomock.Any()).Times(2).Return(&graveler.Branch{
 			StagingToken: "new_token",
 		}, nil)
 		refExpectCommitNotFound()
-		refMgr.EXPECT().GetBranch(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(&graveler.Branch{
+		refMgr.EXPECT().GetBranchCached(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(&graveler.Branch{
 			StagingToken: "new_token",
 		}, nil)
 		stagingMgr := &testutil.StagingFake{}
@@ -422,7 +422,7 @@ func TestGravelerSet_Advanced(t *testing.T) {
 	t.Run("branch token changed max retries", func(t *testing.T) {
 		// Test safeBranchWrite retries when token changed after update, reach the maximal number of retries and then succeed
 		for i := 0; i < graveler.BranchWriteMaxTries-1; i++ {
-			refMgr.EXPECT().GetBranch(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(&graveler.Branch{
+			refMgr.EXPECT().GetBranchCached(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(&graveler.Branch{
 				StagingToken: graveler.StagingToken("new_token_" + strconv.Itoa(i)),
 			}, nil)
 			refExpectCommitNotFound()
@@ -430,7 +430,7 @@ func TestGravelerSet_Advanced(t *testing.T) {
 				StagingToken: graveler.StagingToken("new_token_" + strconv.Itoa(i+1)),
 			}, nil)
 		}
-		refMgr.EXPECT().GetBranch(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(&graveler.Branch{
+		refMgr.EXPECT().GetBranchCached(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(&graveler.Branch{
 			StagingToken: graveler.StagingToken("new_token_" + strconv.Itoa(graveler.BranchWriteMaxTries)),
 		}, nil)
 		refExpectCommitNotFound()
@@ -447,7 +447,7 @@ func TestGravelerSet_Advanced(t *testing.T) {
 	t.Run("branch token changed retry exhausted", func(t *testing.T) {
 		// Test safeBranchWrite retries when token changed after update, exceed the maximal number of retries and expect fail
 		for i := 0; i < graveler.BranchWriteMaxTries; i++ {
-			refMgr.EXPECT().GetBranch(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(&graveler.Branch{
+			refMgr.EXPECT().GetBranchCached(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(&graveler.Branch{
 				StagingToken: graveler.StagingToken("new_token_" + strconv.Itoa(i)),
 			}, nil)
 			refExpectCommitNotFound()

--- a/pkg/graveler/ref/main_test.go
+++ b/pkg/graveler/ref/main_test.go
@@ -26,6 +26,11 @@ var (
 		Size:   5000,
 		Expiry: 20 * time.Millisecond,
 	}
+
+	testBranchCacheConfig = ref.CacheConfig{
+		Size:   500,
+		Expiry: 20 * time.Millisecond,
+	}
 )
 
 func testRefManager(t testing.TB) (graveler.RefManager, *kv.StoreMessage) {
@@ -39,6 +44,7 @@ func testRefManager(t testing.TB) (graveler.RefManager, *kv.StoreMessage) {
 		AddressProvider:       ident.NewHexAddressProvider(),
 		RepositoryCacheConfig: testRepoCacheConfig,
 		CommitCacheConfig:     testCommitCacheConfig,
+		BranchCacheConfig:     testBranchCacheConfig,
 	}
 	return ref.NewRefManager(cfg), storeMessage
 }
@@ -54,6 +60,7 @@ func testRefManagerWithAddressProvider(t testing.TB, addressProvider ident.Addre
 		AddressProvider:       addressProvider,
 		RepositoryCacheConfig: testRepoCacheConfig,
 		CommitCacheConfig:     testCommitCacheConfig,
+		BranchCacheConfig:     testBranchCacheConfig,
 	}
 	return ref.NewRefManager(cfg), storeMessage
 }

--- a/pkg/graveler/ref/main_test.go
+++ b/pkg/graveler/ref/main_test.go
@@ -29,7 +29,7 @@ var (
 
 	testBranchCacheConfig = ref.CacheConfig{
 		Size:   500,
-		Expiry: 20 * time.Millisecond,
+		Expiry: 500 * time.Millisecond,
 	}
 )
 

--- a/pkg/graveler/ref/manager_test.go
+++ b/pkg/graveler/ref/manager_test.go
@@ -47,6 +47,7 @@ func TestManager_GetRepositoryCache(t *testing.T) {
 		AddressProvider:       ident.NewHexAddressProvider(),
 		RepositoryCacheConfig: cacheConfig,
 		CommitCacheConfig:     cacheConfig,
+		BranchCacheConfig:     cacheConfig,
 	}
 	refManager := ref.NewRefManager(cfg)
 	for i := 0; i < calls; i++ {
@@ -94,6 +95,7 @@ func TestManager_GetCommitCache(t *testing.T) {
 		AddressProvider:       ident.NewHexAddressProvider(),
 		RepositoryCacheConfig: cacheConfig,
 		CommitCacheConfig:     cacheConfig,
+		BranchCacheConfig:     cacheConfig,
 	}
 	refManager := ref.NewRefManager(cfg)
 	for i := 0; i < calls; i++ {

--- a/pkg/graveler/settings/manager_test.go
+++ b/pkg/graveler/settings/manager_test.go
@@ -46,6 +46,14 @@ func (m *mockCache) GetOrSet(k interface{}, setFn cache.SetFn) (v interface{}, e
 	return val, nil
 }
 
+func (m *mockCache) Set(k, v interface{}) {
+	m.c[k] = v
+}
+
+func (m *mockCache) Clear(k interface{}) {
+	delete(m.c, k)
+}
+
 func TestSaveAndGet(t *testing.T) {
 	ctx := context.Background()
 	mc := &mockCache{

--- a/pkg/graveler/testutil/fakes.go
+++ b/pkg/graveler/testutil/fakes.go
@@ -159,7 +159,7 @@ func (s *StagingFake) Get(_ context.Context, st graveler.StagingToken, key grave
 	return nil, graveler.ErrNotFound
 }
 
-func (s *StagingFake) Set(_ context.Context, _ graveler.StagingToken, key graveler.Key, value *graveler.Value, _ bool) error {
+func (s *StagingFake) Set(_ context.Context, _ graveler.StagingToken, key graveler.Key, value *graveler.Value) error {
 	if s.SetErr != nil {
 		return s.SetErr
 	}
@@ -333,6 +333,10 @@ func (m *RefsFake) DeleteRepository(context.Context, graveler.RepositoryID) erro
 }
 
 func (m *RefsFake) GetBranch(context.Context, *graveler.RepositoryRecord, graveler.BranchID) (*graveler.Branch, error) {
+	return m.Branch, m.Err
+}
+
+func (m *RefsFake) GetBranchCached(context.Context, *graveler.RepositoryRecord, graveler.BranchID) (*graveler.Branch, error) {
 	return m.Branch, m.Err
 }
 

--- a/pkg/graveler/testutil/fakes.go
+++ b/pkg/graveler/testutil/fakes.go
@@ -159,7 +159,7 @@ func (s *StagingFake) Get(_ context.Context, st graveler.StagingToken, key grave
 	return nil, graveler.ErrNotFound
 }
 
-func (s *StagingFake) Set(_ context.Context, _ graveler.StagingToken, key graveler.Key, value *graveler.Value) error {
+func (s *StagingFake) Set(_ context.Context, _ graveler.StagingToken, key graveler.Key, value *graveler.Value, _ bool) error {
 	if s.SetErr != nil {
 		return s.SetErr
 	}


### PR DESCRIPTION
Safe branch loop access branch token before and after the operation in
order to verify that no commit/revert was done while we performed the
operation on the branch.
In case the branch token updated, we repeat the operation.

To get better performance we cache the branch information and use it
once, before the operation.

Based on https://github.com/treeverse/lakeFS/pull/4770

Close #4769