### PR TITLE
Show delta table name with its operation-wise diff

### DIFF
--- a/webui/src/lib/components/repository/changes.jsx
+++ b/webui/src/lib/components/repository/changes.jsx
@@ -39,7 +39,7 @@ import Col from "react-bootstrap/Col";
  * @param {(after : string, path : string, useDelimiter :? boolean, amount :? number) => Promise<any> } getMore callback to be called when more items need to be rendered
  */
 export const TreeItemRow = ({ entry, repo, reference, leftDiffRefID, rightDiffRefID, internalRefresh, onRevert, onNavigate, delimiter, relativeTo, getMore,
-                                depth=0, setTableDiffExpanded}) => {
+                                depth=0, setTableDiffExpanded, setTableDiffState, setIsTableMerge}) => {
     const [dirExpanded, setDirExpanded] = useState(false); // state of a non-leaf item expansion
     const [afterUpdated, setAfterUpdated] = useState(""); // state of pagination of the item's children
     const [resultsState, setResultsState] = useState({results:[], pagination:{}}); // current retrieved children of the item
@@ -97,7 +97,8 @@ export const TreeItemRow = ({ entry, repo, reference, leftDiffRefID, rightDiffRe
             results.map(child =>
                 (<TreeItemRow key={child.path + "-item"} entry={child} repo={repo} reference={reference} leftDiffRefID={leftDiffRefID} rightDiffRefID={rightDiffRefID} onRevert={onRevert} onNavigate={onNavigate}
                               internalReferesh={internalRefresh} delimiter={delimiter} depth={depth + 1}
-                              relativeTo={entry.path} getMore={getMore} setTableDiffExpanded={setTableDiffExpanded}/>))}
+                              relativeTo={entry.path} getMore={getMore} setTableDiffExpanded={onTableDiffExpansion(child, setTableDiffState, setIsTableMerge)} setTableDiffState={setTableDiffState}
+                              setIsTableMerge={setIsTableMerge}/>))}
             {(!!nextPage || loading) &&
             <TreeEntryPaginator path={entry.path} depth={depth} loading={loading} nextPage={nextPage}
                                 setAfterUpdated={setAfterUpdated}/>
@@ -183,7 +184,7 @@ export const ChangesTreeContainer = ({results, showExperimentalDeltaDiffButton =
                                          leftDiffRefID, rightDiffRefID, repo, reference, internalRefresh, prefix,
                                          getMore, loading, nextPage, setAfterUpdated, onNavigate, onRevert, setIsTableMerge}) => {
     const enableDeltaDiff = JSON.parse(localStorage.getItem(`enable_delta_diff`));
-    const [tableDiffState, setTableDiffState] = useState({isShown: false, expandedTablePath: ""});
+    const [tableDiffState, setTableDiffState] = useState({isShown: false, expandedTablePath: "", expandedTableName: ""});
 
     if (results.length === 0) {
         return <div className="tree-container">
@@ -198,7 +199,7 @@ export const ChangesTreeContainer = ({results, showExperimentalDeltaDiffButton =
                                           variant="secondary"
                                           disabled={false}
                                           onClick={() => {
-                                              setTableDiffState( {isShown: false, expandedTablePath: ""})
+                                              setTableDiffState( {isShown: false, expandedTablePath: "", expandedTableName: ""})
                                               if (setIsTableMerge) {
                                                   setIsTableMerge(false);
                                               }
@@ -210,9 +211,13 @@ export const ChangesTreeContainer = ({results, showExperimentalDeltaDiffButton =
                     }
                     <Card>
                         <Card.Header>
+                            {tableDiffState.isShown
+                                ? tableDiffState.expandedTableName
+                                :
                                 <span className="float-start">
                                     {(delimiter !== "") && uriNavigator}
                                 </span>
+                            }
                         </Card.Header>
                         <Card.Body>
                             {tableDiffState.isShown
@@ -229,12 +234,9 @@ export const ChangesTreeContainer = ({results, showExperimentalDeltaDiffButton =
                                                      onNavigate={onNavigate}
                                                      getMore={getMore}
                                                      onRevert={onRevert}
-                                                     setTableDiffExpanded={() => {
-                                                         setTableDiffState({isShown: true,  expandedTablePath: entry.path})
-                                                         if (setIsTableMerge) {
-                                                             setIsTableMerge(true);
-                                                         }
-                                                     }}
+                                                     setTableDiffExpanded={onTableDiffExpansion(entry, setTableDiffState, setIsTableMerge)}
+                                                     setTableDiffState={setTableDiffState}
+                                                     setIsTableMerge={setIsTableMerge}
                                                  />);
                                 })}
                                 {!!nextPage &&
@@ -251,6 +253,15 @@ export const ChangesTreeContainer = ({results, showExperimentalDeltaDiffButton =
 export const defaultGetMoreChanges = (repo, leftRefId, rightRefId, delimiter) => (afterUpdated, path, useDelimiter= true, amount = -1) => {
     return refs.diff(repo.id, leftRefId, rightRefId, afterUpdated, path, useDelimiter ? delimiter : "", amount > 0 ? amount : undefined);
 };
+
+const onTableDiffExpansion = (entry, setTableDiffState, setIsTableMerge) => () => {
+    const pathParts = entry.path.split('/');
+    const tableName = pathParts.pop() || pathParts.pop();  // handle trailing slash at the end of table name
+    setTableDiffState({isShown: true,  expandedTablePath: entry.path, expandedTableName: tableName})
+    if (setIsTableMerge) {
+        setIsTableMerge(true);
+    }
+}
 
 const ExperimentalDeltaDiffButton = ({showButton = false}) => {
     const [showComingSoonModal, setShowComingSoonModal] = useState(false);


### PR DESCRIPTION
## Change Description
    
Up until now, the delta lake diff view didn't include the name of the table the diff is for. with this pr, table names are preserved while switching to a table diff view. 

### Testing Details

Tested manually with tables of different path depths. 

---

## Additional info
<img width="1369" alt="Screenshot 2023-03-08 at 10 58 01" src="https://user-images.githubusercontent.com/14786381/223668652-ff3a56b0-3d11-4fd5-9bf4-2cb46d19305a.png">
<img width="1439" alt="Screenshot 2023-03-08 at 10 58 09" src="https://user-images.githubusercontent.com/14786381/223668647-92082abc-8079-4df6-9222-bbe2b45068f9.png">
<img width="1353" alt="Screenshot 2023-03-08 at 10 58 19" src="https://user-images.githubusercontent.com/14786381/223668645-aa85f299-7178-4e03-9aa1-54dad25772a0.png">
<img width="1392" alt="Screenshot 2023-03-08 at 10 58 29" src="https://user-images.githubusercontent.com/14786381/223668635-bcc50179-1063-41e9-b1ea-86c2710fe1b0.png">
