### PR TITLE
UI: fix object browser uri wrapping on long uris

### DIFF
--- a/webui/src/styles/globals.css
+++ b/webui/src/styles/globals.css
@@ -602,11 +602,6 @@ td .form-group {
   margin-right: 8px;
 }
 
-.object-viewer-buttons {
-  width: 20%;
-  text-align: right;
-  margin-right: 5px;
-}
 
 .object-viewer-sql-input.form-control {
   background-color: #333333;


### PR DESCRIPTION
On the lakeFS UI, the object screen shows the URI of the current path in the header of the browser card. Currently, the URI breaks into a new line after 40 chars or so, resulting in a broken-looking address line

Recently this component moved to using flexbox - the current CSS class styles are no longer required. Removing them solves the issue.
