### PR TITLE
Support ACLs on backend

### DIFF
--- a/pkg/auth/acl/permission.go
+++ b/pkg/auth/acl/permission.go
@@ -1,0 +1,101 @@
+package acl
+
+import (
+	"fmt"
+
+	"github.com/treeverse/lakefs/pkg/auth"
+	"github.com/treeverse/lakefs/pkg/auth/model"
+	"github.com/treeverse/lakefs/pkg/permissions"
+)
+
+const (
+	// ACLRead allows reading the specified repositories, as well as
+	// managing own credentials.
+	ACLRead model.ACLPermission = "Read"
+	// ACLWrite allows reading and writing the specified repositories,
+	// as well as managing own credentials.
+	ACLWrite model.ACLPermission = "Write"
+	// ACLSuper allows reading, writing, and all other actions on the
+	// specified repositories, as well as managing own credentials.
+	ACLSuper model.ACLPermission = "Super"
+	// ACLAdmin allows all operations, including all reading, writing,
+	// and all other actions on all repositories, and managing
+	// authorization and credentials of all users.
+	ACLAdmin model.ACLPermission = "Admin"
+)
+
+var (
+	ACLPermissions = []model.ACLPermission{ACLRead, ACLWrite, ACLSuper, ACLAdmin}
+
+	all = []string{permissions.All}
+
+	ErrBadACLPermission = fmt.Errorf("%w: Bad ACL permission", model.ErrValidationError)
+)
+
+func RepositoriesToARNs(repositories model.Repositories) []string {
+	if repositories.All {
+		// "*" always treated globally, no specific ARN.
+		return all
+	}
+	arns := make([]string, len(repositories.List))
+	for i, repo := range repositories.List {
+		arns[i] = permissions.RepoArn(repo)
+	}
+	return arns
+}
+
+func ACLToStatement(acl model.ACL) (model.Statements, error) {
+	// if err := ValidateACLPermission(acl.Permission); err != nil {
+	// 	return model.Statement{}, err
+	// }
+
+	var (
+		statements model.Statements
+		err        error
+	)
+
+	repoARNs := RepositoriesToARNs(acl.Repositories)
+
+	switch acl.Permission {
+	case ACLRead:
+		statements, err = auth.MakeStatementForPolicyType("FSRead", repoARNs)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", acl.Permission, ErrBadACLPermission)
+		}
+
+		ownCredentialsStatement, err := auth.MakeStatementForPolicyType("AuthManageOwnCredentials", all)
+		if err != nil {
+			return nil, err
+		}
+		statements = append(statements, ownCredentialsStatement...)
+	case ACLWrite:
+		statements, err = auth.MakeStatementForPolicyType("FSReadWrite", repoARNs)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", acl.Permission, ErrBadACLPermission)
+		}
+
+		ownCredentialsStatement, err := auth.MakeStatementForPolicyType("AuthManageOwnCredentials", all)
+		if err != nil {
+			return nil, err
+		}
+		statements = append(statements, ownCredentialsStatement...)
+	case ACLSuper:
+		statements, err = auth.MakeStatementForPolicyType("FSFullAccess", repoARNs)
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", acl.Permission, ErrBadACLPermission)
+		}
+
+		ownCredentialsStatement, err := auth.MakeStatementForPolicyType("AuthManageOwnCredentials", all)
+		if err != nil {
+			return nil, err
+		}
+		statements = append(statements, ownCredentialsStatement...)
+	case ACLAdmin:
+		statements, err = auth.MakeStatementForPolicyType("AllAccess", []string{permissions.All})
+		if err != nil {
+			return nil, fmt.Errorf("%s: %w", acl.Permission, ErrBadACLPermission)
+		}
+	}
+
+	return statements, nil
+}

--- a/pkg/auth/model/model.go
+++ b/pkg/auth/model/model.go
@@ -143,10 +143,21 @@ type DBGroup struct {
 	Group
 }
 
