### PR TITLE
Pin just-the-docs version

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -11,7 +11,7 @@ aux_links_new_tab: true
 logo: '/assets/logo.svg'
 logo_link: 'https://lakefs.io'
 
-remote_theme: pmarsceill/just-the-docs
+remote_theme: pmarsceill/just-the-docs@v0.4.1
 
 
 


### PR DESCRIPTION
This pins the [just-the-docs](https://just-the-docs.github.io/just-the-docs/MIGRATION/) theme version to avoid potential breaking changes in the future. 
As it currently stands IIUC the docs build will pull the latest version of the theme each time. 

WDYT @adipolak ? 