### PR TITLE
[DX] Nit: remove ambiguity on wording

### DIFF
--- a/cmd/lakectl/cmd/fs.go
+++ b/cmd/lakectl/cmd/fs.go
@@ -526,7 +526,7 @@ var fsDownloadCmd = &cobra.Command{
 					dst := filepath.Join(dest, strings.TrimPrefix(downloadPath, prefix))
 					err := downloadHelper(ctx, client, transport, src, dst)
 					if err == nil {
-						fmt.Printf("Download: %s to %s\n", src.String(), dst)
+						fmt.Printf("Successfully downloaded %s to %s\n", src.String(), dst)
 					} else {
 						_, _ = fmt.Fprintf(os.Stderr, "Download failed: %s to %s - %s\n", src.String(), dst, err)
 						atomic.AddInt64(&errCounter, 1)

--- a/esti/golden/lakectl_fs_download.golden
+++ b/esti/golden/lakectl_fs_download.golden
@@ -1,1 +1,1 @@
-Download: lakefs://${REPO}/${BRANCH}/${PATH}/${FILE} to ${FILE}
+Successfully downloaded lakefs://${REPO}/${BRANCH}/${PATH}/${FILE} to ${FILE}

--- a/esti/golden/lakectl_fs_download_custom.golden
+++ b/esti/golden/lakectl_fs_download_custom.golden
@@ -1,1 +1,1 @@
-Download: lakefs://${REPO}/${BRANCH}/${PATH}/${FILE} to ${DEST}/${FILE}
+Successfully downloaded lakefs://${REPO}/${BRANCH}/${PATH}/${FILE} to ${DEST}/${FILE}

--- a/esti/golden/lakectl_fs_download_recursive.golden
+++ b/esti/golden/lakectl_fs_download_recursive.golden
@@ -1,5 +1,5 @@
-Download: lakefs://${REPO}/${BRANCH}/${PATH}/${FILE_PREFIX}.0 to ${FILE_PREFIX}.0
-Download: lakefs://${REPO}/${BRANCH}/${PATH}/${FILE_PREFIX}.1 to ${FILE_PREFIX}.1
-Download: lakefs://${REPO}/${BRANCH}/${PATH}/${FILE_PREFIX}.2 to ${FILE_PREFIX}.2
-Download: lakefs://${REPO}/${BRANCH}/${PATH}/${FILE_PREFIX}.3 to ${FILE_PREFIX}.3
-Download: lakefs://${REPO}/${BRANCH}/${PATH}/${FILE_PREFIX}.4 to ${FILE_PREFIX}.4
+Successfully downloaded lakefs://${REPO}/${BRANCH}/${PATH}/${FILE_PREFIX}.0 to ${FILE_PREFIX}.0
+Successfully downloaded lakefs://${REPO}/${BRANCH}/${PATH}/${FILE_PREFIX}.1 to ${FILE_PREFIX}.1
+Successfully downloaded lakefs://${REPO}/${BRANCH}/${PATH}/${FILE_PREFIX}.2 to ${FILE_PREFIX}.2
+Successfully downloaded lakefs://${REPO}/${BRANCH}/${PATH}/${FILE_PREFIX}.3 to ${FILE_PREFIX}.3
+Successfully downloaded lakefs://${REPO}/${BRANCH}/${PATH}/${FILE_PREFIX}.4 to ${FILE_PREFIX}.4

--- a/esti/golden/lakectl_fs_download_recursive_custom.golden
+++ b/esti/golden/lakectl_fs_download_recursive_custom.golden
@@ -1,5 +1,5 @@
-Download: lakefs://${REPO}/${BRANCH}/${PATH}/${FILE_PREFIX}.0 to ${DEST}/${FILE_PREFIX}.0
-Download: lakefs://${REPO}/${BRANCH}/${PATH}/${FILE_PREFIX}.1 to ${DEST}/${FILE_PREFIX}.1
-Download: lakefs://${REPO}/${BRANCH}/${PATH}/${FILE_PREFIX}.2 to ${DEST}/${FILE_PREFIX}.2
-Download: lakefs://${REPO}/${BRANCH}/${PATH}/${FILE_PREFIX}.3 to ${DEST}/${FILE_PREFIX}.3
-Download: lakefs://${REPO}/${BRANCH}/${PATH}/${FILE_PREFIX}.4 to ${DEST}/${FILE_PREFIX}.4
+Successfully downloaded lakefs://${REPO}/${BRANCH}/${PATH}/${FILE_PREFIX}.0 to ${DEST}/${FILE_PREFIX}.0
+Successfully downloaded lakefs://${REPO}/${BRANCH}/${PATH}/${FILE_PREFIX}.1 to ${DEST}/${FILE_PREFIX}.1
+Successfully downloaded lakefs://${REPO}/${BRANCH}/${PATH}/${FILE_PREFIX}.2 to ${DEST}/${FILE_PREFIX}.2
+Successfully downloaded lakefs://${REPO}/${BRANCH}/${PATH}/${FILE_PREFIX}.3 to ${DEST}/${FILE_PREFIX}.3
+Successfully downloaded lakefs://${REPO}/${BRANCH}/${PATH}/${FILE_PREFIX}.4 to ${DEST}/${FILE_PREFIX}.4


### PR DESCRIPTION
- Make successful download message unambiguous

<!-- 
Hello Axolotl!
Thank you for contributing to the lakeFS project.
We appreciate the time invested in this pull request and created this template to help make this process easier.
It's really important to have all the information and context, to ensure we can properly address this PR 
Please use the following references to fill out the pull request.
--> 

## Change Description

### Background

The `lakectl` command currently makes the statement: "Download" which is not clear if it's *going to*, *trying to*, or *has done*. 

```bash
$ lakectl fs download lakefs://drones03/main/sensitive/flyers.csv

Download: lakefs://drones03/main/sensitive/flyers.csv to flyers.csv
```

### New Feature

```bash
$ lakectl fs download lakefs://drones03/main/sensitive/flyers.csv

Successfully downloaded lakefs://drones03/main/sensitive/flyers.csv to flyers.csv
```


### Testing Details

How were the changes tested? Manually

### Breaking Change?

Does this change break any existing functionality? (API, CLI, Clients): No

