### PR TITLE
(fix) maven 3.0 finalName readonly in jar plugin

### DIFF
--- a/.github/workflows/compatability-tests.yaml
+++ b/.github/workflows/compatability-tests.yaml
@@ -50,7 +50,7 @@ jobs:
       - name: Build Spark direct-access client
         working-directory: clients/hadoopfs
         run: |
-          mvn -Passembly -Djar.finalName=client -DskipTests --batch-mode --update-snapshots package
+          mvn -Passembly -DfinalName=client -DskipTests --batch-mode --update-snapshots package
 
       - name: Store client assembly
         uses: actions/upload-artifact@v3

--- a/.github/workflows/esti.yaml
+++ b/.github/workflows/esti.yaml
@@ -704,7 +704,7 @@ jobs:
 
       - name: Build Spark direct-access client
         working-directory: clients/hadoopfs
-        run: mvn -Passembly -Djar.finalName=client --batch-mode --update-snapshots package
+        run: mvn -Passembly -DfinalName=client --batch-mode --update-snapshots package
 
       - name: Test lakeFS S3 with Spark 2.x thick client
         timeout-minutes: 8
@@ -784,7 +784,7 @@ jobs:
 
       - name: Build Spark direct-access client
         working-directory: clients/hadoopfs
-        run: mvn -Passembly -Djar.finalName=client --batch-mode --update-snapshots package
+        run: mvn -Passembly -DfinalName=client --batch-mode --update-snapshots package
 
       - name: Test lakeFS S3 with Spark 3.x thick client
         timeout-minutes: 8

--- a/clients/hadoopfs/pom.xml
+++ b/clients/hadoopfs/pom.xml
@@ -196,8 +196,10 @@ To export to S3:
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <name-suffix/>          <!-- Set via profile to rename JAR -->
         <hadoop.version>2.7.7</hadoop.version>
+        <finalName>${project.artifactId}-${project.version}</finalName>
     </properties>
     <build>
+        <finalName>${finalName}</finalName>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Maven 3.0 made `finalName` readonly in the jar plugin ([ref](https://issues.apache.org/jira/browse/MJAR-217)). Replaced with project property and updated GitHub workflows to override it.