### PR TITLE
Make otfDiff use an id property instead of version 

### DIFF
--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -396,7 +396,7 @@ components:
     OtfDiffEntry:
       type: object
       required:
-        - version
+        - id
         - operation
         - timestamp
         - operation_content

--- a/clients/java/api/openapi.yaml
+++ b/clients/java/api/openapi.yaml
@@ -5478,11 +5478,11 @@ components:
           - delete
           type: string
       required:
+      - id
       - operation
       - operation_content
       - operation_type
       - timestamp
-      - version
       type: object
     OtfDiffList:
       example:

--- a/clients/java/docs/OtfDiffEntry.md
+++ b/clients/java/docs/OtfDiffEntry.md
@@ -7,7 +7,7 @@
 
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
-**id** | **String** |  |  [optional]
+**id** | **String** |  | 
 **timestamp** | **Integer** |  | 
 **operation** | **String** |  | 
 **operationContent** | **Object** | free form content describing the returned operation diff | 

--- a/clients/java/src/main/java/io/lakefs/clients/api/model/OtfDiffEntry.java
+++ b/clients/java/src/main/java/io/lakefs/clients/api/model/OtfDiffEntry.java
@@ -109,8 +109,8 @@ public class OtfDiffEntry {
    * Get id
    * @return id
   **/
-  @javax.annotation.Nullable
-  @ApiModelProperty(value = "")
+  @javax.annotation.Nonnull
+  @ApiModelProperty(required = true, value = "")
 
   public String getId() {
     return id;

--- a/clients/python/docs/OtfDiffEntry.md
+++ b/clients/python/docs/OtfDiffEntry.md
@@ -4,11 +4,11 @@
 ## Properties
 Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
+**id** | **str** |  | 
 **timestamp** | **int** |  | 
 **operation** | **str** |  | 
 **operation_content** | **{str: (bool, date, datetime, dict, float, int, list, str, none_type)}** | free form content describing the returned operation diff | 
 **operation_type** | **str** | the operation category (CUD) | 
-**id** | **str** |  | [optional] 
 **any string name** | **bool, date, datetime, dict, float, int, list, str, none_type** | any string name can be used but the value must be the correct type | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/clients/python/lakefs_client/model/otf_diff_entry.py
+++ b/clients/python/lakefs_client/model/otf_diff_entry.py
@@ -87,11 +87,11 @@ class OtfDiffEntry(ModelNormal):
                 and the value is attribute type.
         """
         return {
+            'id': (str,),  # noqa: E501
             'timestamp': (int,),  # noqa: E501
             'operation': (str,),  # noqa: E501
             'operation_content': ({str: (bool, date, datetime, dict, float, int, list, str, none_type)},),  # noqa: E501
             'operation_type': (str,),  # noqa: E501
-            'id': (str,),  # noqa: E501
         }
 
     @cached_property
@@ -100,11 +100,11 @@ class OtfDiffEntry(ModelNormal):
 
 
     attribute_map = {
+        'id': 'id',  # noqa: E501
         'timestamp': 'timestamp',  # noqa: E501
         'operation': 'operation',  # noqa: E501
         'operation_content': 'operation_content',  # noqa: E501
         'operation_type': 'operation_type',  # noqa: E501
-        'id': 'id',  # noqa: E501
     }
 
     read_only_vars = {
@@ -114,10 +114,11 @@ class OtfDiffEntry(ModelNormal):
 
     @classmethod
     @convert_js_args_to_python_args
-    def _from_openapi_data(cls, timestamp, operation, operation_content, operation_type, *args, **kwargs):  # noqa: E501
+    def _from_openapi_data(cls, id, timestamp, operation, operation_content, operation_type, *args, **kwargs):  # noqa: E501
         """OtfDiffEntry - a model defined in OpenAPI
 
         Args:
+            id (str):
             timestamp (int):
             operation (str):
             operation_content ({str: (bool, date, datetime, dict, float, int, list, str, none_type)}): free form content describing the returned operation diff
@@ -154,7 +155,6 @@ class OtfDiffEntry(ModelNormal):
                                 Animal class but this time we won't travel
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
-            id (str): [optional]  # noqa: E501
         """
 
         _check_type = kwargs.pop('_check_type', True)
@@ -182,6 +182,7 @@ class OtfDiffEntry(ModelNormal):
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
 
+        self.id = id
         self.timestamp = timestamp
         self.operation = operation
         self.operation_content = operation_content
@@ -206,10 +207,11 @@ class OtfDiffEntry(ModelNormal):
     ])
 
     @convert_js_args_to_python_args
-    def __init__(self, timestamp, operation, operation_content, operation_type, *args, **kwargs):  # noqa: E501
+    def __init__(self, id, timestamp, operation, operation_content, operation_type, *args, **kwargs):  # noqa: E501
         """OtfDiffEntry - a model defined in OpenAPI
 
         Args:
+            id (str):
             timestamp (int):
             operation (str):
             operation_content ({str: (bool, date, datetime, dict, float, int, list, str, none_type)}): free form content describing the returned operation diff
@@ -246,7 +248,6 @@ class OtfDiffEntry(ModelNormal):
                                 Animal class but this time we won't travel
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
-            id (str): [optional]  # noqa: E501
         """
 
         _check_type = kwargs.pop('_check_type', True)
@@ -272,6 +273,7 @@ class OtfDiffEntry(ModelNormal):
         self._configuration = _configuration
         self._visited_composed_classes = _visited_composed_classes + (self.__class__,)
 
+        self.id = id
         self.timestamp = timestamp
         self.operation = operation
         self.operation_content = operation_content

--- a/docs/assets/js/swagger.yml
+++ b/docs/assets/js/swagger.yml
@@ -396,7 +396,7 @@ components:
     OtfDiffEntry:
       type: object
       required:
-        - version
+        - id
         - operation
         - timestamp
         - operation_content

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -3947,12 +3947,12 @@ func buildOtfDiffListResponse(tableDiffResponse tablediff.Response) OtfDiffList 
 		for k, v := range entry.OperationContent {
 			content[k] = v
 		}
-		v := entry.Version
+		id := entry.Id
 		ol = append(ol, OtfDiffEntry{
 			Operation:        entry.Operation,
 			OperationContent: content,
 			Timestamp:        int(entry.Timestamp.UnixMilli()),
-			Id:               &v,
+			Id:               id,
 			OperationType:    entry.OperationType,
 		})
 	}

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -3947,7 +3947,7 @@ func buildOtfDiffListResponse(tableDiffResponse tablediff.Response) OtfDiffList 
 		for k, v := range entry.OperationContent {
 			content[k] = v
 		}
-		id := entry.Id
+		id := entry.ID
 		ol = append(ol, OtfDiffEntry{
 			Operation:        entry.Operation,
 			OperationContent: content,

--- a/pkg/plugins/diff/delta_differ.go
+++ b/pkg/plugins/diff/delta_differ.go
@@ -60,7 +60,7 @@ func buildDiffEntries(dr *DiffResponse) []DiffEntry {
 	result := make([]DiffEntry, 0, len(dr.GetEntries()))
 	for _, diff := range dr.GetEntries() {
 		result = append(result, DiffEntry{
-			Id:               diff.GetId(),
+			ID:               diff.GetId(),
 			Timestamp:        diff.GetTimestamp().AsTime(),
 			Operation:        diff.GetOperation(),
 			OperationContent: diff.GetContent(),

--- a/pkg/plugins/diff/delta_differ.go
+++ b/pkg/plugins/diff/delta_differ.go
@@ -60,7 +60,7 @@ func buildDiffEntries(dr *DiffResponse) []DiffEntry {
 	result := make([]DiffEntry, 0, len(dr.GetEntries()))
 	for _, diff := range dr.GetEntries() {
 		result = append(result, DiffEntry{
-			Version:          diff.GetId(),
+			Id:               diff.GetId(),
 			Timestamp:        diff.GetTimestamp().AsTime(),
 			Operation:        diff.GetOperation(),
 			OperationContent: diff.GetContent(),

--- a/pkg/plugins/diff/delta_differ_test.go
+++ b/pkg/plugins/diff/delta_differ_test.go
@@ -170,7 +170,7 @@ func validateResults(t *testing.T, resp Response, dr *DiffResponse) {
 	}
 	for _, e := range dr.GetEntries() {
 		expectedResp.Diffs = append(expectedResp.Diffs, DiffEntry{
-			Version:          e.Id,
+			Id:               e.Id,
 			Timestamp:        e.Timestamp.AsTime(),
 			Operation:        e.Operation,
 			OperationContent: e.Content,

--- a/pkg/plugins/diff/delta_differ_test.go
+++ b/pkg/plugins/diff/delta_differ_test.go
@@ -170,7 +170,7 @@ func validateResults(t *testing.T, resp Response, dr *DiffResponse) {
 	}
 	for _, e := range dr.GetEntries() {
 		expectedResp.Diffs = append(expectedResp.Diffs, DiffEntry{
-			Id:               e.Id,
+			ID:               e.Id,
 			Timestamp:        e.Timestamp.AsTime(),
 			Operation:        e.Operation,
 			OperationContent: e.Content,

--- a/pkg/plugins/diff/service.go
+++ b/pkg/plugins/diff/service.go
@@ -45,7 +45,7 @@ func getDiffType(diffType DiffType) string {
 }
 
 type DiffEntry struct {
-	Id          string
+	ID               string
 	Timestamp        time.Time
 	Operation        string
 	OperationContent map[string]string

--- a/pkg/plugins/diff/service.go
+++ b/pkg/plugins/diff/service.go
@@ -45,7 +45,7 @@ func getDiffType(diffType DiffType) string {
 }
 
 type DiffEntry struct {
-	Version          string
+	Id          string
 	Timestamp        time.Time
 	Operation        string
 	OperationContent map[string]string

--- a/pkg/plugins/diff/test_utils.go
+++ b/pkg/plugins/diff/test_utils.go
@@ -86,7 +86,7 @@ func (ctd ControllerTestDiffer) Diff(ctx context.Context, p Params) (Response, e
 func generateDiffs() []DiffEntry {
 	return []DiffEntry{
 		{
-			Id:        "v0",
+			ID:        "v0",
 			Timestamp: time.Unix(0, 0),
 			Operation: "op",
 			OperationContent: map[string]string{

--- a/pkg/plugins/diff/test_utils.go
+++ b/pkg/plugins/diff/test_utils.go
@@ -86,7 +86,7 @@ func (ctd ControllerTestDiffer) Diff(ctx context.Context, p Params) (Response, e
 func generateDiffs() []DiffEntry {
 	return []DiffEntry{
 		{
-			Version:   "v0",
+			Id:        "v0",
 			Timestamp: time.Unix(0, 0),
 			Operation: "op",
 			OperationContent: map[string]string{


### PR DESCRIPTION
## Change Description

Id is a more general term that used to identify an otfDiff entry, use this term in all parts that are related to any table diff entry. In a delta lake-specific parts we keep using the term version. 
