### PR TITLE
Add merge strategy to commit data

### DIFF
--- a/cmd/lakectl/cmd/log.go
+++ b/cmd/lakectl/cmd/log.go
@@ -17,11 +17,12 @@ Date:          {{ $val.CreationDate|date }}
 Merge:         {{ $val.Parents|join ", "|bold }}
 {{ end }}
 	{{ $val.Message }}
-
+{{ if $val.Metadata.AdditionalProperties }}
 Metadata:
 	{{ range $key, $value := $val.Metadata.AdditionalProperties }}
 	{{ $key | printf "%-18s" }} = {{ $value }}
 	{{ end -}}
+{{ end -}}
 {{ end }}{{ if .Pagination  }}
 {{.Pagination | paginate }}{{ end }}`
 

--- a/cmd/lakectl/cmd/log.go
+++ b/cmd/lakectl/cmd/log.go
@@ -20,7 +20,7 @@ Merge:         {{ $val.Parents|join ", "|bold }}
 
 Metadata:
 	{{ range $key, $value := $val.Metadata.AdditionalProperties }}
-	{{ $key }}	=	{{ $value }}
+	{{ $key | printf "%-18s" }} = {{ $value }}
 	{{ end -}}
 {{ end }}{{ if .Pagination  }}
 {{.Pagination | paginate }}{{ end }}`

--- a/cmd/lakectl/cmd/log.go
+++ b/cmd/lakectl/cmd/log.go
@@ -17,9 +17,10 @@ Date:          {{ $val.CreationDate|date }}
 Merge:         {{ $val.Parents|join ", "|bold }}
 {{ end }}
 	{{ $val.Message }}
-	
+
+Metadata:
 	{{ range $key, $value := $val.Metadata.AdditionalProperties }}
