### PR TITLE
GC: add retry mechanism for S3 delete objects

### DIFF
--- a/clients/spark/build.sbt
+++ b/clients/spark/build.sbt
@@ -140,7 +140,7 @@ def getSharedLibraryDependencies(buildType: BuildType): Seq[ModuleID] = {
     "org.scalactic" %% "scalactic" % "3.2.9",
     "dev.failsafe" % "failsafe" % "3.2.4",
     "org.apache.hadoop" % "hadoop-distcp" % buildType.hadoopVersion,
-    "io.github.resilience4j" % "resilience4j-retry" % "2.0.2",
+    "io.github.resilience4j" % "resilience4j-retry" % "1.7.0",
     // https://mvnrepository.com/artifact/com.squareup.okhttp3/mockwebserver
     "com.squareup.okhttp3" % "mockwebserver" % "4.10.0" % "test",
     "xerces" % "xercesImpl" % "2.12.2" % "test",

--- a/clients/spark/build.sbt
+++ b/clients/spark/build.sbt
@@ -140,6 +140,7 @@ def getSharedLibraryDependencies(buildType: BuildType): Seq[ModuleID] = {
     "org.scalactic" %% "scalactic" % "3.2.9",
     "dev.failsafe" % "failsafe" % "3.2.4",
     "org.apache.hadoop" % "hadoop-distcp" % buildType.hadoopVersion,
+    "io.github.resilience4j" % "resilience4j-retry" % "2.0.2",
     // https://mvnrepository.com/artifact/com.squareup.okhttp3/mockwebserver
     "com.squareup.okhttp3" % "mockwebserver" % "4.10.0" % "test",
     "xerces" % "xercesImpl" % "2.12.2" % "test",

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/BulkRemoverFactory.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/BulkRemoverFactory.scala
@@ -77,12 +77,12 @@ object BulkRemoverFactory {
       val removeKeys = removeKeyNames.map(k => new model.DeleteObjectsRequest.KeyVersion(k)).asJava
       val delObjReq = new model.DeleteObjectsRequest(bucket).withKeys(removeKeys)
       val s3Client = getS3Client(hc, bucket, region, S3NumRetries)
-      val deleteFun = wrapDeleteObjectsCall(s3Client)
+      val deleteFun = generateDeleteObjectsFunc(s3Client)
       val res = deleteFun.apply(delObjReq)
       res.getDeletedObjects.asScala.map(_.getKey())
     }
 
-    private def wrapDeleteObjectsCall(s3Client: AmazonS3): java.util.function.Function[DeleteObjectsRequest, DeleteObjectsResult] = {
+    private def generateDeleteObjectsFunc(s3Client: AmazonS3): java.util.function.Function[DeleteObjectsRequest, DeleteObjectsResult] = {
       val intervalFn =
         IntervalFunction.ofExponentialRandomBackoff(500, 2, 0.5)
       val retryConfig = RetryConfig.custom()

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/BulkRemoverFactory.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/BulkRemoverFactory.scala
@@ -84,7 +84,7 @@ object BulkRemoverFactory {
 
     private def wrapDeleteObjectsCall(s3Client: AmazonS3): java.util.function.Function[DeleteObjectsRequest, DeleteObjectsResult] = {
       val intervalFn =
-        IntervalFunction.ofExponentialRandomBackoff(500, 2, 1.5)
+        IntervalFunction.ofExponentialRandomBackoff(500, 2, 0.5)
       val retryConfig = RetryConfig.custom()
         .maxAttempts(2)
         .intervalFunction(intervalFn)


### PR DESCRIPTION
To solve:
```bash
org.xml.sax.SAXParseException; lineNumber: 2; columnNumber: 1; Premature end of file.\nCaused by: com.amazonaws.SdkClientException: Failed to parse XML document with handler class com.amazonaws.services.s3.model.transform.XmlResponsesSaxParser$DeleteObjectsHandler
```
This PR introduces a backoff retry strategy for the `DeleteObjects` function call.

## How was this tested

Ran it over lakeFS Cloud.
