### PR TITLE
Show delta diff results for tables created or dropped

### DIFF
--- a/webui/src/constants.ts
+++ b/webui/src/constants.ts
@@ -9,3 +9,9 @@ export enum TreeItemType {
 export enum OtfType {
     Delta = "delta",
 }
+export enum OtfDiffType {
+    Created = "created",
+    Dropped = "dropped",
+    Changed = "changed",
+}
+

--- a/webui/src/lib/api/index.js
+++ b/webui/src/lib/api/index.js
@@ -488,7 +488,9 @@ class Repositories {
         // }
         // return response.json();
         // const mockRes = '{"results": []}'
-        const mockRes = '{"type": "changed", "results": [{"version": "1", "timestamp": 1515491537026, "operation": "INSERT", "operation_content": {"mode": "Append","partitionBy": "[]"}, "operation_type": "create"}, {"version": "2", "timestamp": 1515491537346, "operation": "DELETE", "operation_content": {"mode": "Append","partitionBy": "[]"}, "operation_type": "delete"}, {"version": "14", "timestamp": 1674393286223, "operation": "DELETE", "operation_content": {"predicate": "[\\"(spark_catalog.delta.lakefs://meetup-repo/experiment-2-branch/raw/.`rating` < 4.0D) aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\\"]"}, "operation_type": "delete"}]}'
+        const mockRes = '{"diff_type": "changed", "results": [{"version": "1", "timestamp": 1515491537026, "operation": "INSERT", "operation_content": {"mode": "Append","partitionBy": "[]"}, "operation_type": "create"}, {"version": "2", "timestamp": 1515491537346, "operation": "DELETE", "operation_content": {"mode": "Append","partitionBy": "[]"}, "operation_type": "delete"}, {"version": "14", "timestamp": 1674393286223, "operation": "DELETE", "operation_content": {"predicate": "[\\"(spark_catalog.delta.lakefs://meetup-repo/experiment-2-branch/raw/.`rating` < 4.0D) aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\\"]"}, "operation_type": "delete"}]}'
+        // const mockRes = '{"diff_type": "created", "results": [{"version": "1", "timestamp": 1515491537026, "operation": "INSERT", "operation_content": {"mode": "Append","partitionBy": "[]"}, "operation_type": "create"}]}'
+        // const mockRes = '{"diff_type": "dropped", "results": []}'
         return JSON.parse(mockRes);
     }
 }

