### PR TITLE
[metadata client] Start scalacheck-ing jpebble

### DIFF
--- a/clients/spark/build.sbt
+++ b/clients/spark/build.sbt
@@ -140,7 +140,8 @@ def getSharedLibraryDependencies(buildType: BuildType) : Seq[ModuleID]  = {
     "org.scalactic" %% "scalactic" % "3.2.9",
     "dev.failsafe" % "failsafe" % "3.2.4",
     "org.apache.hadoop" % "hadoop-distcp" % buildType.hadoopVersion,
-    "org.scalatestplus" %% "mockito-4-6" % "3.2.14.0" % "test",
+    "org.scalatestplus" %% "scalacheck-1-17" % "3.2.15.0" % "test",
+    "org.scalatestplus" %% "mockito-4-6" % "3.2.15.0" % "test",
     // https://mvnrepository.com/artifact/com.squareup.okhttp3/mockwebserver
     "com.squareup.okhttp3" % "mockwebserver" % "4.10.0" % "test",
     "xerces" % "xercesImpl" % "2.12.2" % "test",

--- a/clients/spark/build.sbt
+++ b/clients/spark/build.sbt
@@ -140,12 +140,13 @@ def getSharedLibraryDependencies(buildType: BuildType) : Seq[ModuleID]  = {
     "org.scalactic" %% "scalactic" % "3.2.9",
     "dev.failsafe" % "failsafe" % "3.2.4",
     "org.apache.hadoop" % "hadoop-distcp" % buildType.hadoopVersion,
-    "org.scalatestplus" %% "scalacheck-1-17" % "3.2.15.0" % "test",
-    "org.scalatestplus" %% "mockito-4-6" % "3.2.15.0" % "test",
     // https://mvnrepository.com/artifact/com.squareup.okhttp3/mockwebserver
     "com.squareup.okhttp3" % "mockwebserver" % "4.10.0" % "test",
     "xerces" % "xercesImpl" % "2.12.2" % "test",
     "org.scalatest" %% "scalatest" % "3.2.9" % "test",
+    // scalacheck-1.15 is last version to support Scala 2.11 :-(
+    "org.scalatestplus" %% "scalacheck-1-15" % "3.2.3.0" % "test",
+    "org.scalatestplus" %% "mockito-4-2" % "3.2.11.0" % "test",
     "com.dimafeng" %% "testcontainers-scala-scalatest" % "0.40.10" % "test",
     "com.lihaoyi" %% "upickle" % "1.4.0" % "test",
     "com.lihaoyi" %% "os-lib" % "0.7.8" % "test",

--- a/clients/spark/core/src/main/scala/io/treeverse/jpebble/BlockParser.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/jpebble/BlockParser.scala
@@ -138,6 +138,8 @@ object BlockParser {
     }
   }
 
+  /** Return an int32 with (fixed-width, 4 byte) little-endian encoding from bytes.
+   */
   def readInt32(bytes: Iterator[Byte]): Int =
     // RocksDB format is little-endian.  And Scala applies functions
     // left-to-right, so the first Seq.next call really executes first.
@@ -190,12 +192,6 @@ object BlockParser {
     ret
   }
 
-  /** Return an int32 with (fixed-width, 4 byte) little-endian encoding from bytes.
-   */
-  def readFixedInt(bytes: Iterator[Byte]): Int =
-    (bytes.next() & 0xff) + 256 * ((bytes
-      .next() & 0xff) + 256 * ((bytes.next() & 0xff) + 256 * (bytes.next() & 0xff)))
-
   /** Mix bits of CRC32C to match its use in RocksDB SSTables.  (That format
    *  includes CRCs inside checksummed data, meaning further CRCs of that
    *  block can fail to detect anything; defining this mixing protects that
@@ -217,7 +213,7 @@ object BlockParser {
     val crc = new CRC32C()
     update(crc, block.bytes, block.from, block.size - blockTrailerLen + 1)
     val computedCRC = fixupCRC(crc.getValue().toInt)
-    val expectedCRC = readFixedInt(
+    val expectedCRC = readInt32(
       block.slice(block.size - blockTrailerLen + 1, block.size).iterator
     )
     if (computedCRC != expectedCRC) {
@@ -297,7 +293,7 @@ object BlockParser {
     val blockIndexType = {
       val props = BlockParser.readProperties(in, footer)
       val typeIt = props(BlockParser.INDEX_TYPE_KEY).iterator
-      val typ = BlockParser.readFixedInt(typeIt)
+      val typ = BlockParser.readInt32(typeIt)
       BlockParser.readEnd(typeIt)
       typ
     }

--- a/clients/spark/core/src/main/scala/io/treeverse/jpebble/BlockParser.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/jpebble/BlockParser.scala
@@ -129,12 +129,17 @@ object BlockParser {
 
   def readMagic(bytes: Iterator[Byte]) = {
     val magic = bytes.take(footerMagic.length).toArray
+    if (magic.size < footerMagic.length) {
+      throw new BadFileFormatException(
+        s"Bad magic ${magic.map("%02x".format(_)).mkString(" ")}: too short"
+      )
+    }
     val isMatch = magic
       .zip(BlockParser.footerMagic)
       .filter({ case ((a, b)) => a != b })
       .isEmpty
     if (!isMatch) {
-      throw new BadFileFormatException(s"Bad magic ${magic.map("%02x".format(_)).mkString(" ")}")
+      throw new BadFileFormatException(s"Bad magic ${magic.map("%02x".format(_)).mkString(" ")}: wrong bytes")
     }
   }
 

--- a/clients/spark/core/src/main/scala/io/treeverse/jpebble/BlockParser.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/jpebble/BlockParser.scala
@@ -139,7 +139,9 @@ object BlockParser {
       .filter({ case ((a, b)) => a != b })
       .isEmpty
     if (!isMatch) {
-      throw new BadFileFormatException(s"Bad magic ${magic.map("%02x".format(_)).mkString(" ")}: wrong bytes")
+      throw new BadFileFormatException(
+        s"Bad magic ${magic.map("%02x".format(_)).mkString(" ")}: wrong bytes"
+      )
     }
   }
 

--- a/clients/spark/core/src/test/scala/io/treeverse/jpebble/BlockParserCheck.scala
+++ b/clients/spark/core/src/test/scala/io/treeverse/jpebble/BlockParserCheck.scala
@@ -12,6 +12,17 @@ import funspec._
   * https://github.com/typelevel/scalacheck/blob/main/doc/UserGuide.md.
  */
 class BlockParserCheck extends AnyFunSpec with ScalaCheckDrivenPropertyChecks with Matchers {
+  describe("readMagic") {
+    it("fails on any non-magic bytes") {
+      val gen = Gen.containerOf[Seq, Byte](arbByte.arbitrary)
+      forAll(gen) {
+        case (bytes) => if (bytes != BlockParser.footerMagic)
+          a [BadFileFormatException] should be thrownBy {
+            BlockParser.readMagic(bytes.iterator)
+          }
+      }
+    }
+  }
 
   describe("readInt32") {
     val makeLE32 = (x: Int) => Seq(x, x >>> 8, x >>> 16, x >>> 24).map(_.toByte).iterator

--- a/clients/spark/core/src/test/scala/io/treeverse/jpebble/BlockParserCheck.scala
+++ b/clients/spark/core/src/test/scala/io/treeverse/jpebble/BlockParserCheck.scala
@@ -1,0 +1,29 @@
+package io.treeverse.jpebble
+
+import org.scalatest._
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
+import org.scalacheck.Arbitrary._
+import org.scalacheck.Gen
+
+import matchers.should._
+import funspec._
+
+/** Test suite to perform property-based checking on parsers.  See
+  * https://github.com/typelevel/scalacheck/blob/main/doc/UserGuide.md.
+ */
+class BlockParserCheck extends AnyFunSpec with ScalaCheckDrivenPropertyChecks with Matchers {
+  val makeLE32 = (x: Int) => Seq(x, x >>> 8, x >>> 16, x >>> 24).map(_.toByte).iterator
+
+  describe("readInt32") {
+    it("reads little-endian int32s") {
+      forAll { (a: Int) => BlockParser.readInt32(makeLE32(a)) should be(a) }
+    }
+
+    it("equals readFixedInt") {
+      val gen = Gen.containerOfN[Seq, Byte](4, arbByte.arbitrary)
+      forAll(gen) {
+        case (a) => BlockParser.readInt32(a.iterator) should be(BlockParser.readFixedInt(a.iterator))
+      }
+    }
+  }
+}

--- a/clients/spark/core/src/test/scala/io/treeverse/jpebble/BlockParserCheck.scala
+++ b/clients/spark/core/src/test/scala/io/treeverse/jpebble/BlockParserCheck.scala
@@ -12,18 +12,12 @@ import funspec._
   * https://github.com/typelevel/scalacheck/blob/main/doc/UserGuide.md.
  */
 class BlockParserCheck extends AnyFunSpec with ScalaCheckDrivenPropertyChecks with Matchers {
-  val makeLE32 = (x: Int) => Seq(x, x >>> 8, x >>> 16, x >>> 24).map(_.toByte).iterator
 
   describe("readInt32") {
+    val makeLE32 = (x: Int) => Seq(x, x >>> 8, x >>> 16, x >>> 24).map(_.toByte).iterator
     it("reads little-endian int32s") {
-      forAll { (a: Int) => BlockParser.readInt32(makeLE32(a)) should be(a) }
+      forAll { (bytes: Int) => BlockParser.readInt32(makeLE32(bytes)) should be(bytes) }
     }
 
-    it("equals readFixedInt") {
-      val gen = Gen.containerOfN[Seq, Byte](4, arbByte.arbitrary)
-      forAll(gen) {
-        case (a) => BlockParser.readInt32(a.iterator) should be(BlockParser.readFixedInt(a.iterator))
-      }
-    }
   }
 }


### PR DESCRIPTION
Start testing the jpebble parser using ScalaCheck.
[ScalaCheck](https://github.com/typelevel/scalacheck/blob/main/doc/UserGuide.md)
generates tests automatically from specifications.  Obviously it cannot find
all bugs, but it *is* a pretty nice directed fuzzer.

I only tested a few low-level routines, but already found some nice issues:

* readFixedInt is indeed equivalent to readInt32.  We suspected as much but
  were unsure how to test it.  I added a ScalaCheck to check that they are
  identical.  It passed so I removed readFixedInt, along with the
  ScalaCheck.  View the progression on the commit history.

  Given that the likely divergence would be on negative (high bit set) Ints,
  I believe this ScalaCheck gives us the confidence to do so.
* readMagic would fail when it could not read enough bytes.  This makes
  failures faster for SSTable "files" which are less than 4 bytes in length.
  It also makes readMagic safe to use elsewhere.