### PR TITLE
Test GC with Spark 3 / Hadoop 2

### DIFF
--- a/.github/workflows/esti.yaml
+++ b/.github/workflows/esti.yaml
@@ -925,7 +925,7 @@ jobs:
           - base: treeverse/bitnami-based-spark
             version: 3.2.3-with-hadoop-2.7-for-testing
             suffix: ""
-            allow_failure: false
+            allow_failure: true
     env:
       SPARK_BASE: ${{ matrix.spark.base }}
       SPARK_TAG: ${{ matrix.spark.version }}

--- a/.github/workflows/esti.yaml
+++ b/.github/workflows/esti.yaml
@@ -918,7 +918,12 @@ jobs:
             suffix: ""
           - version: 3.0.2
             suffix: ""
+          # Test with an an actual 3.2.3 on Hadoop 2 build
+          - base: ariels9/bitnami-based-spark
+            version: 3.2.3-with-hadoop-2.7
+            suffix: ""
     env:
+      SPARK_BASE: ${{ matrix.spark.base }}
       SPARK_TAG: ${{ matrix.spark.version }}
       REPO: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com
       TAG: ${{ needs.deploy-image.outputs.tag }}

--- a/.github/workflows/esti.yaml
+++ b/.github/workflows/esti.yaml
@@ -922,7 +922,7 @@ jobs:
           - base: treeverse/bitnami-based-spark
             version: 3.2.3-with-hadoop-2.7-for-testing
             suffix: ""
-            allow_failure: true
+            #allow_failure: true
     env:
       SPARK_BASE: ${{ matrix.spark.base }}
       SPARK_TAG: ${{ matrix.spark.version }}

--- a/.github/workflows/esti.yaml
+++ b/.github/workflows/esti.yaml
@@ -914,21 +914,24 @@ jobs:
         spark:
           - version: 3.2.1
             suffix: "-hadoop3"
+            allow_failure: false
           - version: 3.1.2
             suffix: ""
+            allow_failure: false
           - version: 3.0.2
             suffix: ""
+            allow_failure: false
           # Test with an an actual 3.2.3 on Hadoop 2 build
           - base: treeverse/bitnami-based-spark
             version: 3.2.3-with-hadoop-2.7-for-testing
             suffix: ""
-            #allow_failure: true
+            allow_failure: false
     env:
       SPARK_BASE: ${{ matrix.spark.base }}
       SPARK_TAG: ${{ matrix.spark.version }}
       REPO: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com
       TAG: ${{ needs.deploy-image.outputs.tag }}
-    continue-on-error: ${{ matrix.allow_failure }}
+    continue-on-error: ${{ matrix.spark.allow_failure }}
     steps:
       - name: Check-out code
         uses: actions/checkout@v3

--- a/.github/workflows/esti.yaml
+++ b/.github/workflows/esti.yaml
@@ -922,11 +922,13 @@ jobs:
           - base: ariels9/bitnami-based-spark
             version: 3.2.3-with-hadoop-2.7
             suffix: ""
+            allow_failure: true
     env:
       SPARK_BASE: ${{ matrix.spark.base }}
       SPARK_TAG: ${{ matrix.spark.version }}
       REPO: ${{ secrets.AWS_ACCOUNT_ID }}.dkr.ecr.us-east-1.amazonaws.com
       TAG: ${{ needs.deploy-image.outputs.tag }}
+    continue-on-error: ${{ matrix.allow_failure }}
     steps:
       - name: Check-out code
         uses: actions/checkout@v3

--- a/.github/workflows/esti.yaml
+++ b/.github/workflows/esti.yaml
@@ -919,8 +919,8 @@ jobs:
           - version: 3.0.2
             suffix: ""
           # Test with an an actual 3.2.3 on Hadoop 2 build
-          - base: ariels9/bitnami-based-spark
-            version: 3.2.3-with-hadoop-2.7
+          - base: treeverse/bitnami-based-spark
+            version: 3.2.3-with-hadoop-2.7-for-testing
             suffix: ""
             allow_failure: true
     env:

