### PR TITLE
Stats collector handle post with retry and graceful shutdown

### DIFF
--- a/cmd/lakefs/cmd/run.go
+++ b/cmd/lakefs/cmd/run.go
@@ -234,10 +234,10 @@ var runCmd = &cobra.Command{
 		controllerAuthenticator := append(middlewareAuthenticator, auth.NewEmailAuthenticator(authService))
 
 		auditChecker := version.NewDefaultAuditChecker(cfg.Security.AuditCheckURL, metadata.InstallationID)
+		defer auditChecker.Close()
 		if version.Version != version.UnreleasedVersion {
 			auditChecker.StartPeriodicCheck(ctx, cfg.Security.AuditCheckInterval, logger)
 		}
-		defer auditChecker.Close()
 
 		allowForeign, err := cmd.Flags().GetBool(mismatchedReposFlagName)
 		if err != nil {

--- a/cmd/lakefs/cmd/run.go
+++ b/cmd/lakefs/cmd/run.go
@@ -181,7 +181,8 @@ var runCmd = &cobra.Command{
 		}
 
 		metadata := stats.NewMetadata(ctx, logger, blockstoreType, authMetadataManager, cloudMetadataProvider)
-		bufferedCollector := stats.NewBufferedCollector(metadata.InstallationID, stats.Config(cfg.Stats), stats.WithLogger(logger))
+		bufferedCollector := stats.NewBufferedCollector(metadata.InstallationID, stats.Config(cfg.Stats),
+			stats.WithLogger(logger.WithField("service", "stats_collector")))
 
 		// init block store
 		blockStore, err := factory.BuildBlockAdapter(ctx, bufferedCollector, cfg)
@@ -327,7 +328,7 @@ var runCmd = &cobra.Command{
 			cfg.Logging.TraceRequestHeaders,
 		)
 
-		bufferedCollector.Run(ctx)
+		bufferedCollector.Start(ctx)
 		defer bufferedCollector.Close()
 
 		bufferedCollector.CollectEvent(stats.Event{Class: "global", Name: "run"})

--- a/cmd/lakefs/cmd/run.go
+++ b/cmd/lakefs/cmd/run.go
@@ -115,7 +115,9 @@ var runCmd = &cobra.Command{
 			}
 		})
 
-		ctx := cmd.Context()
+		ctx, stop := signal.NotifyContext(cmd.Context(), syscall.SIGINT, syscall.SIGTERM)
+		defer stop()
+
 		logger.WithField("version", version.Version).Info("lakeFS run")
 
 		kvParams, err := cfg.DatabaseParams()
