### PR TITLE
[DX] Web UI: Add spinner to setup screen button

### DIFF
--- a/webui/src/pages/setup/userConfiguration.tsx
+++ b/webui/src/pages/setup/userConfiguration.tsx
@@ -1,5 +1,6 @@
 import React, {ChangeEvent, FC, FormEvent, useCallback, useState} from "react";
 import Button from "react-bootstrap/Button";
+import Spinner from 'react-bootstrap/Spinner';
 import Card from "react-bootstrap/Card";
 import Col from "react-bootstrap/Col";
 import Form from "react-bootstrap/Form";
@@ -76,7 +77,14 @@ export const UserConfiguration: FC<UserConfigurationProps> = ({
                             </Form.Group>
 
                             {!!setupError && <Error error={setupError}/>}
-                            <Button variant="primary" disabled={disabled} type="submit">Setup</Button>
+                            <Button variant="primary" disabled={disabled} type="submit">
+                                {disabled ? <Spinner as="span"
+                                                     animation="border"
+                                                     size="sm"
+                                                     role="status"
+                                                     aria-hidden="true"
+                                                     /> : 'Setup'}
+                            </Button>
                         </Form>
                     </Card.Body>
                 </Card>


### PR DESCRIPTION
### Linked Issue

Closes #5255

---

## Change Description

### Background

The current UI is not entirely clear that something is happening when the user clicks `Setup`. 

### New Feature

This PR adds a spinner so that it is clearer to the user that something is happening. 

For now it is a default ReactJS component but it might be fun in time to create an axolotl-y version of something [like this](https://www.davidhu.io/react-spinners/storybook/?path=/docs/pacmanloader--main)

### Testing Details

How were the changes tested? Manually

### Breaking Change?

Does this change break any existing functionality? (API, CLI, Clients): No

---

## Additional info

![CleanShot 2023-02-20 at 17 20 58](https://user-images.githubusercontent.com/3671582/220169107-78354356-0fea-465e-92fd-bedc37f43825.gif)
