### PR TITLE
Make storage namespace reuse message clearer

### DIFF
--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -1423,7 +1423,7 @@ func (c *Controller) CreateRepository(w http.ResponseWriter, r *http.Request, bo
 	writeResponse(w, r, http.StatusCreated, response)
 }
 
-var errStorageNamespaceInUse = errors.New("lakeFS repositories can't share storage namespace. This includes re-using storage namespaces from repositories since deleted.")
+var errStorageNamespaceInUse = errors.New("lakeFS repositories can't share storage namespace. This includes re-using storage namespaces from repositories since deleted")
 
 func (c *Controller) ensureStorageNamespace(ctx context.Context, storageNamespace string) error {
 	const (

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -1423,7 +1423,7 @@ func (c *Controller) CreateRepository(w http.ResponseWriter, r *http.Request, bo
 	writeResponse(w, r, http.StatusCreated, response)
 }
 
-var errStorageNamespaceInUse = errors.New("lakeFS repositories can't share storage namespace")
+var errStorageNamespaceInUse = errors.New("lakeFS repositories can't share storage namespace. This includes re-using storage namespaces from repositories since deleted.")
 
 func (c *Controller) ensureStorageNamespace(ctx context.Context, storageNamespace string) error {
 	const (


### PR DESCRIPTION
### Linked Issue

Closes #5363

---

## Change Description

### Background

One of the common actions a user test-driving lakeFS might do is creating and recreating repositories. 

This PR adds detail to the message that the user gets if they try to recreate a repo with the same name as 
one already used. 
      
### Testing Details

Local build and walk through to validate the error and repository creation. 

https://user-images.githubusercontent.com/3671582/224657529-c095187c-9b85-4d9b-9dac-30dc9c14d0da.mp4

