### PR TITLE
[DX] WebUI: Add lakeFS header bar to setup screens

### DIFF
--- a/webui/src/lib/components/navbar.jsx
+++ b/webui/src/lib/components/navbar.jsx
@@ -56,9 +56,11 @@ const TopNav = ({logged = true}) => {
     if (!logged) {
         return (
             <Navbar variant="dark" bg="dark" expand="md">
+            <Container fluid={true}>
                 <Link component={Navbar.Brand} href="/">
                     <img src="/logo.png" alt="lakeFS" className="logo"/>
                 </Link>
+            </Container>
             </Navbar>
         );
     }

--- a/webui/src/pages/setup/index.jsx
+++ b/webui/src/pages/setup/index.jsx
@@ -1,4 +1,5 @@
 import React, {useCallback, useEffect} from "react";
+import Layout from "../../lib/components/layout";
 import {useState} from "react";
 import {API_ENDPOINT, setup, SETUP_STATE_NOT_INITIALIZED, SETUP_STATE_INITIALIZED, SETUP_STATE_COMMUNICATION_PERFS_DONE} from "../../lib/api";
 import {useRouter} from "../../lib/hooks/router";
@@ -48,11 +49,13 @@ const SetupContents = () => {
 
     if (setupData && setupData.access_key_id) {
         return (
-            <SetupComplete
-                accessKeyId={setupData.access_key_id}
-                secretAccessKey={setupData.secret_access_key}
-                apiEndpoint={API_ENDPOINT}
-            />
+            <Layout logged={false}>
+                <SetupComplete
+                    accessKeyId={setupData.access_key_id}
+                    secretAccessKey={setupData.secret_access_key}
+                    apiEndpoint={API_ENDPOINT}
+                    />
+            </Layout>
         );
     }
 
@@ -63,11 +66,13 @@ const SetupContents = () => {
         case SETUP_STATE_COMMUNICATION_PERFS_DONE:
         case SETUP_STATE_NOT_INITIALIZED:
                 return (
-                <UserConfiguration
-                    onSubmit={onSubmitUserConfiguration}
-                    setupError={setupError}
-                    disabled={disabled}
-                />
+                    <Layout logged={false}>
+                        <UserConfiguration
+                            onSubmit={onSubmitUserConfiguration}
+                            setupError={setupError}
+                            disabled={disabled}
+                            />
+                    </Layout>
             );
         default:
             return null;


### PR DESCRIPTION
### Linked Issue

Closes #5299

---

## Change Description

### Background

The initial setup screen looks quite bare: 

![CleanShot 2023-02-21 at 14 49 08](https://user-images.githubusercontent.com/3671582/220377636-a9d4410a-6ec5-4b5a-ab84-27a4b8d68033.png)

The login screen and subsequent pages all have a lakeFS top nav bar with logo: 

![CleanShot 2023-02-21 at 14 49 43](https://user-images.githubusercontent.com/3671582/220377759-553448c1-2a0e-46dc-b04a-7f21959b1079.png)
      
### New Feature

This adds the header bar to the setup screens too

### Testing Details

How were the changes tested? Manually

### Breaking Change?

Does this change break any existing functionality? (API, CLI, Clients): No

---

## Additional info

![CleanShot 2023-02-22 at 14 50 18](https://user-images.githubusercontent.com/3671582/220658700-df6d9017-13ca-47f0-b736-2976d8a91706.png)

![CleanShot 2023-02-22 at 14 51 08](https://user-images.githubusercontent.com/3671582/220658817-cf3d21cf-14ca-402e-9e63-297197901bf3.png)