@@ -232,10 +234,10 @@ var runCmd = &cobra.Command{
 		controllerAuthenticator := append(middlewareAuthenticator, auth.NewEmailAuthenticator(authService))
 
 		auditChecker := version.NewDefaultAuditChecker(cfg.Security.AuditCheckURL, metadata.InstallationID)
-		defer auditChecker.Close()
 		if version.Version != version.UnreleasedVersion {
 			auditChecker.StartPeriodicCheck(ctx, cfg.Security.AuditCheckInterval, logger)
 		}
+		defer auditChecker.Close()
 
 		allowForeign, err := cmd.Flags().GetBool(mismatchedReposFlagName)
 		if err != nil {
@@ -250,15 +252,11 @@ var runCmd = &cobra.Command{
 		httputil.SetHealthHandlerInfo(metadata.InstallationID)
 
 		// start API server
-		done := make(chan bool, 1)
-		quit := make(chan os.Signal, 1)
-		signal.Notify(quit, syscall.SIGINT, syscall.SIGTERM)
-
 		var oauthConfig *oauth2.Config
 		var oidcProvider *oidc.Provider
 		if cfg.Auth.OIDC.Enabled {
 			oidcProvider, err = oidc.NewProvider(
-				cmd.Context(),
+				ctx,
 				cfg.Auth.OIDC.URL,
 			)
 			if err != nil {
@@ -328,13 +326,13 @@ var runCmd = &cobra.Command{
 			cfg.Logging.AuditLogLevel,
 			cfg.Logging.TraceRequestHeaders,
 		)
-		ctx, cancelFn := context.WithCancel(cmd.Context())
+
 		bufferedCollector.Run(ctx)
 		defer bufferedCollector.Close()
 
 		bufferedCollector.CollectEvent(stats.Event{Class: "global", Name: "run"})
 
-		logging.Default().WithField("listen_address", cfg.ListenAddress).Info("starting HTTP server")
+		logger.WithField("listen_address", cfg.ListenAddress).Info("starting HTTP server")
 		server := &http.Server{
 			Addr:              cfg.ListenAddress,
 			ReadHeaderTimeout: time.Minute,
@@ -356,15 +354,12 @@ var runCmd = &cobra.Command{
 
 		go func() {
 			if err := server.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
-				fmt.Printf("server failed to listen on %s: %v\n", cfg.ListenAddress, err)
+				_, _ = fmt.Fprintf(os.Stderr, "Failed to listen on %s: %v\n", cfg.ListenAddress, err)
 				os.Exit(1)
 			}
 		}()
 
-		go gracefulShutdown(cmd.Context(), quit, done, server)
-
-		<-done
-		cancelFn()
+		gracefulShutdown(ctx, server)
 	},
 }
 
@@ -499,24 +494,19 @@ func printLocalWarning(w io.Writer, msg string) {
 	_, _ = fmt.Fprintf(w, localWarningBanner, msg)
 }
 
-func gracefulShutdown(ctx context.Context, quit <-chan os.Signal, done chan<- bool, servers ...Shutter) {
-	logger := logging.Default()
-	logger.WithField("version", version.Version).Info("Up and running (^C to shutdown)...")
-
+func gracefulShutdown(ctx context.Context, services ...Shutter) {
+	_, _ = fmt.Fprintf(os.Stderr, "lakeFS %s - Up and running (^C to shutdown)...\n", version.Version)
 	printWelcome(os.Stderr)
+	<-ctx.Done()
 
-	<-quit
-	logger.Warn("shutting down...")
-
+	_, _ = fmt.Fprintf(os.Stderr, "Shutting down...\n")
 	ctx, cancel := context.WithTimeout(ctx, gracefulShutdownTimeout)
 	defer cancel()
-
-	for i, server := range servers {
-		if err := server.Shutdown(ctx); err != nil {
-			fmt.Printf("Error while shutting down service (%d): %s\n", i, err)
+	for i, service := range services {
+		if err := service.Shutdown(ctx); err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "Failed shutting down service [%d]: %s\n", i, err)
 		}
 	}
-	close(done)
 }
 
 // enableKVParamsMetrics returns a copy of params.KV with postgres metrics enabled.

--- a/cmd/lakefs/cmd/setup.go
+++ b/cmd/lakefs/cmd/setup.go
@@ -93,8 +93,9 @@ var setupCmd = &cobra.Command{
 		}
 
 		ctx, cancelFn := context.WithCancel(ctx)
-		collector := stats.NewBufferedCollector(metadata.InstallationID, stats.Config(cfg.Stats), stats.WithLogger(logger))
-		collector.Run(ctx)
+		collector := stats.NewBufferedCollector(metadata.InstallationID, stats.Config(cfg.Stats),
+			stats.WithLogger(logger.WithField("service", "stats_collector")))
+		collector.Start(ctx)
 		defer collector.Close()
 
 		collector.CollectMetadata(metadata)

--- a/cmd/lakefs/cmd/superuser.go
+++ b/cmd/lakefs/cmd/superuser.go
@@ -75,8 +75,9 @@ var superuserCmd = &cobra.Command{
 		}
 
 		ctx, cancelFn := context.WithCancel(ctx)
-		collector := stats.NewBufferedCollector(metadata.InstallationID, stats.Config(cfg.Stats), stats.WithLogger(logger))
-		collector.Run(ctx)
+		collector := stats.NewBufferedCollector(metadata.InstallationID, stats.Config(cfg.Stats),
+			stats.WithLogger(logger.WithField("service", "stats_collector")))
+		collector.Start(ctx)
 		defer collector.Close()
 
 		collector.CollectMetadata(metadata)

--- a/go.mod
+++ b/go.mod
@@ -85,6 +85,7 @@ require (
 	github.com/go-co-op/gocron v1.18.0
 	github.com/gorilla/securecookie v1.1.1
 	github.com/gorilla/sessions v1.2.1
+	github.com/hashicorp/go-retryablehttp v0.7.2
 )
 
 require (
@@ -111,6 +112,7 @@ require (
 	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b // indirect
 	github.com/google/flatbuffers v2.0.0+incompatible // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.2.1 // indirect
+	github.com/hashicorp/go-cleanhttp v0.5.2 // indirect
 	github.com/hashicorp/go-version v1.6.0 // indirect
 	github.com/hexops/gotextdiff v1.0.3 // indirect
 	github.com/kkHAIKE/contextcheck v1.1.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -573,8 +573,14 @@ github.com/grpc-ecosystem/go-grpc-prometheus v1.2.0/go.mod h1:8NvIoxWQoOIhqOTXgf
 github.com/grpc-ecosystem/grpc-gateway v1.9.0/go.mod h1:vNeuVxBJEsws4ogUvrchl83t/GYV9WGTSLVdBhOQFDY=
 github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
+github.com/hashicorp/go-cleanhttp v0.5.2 h1:035FKYIWjmULyFRBKPs8TBQoi0x6d9G4xc9neXJWAZQ=
+github.com/hashicorp/go-cleanhttp v0.5.2/go.mod h1:kO/YDlP8L1346E6Sodw+PrpBSV4/SoxCXGY6BqNFT48=
+github.com/hashicorp/go-hclog v0.9.2/go.mod h1:5CU+agLiy3J7N7QjHK5d05KxGsuXiQLrjA0H7acj2lQ=
+github.com/hashicorp/go-hclog v1.2.0 h1:La19f8d7WIlm4ogzNHB0JGqs5AUDAZ2UfCY4sJXcJdM=
 github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
+github.com/hashicorp/go-retryablehttp v0.7.2 h1:AcYqCvkpalPnPF2pn0KamgwamS42TqUDDYFRKq/RAd0=
+github.com/hashicorp/go-retryablehttp v0.7.2/go.mod h1:Jy/gPYAdjqffZ/yFGCFV2doI5wjtH1ewM9u8iYVjtX8=
 github.com/hashicorp/go-uuid v0.0.0-20180228145832-27454136f036/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.2.1/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=

--- a/pkg/actions/service_test.go
+++ b/pkg/actions/service_test.go
@@ -50,7 +50,8 @@ func (c *ActionStatsMockCollector) CollectEvents(ev stats.Event, count uint64) {
 	c.Hits[ev.Name] += int(count)
 }
 
-func (c *ActionStatsMockCollector) CollectMetadata(_ *stats.Metadata)       {}
+func (c *ActionStatsMockCollector) CollectMetadata(accountMetadata *stats.Metadata) {
+}
 func (c *ActionStatsMockCollector) SetInstallationID(_ string)              {}
 func (c *ActionStatsMockCollector) CollectCommPrefs(_, _ string, _, _ bool) {}
 func (c *ActionStatsMockCollector) Close()                                  {}

--- a/pkg/api/serve_test.go
+++ b/pkg/api/serve_test.go
@@ -70,7 +70,7 @@ func (m *memCollector) CollectEvent(ev stats.Event) {
 func (m *memCollector) CollectMetadata(accountMetadata *stats.Metadata) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	m.Metadata = append(m.Metadata, metadata)
+	m.Metadata = append(m.Metadata, accountMetadata)
 }
 
 func (m *memCollector) SetInstallationID(installationID string) {

--- a/pkg/api/serve_test.go
+++ b/pkg/api/serve_test.go
@@ -67,7 +67,7 @@ func (m *memCollector) CollectEvent(ev stats.Event) {
 	m.CollectEvents(ev, 1)
 }
 
-func (m *memCollector) CollectMetadata(metadata *stats.Metadata) {
+func (m *memCollector) CollectMetadata(accountMetadata *stats.Metadata) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	m.Metadata = append(m.Metadata, metadata)

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -198,39 +198,39 @@ func (l *logrusEntryWrapper) WithError(err error) Logger {
 	return &logrusEntryWrapper{l.e.WithError(err)}
 }
 
-func (l logrusEntryWrapper) Trace(args ...interface{}) {
+func (l *logrusEntryWrapper) Trace(args ...interface{}) {
 	l.e.Trace(args...)
 }
 
-func (l logrusEntryWrapper) Debug(args ...interface{}) {
+func (l *logrusEntryWrapper) Debug(args ...interface{}) {
 	l.e.Debug(args...)
 }
 
-func (l logrusEntryWrapper) Info(args ...interface{}) {
+func (l *logrusEntryWrapper) Info(args ...interface{}) {
 	l.e.Info(args...)
 }
 
-func (l logrusEntryWrapper) Warn(args ...interface{}) {
+func (l *logrusEntryWrapper) Warn(args ...interface{}) {
 	l.e.Warn(args...)
 }
 
-func (l logrusEntryWrapper) Warning(args ...interface{}) {
+func (l *logrusEntryWrapper) Warning(args ...interface{}) {
 	l.e.Warning(args...)
 }
 
-func (l logrusEntryWrapper) Error(args ...interface{}) {
+func (l *logrusEntryWrapper) Error(args ...interface{}) {
 	l.e.Error(args...)
 }
 
-func (l logrusEntryWrapper) Fatal(args ...interface{}) {
+func (l *logrusEntryWrapper) Fatal(args ...interface{}) {
 	l.e.Fatal(args...)
 }
 
-func (l logrusEntryWrapper) Panic(args ...interface{}) {
+func (l *logrusEntryWrapper) Panic(args ...interface{}) {
 	l.e.Panic(args...)
 }
 
-func (l logrusEntryWrapper) Log(level logrus.Level, args ...interface{}) {
+func (l *logrusEntryWrapper) Log(level logrus.Level, args ...interface{}) {
 	l.e.Log(level, args...)
 }
 
@@ -266,7 +266,7 @@ func (l *logrusEntryWrapper) Panicf(format string, args ...interface{}) {
 	l.e.Panicf(format, args...)
 }
 
-func (l logrusEntryWrapper) Logf(level logrus.Level, format string, args ...interface{}) {
+func (l *logrusEntryWrapper) Logf(level logrus.Level, format string, args ...interface{}) {
 	l.e.Logf(level, format, args...)
 }
 

--- a/pkg/stats/collector.go
+++ b/pkg/stats/collector.go
@@ -113,9 +113,7 @@ type BufferedCollector struct {
 	runtimeCollector func() map[string]string
 	runtimeStats     map[string]string
 	inFlight         sync.WaitGroup
-	pendingRequests  sync.WaitGroup
 	closed           int32
-	done             chan bool
 	extended         bool
 	log              logging.Logger
 	wg               sync.WaitGroup
@@ -181,9 +179,7 @@ func NewBufferedCollector(installationID string, cfg Config, opts ...BufferedCol
 		installationID:  installationID,
 		processID:       uuid.Must(uuid.NewUUID()).String(),
 		inFlight:        sync.WaitGroup{},
-		pendingRequests: sync.WaitGroup{},
 		closed:          0,
-		done:            make(chan bool),
 		extended:        cfg.Extended,
 		log:             logging.Default(),
 		sendCh:          make(chan *InputEvent),

--- a/pkg/stats/collector_test.go
+++ b/pkg/stats/collector_test.go
@@ -15,17 +15,17 @@ type mockSender struct {
 	metadata chan stats.Metadata
 }
 
-func (s *mockSender) SendEvent(ctx context.Context, installationID, processID string, m []stats.Metric) error {
+func (s *mockSender) SendEvent(_ context.Context, _, _ string, m []stats.Metric) error {
 	s.metrics <- m
 	return nil
 }
 
-func (s *mockSender) UpdateMetadata(ctx context.Context, m stats.Metadata) error {
+func (s *mockSender) UpdateMetadata(_ context.Context, m stats.Metadata) error {
 	s.metadata <- m
 	return nil
 }
 
-func (s *mockSender) UpdateCommPrefs(ctx context.Context, commPrefs *stats.CommPrefsData) error {
+func (s *mockSender) UpdateCommPrefs(context.Context, *stats.CommPrefsData) error {
 	return nil
 }
 

--- a/pkg/stats/collector_test.go
+++ b/pkg/stats/collector_test.go
@@ -15,8 +15,8 @@ type mockSender struct {
 	metadata chan stats.Metadata
 }
 
-func (s *mockSender) SendEvent(_ context.Context, _, _ string, m []stats.Metric) error {
-	s.metrics <- m
+func (s *mockSender) SendEvent(_ context.Context, evt *stats.InputEvent) error {
+	s.metrics <- evt.Metrics
 	return nil
 }
 

--- a/pkg/stats/collector_test.go
+++ b/pkg/stats/collector_test.go
@@ -44,7 +44,7 @@ func (m *mockTicker) Tick() <-chan time.Time {
 	return m.tc
 }
 
-func setupTest(buffer int, opts ...stats.BufferedCollectorOpts) (*mockSender, *mockTicker, *stats.BufferedCollector) {
+func setupTest(ctx context.Context, buffer int, opts ...stats.BufferedCollectorOpts) (*mockSender, *mockTicker, *stats.BufferedCollector) {
 	sender := &mockSender{metrics: make(chan []stats.Metric, 10), metadata: make(chan stats.Metadata, 10)}
 	ticker := &mockTicker{tc: make(chan time.Time)}
 	opts = append(opts, stats.WithSender(sender), stats.WithTicker(ticker), stats.WithWriteBufferSize(buffer))
@@ -58,20 +58,19 @@ func setupTest(buffer int, opts ...stats.BufferedCollectorOpts) (*mockSender, *m
 	collector.SetRuntimeCollector(func() map[string]string {
 		return map[string]string{"runtime": "stat"}
 	})
-
+	collector.Start(ctx)
 	return sender, ticker, collector
 }
 
 func TestCallHomeCollector_QuickNoTick(t *testing.T) {
-	sender, _, collector := setupTest(10)
 	ctx, cancelFn := context.WithCancel(context.Background())
+	sender, _, collector := setupTest(ctx, 10)
 
 	// Forcing collector to run last so that we make sure a race between context and collector
 	// isn't impacting what's being sent
 	collector.CollectEvent(stats.Event{Class: "foo", Name: "bar"})
 	cancelFn()
 
-	collector.Run(ctx)
 	collector.Close()
 
 	counters, ok := <-sender.metrics
@@ -84,10 +83,8 @@ func TestCallHomeCollector_QuickNoTick(t *testing.T) {
 }
 
 func TestCallHomeCollector_Collect(t *testing.T) {
-	sender, ticker, collector := setupTest(0)
 	ctx, cancelFn := context.WithCancel(context.Background())
-
-	collector.Run(ctx)
+	sender, ticker, collector := setupTest(ctx, 0)
 
 	// add metrics
 	collector.CollectEvent(stats.Event{Class: "foo", Name: "bar"})
@@ -153,9 +150,8 @@ func TestCallHomeCollector_Collect(t *testing.T) {
 }
 
 func TestCallHomeCollector_ExtendedHashValues(t *testing.T) {
-	sender, ticker, collector := setupTest(0, stats.WithExtended(true))
 	ctx, cancelFn := context.WithCancel(context.Background())
-	collector.Run(ctx)
+	sender, ticker, collector := setupTest(ctx, 0, stats.WithExtended(true))
 
 	const events = 2
 	for i := 0; i < events; i++ {
@@ -201,9 +197,9 @@ func TestCallHomeCollector_ExtendedHashValues(t *testing.T) {
 }
 
 func TestCallHomeCollector_NoExtendedValues(t *testing.T) {
-	sender, ticker, collector := setupTest(0, stats.WithExtended(false))
 	ctx, cancelFn := context.WithCancel(context.Background())
-	collector.Run(ctx)
+	sender, ticker, collector := setupTest(ctx, 0, stats.WithExtended(false))
+	collector.Start(ctx)
 
 	const events = 2
 	for i := 0; i < events; i++ {

--- a/pkg/stats/nullcollector.go
+++ b/pkg/stats/nullcollector.go
@@ -6,7 +6,7 @@ func (m *NullCollector) CollectMetadata(_ *Metadata) {}
 
 func (m *NullCollector) CollectEvent(_ Event) {}
 
-func (m *NullCollector) CollectEvents(ev Event, count uint64) {}
+func (m *NullCollector) CollectEvents(_ Event, _ uint64) {}
 
 func (m *NullCollector) SetInstallationID(_ string) {}
 


### PR DESCRIPTION
Close #5048

- retry on client error while sending metrics (configured to have 2 more tries)
- remove low timeout while posting events.
- sending metrics will not abort on cancellation.
- separate background processing of metrics and one sending metrics.
- shutdown using context cancellation
- first audit check done in the background