### PR TITLE
GetCommit API should return the commit reference for tag and branch

### DIFF
--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -2466,9 +2466,9 @@ func (c *Controller) GetCommit(w http.ResponseWriter, r *http.Request, repositor
 		AdditionalProperties: map[string]string(commit.Metadata),
 	}
 	response := Commit{
+		Id:           commit.Reference,
 		Committer:    commit.Committer,
 		CreationDate: commit.CreationDate.Unix(),
-		Id:           commitID,
 		Message:      commit.Message,
 		MetaRangeId:  commit.MetaRangeID,
 		Metadata:     &metadata,

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -1038,7 +1038,7 @@ func (c *Catalog) GetCommit(ctx context.Context, repositoryID string, reference 
 		return nil, err
 	}
 	catalogCommitLog := &CommitLog{
-		Reference:    reference,
+		Reference:    commitID.String(),
 		Committer:    commit.Committer,
 		Message:      commit.Message,
 		CreationDate: commit.CreationDate,


### PR DESCRIPTION
This change modify the API behaviour (bug fix).
The current behaviour returns the requested reference as the commit ID (as in the request).
The fix will return the full commit ID for partial commit ID, tag or branch name.

Fix #3436