### PR TITLE
Use background context for batched code execution

### DIFF
--- a/pkg/batch/executor_test.go
+++ b/pkg/batch/executor_test.go
@@ -94,7 +94,7 @@ func testReadAfterWrite(t *testing.T) {
 
 	// reader1 starts
 	go func() {
-		r1, _ := exec.BatchFor(context.Background(), "k", time.Millisecond*50, batch.BatchFn(func() (interface{}, error) {
+		r1, _ := exec.BatchFor(context.Background(), "k", time.Millisecond*50, batch.ExecuterFunc(func() (interface{}, error) {
 			version, _ := db.Get("v")
 			return version, nil
 		}))
@@ -157,7 +157,7 @@ func testBatchExpiration(t *testing.T) {
 
 	// reader1 starts
 	go func() {
-		r1, _ := exec.BatchFor(context.Background(), "k", time.Millisecond*50, batch.BatchFn(func() (interface{}, error) {
+		r1, _ := exec.BatchFor(context.Background(), "k", time.Millisecond*50, batch.ExecuterFunc(func() (interface{}, error) {
 			return "v1", nil
 		}))
 		if r1 != "v1" {
@@ -168,7 +168,7 @@ func testBatchExpiration(t *testing.T) {
 
 	go func() {
 		<-read1Done // ensure r2 starts after r1 has returned
-		r2, _ := exec.BatchFor(context.Background(), "k", time.Millisecond*50, batch.BatchFn(func() (interface{}, error) {
+		r2, _ := exec.BatchFor(context.Background(), "k", time.Millisecond*50, batch.ExecuterFunc(func() (interface{}, error) {
 			return "v2", nil
 		}))
 		if r2 != "v2" {


### PR DESCRIPTION
The current BatchFor mechanism will use the first callback to perform the work for all callers on the same batch key.

In the case the used context in the callback is canceled (example by client disconnect or context timeout) the result will be returned to all callers.

Updated all the context use in these scope to use context.Background().

Changelog: handle

Fix #5502