### PR TITLE
[GC] Partition and aggregate expired addresses more efficiently

### DIFF
--- a/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
@@ -10,13 +10,14 @@ import org.apache.spark.sql._
 import org.apache.spark.sql.functions._
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.sql.types.{StringType, StructField, StructType}
-import org.apache.spark.{HashPartitioner, Partitioner}
+import org.apache.spark.{HashPartitioner}
 import org.json4s.JsonDSL._
 import org.json4s._
 import org.json4s.native.JsonMethods._
 
 import java.time.format.DateTimeFormatter
 import java.time.{LocalDateTime, ZoneOffset}
+import java.net.URI
 import java.util.UUID
 import org.apache.commons.lang3.StringUtils
 

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
@@ -465,6 +465,8 @@ object GarbageCollector {
     var gcCommitsLocation = ""
     var gcAddressesLocation = ""
     if (runIDToReproduce == "") {
+      prepareResult = apiClient.prepareGarbageCollectionCommits(repo, previousRunID)
+      runID = prepareResult.getRunId
       gcCommitsLocation = hc.get(
         "debug.gc.commits",
         ApiClient.translateURI(new URI(prepareResult.getGcCommitsLocation), storageType).toString

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/LakeFSContext.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/LakeFSContext.scala
@@ -64,7 +64,8 @@ object LakeFSContext {
   val LAKEFS_CONF_GC_NUM_COMMIT_PARTITIONS = "lakefs.gc.commit.num_partitions"
   val LAKEFS_CONF_GC_NUM_RANGE_PARTITIONS = "lakefs.gc.range.num_partitions"
   val LAKEFS_CONF_GC_NUM_ADDRESS_PARTITIONS = "lakefs.gc.address.num_partitions"
-  val LAKEFS_CONF_GC_APPROX_NUM_RANGES_TO_SPREAD_PER_PARTITION = "lakefs.gc.address.approx_num_ranges_to_spread_per_partition"
+  val LAKEFS_CONF_GC_APPROX_NUM_RANGES_TO_SPREAD_PER_PARTITION =
+    "lakefs.gc.address.approx_num_ranges_to_spread_per_partition"
   val LAKEFS_CONF_DEBUG_GC_MAX_COMMIT_ISO_DATETIME_KEY = "lakefs.debug.gc.max_commit_iso_datetime"
   val LAKEFS_CONF_DEBUG_GC_MAX_COMMIT_EPOCH_SECONDS_KEY = "lakefs.debug.gc.max_commit_epoch_seconds"
   val LAKEFS_CONF_DEBUG_GC_REPRODUCE_RUN_ID_KEY = "lakefs.debug.gc.reproduce_run_id"

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/LakeFSContext.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/LakeFSContext.scala
@@ -64,9 +64,11 @@ object LakeFSContext {
   val LAKEFS_CONF_GC_NUM_COMMIT_PARTITIONS = "lakefs.gc.commit.num_partitions"
   val LAKEFS_CONF_GC_NUM_RANGE_PARTITIONS = "lakefs.gc.range.num_partitions"
   val LAKEFS_CONF_GC_NUM_ADDRESS_PARTITIONS = "lakefs.gc.address.num_partitions"
+  val LAKEFS_CONF_GC_APPROX_NUM_RANGES_TO_SPREAD_PER_PARTITION = "lakefs.gc.address.approx_num_ranges_to_spread_per_partition"
   val LAKEFS_CONF_DEBUG_GC_MAX_COMMIT_ISO_DATETIME_KEY = "lakefs.debug.gc.max_commit_iso_datetime"
   val LAKEFS_CONF_DEBUG_GC_MAX_COMMIT_EPOCH_SECONDS_KEY = "lakefs.debug.gc.max_commit_epoch_seconds"
   val LAKEFS_CONF_DEBUG_GC_REPRODUCE_RUN_ID_KEY = "lakefs.debug.gc.reproduce_run_id"
+  val LAKEFS_CONF_DEBUG_GC_SAMPLE_FRACTION = "lakefs.debug.gc.addresses_sample_fraction"
 
   //  Objects that are written during this duration are not collected
   val LAKEFS_CONF_DEBUG_GC_UNCOMMITTED_MIN_AGE_SECONDS_KEY =
@@ -82,7 +84,7 @@ object LakeFSContext {
   val DEFAULT_LAKEFS_CONF_GC_NUM_COMMIT_PARTITIONS = 24
   val DEFAULT_LAKEFS_CONF_GC_NUM_RANGE_PARTITIONS = 50
   val DEFAULT_LAKEFS_CONF_GC_NUM_ADDRESS_PARTITIONS = 200
-
+  val DEFAULT_LAKEFS_CONF_GC_APPROX_NUM_RANGES_TO_SPREAD_PER_PARTITION = 1e5
   // By default, objects that are written in the last 6 hours are not collected
   val DEFAULT_GC_UNCOMMITTED_MIN_AGE_SECONDS = 6 * 60 * 60
 

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/LakeFSContext.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/LakeFSContext.scala
@@ -64,7 +64,7 @@ object LakeFSContext {
   val LAKEFS_CONF_GC_NUM_COMMIT_PARTITIONS = "lakefs.gc.commit.num_partitions"
   val LAKEFS_CONF_GC_NUM_RANGE_PARTITIONS = "lakefs.gc.range.num_partitions"
   val LAKEFS_CONF_GC_NUM_ADDRESS_PARTITIONS = "lakefs.gc.address.num_partitions"
-  val LAKEFS_CONF_GC_APPROX_NUM_RANGES_TO_SPREAD_PER_PARTITION =
+  val LAKEFS_CONF_GC_APPROX_NUM_RANGES_PER_PARTITION =
     "lakefs.gc.address.approx_num_ranges_to_spread_per_partition"
   val LAKEFS_CONF_DEBUG_GC_MAX_COMMIT_ISO_DATETIME_KEY = "lakefs.debug.gc.max_commit_iso_datetime"
   val LAKEFS_CONF_DEBUG_GC_MAX_COMMIT_EPOCH_SECONDS_KEY = "lakefs.debug.gc.max_commit_epoch_seconds"
@@ -85,7 +85,7 @@ object LakeFSContext {
   val DEFAULT_LAKEFS_CONF_GC_NUM_COMMIT_PARTITIONS = 24
   val DEFAULT_LAKEFS_CONF_GC_NUM_RANGE_PARTITIONS = 50
   val DEFAULT_LAKEFS_CONF_GC_NUM_ADDRESS_PARTITIONS = 200
-  val DEFAULT_LAKEFS_CONF_GC_APPROX_NUM_RANGES_TO_SPREAD_PER_PARTITION = 1e5
+  val DEFAULT_LAKEFS_CONF_GC_APPROX_NUM_RANGES_PER_PARTITION = 1e5
   // By default, objects that are written in the last 6 hours are not collected
   val DEFAULT_GC_UNCOMMITTED_MIN_AGE_SECONDS = 6 * 60 * 60
 

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/LakeFSInputFormat.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/LakeFSInputFormat.scala
@@ -95,7 +95,7 @@ class EntryRecordReader[Proto <: GeneratedMessage with scalapb.Message[Proto]](
     val fs = gravelerSplit.path.getFileSystem(context.getConfiguration)
     fs.copyToLocalFile(false, gravelerSplit.path, new Path(localFile.getAbsolutePath), true)
     // TODO(johnnyaug) should we cache this?
-    sstableReader = new SSTableReader(localFile.getAbsolutePath, companion)
+    sstableReader = new SSTableReader(localFile.getAbsolutePath, companion, true)
     if (!gravelerSplit.isValidated) {
       // this file may not be a valid range file, validate it
       val props = sstableReader.getProperties

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/SSTableReader.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/SSTableReader.scala
@@ -23,11 +23,18 @@ private object local {
 
 class SSTableIterator[Proto <: GeneratedMessage with scalapb.Message[Proto]](
     val it: Iterator[PebbleEntry],
+    val resource: Closeable,
     val companion: GeneratedMessageCompanion[Proto]
 ) extends Iterator[Item[Proto]] {
   // TODO(ariels): explicitly make it closeable, and figure out how to close it when used by
   //     Spark.
-  override def hasNext: Boolean = it.hasNext
+  override def hasNext: Boolean = {
+    val ret = it.hasNext
+    if (!ret) {
+      resource.close()
+    }
+    ret
+  }
 
   override def next(): Item[Proto] = {
     val entry = it.next
@@ -66,29 +73,37 @@ object SSTableReader {
     localFile
   }
 
-  def forMetaRange(configuration: Configuration, metaRangeURL: String): SSTableReader[RangeData] = {
+  def forMetaRange(configuration: Configuration, metaRangeURL: String, dontOwn: Boolean = false): SSTableReader[RangeData] = {
     val localFile: File = copyToLocal(configuration, metaRangeURL)
-    new SSTableReader(localFile, RangeData.messageCompanion)
+    val ret = new SSTableReader(localFile, RangeData.messageCompanion, dontOwn)
+    Option(TaskContext.get()).foreach(_.addTaskCompletionListener[Unit](_ => ret.close()))
+    ret
   }
 
-  def forRange(configuration: Configuration, rangeURL: String): SSTableReader[Entry] = {
+  def forRange(configuration: Configuration, rangeURL: String, dontOwn: Boolean = false): SSTableReader[Entry] = {
     val localFile: File = copyToLocal(configuration, rangeURL)
-    new SSTableReader(localFile, Entry.messageCompanion)
+    val ret = new SSTableReader(localFile, Entry.messageCompanion, dontOwn)
+    Option(TaskContext.get()).foreach(_.addTaskCompletionListener[Unit](_ => ret.close()))
+    ret
   }
 }
 
 class SSTableReader[Proto <: GeneratedMessage with scalapb.Message[Proto]] private (
     val file: java.io.File,
-    val companion: GeneratedMessageCompanion[Proto]
+    val companion: GeneratedMessageCompanion[Proto],
+    val dontOwn: Boolean = false
 ) extends Closeable {
   private val fp = new java.io.RandomAccessFile(file, "r")
   private val reader = new BlockReadableFile(fp)
 
-  def this(sstableFilename: String, companion: GeneratedMessageCompanion[Proto]) =
-    this(new java.io.File(sstableFilename), companion)
+  def this(sstableFilename: String, companion: GeneratedMessageCompanion[Proto], dontOwn: Boolean) =
+    this(new java.io.File(sstableFilename), companion, dontOwn)
 
   def close(): Unit = {
     fp.close()
+    if (!dontOwn) {
+      file.delete()
+    }
   }
 
   def getProperties: Map[String, Array[Byte]] = {
@@ -99,6 +114,6 @@ class SSTableReader[Proto <: GeneratedMessage with scalapb.Message[Proto]] priva
 
   def newIterator(): SSTableIterator[Proto] = {
     val it = BlockParser.entryIterator(reader)
-    new SSTableIterator(it, companion)
+    new SSTableIterator(it, this, companion)
   }
 }

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/SSTableReader.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/SSTableReader.scala
@@ -73,14 +73,22 @@ object SSTableReader {
     localFile
   }
 
-  def forMetaRange(configuration: Configuration, metaRangeURL: String, dontOwn: Boolean = false): SSTableReader[RangeData] = {
+  def forMetaRange(
+      configuration: Configuration,
+      metaRangeURL: String,
+      dontOwn: Boolean = false
+  ): SSTableReader[RangeData] = {
     val localFile: File = copyToLocal(configuration, metaRangeURL)
     val ret = new SSTableReader(localFile, RangeData.messageCompanion, dontOwn)
     Option(TaskContext.get()).foreach(_.addTaskCompletionListener[Unit](_ => ret.close()))
     ret
   }
 
-  def forRange(configuration: Configuration, rangeURL: String, dontOwn: Boolean = false): SSTableReader[Entry] = {
+  def forRange(
+      configuration: Configuration,
+      rangeURL: String,
+      dontOwn: Boolean = false
+  ): SSTableReader[Entry] = {
     val localFile: File = copyToLocal(configuration, rangeURL)
     val ret = new SSTableReader(localFile, Entry.messageCompanion, dontOwn)
     Option(TaskContext.get()).foreach(_.addTaskCompletionListener[Unit](_ => ret.close()))

--- a/clients/spark/core/src/test/scala/io/treeverse/clients/DumpSSTable.scala
+++ b/clients/spark/core/src/test/scala/io/treeverse/clients/DumpSSTable.scala
@@ -18,7 +18,7 @@ object ReadSSTableBenchmark extends Bench.LocalTime {
     measure method "next" in {
       using (sstables) in {
         sst => {
-          val reader: SSTableReader[Entry] = new SSTableReader(sst, Entry.messageCompanion, true)
+          val reader: SSTableReader[Entry] = new SSTableReader(sst, Entry.messageCompanion, false)
           val count = reader.newIterator.length
         }
       }

--- a/clients/spark/core/src/test/scala/io/treeverse/clients/DumpSSTable.scala
+++ b/clients/spark/core/src/test/scala/io/treeverse/clients/DumpSSTable.scala
@@ -18,7 +18,7 @@ object ReadSSTableBenchmark extends Bench.LocalTime {
     measure method "next" in {
       using (sstables) in {
         sst => {
-          val reader: SSTableReader[Entry] = new SSTableReader(sst, Entry.messageCompanion)
+          val reader: SSTableReader[Entry] = new SSTableReader(sst, Entry.messageCompanion, true)
           val count = reader.newIterator.length
         }
       }

--- a/clients/spark/core/src/test/scala/io/treeverse/clients/GarbageCollectorSpec.scala
+++ b/clients/spark/core/src/test/scala/io/treeverse/clients/GarbageCollectorSpec.scala
@@ -90,22 +90,6 @@ class GarbageCollectorSpec extends AnyFunSpec with Matchers with SparkSessionSet
                                )
 
   describe("GarbageCollector") {
-    describe("minus") {
-      it("removes elements in a simple case") {
-        withSparkSession(spark => {
-          import spark.implicits._
-          val sc = spark.sparkContext
-          val gc = new GarbageCollector(getter)
-
-          val partitioner = new HashPartitioner(3)
-          val threes = sc.parallelize(0 to 100 by 3).map(_.toString).toDS
-          val sevens = sc.parallelize(0 to 100 by 7).map(_.toString).toDS
-          val m = gc.minus(threes, sevens, partitioner).map(_.toInt)
-          compareDS(m, sc.parallelize((0 to 100 by 3).filter(x => x % 7 != 0)).toDS)
-        })
-      }
-    }
-
     val approxNumRangesToSpreadPerPartition = Table(
       ("approx_num_ranges_to_spread_per_partition"),
       (0.5), (1.0), (1.1), (10.0), (100.0))

--- a/clients/spark/core/src/test/scala/io/treeverse/clients/GarbageCollectorSpec.scala
+++ b/clients/spark/core/src/test/scala/io/treeverse/clients/GarbageCollectorSpec.scala
@@ -108,6 +108,7 @@ class GarbageCollectorSpec extends AnyFunSpec with Matchers with SparkSessionSet
               Seq[(String, Boolean)]().toDS,
               "repo",
               "",
+              numRangePartitions,
               numAddressPartitions,
               approxNumRangesToSpreadPerPartition,
               1)
@@ -128,6 +129,7 @@ class GarbageCollectorSpec extends AnyFunSpec with Matchers with SparkSessionSet
               Seq(("aaa", true), ("222", true), ("bbb", true)).toDS,
               "repo",
               "s3://some-ns/",
+              numRangePartitions,
               numAddressPartitions,
               approxNumRangesToSpreadPerPartition,
               1)
@@ -148,6 +150,7 @@ class GarbageCollectorSpec extends AnyFunSpec with Matchers with SparkSessionSet
               Seq(("aaa", true), ("bbb", true), ("222", false)).toDS,
               "repo",
               "s3://some-other-ns/",
+              numRangePartitions,
               numAddressPartitions,
               approxNumRangesToSpreadPerPartition,
               1)
@@ -168,6 +171,7 @@ class GarbageCollectorSpec extends AnyFunSpec with Matchers with SparkSessionSet
               Seq(("aaa", true), ("bbb", true), ("bbb", false)).toDS,
               "repo",
               "s3://some-ns/",
+              numRangePartitions,
               numAddressPartitions,
               approxNumRangesToSpreadPerPartition,
               1)
@@ -188,6 +192,7 @@ class GarbageCollectorSpec extends AnyFunSpec with Matchers with SparkSessionSet
               Seq(("aaa", true), ("bbb", true), ("ab12", true), ("bbb", false), ("222", false)).toDS,
               "repo",
               "s3://some-other-ns/",
+              numRangePartitions,
               numAddressPartitions,
               approxNumRangesToSpreadPerPartition,
               1)

--- a/clients/spark/core/src/test/scala/io/treeverse/clients/GarbageCollectorSpec.scala
+++ b/clients/spark/core/src/test/scala/io/treeverse/clients/GarbageCollectorSpec.scala
@@ -9,7 +9,7 @@ import funspec._
 import io.treeverse.lakefs.catalog
 
 import org.apache.commons.io.FileUtils
-import org.apache.spark.{HashPartitioner, SparkConf}
+import org.apache.spark.SparkConf
 import org.apache.spark.sql.{Dataset, SparkSession}
 
 import org.json4s._


### PR DESCRIPTION
New flow:

* Work on RDDs that hold expired and kept ranges/addresses together
* Remove range duplicates
* Compute a reasonable number of range IDs to expand per partition.

  New configuration option:
  `lakefs.gc.address.approx_num_ranges_to_spread_per_partition`
* Expand ranges and hash-partition

  We hash-partition rather than range-partition.  Range partitions work well
  (give similar sizes) when Spark can compute a good "sketch" of the ranges.
  However we need to reduce over object addresses.  Object addresses are
  random _and_ appear with a very unstable distribution.  So there is no
  good way for Spark to find a good range partition.  Hash partitions can
  have their sizes skewed by around $3\cdot\sqrt N$; even for N=1000
  partitions this is very acceptable.
* Directly aggregateByKey to reduce addresses and find those that appear
  only in expired commits.

Also close and delete ranges and metaranges when we are done with them.
This is surprisingly difficult to do correctly in a garbage-collected
language, because it is hard to track lifetimes.  In particular, iterators
extend lifetime beyond dynamic scope.[^1]


Fixes #5612.

[^1]: It is embarrassingly easy to do this in a language with explicit
    lifetimes, such as C++.  And also faster.