### PR TITLE
Export gob registration to let external services to use auth.Claims

### DIFF
--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -4,7 +4,6 @@ import (
 	"bytes"
 	"context"
 	"encoding/base64"
-	"encoding/gob"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -4021,7 +4020,6 @@ func NewController(
 	sessionStore sessions.Store,
 	pathProvider upload.PathProvider,
 ) *Controller {
-	gob.Register(oidc.Claims{})
 	return &Controller{
 		Config:                cfg,
 		Catalog:               catalog,

--- a/pkg/auth/oidc/authenticator.go
+++ b/pkg/auth/oidc/authenticator.go
@@ -4,11 +4,18 @@ import (
 	"context"
 	"errors"
 
+	"github.com/treeverse/lakefs/pkg/auth/oidc/encoding"
+
 	"github.com/coreos/go-oidc/v3/oidc"
 	"golang.org/x/oauth2"
 )
 
 var ErrTokenExtract = errors.New("failed to extract id token")
+
+// Claims is encoding.Claims.  To preserve serialization, it must be an
+// alias declaration of encoding.Claims (with an "=") and not a type
+// declaration.
+type Claims = encoding.Claims
 
 type Authenticator struct {
 	oauthConfig  *oauth2.Config
@@ -18,8 +25,6 @@ type Authenticator struct {
 func NewAuthenticator(oauthConfig *oauth2.Config, oidcProvider *oidc.Provider) *Authenticator {
 	return &Authenticator{oauthConfig: oauthConfig, oidcProvider: oidcProvider}
 }
-
-type Claims map[string]interface{}
 
 // GetIDTokenClaims exchanges a temporary code for an ID token.
 // The ID token is verified to be valid, and its Claims are then returned.

--- a/pkg/auth/oidc/encoding/encoding.go
+++ b/pkg/auth/oidc/encoding/encoding.go
@@ -1,0 +1,21 @@
+// Package encoding defines Claims for interoperable external services to
+// use in JWTs.  An external service that imports this package receives a
+// Claims with a stable gob encoding.
+package encoding
+
+import "encoding/gob"
+
+type Claims map[string]interface{}
+
+// OIDCClaimsSerdeNickname is the typename used to serialize Claims using
+// gob encoding in JWT.  It is the default value that gob would give had
+// Claims been part of auth.  It is not (any longer), explicitly to allow
+// external services to serialize matching claims.
+const OIDCClaimsSerdeNickname = "github.com/treeverse/lakefs/pkg/auth/oidc.Claims"
+
+// init registers OIDCSerdeNickname as the typename used to serialize Claims
+// using gob encoding in JWT.  It should be called in an init() func of a
+// package in any external service that produces matching claims.
+func init() {
+	gob.RegisterName(OIDCClaimsSerdeNickname, Claims{})
+}

--- a/pkg/auth/oidc/encoding/encoding.go
+++ b/pkg/auth/oidc/encoding/encoding.go
@@ -16,6 +16,10 @@ const OIDCClaimsSerdeNickname = "github.com/treeverse/lakefs/pkg/auth/oidc.Claim
 // init registers OIDCSerdeNickname as the typename used to serialize Claims
 // using gob encoding in JWT.  It should be called in an init() func of a
 // package in any external service that produces matching claims.
+//
+// nolint:gochecknoinits
 func init() {
+	// Register at startup, gob.Register says: "Expecting to be used
+	// only during initialization...".
 	gob.RegisterName(OIDCClaimsSerdeNickname, Claims{})
 }


### PR DESCRIPTION
Add a new package github.com/treeverse/lakefs/pkg/auth/oidc/encoding that
holds Claims and registers it for use in JWTs.  External auth services may
use these Claims to be interoperable with lakeFS.

This separate package allows a small minimal import.