### PR TITLE
GC: Parallelize tests

### DIFF
--- a/clients/spark/build.sbt
+++ b/clients/spark/build.sbt
@@ -61,10 +61,6 @@ def generateCoreProject(buildType: BuildType) =
       // (or similar).
       //
       //     Test / parallelExecution := false,
-
-      // Uncomment to get (very) full stacktraces in test:
-      //      Test / 
-      += Tests.Argument("-oF"),
       target := file(s"target/core-${buildType.name}/"),
       buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
       buildInfoPackage := "io.treeverse.clients"

--- a/clients/spark/build.sbt
+++ b/clients/spark/build.sbt
@@ -18,6 +18,7 @@ def settingsToCompileIn(dir: String, flavour: String = "") = {
   lazy val allSettings = Seq(
     Compile / scalaSource := (ThisBuild / baseDirectory).value / dir / "src" / "main" / "scala",
     Test / scalaSource := (ThisBuild / baseDirectory).value / dir / "src" / "test" / "scala",
+    Test / testOptions += Tests.Argument("-P")
     Compile / resourceDirectory := (ThisBuild / baseDirectory).value / dir / "src" / "main" / "resources",
     Compile / PB.includePaths += (Compile / resourceDirectory).value,
     Compile / PB.protoSources += (Compile / resourceDirectory).value
@@ -62,7 +63,8 @@ def generateCoreProject(buildType: BuildType) =
       //     Test / parallelExecution := false,
 
       // Uncomment to get (very) full stacktraces in test:
-      //      Test / testOptions += Tests.Argument("-oF"),
+      //      Test / 
+      += Tests.Argument("-oF"),
       target := file(s"target/core-${buildType.name}/"),
       buildInfoKeys := Seq[BuildInfoKey](name, version, scalaVersion, sbtVersion),
       buildInfoPackage := "io.treeverse.clients"

--- a/clients/spark/build.sbt
+++ b/clients/spark/build.sbt
@@ -18,7 +18,7 @@ def settingsToCompileIn(dir: String, flavour: String = "") = {
   lazy val allSettings = Seq(
     Compile / scalaSource := (ThisBuild / baseDirectory).value / dir / "src" / "main" / "scala",
     Test / scalaSource := (ThisBuild / baseDirectory).value / dir / "src" / "test" / "scala",
-    Test / testOptions += Tests.Argument("-P"),
+    Test / testOptions += Tests.Argument("-P4"),
     Compile / resourceDirectory := (ThisBuild / baseDirectory).value / dir / "src" / "main" / "resources",
     Compile / PB.includePaths += (Compile / resourceDirectory).value,
     Compile / PB.protoSources += (Compile / resourceDirectory).value

--- a/clients/spark/build.sbt
+++ b/clients/spark/build.sbt
@@ -18,7 +18,7 @@ def settingsToCompileIn(dir: String, flavour: String = "") = {
   lazy val allSettings = Seq(
     Compile / scalaSource := (ThisBuild / baseDirectory).value / dir / "src" / "main" / "scala",
     Test / scalaSource := (ThisBuild / baseDirectory).value / dir / "src" / "test" / "scala",
-    Test / testOptions += Tests.Argument("-P")
+    Test / testOptions += Tests.Argument("-P"),
     Compile / resourceDirectory := (ThisBuild / baseDirectory).value / dir / "src" / "main" / "resources",
     Compile / PB.includePaths += (Compile / resourceDirectory).value,
     Compile / PB.protoSources += (Compile / resourceDirectory).value

--- a/clients/spark/core/src/test/scala/io/treeverse/clients/DumpSSTable.scala
+++ b/clients/spark/core/src/test/scala/io/treeverse/clients/DumpSSTable.scala
@@ -1,6 +1,4 @@
-// Standalone reader for SSTables.
-
-// Usage from SBT: "lakefs-spark-client-312-hadoop3/test:run /path/to/table.sst"
+// Benchmark standalone reader for SSTables.
 
 package io.treeverse.clients
 

--- a/clients/spark/core/src/test/scala/io/treeverse/clients/GarbageCollectorSpec.scala
+++ b/clients/spark/core/src/test/scala/io/treeverse/clients/GarbageCollectorSpec.scala
@@ -60,7 +60,7 @@ class ARangeGetter(
   }
 }
 
-class GarbageCollectorSpec extends AnyFunSpec with Matchers with SparkSessionSetup {
+class GarbageCollectorSpec extends AnyFunSpec with Matchers with SparkSessionSetup with ParallelTestExecution {
   describe("Spark") {
     it("should perform Gauss summation") {
       withSparkSession(spark => {

--- a/clients/spark/core/src/test/scala/io/treeverse/gc/UncommittedGarbageCollectorSpec.scala
+++ b/clients/spark/core/src/test/scala/io/treeverse/gc/UncommittedGarbageCollectorSpec.scala
@@ -6,6 +6,7 @@ import org.apache.commons.lang3.time.DateUtils
 import org.apache.spark.sql.Dataset
 import org.apache.spark.sql.functions.col
 import org.scalatest.BeforeAndAfter
+import org.scalatest.ParallelTestExecution
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should
 import org.scalatestplus.mockito.MockitoSugar
@@ -20,7 +21,8 @@ class UncommittedGarbageCollectorSpec
     with SparkSessionSetup
     with should.Matchers
     with BeforeAndAfter
-    with MockitoSugar {
+    with MockitoSugar
+    with ParallelTestExecution {
 
   describe("UncommittedGarbageCollector") {
     var dir: java.nio.file.Path = null


### PR DESCRIPTION
Parallelize tests for uncommitted GC spec.  There are many of these, it might make sense to parallelize running them.

(This change will only take effect with a "-P" option to scalatest, to add a parallelizing distributor).
