### PR TITLE
Changed health-check to run list repositories and analyze command

### DIFF
--- a/cmd/lakefs/cmd/run.go
+++ b/cmd/lakefs/cmd/run.go
@@ -298,6 +298,7 @@ var runCmd = &cobra.Command{
 			oidcProvider,
 			oauthConfig,
 			upload.DefaultPathProvider,
+			ctx,
 		)
 
 		// init gateway server

--- a/pkg/api/serve_test.go
+++ b/pkg/api/serve_test.go
@@ -193,6 +193,7 @@ func setupHandlerWithWalkerFactory(t testing.TB, factory catalog.WalkerFactory) 
 		nil,
 		nil,
 		upload.DefaultPathProvider,
+		ctx,
 	)
 
 	return handler, &dependencies{

--- a/pkg/health/health.go
+++ b/pkg/health/health.go
@@ -1,0 +1,29 @@
+package health
+
+import (
+	"context"
+
+	"github.com/treeverse/lakefs/cmd/lakectl/cmd"
+)
+
+type HealthStatus struct {
+	lakeFS string `json:"lakeFS"`
+}
+
+type Service interface {
+	Health(ctx context.Context) HealthStatus
+}
+
+type service struct{}
+
+func New() Service {
+	return &service{}
+}
+
+func (s *service) Health(ctx context.Context) HealthStatus {
+	err := cmd.ListRepositoriesAndAnalyze(ctx)
+
+	return HealthStatus{
+		lakeFS: err.Error(),
+	}
+}

--- a/pkg/loadtest/local_load_test.go
+++ b/pkg/loadtest/local_load_test.go
@@ -106,6 +106,7 @@ func TestLocalLoad(t *testing.T) {
 		nil,
 		nil,
 		upload.DefaultPathProvider,
+		ctx,
 	)
 
 	ts := httptest.NewServer(handler)


### PR DESCRIPTION

### Background

Currently, lakeFS health-check doesn't check the basic functionality of lakeFS.
It means, that if for an instance, there's a connection issue for the ref-store, the health will pass and we won't have an indication that something is broken.
      
### New Feature

This PR, change the health-check to run the `list repositories and analyze` command as health-check as it's the most basic command that can indicate that something with our installation is broken.
