### PR TITLE
Merge result summary deprecation

### DIFF
--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -176,28 +176,26 @@ components:
           items:
             $ref: "#/components/schemas/Repository"
 
+    MergeResultSummary:
+      description: "Deprecated: merge summary will be removed"
+      type: object
+      properties:
+        added:
+          type: integer
+        removed:
+          type: integer
+        changed:
+          type: integer
+        conflict:
+          type: integer
+
     MergeResult:
       type: object
       required:
-        - summary
         - reference
       properties:
         summary:
-          type: object
-          required:
-            - added
-            - removed
-            - changed
-            - conflict
-          properties:
-            added:
-              type: integer
-            removed:
-              type: integer
-            changed:
-              type: integer
-            conflict:
-              type: integer
+          $ref: "#/components/schemas/MergeResultSummary"
         reference:
           type: string
 
@@ -2635,7 +2633,9 @@ paths:
         404:
           $ref: "#/components/responses/NotFound"
         409:
-          description: conflict
+          description: |
+            Conflict
+            Deprecated: content schema will return Error format and not an empty MergeResult
           content:
             application/json:
               schema:

--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -177,17 +177,24 @@ components:
             $ref: "#/components/schemas/Repository"
 
     MergeResultSummary:
-      description: "Deprecated: merge summary will be removed"
       type: object
       properties:
         added:
           type: integer
+          deprecated: true
+          description: "Deprecated: inaccurate and will be removed."
         removed:
           type: integer
+          deprecated: true
+          description: "Deprecated: inaccurate and will be removed."
         changed:
           type: integer
+          deprecated: true
+          description: "Deprecated: inaccurate and will be removed."
         conflict:
           type: integer
+          deprecated: true
+          description: "Deprecated: inaccurate and will be removed."
 
     MergeResult:
       type: object

--- a/clients/java/api/openapi.yaml
+++ b/clients/java/api/openapi.yaml
@@ -5072,7 +5072,6 @@ components:
       - results
       type: object
     MergeResultSummary:
-      description: 'Deprecated: merge summary will be removed'
       example:
         removed: 6
         added: 0
@@ -5080,12 +5079,20 @@ components:
         conflict: 5
       properties:
         added:
+          deprecated: true
+          description: 'Deprecated: inaccurate and will be removed.'
           type: integer
         removed:
+          deprecated: true
+          description: 'Deprecated: inaccurate and will be removed.'
           type: integer
         changed:
+          deprecated: true
+          description: 'Deprecated: inaccurate and will be removed.'
           type: integer
         conflict:
+          deprecated: true
+          description: 'Deprecated: inaccurate and will be removed.'
           type: integer
       type: object
     MergeResult:

--- a/clients/java/api/openapi.yaml
+++ b/clients/java/api/openapi.yaml
@@ -2675,7 +2675,9 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MergeResult'
-          description: conflict
+          description: |
+            Conflict
+            Deprecated: content schema will return Error format and not an empty MergeResult
         "412":
           content:
             application/json:
@@ -5069,6 +5071,23 @@ components:
       - pagination
       - results
       type: object
+    MergeResultSummary:
+      description: 'Deprecated: merge summary will be removed'
+      example:
+        removed: 6
+        added: 0
+        changed: 1
+        conflict: 5
+      properties:
+        added:
+          type: integer
+        removed:
+          type: integer
+        changed:
+          type: integer
+        conflict:
+          type: integer
+      type: object
     MergeResult:
       example:
         summary:
@@ -5079,12 +5098,11 @@ components:
         reference: reference
       properties:
         summary:
-          $ref: '#/components/schemas/MergeResult_summary'
+          $ref: '#/components/schemas/MergeResultSummary'
         reference:
           type: string
       required:
       - reference
-      - summary
       type: object
     RepositoryCreation:
       example:
@@ -6540,27 +6558,6 @@ components:
           type: string
       required:
       - pattern
-      type: object
-    MergeResult_summary:
-      example:
-        removed: 6
-        added: 0
-        changed: 1
-        conflict: 5
-      properties:
-        added:
-          type: integer
-        removed:
-          type: integer
-        changed:
-          type: integer
-        conflict:
-          type: integer
-      required:
-      - added
-      - changed
-      - conflict
-      - removed
       type: object
   securitySchemes:
     basic_auth:

