### PR TITLE
presign: added esti tests that call the pre-signed URL

### DIFF
--- a/esti/main_test.go
+++ b/esti/main_test.go
@@ -64,10 +64,11 @@ const (
 )
 
 var (
-	logger logging.Logger
-	client api.ClientWithResponsesInterface
-	svc    *s3.S3
-	server *webhookServer
+	logger      logging.Logger
+	client      api.ClientWithResponsesInterface
+	endpointURL string
+	svc         *s3.S3
+	server      *webhookServer
 
 	testDirectDataAccess = Booleans{false}
 
@@ -296,7 +297,7 @@ func TestMain(m *testing.M) {
 	}
 	viper.SetDefault("post_migrate", false)
 
-	logger, client, svc = testutil.SetupTestingEnv(&params)
+	logger, client, svc, endpointURL = testutil.SetupTestingEnv(&params)
 
 	var err error
 	setupLakeFS := viper.GetBool("setup_lakefs")

--- a/esti/presign_test.go
+++ b/esti/presign_test.go
@@ -149,6 +149,6 @@ func TestPreSign(t *testing.T) {
 		require.NoError(t, err, "failed to read back linked object")
 		require.Equalf(t, readBackResponse.StatusCode(), http.StatusOK, "unexpected HTTP code for get_object after linking: %s", readBackResponse.Status())
 		returnedContent := readBackResponse.Body
-		require.Equal(t, returnedContent, objContent, "the body returned is different from the one uploaded")
+		require.Equal(t, string(returnedContent), objContent, "the body returned is different from the one uploaded")
 	})
 }

