### PR TITLE
Delta diff MVP: add an experimental merge delta diff button

### DIFF
--- a/webui/src/lib/components/modals.tsx
+++ b/webui/src/lib/components/modals.tsx
@@ -6,7 +6,6 @@ import Tooltip from "react-bootstrap/Tooltip";
 import {OverlayTrigger} from "react-bootstrap";
 import { ButtonVariant } from "react-bootstrap/esm/types";
 import { GetUserEmailByIdContext } from "../../pages/auth/users";
-import Container from "react-bootstrap/Container";
 import Row from "react-bootstrap/Row";
 import Col from "react-bootstrap/Col";
 
@@ -113,7 +112,7 @@ export const ConfirmationButton: FC<ConfirmationButtonProps> = ({ msg, onConfirm
     );
 };
 
-const GenericModal =  ({children, show = false, heading, onCancel, footer=null}) => {
+const SimpleModal =  ({children, show = false, heading, onCancel, footer=null}) => {
     return (
         <Modal show={show} onHide={onCancel}
                size="lg"
@@ -149,8 +148,8 @@ const GenericModal =  ({children, show = false, heading, onCancel, footer=null})
 
 export const ComingSoonModal: FC<BasicModal> = ({display, children, onCancel}) => {
     return (
-        <GenericModal show={display} heading={"Coming soon!"} onCancel={onCancel}>
+        <SimpleModal show={display} heading={"Coming soon!"} onCancel={onCancel}>
             {children}
-        </GenericModal>
+        </SimpleModal>
     )
 };

--- a/webui/src/lib/components/modals.tsx
+++ b/webui/src/lib/components/modals.tsx
@@ -113,46 +113,44 @@ export const ConfirmationButton: FC<ConfirmationButtonProps> = ({ msg, onConfirm
     );
 };
 
-const ModalContainer = ({children, show = false, heading, onCancel, footer=null}) => {
+const GenericModal =  ({children, show = false, heading, onCancel, footer=null}) => {
     return (
-        <Container fluid={true} className="justify-content-center">
-            <Modal show={show} onHide={onCancel}
-                   size="lg"
-                   restoreFocus={false}
-                   aria-labelledby="contained-modal-title-vcenter"
-                   centered>
-                <Row>
-                    <Col>
-                        <Modal.Header className="justify-content-center">
-                            <Modal.Title>{heading}</Modal.Title>
-                        </Modal.Header>
-                    </Col>
-                </Row>
-                <Row>
-                    <Col>
-                        <Modal.Body className="justify-content-center">
-                            {children}
-                        </Modal.Body>
-                    </Col>
-                </Row>
-                {footer &&
-                    <Row>
-                        <Col>
-                            <Modal.Footer>
-                                {footer}
-                            </Modal.Footer>
-                        </Col>
-                    </Row>
-                }
-            </Modal>
-        </Container>
+        <Modal show={show} onHide={onCancel}
+               size="lg"
+               restoreFocus={false}
+               aria-labelledby="contained-modal-title-vcenter"
+               centered>
+            <Row>
+                <Col>
+                    <Modal.Header className="justify-content-center">
+                        <Modal.Title>{heading}</Modal.Title>
+                    </Modal.Header>
+                </Col>
+            </Row>
+            <Row>
+                <Col>
+                    <Modal.Body className="justify-content-center">
+                        {children}
+                    </Modal.Body>
+                </Col>
+            </Row>
+            {footer &&
+            <Row>
+                <Col>
+                    <Modal.Footer>
+                        {footer}
+                    </Modal.Footer>
+                </Col>
+            </Row>
+            }
+        </Modal>
     )
 };
 
 export const ComingSoonModal: FC<BasicModal> = ({display, children, onCancel}) => {
     return (
-        <ModalContainer show={display} heading={"Coming soon!"} onCancel={onCancel}>
+        <GenericModal show={display} heading={"Coming soon!"} onCancel={onCancel}>
             {children}
-        </ModalContainer>
+        </GenericModal>
     )
 };

--- a/webui/src/lib/components/repository/changes.jsx
+++ b/webui/src/lib/components/repository/changes.jsx
@@ -178,7 +178,7 @@ function useTreeItemType(entry, repo, leftDiffRefID, rightDiffRefID) {
  */
 export const ChangesTreeContainer = ({results, showExperimentalDeltaDiffButton = false, delimiter, uriNavigator,
                                          leftDiffRefID, rightDiffRefID, repo, reference, internalRefresh, prefix,
-                                         getMore, loading, nextPage, setAfterUpdated, onNavigate, onRevert}) => {
+                                         getMore, loading, nextPage, setAfterUpdated, onNavigate, onRevert, setIsTableMerge}) => {
     const enableDeltaDiff = JSON.parse(localStorage.getItem(`enable_delta_diff`));
     const [tableDiffState, setTableDiffState] = useState({isShown: false, expandedTablePath: ""});
 
@@ -194,7 +194,12 @@ export const ChangesTreeContainer = ({results, showExperimentalDeltaDiffButton =
                                 ? <Button className="action-bar"
                                           variant="secondary"
                                           disabled={false}
-                                          onClick={() => setTableDiffState( {isShown: false, expandedTablePath: ""})}>
+                                          onClick={() => {
+                                              setTableDiffState( {isShown: false, expandedTablePath: ""})
+                                              if (setIsTableMerge) {
+                                                  setIsTableMerge(false);
+                                              }
+                                          }}>
                                     <ArrowLeftIcon/> Back to object comparison
                                   </Button>
                                 : <div className="mr-1 mb-2"><Alert variant={"info"}><InfoIcon/> You can now use lakeFS to
@@ -221,7 +226,12 @@ export const ChangesTreeContainer = ({results, showExperimentalDeltaDiffButton =
                                                      onNavigate={onNavigate}
                                                      getMore={getMore}
                                                      onRevert={onRevert}
-                                                     setTableDiffExpanded={() => setTableDiffState({isShown: true,  expandedTablePath: entry.path})}
+                                                     setTableDiffExpanded={() => {
+                                                         setTableDiffState({isShown: true,  expandedTablePath: entry.path})
+                                                         if (setIsTableMerge) {
+                                                             setIsTableMerge(true);
+                                                         }
+                                                     }}
                                                  />);
                                 })}
                                 {!!nextPage &&

--- a/webui/src/pages/repositories/repository/compare.jsx
+++ b/webui/src/pages/repositories/repository/compare.jsx
@@ -271,7 +271,7 @@ const MergeButton = ({repo, onDone, source, dest, disabled = false, isTableMerge
                 <div>lakeFS Delta Lake tables merge is under development</div>
             </ComingSoonModal>
             <Button variant="success" disabled={disabled} onClick={() => onClickMerge(isTableMerge)}>
-                <GitMergeIcon/> Merge
+                <GitMergeIcon/> {isTableMerge ? "Merge Tables" : "Merge"}
             </Button>
         </>
     );

--- a/webui/src/pages/repositories/repository/compare.jsx
+++ b/webui/src/pages/repositories/repository/compare.jsx
@@ -115,7 +115,8 @@ const CompareList = ({ repo, reference, compareReference, prefix, onSelectRef, o
                                          uriNavigator={uriNavigator} leftDiffRefID={leftCommittedRef} rightDiffRefID={rightCommittedRef}
                                          repo={repo} reference={reference} internalReferesh={internalRefresh} prefix={prefix}
                                          getMore={defaultGetMoreChanges(repo, reference.id, compareReference.id, delimiter)}
-                                         loading={loading} nextPage={nextPage} setAfterUpdated={setAfterUpdated} onNavigate={onNavigate}/>
+                                         loading={loading} nextPage={nextPage} setAfterUpdated={setAfterUpdated} onNavigate={onNavigate}
+                                         setIsTableMerge={setIsTableMerge}/>
 
     const emptyDiff = (!loading && !error && !!results && results.length === 0);
 
@@ -165,6 +166,7 @@ const CompareList = ({ repo, reference, compareReference, prefix, onSelectRef, o
                             source={compareReference.id}
                             dest={reference.id}
                             onDone={refresh}
+                            isTableMerge={isTableMerge}
                         />
                     }
                 </ActionGroup>


### PR DESCRIPTION
### Linked Issue

Closes #5054

---

## Change Description

### Background

Intelligent merge of delta lake tables is currently unsupported and we would like to understand if there is an interest around it. 
      
### New Feature

While comparing two delta lake tables using lakeFS delta diff feature show a coming soon modal and collect stats (if they are enabled) while trying to merge the changes. 

### Testing Details

Tested manually. This change applies only to the Compare tab where the Merge operation is enabled. 

## Additional info
<img width="914" alt="Screen Shot 2023-02-19 at 17 07 26" src="https://user-images.githubusercontent.com/14786381/219956651-edd90e55-8614-49e6-b38f-d015eb4a9a81.png">
<img width="1749" alt="Screen Shot 2023-02-19 at 17 07 16" src="https://user-images.githubusercontent.com/14786381/219956655-7ab3b643-1ed7-4fff-8355-030bd8c2e73e.png">
