### PR TITLE
Fix spelling of configuration option

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -179,7 +179,7 @@ This reference uses `.` to denote the nesting of values.
 * `stats.flush_interval` `(duration : 30s)` - Interval used to post anonymous statistics collected
 * `stats.flush_size` `(int : 100)` - A size (in records) of anonymous statistics collected in which we post
 * `security.audit_check_interval` `(duration : 24h)` - Duration in which we check for security audit.
-* `ui.enable` `(bool: true)` - Whether to server the embedded UI from the binary  
+* `ui.enabled` `(bool: true)` - Whether to server the embedded UI from the binary  
 {: .ref-list }
 
 ## Using Environment Variables


### PR DESCRIPTION
It really is `ui.enabled`, see [the source][ui.enabled-source].

[ui.enabled-source]:  blob/71c9c3c1ede4199e4bd3f4389798fcf0e1432de8/pkg/config/config.go#L280