--- a/deployments/utils/spark3-hadoop2/Dockerfile
+++ b/deployments/utils/spark3-hadoop2/Dockerfile
@@ -1,0 +1,33 @@
+# INSTRUCTIONS
+#
+# Build:
+#     docker build --tag treeverse/bitnami-based-spark:3.2.3-with-hadoop-2.7-for-testing .
+#
+# Push:
+#     docker push treeverse/bitnami-based-spark:3.2.3-with-hadoop-2.7-for-testing
+#
+# Use *only* in Esti.  This is **NOT** a good Docker image to use for
+# running Spark, except for testing.
+
+FROM --platform=$BUILDPLATFORM ubuntu:21.04 AS extract
+
+WORKDIR /build
+# Extract hadoop-aws-2.7.4 and its dependency aws-java-sdk-1.7.4 from an old
+# archived version of Apachehe Hadoop.  These JARs are so long-dead that
+# this is the *easy* way of getting our actual test code onthem.
+#
+# See, fear, and never use this Docker image except in tests.
+ADD https://archive.apache.org/dist/hadoop/common/hadoop-2.7.4/hadoop-2.7.4.tar.gz /tmp/hadoop-2.7.4.tar.gz
+RUN tar --extract --to-stdout --gzip --strip 5 --file /tmp/hadoop-2.7.4.tar.gz hadoop-2.7.4/share/hadoop/tools/lib/hadoop-aws-2.7.4.jar > ./hadoop-aws-2.7.4.jar
+RUN tar --extract --to-stdout --gzip --strip 5 --file /tmp/hadoop-2.7.4.tar.gz hadoop-2.7.4/share/hadoop/tools/lib/aws-java-sdk-1.7.4.jar > ./aws-java-sdk-1.7.4.jar
+
+# Build Bitnami Spark 3.2.x but with Hadoop 2.  Details in
+# https://github.com/bitnami/bitnami-docker-spark#using-a-different-version-of-hadoop-jars.
+FROM bitnami/spark:3.2.3
+
+USER root
+RUN rm -r /opt/bitnami/spark/jars
+ADD https://dlcdn.apache.org/spark/spark-3.2.3/spark-3.2.3-bin-hadoop2.7.tgz /tmp/
+RUN tar --extract --gzip --strip=1 < /tmp/spark-3.2.3-bin-hadoop2.7.tgz --directory /opt/bitnami/spark/ spark-3.2.3-bin-hadoop2.7/jars/ && rm /tmp/spark-3.2.3-bin-hadoop2.7.tgz
+COPY --from=extract /build/*.jar /opt/bitnami/spark/jars/
+USER 1001

--- a/test/spark/docker-compose.yaml
+++ b/test/spark/docker-compose.yaml
@@ -40,7 +40,7 @@ services:
         - tester.env
     entrypoint: ["/app/wait-for", "postgres:5432", "--", "/app/lakefs", "run"]
   spark:
-    image: docker.io/bitnami/spark:${SPARK_TAG:-3}
+    image: docker.io/${SPARK_BASE:-bitnami/spark}:${SPARK_TAG:-3}
     environment:
       - SPARK_MODE=master
       - SPARK_MASTER_HOST=spark
@@ -63,7 +63,7 @@ services:
       - "gateway-test-spark3.s3.docker.lakefs.io:10.5.0.55"
       - "thick-client-test.s3.docker.lakefs.io:10.5.0.55"
   spark-worker:
-    image: docker.io/bitnami/spark:${SPARK_TAG:-3}
+    image: docker.io/${SPARK_BASE:-bitnami/spark}:${SPARK_TAG:-3}
     ports:
       - 8081
     environment:
@@ -88,7 +88,7 @@ services:
       - "gateway-test-spark3.s3.docker.lakefs.io:10.5.0.55"
       - "thick-client-test.s3.docker.lakefs.io:10.5.0.55"
   spark-submit:
-    image: docker.io/bitnami/spark:${SPARK_TAG:-3}
+    image: docker.io/${SPARK_BASE:-bitnami/spark}:${SPARK_TAG:-3}
     profiles: ["command"]
     volumes:
       - ./:/local


### PR DESCRIPTION
Build a new version (manually for now) and use it to test GC when Spark 3
itself is running with Hadoop 2.  (Currently the Hadoop 2 version is tested
to run on Spark 3 with Hadoop 3, which is nice but not the main use-case!)