### PR TITLE
Add compatibility checks for lakeFSFS

### DIFF
--- a/.github/workflows/compatability-tests.yaml
+++ b/.github/workflows/compatability-tests.yaml
@@ -66,16 +66,6 @@ jobs:
             name: generated-code
             path: /tmp/generated.tar.gz
 
-#      - name: Package Spark App
-#        working-directory: test/spark/app
-#        run: sbt sonnets-311/package
-#
-#      - name: Store Sonnets Spark app
-#        uses: actions/upload-artifact@v3
-#        with:
-#          name: generated-sonnets
-#          path: test/spark/app/target/sonnets-311/target/sonnets-311/scala-2.12/sonnets-311_2.12-0.1.0.jar
-
       - name: Build Spark direct-access client
         working-directory: clients/hadoopfs
         run: |
@@ -216,7 +206,7 @@ jobs:
         run: docker-compose logs --tail=15000 lakefs
 
   compatibility-checks-server:
-    name: Test lakeFS server FileSystem ccompatibility
+    name: Test lakeFS server FileSystem compatibility
     needs: [gen-code, deploy-image]
     strategy:
       fail-fast: false

--- a/.github/workflows/compatability-tests.yaml
+++ b/.github/workflows/compatability-tests.yaml
@@ -1,6 +1,7 @@
 name: lakeFS HadoopFS Compatability Tests
 
 on:
+  pull_request:
   push:
     branches:
       - master
@@ -216,9 +217,7 @@ jobs:
           path: /tmp
 
       - name: Load Docker image
-        run: |
-          docker load --input /tmp/lakefs.tar
-          docker image ls -a
+        run: docker load --input /tmp/lakefs.tar
 
       - uses: actions/setup-java@v3
         with:
@@ -284,5 +283,5 @@ jobs:
         payload: |
           {
             "mrkdwn": true,
-            "text": "Compatibility tests failure in master branch: https://github.com/treeverse/lakeFS/actions/workflows/compatability-tests.yaml"
+            "text": "Compatibility tests failure in master branch: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
           }

--- a/.github/workflows/compatability-tests.yaml
+++ b/.github/workflows/compatability-tests.yaml
@@ -1,7 +1,9 @@
 name: lakeFS HadoopFS Compatability Tests
 
 on:
-  pull_request:
+  push:
+    branches:
+      - master
 
 # These permissions are needed to interact with GitHub's OIDC Token endpoint.
 permissions:
@@ -282,5 +284,5 @@ jobs:
         payload: |
           {
             "mrkdwn": true,
-            "text": "Compatibility tests failure in master branch, [link](https://github.com/treeverse/lakeFS/actions/workflows/compatability-tests.yaml)"
+            "text": "Compatibility tests failure in master branch: https://github.com/treeverse/lakeFS/actions/workflows/compatability-tests.yaml"
           }

--- a/.github/workflows/compatability-tests.yaml
+++ b/.github/workflows/compatability-tests.yaml
@@ -279,4 +279,8 @@ jobs:
       env:
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
       with:
