### PR TITLE
Fix: import button disabled eventhough config enabled (#5336)

### DIFF
--- a/webui/src/pages/repositories/repository/objects.jsx
+++ b/webui/src/pages/repositories/repository/objects.jsx
@@ -402,7 +402,7 @@ const ObjectsBrowser = ({config, configError}) => {
                     />
                     <ImportButton
                         onClick={() => setShowImport(true)}
-                        enabled={config.blockstore_type.import_support}
+                        enabled={config.import_support}
                     />
                     <ImportModal
                         config={config}


### PR DESCRIPTION
### Linked Issue

Closes #5336

---

## Change Description

Seems that the wrong config value is taken to determine whether or not there's support for import. Changed to pick up the correct value from the config.

I believe the config value might have been changed recently to support local imports, perhaps @nopcoder will know for sure :)