### PR TITLE
Bug fix: identify treeItem types consistently

### DIFF
--- a/webui/src/constants.ts
+++ b/webui/src/constants.ts
@@ -14,4 +14,9 @@ export enum OtfDiffType {
     Dropped = "dropped",
     Changed = "changed",
 }
+export enum TreeRowType {
+    Object,
+    Prefix,
+    Table
+}
 

--- a/webui/src/lib/components/repository/changes.jsx
+++ b/webui/src/lib/components/repository/changes.jsx
@@ -141,19 +141,18 @@ function useTreeItemType(entry, repo, leftDiffRefID, rightDiffRefID) {
     let leftResult = useAPI(() => tablesUtil.isDeltaLakeTable(entry, repo, rightDiffRefID));
     let rightResult = useAPI(() => tablesUtil.isDeltaLakeTable(entry, repo, leftDiffRefID));
     useEffect(() => {
-        if (entry.path_type === "object") {
-            setTreeItemType({ type: TreeItemType.Object, loading: false });
-        }
-    }, [entry]);
-    useEffect(() => {
-        if (treeItemType.loading && !leftResult.loading && !rightResult.loading) {
-            setTreeItemType({
-                type:
-                    leftResult.response || rightResult.response
-                        ? TreeItemType.DeltaLakeTable
-                        : TreeItemType.Prefix,
-                loading: false,
-            });
+        if (treeItemType.loading) {
+            if (entry.path_type === "object") {
+                setTreeItemType({ type: TreeItemType.Object, loading: false });
+            } else if (!leftResult.loading && !rightResult.loading) {
+                setTreeItemType({
+                    type:
+                        leftResult.response || rightResult.response
+                            ? TreeItemType.DeltaLakeTable
+                            : TreeItemType.Prefix,
+                    loading: false,
+                });
+            }
         }
     }, [leftResult, rightResult]);
     return treeItemType;

--- a/webui/src/lib/components/repository/changes.jsx
+++ b/webui/src/lib/components/repository/changes.jsx
@@ -154,7 +154,7 @@ function useTreeItemType(entry, repo, leftDiffRefID, rightDiffRefID) {
                 });
             }
         }
-    }, [leftResult, rightResult]);
+    }, [leftResult, rightResult, entry]);
     return treeItemType;
 }
 

--- a/webui/src/lib/components/repository/treeRows.jsx
+++ b/webui/src/lib/components/repository/treeRows.jsx
@@ -13,6 +13,7 @@ import {ConfirmationModal} from "../modals";
 import {OverlayTrigger} from "react-bootstrap";
 import Tooltip from "react-bootstrap/Tooltip";
 import Button from "react-bootstrap/Button";
+import {TreeRowType} from "../../../constants";
 
 class RowAction {
     /**
@@ -51,7 +52,7 @@ export const ObjectTreeEntryRow = ({entry, relativeTo = "", diffExpanded, depth 
     const [showRevertConfirm, setShowRevertConfirm] = useState(false)
     let rowClass = 'tree-entry-row ' + diffType(entry);
     let pathSection = extractPathText(entry, relativeTo);
-    const diffIndicator = <DiffIndicationIcon entry={entry}/>;
+    const diffIndicator = <DiffIndicationIcon entry={entry} rowType={TreeRowType.Object}/>;
 
     const rowActions = []
     if (onClickExpandDiff) {
@@ -73,7 +74,7 @@ export const PrefixTreeEntryRow = ({entry, relativeTo = "", dirExpanded, depth =
     const [showRevertConfirm, setShowRevertConfirm] = useState(false)
     let rowClass = 'tree-entry-row ' + diffType(entry);
     let pathSection = extractPathText(entry, relativeTo);
-    let diffIndicator = <DiffIndicationIcon entry={entry}/>;
+    let diffIndicator = <DiffIndicationIcon entry={entry} rowType={TreeRowType.Prefix}/>;
     const [showSummary, setShowSummary] = useState(false);
     if (entry.path_type === "common_prefix") {
         pathSection = <Link href={onNavigate(entry)}>{pathSection}</Link>
@@ -99,7 +100,7 @@ export const TableTreeEntryRow = ({entry, relativeTo = "", onClickExpandDiff, de
     const [showRevertConfirm, setShowRevertConfirm] = useState(false)
     let rowClass = 'tree-entry-row ' + diffType(entry);
     let pathSection = extractTableName(entry, relativeTo);
-    const diffIndicator = <DiffIndicationIcon entry={entry} isTableRow={true}/>
+    const diffIndicator = <DiffIndicationIcon entry={entry} rowType={TreeRowType.Table}/>
 
     const rowActions = []
     rowActions.push(new RowAction(<DiffIcon/>, "Show table changes", true, onClickExpandDiff))
@@ -178,43 +179,42 @@ function extractTableName(entry, relativeTo) {
     return pathText;
 }
 
-export const DiffIndicationIcon = ({entry, isTableRow = false}) => {
+export const DiffIndicationIcon = ({entry, rowType}) => {
     let diffIcon;
     let tooltipId;
     let tooltipText;
-    if (entry.path_type === 'common_prefix') {
+    if (rowType === TreeRowType.Prefix) {
         diffIcon = <FileDirectoryIcon/>;
         tooltipId = "tooltip-prefix";
         tooltipText = "Changes under prefix";
-    }
-    if (isTableRow) {
+    } else if (rowType === TreeRowType.Table) {
         diffIcon = <TableIcon/>;
         tooltipId = "tooltip-table";
         tooltipText = "Table changed"
-    }
-
-    switch (entry.type) {
-        case 'removed':
-            diffIcon = <TrashIcon/>;
-            tooltipId = "tooltip-removed";
-            tooltipText = "Removed";
-            break;
-        case 'added':
-            diffIcon = <PlusIcon/>;
-            tooltipId = "tooltip-added";
-            tooltipText = "Added";
-            break;
-        case 'changed':
-            diffIcon = <PencilIcon/>;
-            tooltipId = "tooltip-changed";
-            tooltipText = "Changed";
-            break;
-        case 'conflict':
-            diffIcon = <CircleSlashIcon/>;
-            tooltipId = "tooltip-conflict";
-            tooltipText = "Conflict";
-            break;
-        default:
+    } else {
+        switch (entry.type) {
+            case 'removed':
+                diffIcon = <TrashIcon/>;
+                tooltipId = "tooltip-removed";
+                tooltipText = "Removed";
+                break;
+            case 'added':
+                diffIcon = <PlusIcon/>;
+                tooltipId = "tooltip-added";
+                tooltipText = "Added";
+                break;
+            case 'changed':
+                diffIcon = <PencilIcon/>;
+                tooltipId = "tooltip-changed";
+                tooltipText = "Changed";
+                break;
+            case 'conflict':
+                diffIcon = <CircleSlashIcon/>;
+                tooltipId = "tooltip-conflict";
+                tooltipText = "Conflict";
+                break;
+            default:
+        }
     }
 
     return <OverlayTrigger placement="bottom" overlay={(<Tooltip id={tooltipId}>{tooltipText}</Tooltip>)}>


### PR DESCRIPTION
### Linked Issue

Fixes #5415

---

## Change Description

### Bug Fix

#### Problem 
Object paths are expandable and identified as prefixes after showing delta diff view. 

#### Root cause
The custom hook which calculates the treeItemType used two useEffect hooks: 
1. to check if an item is an object item. 
2. calculate other tree item types.  

The order of hooks calls is inconsistent.  

#### Solution
Combine both useEffect hooks into one and relay on its internal order. 

### Testing Details
Tested manually 

