### PR TITLE
Deprecate Message for LDAP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ Deprecated:
 - Authorization using Role-Based Access Control
 - LDAP Embedded Support
 
+## Upcoming (ASSIGN NEXT VERSION NUMBER to release!)
+
+- Deprecate embedded support for LDAP Authentication (#5262)
+
 ## v0.93.0
 
 :new: What's new:

--- a/cmd/lakefs/cmd/run.go
+++ b/cmd/lakefs/cmd/run.go
@@ -232,6 +232,9 @@ var runCmd = &cobra.Command{
 		}
 
 		if cfg.Auth.LDAP != nil {
+			logger.
+				WithField("feature", "LDAP").
+				Warn("Enabling LDAP on lakeFS server, but this functionality is deprecated")
 			middlewareAuthenticator = append(middlewareAuthenticator, newLDAPAuthenticator(cfg.Auth.LDAP, authService))
 		}
 		controllerAuthenticator := append(middlewareAuthenticator, auth.NewEmailAuthenticator(authService))

--- a/docs/reference/authentication.md
+++ b/docs/reference/authentication.md
@@ -18,7 +18,7 @@ has_children: false
 ### User Authentication
 
 lakeFS authenticates users from a built-in authentication database, or,
-optionally, from a configured LDAP server.
+optionally.
 
 #### Built-in database
 

--- a/docs/reference/authentication.md
+++ b/docs/reference/authentication.md
@@ -17,8 +17,7 @@ has_children: false
 
 ### User Authentication
 
-lakeFS authenticates users from a built-in authentication database, or,
-optionally.
+lakeFS authenticates users from a built-in authentication database.
 
 #### Built-in database
 


### PR DESCRIPTION
Small update to already marked as deprecated LDAP to log to terminal warning message incase of using LDAP. 

Closes #5266