### PR TITLE
Delta Lake Diff: Structured config + Error handling

### DIFF
--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -4016,6 +4016,11 @@ func (c *Controller) OtfDiff(w http.ResponseWriter, r *http.Request, repository,
 
 	entries, err := c.otfDiffService.RunDiff(ctx, params.Type, tdp)
 	if err != nil {
+		c.Logger.WithError(err).
+			WithField("type", params.Type).
+			WithField("table_diff_paths", fmt.Sprintf("%+v", tdp.TablePaths)).
+			WithField("repo", tdp.Repo).
+			Error("OTF Diff service failed")
 		if errors.Is(err, tablediff.ErrTableNotFound) {
 			writeError(w, r, http.StatusNotFound, err)
 		} else {

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -4017,6 +4017,7 @@ func (c *Controller) OtfDiff(w http.ResponseWriter, r *http.Request, repository,
 	entries, err := c.otfDiffService.RunDiff(ctx, params.Type, tdp)
 	if err != nil {
 		c.Logger.WithError(err).
+			WithContext(ctx).
 			WithField("type", params.Type).
 			WithField("table_diff_paths", fmt.Sprintf("%+v", tdp.TablePaths)).
 			WithField("repo", tdp.Repo).

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -4016,7 +4016,6 @@ func (c *Controller) OtfDiff(w http.ResponseWriter, r *http.Request, repository,
 
 	entries, err := c.otfDiffService.RunDiff(ctx, params.Type, tdp)
 	if err != nil {
-		c.Logger.Error(err)
 		if errors.Is(err, tablediff.ErrTableNotFound) {
 			writeError(w, r, http.StatusNotFound, err)
 		} else {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -89,9 +89,14 @@ type Plugins struct {
 	Properties  map[string]PluginProps `mapstructure:"properties"`
 }
 
+// DeltaDiffPlugin includes properties for the Delta Lake diff plugin
+type DeltaDiffPlugin struct {
+	PluginName string `mapstructure:"plugin"`
+}
+
 // DiffProps struct holds the properties that define the details necessary to run a diff.
 type DiffProps struct {
-	PluginName string `mapstructure:"plugin"`
+	Delta DeltaDiffPlugin `mapstructure:"delta"`
 }
 
 // Config - Output struct of configuration, used to validate.  If you read a key using a viper accessor
@@ -337,8 +342,8 @@ type Config struct {
 			Code string `mapstructure:"code"`
 		} `mapstructure:"snippets"`
 	} `mapstructure:"ui"`
-	Diff    map[string]DiffProps `mapstructure:"diff"`
-	Plugins Plugins              `mapstructure:"plugins"`
+	Diff    DiffProps `mapstructure:"diff"`
+	Plugins Plugins   `mapstructure:"plugins"`
 }
 
 func NewConfig() (*Config, error) {

--- a/pkg/plugins/diff/service.go
+++ b/pkg/plugins/diff/service.go
@@ -20,7 +20,7 @@ import (
 var (
 	ErrTableNotFound = errors.New("table not found")
 	ErrLoadingPlugin = errors.New("failed to load diff plugin")
-	ErrFailedDiff    = errors.New("failed running the diff")
+	ErrFailedDiff    = errors.New("failed to run diff")
 )
 
 const (

--- a/pkg/plugins/diff/service_test.go
+++ b/pkg/plugins/diff/service_test.go
@@ -27,13 +27,13 @@ func TestService_RunDiff(t *testing.T) {
 		{
 			register:    false,
 			description: "failure - no client loaded",
-			expectedErr: ErrNotFound,
+			expectedErr: ErrLoadingPlugin,
 		},
 		{
 			register:    true,
 			diffFailure: true,
 			description: "failure - internal diff failed",
-			expectedErr: ErrDiffFailed,
+			expectedErr: ErrFailedDiff,
 		},
 	}
 	for _, tc := range testCases {

--- a/pkg/plugins/diff/service_test.go
+++ b/pkg/plugins/diff/service_test.go
@@ -59,7 +59,7 @@ func Test_registerPlugins(t *testing.T) {
 	customPluginVersion := 9
 	type args struct {
 		service     *Service
-		diffProps   map[string]config.DiffProps
+		diffProps   config.DiffProps
 		pluginProps config.Plugins
 	}
 	testCases := []struct {
@@ -75,10 +75,8 @@ func Test_registerPlugins(t *testing.T) {
 			pluginName:  pluginName,
 			args: args{
 				service: NewMockService(),
-				diffProps: map[string]config.DiffProps{
-					"delta": {
-						PluginName: pluginName,
-					},
+				diffProps: config.DiffProps{
+					Delta: config.DeltaDiffPlugin{PluginName: pluginName},
 				},
 				pluginProps: config.Plugins{},
 			},
@@ -89,55 +87,8 @@ func Test_registerPlugins(t *testing.T) {
 			pluginName:  pluginName,
 			args: args{
 				service: NewMockService(),
-				diffProps: map[string]config.DiffProps{
-					"delta": {
-						PluginName: pluginName,
-					},
-				},
-				pluginProps: config.Plugins{
-					DefaultPath: "",
-					Properties: map[string]config.PluginProps{
-						pluginName: {
-							Path:    customPluginPath,
-							Version: customPluginVersion,
-						},
-					},
-				},
-			},
-		},
-		{
-			description: "register unknown diff plugins - default path - failure",
-			diffTypes:   []string{"unknown1", "unknown2", "unknown3"},
-			args: args{
-				service: NewMockService(),
-				diffProps: map[string]config.DiffProps{
-					"unknown1": {
-						PluginName: pluginName,
-					},
-					"unknown2": {
-						PluginName: pluginName,
-					},
-					"unknown3": {
-						PluginName: pluginName,
-					},
-				},
-				pluginProps: config.Plugins{},
-			},
-			expectedErr: ErrNotFound,
-		},
-		{
-			description: "register delta and unknown diff plugin - custom path and version - success for delta",
-			diffTypes:   []string{"delta"},
-			pluginName:  pluginName,
-			args: args{
-				service: NewMockService(),
-				diffProps: map[string]config.DiffProps{
-					"unknown": {
-						PluginName: "doesntmatter",
-					},
-					"delta": {
-						PluginName: pluginName,
-					},
+				diffProps: config.DiffProps{
+					Delta: config.DeltaDiffPlugin{PluginName: pluginName},
 				},
 				pluginProps: config.Plugins{
 					DefaultPath: "",


### PR DESCRIPTION
### Linked Issue

Closes #5518 

---

## Changes Description

1. Since the diff plugins require a piece of dedicated code tailored to each type of diff, it makes sense to include only diff types that are known to have such code implementations.
This PR changes the Delta Diff config structure from a map to a dedicated Delta diff struct.
2. The PR also includes changes in the error handling so that no messed-up-internal errors will result in the UI.
3. The manager will now re-register a plugin if the error was related to starting the plugin executable. This is because in some cases the user will be able to solve the issue since it would probably be related to the binary rather than lakeFS. After solving the issue, the user won't need to re-run lakeFS for changes to take effect.