+type Repositories struct {
+	All  bool     `json:"all,omitempty"`
+	List []string `json:"list,omitempty"`
+}
+
+type UI struct {
+	Permission   string       `json:"permission,omitempty"`
+	Repositories Repositories `json:"repositories,omitempty"`
+}
+
 type Policy struct {
 	CreatedAt   time.Time  `db:"created_at"`
 	DisplayName string     `db:"display_name" json:"display_name"`
 	Statement   Statements `db:"statement"`
+	UI          UI         `db:"ui" json:"ui,omitempty"`
 }
 
 type DBPolicy struct {

--- a/pkg/auth/model/model.go
+++ b/pkg/auth/model/model.go
@@ -148,16 +148,18 @@ type Repositories struct {
 	List []string `json:"list,omitempty"`
 }
 
-type UI struct {
-	Permission   string       `json:"permission,omitempty"`
-	Repositories Repositories `json:"repositories,omitempty"`
+type ACLPermission string
+
+type ACL struct {
+	Permission   ACLPermission `json:"permission,omitempty"`
+	Repositories Repositories  `json:"repositories,omitempty"`
 }
 
 type Policy struct {
 	CreatedAt   time.Time  `db:"created_at"`
 	DisplayName string     `db:"display_name" json:"display_name"`
 	Statement   Statements `db:"statement"`
-	UI          UI         `db:"ui" json:"ui,omitempty"`
+	ACL         ACL        `db:"acl" json:"acl,omitempty"`
 }
 
 type DBPolicy struct {

--- a/pkg/auth/model/model.pb.go
+++ b/pkg/auth/model/model.pb.go
@@ -434,6 +434,118 @@ func (x *TokenData) GetExpiredAt() *timestamppb.Timestamp {
 	return nil
 }
 
+// message data model for repositories / all repositories in UI
+type RepositoriesData struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	All  bool     `protobuf:"varint,1,opt,name=all,proto3" json:"all,omitempty"`
+	List []string `protobuf:"bytes,2,rep,name=list,proto3" json:"list,omitempty"`
+}
+
+func (x *RepositoriesData) Reset() {
+	*x = RepositoriesData{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_model_proto_msgTypes[6]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *RepositoriesData) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*RepositoriesData) ProtoMessage() {}
+
+func (x *RepositoriesData) ProtoReflect() protoreflect.Message {
+	mi := &file_model_proto_msgTypes[6]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use RepositoriesData.ProtoReflect.Descriptor instead.
+func (*RepositoriesData) Descriptor() ([]byte, []int) {
+	return file_model_proto_rawDescGZIP(), []int{6}
+}
+
+func (x *RepositoriesData) GetAll() bool {
+	if x != nil {
+		return x.All
+	}
+	return false
+}
+
+func (x *RepositoriesData) GetList() []string {
+	if x != nil {
+		return x.List
+	}
+	return nil
+}
+
+// message data model for UI structure
+type UIData struct {
+	state         protoimpl.MessageState
+	sizeCache     protoimpl.SizeCache
+	unknownFields protoimpl.UnknownFields
+
+	Permission   string            `protobuf:"bytes,1,opt,name=permission,proto3" json:"permission,omitempty"`
+	Repositories *RepositoriesData `protobuf:"bytes,2,opt,name=repositories,proto3" json:"repositories,omitempty"`
+}
+
+func (x *UIData) Reset() {
+	*x = UIData{}
+	if protoimpl.UnsafeEnabled {
+		mi := &file_model_proto_msgTypes[7]
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		ms.StoreMessageInfo(mi)
+	}
+}
+
+func (x *UIData) String() string {
+	return protoimpl.X.MessageStringOf(x)
+}
+
+func (*UIData) ProtoMessage() {}
+
+func (x *UIData) ProtoReflect() protoreflect.Message {
+	mi := &file_model_proto_msgTypes[7]
+	if protoimpl.UnsafeEnabled && x != nil {
+		ms := protoimpl.X.MessageStateOf(protoimpl.Pointer(x))
+		if ms.LoadMessageInfo() == nil {
+			ms.StoreMessageInfo(mi)
+		}
+		return ms
+	}
+	return mi.MessageOf(x)
+}
+
+// Deprecated: Use UIData.ProtoReflect.Descriptor instead.
+func (*UIData) Descriptor() ([]byte, []int) {
+	return file_model_proto_rawDescGZIP(), []int{7}
+}
+
+func (x *UIData) GetPermission() string {
+	if x != nil {
+		return x.Permission
+	}
+	return ""
+}
+
+func (x *UIData) GetRepositories() *RepositoriesData {
+	if x != nil {
+		return x.Repositories
+	}
+	return nil
+}
+
 var File_model_proto protoreflect.FileDescriptor
 
 var file_model_proto_rawDesc = []byte{
@@ -502,10 +614,21 @@ var file_model_proto_rawDesc = []byte{
 	0x72, 0x65, 0x64, 0x5f, 0x61, 0x74, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x1a, 0x2e, 0x67,
 	0x6f, 0x6f, 0x67, 0x6c, 0x65, 0x2e, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x62, 0x75, 0x66, 0x2e, 0x54,
 	0x69, 0x6d, 0x65, 0x73, 0x74, 0x61, 0x6d, 0x70, 0x52, 0x09, 0x65, 0x78, 0x70, 0x69, 0x72, 0x65,
-	0x64, 0x41, 0x74, 0x42, 0x28, 0x5a, 0x26, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f,
-	0x6d, 0x2f, 0x74, 0x72, 0x65, 0x65, 0x76, 0x65, 0x72, 0x73, 0x65, 0x2f, 0x6c, 0x61, 0x6b, 0x65,
-	0x66, 0x73, 0x2f, 0x61, 0x75, 0x74, 0x68, 0x2f, 0x6d, 0x6f, 0x64, 0x65, 0x6c, 0x62, 0x06, 0x70,
-	0x72, 0x6f, 0x74, 0x6f, 0x33,
+	0x64, 0x41, 0x74, 0x22, 0x38, 0x0a, 0x10, 0x52, 0x65, 0x70, 0x6f, 0x73, 0x69, 0x74, 0x6f, 0x72,
+	0x69, 0x65, 0x73, 0x44, 0x61, 0x74, 0x61, 0x12, 0x10, 0x0a, 0x03, 0x61, 0x6c, 0x6c, 0x18, 0x01,
+	0x20, 0x01, 0x28, 0x08, 0x52, 0x03, 0x61, 0x6c, 0x6c, 0x12, 0x12, 0x0a, 0x04, 0x6c, 0x69, 0x73,
+	0x74, 0x18, 0x02, 0x20, 0x03, 0x28, 0x09, 0x52, 0x04, 0x6c, 0x69, 0x73, 0x74, 0x22, 0x7e, 0x0a,
+	0x06, 0x55, 0x49, 0x44, 0x61, 0x74, 0x61, 0x12, 0x1e, 0x0a, 0x0a, 0x70, 0x65, 0x72, 0x6d, 0x69,
+	0x73, 0x73, 0x69, 0x6f, 0x6e, 0x18, 0x01, 0x20, 0x01, 0x28, 0x09, 0x52, 0x0a, 0x70, 0x65, 0x72,
+	0x6d, 0x69, 0x73, 0x73, 0x69, 0x6f, 0x6e, 0x12, 0x54, 0x0a, 0x0c, 0x72, 0x65, 0x70, 0x6f, 0x73,
+	0x69, 0x74, 0x6f, 0x72, 0x69, 0x65, 0x73, 0x18, 0x02, 0x20, 0x01, 0x28, 0x0b, 0x32, 0x30, 0x2e,
+	0x69, 0x6f, 0x2e, 0x74, 0x72, 0x65, 0x65, 0x76, 0x65, 0x72, 0x73, 0x65, 0x2e, 0x6c, 0x61, 0x6b,
+	0x65, 0x66, 0x73, 0x2e, 0x61, 0x75, 0x74, 0x68, 0x2e, 0x6d, 0x6f, 0x64, 0x65, 0x6c, 0x2e, 0x52,
+	0x65, 0x70, 0x6f, 0x73, 0x69, 0x74, 0x6f, 0x72, 0x69, 0x65, 0x73, 0x44, 0x61, 0x74, 0x61, 0x52,
+	0x0c, 0x72, 0x65, 0x70, 0x6f, 0x73, 0x69, 0x74, 0x6f, 0x72, 0x69, 0x65, 0x73, 0x42, 0x28, 0x5a,
+	0x26, 0x67, 0x69, 0x74, 0x68, 0x75, 0x62, 0x2e, 0x63, 0x6f, 0x6d, 0x2f, 0x74, 0x72, 0x65, 0x65,
+	0x76, 0x65, 0x72, 0x73, 0x65, 0x2f, 0x6c, 0x61, 0x6b, 0x65, 0x66, 0x73, 0x2f, 0x61, 0x75, 0x74,
+	0x68, 0x2f, 0x6d, 0x6f, 0x64, 0x65, 0x6c, 0x62, 0x06, 0x70, 0x72, 0x6f, 0x74, 0x6f, 0x33,
 }
 
 var (
@@ -520,7 +643,7 @@ func file_model_proto_rawDescGZIP() []byte {
 	return file_model_proto_rawDescData
 }
 
-var file_model_proto_msgTypes = make([]protoimpl.MessageInfo, 6)
+var file_model_proto_msgTypes = make([]protoimpl.MessageInfo, 8)
 var file_model_proto_goTypes = []interface{}{
 	(*UserData)(nil),              // 0: io.treeverse.lakefs.auth.model.UserData
 	(*GroupData)(nil),             // 1: io.treeverse.lakefs.auth.model.GroupData
@@ -528,20 +651,23 @@ var file_model_proto_goTypes = []interface{}{
 	(*CredentialData)(nil),        // 3: io.treeverse.lakefs.auth.model.CredentialData
 	(*StatementData)(nil),         // 4: io.treeverse.lakefs.auth.model.StatementData
 	(*TokenData)(nil),             // 5: io.treeverse.lakefs.auth.model.TokenData
-	(*timestamppb.Timestamp)(nil), // 6: google.protobuf.Timestamp
+	(*RepositoriesData)(nil),      // 6: io.treeverse.lakefs.auth.model.RepositoriesData
+	(*UIData)(nil),                // 7: io.treeverse.lakefs.auth.model.UIData
+	(*timestamppb.Timestamp)(nil), // 8: google.protobuf.Timestamp
 }
 var file_model_proto_depIdxs = []int32{
-	6, // 0: io.treeverse.lakefs.auth.model.UserData.created_at:type_name -> google.protobuf.Timestamp
-	6, // 1: io.treeverse.lakefs.auth.model.GroupData.created_at:type_name -> google.protobuf.Timestamp
-	6, // 2: io.treeverse.lakefs.auth.model.PolicyData.created_at:type_name -> google.protobuf.Timestamp
+	8, // 0: io.treeverse.lakefs.auth.model.UserData.created_at:type_name -> google.protobuf.Timestamp
+	8, // 1: io.treeverse.lakefs.auth.model.GroupData.created_at:type_name -> google.protobuf.Timestamp
+	8, // 2: io.treeverse.lakefs.auth.model.PolicyData.created_at:type_name -> google.protobuf.Timestamp
 	4, // 3: io.treeverse.lakefs.auth.model.PolicyData.statements:type_name -> io.treeverse.lakefs.auth.model.StatementData
-	6, // 4: io.treeverse.lakefs.auth.model.CredentialData.issued_date:type_name -> google.protobuf.Timestamp
-	6, // 5: io.treeverse.lakefs.auth.model.TokenData.expired_at:type_name -> google.protobuf.Timestamp
-	6, // [6:6] is the sub-list for method output_type
-	6, // [6:6] is the sub-list for method input_type
-	6, // [6:6] is the sub-list for extension type_name
-	6, // [6:6] is the sub-list for extension extendee
-	0, // [0:6] is the sub-list for field type_name
+	8, // 4: io.treeverse.lakefs.auth.model.CredentialData.issued_date:type_name -> google.protobuf.Timestamp
+	8, // 5: io.treeverse.lakefs.auth.model.TokenData.expired_at:type_name -> google.protobuf.Timestamp
+	6, // 6: io.treeverse.lakefs.auth.model.UIData.repositories:type_name -> io.treeverse.lakefs.auth.model.RepositoriesData
+	7, // [7:7] is the sub-list for method output_type
+	7, // [7:7] is the sub-list for method input_type
+	7, // [7:7] is the sub-list for extension type_name
+	7, // [7:7] is the sub-list for extension extendee
+	0, // [0:7] is the sub-list for field type_name
 }
 
 func init() { file_model_proto_init() }
@@ -622,6 +748,30 @@ func file_model_proto_init() {
 				return nil
 			}
 		}
+		file_model_proto_msgTypes[6].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*RepositoriesData); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
+		file_model_proto_msgTypes[7].Exporter = func(v interface{}, i int) interface{} {
+			switch v := v.(*UIData); i {
+			case 0:
+				return &v.state
+			case 1:
+				return &v.sizeCache
+			case 2:
+				return &v.unknownFields
+			default:
+				return nil
+			}
+		}
 	}
 	type x struct{}
 	out := protoimpl.TypeBuilder{
@@ -629,7 +779,7 @@ func file_model_proto_init() {
 			GoPackagePath: reflect.TypeOf(x{}).PkgPath(),
 			RawDescriptor: file_model_proto_rawDesc,
 			NumEnums:      0,
-			NumMessages:   6,
+			NumMessages:   8,
 			NumExtensions: 0,
 			NumServices:   0,
 		},

--- a/pkg/auth/model/model.proto
+++ b/pkg/auth/model/model.proto
@@ -50,3 +50,14 @@ message TokenData {
     google.protobuf.Timestamp expired_at = 2;
 }
 
+// message data model for repositories / all repositories in UI
+message RepositoriesData {
+    bool all = 1;
+    repeated string list = 2;
+}
+
+// message data model for UI structure
+message UIData {
+    string permission = 1;
+    RepositoriesData repositories = 2;
+}

--- a/pkg/auth/service_test.go
+++ b/pkg/auth/service_test.go
@@ -622,6 +622,13 @@ func TestACL(t *testing.T) {
 				acl.ACLWrite: []permissions.Permission{
 					{Action: permissions.WriteObjectAction, Resource: permissions.ObjectArn("foo", "some/path")},
 					{Action: permissions.DeleteObjectAction, Resource: permissions.ObjectArn("foo", "some/path")},
+					{Action: permissions.CreateBranchAction, Resource: permissions.BranchArn("foo", "twig")},
+					{Action: permissions.CreateCommitAction, Resource: permissions.BranchArn("foo", "twig")},
+				},
+				acl.ACLSuper: []permissions.Permission{
+					{Action: permissions.CreateMetaRangeAction, Resource: permissions.RepoArn("foo")},
+					{Action: permissions.AttachStorageNamespace, Resource: permissions.StorageNamespace("storage://bucket/path")},
+					{Action: permissions.ImportFromStorage, Resource: permissions.StorageNamespace("storage://bucket/path")},
 				},
 				acl.ACLAdmin: []permissions.Permission{
 					{Action: permissions.CreateUserAction, Resource: permissions.UserArn("you")},


### PR DESCRIPTION
This only _adds_ ACL support.  It does not change the default authorization
configuration, which remains PBAC / RBAC.

Closes #5296.