-        slack-message: "Compatibility tests failure in master branch: https://github.com/treeverse/lakeFS/actions/workflows/compatability-tests.yaml"
+        payload: |
+          {
+            "mrkdwn": true,
+            "text": ("Compatibility tests failure in master branch <https://github.com/treeverse/lakeFS/actions/workflows/compatability-tests.yaml+"|View>")
+          }

--- a/.github/workflows/compatability-tests.yaml
+++ b/.github/workflows/compatability-tests.yaml
@@ -272,7 +272,7 @@ jobs:
     name: Notify slack on workflow failures
     needs: [compatibility-checks-client, compatibility-checks-server]
     runs-on: ubuntu-20.04
-#    if: ${{ always() && contains(needs.*.result, 'failure') }}
+    if: ${{ always() && contains(needs.*.result, 'failure') }}
     steps:
     - name: slack-send
       uses: slackapi/slack-github-action@v1.23.0

--- a/.github/workflows/compatability-tests.yaml
+++ b/.github/workflows/compatability-tests.yaml
@@ -1,7 +1,6 @@
 name: lakeFS HadoopFS Compatability Tests
 
 on:
-  pull_request:
   push:
     branches:
       - master

--- a/.github/workflows/compatability-tests.yaml
+++ b/.github/workflows/compatability-tests.yaml
@@ -1,0 +1,300 @@
+name: Compatability Tests
+
+on:
+  pull_request:
+
+# These permissions are needed to interact with GitHub's OIDC Token endpoint.
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  gen-code:
+    name: Generate code from latest lakeFS app
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check-out code
+        uses: actions/checkout@v3
+
+      # No way to share code between workflows :-( If you change this, find and change the
+      # same code wherever "Find Go module and build caches" appears!
+      - name: Find Go module and build caches
+        run: |
+          echo GOMODCACHE=`go env GOMODCACHE` >> $GITHUB_ENV
+          echo GOCACHE=`go env GOCACHE` >> $GITHUB_ENV
+          cat $GITHUB_ENV
+
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19.2
+        id: go
+
+      - name: Cache Go modules and builds
+        uses: actions/cache@v3
+        env:
+          cache-name: cache-go-modules
+        with:
+          path: |
+            ${{ env.GOMODCACHE }}
+            ${{ env.GOCACHE }}
+          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('go.mod', 'go.sum') }}
+          restore-keys: ${{ runner.os }}-build-${{ env.cache-name }}-
+            ${{ runner.os }}-build-
+            ${{ runner.os }}-
+
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "16.17.1"
+
+      - uses: actions/setup-java@v3
+        with:
+          distribution: "adopt-hotspot"
+          java-version: "8"
+          cache: "sbt"
+
+      - name: Generate code
+        run: |
+          make -j3 gen-api VERSION=${{ steps.version.outputs.tag }}
+          mkdir webui/dist
+          touch webui/dist/index.html
+          tar -cf /tmp/generated.tar.gz .
+
+      - name: Store generated code
+        uses: actions/upload-artifact@v3
+        with:
+            name: generated-code
+            path: /tmp/generated.tar.gz
+
+#      - name: Package Spark App
+#        working-directory: test/spark/app
+#        run: sbt sonnets-311/package
+#
+#      - name: Store Sonnets Spark app
+#        uses: actions/upload-artifact@v3
+#        with:
+#          name: generated-sonnets
+#          path: test/spark/app/target/sonnets-311/target/sonnets-311/scala-2.12/sonnets-311_2.12-0.1.0.jar
+
+      - name: Build Spark direct-access client
+        working-directory: clients/hadoopfs
+        run: |
+          mvn -Passembly -Djar.finalName=client -DskipTests --batch-mode --update-snapshots package
+
+      - name: Store client assembly
+        uses: actions/upload-artifact@v3
+        with:
+          name: client-assembly
+          path: clients/hadoopfs/target/client.jar
+
+  deploy-image:
+    name: Build and cache Docker image
+    needs: [gen-code]
+    runs-on: ubuntu-20.04
+    outputs:
+      tag: ${{ steps.version.outputs.tag }}
+      image_id: ${{ steps.build_export.outputs.ImageID }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Setup NodeJS
+        uses: actions/setup-node@v3
+        with:
+          node-version: "16.17.1"
+
+      - name: Setup Go
+        uses: actions/setup-go@v3
+        with:
+          go-version: 1.19.2
+        id: go
+
+      - name: Retrieve generated code
+        uses: actions/download-artifact@v3
+        with:
+          name: generated-code
+          path: /tmp/
+
+      - name: Unpack generated code
+        run: tar -xf /tmp/generated.tar.gz
+
+      - name: Extract version
+        shell: bash
+        run: echo "tag=sha-$(git rev-parse --short HEAD | sed s/^v//g)" >> $GITHUB_OUTPUT
+        id: version
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Build and export
+        uses: docker/build-push-action@v2
+        id: build_export
+        with:
+          context: .
+          file: ./Dockerfile
+          tags: treeverse/lakefs:${{ steps.version.outputs.tag }}
+          outputs: type=docker,dest=/tmp/lakefs.tar
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: lakefs-image
+          path: /tmp/lakefs.tar
+
+  compatibility-checks-client:
+    name: Test lakeFS Hadoop FileSystem compatibility
+    needs: gen-code
+    strategy:
+      fail-fast: false
+      matrix:
+        # Removing a version from this list means the published client is no longer compatible with
+        # that lakeFS version.
+        lakeFS_version: [ 0.89.1, 0.90.0, 0.91.0, 0.92.0 ]
+    runs-on: ubuntu-20.04
+    env:
+      TAG: ${{ matrix.lakeFS_version }}
+      REPO: treeverse
+      SPARK_TAG: 3
+    steps:
+      - name: Check-out code
+        uses: actions/checkout@v3
+
+      - uses: actions/setup-java@v3
+        with:
+          distribution: "adopt-hotspot"
+          java-version: "8"
+          cache: "sbt"
+
+      - name: Package Spark App
+        working-directory: test/spark/app
+        run: sbt sonnets-311/package
+
+      - name: Generate uniquifying value
+        id: unique
+        run: echo "value=$RANDOM" >> $GITHUB_OUTPUT
+
+      - name: Start lakeFS for Spark tests
+        uses: ./.github/actions/bootstrap-test-lakefs
+        with:
+          compose-directory: test/spark
+        env:
+          REPO: treeverse
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          LAKEFS_DATABASE_TYPE: postgres
+          LAKEFS_BLOCKSTORE_TYPE: s3
+          LAKEFS_BLOCKSTORE_S3_CREDENTIALS_ACCESS_KEY_ID: ${{ secrets.ESTI_AWS_ACCESS_KEY_ID }}
+          LAKEFS_BLOCKSTORE_S3_CREDENTIALS_SECRET_ACCESS_KEY: ${{ secrets.ESTI_AWS_SECRET_ACCESS_KEY }}
+
+      - name: Setup lakeFS for tests
+        working-directory: test/spark
+        run: ./setup-test.sh
+
+      - name: Retrieve client
+        uses: actions/download-artifact@v3
+        with:
+          name: client-assembly
+          path: clients/hadoopfs/target
+
+      - name: Test lakeFS S3 with Spark 3.x thick client
+        timeout-minutes: 8
+        env:
+          JARS: clients/hadoopfs/
+          STORAGE_NAMESPACE: s3://esti-system-testing/compatibility/${{ github.run_number }}-spark3-client/${{ steps.unique.outputs.value }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.ESTI_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.ESTI_AWS_SECRET_ACCESS_KEY }}
+          USE_DIRECT_ACCESS: "true"
+          REPOSITORY: thick-client-test
+          SONNET_JAR: sonnets-311/target/sonnets-311/scala-2.12/sonnets-311_2.12-0.1.0.jar
+        working-directory: test/spark
+        run: ./run-test.sh
+
+      - name: lakeFS Logs on Spark with client failure
+        if: ${{ failure() }}
+        continue-on-error: true
+        working-directory: test/spark
+        run: docker-compose logs --tail=15000 lakefs
+
+  compatibility-checks-server:
+    name: Test lakeFS server FileSystem ccompatibility
+    needs: [gen-code, deploy-image]
+    strategy:
+      fail-fast: false
+      matrix:
+        # Removing a version from this list means the current lakeFS is no longer compatible with
+        # that Hadoop lakeFS client version.
+        client_version: [ 0.1.10, 0.1.11, 0.1.12 ]
+    runs-on: ubuntu-20.04
+    env:
+      CLIENT_VERSION: ${{ matrix.client_version }}
+      TAG: ${{ needs.deploy-image.outputs.tag }}
+      IMAGE_ID: ${{ needs.deploy-image.outputs.image_id }}
+      REPO: treeverse
+      SPARK_TAG: 3
+    steps:
+      - name: Check-out code
+        uses: actions/checkout@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+
+      - name: Download artifact
+        uses: actions/download-artifact@v3
+        with:
+          name: lakefs-image
+          path: /tmp
+
+      - name: Load Docker image
+        run: |
+          docker load --input /tmp/lakefs.tar
+          docker image ls -a
+
+      - uses: actions/setup-java@v3
+        with:
+          distribution: "adopt-hotspot"
+          java-version: "8"
+          cache: "sbt"
+
+      - name: Package Spark App
+        working-directory: test/spark/app
+        run: sbt sonnets-311/package
+
+      - name: Generate uniquifying value
+        id: unique
+        run: echo "value=$RANDOM" >> $GITHUB_OUTPUT
+
+      - name: Start lakeFS for Spark tests
+        uses: ./.github/actions/bootstrap-test-lakefs
+        with:
+          compose-directory: test/spark
+        env:
+          REPO: treeverse
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          LAKEFS_DATABASE_TYPE: postgres
+          LAKEFS_BLOCKSTORE_TYPE: s3
+          LAKEFS_BLOCKSTORE_S3_CREDENTIALS_ACCESS_KEY_ID: ${{ secrets.ESTI_AWS_ACCESS_KEY_ID }}
+          LAKEFS_BLOCKSTORE_S3_CREDENTIALS_SECRET_ACCESS_KEY: ${{ secrets.ESTI_AWS_SECRET_ACCESS_KEY }}
+
+      - name: Setup lakeFS for tests
+        working-directory: test/spark
+        run: ./setup-test.sh
+
+      - name: Test lakeFS S3 with Spark 3.x thick client
+        timeout-minutes: 8
+        env:
+          JARS: clients/hadoopfs/
+          STORAGE_NAMESPACE: s3://esti-system-testing/compatibility/${{ github.run_number }}-spark3-client/${{ steps.unique.outputs.value }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.ESTI_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.ESTI_AWS_SECRET_ACCESS_KEY }}
+          USE_DIRECT_ACCESS: "true"
+          REPOSITORY: thick-client-test
+          SONNET_JAR: sonnets-311/target/sonnets-311/scala-2.12/sonnets-311_2.12-0.1.0.jar
+        working-directory: test/spark
+        run: ./run-test.sh
+
+      - name: lakeFS Logs on Spark with client failure
+        if: ${{ failure() }}
+        continue-on-error: true
+        working-directory: test/spark
+        run: docker-compose logs --tail=15000 lakefs

--- a/.github/workflows/compatability-tests.yaml
+++ b/.github/workflows/compatability-tests.yaml
@@ -267,3 +267,16 @@ jobs:
         continue-on-error: true
         working-directory: test/spark
         run: docker-compose logs --tail=15000 lakefs
+
+  notify-slack:
+    name: Notify slack on workflow failures
+    needs: [compatibility-checks-client, compatibility-checks-server]
+    runs-on: ubuntu-20.04
+#    if: ${{ always() && contains(needs.*.result, 'failure') }}
+    steps:
+    - name: slack-send
+      uses: slackapi/slack-github-action@v1.23.0
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+      with:
+        slack-message: "Compatibility tests failure in master branch: https://github.com/treeverse/lakeFS/actions/workflows/compatability-tests.yaml"

--- a/.github/workflows/compatability-tests.yaml
+++ b/.github/workflows/compatability-tests.yaml
@@ -1,4 +1,4 @@
-name: Compatability Tests
+name: lakeFS HadoopFS Compatability Tests
 
 on:
   pull_request:
@@ -16,32 +16,11 @@ jobs:
       - name: Check-out code
         uses: actions/checkout@v3
 
-      # No way to share code between workflows :-( If you change this, find and change the
-      # same code wherever "Find Go module and build caches" appears!
-      - name: Find Go module and build caches
-        run: |
-          echo GOMODCACHE=`go env GOMODCACHE` >> $GITHUB_ENV
-          echo GOCACHE=`go env GOCACHE` >> $GITHUB_ENV
-          cat $GITHUB_ENV
-
       - name: Setup Go
         uses: actions/setup-go@v3
         with:
           go-version: 1.19.2
         id: go
-
-      - name: Cache Go modules and builds
-        uses: actions/cache@v3
-        env:
-          cache-name: cache-go-modules
-        with:
-          path: |
-            ${{ env.GOMODCACHE }}
-            ${{ env.GOCACHE }}
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('go.mod', 'go.sum') }}
-          restore-keys: ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
 
       - uses: actions/setup-node@v3
         with:
