### PR TITLE
Add default Utc TZ env var to jekyll example

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -166,7 +166,7 @@ To render the documentation locally and preview changes you can run the Jeykll s
    This can take a short while—you'll see something like this in the server's output when it's done. 
    
    ```
-   ...done in 34.714073461 seconds.
+   ...done in 34.714073460 seconds.
    ```
 
    Your page will automatically reload to show the changes.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -138,6 +138,7 @@ To render the documentation locally and preview changes you can run the Jeykll s
    ```sh
    docker run --rm \
               --name lakefs_docs \
+              -e TZ="Etc/UTC" \
               --publish 4000:4000 --publish 35729:35729 \
               --volume="$PWD/docs:/srv/jekyll:Z" \
               --volume="$PWD/docs/.jekyll-bundle-cache:/usr/local/bundle:Z" \


### PR DESCRIPTION
The Jekyll container defaults to Chicago TZ. This PR sets it to UTC and 
in doing so gives the user an example of what to change if they want it in
their own local TZ.  
