### PR TITLE
Fix: dotgraph commit urls are broken

### DIFF
--- a/cmd/lakectl/cmd/log.go
+++ b/cmd/lakectl/cmd/log.go
@@ -101,7 +101,7 @@ var logCmd = &cobra.Command{
 
 		graph := &dotWriter{
 			w:            os.Stdout,
-			repositoryID: branchURI.Ref,
+			repositoryID: branchURI.Repository,
 		}
 		if dot {
 			graph.Start()


### PR DESCRIPTION
Fix the URLs rendered when running `lakectl log --dot`. 
Accidentally used the branch/ref instead of the repository.