--- a/clients/java/docs/MergeResult.md
+++ b/clients/java/docs/MergeResult.md
@@ -7,7 +7,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**summary** | [**MergeResultSummary**](MergeResultSummary.md) |  | 
+**summary** | [**MergeResultSummary**](MergeResultSummary.md) |  |  [optional]
 **reference** | **String** |  | 
 
 

--- a/clients/java/docs/MergeResultSummary.md
+++ b/clients/java/docs/MergeResultSummary.md
@@ -2,16 +2,15 @@
 
 # MergeResultSummary
 
-Deprecated: merge summary will be removed
 
 ## Properties
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**added** | **Integer** |  |  [optional]
-**removed** | **Integer** |  |  [optional]
-**changed** | **Integer** |  |  [optional]
-**conflict** | **Integer** |  |  [optional]
+**added** | **Integer** | Deprecated: inaccurate and will be removed. |  [optional]
+**removed** | **Integer** | Deprecated: inaccurate and will be removed. |  [optional]
+**changed** | **Integer** | Deprecated: inaccurate and will be removed. |  [optional]
+**conflict** | **Integer** | Deprecated: inaccurate and will be removed. |  [optional]
 
 
 

--- a/clients/java/docs/MergeResultSummary.md
+++ b/clients/java/docs/MergeResultSummary.md
@@ -2,15 +2,16 @@
 
 # MergeResultSummary
 
+Deprecated: merge summary will be removed
 
 ## Properties
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**added** | **Integer** |  | 
-**removed** | **Integer** |  | 
-**changed** | **Integer** |  | 
-**conflict** | **Integer** |  | 
+**added** | **Integer** |  |  [optional]
+**removed** | **Integer** |  |  [optional]
+**changed** | **Integer** |  |  [optional]
+**conflict** | **Integer** |  |  [optional]
 
 
 

--- a/clients/java/docs/RefsApi.md
+++ b/clients/java/docs/RefsApi.md
@@ -383,7 +383,7 @@ Name | Type | Description  | Notes
 **400** | Validation Error |  -  |
 **401** | Unauthorized |  -  |
 **404** | Resource Not Found |  -  |
-**409** | conflict |  -  |
+**409** | Conflict Deprecated: content schema will return Error format and not an empty MergeResult  |  -  |
 **412** | precondition failed (e.g. a pre-merge hook returned a failure) |  -  |
 **0** | Internal Server Error |  -  |
 

