### PR TITLE
docs: Expand instructions on building docs locally

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@
 # Docs
 /docs/_site/
 /docs/.jekyll-metadata
+/docs/.jekyll-bundle-cache
 
 # terraform
 # Local .terraform directories

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -134,6 +134,7 @@ To render the documentation locally and preview changes you can run the Jeykll s
 
    ```sh
    docker run --rm \
+              --name lakefs_docs \
               --publish 4000:4000 --publish 35729:35729 \
               --volume="$PWD/docs:/srv/jekyll:Z" \
               --volume="$PWD/docs/.jekyll-bundle-cache:/usr/local/bundle:Z" \
@@ -166,7 +167,7 @@ To render the documentation locally and preview changes you can run the Jeykll s
 
    Your page will automatically reload to show the changes.
 
-_If you are doing lots of work on the docs you may want to leave the Docker container in place (so that you don't have to wait for the dependencies to load each time you re-create it). To do this remove the `--rm` from the `docker run` command._
+_If you are doing lots of work on the docs you may want to leave the Docker container in place (so that you don't have to wait for the dependencies to load each time you re-create it). To do this replace the `--rm` with `--detach` in the `docker run` command, and use `docker logs -f lakefs_docs` to view the server log._
 
 ### CHANGELOG.md
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -126,16 +126,47 @@ Customizing the lakeFS docs site should follow the following guidelines: [Just T
 * You can explain things better by including examples. Show, not tell. Use illustrations, images, gifs, code snippets, etc.
 * Establish a visual hierarchy to help people quickly find the information they need. Use text formatting to create levels of title and subtitle (such as h1 to h6 headings in HTML).
 
-### Test your changes localy
-To render the documentation locally and preview changes, use the following command and [browse the documentation locally](http://localhost:4000):
+### Test your changes locally
 
-```sh
-cd docs
-docker run --rm -p 4000:4000 --volume="$PWD:/srv/jekyll:Z" -it jekyll/jekyll:3.8 jekyll serve
-```
+To render the documentation locally and preview changes you can run the Jeykll server under Docker. 
 
+1. Launch the Docker container:
 
+   ```sh
+   docker run --rm \
+              --publish 4000:4000 --publish 35729:35729 \
+              --volume="$PWD/docs:/srv/jekyll:Z" \
+              --volume="$PWD/docs/.jekyll-bundle-cache:/usr/local/bundle:Z" \
+              --interactive --tty \
+              jekyll/jekyll:3.8 \
+              jekyll serve --livereload
+   ```
 
+2. The first time you run the container it will need to download dependencies and will take several minutes to be ready. 
+
+   Once you see the following output, the docs server is ready to [open in your web browser](http://localhost:4000): 
+
+   ```
+   Server running... press ctrl-c to stop.
+   ```
+
+3. When you make a change to a page's source the server will automatically rebuild the page which will be shown in the server log by this entry:
+
+   ```
+   Regenerating: 1 file(s) changed at 2023-01-26 08:34:47
+                  contributing.md
+   Remote Theme: Using theme pmarsceill/just-the-docs
+   ```
+
+   This can take a short while—you'll see something like this in the server's output when it's done. 
+   
+   ```
+   ...done in 34.714073461 seconds.
+   ```
+
+   Your page will automatically reload to show the changes.
+
+_If you are doing lots of work on the docs you may want to leave the Docker container in place (so that you don't have to wait for the dependencies to load each time you re-create it). To do this remove the `--rm` from the `docker run` command._
 
 ### CHANGELOG.md
 


### PR DESCRIPTION
1. Expand instructions on how to build docs locally
2. Add Live Reload
3. Add local caching to speed up subsequent local builds (removes the ~4 min fetch of dependencies next time)