### PR TITLE
lakefs lua run command to evaluate lua script

### DIFF
--- a/cmd/lakefs/cmd/lua.go
+++ b/cmd/lakefs/cmd/lua.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/Shopify/go-lua"
+	"github.com/spf13/cobra"
+	lualibs "github.com/treeverse/lakefs/pkg/actions/lua"
+	luautil "github.com/treeverse/lakefs/pkg/actions/lua/util"
+)
+
+var luaCmd = &cobra.Command{
+	Use:    "lua",
+	Short:  "Lua related commands for dev/test scripting",
+	Hidden: true,
+}
+
+var luaRunCmd = &cobra.Command{
+	Use:   "run [file.lua]",
+	Short: "Run lua code locally for testing. Use stdin when no file is given",
+	Args:  cobra.RangeArgs(0, 1),
+	Run: func(cmd *cobra.Command, args []string) {
+		var filename string
+		if len(args) > 0 {
+			filename = args[0]
+		}
+
+		ctx := cmd.Context()
+		l := lua.NewStateEx()
+		lualibs.OpenSafe(l, ctx, os.Stdout)
+		luautil.DeepPush(l, args)
+		l.SetGlobal("args") // add cmd line args as lua args
+		if err := lua.DoFile(l, filename); err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "%s\n", err)
+			os.Exit(1)
+		}
+	},
+}
+
+//nolint:gochecknoinits
+func init() {
+	rootCmd.AddCommand(luaCmd)
+	luaCmd.AddCommand(luaRunCmd)
+}


### PR DESCRIPTION
Enable hidden lakefs cmd to run lua script locally for debug/test.

Current limitations:
- Doesn't simulate actions event. Can enable reading and embedding data from JSON files.
- Doesn't expose lakefs package. Will require setup lakefs or configure lakefs endpoint + login/load user credentials to enable operations done by the lakefs package.