### PR TITLE
Fix: Local adapter check address on stage

### DIFF
--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -3347,6 +3347,8 @@ paths:
           $ref: "#/components/responses/ValidationError"
         401:
           $ref: "#/components/responses/Unauthorized"
+        403:
+          $ref: "#/components/responses/Forbidden"
         404:
           $ref: "#/components/responses/NotFound"
         default:

--- a/clients/java/api/openapi.yaml
+++ b/clients/java/api/openapi.yaml
@@ -3825,6 +3825,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: Unauthorized
+        "403":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Forbidden
         "404":
           content:
             application/json:

--- a/clients/java/docs/ObjectsApi.md
+++ b/clients/java/docs/ObjectsApi.md
@@ -802,6 +802,7 @@ public class Example {
 | **201** | object metadata |  -  |
 | **400** | Validation Error |  -  |
 | **401** | Unauthorized |  -  |
+| **403** | Forbidden |  -  |
 | **404** | Resource Not Found |  -  |
 | **0** | Internal Server Error |  -  |
 

--- a/clients/java/src/main/java/io/lakefs/clients/api/ObjectsApi.java
+++ b/clients/java/src/main/java/io/lakefs/clients/api/ObjectsApi.java
@@ -1300,6 +1300,7 @@ public class ObjectsApi {
         <tr><td> 201 </td><td> object metadata </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Validation Error </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized </td><td>  -  </td></tr>
+        <tr><td> 403 </td><td> Forbidden </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Resource Not Found </td><td>  -  </td></tr>
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
@@ -1396,6 +1397,7 @@ public class ObjectsApi {
         <tr><td> 201 </td><td> object metadata </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Validation Error </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized </td><td>  -  </td></tr>
+        <tr><td> 403 </td><td> Forbidden </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Resource Not Found </td><td>  -  </td></tr>
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
@@ -1420,6 +1422,7 @@ public class ObjectsApi {
         <tr><td> 201 </td><td> object metadata </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Validation Error </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized </td><td>  -  </td></tr>
+        <tr><td> 403 </td><td> Forbidden </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Resource Not Found </td><td>  -  </td></tr>
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
@@ -1446,6 +1449,7 @@ public class ObjectsApi {
         <tr><td> 201 </td><td> object metadata </td><td>  -  </td></tr>
         <tr><td> 400 </td><td> Validation Error </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized </td><td>  -  </td></tr>
+        <tr><td> 403 </td><td> Forbidden </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Resource Not Found </td><td>  -  </td></tr>
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>

--- a/clients/python/docs/apis/tags/ObjectsApi.md
+++ b/clients/python/docs/apis/tags/ObjectsApi.md
@@ -1943,6 +1943,7 @@ n/a | api_client.ApiResponseWithoutDeserialization | When skip_deserialization i
 201 | [ApiResponseFor201](#stage_object.ApiResponseFor201) | object metadata
 400 | [ApiResponseFor400](#stage_object.ApiResponseFor400) | Validation Error
 401 | [ApiResponseFor401](#stage_object.ApiResponseFor401) | Unauthorized
+403 | [ApiResponseFor403](#stage_object.ApiResponseFor403) | Forbidden
 404 | [ApiResponseFor404](#stage_object.ApiResponseFor404) | Resource Not Found
 default | [ApiResponseForDefault](#stage_object.ApiResponseForDefault) | Internal Server Error
 
@@ -1980,6 +1981,19 @@ body | typing.Union[SchemaFor401ResponseBodyApplicationJson, ] |  |
 headers | Unset | headers were not defined |
 
 # SchemaFor401ResponseBodyApplicationJson
+Type | Description  | Notes
+------------- | ------------- | -------------
+[**Error**](../../models/Error.md) |  | 
+
+
+#### stage_object.ApiResponseFor403
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+response | urllib3.HTTPResponse | Raw response |
+body | typing.Union[SchemaFor403ResponseBodyApplicationJson, ] |  |
+headers | Unset | headers were not defined |
+
+# SchemaFor403ResponseBodyApplicationJson
 Type | Description  | Notes
 ------------- | ------------- | -------------
 [**Error**](../../models/Error.md) |  | 

--- a/clients/python/lakefs_client/paths/repositories_repository_branches_branch_objects/put.py
+++ b/clients/python/lakefs_client/paths/repositories_repository_branches_branch_objects/put.py
@@ -167,6 +167,25 @@ _response_for_401 = api_client.OpenApiResponse(
             schema=SchemaFor401ResponseBodyApplicationJson),
     },
 )
+SchemaFor403ResponseBodyApplicationJson = Error
+
+
+@dataclass
+class ApiResponseFor403(api_client.ApiResponse):
+    response: urllib3.HTTPResponse
+    body: typing.Union[
+        SchemaFor403ResponseBodyApplicationJson,
+    ]
+    headers: schemas.Unset = schemas.unset
+
+
+_response_for_403 = api_client.OpenApiResponse(
+    response_cls=ApiResponseFor403,
+    content={
+        'application/json': api_client.MediaType(
+            schema=SchemaFor403ResponseBodyApplicationJson),
+    },
+)
 SchemaFor404ResponseBodyApplicationJson = Error
 
 
@@ -209,6 +228,7 @@ _status_code_to_response = {
     '201': _response_for_201,
     '400': _response_for_400,
     '401': _response_for_401,
+    '403': _response_for_403,
     '404': _response_for_404,
     'default': _response_for_default,
 }

--- a/clients/python/lakefs_client/paths/repositories_repository_branches_branch_objects/put.pyi
+++ b/clients/python/lakefs_client/paths/repositories_repository_branches_branch_objects/put.pyi
@@ -158,6 +158,25 @@ _response_for_401 = api_client.OpenApiResponse(
             schema=SchemaFor401ResponseBodyApplicationJson),
     },
 )
+SchemaFor403ResponseBodyApplicationJson = Error
+
+
+@dataclass
+class ApiResponseFor403(api_client.ApiResponse):
+    response: urllib3.HTTPResponse
+    body: typing.Union[
+        SchemaFor403ResponseBodyApplicationJson,
+    ]
+    headers: schemas.Unset = schemas.unset
+
+
+_response_for_403 = api_client.OpenApiResponse(
+    response_cls=ApiResponseFor403,
+    content={
+        'application/json': api_client.MediaType(
+            schema=SchemaFor403ResponseBodyApplicationJson),
+    },
+)
 SchemaFor404ResponseBodyApplicationJson = Error
 
 

--- a/docs/assets/js/swagger.yml
+++ b/docs/assets/js/swagger.yml
@@ -3347,6 +3347,8 @@ paths:
           $ref: "#/components/responses/ValidationError"
         401:
           $ref: "#/components/responses/Unauthorized"
+        403:
+          $ref: "#/components/responses/Forbidden"
         404:
           $ref: "#/components/responses/NotFound"
         default:

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -2295,8 +2295,7 @@ func (c *Controller) StageObject(w http.ResponseWriter, r *http.Request, body St
 	}
 	// write metadata
 	qk, err := c.BlockAdapter.ResolveNamespace(repo.StorageNamespace, body.PhysicalAddress, block.IdentifierTypeFull)
-	if err != nil {
-		writeError(w, r, http.StatusInternalServerError, err)
+	if c.handleAPIError(ctx, w, r, err) {
 		return
 	}
 

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -12,6 +12,7 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"path/filepath"
 	"reflect"
 	"regexp"
@@ -36,6 +37,7 @@ import (
 	"github.com/treeverse/lakefs/pkg/block"
 	"github.com/treeverse/lakefs/pkg/catalog"
 	"github.com/treeverse/lakefs/pkg/catalog/testutils"
+	"github.com/treeverse/lakefs/pkg/config"
 	"github.com/treeverse/lakefs/pkg/graveler"
 	"github.com/treeverse/lakefs/pkg/httputil"
 	"github.com/treeverse/lakefs/pkg/ingest/store"
@@ -4444,4 +4446,29 @@ func generateJWTToken(authService auth.Service, username string) *securityprovid
 	apiToken, _ := api.GenerateJWTLogin(secret, username, now, expires)
 	authProvider, _ := securityprovider.NewSecurityProviderApiKey("header", "Authorization", "Bearer "+apiToken)
 	return authProvider
+}
+
+func TestController_LocalAdapter_StageObject(t *testing.T) {
+	path := os.TempDir()
+	forbiddenPath := "local:///not_allowed"
+	viper.Set(config.BlockstoreTypeKey, block.BlockstoreTypeLocal)
+	viper.Set("blockstore.local.path", path)
+	clt, deps := setupClientWithAdmin(t)
+	ctx := context.Background()
+
+	repo := testUniqueRepoName()
+	_, err := deps.catalog.CreateRepository(ctx, repo, onBlock(deps, "bucket/prefix"), "main")
+	require.NoError(t, err)
+	_, err = deps.catalog.CreateBranch(ctx, repo, "alt", "main")
+	require.NoError(t, err)
+
+	t.Run("stage_forbidden_address", func(t *testing.T) {
+		resp, err := clt.StageObjectWithResponse(ctx, repo, "main", &api.StageObjectParams{
+			Path: "some_path",
+		}, api.StageObjectJSONRequestBody{
+			PhysicalAddress: forbiddenPath,
+		})
+		require.NoError(t, err)
+		require.NotNil(t, resp.JSON403)
+	})
 }

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -12,7 +12,6 @@ import (
 	"net"
 	"net/http"
 	"net/http/httptest"
-	"os"
 	"path/filepath"
 	"reflect"
 	"regexp"
@@ -4449,10 +4448,10 @@ func generateJWTToken(authService auth.Service, username string) *securityprovid
 }
 
 func TestController_LocalAdapter_StageObject(t *testing.T) {
-	path := os.TempDir()
+	p := t.TempDir()
 	forbiddenPath := "local:///not_allowed"
 	viper.Set(config.BlockstoreTypeKey, block.BlockstoreTypeLocal)
-	viper.Set("blockstore.local.path", path)
+	viper.Set("blockstore.local.path", p)
 	clt, deps := setupClientWithAdmin(t)
 	ctx := context.Background()
 

--- a/pkg/api/serve_test.go
+++ b/pkg/api/serve_test.go
@@ -121,7 +121,7 @@ func createDefaultAdminUser(t testing.TB, clt api.ClientWithResponsesInterface) 
 func setupHandlerWithWalkerFactory(t testing.TB, factory catalog.WalkerFactory) (http.Handler, *dependencies) {
 	t.Helper()
 	ctx := context.Background()
-	viper.Set("blockstore.type", block.BlockstoreTypeMem)
+	viper.SetDefault(config.BlockstoreTypeKey, block.BlockstoreTypeMem)
 	viper.Set("database.type", mem.DriverName)
 
 	collector := &memCollector{}

--- a/pkg/api/serve_test.go
+++ b/pkg/api/serve_test.go
@@ -121,7 +121,10 @@ func createDefaultAdminUser(t testing.TB, clt api.ClientWithResponsesInterface) 
 func setupHandlerWithWalkerFactory(t testing.TB, factory catalog.WalkerFactory) (http.Handler, *dependencies) {
 	t.Helper()
 	ctx := context.Background()
-	viper.SetDefault(config.BlockstoreTypeKey, block.BlockstoreTypeMem)
+
+	if viper.Get(config.BlockstoreTypeKey) == nil {
+		viper.Set(config.BlockstoreTypeKey, block.BlockstoreTypeMem)
+	}
 	viper.Set("database.type", mem.DriverName)
 
 	collector := &memCollector{}

--- a/pkg/block/local/adapter.go
+++ b/pkg/block/local/adapter.go
@@ -542,7 +542,17 @@ func (l *Adapter) GetStorageNamespaceInfo() block.StorageNamespaceInfo {
 func (l *Adapter) ResolveNamespace(storageNamespace, key string, identifierType block.IdentifierType) (block.QualifiedKey, error) {
 	qk, err := block.DefaultResolveNamespace(storageNamespace, key, identifierType)
 	if err != nil {
-		return qk, err
+		return nil, err
+	}
+
+	// Check if path allowed and return error if path is not allowed
+	_, err = l.extractParamsFromObj(block.ObjectPointer{
+		StorageNamespace: storageNamespace,
+		Identifier:       key,
+		IdentifierType:   identifierType,
+	})
+	if err != nil {
+		return nil, err
 	}
 
 	return QualifiedKey{

--- a/pkg/gateway/testutil/gateway_setup.go
+++ b/pkg/gateway/testutil/gateway_setup.go
@@ -32,7 +32,7 @@ type Dependencies struct {
 
 func GetBasicHandler(t *testing.T, authService *FakeAuthService, repoName string) (http.Handler, *Dependencies) {
 	ctx := context.Background()
-	viper.Set("blockstore.type", block.BlockstoreTypeMem)
+	viper.Set(config.BlockstoreTypeKey, block.BlockstoreTypeMem)
 
 	store := kvtest.MakeStoreByName("mem", kvparams.Config{})(t, ctx)
 	defer store.Close()

--- a/pkg/loadtest/local_load_test.go
+++ b/pkg/loadtest/local_load_test.go
@@ -35,7 +35,7 @@ func TestLocalLoad(t *testing.T) {
 
 	// Only once
 	ctx := context.Background()
-	viper.Set("blockstore.type", block.BlockstoreTypeLocal)
+	viper.Set(config.BlockstoreTypeKey, block.BlockstoreTypeLocal)
 
 	conf, err := config.NewConfig()
 	testutil.MustDo(t, "config", err)


### PR DESCRIPTION
<!-- 
Hello Axolotl!
Thank you for contributing to the lakeFS project.
We appreciate the time invested in this pull request and created this template to help make this process easier.
It's really important to have all the information and context, to ensure we can properly address this PR 
Please use the following references to fill out the pull request.
--> 

### Linked Issue

Closes #5361

---

## Change Description

### Background

Enabling local import - we need to check that stageObject api doesn't allow staging physical addresses which are not allowed by the local block adapter

### Bug Fix

Added check when resolving namespace to return error if address is not part of the block adapter's allowed prefixes

### Testing Details

Added new controller unit test for this specific scenario

### Breaking Change?

Nyet