### PR TITLE
Bug: Clearing internal auth cookie at login

### DIFF
--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -237,10 +237,6 @@ func (c *Controller) DeleteObjects(w http.ResponseWriter, r *http.Request, body 
 }
 
 func (c *Controller) Login(w http.ResponseWriter, r *http.Request, body LoginJSONRequestBody) {
-	err := clearSession(w, r, c.sessionStore, InternalAuthSessionName)
-	if err != nil {
-		c.Logger.WithError(err).Error("failed to logout previous session")
-	}
 	ctx := r.Context()
 	user, err := userByAuth(ctx, c.Logger, c.Authenticator, c.Auth, body.AccessKeyId, body.SecretAccessKey)
 	if errors.Is(err, ErrAuthenticatingRequest) {


### PR DESCRIPTION
**Impact:** 
This causes for all requests to `auth/login` that use `internal_auth_session` to fail in the UI. 
The JWT token is cleared and in followup requests (getCurrentUser) the UI can't login.

The API still works since it's not relying on that cookie. 

The Bug introduced in PR #5233 1 day ago. 

**How to reproduce:** 

- Try to login with Access Key and Secret key via the UI `auth/login` endpoint. 