### PR TITLE
Add redirect for old /quickstart/try.html page (Fixes #devex-internal/104)

### DIFF
--- a/docs/quickstart/run.md
+++ b/docs/quickstart/run.md
@@ -6,7 +6,7 @@ parent: Quickstart
 nav_order: 10
 has_children: false
 next: ["Create your first repository", "./repository.html"]
-redirect_from: [ "./quickstart/", "quickstart/installing.html"]
+redirect_from: [ "./quickstart/", "quickstart/installing.html", "quickstart/try.html"]
 ---
 
 # Run lakeFS


### PR DESCRIPTION
Fixes https://github.com/treeverse/devex-internal/issues/104