### PR TITLE
lakectl: output commit log as dotgraph

### DIFF
--- a/cmd/lakectl/cmd/log.go
+++ b/cmd/lakectl/cmd/log.go
@@ -43,6 +43,7 @@ var logCmd = &cobra.Command{
 	Use:               "log <branch uri>",
 	Short:             "Show log of commits",
 	Long:              "Show log of commits for a given branch",
+	Example:           "lakectl log --dot lakefs://example-repository/main | dot -Tsvg > graph.svg",
 	Args:              cobra.ExactArgs(1),
 	ValidArgsFunction: ValidArgsRepository,
 	Run: func(cmd *cobra.Command, args []string) {

--- a/cmd/lakectl/cmd/log.go
+++ b/cmd/lakectl/cmd/log.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"bytes"
+	"encoding/xml"
 	"fmt"
 	"net/http"
 	"strings"
@@ -27,6 +29,14 @@ Metadata:
 {{ end -}}
 {{ end }}{{ if .Pagination  }}
 {{.Pagination | paginate }}{{ end }}`
+
+// escapeDot escapes a string to match the graphviz dot-graph syntax
+// based on: https://graphviz.org/doc/info/lang.html
+func escapeDot(s string) string {
+	var buf bytes.Buffer
+	_ = xml.EscapeText(&buf, []byte(s))
+	return buf.String()
+}
 
 // logCmd represents the log command
 var logCmd = &cobra.Command{
@@ -91,9 +101,7 @@ var logCmd = &cobra.Command{
 			if dot {
 				for _, commit := range resp.JSON200.Results {
 					isMerge := len(commit.Parents) > 1
-					label := fmt.Sprintf("%s<br/> %s",
-						commit.Id[:8],
-						strings.ReplaceAll(commit.Message, "\"", "\\\""))
+					label := fmt.Sprintf("%s<br/> %s", commit.Id[:8], escapeDot(commit.Message))
 					if isMerge {
 						label = fmt.Sprintf("<b>%s</b>", label)
 					}

--- a/cmd/lakectl/cmd/log.go
+++ b/cmd/lakectl/cmd/log.go
@@ -34,7 +34,7 @@ Metadata:
 
 type dotWriter struct {
 	w            io.Writer
-	repositoryId string
+	repositoryID string
 }
 
 func (d *dotWriter) Start() {
@@ -46,7 +46,7 @@ func (d *dotWriter) End() {
 }
 
 func (d *dotWriter) Write(commits []api.Commit) {
-	repoId := url.PathEscape(d.repositoryId)
+	repoId := url.PathEscape(d.repositoryID)
 	for _, commit := range commits {
 		isMerge := len(commit.Parents) > 1
 		label := fmt.Sprintf("%s<br/> %s", commit.Id[:8], html.EscapeString(commit.Message))
@@ -101,7 +101,7 @@ var logCmd = &cobra.Command{
 
 		graph := &dotWriter{
 			w:            os.Stdout,
-			repositoryId: branchURI.Ref,
+			repositoryID: branchURI.Ref,
 		}
 		if dot {
 			graph.Start()

--- a/cmd/lakectl/cmd/log.go
+++ b/cmd/lakectl/cmd/log.go
@@ -46,17 +46,17 @@ func (d *dotWriter) End() {
 }
 
 func (d *dotWriter) Write(commits []api.Commit) {
-	repoId := url.PathEscape(d.repositoryID)
+	repoID := url.PathEscape(d.repositoryID)
 	for _, commit := range commits {
 		isMerge := len(commit.Parents) > 1
 		label := fmt.Sprintf("%s<br/> %s", commit.Id[:8], html.EscapeString(commit.Message))
 		if isMerge {
 			label = fmt.Sprintf("<b>%s</b>", label)
 		}
-		baseUrl := strings.TrimSuffix(strings.TrimSuffix(
+		baseURL := strings.TrimSuffix(strings.TrimSuffix(
 			cfg.Values.Server.EndpointURL, "/api/v1"), "/")
 		_, _ = fmt.Fprintf(d.w, "\n\t\"%s\" [shape=note target=\"_blank\" href=\"%s/repositories/%s/commits/%s\" label=< %s >]\n",
-			commit.Id, baseUrl, repoId, commit.Id, label)
+			commit.Id, baseURL, repoID, commit.Id, label)
 		for _, parent := range commit.Parents {
 			_, _ = fmt.Fprintf(d.w, "\t\"%s\" -> \"%s\";\n", parent, commit.Id)
 		}

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2253,6 +2253,13 @@ Show log of commits for a given branch
 lakectl log <branch uri> [flags]
 ```
 
+#### Examples
+{:.no_toc}
+
+```
+lakectl log --dot lakefs://example-repository/main | dot -Tsvg > graph.svg
+```
+
 #### Options
 {:.no_toc}
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2259,6 +2259,7 @@ lakectl log <branch uri> [flags]
 ```
       --after string         show results after this value (used for pagination)
       --amount int           number of results to return. By default, all results are returned
+      --dot                  return results in a dotgraph format
   -h, --help                 help for log
       --limit                limit result just to amount. By default, returns whether more items are available.
       --objects strings      show results that contains changes to at least one path in that list of objects. Use comma separator to pass all objects together


### PR DESCRIPTION
Added the ability to output `lakectl log` as a [dotgraph](https://en.wikipedia.org/wiki/DOT_(graph_description_language)).

Example Usage:

```bash
$ lakectl log --dot lakefs://example-repository/main | dot -Tsvg > graph.svg
```

This yields an image that when opened in the browser, looks something like this:

![image](https://user-images.githubusercontent.com/205955/223445823-88cf85fe-bcc1-48a3-885e-a422a6dd918d.png)

(withe each commit ID being clickable and opens the lakeFS UI).

_Note: rendering the svg requires [graphviz](https://graphviz.org/download/), so e.g. `brew install graphviz` first._

