### PR TITLE
Add dependency note re. linting

### DIFF
--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -86,7 +86,7 @@ Check that linting rules are passing.
 make checks-validator
 ```
 
-You will need diffutils to run this. On the Mac it can be installed with `brew install diffutils`
+You will need GNU diff to run this. On the macOS it can be installed with `brew install diffutils`
 {: .note .note-info }
 
 lakeFS uses [go fmt](https://golang.org/cmd/gofmt/) as a style guide for Go code.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -80,11 +80,15 @@ Run unit tests:
 make test
 ```
 
-Check that linting rules are passing:
+Check that linting rules are passing. 
 
 ```shell
 make checks-validator
 ```
+
+You will need diffutils to run this. On the Mac it can be installed with `brew install diffutils`
+{: .note .note-info }
+
 lakeFS uses [go fmt](https://golang.org/cmd/gofmt/) as a style guide for Go code.
 
 Run system-tests:


### PR DESCRIPTION
Without [`diffutils`](https://www.gnu.org/software/diffutils/) installed `make checks-validator` fails: 

```bash
/opt/homebrew/bin/go mod download
/opt/homebrew/bin/go install github.com/golangci/golangci-lint/cmd/golangci-lint
/opt/homebrew/bin/go install google.golang.org/protobuf/cmd/protoc-gen-go
/Users/rmoff/go/bin/golangci-lint run
WARN [runner] Can't run linter goanalysis_metalinter: gofmt: can't extract issues from gofmt diff output "--- /Users/rmoff/git/lakeFS/pkg/permissions/actions.gen.go.orig\t2023-03-13 11:30:11\n+++ /Users/rmoff/git/lakeFS/pkg/permissions/actions.gen.go\t2023-03-13 11:30:11\n@@ -1,5 +1,4 @@\n // Code generated by extract_actions. DO NOT EDIT.\n-//\n package permissions\n \n var Actions = []string{\n": can't parse patch: parsing time "2023-03-13 11:30:11" as "2006-01-02 15:04:05 -0700": cannot parse "" as "-0700"
ERRO Running error: 1 error occurred:
        * can't run linter goanalysis_metalinter: gofmt: can't extract issues from gofmt diff output "--- /Users/rmoff/git/lakeFS/pkg/permissions/actions.gen.go.orig\t2023-03-13 11:30:11\n+++ /Users/rmoff/git/lakeFS/pkg/permissions/actions.gen.go\t2023-03-13 11:30:11\n@@ -1,5 +1,4 @@\n // Code generated by extract_actions. DO NOT EDIT.\n-//\n package permissions\n \n var Actions = []string{\n": can't parse patch: parsing time "2023-03-13 11:30:11" as "2006-01-02 15:04:05 -0700": cannot parse "" as "-0700"

make: *** [lint] Error 3
```

On the Mac the solution is to `brew install diffutils`. 