### PR TITLE
Reduce the use of specific catalog errors to fix missing checks

### DIFF
--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -199,7 +199,7 @@ func (c *Controller) DeleteObjects(w http.ResponseWriter, r *http.Request, body 
 		}
 		lg := c.Logger.WithField("path", objectPath)
 		switch {
-		case errors.Is(err, catalog.ErrNotFound), errors.Is(err, graveler.ErrNotFound):
+		case errors.Is(err, graveler.ErrNotFound):
 			lg.WithError(err).Debug("tried to delete a non-existent object")
 		case errors.Is(err, graveler.ErrWriteToProtectedBranch):
 			errs = append(errs, ObjectError{
@@ -303,7 +303,7 @@ func (c *Controller) GetPhysicalAddress(w http.ResponseWriter, r *http.Request, 
 	c.LogAction(ctx, "generate_physical_address", r, repository, branch, "")
 
 	repo, err := c.Catalog.GetRepository(ctx, repository)
-	if errors.Is(err, catalog.ErrNotFound) {
+	if errors.Is(err, graveler.ErrNotFound) {
 		writeError(w, r, http.StatusNotFound, err)
 		return
 	}
@@ -313,7 +313,7 @@ func (c *Controller) GetPhysicalAddress(w http.ResponseWriter, r *http.Request, 
 	}
 
 	token, err := c.Catalog.GetStagingToken(ctx, repository, branch)
-	if errors.Is(err, catalog.ErrNotFound) {
+	if errors.Is(err, graveler.ErrNotFound) {
 		writeError(w, r, http.StatusNotFound, err)
 		return
 	}
@@ -350,7 +350,7 @@ func (c *Controller) LinkPhysicalAddress(w http.ResponseWriter, r *http.Request,
 	c.LogAction(ctx, "stage_object", r, repository, branch, "")
 
 	repo, err := c.Catalog.GetRepository(ctx, repository)
-	if errors.Is(err, catalog.ErrNotFound) {
+	if errors.Is(err, graveler.ErrNotFound) {
 		writeError(w, r, http.StatusNotFound, err)
 		return
 	}
@@ -395,7 +395,7 @@ func (c *Controller) LinkPhysicalAddress(w http.ResponseWriter, r *http.Request,
 	entry := entryBuilder.Build()
 
 	err = c.Catalog.CreateEntry(ctx, repo.Name, branch, entry)
-	if errors.Is(err, catalog.ErrNotFound) {
+	if errors.Is(err, graveler.ErrNotFound) {
 		writeError(w, r, http.StatusNotFound, err)
 		return
 	}
@@ -1475,8 +1475,7 @@ func (c *Controller) GetRepository(w http.ResponseWriter, r *http.Request, repos
 		}
 		writeResponse(w, r, http.StatusOK, response)
 
-	case errors.Is(err, catalog.ErrNotFound),
-		errors.Is(err, catalog.ErrRepositoryNotFound):
+	case errors.Is(err, graveler.ErrNotFound):
 		writeError(w, r, http.StatusNotFound, "repository not found")
 
 	case errors.Is(err, graveler.ErrRepositoryInDeletion):
@@ -1808,8 +1807,7 @@ func (c *Controller) handleAPIErrorCallback(ctx context.Context, w http.Response
 	}
 
 	switch {
-	case errors.Is(err, catalog.ErrNotFound),
-		errors.Is(err, graveler.ErrNotFound),
+	case errors.Is(err, graveler.ErrNotFound),
 		errors.Is(err, actions.ErrNotFound),
 		errors.Is(err, auth.ErrNotFound),
 		errors.Is(err, kv.ErrNotFound):
@@ -1817,7 +1815,6 @@ func (c *Controller) handleAPIErrorCallback(ctx context.Context, w http.Response
 
 	case errors.Is(err, graveler.ErrDirtyBranch),
 		errors.Is(err, graveler.ErrCommitMetaRangeDirtyBranch),
-		errors.Is(err, catalog.ErrNoDifferenceWasFound),
 		errors.Is(err, graveler.ErrNoChanges),
 		errors.Is(err, permissions.ErrInvalidServiceName),
 		errors.Is(err, permissions.ErrInvalidAction),
@@ -1831,9 +1828,6 @@ func (c *Controller) handleAPIErrorCallback(ctx context.Context, w http.Response
 		errors.Is(err, graveler.ErrConflictFound),
 		errors.Is(err, graveler.ErrRevertMergeNoParent):
 		cb(w, r, http.StatusConflict, err)
-
-	case errors.Is(err, catalog.ErrFeatureNotSupported):
-		cb(w, r, http.StatusNotImplemented, err)
 
 	case errors.Is(err, graveler.ErrLockNotAcquired):
 		cb(w, r, http.StatusInternalServerError, "branch is currently locked, try again later")
@@ -2127,7 +2121,7 @@ func (c *Controller) UploadObject(w http.ResponseWriter, r *http.Request, reposi
 			writeError(w, r, http.StatusPreconditionFailed, "path already exists")
 			return
 		}
-		if !errors.Is(err, catalog.ErrNotFound) {
+		if !errors.Is(err, graveler.ErrNotFound) {
 			writeError(w, r, http.StatusInternalServerError, err)
 			return
 		}
@@ -2344,11 +2338,11 @@ func (c *Controller) GetCommit(w http.ResponseWriter, r *http.Request, repositor
 	ctx := r.Context()
 	c.LogAction(ctx, "get_commit", r, repository, commitID, "")
 	commit, err := c.Catalog.GetCommit(ctx, repository, commitID)
-	if errors.Is(err, catalog.ErrRepositoryNotFound) {
+	if errors.Is(err, graveler.ErrRepositoryNotFound) {
 		writeError(w, r, http.StatusNotFound, "repository not found")
 		return
 	}
-	if errors.Is(err, catalog.ErrNotFound) {
+	if errors.Is(err, graveler.ErrNotFound) {
 		writeError(w, r, http.StatusNotFound, "commit not found")
 		return
 	}
@@ -3232,7 +3226,7 @@ func (c *Controller) MergeIntoBranch(w http.ResponseWriter, r *http.Request, bod
 		c.Logger.WithError(err).WithField("run_id", hookAbortErr.RunID).Warn("aborted by hooks")
 		writeError(w, r, http.StatusPreconditionFailed, err)
 		return
-	case errors.Is(err, catalog.ErrConflictFound) || errors.Is(err, graveler.ErrConflictFound):
+	case errors.Is(err, graveler.ErrConflictFound):
 		writeResponse(w, r, http.StatusConflict, MergeResult{Reference: res})
 		return
 	}

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -1821,7 +1821,8 @@ func (c *Controller) handleAPIErrorCallback(ctx context.Context, w http.Response
 		errors.Is(err, model.ErrValidationError),
 		errors.Is(err, graveler.ErrInvalidRef),
 		errors.Is(err, graveler.ErrInvalidValue),
-		errors.Is(err, actions.ErrParamConflict):
+		errors.Is(err, actions.ErrParamConflict),
+		errors.Is(err, graveler.ErrDereferenceCommitWithStaging):
 		cb(w, r, http.StatusBadRequest, err)
 
 	case errors.Is(err, graveler.ErrNotUnique),

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -1591,7 +1591,7 @@ func TestController_DeleteBranchHandler(t *testing.T) {
 		verifyResponseOK(t, delResp, err)
 
 		_, err = deps.catalog.GetBranchReference(ctx, "my-new-repo", "main2")
-		if !errors.Is(err, catalog.ErrNotFound) {
+		if !errors.Is(err, graveler.ErrNotFound) {
 			t.Fatalf("expected branch to be gone, instead got error: %s", err)
 		}
 	})
@@ -3695,8 +3695,8 @@ func TestController_PostStatsEvents(t *testing.T) {
 			}
 
 			for _, sentEv := range tt.events {
-				var collectedEventsToCount = map[key]int{}
-				var k = key{class: sentEv.Class, name: sentEv.Name}
+				collectedEventsToCount := map[key]int{}
+				k := key{class: sentEv.Class, name: sentEv.Name}
 				_, isMapContainKey := collectedEventsToCount[k]
 				if isMapContainKey {
 					continue

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -2970,8 +2970,8 @@ func TestController_CreateTag(t *testing.T) {
 			Ref: "main$",
 		})
 		testutil.Must(t, err)
-		if tagResp.JSONDefault == nil {
-			t.Errorf("Create tag to explicit stage should fail with error, got %v", tagResp)
+		if tagResp.JSON400 == nil {
+			t.Errorf("Create tag to explicit stage should fail with validation error, got (status code: %d): %s", tagResp.StatusCode(), tagResp.Body)
 		}
 	})
 
@@ -3078,8 +3078,8 @@ func TestController_Revert(t *testing.T) {
 	t.Run("staging", func(t *testing.T) {
 		revertResp, err := clt.RevertBranchWithResponse(ctx, repo, "main", api.RevertBranchJSONRequestBody{Ref: "main$"})
 		testutil.Must(t, err)
-		if revertResp.JSONDefault == nil {
-			t.Errorf("Revert to explicit staging should fail with error, got %v", revertResp)
+		if revertResp.JSON400 == nil {
+			t.Errorf("Revert should fail with stating reference, got (status code: %d): %s", revertResp.StatusCode(), revertResp.Body)
 		}
 	})
 

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -1554,6 +1554,21 @@ func TestController_UploadObject(t *testing.T) {
 		}
 	})
 
+	t.Run("disable overwrite with if-none-match (no entry)", func(t *testing.T) {
+		ifNoneMatch := api.StringPtr("*")
+		contentType, buf := writeMultipart("content", "baz4", "something else!")
+		resp, err := clt.UploadObjectWithBodyWithResponse(ctx, "my-new-repo", "main", &api.UploadObjectParams{
+			Path:        "foo/baz4",
+			IfNoneMatch: ifNoneMatch,
+		}, contentType, buf)
+		if err != nil {
+			t.Fatalf("UploadObject err=%s, expected no error", err)
+		}
+		if resp.JSON201 == nil {
+			t.Fatalf("UploadObject status code=%d, expected 201", resp.StatusCode())
+		}
+	})
+
 	t.Run("upload object missing 'content' key", func(t *testing.T) {
 		// write
 		contentType, buf := writeMultipart("this-is-not-content", "bar", "hello world!")

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -313,14 +313,7 @@ func (c *Catalog) CreateBareRepository(ctx context.Context, repository string, s
 
 func (c *Catalog) getRepository(ctx context.Context, repository string) (*graveler.RepositoryRecord, error) {
 	repositoryID := graveler.RepositoryID(repository)
-	repo, err := c.Store.GetRepository(ctx, repositoryID)
-	if err != nil {
-		if errors.Is(err, graveler.ErrRepositoryNotFound) {
-			return nil, ErrRepositoryNotFound
-		}
-		return nil, err
-	}
-	return repo, err
+	return c.Store.GetRepository(ctx, repositoryID)
 }
 
 // GetRepository get repository information
@@ -594,9 +587,6 @@ func (c *Catalog) GetBranchReference(ctx context.Context, repositoryID string, b
 	}
 	b, err := c.Store.GetBranch(ctx, repository, branchID)
 	if err != nil {
-		if errors.Is(err, graveler.ErrBranchNotFound) {
-			err = ErrBranchNotFound
-		}
 		return "", err
 	}
 	return string(b.CommitID), nil
@@ -1095,7 +1085,7 @@ func (c *Catalog) ListCommits(ctx context.Context, repositoryID string, branch s
 func (c *Catalog) listCommitsWithPaths(ctx context.Context, repository *graveler.RepositoryRecord, it graveler.CommitIterator, params LogParams) ([]*CommitLog, bool, error) {
 	// verify we are not listing commits without any paths
 	if len(params.PathList) == 0 {
-		return nil, false, fmt.Errorf("%w: list commits without paths", ErrInvalid)
+		return nil, false, fmt.Errorf("%w: list commits without paths", graveler.ErrInvalid)
 	}
 	// commit/key to value cache - helps when fetching the same commit/key while processing parent commits
 	const commitLogCacheSize = 1024 * 5
@@ -1952,10 +1942,10 @@ func (c *Catalog) dereferenceCommitID(ctx context.Context, repository *graveler.
 		return "", err
 	}
 	if resolvedRef.CommitID == "" {
-		return "", fmt.Errorf("%w: no commit", ErrInvalidRef)
+		return "", fmt.Errorf("%w: no commit", graveler.ErrInvalidRef)
 	}
 	if resolvedRef.ResolvedBranchModifier == graveler.ResolvedBranchModifierStaging {
-		return "", fmt.Errorf("%w: should point to a commit", ErrInvalidRef)
+		return "", fmt.Errorf("%w: should point to a commit", graveler.ErrInvalidRef)
 	}
 	return resolvedRef.CommitID, nil
 }

--- a/pkg/catalog/errors.go
+++ b/pkg/catalog/errors.go
@@ -3,21 +3,12 @@ package catalog
 import (
 	"errors"
 	"fmt"
+
+	"github.com/treeverse/lakefs/pkg/graveler"
 )
 
 var (
-	ErrInvalid                  = errors.New("validation error")
-	ErrInvalidType              = fmt.Errorf("invalid type: %w", ErrInvalid)
-	ErrRequiredValue            = fmt.Errorf("required value: %w", ErrInvalid)
-	ErrPathRequiredValue        = fmt.Errorf("missing path: %w", ErrRequiredValue)
-	ErrInvalidValue             = fmt.Errorf("invalid value: %w", ErrInvalid)
-	ErrNotFound                 = errors.New("not found")
+	ErrPathRequiredValue        = fmt.Errorf("missing path: %w", graveler.ErrRequiredValue)
 	ErrInvalidMetadataSrcFormat = errors.New("invalid metadata src format")
 	ErrExpired                  = errors.New("expired from storage")
-	ErrFeatureNotSupported      = errors.New("feature not supported")
-	ErrBranchNotFound           = fmt.Errorf("branch %w", ErrNotFound)
-	ErrRepositoryNotFound       = fmt.Errorf("repository %w", ErrNotFound)
-	ErrNoDifferenceWasFound     = errors.New("no difference was found")
-	ErrConflictFound            = errors.New("conflict found")
-	ErrInvalidRef               = errors.New("invalid ref")
 )

--- a/pkg/catalog/errors.go
+++ b/pkg/catalog/errors.go
@@ -7,8 +7,13 @@ import (
 	"github.com/treeverse/lakefs/pkg/graveler"
 )
 
+// Define errors we raise from this package - do not convert underlying errors, optionally wrap if needed to consolidate
 var (
 	ErrPathRequiredValue        = fmt.Errorf("missing path: %w", graveler.ErrRequiredValue)
 	ErrInvalidMetadataSrcFormat = errors.New("invalid metadata src format")
 	ErrExpired                  = errors.New("expired from storage")
+	// ErrItClosed is used to determine the reason for the end of the walk
+	ErrItClosed = errors.New("iterator closed")
+
+	ErrFeatureNotSupported = errors.New("feature not supported")
 )

--- a/pkg/catalog/validate.go
+++ b/pkg/catalog/validate.go
@@ -3,6 +3,7 @@ package catalog
 import (
 	"fmt"
 
+	"github.com/treeverse/lakefs/pkg/graveler"
 	"github.com/treeverse/lakefs/pkg/validator"
 )
 
@@ -13,7 +14,7 @@ const (
 func ValidatePath(v interface{}) error {
 	s, ok := v.(Path)
 	if !ok {
-		panic(ErrInvalidType)
+		panic(graveler.ErrInvalidType)
 	}
 
 	l := len(s)
@@ -21,7 +22,7 @@ func ValidatePath(v interface{}) error {
 		return ErrPathRequiredValue
 	}
 	if l > MaxPathLength {
-		return fmt.Errorf("%w: %d is above maximum length (%d)", ErrInvalidValue, l, MaxPathLength)
+		return fmt.Errorf("%w: %d is above maximum length (%d)", graveler.ErrInvalidValue, l, MaxPathLength)
 	}
 	return nil
 }

--- a/pkg/catalog/walk_entry_iterator.go
+++ b/pkg/catalog/walk_entry_iterator.go
@@ -30,13 +30,6 @@ type EntryWithMarker struct {
 	Mark
 }
 
-var (
-	// ErrItClosed is used to determine the reason for the end of the walk
-	ErrItClosed = errors.New("iterator closed")
-
-	errSeekGENotSupported = errors.New("SeekGE not supported for walk entry iterator")
-)
-
 // bufferSize - buffer size of the buffer between reading entries from the blockstore Walk and passing it on
 const bufferSize = 100
 
@@ -117,7 +110,7 @@ func (it *walkEntryIterator) Next() bool {
 }
 
 func (it *walkEntryIterator) SeekGE(Path) {
-	it.err.Store(errSeekGENotSupported)
+	it.err.Store(ErrFeatureNotSupported)
 }
 
 func (it *walkEntryIterator) Value() *EntryRecord {

--- a/pkg/gateway/middleware.go
+++ b/pkg/gateway/middleware.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"time"
 
+	"github.com/treeverse/lakefs/pkg/graveler"
+
 	"github.com/treeverse/lakefs/pkg/auth"
 	"github.com/treeverse/lakefs/pkg/auth/model"
 	"github.com/treeverse/lakefs/pkg/catalog"
@@ -159,7 +161,7 @@ func EnrichWithRepositoryOrFallback(c catalog.Interface, authService auth.Gatewa
 			return
 		}
 		repo, err := c.GetRepository(ctx, repoID)
-		if errors.Is(err, catalog.ErrNotFound) {
+		if errors.Is(err, graveler.ErrNotFound) {
 			authResp, authErr := authService.Authorize(ctx, &auth.AuthorizationRequest{
 				Username: username,
 				RequiredPermissions: permissions.Node{

--- a/pkg/gateway/middleware.go
+++ b/pkg/gateway/middleware.go
@@ -9,8 +9,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/treeverse/lakefs/pkg/graveler"
-
 	"github.com/treeverse/lakefs/pkg/auth"
 	"github.com/treeverse/lakefs/pkg/auth/model"
 	"github.com/treeverse/lakefs/pkg/catalog"
@@ -18,6 +16,7 @@ import (
 	"github.com/treeverse/lakefs/pkg/gateway/operations"
 	"github.com/treeverse/lakefs/pkg/gateway/path"
 	"github.com/treeverse/lakefs/pkg/gateway/sig"
+	"github.com/treeverse/lakefs/pkg/graveler"
 	"github.com/treeverse/lakefs/pkg/httputil"
 	"github.com/treeverse/lakefs/pkg/logging"
 	"github.com/treeverse/lakefs/pkg/permissions"

--- a/pkg/gateway/operations/deleteobject.go
+++ b/pkg/gateway/operations/deleteobject.go
@@ -5,7 +5,6 @@ import (
 	"net/http"
 
 	"github.com/treeverse/lakefs/pkg/block"
-	"github.com/treeverse/lakefs/pkg/catalog"
 	gatewayerrors "github.com/treeverse/lakefs/pkg/gateway/errors"
 	"github.com/treeverse/lakefs/pkg/graveler"
 	"github.com/treeverse/lakefs/pkg/logging"
@@ -51,7 +50,7 @@ func (controller *DeleteObject) Handle(w http.ResponseWriter, req *http.Request,
 	lg := o.Log(req).WithField("key", o.Path)
 	err := o.Catalog.DeleteEntry(req.Context(), o.Repository.Name, o.Reference, o.Path)
 	switch {
-	case errors.Is(err, catalog.ErrNotFound) || errors.Is(err, graveler.ErrNotFound):
+	case errors.Is(err, graveler.ErrNotFound):
 		lg.WithError(err).Debug("could not delete object, it doesn't exist")
 	case errors.Is(err, graveler.ErrWriteToProtectedBranch):
 		_ = o.EncodeError(w, req, gatewayerrors.Codes.ToAPIErr(gatewayerrors.ErrWriteToProtectedBranch))

--- a/pkg/gateway/operations/deleteobjects.go
+++ b/pkg/gateway/operations/deleteobjects.go
@@ -148,7 +148,7 @@ func updateDeleteResult(result *serde.DeleteResult, quiet bool, log logging.Logg
 
 func checkForDeleteError(log logging.Logger, key string, err error) *serde.DeleteError {
 	switch {
-	case errors.Is(err, catalog.ErrNotFound), errors.Is(err, graveler.ErrNotFound):
+	case errors.Is(err, graveler.ErrNotFound):
 		log.Debug("tried to delete a non-existent object (OK)")
 	case errors.Is(err, graveler.ErrWriteToProtectedBranch):
 		apiErr := gerrors.Codes.ToAPIErr(gerrors.ErrWriteToProtectedBranch)

--- a/pkg/gateway/operations/getobject.go
+++ b/pkg/gateway/operations/getobject.go
@@ -48,7 +48,7 @@ func (controller *GetObject) Handle(w http.ResponseWriter, req *http.Request, o 
 		WithError(err).
 		Debug("metadata operation to retrieve object done")
 
-	if errors.Is(err, catalog.ErrNotFound) || errors.Is(err, graveler.ErrNotFound) {
+	if errors.Is(err, graveler.ErrNotFound) {
 		// TODO: create distinction between missing repo & missing key
 		_ = o.EncodeError(w, req, gatewayerrors.Codes.ToAPIErr(gatewayerrors.ErrNoSuchKey))
 		return

--- a/pkg/gateway/operations/headobject.go
+++ b/pkg/gateway/operations/headobject.go
@@ -26,7 +26,7 @@ func (controller *HeadObject) RequiredPermissions(_ *http.Request, repoID, _, pa
 func (controller *HeadObject) Handle(w http.ResponseWriter, req *http.Request, o *PathOperation) {
 	o.Incr("stat_object", o.Principal, o.Repository.Name, o.Reference)
 	entry, err := o.Catalog.GetEntry(req.Context(), o.Repository.Name, o.Reference, o.Path, catalog.GetEntryParams{ReturnExpired: true})
-	if errors.Is(err, catalog.ErrNotFound) || errors.Is(err, graveler.ErrNotFound) {
+	if errors.Is(err, graveler.ErrNotFound) {
 		// TODO: create distinction between missing repo & missing key
 		o.Log(req).Debug("path not found")
 		_ = o.EncodeError(w, req, gatewayerrors.Codes.ToAPIErr(gatewayerrors.ErrNoSuchKey))

--- a/pkg/gateway/operations/listobjects.go
+++ b/pkg/gateway/operations/listobjects.go
@@ -183,7 +183,7 @@ func (controller *ListObjects) ListV2(w http.ResponseWriter, req *http.Request, 
 			delimiter,
 			maxKeys,
 		)
-		if errors.Is(err, catalog.ErrBranchNotFound) {
+		if errors.Is(err, graveler.ErrBranchNotFound) {
 			o.Log(req).WithError(err).WithFields(logging.Fields{
 				"ref":  prefix.Ref,
 				"path": prefix.Path,
@@ -314,7 +314,7 @@ func (controller *ListObjects) ListV1(w http.ResponseWriter, req *http.Request, 
 			delimiter,
 			maxKeys,
 		)
-		if errors.Is(err, catalog.ErrNotFound) || errors.Is(err, graveler.ErrNotFound) {
+		if errors.Is(err, graveler.ErrNotFound) {
 			results = make([]*catalog.DBEntry, 0) // no results found
 		} else if err != nil {
 			o.Log(req).WithError(err).WithFields(logging.Fields{

--- a/pkg/graveler/errors.go
+++ b/pkg/graveler/errors.go
@@ -8,6 +8,7 @@ import (
 	"github.com/treeverse/lakefs/pkg/kv"
 )
 
+// Define errors we raise from this package - do not convert underlying errors, optionally wrap if needed to consolidate
 var (
 	// ErrUserVisible is base error for "user-visible" errors, which should not be wrapped with internal debug info.
 	ErrUserVisible = errors.New("")


### PR DESCRIPTION
Catalog defined set of error that just map 1:1 errors found in Graveler.
In order to reduce bugs where we compare different type - reuse or map these errors with the ones found in the graveler  package.
+ Add test to make sure it will never happen again.

Fix #4984