### PR TITLE
GC: add retry mechanism for S3 client

### DIFF
--- a/clients/spark/core/src/main/hadoop2/scala/io/treeverse/clients/conditional/S3ClientBuilder.scala
+++ b/clients/spark/core/src/main/hadoop2/scala/io/treeverse/clients/conditional/S3ClientBuilder.scala
@@ -1,10 +1,18 @@
 package io.treeverse.clients.conditional
 
-import com.amazonaws.ClientConfiguration
+import com.amazonaws.retry.PredefinedRetryPolicies.SDKDefaultRetryCondition
+import com.amazonaws.retry.RetryPolicy
 import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
+import com.amazonaws.{AmazonClientException, AmazonWebServiceRequest, ClientConfiguration, SdkClientException}
 import io.treeverse.clients.StorageUtils.S3.createAndValidateS3Client
 import org.apache.hadoop.conf.Configuration
 import org.slf4j.{Logger, LoggerFactory}
+
+class S3RetryCondition extends SDKDefaultRetryCondition {
+  override def shouldRetry(originalRequest: AmazonWebServiceRequest, exception: AmazonClientException, retriesAttempted: Int): Boolean =  {
+    super.shouldRetry(originalRequest, exception, retriesAttempted) || exception.isInstanceOf[SdkClientException]
+  }
+}
 
 object S3ClientBuilder extends io.treeverse.clients.S3ClientBuilder {
   val logger: Logger = LoggerFactory.getLogger(getClass.toString + "[hadoop2]")
@@ -13,7 +21,8 @@ object S3ClientBuilder extends io.treeverse.clients.S3ClientBuilder {
     import com.amazonaws.auth.{AWSStaticCredentialsProvider, BasicAWSCredentials}
     import org.apache.hadoop.fs.s3a.Constants
 
-    val configuration = new ClientConfiguration().withMaxErrorRetry(numRetries)
+    val retryPolicy = new RetryPolicy(new S3RetryCondition(), null, numRetries, true)
+    val configuration = new ClientConfiguration().withRetryPolicy(retryPolicy)
     val s3Endpoint = hc.get(Constants.ENDPOINT, null)
 
     val credentialsProvider =

--- a/clients/spark/core/src/main/hadoop3/scala/io/treeverse/clients/conditional/S3ClientBuilder.scala
+++ b/clients/spark/core/src/main/hadoop3/scala/io/treeverse/clients/conditional/S3ClientBuilder.scala
@@ -1,10 +1,18 @@
 package io.treeverse.clients.conditional
 
-import com.amazonaws.ClientConfiguration
+import com.amazonaws.retry.PredefinedRetryPolicies.SDKDefaultRetryCondition
+import com.amazonaws.retry.RetryPolicy
 import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
+import com.amazonaws.{AmazonClientException, AmazonWebServiceRequest, ClientConfiguration, SdkClientException}
 import io.treeverse.clients.StorageUtils.S3.createAndValidateS3Client
 import org.apache.hadoop.conf.Configuration
 import org.slf4j.{Logger, LoggerFactory}
+
+class S3RetryCondition extends SDKDefaultRetryCondition {
+  override def shouldRetry(originalRequest: AmazonWebServiceRequest, exception: AmazonClientException, retriesAttempted: Int): Boolean =  {
+    super.shouldRetry(originalRequest, exception, retriesAttempted) || exception.isInstanceOf[SdkClientException]
+  }
+}
 
 object S3ClientBuilder extends io.treeverse.clients.S3ClientBuilder {
   val logger: Logger = LoggerFactory.getLogger(getClass.toString + "[hadoop3]")
@@ -14,7 +22,8 @@ object S3ClientBuilder extends io.treeverse.clients.S3ClientBuilder {
     import org.apache.hadoop.fs.s3a.auth.AssumedRoleCredentialProvider
     import com.amazonaws.auth.{BasicAWSCredentials, AWSStaticCredentialsProvider}
 
-    val configuration = new ClientConfiguration().withMaxErrorRetry(numRetries)
+    val retryPolicy = new RetryPolicy(new S3RetryCondition(), null, numRetries, true)
+    val configuration = new ClientConfiguration().withRetryPolicy(retryPolicy)
     val s3Endpoint = hc.get(Constants.ENDPOINT, null)
 
     // TODO(ariels): Support different per-bucket configuration methods.

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
@@ -590,7 +590,7 @@ object GarbageCollector {
     bulkedKeyStrings
       .mapPartitions(iter => {
         // mapPartitions lambda executions are sent over to Spark executors, the executors don't have access to the
-        // bulkRemover created above because it was created on the driver and it is not a serializeable object. Therefore,
+        // bulkRemover created above because it was created on the driver and it is not a serializable object. Therefore,
         // we create new bulkRemovers.
         val bulkRemover =
           BulkRemoverFactory(storageType, configMapper.configuration, storageNamespace, region)

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/StorageUtils.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/StorageUtils.scala
@@ -117,8 +117,8 @@ object StorageUtils {
           builder.withRegion(region)
 
       val builderWithCredentials = credentialsProvider match {
-        case Some(cp) => builder.withCredentials(cp)
-        case None     => builder
+        case Some(cp) => builderWithEndpoint.withCredentials(cp)
+        case None     => builderWithEndpoint
       }
       builderWithCredentials.build
     }


### PR DESCRIPTION
To solve:
```bash
org.xml.sax.SAXParseException; lineNumber: 2; columnNumber: 1; Premature end of file.\nCaused by: com.amazonaws.SdkClientException: Failed to parse XML document with handler class com.amazonaws.services.s3.model.transform.XmlResponsesSaxParser$DeleteObjectsHandler
```
This PR introduces a backoff retry policy for the S3 client.

## How was this tested

Ran it over lakeFS Cloud.