--- a/clients/java/src/main/java/io/lakefs/clients/api/RefsApi.java
+++ b/clients/java/src/main/java/io/lakefs/clients/api/RefsApi.java
@@ -561,7 +561,7 @@ public class RefsApi {
         <tr><td> 400 </td><td> Validation Error </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Resource Not Found </td><td>  -  </td></tr>
-        <tr><td> 409 </td><td> conflict </td><td>  -  </td></tr>
+        <tr><td> 409 </td><td> Conflict Deprecated: content schema will return Error format and not an empty MergeResult  </td><td>  -  </td></tr>
         <tr><td> 412 </td><td> precondition failed (e.g. a pre-merge hook returned a failure) </td><td>  -  </td></tr>
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
@@ -639,7 +639,7 @@ public class RefsApi {
         <tr><td> 400 </td><td> Validation Error </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Resource Not Found </td><td>  -  </td></tr>
-        <tr><td> 409 </td><td> conflict </td><td>  -  </td></tr>
+        <tr><td> 409 </td><td> Conflict Deprecated: content schema will return Error format and not an empty MergeResult  </td><td>  -  </td></tr>
         <tr><td> 412 </td><td> precondition failed (e.g. a pre-merge hook returned a failure) </td><td>  -  </td></tr>
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
@@ -665,7 +665,7 @@ public class RefsApi {
         <tr><td> 400 </td><td> Validation Error </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Resource Not Found </td><td>  -  </td></tr>
-        <tr><td> 409 </td><td> conflict </td><td>  -  </td></tr>
+        <tr><td> 409 </td><td> Conflict Deprecated: content schema will return Error format and not an empty MergeResult  </td><td>  -  </td></tr>
         <tr><td> 412 </td><td> precondition failed (e.g. a pre-merge hook returned a failure) </td><td>  -  </td></tr>
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
@@ -693,7 +693,7 @@ public class RefsApi {
         <tr><td> 400 </td><td> Validation Error </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Resource Not Found </td><td>  -  </td></tr>
-        <tr><td> 409 </td><td> conflict </td><td>  -  </td></tr>
+        <tr><td> 409 </td><td> Conflict Deprecated: content schema will return Error format and not an empty MergeResult  </td><td>  -  </td></tr>
         <tr><td> 412 </td><td> precondition failed (e.g. a pre-merge hook returned a failure) </td><td>  -  </td></tr>
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>

--- a/clients/java/src/main/java/io/lakefs/clients/api/model/MergeResult.java
+++ b/clients/java/src/main/java/io/lakefs/clients/api/model/MergeResult.java
@@ -49,8 +49,8 @@ public class MergeResult {
    * Get summary
    * @return summary
   **/
-  @javax.annotation.Nonnull
-  @ApiModelProperty(required = true, value = "")
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "")
 
   public MergeResultSummary getSummary() {
     return summary;

--- a/clients/java/src/main/java/io/lakefs/clients/api/model/MergeResultSummary.java
+++ b/clients/java/src/main/java/io/lakefs/clients/api/model/MergeResultSummary.java
@@ -25,8 +25,9 @@ import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
 
 /**
- * MergeResultSummary
+ * Deprecated: merge summary will be removed
  */
+@ApiModel(description = "Deprecated: merge summary will be removed")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class MergeResultSummary {
   public static final String SERIALIZED_NAME_ADDED = "added";
@@ -56,8 +57,8 @@ public class MergeResultSummary {
    * Get added
    * @return added
   **/
-  @javax.annotation.Nonnull
-  @ApiModelProperty(required = true, value = "")
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "")
 
   public Integer getAdded() {
     return added;
@@ -79,8 +80,8 @@ public class MergeResultSummary {
    * Get removed
    * @return removed
   **/
-  @javax.annotation.Nonnull
-  @ApiModelProperty(required = true, value = "")
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "")
 
   public Integer getRemoved() {
     return removed;
@@ -102,8 +103,8 @@ public class MergeResultSummary {
    * Get changed
    * @return changed
   **/
-  @javax.annotation.Nonnull
-  @ApiModelProperty(required = true, value = "")
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "")
 
   public Integer getChanged() {
     return changed;
@@ -125,8 +126,8 @@ public class MergeResultSummary {
    * Get conflict
    * @return conflict
   **/
-  @javax.annotation.Nonnull
-  @ApiModelProperty(required = true, value = "")
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "")
 
   public Integer getConflict() {
     return conflict;

--- a/clients/java/src/main/java/io/lakefs/clients/api/model/MergeResultSummary.java
+++ b/clients/java/src/main/java/io/lakefs/clients/api/model/MergeResultSummary.java
@@ -25,9 +25,8 @@ import io.swagger.annotations.ApiModelProperty;
 import java.io.IOException;
 
 /**
- * Deprecated: merge summary will be removed
+ * MergeResultSummary
  */
-@ApiModel(description = "Deprecated: merge summary will be removed")
 @javax.annotation.Generated(value = "org.openapitools.codegen.languages.JavaClientCodegen")
 public class MergeResultSummary {
   public static final String SERIALIZED_NAME_ADDED = "added";
@@ -54,11 +53,13 @@ public class MergeResultSummary {
   }
 
    /**
-   * Get added
+   * Deprecated: inaccurate and will be removed.
    * @return added
+   * @deprecated
   **/
+  @Deprecated
   @javax.annotation.Nullable
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(value = "Deprecated: inaccurate and will be removed.")
 
   public Integer getAdded() {
     return added;
@@ -77,11 +78,13 @@ public class MergeResultSummary {
   }
 
    /**
-   * Get removed
+   * Deprecated: inaccurate and will be removed.
    * @return removed
+   * @deprecated
   **/
+  @Deprecated
   @javax.annotation.Nullable
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(value = "Deprecated: inaccurate and will be removed.")
 
   public Integer getRemoved() {
     return removed;
@@ -100,11 +103,13 @@ public class MergeResultSummary {
   }
 
    /**
-   * Get changed
+   * Deprecated: inaccurate and will be removed.
    * @return changed
+   * @deprecated
   **/
+  @Deprecated
   @javax.annotation.Nullable
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(value = "Deprecated: inaccurate and will be removed.")
 
   public Integer getChanged() {
     return changed;
@@ -123,11 +128,13 @@ public class MergeResultSummary {
   }
 
    /**
-   * Get conflict
+   * Deprecated: inaccurate and will be removed.
    * @return conflict
+   * @deprecated
   **/
+  @Deprecated
   @javax.annotation.Nullable
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(value = "Deprecated: inaccurate and will be removed.")
 
   public Integer getConflict() {
     return conflict;

--- a/clients/python/docs/MergeResult.md
+++ b/clients/python/docs/MergeResult.md
@@ -4,8 +4,8 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**summary** | [**MergeResultSummary**](MergeResultSummary.md) |  | 
 **reference** | **str** |  | 
+**summary** | [**MergeResultSummary**](MergeResultSummary.md) |  | [optional] 
 **any string name** | **bool, date, datetime, dict, float, int, list, str, none_type** | any string name can be used but the value must be the correct type | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/clients/python/docs/MergeResultSummary.md
+++ b/clients/python/docs/MergeResultSummary.md
@@ -1,14 +1,13 @@
 # MergeResultSummary
 
-Deprecated: merge summary will be removed
 
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**added** | **int** |  | [optional] 
-**removed** | **int** |  | [optional] 
-**changed** | **int** |  | [optional] 
-**conflict** | **int** |  | [optional] 
+**added** | **int** | Deprecated: inaccurate and will be removed. | [optional] 
+**removed** | **int** | Deprecated: inaccurate and will be removed. | [optional] 
+**changed** | **int** | Deprecated: inaccurate and will be removed. | [optional] 
+**conflict** | **int** | Deprecated: inaccurate and will be removed. | [optional] 
 **any string name** | **bool, date, datetime, dict, float, int, list, str, none_type** | any string name can be used but the value must be the correct type | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/clients/python/docs/MergeResultSummary.md
+++ b/clients/python/docs/MergeResultSummary.md
@@ -1,13 +1,14 @@
 # MergeResultSummary
 
+Deprecated: merge summary will be removed
 
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**added** | **int** |  | 
-**removed** | **int** |  | 
-**changed** | **int** |  | 
-**conflict** | **int** |  | 
+**added** | **int** |  | [optional] 
+**removed** | **int** |  | [optional] 
+**changed** | **int** |  | [optional] 
+**conflict** | **int** |  | [optional] 
 **any string name** | **bool, date, datetime, dict, float, int, list, str, none_type** | any string name can be used but the value must be the correct type | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/clients/python/docs/RefsApi.md
+++ b/clients/python/docs/RefsApi.md
@@ -479,7 +479,7 @@ Name | Type | Description  | Notes
 **400** | Validation Error |  -  |
 **401** | Unauthorized |  -  |
 **404** | Resource Not Found |  -  |
-**409** | conflict |  -  |
+**409** | Conflict Deprecated: content schema will return Error format and not an empty MergeResult  |  -  |
 **412** | precondition failed (e.g. a pre-merge hook returned a failure) |  -  |
 **0** | Internal Server Error |  -  |
 

--- a/clients/python/lakefs_client/model/merge_result.py
+++ b/clients/python/lakefs_client/model/merge_result.py
@@ -88,8 +88,8 @@ class MergeResult(ModelNormal):
         """
         lazy_import()
         return {
-            'summary': (MergeResultSummary,),  # noqa: E501
             'reference': (str,),  # noqa: E501
+            'summary': (MergeResultSummary,),  # noqa: E501
         }
 
     @cached_property
@@ -98,8 +98,8 @@ class MergeResult(ModelNormal):
 
 
     attribute_map = {
-        'summary': 'summary',  # noqa: E501
         'reference': 'reference',  # noqa: E501
+        'summary': 'summary',  # noqa: E501
     }
 
     read_only_vars = {
@@ -109,11 +109,10 @@ class MergeResult(ModelNormal):
 
     @classmethod
     @convert_js_args_to_python_args
-    def _from_openapi_data(cls, summary, reference, *args, **kwargs):  # noqa: E501
+    def _from_openapi_data(cls, reference, *args, **kwargs):  # noqa: E501
         """MergeResult - a model defined in OpenAPI
 
         Args:
-            summary (MergeResultSummary):
             reference (str):
 
         Keyword Args:
@@ -147,6 +146,7 @@ class MergeResult(ModelNormal):
                                 Animal class but this time we won't travel
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
+            summary (MergeResultSummary): [optional]  # noqa: E501
         """
 
         _check_type = kwargs.pop('_check_type', True)
@@ -174,7 +174,6 @@ class MergeResult(ModelNormal):
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
 
-        self.summary = summary
         self.reference = reference
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
@@ -196,11 +195,10 @@ class MergeResult(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, summary, reference, *args, **kwargs):  # noqa: E501
+    def __init__(self, reference, *args, **kwargs):  # noqa: E501
         """MergeResult - a model defined in OpenAPI
 
         Args:
-            summary (MergeResultSummary):
             reference (str):
 
         Keyword Args:
@@ -234,6 +232,7 @@ class MergeResult(ModelNormal):
                                 Animal class but this time we won't travel
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
+            summary (MergeResultSummary): [optional]  # noqa: E501
         """
 
         _check_type = kwargs.pop('_check_type', True)
@@ -259,7 +258,6 @@ class MergeResult(ModelNormal):
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
 
-        self.summary = summary
         self.reference = reference
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \

--- a/clients/python/lakefs_client/model/merge_result_summary.py
+++ b/clients/python/lakefs_client/model/merge_result_summary.py
@@ -107,14 +107,8 @@ class MergeResultSummary(ModelNormal):
 
     @classmethod
     @convert_js_args_to_python_args
-    def _from_openapi_data(cls, added, removed, changed, conflict, *args, **kwargs):  # noqa: E501
+    def _from_openapi_data(cls, *args, **kwargs):  # noqa: E501
         """MergeResultSummary - a model defined in OpenAPI
-
-        Args:
-            added (int):
-            removed (int):
-            changed (int):
-            conflict (int):
 
         Keyword Args:
             _check_type (bool): if True, values for parameters in openapi_types
@@ -147,6 +141,10 @@ class MergeResultSummary(ModelNormal):
                                 Animal class but this time we won't travel
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
+            added (int): [optional]  # noqa: E501
+            removed (int): [optional]  # noqa: E501
+            changed (int): [optional]  # noqa: E501
+            conflict (int): [optional]  # noqa: E501
         """
 
         _check_type = kwargs.pop('_check_type', True)
@@ -174,10 +172,6 @@ class MergeResultSummary(ModelNormal):
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
 
-        self.added = added
-        self.removed = removed
-        self.changed = changed
-        self.conflict = conflict
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \
@@ -198,14 +192,8 @@ class MergeResultSummary(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, added, removed, changed, conflict, *args, **kwargs):  # noqa: E501
+    def __init__(self, *args, **kwargs):  # noqa: E501
         """MergeResultSummary - a model defined in OpenAPI
-
-        Args:
-            added (int):
-            removed (int):
-            changed (int):
-            conflict (int):
 
         Keyword Args:
             _check_type (bool): if True, values for parameters in openapi_types
@@ -238,6 +226,10 @@ class MergeResultSummary(ModelNormal):
                                 Animal class but this time we won't travel
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
+            added (int): [optional]  # noqa: E501
+            removed (int): [optional]  # noqa: E501
+            changed (int): [optional]  # noqa: E501
+            conflict (int): [optional]  # noqa: E501
         """
 
         _check_type = kwargs.pop('_check_type', True)
@@ -263,10 +255,6 @@ class MergeResultSummary(ModelNormal):
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
 
-        self.added = added
-        self.removed = removed
-        self.changed = changed
-        self.conflict = conflict
         for var_name, var_value in kwargs.items():
             if var_name not in self.attribute_map and \
                         self._configuration is not None and \

--- a/clients/python/lakefs_client/model/merge_result_summary.py
+++ b/clients/python/lakefs_client/model/merge_result_summary.py
@@ -141,10 +141,10 @@ class MergeResultSummary(ModelNormal):
                                 Animal class but this time we won't travel
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
-            added (int): [optional]  # noqa: E501
-            removed (int): [optional]  # noqa: E501
-            changed (int): [optional]  # noqa: E501
-            conflict (int): [optional]  # noqa: E501
+            added (int): Deprecated: inaccurate and will be removed.. [optional]  # noqa: E501
+            removed (int): Deprecated: inaccurate and will be removed.. [optional]  # noqa: E501
+            changed (int): Deprecated: inaccurate and will be removed.. [optional]  # noqa: E501
+            conflict (int): Deprecated: inaccurate and will be removed.. [optional]  # noqa: E501
         """
 
         _check_type = kwargs.pop('_check_type', True)
@@ -226,10 +226,10 @@ class MergeResultSummary(ModelNormal):
                                 Animal class but this time we won't travel
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
-            added (int): [optional]  # noqa: E501
-            removed (int): [optional]  # noqa: E501
-            changed (int): [optional]  # noqa: E501
-            conflict (int): [optional]  # noqa: E501
+            added (int): Deprecated: inaccurate and will be removed.. [optional]  # noqa: E501
+            removed (int): Deprecated: inaccurate and will be removed.. [optional]  # noqa: E501
+            changed (int): Deprecated: inaccurate and will be removed.. [optional]  # noqa: E501
+            conflict (int): Deprecated: inaccurate and will be removed.. [optional]  # noqa: E501
         """
 
         _check_type = kwargs.pop('_check_type', True)

--- a/docs/assets/js/swagger.yml
+++ b/docs/assets/js/swagger.yml
@@ -176,28 +176,26 @@ components:
           items:
             $ref: "#/components/schemas/Repository"
 
+    MergeResultSummary:
+      description: "Deprecated: merge summary will be removed"
+      type: object
+      properties:
+        added:
+          type: integer
+        removed:
+          type: integer
+        changed:
+          type: integer
+        conflict:
+          type: integer
+
     MergeResult:
       type: object
       required:
-        - summary
         - reference
       properties:
         summary:
-          type: object
-          required:
-            - added
-            - removed
-            - changed
-            - conflict
-          properties:
-            added:
-              type: integer
-            removed:
-              type: integer
-            changed:
-              type: integer
-            conflict:
-              type: integer
+          $ref: "#/components/schemas/MergeResultSummary"
         reference:
           type: string
 
@@ -2635,7 +2633,9 @@ paths:
         404:
           $ref: "#/components/responses/NotFound"
         409:
-          description: conflict
+          description: |
+            Conflict
+            Deprecated: content schema will return Error format and not an empty MergeResult
           content:
             application/json:
               schema:

--- a/docs/assets/js/swagger.yml
+++ b/docs/assets/js/swagger.yml
@@ -177,17 +177,24 @@ components:
             $ref: "#/components/schemas/Repository"
 
     MergeResultSummary:
-      description: "Deprecated: merge summary will be removed"
       type: object
       properties:
         added:
           type: integer
+          deprecated: true
+          description: "Deprecated: inaccurate and will be removed."
         removed:
           type: integer
+          deprecated: true
+          description: "Deprecated: inaccurate and will be removed."
         changed:
           type: integer
+          deprecated: true
+          description: "Deprecated: inaccurate and will be removed."
         conflict:
           type: integer
+          deprecated: true
+          description: "Deprecated: inaccurate and will be removed."
 
     MergeResult:
       type: object

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -3377,27 +3377,36 @@ func (c *Controller) MergeIntoBranch(w http.ResponseWriter, r *http.Request, bod
 	if body.Metadata != nil {
 		metadata = body.Metadata.AdditionalProperties
 	}
-	res, err := c.Catalog.Merge(ctx,
+	reference, err := c.Catalog.Merge(ctx,
 		repository, destinationBranch, sourceRef,
 		user.Username,
 		StringValue(body.Message),
 		metadata,
 		StringValue(body.Strategy))
 
-	var hookAbortErr *graveler.HookAbortError
+	var (
+		hookAbortErr *graveler.HookAbortError
+		zero         int
+	)
 	switch {
 	case errors.As(err, &hookAbortErr):
 		c.Logger.WithError(err).WithField("run_id", hookAbortErr.RunID).Warn("aborted by hooks")
 		writeError(w, r, http.StatusPreconditionFailed, err)
 		return
 	case errors.Is(err, graveler.ErrConflictFound):
-		writeResponse(w, r, http.StatusConflict, MergeResult{Reference: res})
+		writeResponse(w, r, http.StatusConflict, MergeResult{
+			Reference: reference,
+			Summary:   &MergeResultSummary{Added: &zero, Changed: &zero, Conflict: &zero, Removed: &zero},
+		})
 		return
 	}
 	if c.handleAPIError(ctx, w, r, err) {
 		return
 	}
-	writeResponse(w, r, http.StatusOK, MergeResult{Reference: res})
+	writeResponse(w, r, http.StatusOK, MergeResult{
+		Reference: reference,
+		Summary:   &MergeResultSummary{Added: &zero, Changed: &zero, Conflict: &zero, Removed: &zero},
+	})
 }
 
 func (c *Controller) ListTags(w http.ResponseWriter, r *http.Request, repository string, params ListTagsParams) {


### PR DESCRIPTION
Merge API change and deprecation waring - step before we  can remove the summary fields from merge result.

This version will always return the summary field and define the field as optional.
It will enable users to switch to a version which will not break when the field is gone.

Related to #3978