### PR TITLE
Use copy instead of stage object in lakeFSFS rename

### DIFF
--- a/clients/hadoopfs/pom.xml
+++ b/clients/hadoopfs/pom.xml
@@ -248,7 +248,7 @@ To export to S3:
         <dependency>
             <groupId>io.lakefs</groupId>
             <artifactId>api-client</artifactId>
-            <version>0.81.0</version>
+            <version>0.89.1-RC1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileSystem.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileSystem.java
@@ -503,10 +503,6 @@ public class LakeFSFileSystem extends FileSystem {
                 return (FileNotFoundException) new FileNotFoundException(msg).initCause(e);
             case HttpStatus.SC_FORBIDDEN:
                 return (AccessDeniedException) new AccessDeniedException(msg).initCause(e);
-            case HttpStatus.SC_INTERNAL_SERVER_ERROR:
-                if (msg.contains("invalid API endpoint")){
-                    return (AccessDeniedException) new AccessDeniedException(msg).initCause(e);
-                }
             default:
                 return new IOException(msg, e);
         }

--- a/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileSystem.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileSystem.java
@@ -426,6 +426,13 @@ public class LakeFSFileSystem extends FileSystem {
     }
 
     /**
+     * fallbackToStage determines whether the old StageObject API should be use,
+     * turn true when CopyObject API is not supported.
+     */
+    private boolean fallbackToStage = false;
+
+
+    /**
      * Non-atomic rename operation.
      *
      * @return true if rename succeeded, false otherwise
@@ -444,13 +451,12 @@ public class LakeFSFileSystem extends FileSystem {
                 .srcRef(srcObjectLoc.getRef())
                 .srcPath(srcObjectLoc.getPath());
 
-        Boolean fallbackToStage = false;
         try {
             objects.copyObject(dstObjectLoc.getRepository(), dstObjectLoc.getRef(), dstObjectLoc.getPath(),
                     creationReq);
         } catch (ApiException e) {
-            if (e.getCode() !=HttpStatus.SC_INTERNAL_SERVER_ERROR ||
-                    e.getMessage().contains("invalid API endpoint")){
+            if (e.getCode() != HttpStatus.SC_INTERNAL_SERVER_ERROR ||
+                    !e.getMessage().contains("invalid API endpoint")){
                 throw translateException("renameObject: src:" + srcStatus.getPath() + ", dst: " + dst + ", failed to copy object", e);
             }
 

--- a/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileSystem.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileSystem.java
@@ -465,7 +465,7 @@ public class LakeFSFileSystem extends FileSystem {
             }
         }
 
-        if (fallbackToStage){
+        if (fallbackToStage) {
             ObjectStageCreation stageCreationReq = new ObjectStageCreation()
                     .checksum(srcStatus.getChecksum())
                     .sizeBytes(srcStatus.getLen())

--- a/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileSystem.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileSystem.java
@@ -440,16 +440,15 @@ public class LakeFSFileSystem extends FileSystem {
 
         ObjectsApi objects = lfsClient.getObjects();
         //TODO (Tals): Can we add metadata? we currently don't have an API to get the metadata of an object.
-        ObjectStageCreation creationReq = new ObjectStageCreation()
-                .checksum(srcStatus.getChecksum())
-                .sizeBytes(srcStatus.getLen())
-                .physicalAddress(srcStatus.getPhysicalAddress());
+        ObjectCopyCreation creationReq = new ObjectCopyCreation()
+                .srcRef(srcObjectLoc.getRef())
+                .srcPath(srcObjectLoc.getPath());
 
         try {
-            objects.stageObject(dstObjectLoc.getRepository(), dstObjectLoc.getRef(), dstObjectLoc.getPath(),
+            objects.copyObject(dstObjectLoc.getRepository(), dstObjectLoc.getRef(), dstObjectLoc.getPath(),
                     creationReq);
         } catch (ApiException e) {
-            throw translateException("renameObject: src:" + srcStatus.getPath() + ", dst: " + dst + ", failed to stage object", e);
+            throw translateException("renameObject: src:" + srcStatus.getPath() + ", dst: " + dst + ", failed to copy object", e);
         }
 
         // delete src path

--- a/clients/hadoopfs/src/test/java/io/lakefs/LakeFSFileSystemTest.java
+++ b/clients/hadoopfs/src/test/java/io/lakefs/LakeFSFileSystemTest.java
@@ -821,13 +821,13 @@ public class LakeFSFileSystemTest {
     }
 
     private boolean dstPathLinkedToSrcPhysicalAddress(ObjectLocation srcObjLoc, ObjectLocation dstObjLoc) throws ApiException {
-        ArgumentCaptor<ObjectStageCreation> creationReqCapture = ArgumentCaptor.forClass(ObjectStageCreation.class);
-        verify(objectsApi).stageObject(eq(dstObjLoc.getRepository()), eq(dstObjLoc.getRef()), eq(dstObjLoc.getPath()),
+        ArgumentCaptor<ObjectCopyCreation> creationReqCapture = ArgumentCaptor.forClass(ObjectCopyCreation.class);
+        verify(objectsApi).copyObject(eq(dstObjLoc.getRepository()), eq(dstObjLoc.getRef()), eq(dstObjLoc.getPath()),
                 creationReqCapture.capture());
-        ObjectStageCreation actualCreationReq = creationReqCapture.getValue();
+        ObjectCopyCreation actualCreationReq = creationReqCapture.getValue();
         // Rename is a metadata operation, therefore the dst name is expected to link to the src physical address.
-        String expectedPhysicalAddress = s3Url(objectLocToS3ObjKey(srcObjLoc));
-        return expectedPhysicalAddress.equals(actualCreationReq.getPhysicalAddress());
+        return srcObjLoc.getRef().equals(actualCreationReq.getSrcRef()) &&
+                srcObjLoc.getPath().equals(actualCreationReq.getSrcPath());
     }
 
     /**
@@ -974,7 +974,7 @@ public class LakeFSFileSystemTest {
         boolean renamed = fs.rename(src, dst);
         Assert.assertFalse(renamed);
         Mockito.verify(objectsApi, never()).statObject(any(), any(), any(), any());
-        Mockito.verify(objectsApi, never()).stageObject(any(), any(), any(), any());
+        Mockito.verify(objectsApi, never()).copyObject(any(), any(), any(), any());
         Mockito.verify(objectsApi, never()).deleteObject(any(), any(), any());
     }
 
@@ -988,7 +988,7 @@ public class LakeFSFileSystemTest {
         boolean renamed = fs.rename(src, dst);
         Assert.assertTrue(renamed);
         Mockito.verify(objectsApi, never()).statObject(any(), any(), any(), any());
-        Mockito.verify(objectsApi, never()).stageObject(any(), any(), any(), any());
+        Mockito.verify(objectsApi, never()).copyObject(any(), any(), any(), any());
         Mockito.verify(objectsApi, never()).deleteObject(any(), any(), any());
     }
 

--- a/clients/hadoopfs/src/test/java/io/lakefs/LakeFSFileSystemTest.java
+++ b/clients/hadoopfs/src/test/java/io/lakefs/LakeFSFileSystemTest.java
@@ -783,6 +783,11 @@ public class LakeFSFileSystemTest {
         return srcStats;
     }
 
+    private void mockMissingCopyAPI() throws ApiException {
+        when(objectsApi.copyObject(any(), any(), any(), any())).thenThrow(new ApiException(HttpStatus.SC_INTERNAL_SERVER_ERROR, "{\"message\":\"invalid API endpoint\"}"));
+        when(objectsApi.stageObject(any(), any(), any(), any())).thenReturn(new ObjectStats());
+    }
+
     private ObjectStats mockEmptyDirectoryMarker(ObjectLocation objectLoc) throws ApiException {
         String key = objectLocToS3ObjKey(objectLoc);
 
@@ -965,6 +970,32 @@ public class LakeFSFileSystemTest {
 
         boolean renamed = fs.rename(srcDir, dstDir);
         Assert.assertFalse(renamed);
+    }
+
+    /**
+     * Check that a file is renamed when working against a lakeFS version
+     * where CopyObject API doesn't exist
+     */
+    @Test
+    public void testRename_fallbackStageAPI() throws ApiException, IOException {
+        Path src = new Path("lakefs://repo/main/existing-dir1/existing.src");
+        ObjectLocation srcObjLoc = fs.pathToObjectLocation(src);
+        mockExistingFilePath(srcObjLoc);
+
+        Path fileInDstDir = new Path("lakefs://repo/main/existing-dir2/existing.src");
+        ObjectLocation fileObjLoc = fs.pathToObjectLocation(fileInDstDir);
+        Path dst = new Path("lakefs://repo/main/existing-dir2");
+        ObjectLocation dstObjLoc = fs.pathToObjectLocation(dst);
+
+        mockExistingDirPath(dstObjLoc, ImmutableList.of(fileObjLoc));
+        mockDirectoryMarker(fs.pathToObjectLocation(src.getParent()));
+        mockMissingCopyAPI();
+
+        boolean renamed = fs.rename(src, dst);
+        Assert.assertTrue(renamed);
+        Path expectedDstPath = new Path("lakefs://repo/main/existing-dir2/existing.src");
+        Assert.assertTrue(dstPathLinkedToSrcPhysicalAddress(srcObjLoc, fs.pathToObjectLocation(expectedDstPath)));
+        verifyObjDeletion(srcObjLoc);
     }
 
     @Test


### PR DESCRIPTION
close #4479 

Context: UGC milestone 2 aims to enable "safe" runs of the UGC. "safe" means that lakeFS is accepting writes and that they don't get accidentally picked up by UGC. To ensure that, we need to block `StageObject` from staging objects in the repo's storage namespace. The new `CopyObject` API will create the link (without physical copying) for uncommitted objects on the same branch, hence is equal to the current `StageObject` behaviour.