### PR TITLE
Use default storage namespace in local settings

### DIFF
--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -1280,11 +1280,15 @@ func (c *Controller) GetStorageConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	info := c.BlockAdapter.GetStorageNamespaceInfo()
+	defaultNamespacePrefix := swag.String(info.DefaultNamespacePrefix)
+	if c.Config.Blockstore.DefaultNamespacePrefix != nil {
+		defaultNamespacePrefix = c.Config.Blockstore.DefaultNamespacePrefix
+	}
 	response := StorageConfig{
 		BlockstoreType:                   c.Config.BlockstoreType(),
 		BlockstoreNamespaceValidityRegex: info.ValidityRegex,
 		BlockstoreNamespaceExample:       info.Example,
-		DefaultNamespacePrefix:           swag.String(c.Config.Blockstore.DefaultNamespacePrefix),
+		DefaultNamespacePrefix:           defaultNamespacePrefix,
 		PreSignSupport:                   info.PreSignSupport,
 		ImportSupport:                    info.ImportSupport,
 	}

--- a/pkg/block/local/adapter.go
+++ b/pkg/block/local/adapter.go
@@ -29,7 +29,7 @@ type Adapter struct {
 }
 
 const (
-	DefaultNamespacePrefix = "local://data"
+	DefaultNamespacePrefix = "local:/"
 )
 
 var (

--- a/pkg/block/local/adapter.go
+++ b/pkg/block/local/adapter.go
@@ -28,6 +28,10 @@ type Adapter struct {
 	importEnabled           bool
 }
 
+const (
+	DefaultNamespacePrefix = "local://data"
+)
+
 var (
 	ErrPathNotWritable       = errors.New("path provided is not writable")
 	ErrInventoryNotSupported = errors.New("inventory feature not implemented for local storage adapter")
@@ -480,6 +484,7 @@ func (l *Adapter) BlockstoreType() string {
 func (l *Adapter) GetStorageNamespaceInfo() block.StorageNamespaceInfo {
 	info := block.DefaultStorageNamespaceInfo(block.BlockstoreTypeLocal)
 	info.PreSignSupport = false
+	info.DefaultNamespacePrefix = DefaultNamespacePrefix
 	info.ImportSupport = l.importEnabled
 	return info
 }

--- a/pkg/block/namespace.go
+++ b/pkg/block/namespace.go
@@ -48,10 +48,11 @@ func (s StorageType) Scheme() string {
 }
 
 type StorageNamespaceInfo struct {
-	ValidityRegex  string // regex pattern that could be used to validate the namespace
-	Example        string // example of a valid namespace
-	PreSignSupport bool
-	ImportSupport  bool
+	ValidityRegex          string // regex pattern that could be used to validate the namespace
+	Example                string // example of a valid namespace
+	DefaultNamespacePrefix string // when a repo is created from the UI, suggest a default storage namespace under this prefix
+	PreSignSupport         bool
+	ImportSupport          bool
 }
 
 type QualifiedKey struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -178,8 +178,8 @@ type Config struct {
 		} `mapstructure:"ui_config"`
 	}
 	Blockstore struct {
-		Type                   string `mapstructure:"type" validate:"required"`
-		DefaultNamespacePrefix string `mapstructure:"default_namespace_prefix"`
+		Type                   string  `mapstructure:"type" validate:"required"`
+		DefaultNamespacePrefix *string `mapstructure:"default_namespace_prefix"`
 		Local                  *struct {
 			Path                    string   `mapstructure:"path"`
 			ImportEnabled           bool     `mapstructure:"import_enabled"`

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -20,6 +20,7 @@ func setDefaults(local bool) {
 		viper.SetDefault("database.type", "local")
 		viper.SetDefault("auth.encrypt.secret_key", "THIS_MUST_BE_CHANGED_IN_PRODUCTION") // #nosec
 		viper.SetDefault(BlockstoreTypeKey, "local")
+		viper.SetDefault("blockstore.default_namespace_prefix", "local://")
 	}
 
 	viper.SetDefault("listen_address", DefaultListenAddress)

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -20,7 +20,6 @@ func setDefaults(local bool) {
 		viper.SetDefault("database.type", "local")
 		viper.SetDefault("auth.encrypt.secret_key", "THIS_MUST_BE_CHANGED_IN_PRODUCTION") // #nosec
 		viper.SetDefault(BlockstoreTypeKey, "local")
-		viper.SetDefault("blockstore.default_namespace_prefix", "local://")
 	}
 
 	viper.SetDefault("listen_address", DefaultListenAddress)


### PR DESCRIPTION
Resolves #5368.

Fill in storage namespace automatically for local storage adapter.
This can still be overridden with `blockstore.default_namespace_prefix` setting.