@@ -139,10 +118,10 @@ jobs:
       matrix:
         # Removing a version from this list means the published client is no longer compatible with
         # that lakeFS version.
-        lakeFS_version: [ 0.89.1, 0.90.0, 0.91.0, 0.92.0 ]
+        lakefs_version: [ 0.89.1, 0.90.0, 0.91.0, 0.92.0 ]
     runs-on: ubuntu-20.04
     env:
-      TAG: ${{ matrix.lakeFS_version }}
+      TAG: ${{ matrix.lakefs_version }}
       REPO: treeverse
       SPARK_TAG: 3
     steps:

--- a/.github/workflows/compatability-tests.yaml
+++ b/.github/workflows/compatability-tests.yaml
@@ -282,5 +282,5 @@ jobs:
         payload: |
           {
             "mrkdwn": true,
-            "text": ("Compatibility tests failure in master branch <https://github.com/treeverse/lakeFS/actions/workflows/compatability-tests.yaml+"|View>")
+            "text": "Compatibility tests failure in master branch, [link](https://github.com/treeverse/lakeFS/actions/workflows/compatability-tests.yaml)"
           }

--- a/test/spark/docker-compose.yaml
+++ b/test/spark/docker-compose.yaml
@@ -24,7 +24,7 @@ services:
       - LAKEFS_AUTH_ENCRYPT_SECRET_KEY=some random secret string
       - LAKEFS_DATABASE_TYPE=postgres
       - LAKEFS_DATABASE_POSTGRES_CONNECTION_STRING=postgres://lakefs:lakefs@postgres/postgres?sslmode=disable
-      - LAKEFS_LOGGING_LEVEL=TRACE
+      - LAKEFS_LOGGING_LEVEL=DEBUG
       - LAKEFS_STATS_ENABLED=false
       - LAKEFS_BLOCKSTORE_LOCAL_PATH=/home/lakefs
       - LAKEFS_BLOCKSTORE_TYPE

--- a/test/spark/docker-compose.yaml
+++ b/test/spark/docker-compose.yaml
@@ -24,7 +24,7 @@ services:
       - LAKEFS_AUTH_ENCRYPT_SECRET_KEY=some random secret string
       - LAKEFS_DATABASE_TYPE=postgres
       - LAKEFS_DATABASE_POSTGRES_CONNECTION_STRING=postgres://lakefs:lakefs@postgres/postgres?sslmode=disable
-      - LAKEFS_LOGGING_LEVEL=DEBUG
+      - LAKEFS_LOGGING_LEVEL=TRACE
       - LAKEFS_STATS_ENABLED=false
       - LAKEFS_BLOCKSTORE_LOCAL_PATH=/home/lakefs
       - LAKEFS_BLOCKSTORE_TYPE

--- a/test/spark/run-test.sh
+++ b/test/spark/run-test.sh
@@ -14,10 +14,10 @@ STORAGE_NAMESPACE=${STORAGE_NAMESPACE:-local://}
 REPOSITORY=${REPOSITORY:-example}
 SONNET_JAR=${SONNET_JAR:-sonnets-246/target/sonnets/246/scala-2.12/sonnets-246_2.12-0.1.jar}
 
-if [ -v CLIENT_VERSION ]; then # Direct access using thick Spark client.
-    CLIENT_PATH="--packages io.lakefs:hadoop-lakefs-assembly:"$CLIENT_VERSION
+if [ -n "$CLIENT_VERSION" ]; then # Using a published or a built version
+    CLIENT_CMD="--packages io.lakefs:hadoop-lakefs-assembly:${CLIENT_VERSION}"
 else
-    CLIENT_PATH="--jars /target/client.jar"
+    CLIENT_CMD="--jars /target/client.jar"
 fi
 
 export input="lakefs://${REPOSITORY}/main/sonnets.txt"
@@ -28,7 +28,7 @@ docker-compose exec -T lakefs lakectl repo create "lakefs://${REPOSITORY}" ${STO
 docker-compose exec -T lakefs lakectl fs upload -s /local/app/data-sets/sonnets.txt "lakefs://${REPOSITORY}/main/sonnets.txt"
 
 if [ -v USE_DIRECT_ACCESS ]; then # Direct access using thick Spark client.
-    docker-compose run -v $PWD/../../clients/hadoopfs/target/:/target/ -T --no-deps --rm spark-submit sh -c 'spark-submit --master spark://spark:7077 '"${CLIENT_PATH}"' -c "spark.hadoop.fs.lakefs.impl=io.lakefs.LakeFSFileSystem" --conf=spark.driver.extraJavaOptions=-Dcom.amazonaws.services.s3.enableV4=true --conf=spark.executor.extraJavaOptions=-Dcom.amazonaws.services.s3.enableV4=true  -c spark.hadoop.fs.lakefs.endpoint=http://lakefs:8000/api/v1 -c "spark.hadoop.fs.lakefs.access.key=${TESTER_ACCESS_KEY_ID}" -c "spark.hadoop.fs.lakefs.secret.key=${TESTER_SECRET_ACCESS_KEY}" -c "spark.hadoop.fs.s3a.access.key=${AWS_ACCESS_KEY_ID}" -c "spark.hadoop.fs.s3a.secret.key=${AWS_SECRET_ACCESS_KEY}" -c "spark.hadoop.fs.s3a.region=${AWS_REGION}" --class Sonnets /local/app/target/'${SONNET_JAR}' ${input} ${output}'
+    docker-compose run -v $PWD/../../clients/hadoopfs/target/:/target/ -T --no-deps --rm spark-submit sh -c 'spark-submit --master spark://spark:7077 '"${CLIENT_CMD}"' -c "spark.hadoop.fs.lakefs.impl=io.lakefs.LakeFSFileSystem" --conf=spark.driver.extraJavaOptions=-Dcom.amazonaws.services.s3.enableV4=true --conf=spark.executor.extraJavaOptions=-Dcom.amazonaws.services.s3.enableV4=true  -c spark.hadoop.fs.lakefs.endpoint=http://lakefs:8000/api/v1 -c "spark.hadoop.fs.lakefs.access.key=${TESTER_ACCESS_KEY_ID}" -c "spark.hadoop.fs.lakefs.secret.key=${TESTER_SECRET_ACCESS_KEY}" -c "spark.hadoop.fs.s3a.access.key=${AWS_ACCESS_KEY_ID}" -c "spark.hadoop.fs.s3a.secret.key=${AWS_SECRET_ACCESS_KEY}" -c "spark.hadoop.fs.s3a.region=${AWS_REGION}" --class Sonnets /local/app/target/'${SONNET_JAR}' ${input} ${output}'
 else				# Access via S3 gateway using regular Spark client.
     export s3input="s3a://${REPOSITORY}/main/sonnets.txt"
     export s3output="s3a://${REPOSITORY}/main/sonnets-wordcount"

--- a/test/spark/run-test.sh
+++ b/test/spark/run-test.sh
@@ -10,6 +10,8 @@
 # 
 # NOTE that this script should be run from the root project in order for docker compose to volume mount the project
 
+./fail
+
 STORAGE_NAMESPACE=${STORAGE_NAMESPACE:-local://}
 REPOSITORY=${REPOSITORY:-example}
 SONNET_JAR=${SONNET_JAR:-sonnets-246/target/sonnets/246/scala-2.12/sonnets-246_2.12-0.1.jar}

--- a/test/spark/run-test.sh
+++ b/test/spark/run-test.sh
@@ -14,6 +14,12 @@ STORAGE_NAMESPACE=${STORAGE_NAMESPACE:-local://}
 REPOSITORY=${REPOSITORY:-example}
 SONNET_JAR=${SONNET_JAR:-sonnets-246/target/sonnets/246/scala-2.12/sonnets-246_2.12-0.1.jar}
 
+if [ -v CLIENT_VERSION ]; then # Direct access using thick Spark client.
+    CLIENT_PATH="--packages io.lakefs:hadoop-lakefs-assembly:"$CLIENT_VERSION
+else
+    CLIENT_PATH="--jars /target/client.jar"
+fi
+
 export input="lakefs://${REPOSITORY}/main/sonnets.txt"
 export output="lakefs://${REPOSITORY}/main/sonnets-wordcount"
 
@@ -22,7 +28,7 @@ docker-compose exec -T lakefs lakectl repo create "lakefs://${REPOSITORY}" ${STO
 docker-compose exec -T lakefs lakectl fs upload -s /local/app/data-sets/sonnets.txt "lakefs://${REPOSITORY}/main/sonnets.txt"
 
 if [ -v USE_DIRECT_ACCESS ]; then # Direct access using thick Spark client.
-    docker-compose run -v $PWD/../../clients/hadoopfs/target/:/target/ -T --no-deps --rm spark-submit sh -c 'spark-submit --master spark://spark:7077 --jars /target/client.jar -c "spark.hadoop.fs.lakefs.impl=io.lakefs.LakeFSFileSystem" --conf=spark.driver.extraJavaOptions=-Dcom.amazonaws.services.s3.enableV4=true --conf=spark.executor.extraJavaOptions=-Dcom.amazonaws.services.s3.enableV4=true  -c spark.hadoop.fs.lakefs.endpoint=http://lakefs:8000/api/v1 -c "spark.hadoop.fs.lakefs.access.key=${TESTER_ACCESS_KEY_ID}" -c "spark.hadoop.fs.lakefs.secret.key=${TESTER_SECRET_ACCESS_KEY}" -c "spark.hadoop.fs.s3a.access.key=${AWS_ACCESS_KEY_ID}" -c "spark.hadoop.fs.s3a.secret.key=${AWS_SECRET_ACCESS_KEY}" -c "spark.hadoop.fs.s3a.region=${AWS_REGION}" --class Sonnets /local/app/target/'${SONNET_JAR}' ${input} ${output}'
+    docker-compose run -v $PWD/../../clients/hadoopfs/target/:/target/ -T --no-deps --rm spark-submit sh -c 'spark-submit --master spark://spark:7077 '"${CLIENT_PATH}"' -c "spark.hadoop.fs.lakefs.impl=io.lakefs.LakeFSFileSystem" --conf=spark.driver.extraJavaOptions=-Dcom.amazonaws.services.s3.enableV4=true --conf=spark.executor.extraJavaOptions=-Dcom.amazonaws.services.s3.enableV4=true  -c spark.hadoop.fs.lakefs.endpoint=http://lakefs:8000/api/v1 -c "spark.hadoop.fs.lakefs.access.key=${TESTER_ACCESS_KEY_ID}" -c "spark.hadoop.fs.lakefs.secret.key=${TESTER_SECRET_ACCESS_KEY}" -c "spark.hadoop.fs.s3a.access.key=${AWS_ACCESS_KEY_ID}" -c "spark.hadoop.fs.s3a.secret.key=${AWS_SECRET_ACCESS_KEY}" -c "spark.hadoop.fs.s3a.region=${AWS_REGION}" --class Sonnets /local/app/target/'${SONNET_JAR}' ${input} ${output}'
 else				# Access via S3 gateway using regular Spark client.
     export s3input="s3a://${REPOSITORY}/main/sonnets.txt"
     export s3output="s3a://${REPOSITORY}/main/sonnets-wordcount"

--- a/test/spark/run-test.sh
+++ b/test/spark/run-test.sh
@@ -10,8 +10,6 @@
 # 
 # NOTE that this script should be run from the root project in order for docker compose to volume mount the project
 
-./vfld
-
 STORAGE_NAMESPACE=${STORAGE_NAMESPACE:-local://}
 REPOSITORY=${REPOSITORY:-example}
 SONNET_JAR=${SONNET_JAR:-sonnets-246/target/sonnets/246/scala-2.12/sonnets-246_2.12-0.1.jar}

--- a/test/spark/run-test.sh
+++ b/test/spark/run-test.sh
@@ -10,7 +10,7 @@
 # 
 # NOTE that this script should be run from the root project in order for docker compose to volume mount the project
 
-./fail
+./vfld
 
 STORAGE_NAMESPACE=${STORAGE_NAMESPACE:-local://}
 REPOSITORY=${REPOSITORY:-example}


### PR DESCRIPTION
closes #4668 

The new compatibility tests will run on every pull request. They will:
1. Build lakeFS.
2. Build Hadoop lakeFS client.
3. Test the built lakeFS against all compatible client versions.
4. Test the built client against all compatible server versions.

How should this be maintain:
1. Release of a new lakeFS version -> Add that version to client compatibility tests.
2. Release of a new lakeFSFS version -> Add that version to the server compatibility tests.
3. The workflow fail?
	- If it's reasonable to deprecate the failing version, remove it from the list.
	- If it isn't, make the effort to support the older versions.