--- a/webui/src/lib/components/repository/TableDiff.jsx
+++ b/webui/src/lib/components/repository/TableDiff.jsx
@@ -18,7 +18,7 @@ export const DeltaLakeDiff = ({repo, leftRef, rightRef, tablePath}) => {
     const otfDiffs = response.results;
     const diffType = response.diff_type;
     return <>
-        {(OtfDiffType.Dropped != diffType && otfDiffs.length === 0) ?  <Alert variant="info" style={{margin: 0+"px"}}>No changes</Alert> :
+        {(OtfDiffType.Dropped !== diffType && otfDiffs.length === 0) ?  <Alert variant="info" style={{margin: 0+"px"}}>No changes</Alert> :
             <Table className="table-diff" size="md">
                 <tbody>
                 <TableDiffTypeRow diffType={diffType}/>
@@ -34,7 +34,7 @@ export const DeltaLakeDiff = ({repo, leftRef, rightRef, tablePath}) => {
 }
 
 const TableDiffTypeRow = ({diffType}) => {
-    if (OtfDiffType.Changed == diffType) {
+    if (OtfDiffType.Changed === diffType) {
         return "";
     }
     return <tr>

--- a/webui/src/lib/components/repository/TableDiff.jsx
+++ b/webui/src/lib/components/repository/TableDiff.jsx
@@ -39,8 +39,8 @@ const TableDiffTypeRow = ({diffType}) => {
     }
     return <tr>
         <td className="table-diff-type pl-lg-10 col-10"><InfoIcon/> Table {diffType}</td>
-        <td className="table-version col-sm-auto"></td>
-        <td className="operation-expansion col-sm-auto"></td>
+        <td className="table-version-placeholder col-sm-auto"></td>
+        <td className="operation-expansion-placeholder col-sm-auto"></td>
     </tr>
 }
 

--- a/webui/src/lib/components/repository/TableDiff.jsx
+++ b/webui/src/lib/components/repository/TableDiff.jsx
@@ -1,9 +1,9 @@
 import React, {useState} from "react";
 import Table from "react-bootstrap/Table";
-import {ChevronDownIcon, ChevronRightIcon} from "@primer/octicons-react";
+import {ChevronDownIcon, ChevronRightIcon, InfoIcon} from "@primer/octicons-react";
 import {OverlayTrigger} from "react-bootstrap";
 import Tooltip from "react-bootstrap/Tooltip";
-import {OtfType} from "../../../constants";
+import {OtfDiffType, OtfType} from "../../../constants";
 import {useAPI} from "../../hooks/api";
 import {repositories} from "../../api";
 import {Error, Loading} from "../controls";
@@ -16,12 +16,14 @@ export const DeltaLakeDiff = ({repo, leftRef, rightRef, tablePath}) => {
     if (!loading && error) return <Error error={error}/>;
 
     const otfDiffs = response.results;
+    const diffType = response.diff_type;
     return <>
-        {(otfDiffs.length === 0) ?  <Alert variant="info" style={{margin: 0+"px"}}>No changes</Alert> :
+        {(OtfDiffType.Dropped != diffType && otfDiffs.length === 0) ?  <Alert variant="info" style={{margin: 0+"px"}}>No changes</Alert> :
             <Table className="table-diff" size="md">
                 <tbody>
+                <TableDiffTypeRow diffType={diffType}/>
                 {
-                    response.results.map(otfDiff => {
+                    otfDiffs.map(otfDiff => {
                         return <OtfDiffRow key={otfDiff.timestamp + "-diff-row"} otfDiff={otfDiff}/>;
                     })
                 }
@@ -29,6 +31,17 @@ export const DeltaLakeDiff = ({repo, leftRef, rightRef, tablePath}) => {
             </Table>
         }
     </>
+}
+
+const TableDiffTypeRow = ({diffType}) => {
+    if (OtfDiffType.Changed == diffType) {
+        return "";
+    }
+    return <tr>
+        <td className="table-diff-type pl-lg-10 col-10"><InfoIcon/> Table {diffType}</td>
+        <td className="table-version col-sm-auto"></td>
+        <td className="operation-expansion col-sm-auto"></td>
+    </tr>
 }
 
 const OtfDiffRow = ({otfDiff}) => {

--- a/webui/src/styles/globals.css
+++ b/webui/src/styles/globals.css
@@ -663,12 +663,12 @@ td.table-operation-type {
   padding-left: 30px;
 }
 
-td.table-version {
+td.table-version, td.table-version-placeholder {
   text-align: left;
   width: 8%;
 }
 
-td.operation-expansion {
+td.operation-expansion, td.operation-expansion-placeholder {
   padding-right: 0px;
   width: 4%;
 }

--- a/webui/src/styles/globals.css
+++ b/webui/src/styles/globals.css
@@ -681,3 +681,8 @@ td.table-operation-details {
   color: black;
 }
 
+td.table-diff-type {
+  padding: 10px;
+  font-size: medium;
+}
+


### PR DESCRIPTION
### Linked Issue

Closes #5199

---

## Change Description

### Background

The delta-diff prototype did not support diff presentations for tables that were created or removed, instead it showed a table not found error in case one of the refs was missing. 
      
### New Feature

Add a table diff type indicator when the diff results are for new or deleted tables, and in case of new tables show the operations done on the tables since it was added. 

### Testing Details

Tested manually, see screenshots below. 

## Additional info

<img width="1786" alt="Screen Shot 2023-02-19 at 10 04 40" src="https://user-images.githubusercontent.com/14786381/219936630-718ce263-55f9-4e92-b5d4-80934f8b25e4.png">
<img width="1697" alt="Screen Shot 2023-02-19 at 10 04 23" src="https://user-images.githubusercontent.com/14786381/219936638-06dd4a5c-514b-43b3-a5eb-baeab0d34c20.png">
<img width="1715" alt="Screen Shot 2023-02-19 at 10 04 03" src="https://user-images.githubusercontent.com/14786381/219936640-eee90d49-da51-4536-8a8f-d6cea763335b.png">
