### PR TITLE
Docker publish on release only

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -1,7 +1,8 @@
 name: Docker
 on:
   release:
-    types: [published]
+    types: [released]
+  workflow_dispatch:
 
 # These permissions are needed to interact with GitHub's OIDC Token endpoint.
 permissions:


### PR DESCRIPTION
Publish docker images only when release becomes official
