### PR TITLE
Spark docs: move S3-compatible API to top

### DIFF
--- a/docs/integrations/spark.md
+++ b/docs/integrations/spark.md
@@ -20,199 +20,16 @@ redirect_from:
 
 There are two ways to use lakeFS with Spark:
 
-* Using the [lakeFS Hadoop FileSystem](#use-the-lakefs-hadoop-filesystem): Highly scalable, data flows directly from client to storage.
-* Using the lakeFS [S3-compatible API](#use-the-s3-compatible-api): Scalable and simpler to set up.
+* [With the S3-compatible API](#use-the-s3-compatible-api): Scalable and simpler to set up.
+* [With the lakeFS Hadoop FileSystem](#use-the-lakefs-hadoop-filesystem): Highly scalable, data flows directly from client to storage.
 
 {: .pb-5 }
-
-## Use the lakeFS Hadoop FileSystem
-
-If you're using lakeFS on top of S3, this mode will enhance your application's performance.
-In this mode, Spark will read and write objects directly from S3, reducing the load on the lakeFS server.
-It will still access the lakeFS server for metadata operations.
-
-After configuring the lakeFS Hadoop FileSystem below, use URIs of the form `lakefs://example-repo/ref/path/to/data` to
-interact with your data on lakeFS.
-
-### Installation
-
-<div class="tabs">
-  <ul>
-    <li><a href="#install-standalone">Spark Standalone</a></li>
-    <li><a href="#install-databricks">Databricks</a></li>
-  </ul> 
-  <div markdown="1" id="install-standalone">
-
-  Add the package to your `spark-submit` command:
-
-  ```
-  --packages io.lakefs:hadoop-lakefs-assembly:0.1.12
-  ```
-
-  </div>
-  <div markdown="2" id="install-databricks">
-In  your cluster settings, under the _Libraries_ tab, add the following Maven package:
-
-```
-io.lakefs:hadoop-lakefs-assembly:0.1.12
-```
-
-Once installed, it should look something like this:
-
-![Databricks - Adding the lakeFS client Jar](../assets/img/databricks-install-package.png)
-  
-  </div>
-</div>
-
-
-### Configuration
-
-Set the `fs.lakefs.*` Hadoop configurations to point to your lakeFS installation:
-* `fs.lakefs.impl`: `io.lakefs.LakeFSFileSystem`
-* `fs.lakefs.access.key`: lakeFS access key
-* `fs.lakefs.secret.key`: lakeFS secret key
-* `fs.lakefs.endpoint`: lakeFS API URL (e.g. `https://example-org.us-east-1.lakefscloud.io/api/v1`)
-
-Configure the S3A FileSystem to access your S3 storage, for example using the `fs.s3a.*` configurations (these are **not** your lakeFS credentials):
-* `fs.s3a.access.key`: AWS S3 access key
-* `fs.s3a.secret.key`: AWS S3 secret key
-
-Here are some configuration examples:
-<div class="tabs">
-  <ul>
-    <li><a href="#config-cli">CLI</a></li>
-    <li><a href="#config-scala">Scala</a></li>
-    <li><a href="#config-pyspark">PySpark</a></li>
-    <li><a href="#config-xml">XML Configuration</a></li>
-    <li><a href="#config-databricks">Databricks</a></li>
-  </ul> 
-  <div markdown="1" id="config-cli">
-```shell
-spark-shell --conf spark.hadoop.fs.s3a.access.key='AKIAIOSFODNN7EXAMPLE' \
-              --conf spark.hadoop.fs.s3a.secret.key='wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY' \
-              --conf spark.hadoop.fs.s3a.endpoint='https://s3.eu-central-1.amazonaws.com' \
-              --conf spark.hadoop.fs.lakefs.impl=io.lakefs.LakeFSFileSystem \
-              --conf spark.hadoop.fs.lakefs.access.key=AKIAlakefs12345EXAMPLE \
-              --conf spark.hadoop.fs.lakefs.secret.key=abc/lakefs/1234567bPxRfiCYEXAMPLEKEY \
-              --conf spark.hadoop.fs.lakefs.endpoint=https://example-org.us-east-1.lakefscloud.io/api/v1 \
-              --packages io.lakefs:hadoop-lakefs-assembly:0.1.12 \
-              io.example.ExampleClass
-```
-  </div>
-  <div markdown="1" id="config-scala">
-
-```scala
-spark.sparkContext.hadoopConfiguration.set("fs.s3a.access.key", "AKIAIOSFODNN7EXAMPLE")
-spark.sparkContext.hadoopConfiguration.set("fs.s3a.secret.key", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
-spark.sparkContext.hadoopConfiguration.set("fs.s3a.endpoint", "https://s3.eu-central-1.amazonaws.com")
-spark.sparkContext.hadoopConfiguration.set("fs.lakefs.impl", "io.lakefs.LakeFSFileSystem")
-spark.sparkContext.hadoopConfiguration.set("fs.lakefs.access.key", "AKIAlakefs12345EXAMPLE")
-spark.sparkContext.hadoopConfiguration.set("fs.lakefs.secret.key", "abc/lakefs/1234567bPxRfiCYEXAMPLEKEY")
-spark.sparkContext.hadoopConfiguration.set("fs.lakefs.endpoint", "https://example-org.us-east-1.lakefscloud.io/api/v1")
-```
-  </div>
-  <div markdown="1" id="config-pyspark">
-
-```python
-sc._jsc.hadoopConfiguration().set("fs.s3a.access.key", "AKIAIOSFODNN7EXAMPLE")
-sc._jsc.hadoopConfiguration().set("fs.s3a.secret.key", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
-sc._jsc.hadoopConfiguration().set("fs.s3a.endpoint", "https://s3.eu-central-1.amazonaws.com")
-sc._jsc.hadoopConfiguration().set("fs.lakefs.impl", "io.lakefs.LakeFSFileSystem")
-sc._jsc.hadoopConfiguration().set("fs.lakefs.access.key", "AKIAlakefs12345EXAMPLE")
-sc._jsc.hadoopConfiguration().set("fs.lakefs.secret.key", "abc/lakefs/1234567bPxRfiCYEXAMPLEKEY")
-sc._jsc.hadoopConfiguration().set("fs.lakefs.endpoint", "https://example-org.us-east-1.lakefscloud.io/api/v1")
-```
-  </div>
-  <div markdown="1" id="config-xml">
-   
-Make sure that you load the lakeFS FileSystem into Spark by running it with `--packages` or `--jars`,
-and then add these into a configuration file, e.g., `$SPARK_HOME/conf/hdfs-site.xml`:
-
-```xml
-<?xml version="1.0"?>
-<configuration>
-    <property>
-        <name>fs.s3a.access.key</name>
-        <value>AKIAIOSFODNN7EXAMPLE</value>
-    </property>
-    <property>
-            <name>fs.s3a.secret.key</name>
-            <value>wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY</value>
-    </property>
-    <property>
-        <name>fs.s3a.endpoint</name>
-        <value>https://s3.eu-central-1.amazonaws.com</value>
-    </property>
-    <property>
-        <name>fs.lakefs.impl</name>
-        <value>io.lakefs.LakeFSFileSystem</value>
-    </property>
-    <property>
-        <name>fs.lakefs.access.key</name>
-        <value>AKIAlakefs12345EXAMPLE</value>
-    </property>
-    <property>
-        <name>fs.lakefs.secret.key</name>
-        <value>abc/lakefs/1234567bPxRfiCYEXAMPLEKEY</value>
-    </property>
-    <property>
-        <name>fs.lakefs.endpoint</name>
-        <value>https://example-org.us-east-1.lakefscloud.io/api/v1</value>
-    </property>
-</configuration>
-```
-  </div>
-  <div markdown="1" id="config-databricks">
-
-Add the following the cluster's configuration under `Configuration ➡️ Advanced options`:
-
-```
-spark.hadoop.fs.lakefs.impl io.lakefs.LakeFSFileSystem
-spark.hadoop.fs.lakefs.access.key AKIAlakefs12345EXAMPLE
-spark.hadoop.fs.lakefs.secret.key abc/lakefs/1234567bPxRfiCYEXAMPLEKEY
-spark.hadoop.fs.s3a.access.key AKIAIOSFODNN7EXAMPLE
-spark.hadoop.fs.s3a.secret.key wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
-spark.hadoop.fs.s3a.impl shaded.databricks.org.apache.hadoop.fs.s3a.S3AFileSystem
-spark.hadoop.fs.lakefs.endpoint https://example-org.us-east-1.lakefscloud.io/api/v1
-```
-
-  Alternatively, follow this [step by step Databricks integration tutorial, including lakeFS Hadoop File System, Python client and lakeFS SPARK client](https://lakefs.io/blog/databricks-lakefs-integration-tutorial/).
-  </div>
-</div>
-   
-⚠️ If your bucket is on a region other than us-east-1, you may also need to configure `fs.s3a.endpoint` with the correct region.
-Amazon provides [S3 endpoints](https://docs.aws.amazon.com/general/latest/gr/s3.html) you can use.
-{: .note }
-
-### Usage
-
-Hadoop FileSystem paths use the `lakefs://` protocol, with paths taking the form `lakefs://<repository>/<ref>/path/to/object`.
-`<ref>` can be a branch, tag, or commit ID in lakeFS.
-Here's an example for reading a Parquet file from lakeFS to a Spark DataFrame:
-
-```scala
-val repo = "example-repo"
-val branch = "main"
-val df = spark.read.parquet(s"lakefs://${repo}/${branch}/example-path/example-file.parquet")
-```
-
-Here's how to write some results back to a lakeFS path:
-
-```scala
-df.write.partitionBy("example-column").parquet(s"lakefs://${repo}/${branch}/output-path/")
-```
-
-The data is now created in lakeFS as new changes in your branch. You can now commit these changes or revert them.
-
-### Notes for the lakeFS Hadoop FileSystem
-
-* Since data will not be sent to the lakeFS server, using this mode maximizes data security.
-* The FileSystem implementation is tested with the latest Spark 2.X (Hadoop 2) and Spark 3.X (Hadoop 3) Bitnami images.
 
 ## Use the S3-compatible API
 
 lakeFS has an S3-compatible endpoint. Simply point Spark to this endpoint to get started quickly.
 You will access your data using S3-style URIs, e.g. `s3a://example-repo/example-branch/example-table`.
+You can use the S3-compatible API regardless of where your data is hosted.
 
 ### Configuration
 {: .no_toc }
@@ -572,6 +389,190 @@ spark.hadoop.fs.lakefs.endpoint=‘https://example-org.us-east-1.lakefscloud.io�
 ```
 
 For more details about [Mounting cloud object storage on Databricks](https://docs.databricks.com/dbfs/mounts.html).
+
+## Use the lakeFS Hadoop FileSystem
+
+If you're using lakeFS on top of S3, this mode will enhance your application's performance.
+In this mode, Spark will read and write objects directly from S3, reducing the load on the lakeFS server.
+It will still access the lakeFS server for metadata operations.
+
+After configuring the lakeFS Hadoop FileSystem below, use URIs of the form `lakefs://example-repo/ref/path/to/data` to
+interact with your data on lakeFS.
+
+### Installation
+
+<div class="tabs">
+  <ul>
+    <li><a href="#install-standalone">Spark Standalone</a></li>
+    <li><a href="#install-databricks">Databricks</a></li>
+  </ul> 
+  <div markdown="1" id="install-standalone">
+
+Add the package to your `spark-submit` command:
+
+  ```
+  --packages io.lakefs:hadoop-lakefs-assembly:0.1.12
+  ```
+
+  </div>
+  <div markdown="2" id="install-databricks">
+In  your cluster settings, under the _Libraries_ tab, add the following Maven package:
+
+```
+io.lakefs:hadoop-lakefs-assembly:0.1.12
+```
+
+Once installed, it should look something like this:
+
+![Databricks - Adding the lakeFS client Jar](../assets/img/databricks-install-package.png)
+
+  </div>
+</div>
+
+
+### Configuration
+
+Set the `fs.lakefs.*` Hadoop configurations to point to your lakeFS installation:
+* `fs.lakefs.impl`: `io.lakefs.LakeFSFileSystem`
+* `fs.lakefs.access.key`: lakeFS access key
+* `fs.lakefs.secret.key`: lakeFS secret key
+* `fs.lakefs.endpoint`: lakeFS API URL (e.g. `https://example-org.us-east-1.lakefscloud.io/api/v1`)
+
+Configure the S3A FileSystem to access your S3 storage, for example using the `fs.s3a.*` configurations (these are **not** your lakeFS credentials):
+* `fs.s3a.access.key`: AWS S3 access key
+* `fs.s3a.secret.key`: AWS S3 secret key
+
+Here are some configuration examples:
+<div class="tabs">
+  <ul>
+    <li><a href="#config-cli">CLI</a></li>
+    <li><a href="#config-scala">Scala</a></li>
+    <li><a href="#config-pyspark">PySpark</a></li>
+    <li><a href="#config-xml">XML Configuration</a></li>
+    <li><a href="#config-databricks">Databricks</a></li>
+  </ul> 
+  <div markdown="1" id="config-cli">
+```shell
+spark-shell --conf spark.hadoop.fs.s3a.access.key='AKIAIOSFODNN7EXAMPLE' \
+              --conf spark.hadoop.fs.s3a.secret.key='wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY' \
+              --conf spark.hadoop.fs.s3a.endpoint='https://s3.eu-central-1.amazonaws.com' \
+              --conf spark.hadoop.fs.lakefs.impl=io.lakefs.LakeFSFileSystem \
+              --conf spark.hadoop.fs.lakefs.access.key=AKIAlakefs12345EXAMPLE \
+              --conf spark.hadoop.fs.lakefs.secret.key=abc/lakefs/1234567bPxRfiCYEXAMPLEKEY \
+              --conf spark.hadoop.fs.lakefs.endpoint=https://example-org.us-east-1.lakefscloud.io/api/v1 \
+              --packages io.lakefs:hadoop-lakefs-assembly:0.1.12 \
+              io.example.ExampleClass
+```
+  </div>
+  <div markdown="1" id="config-scala">
+
+```scala
+spark.sparkContext.hadoopConfiguration.set("fs.s3a.access.key", "AKIAIOSFODNN7EXAMPLE")
+spark.sparkContext.hadoopConfiguration.set("fs.s3a.secret.key", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
+spark.sparkContext.hadoopConfiguration.set("fs.s3a.endpoint", "https://s3.eu-central-1.amazonaws.com")
+spark.sparkContext.hadoopConfiguration.set("fs.lakefs.impl", "io.lakefs.LakeFSFileSystem")
+spark.sparkContext.hadoopConfiguration.set("fs.lakefs.access.key", "AKIAlakefs12345EXAMPLE")
+spark.sparkContext.hadoopConfiguration.set("fs.lakefs.secret.key", "abc/lakefs/1234567bPxRfiCYEXAMPLEKEY")
+spark.sparkContext.hadoopConfiguration.set("fs.lakefs.endpoint", "https://example-org.us-east-1.lakefscloud.io/api/v1")
+```
+  </div>
+  <div markdown="1" id="config-pyspark">
+
+```python
+sc._jsc.hadoopConfiguration().set("fs.s3a.access.key", "AKIAIOSFODNN7EXAMPLE")
+sc._jsc.hadoopConfiguration().set("fs.s3a.secret.key", "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY")
+sc._jsc.hadoopConfiguration().set("fs.s3a.endpoint", "https://s3.eu-central-1.amazonaws.com")
+sc._jsc.hadoopConfiguration().set("fs.lakefs.impl", "io.lakefs.LakeFSFileSystem")
+sc._jsc.hadoopConfiguration().set("fs.lakefs.access.key", "AKIAlakefs12345EXAMPLE")
+sc._jsc.hadoopConfiguration().set("fs.lakefs.secret.key", "abc/lakefs/1234567bPxRfiCYEXAMPLEKEY")
+sc._jsc.hadoopConfiguration().set("fs.lakefs.endpoint", "https://example-org.us-east-1.lakefscloud.io/api/v1")
+```
+  </div>
+  <div markdown="1" id="config-xml">
+
+Make sure that you load the lakeFS FileSystem into Spark by running it with `--packages` or `--jars`,
+and then add these into a configuration file, e.g., `$SPARK_HOME/conf/hdfs-site.xml`:
+
+```xml
+<?xml version="1.0"?>
+<configuration>
+    <property>
+        <name>fs.s3a.access.key</name>
+        <value>AKIAIOSFODNN7EXAMPLE</value>
+    </property>
+    <property>
+            <name>fs.s3a.secret.key</name>
+            <value>wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY</value>
+    </property>
+    <property>
+        <name>fs.s3a.endpoint</name>
+        <value>https://s3.eu-central-1.amazonaws.com</value>
+    </property>
+    <property>
+        <name>fs.lakefs.impl</name>
+        <value>io.lakefs.LakeFSFileSystem</value>
+    </property>
+    <property>
+        <name>fs.lakefs.access.key</name>
+        <value>AKIAlakefs12345EXAMPLE</value>
+    </property>
+    <property>
+        <name>fs.lakefs.secret.key</name>
+        <value>abc/lakefs/1234567bPxRfiCYEXAMPLEKEY</value>
+    </property>
+    <property>
+        <name>fs.lakefs.endpoint</name>
+        <value>https://example-org.us-east-1.lakefscloud.io/api/v1</value>
+    </property>
+</configuration>
+```
+  </div>
+  <div markdown="1" id="config-databricks">
+
+Add the following the cluster's configuration under `Configuration ➡️ Advanced options`:
+
+```
+spark.hadoop.fs.lakefs.impl io.lakefs.LakeFSFileSystem
+spark.hadoop.fs.lakefs.access.key AKIAlakefs12345EXAMPLE
+spark.hadoop.fs.lakefs.secret.key abc/lakefs/1234567bPxRfiCYEXAMPLEKEY
+spark.hadoop.fs.s3a.access.key AKIAIOSFODNN7EXAMPLE
+spark.hadoop.fs.s3a.secret.key wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+spark.hadoop.fs.s3a.impl shaded.databricks.org.apache.hadoop.fs.s3a.S3AFileSystem
+spark.hadoop.fs.lakefs.endpoint https://example-org.us-east-1.lakefscloud.io/api/v1
+```
+
+Alternatively, follow this [step by step Databricks integration tutorial, including lakeFS Hadoop File System, Python client and lakeFS SPARK client](https://lakefs.io/blog/databricks-lakefs-integration-tutorial/).
+  </div>
+</div>
+
+⚠️ If your bucket is on a region other than us-east-1, you may also need to configure `fs.s3a.endpoint` with the correct region.
+Amazon provides [S3 endpoints](https://docs.aws.amazon.com/general/latest/gr/s3.html) you can use.
+{: .note }
+
+### Usage
+
+Hadoop FileSystem paths use the `lakefs://` protocol, with paths taking the form `lakefs://<repository>/<ref>/path/to/object`.
+`<ref>` can be a branch, tag, or commit ID in lakeFS.
+Here's an example for reading a Parquet file from lakeFS to a Spark DataFrame:
+
+```scala
+val repo = "example-repo"
+val branch = "main"
+val df = spark.read.parquet(s"lakefs://${repo}/${branch}/example-path/example-file.parquet")
+```
+
+Here's how to write some results back to a lakeFS path:
+
+```scala
+df.write.partitionBy("example-column").parquet(s"lakefs://${repo}/${branch}/output-path/")
+```
+
+The data is now created in lakeFS as new changes in your branch. You can now commit these changes or revert them.
+
+### Notes for the lakeFS Hadoop FileSystem
+
+* Since data will not be sent to the lakeFS server, using this mode maximizes data security.
+* The FileSystem implementation is tested with the latest Spark 2.X (Hadoop 2) and Spark 3.X (Hadoop 3) Bitnami images.
 
 ## Case Study: SimilarWeb
 


### PR DESCRIPTION
Moved the simple way of using Spark to be first - it just doesn't make sense the other way around.