--- a/esti/presign_test.go
+++ b/esti/presign_test.go
@@ -53,7 +53,7 @@ func TestPreSign(t *testing.T) {
 	_, _ = uploadFileRandomData(ctx, t, repo, mainBranch, "foo/bar", false)
 
 	objContent := randstr.String(randomDataContentLength)
-	_, err := uploadFileAndReport(ctx, repo, mainBranch, "foo/bar", objContent, false)
+	_, err = uploadFileAndReport(ctx, repo, mainBranch, "foo/bar", objContent, false)
 	if err != nil {
 		t.Errorf("could no upload data file")
 	}

--- a/esti/presign_test.go
+++ b/esti/presign_test.go
@@ -1,9 +1,13 @@
 package esti
 
 import (
+	"io"
+	"net/http"
 	"net/url"
 	"strings"
 	"testing"
+
+	"github.com/thanhpk/randstr"
 
 	"github.com/go-openapi/swag"
 	"github.com/spf13/viper"
@@ -11,6 +15,17 @@ import (
 	"github.com/treeverse/lakefs/pkg/api"
 	"github.com/treeverse/lakefs/pkg/block"
 )
+
+func matchPreSignedURLContent(t *testing.T, preSignedURL, content string) {
+	// Running an HTTP GET on the URL should return the object's content in body.
+	r, err := http.Get(preSignedURL)
+	require.NoErrorf(t, err, "failed to GET pre-signed url - %s", preSignedURL)
+
+	retrievedData, err := io.ReadAll(r.Body)
+	require.NoErrorf(t, err, "failed to read GET body from pre-signed url - %s", preSignedURL)
+	require.Equal(t, string(retrievedData), content, "pre-signed url body doesn't match uploaded content")
+	require.NoError(t, r.Body.Close(), "could not close response body")
+}
 
 func TestPreSign(t *testing.T) {
 	SkipTestIfAskedTo(t)
@@ -29,15 +44,57 @@ func TestPreSign(t *testing.T) {
 	ctx, _, repo := setupTest(t)
 	defer tearDownTest(repo)
 	_, _ = uploadFileRandomData(ctx, t, repo, mainBranch, "foo/bar", false)
-	response, err := client.StatObjectWithResponse(ctx, repo, mainBranch, &api.StatObjectParams{
-		Path:    "foo/bar",
-		Presign: swag.Bool(true),
+
+	objContent := randstr.String(randomDataContentLength)
+	_, err := uploadFileAndReport(ctx, repo, mainBranch, "foo/bar", objContent, false)
+	if err != nil {
+		t.Errorf("could no upload data file")
+	}
+
+	t.Run("preSignStat", func(t *testing.T) {
+		response, err := client.StatObjectWithResponse(ctx, repo, mainBranch, &api.StatObjectParams{
+			Path:    "foo/bar",
+			Presign: swag.Bool(true),
+		})
+		require.NoError(t, err, "failed to stat object with presign=true")
+		require.NotNil(t, response.JSON200, "successful response")
+		signedURL := response.JSON200.PhysicalAddress
+		parsedSignedURL, err := url.Parse(signedURL)
+		require.NoErrorf(t, err, "failed to parse url - %s", signedURL)
+		require.Truef(t, strings.HasPrefix(parsedSignedURL.Scheme, "http"), "URL scheme http(s) - %s", signedURL)
+		require.NotEmptyf(t, parsedSignedURL.Query().Get(expectedKey), "signature expected in key '%s' - %s", expectedKey, signedURL)
+		matchPreSignedURLContent(t, signedURL, objContent)
 	})
-	require.NoError(t, err, "failed to stat object with presign=true")
-	require.NotNil(t, response.JSON200, "successful response")
-	signedURL := response.JSON200.PhysicalAddress
-	parsedSignedURL, err := url.Parse(signedURL)
-	require.NoErrorf(t, err, "failed to parse url - %s", signedURL)
-	require.Truef(t, strings.HasPrefix(parsedSignedURL.Scheme, "http"), "URL scheme http(s) - %s", signedURL)
-	require.NotEmptyf(t, parsedSignedURL.Query().Get(expectedKey), "signature expected in key '%s' - %s", expectedKey, signedURL)
+
+	t.Run("preSignList", func(t *testing.T) {
+		paginationDelimiter := api.PaginationDelimiter("/")
+		paginationPrefix := api.PaginationPrefix("foo/")
+		response, err := client.ListObjectsWithResponse(ctx, repo, mainBranch, &api.ListObjectsParams{
+			Prefix:    &paginationPrefix,
+			Presign:   swag.Bool(true),
+			Delimiter: &paginationDelimiter,
+		})
+		require.NoError(t, err, "failed to list objects with presign=true")
+		require.NotNil(t, response.JSON200, "successful response")
+		entry := response.JSON200.Results[0]
+		signedURL := entry.PhysicalAddress
+		parsedSignedURL, err := url.Parse(signedURL)
+		require.NoErrorf(t, err, "failed to parse url - %s", signedURL)
+		require.Truef(t, strings.HasPrefix(parsedSignedURL.Scheme, "http"), "URL scheme http(s) - %s", signedURL)
+		require.NotEmptyf(t, parsedSignedURL.Query().Get(expectedKey), "signature expected in key '%s' - %s", expectedKey, signedURL)
+		matchPreSignedURLContent(t, signedURL, objContent)
+	})
+
+	t.Run("preSignGet", func(t *testing.T) {
+		response, err := client.GetObjectWithResponse(ctx, repo, mainBranch, &api.GetObjectParams{
+			Path:    "foo/bar",
+			Presign: swag.Bool(true),
+		})
+		require.NoError(t, err, "failed to get object with presign=true")
+		require.Equal(t, string(response.Body), objContent, "pre-signed url body doesn't match uploaded content")
+		responseHost := response.HTTPResponse.Header.Get("Host")
+		endpointParsedURL, err := url.Parse(endpointURL)
+		require.NoError(t, err, "failed to parse the endpoint URL used by esti")
+		require.NotEqual(t, endpointParsedURL.Host, responseHost, "Should have been redirected to the object store")
+	})
 }

--- a/pkg/testutil/setup.go
+++ b/pkg/testutil/setup.go
@@ -31,7 +31,7 @@ type SetupTestingEnvParams struct {
 	AdminSecretAccessKey string
 }
 
-func SetupTestingEnv(params *SetupTestingEnvParams) (logging.Logger, api.ClientWithResponsesInterface, *s3.S3) {
+func SetupTestingEnv(params *SetupTestingEnvParams) (logging.Logger, api.ClientWithResponsesInterface, *s3.S3, string) {
 	logger := logging.Default()
 
 	viper.SetDefault("setup_lakefs", true)
@@ -117,7 +117,7 @@ func SetupTestingEnv(params *SetupTestingEnvParams) (logging.Logger, api.ClientW
 	key := viper.GetString("access_key_id")
 	secret := viper.GetString("secret_access_key")
 	svc := SetupTestS3Client(s3Endpoint, key, secret)
-	return logger, client, svc
+	return logger, client, svc, endpointURL
 }
 
 func SetupTestS3Client(endpoint, key, secret string) *s3.S3 {
@@ -134,7 +134,8 @@ func SetupTestS3Client(endpoint, key, secret string) *s3.S3 {
 					Value: credentials.Value{
 						AccessKeyID:     key,
 						SecretAccessKey: secret,
-					}})))
+					},
+				})))
 	return svc
 }
 


### PR DESCRIPTION
Added HTTP GET tests for endpoints that return a pre-signed URL (stat, get and list)
The tests call out to the resulting URL using a default HTTP client and make sure the returned content is correct.