### PR TITLE
Fix goreleaser + promote to 0.97.2

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -54,8 +54,7 @@ archives:
     {{ .ProjectName }}_
     {{ .Version }}_
     {{ tolower .Os }}_
-    {{- if eq .Arch "x86_64" }}amd64
-    {{- else if eq .Arch "Darwin" }}darwin
+    {{- if eq .Arch "amd64" }}x86_64
     {{- else }}{{ .Arch }}{{ end }}
   format: tar.gz
   format_overrides:

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -50,12 +50,13 @@ archives:
   name_template: "{{ .Os }}_{{ .Arch }}/lakectl"
   builds:
    - lakectl
-- replacements:
-    darwin: Darwin
-    linux: Linux
-    windows: Windows
-    amd64: x86_64
-  id: release
+- name_template: >-
+    {{ .ProjectName }}_
+    {{ .Version }}_
+    {{ tolower .Os }}_
+    {{- if eq .Arch "x86_64" }}amd64
+    {{- else if eq .Arch "Darwin" }}darwin
+    {{- else }}{{ .Arch }}{{ end }}
   format: tar.gz
   format_overrides:
     - goos: windows
@@ -63,7 +64,6 @@ archives:
   files:
     - src: '{{ .Env.DELTA_ARTIFACTS_LOCATION }}/delta-{{ tolower .Os }}-{{ tolower .Arch }}/delta_diff*'
       strip_parent: true
-  name_template: "{{.ProjectName}}_{{.Version}}_{{ .Os }}_{{ .Arch }}"
   builds:
    - lakefs
    - lakectl

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -53,7 +53,7 @@ archives:
 - name_template: >-
     {{ .ProjectName }}_
     {{ .Version }}_
-    {{ tolower .Os }}_
+    {{- title .Os }}_
     {{- if eq .Arch "amd64" }}x86_64
     {{- else }}{{ .Arch }}{{ end }}
   format: tar.gz

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## UNRELEASED
 
-## v0.97.1
+## v0.97.2
 
 :new: What's new:
 


### PR DESCRIPTION
* `archives.replacements` is [deprecated](https://goreleaser.com/deprecations/#archivesreplacements). 
* removed the `id` field from the archive so that it would be released.
* promoted the version to 0.97.2