### PR TITLE
Fix: show GC rules missing warning not showing up

### DIFF
--- a/webui/src/pages/repositories/repository/objects.jsx
+++ b/webui/src/pages/repositories/repository/objects.jsx
@@ -1,5 +1,5 @@
 import React, {useCallback, useEffect, useRef, useState} from "react";
-import * as dayjs from 'dayjs'
+import dayjs from 'dayjs';
 import {UploadIcon} from "@primer/octicons-react";
 import {RepositoryPageLayout} from "../../../lib/components/repository/layout";
 import RefDropdown from "../../../lib/components/repository/refDropdown";


### PR DESCRIPTION
Vite will happily compile and use the prior import statement in its dev server, but not when asked to compile.

The result of this is that the GC warning works when running `npm run dev` but not in the compiled binary 🤦‍♂️
