### PR TITLE
Delta Diff MVP: add makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ GOCMD=$(or $(shell which go), $(error "Missing dependency - no go in PATH"))
 DOCKER=$(or $(shell which docker), $(error "Missing dependency - no docker in PATH"))
 GOBINPATH=$(shell $(GOCMD) env GOPATH)/bin
 NPM=$(or $(shell which npm), $(error "Missing dependency - no npm in PATH"))
+CARGOCMD=$(or $(shell which cargo), $(error "Missing dependency - no cargo in PATH"))
 
 UID_GID := $(shell id -u):$(shell id -g)
 
@@ -263,3 +264,7 @@ help:  ## Show Help menu
 
 # helpers
 gen: gen-ui gen-api clients gen-docs
+
+delta-plugin:
+	$(CARGOCMD) clean --manifest-path pkg/plugins/diff/delta_diff_server/Cargo.toml
+	$(CARGOCMD) build --release --manifest-path pkg/plugins/diff/delta_diff_server/Cargo.toml

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@ GOCMD=$(or $(shell which go), $(error "Missing dependency - no go in PATH"))
 DOCKER=$(or $(shell which docker), $(error "Missing dependency - no docker in PATH"))
 GOBINPATH=$(shell $(GOCMD) env GOPATH)/bin
 NPM=$(or $(shell which npm), $(error "Missing dependency - no npm in PATH"))
-CARGOCMD=$(or $(shell which cargo), $(error "Missing dependency - no cargo in PATH"))
 
 UID_GID := $(shell id -u):$(shell id -g)
 
@@ -266,5 +265,6 @@ help:  ## Show Help menu
 gen: gen-ui gen-api clients gen-docs
 
 delta-plugin:
+	CARGOCMD=$(or $(shell which cargo), $(error "Missing dependency - no cargo in PATH"))
 	$(CARGOCMD) clean --manifest-path pkg/plugins/diff/delta_diff_server/Cargo.toml
 	$(CARGOCMD) build --release --manifest-path pkg/plugins/diff/delta_diff_server/Cargo.toml


### PR DESCRIPTION
### Linked Issue

Closes #4974

---

## Change Description

Added a target to lakeFS's makefile to build the Delta Lake diff plugin.
Notice that it demands that the runtime will include `cargo` to build it. in order to make it easier for other users to develop and build lakeFS, the Delta Lake diff plugin target isn't a part of the `all` target. 