-		{{ $key }} = {{ $value }}
+	{{ $key }}	=	{{ $value }}
 	{{ end -}}
 {{ end }}{{ if .Pagination  }}
 {{.Pagination | paginate }}{{ end }}`

--- a/esti/golden/lakectl_log_initial.golden
+++ b/esti/golden/lakectl_log_initial.golden
@@ -3,5 +3,4 @@ ID:            <COMMIT_ID>
 Date:          <DATE> <TIME> <TZ>
 
 	Repository created
-	
-	
+

--- a/esti/golden/lakectl_log_with_commit.golden
+++ b/esti/golden/lakectl_log_with_commit.golden
@@ -4,18 +4,15 @@ Author:        esti
 Date:          <DATE> <TIME> <TZ>
 
 	${MESSAGE}
-	
-	
+
 ID:            <COMMIT_ID>
 Author:        esti
 Date:          <DATE> <TIME> <TZ>
 
 	 
-	
-	
+
 ID:            <COMMIT_ID>
 Date:          <DATE> <TIME> <TZ>
 
 	Repository created
-	
-	
+

--- a/esti/golden/lakectl_log_with_commit_custom_date.golden
+++ b/esti/golden/lakectl_log_with_commit_custom_date.golden
@@ -4,5 +4,4 @@ Author:        esti
 Date:          ${DATE}
 
 	${MESSAGE}
-	
-	
+

--- a/esti/golden/lakectl_show_commit.golden
+++ b/esti/golden/lakectl_show_commit.golden
@@ -4,5 +4,3 @@ Author:        esti
 Date:          ${DATE}
 
 	${MESSAGE}
-	
-	

--- a/esti/golden/lakectl_show_commit_metarange.golden
+++ b/esti/golden/lakectl_show_commit_metarange.golden
@@ -5,5 +5,3 @@ Date:          ${DATE}
 Meta Range ID: <COMMIT_ID>
 
 	${MESSAGE}
-	
-	

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -1856,7 +1856,8 @@ func (c *Controller) handleAPIErrorCallback(ctx context.Context, w http.Response
 		errors.Is(err, model.ErrValidationError),
 		errors.Is(err, graveler.ErrInvalidRef),
 		errors.Is(err, actions.ErrParamConflict),
-		errors.Is(err, graveler.ErrDereferenceCommitWithStaging):
+		errors.Is(err, graveler.ErrDereferenceCommitWithStaging),
+		errors.Is(err, graveler.ErrInvalidMergeStrategy):
 		cb(w, r, http.StatusBadRequest, err)
 
 	case errors.Is(err, graveler.ErrNotUnique),
@@ -3372,10 +3373,11 @@ func (c *Controller) MergeIntoBranch(w http.ResponseWriter, r *http.Request, bod
 		writeError(w, r, http.StatusUnauthorized, "user not found")
 		return
 	}
-	var metadata map[string]string
+	metadata := map[string]string{}
 	if body.Metadata != nil {
 		metadata = body.Metadata.AdditionalProperties
 	}
+
 	reference, err := c.Catalog.Merge(ctx,
 		repository, destinationBranch, sourceRef,
 		user.Username,

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -599,7 +599,7 @@ func TestController_CommitsGetBranchCommitLogByPath(t *testing.T) {
 		user:         "user3",
 		commitName:   "P",
 	})
-	mergeCommit, err := deps.catalog.Merge(ctx, "repo3", "main", "branch-b", "user3", "commitR", nil, "")
+	mergeCommit, err := deps.catalog.Merge(ctx, "repo3", "main", "branch-b", "user3", "commitR", catalog.Metadata{}, "")
 	testutil.Must(t, err)
 	commitsMap["commitR"] = mergeCommit
 	commitsMap["commitM"] = testCommitEntries(t, ctx, deps.catalog, deps, commitEntriesParams{
@@ -610,7 +610,7 @@ func TestController_CommitsGetBranchCommitLogByPath(t *testing.T) {
 		user:         "user2",
 		commitName:   "M",
 	})
-	mergeCommit, err = deps.catalog.Merge(ctx, "repo3", "main", "branch-a", "user2", "commitN", nil, "")
+	mergeCommit, err = deps.catalog.Merge(ctx, "repo3", "main", "branch-a", "user2", "commitN", catalog.Metadata{}, "")
 	testutil.Must(t, err)
 	commitsMap["commitN"] = mergeCommit
 	commitsMap["commitX"] = testCommitEntries(t, ctx, deps.catalog, deps, commitEntriesParams{
@@ -3272,7 +3272,7 @@ func TestController_Revert(t *testing.T) {
 		_, err = deps.catalog.Commit(ctx, repo, "branch1", "second", DefaultUserID, nil, nil, nil)
 		testutil.Must(t, err)
 		// merge branch1 to main
-		mergeRef, err := deps.catalog.Merge(ctx, repo, "main", "branch1", DefaultUserID, "merge to main", nil, "")
+		mergeRef, err := deps.catalog.Merge(ctx, repo, "main", "branch1", DefaultUserID, "merge to main", catalog.Metadata{}, "")
 		testutil.Must(t, err)
 
 		// revert changes should fail

--- a/pkg/graveler/committed/merge.go
+++ b/pkg/graveler/committed/merge.go
@@ -108,7 +108,7 @@ func (m *merger) destBeforeSource(destValue *graveler.ValueRecord) error {
 			switch m.strategy {
 			case graveler.MergeStrategyDest:
 				break
-			case graveler.MergeStrategySource:
+			case graveler.MergeStrategySrc:
 				m.haveDest = m.dest.Next()
 				return nil
 			default: // graveler.MergeStrategyNone
@@ -138,7 +138,7 @@ func (m *merger) sourceBeforeDest(sourceValue *graveler.ValueRecord) error {
 			case graveler.MergeStrategyDest:
 				m.haveSource = m.source.Next()
 				return nil
-			case graveler.MergeStrategySource:
+			case graveler.MergeStrategySrc:
 				break
 			default: // graveler.MergeStrategyNone
 				return graveler.ErrConflictFound
@@ -306,7 +306,7 @@ func (m *merger) handleConflict(sourceValue *graveler.ValueRecord, destValue *gr
 		if err != nil {
 			return fmt.Errorf("write record: %w", err)
 		}
-	case graveler.MergeStrategySource:
+	case graveler.MergeStrategySrc:
 		err := m.writeRecord(sourceValue)
 		if err != nil {
 			return fmt.Errorf("write record: %w", err)
@@ -468,7 +468,7 @@ func (m *merger) merge() error {
 	}
 
 	if m.haveSource {
-		if err := m.handleAll(m.source, graveler.MergeStrategySource); err != nil {
+		if err := m.handleAll(m.source, graveler.MergeStrategySrc); err != nil {
 			return err
 		}
 	}

--- a/pkg/graveler/committed/merge_test.go
+++ b/pkg/graveler/committed/merge_test.go
@@ -131,7 +131,7 @@ func Test_merge(t *testing.T) {
 				{rng: committed.Range{ID: "base:k3-k6", MinKey: committed.Key("k3"), MaxKey: committed.Key("k6"), Count: 2, EstimatedSize: 1234}},
 			}),
 			expectedResult: []testRunResult{{
-				mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySource},
+				mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySrc},
 				expectedActions: []writeAction{
 					{
 						action: actionTypeWriteRange,
@@ -158,7 +158,7 @@ func Test_merge(t *testing.T) {
 				{rng: committed.Range{ID: "base:k3-k6", MinKey: committed.Key("k3"), MaxKey: committed.Key("k6"), Count: 2, EstimatedSize: 1024}},
 			}),
 			expectedResult: []testRunResult{{
-				mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySource},
+				mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySrc},
 				expectedActions: []writeAction{
 					{
 						action: actionTypeWriteRange,
@@ -187,7 +187,7 @@ func Test_merge(t *testing.T) {
 				{rng: committed.Range{ID: "base:k3-k6", MinKey: committed.Key("k3"), MaxKey: committed.Key("k6"), Count: 2, EstimatedSize: 1024}},
 			}),
 			expectedResult: []testRunResult{{
-				mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySource},
+				mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySrc},
 				expectedActions: []writeAction{
 					{
 						action: actionTypeWriteRange,
@@ -217,7 +217,7 @@ func Test_merge(t *testing.T) {
 				}},
 			}),
 			expectedResult: []testRunResult{{
-				mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySource},
+				mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySrc},
 				expectedActions: []writeAction{
 					{
 						action: actionTypeWriteRange,
@@ -250,7 +250,7 @@ func Test_merge(t *testing.T) {
 				}},
 			}),
 			expectedResult: []testRunResult{{
-				mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySource},
+				mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySrc},
 				expectedActions: []writeAction{
 					{
 						action: actionTypeWriteRange,
@@ -286,7 +286,7 @@ func Test_merge(t *testing.T) {
 			}),
 			expectedResult: []testRunResult{
 				{
-					mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySource},
+					mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySrc},
 					expectedActions: []writeAction{
 						{
 							action:   actionTypeWriteRecord,
@@ -342,7 +342,7 @@ func Test_merge(t *testing.T) {
 				},
 			}),
 			expectedResult: []testRunResult{{
-				mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySource},
+				mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySrc},
 				expectedActions: []writeAction{
 					{
 						action:   actionTypeWriteRecord,
@@ -393,7 +393,7 @@ func Test_merge(t *testing.T) {
 				}},
 			}),
 			expectedResult: []testRunResult{{
-				mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySource},
+				mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySrc},
 				expectedActions: []writeAction{
 					{action: actionTypeWriteRecord, key: "k1", identity: "base:k1"},
 					{action: actionTypeWriteRecord, key: "k3", identity: "base:k3"},
@@ -424,7 +424,7 @@ func Test_merge(t *testing.T) {
 				}},
 			}),
 			expectedResult: []testRunResult{{
-				mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySource},
+				mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySrc},
 				expectedActions: []writeAction{
 					{action: actionTypeWriteRecord, key: "k1", identity: "base:k1"},
 					{action: actionTypeWriteRecord, key: "k3", identity: "base:k3"},
@@ -456,7 +456,7 @@ func Test_merge(t *testing.T) {
 				}},
 			}),
 			expectedResult: []testRunResult{{
-				mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySource},
+				mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySrc},
 				expectedActions: []writeAction{
 					{action: actionTypeWriteRecord, key: "k1", identity: "base:k1"},
 					{action: actionTypeWriteRecord, key: "k3", identity: "base:k3"},
@@ -490,7 +490,7 @@ func Test_merge(t *testing.T) {
 				}},
 			}),
 			expectedResult: []testRunResult{{
-				mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySource},
+				mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySrc},
 				expectedActions: []writeAction{
 					{
 						action:   actionTypeWriteRecord,
@@ -532,7 +532,7 @@ func Test_merge(t *testing.T) {
 				{rng: committed.Range{ID: "base:k3-k6", MinKey: committed.Key("k3"), MaxKey: committed.Key("k6"), Count: 2, EstimatedSize: 1234}},
 			}),
 			expectedResult: []testRunResult{{
-				mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySource},
+				mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySrc},
 				expectedActions: []writeAction{
 					{
 						action: actionTypeWriteRange,
@@ -558,7 +558,7 @@ func Test_merge(t *testing.T) {
 				{rng: committed.Range{ID: "base:k3-k6", MinKey: committed.Key("k3"), MaxKey: committed.Key("k6"), Count: 2, EstimatedSize: 1234}},
 			}),
 			expectedResult: []testRunResult{{
-				mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySource},
+				mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySrc},
 				expectedActions: []writeAction{
 					{
 						action: actionTypeWriteRange,
@@ -600,7 +600,7 @@ func Test_merge(t *testing.T) {
 				},
 			}),
 			expectedResult: []testRunResult{{
-				mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySource},
+				mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySrc},
 				expectedActions: []writeAction{
 					{action: actionTypeWriteRange, rng: committed.Range{ID: "base:k1-k2", MinKey: committed.Key("k1"), MaxKey: committed.Key("k2"), Count: 2, EstimatedSize: 1234}},
 					{action: actionTypeWriteRange, rng: committed.Range{ID: "source:k3-k6", MinKey: committed.Key("k3"), MaxKey: committed.Key("k6"), Count: 2, EstimatedSize: 1234}},
@@ -639,7 +639,7 @@ func Test_merge(t *testing.T) {
 				},
 			}),
 			expectedResult: []testRunResult{{
-				mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySource},
+				mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySrc},
 				expectedActions: []writeAction{
 					{action: actionTypeWriteRange, rng: committed.Range{ID: "base:k1-k2", MinKey: committed.Key("k1"), MaxKey: committed.Key("k2"), Count: 2, EstimatedSize: 1234}},
 					{action: actionTypeWriteRecord, key: "k3", identity: "base:k3"},
@@ -679,7 +679,7 @@ func Test_merge(t *testing.T) {
 				},
 			}),
 			expectedResult: []testRunResult{{
-				mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySource},
+				mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySrc},
 				expectedActions: []writeAction{
 					{action: actionTypeWriteRange, rng: committed.Range{ID: "base:k1-k2", MinKey: committed.Key("k1"), MaxKey: committed.Key("k2"), Count: 2, EstimatedSize: 1234}},
 					{action: actionTypeWriteRange, rng: committed.Range{ID: "dest:k3-k6", MinKey: committed.Key("k3"), MaxKey: committed.Key("k6"), Count: 2, EstimatedSize: 1234}},
@@ -695,7 +695,7 @@ func Test_merge(t *testing.T) {
 				{rng: committed.Range{ID: "base:k3-k6", MinKey: committed.Key("k3"), MaxKey: committed.Key("k6"), Count: 2, EstimatedSize: 1234}},
 			}),
 			expectedResult: []testRunResult{{
-				mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySource},
+				mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySrc},
 				expectedActions: []writeAction{},
 				expectedErr:     graveler.ErrNoChanges,
 			}},
@@ -730,7 +730,7 @@ func Test_merge(t *testing.T) {
 				},
 			}),
 			expectedResult: []testRunResult{{
-				mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySource},
+				mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySrc},
 				expectedActions: []writeAction{
 					{action: actionTypeWriteRecord, key: "k6", identity: "dest:k6"},
 					{action: actionTypeWriteRecord, key: "k7", identity: "dest:k7"},
@@ -764,7 +764,7 @@ func Test_merge(t *testing.T) {
 				},
 			}),
 			expectedResult: []testRunResult{{
-				mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySource},
+				mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySrc},
 				expectedActions: []writeAction{},
 				expectedErr:     graveler.ErrNoChanges,
 			}},
@@ -801,7 +801,7 @@ func Test_merge(t *testing.T) {
 				},
 			}),
 			expectedResult: []testRunResult{{
-				mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySource},
+				mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySrc},
 				expectedActions: []writeAction{
 					{
 						action:   actionTypeWriteRecord,
@@ -842,7 +842,7 @@ func Test_merge(t *testing.T) {
 			}),
 			destRange: newTestMetaRange([]testRange{}),
 			expectedResult: []testRunResult{{
-				mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySource},
+				mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySrc},
 				expectedActions: []writeAction{
 					{
 						action:   actionTypeWriteRecord,
@@ -878,7 +878,7 @@ func Test_merge(t *testing.T) {
 				},
 			}),
 			expectedResult: []testRunResult{{
-				mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySource},
+				mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySrc},
 				expectedActions: []writeAction{
 					{
 						action:   actionTypeWriteRecord,
@@ -914,7 +914,7 @@ func Test_merge(t *testing.T) {
 			}),
 			destRange: newTestMetaRange([]testRange{}),
 			expectedResult: []testRunResult{{
-				mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySource},
+				mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySrc},
 				expectedActions: []writeAction{
 					{
 						action: actionTypeWriteRange,
@@ -939,7 +939,7 @@ func Test_merge(t *testing.T) {
 			}),
 			destRange: newTestMetaRange([]testRange{}),
 			expectedResult: []testRunResult{{
-				mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySource},
+				mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySrc},
 				expectedActions: []writeAction{
 					{
 						action:   actionTypeWriteRecord,
@@ -973,7 +973,7 @@ func Test_merge(t *testing.T) {
 			}),
 			destRange: newTestMetaRange([]testRange{}),
 			expectedResult: []testRunResult{{
-				mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySource},
+				mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySrc},
 				expectedActions: []writeAction{
 					{
 						action:   actionTypeWriteRecord,
@@ -1013,7 +1013,7 @@ func Test_merge(t *testing.T) {
 				},
 			}),
 			expectedResult: []testRunResult{{
-				mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySource},
+				mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySrc},
 				expectedActions: []writeAction{
 					{
 						action:   actionTypeWriteRecord,
@@ -1057,7 +1057,7 @@ func Test_merge(t *testing.T) {
 				},
 			}),
 			expectedResult: []testRunResult{{
-				mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySource},
+				mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySrc},
 				expectedActions: []writeAction{
 					{
 						action:   actionTypeWriteRecord,
@@ -1105,7 +1105,7 @@ func Test_merge(t *testing.T) {
 				},
 			}),
 			expectedResult: []testRunResult{{
-				mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySource},
+				mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySrc},
 				expectedActions: []writeAction{
 					{
 						action:   actionTypeWriteRecord,
@@ -1153,7 +1153,7 @@ func Test_merge(t *testing.T) {
 				},
 			}),
 			expectedResult: []testRunResult{{
-				mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySource},
+				mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySrc},
 				expectedActions: []writeAction{
 					{
 						action:   actionTypeWriteRecord,
@@ -1190,7 +1190,7 @@ func Test_merge(t *testing.T) {
 				}},
 			}),
 			expectedResult: []testRunResult{{
-				mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySource},
+				mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySrc},
 				expectedActions: []writeAction{},
 			}},
 		},
@@ -1211,7 +1211,7 @@ func Test_merge(t *testing.T) {
 				}},
 			}),
 			expectedResult: []testRunResult{{
-				mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySource},
+				mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategyNone, graveler.MergeStrategyDest, graveler.MergeStrategySrc},
 				expectedActions: []writeAction{},
 				expectedErr:     graveler.ErrNoChanges,
 			}},
@@ -1256,7 +1256,7 @@ func TestMergeStrategies(t *testing.T) {
 					expectedErr:     nil,
 				},
 				{
-					mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategySource},
+					mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategySrc},
 					expectedActions: []writeAction{
 						{
 							action:   actionTypeWriteRecord,
@@ -1330,7 +1330,7 @@ func TestMergeStrategies(t *testing.T) {
 					expectedErr: nil,
 				},
 				{
-					mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategySource},
+					mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategySrc},
 					expectedActions: []writeAction{
 						{
 							action:   actionTypeWriteRecord,
@@ -1407,7 +1407,7 @@ func TestMergeStrategies(t *testing.T) {
 					expectedErr: nil,
 				},
 				{
-					mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategySource},
+					mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategySrc},
 					expectedActions: []writeAction{
 						{
 							action:   actionTypeWriteRecord,
@@ -1466,7 +1466,7 @@ func TestMergeStrategies(t *testing.T) {
 					expectedErr: nil,
 				},
 				{
-					mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategySource},
+					mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategySrc},
 					expectedActions: []writeAction{
 						{
 							action:   actionTypeWriteRecord,
@@ -1536,7 +1536,7 @@ func TestMergeStrategies(t *testing.T) {
 					expectedErr: nil,
 				},
 				{
-					mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategySource},
+					mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategySrc},
 					expectedActions: []writeAction{
 						{
 							action:   actionTypeWriteRecord,
@@ -1601,7 +1601,7 @@ func TestMergeStrategies(t *testing.T) {
 					expectedErr: nil,
 				},
 				{
-					mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategySource},
+					mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategySrc},
 					expectedActions: []writeAction{
 						{
 							action:   actionTypeWriteRecord,
@@ -1670,7 +1670,7 @@ func TestMergeStrategies(t *testing.T) {
 					expectedErr: nil,
 				},
 				{
-					mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategySource},
+					mergeStrategies: []graveler.MergeStrategy{graveler.MergeStrategySrc},
 					expectedActions: []writeAction{
 						{
 							action:   actionTypeWriteRecord,

--- a/pkg/graveler/errors.go
+++ b/pkg/graveler/errors.go
@@ -24,7 +24,7 @@ var (
 	ErrInvalidMergeBase             = fmt.Errorf("only 2 commits allowed in FindMergeBase: %w", ErrInvalidValue)
 	ErrNoCommitGeneration           = errors.New("no commit generation")
 	ErrNoMergeBase                  = errors.New("no merge base")
-	ErrInvalidMergeStrategy         = errors.New("invalid merge strategy")
+	ErrInvalidMergeStrategy         = wrapError(ErrUserVisible, "invalid merge strategy")
 	ErrInvalidRef                   = fmt.Errorf("ref: %w", ErrInvalidValue)
 	ErrInvalidCommitID              = fmt.Errorf("commit id: %w", ErrInvalidValue)
 	ErrInvalidBranchID              = fmt.Errorf("branch id: %w", ErrInvalidValue)

--- a/pkg/graveler/errors.go
+++ b/pkg/graveler/errors.go
@@ -24,6 +24,7 @@ var (
 	ErrInvalidMergeBase             = fmt.Errorf("only 2 commits allowed in FindMergeBase: %w", ErrInvalidValue)
 	ErrNoCommitGeneration           = errors.New("no commit generation")
 	ErrNoMergeBase                  = errors.New("no merge base")
+	ErrInvalidMergeStrategy         = errors.New("invalid merge strategy")
 	ErrInvalidRef                   = fmt.Errorf("ref: %w", ErrInvalidValue)
 	ErrInvalidCommitID              = fmt.Errorf("commit id: %w", ErrInvalidValue)
 	ErrInvalidBranchID              = fmt.Errorf("branch id: %w", ErrInvalidValue)

--- a/pkg/graveler/graveler.go
+++ b/pkg/graveler/graveler.go
@@ -2282,13 +2282,10 @@ func (g *Graveler) Merge(ctx context.Context, repository *RepositoryRecord, dest
 		switch strategy {
 		case MergeStrategyDestWinsStr:
 			mergeStrategy = MergeStrategyDest
-
 		case MergeStrategySrcWinsStr:
 			mergeStrategy = MergeStrategySrc
-
 		case "":
 			mergeStrategy = MergeStrategyNone
-
 		default:
 			return nil, ErrInvalidMergeStrategy
 		}

--- a/pkg/graveler/graveler.go
+++ b/pkg/graveler/graveler.go
@@ -114,7 +114,7 @@ const (
 	MergeStrategyDestWinsStr = "dest-wins"
 	MergeStrategySrcWinsStr  = "source-wins"
 
-	MergeStrategyMetadataKey = "lakefs.merge.strategy"
+	MergeStrategyMetadataKey = ".lakefs.merge.strategy"
 )
 
 // mergeStrategyString String representation for MergeStrategy consts. Pay attention to the order!

--- a/pkg/graveler/graveler_v2_test.go
+++ b/pkg/graveler/graveler_v2_test.go
@@ -44,11 +44,6 @@ var (
 		SealedTokens: []graveler.StagingToken{stagingToken2, stagingToken3},
 	}
 
-	branch2 = graveler.Branch{
-		CommitID:     commit2ID,
-		StagingToken: stagingToken1,
-	}
-
 	commit1       = graveler.Commit{MetaRangeID: mr1ID, Parents: []graveler.CommitID{commit4ID}}
 	commit2       = graveler.Commit{MetaRangeID: mr2ID, Parents: []graveler.CommitID{commit4ID}}
 	commit3       = graveler.Commit{MetaRangeID: mr3ID}
@@ -61,8 +56,6 @@ var (
 	key2          = []byte("some/key/2")
 	value1        = &graveler.Value{Identity: []byte("id1"), Data: []byte("data1")}
 	value2        = &graveler.Value{Identity: []byte("id2"), Data: []byte("data2")}
-
-	ErrTestGraveler = errors.New("test error")
 )
 
 func TestGravelerGet(t *testing.T) {
@@ -223,7 +216,7 @@ func TestGravelerMerge(t *testing.T) {
 		test.StagingManager.EXPECT().DropAsync(ctx, stagingToken2).Times(1)
 		test.StagingManager.EXPECT().DropAsync(ctx, stagingToken3).Times(1)
 
-		val, err := test.Sut.Merge(ctx, repository, branch1ID, graveler.Ref(branch2ID), graveler.CommitParams{}, "")
+		val, err := test.Sut.Merge(ctx, repository, branch1ID, graveler.Ref(branch2ID), graveler.CommitParams{Metadata: graveler.Metadata{}}, "")
 
 		require.NoError(t, err)
 		require.NotNil(t, val)

--- a/pkg/graveler/graveler_v2_test.go
+++ b/pkg/graveler/graveler_v2_test.go
@@ -249,7 +249,7 @@ func TestGravelerMerge(t *testing.T) {
 		test.RefManager.EXPECT().GetCommit(ctx, repository, commit1ID).Times(1).Return(&commit1, nil)
 		test.CommittedManager.EXPECT().List(ctx, repository.StorageNamespace, mr1ID).Times(1).Return(testutils.NewFakeValueIterator(nil), nil)
 
-		val, err := test.Sut.Merge(ctx, repository, branch1ID, graveler.Ref(branch2ID), graveler.CommitParams{}, "")
+		val, err := test.Sut.Merge(ctx, repository, branch1ID, graveler.Ref(branch2ID), graveler.CommitParams{Metadata: graveler.Metadata{}}, "")
 		require.Equal(t, graveler.ErrDirtyBranch, err)
 		require.Equal(t, graveler.CommitID(""), val)
 	})
@@ -289,7 +289,7 @@ func TestGravelerMerge(t *testing.T) {
 		test.StagingManager.EXPECT().DropAsync(ctx, stagingToken2).Times(1)
 		test.StagingManager.EXPECT().DropAsync(ctx, stagingToken3).Times(1)
 
-		val, err := test.Sut.Merge(ctx, repository, branch1ID, graveler.Ref(branch2ID), graveler.CommitParams{}, "")
+		val, err := test.Sut.Merge(ctx, repository, branch1ID, graveler.Ref(branch2ID), graveler.CommitParams{Metadata: graveler.Metadata{}}, "")
 
 		require.NoError(t, err)
 		require.NotNil(t, val)
@@ -307,7 +307,7 @@ func TestGravelerMerge(t *testing.T) {
 				return kv.ErrPredicateFailed
 			}).Times(graveler.BranchUpdateMaxTries)
 
-		val, err := test.Sut.Merge(ctx, repository, branch1ID, graveler.Ref(branch2ID), graveler.CommitParams{}, "")
+		val, err := test.Sut.Merge(ctx, repository, branch1ID, graveler.Ref(branch2ID), graveler.CommitParams{Metadata: graveler.Metadata{}}, "")
 
 		require.ErrorIs(t, err, graveler.ErrTooManyTries)
 		require.Empty(t, val)


### PR DESCRIPTION
<!-- 
Hello Axolotl!
Thank you for contributing to the lakeFS project.
We appreciate the time invested in this pull request and created this template to help make this process easier.
It's really important to have all the information and context, to ensure we can properly address this PR 
Please use the following references to fill out the pull request.
--> 

### Linked Issue

Closes #5222
---

## Change Description

### Background

During investigation of a potential issue - we found the need to understand what merge strategy was performed for a given merge commit
      
### New Feature

On new merge commit - added the merge strategy used to the commit metadata

### Testing Details

Add controller unit test
Modified esti integration tests
Tested manually

### Breaking Change?

No
