### PR TITLE
Connect delta diff ui client with otfDiff endpoint

### DIFF
--- a/webui/src/lib/api/index.js
+++ b/webui/src/lib/api/index.js
@@ -492,12 +492,6 @@ class Repositories {
             }
         }
         return response.json();
-
-        // const mockRes = '{"results": []}'
-        // const mockRes = '{"diff_type": "changed", "results": [{"version": "1", "timestamp": 1515491537026, "operation": "INSERT", "operation_content": {"mode": "Append","partitionBy": "[]"}, "operation_type": "create"}, {"version": "2", "timestamp": 1515491537346, "operation": "DELETE", "operation_content": {"mode": "Append","partitionBy": "[]"}, "operation_type": "delete"}, {"version": "14", "timestamp": 1674393286223, "operation": "DELETE", "operation_content": {"predicate": "[\\"(spark_catalog.delta.lakefs://meetup-repo/experiment-2-branch/raw/.`rating` < 4.0D) aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\\"]"}, "operation_type": "delete"}]}'
-        // const mockRes = '{"diff_type": "created", "results": [{"version": "1", "timestamp": 1515491537026, "operation": "INSERT", "operation_content": {"mode": "Append","partitionBy": "[]"}, "operation_type": "create"}]}'
-        // const mockRes = '{"diff_type": "dropped", "results": []}'
-        // return JSON.parse(mockRes);
     }
 }
 

--- a/webui/src/lib/api/index.js
+++ b/webui/src/lib/api/index.js
@@ -479,19 +479,25 @@ class Repositories {
     }
 
     async otfDiff(repoId, leftRef, rightRef, tablePath = "", type) {
-        //TODO (Tals): enable while connecting with endpoint
-        // const query = qs({tablePath, type});
-        // const response = await apiRequest(`/repositories/${encodeURIComponent(repoId)}/otf/refs/${encodeURIComponent(leftRef)}/diff/${encodeURIComponent(rightRef)}?` + query);
-        // if (response.status !== 200) {
-        //     //TODO (Tals): improve error handling
-        //     throw new NotFoundError(`table ${tablePath} not found`);
-        // }
-        // return response.json();
+        const query = qs({table_path: tablePath, type});
+        const response = await apiRequest(`/repositories/${encodeURIComponent(repoId)}/otf/refs/${encodeURIComponent(leftRef)}/diff/${encodeURIComponent(rightRef)}?` + query);
+        if (response.status !== 200) {
+            switch (response.status) {
+                case 401:
+                    throw new AuthorizationError('user unauthorized');
+                case 404:
+                    throw new NotFoundError(`table ${tablePath} not found`);
+                default:
+                    throw new Error(await extractError(response));
+            }
+        }
+        return response.json();
+
         // const mockRes = '{"results": []}'
-        const mockRes = '{"diff_type": "changed", "results": [{"version": "1", "timestamp": 1515491537026, "operation": "INSERT", "operation_content": {"mode": "Append","partitionBy": "[]"}, "operation_type": "create"}, {"version": "2", "timestamp": 1515491537346, "operation": "DELETE", "operation_content": {"mode": "Append","partitionBy": "[]"}, "operation_type": "delete"}, {"version": "14", "timestamp": 1674393286223, "operation": "DELETE", "operation_content": {"predicate": "[\\"(spark_catalog.delta.lakefs://meetup-repo/experiment-2-branch/raw/.`rating` < 4.0D) aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\\"]"}, "operation_type": "delete"}]}'
+        // const mockRes = '{"diff_type": "changed", "results": [{"version": "1", "timestamp": 1515491537026, "operation": "INSERT", "operation_content": {"mode": "Append","partitionBy": "[]"}, "operation_type": "create"}, {"version": "2", "timestamp": 1515491537346, "operation": "DELETE", "operation_content": {"mode": "Append","partitionBy": "[]"}, "operation_type": "delete"}, {"version": "14", "timestamp": 1674393286223, "operation": "DELETE", "operation_content": {"predicate": "[\\"(spark_catalog.delta.lakefs://meetup-repo/experiment-2-branch/raw/.`rating` < 4.0D) aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa\\"]"}, "operation_type": "delete"}]}'
         // const mockRes = '{"diff_type": "created", "results": [{"version": "1", "timestamp": 1515491537026, "operation": "INSERT", "operation_content": {"mode": "Append","partitionBy": "[]"}, "operation_type": "create"}]}'
         // const mockRes = '{"diff_type": "dropped", "results": []}'
-        return JSON.parse(mockRes);
+        // return JSON.parse(mockRes);
     }
 }
 

--- a/webui/src/lib/components/repository/TableDiff.jsx
+++ b/webui/src/lib/components/repository/TableDiff.jsx
@@ -39,7 +39,7 @@ const TableDiffTypeRow = ({diffType}) => {
     }
     return <tr>
         <td className="table-diff-type pl-lg-10 col-10"><InfoIcon/> Table {diffType}</td>
-        <td className="table-version-placeholder col-sm-auto"></td>
+        <td className="table-id-placeholder col-sm-auto"></td>
         <td className="operation-expansion-placeholder col-sm-auto"></td>
     </tr>
 }
@@ -58,7 +58,7 @@ const OtfDiffRow = ({otfDiff}) => {
 const OperationMetadataRow = ({otfDiff, operationExpanded, onExpand, ...rest}) => {
     return <tr {...rest}>
         <td className={"table-operation-type pl-lg-10 col-10"}>{otfDiff.operation}</td>
-        <td className="table-version col-sm-auto">Version = {otfDiff.version}</td>
+        <td className="table-id col-sm-auto">Version = {otfDiff.id}</td>
         <td className="operation-expansion col-sm-auto">
             <OperationExpansionSection operationExpanded={operationExpanded} onExpand={onExpand}/>
         </td>

--- a/webui/src/styles/globals.css
+++ b/webui/src/styles/globals.css
@@ -663,7 +663,7 @@ td.table-operation-type {
   padding-left: 30px;
 }
 
-td.table-version, td.table-version-placeholder {
+td.table-id, td.table-id-placeholder {
   text-align: left;
   width: 8%;
 }


### PR DESCRIPTION
### Linked Issue

Closes #5319

---

## Change Description
      
### New Feature

Use the otfDiff endpoint that was implemented in https://github.com/treeverse/lakeFS/pull/5228 to show delta lake tables diff. 

### Testing Details

Tested manually, see screenshots below. 

## Additional info

![table_dropped](https://user-images.githubusercontent.com/14786381/220964177-c6458255-c651-4b5a-9bee-8c6440e72eb3.png)
![table_changed](https://user-images.githubusercontent.com/14786381/220964181-5eb1d7ae-570d-40dc-aded-b39538d2f842.png)
![table_created](https://user-images.githubusercontent.com/14786381/220964190-7f4a6073-64fb-49e3-a699-785ba7ed1e87.png)
