### PR TITLE
Remove production warning while using local blockstore

### DIFF
--- a/cmd/lakefs/cmd/run.go
+++ b/cmd/lakefs/cmd/run.go
@@ -172,7 +172,7 @@ var runCmd = &cobra.Command{
 
 		cloudMetadataProvider := stats.BuildMetadataProvider(logger, cfg)
 		blockstoreType := cfg.BlockstoreType()
-		if blockstoreType == "local" || blockstoreType == "mem" {
+		if blockstoreType == "mem" {
 			printLocalWarning(os.Stderr, fmt.Sprintf("blockstore type %s", blockstoreType))
 			logger.WithField("adapter_type", blockstoreType).Warn("Block adapter NOT SUPPORTED for production use")
 		}

--- a/webui/src/lib/api/index.js
+++ b/webui/src/lib/api/index.js
@@ -904,7 +904,7 @@ class Config {
             case 200:
                 cfg = await response.json();
                 cfg.warnings = []
-                if (cfg.blockstore_type === 'local' || cfg.blockstore_type === 'mem') {
+                if (cfg.blockstore_type === 'mem') {
                     cfg.warnings.push(`Block adapter ${cfg.blockstore_type} not usable in production`)
                 }
                 return cfg;


### PR DESCRIPTION
We will keep the warning if using the default local settings as we use default encryption key which is not recommended for production use.

Part of #5305