### PR TITLE
Write expired addresses once

### DIFF
--- a/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
@@ -489,7 +489,7 @@ object GarbageCollector {
     )
     val sampleFraction = hc.getDouble(LAKEFS_CONF_DEBUG_GC_SAMPLE_FRACTION, 1.0)
 
-    val expiredAddressesToWrite = gc
+    val expiredAddresses = gc
       .getExpiredAddresses(repo,
                            storageNS,
                            runID,
@@ -505,14 +505,10 @@ object GarbageCollector {
       .persist(StorageLevel.MEMORY_AND_DISK_SER)
 
     spark.conf.set("spark.sql.sources.partitionOverwriteMode", "dynamic")
-    expiredAddressesToWrite.write
+    expiredAddresses.write
       .partitionBy(MARK_ID_KEY)
       .mode(SaveMode.Overwrite)
       .parquet(gcAddressesLocation)
-
-    // Read expired addresses as written for further processing.  It may be
-    // too large to hold in memory or even on local disk!
-    val expiredAddresses = spark.read.parquet(gcAddressesLocation)
 
     println(f"Total expired addresses: ${expiredAddresses.count()}")
     println("Expired addresses:")

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
@@ -10,7 +10,7 @@ import org.apache.spark.sql._
 import org.apache.spark.sql.functions._
 import org.apache.spark.storage.StorageLevel
 import org.apache.spark.sql.types.{StringType, StructField, StructType}
-import org.apache.spark.{HashPartitioner}
+import org.apache.spark.HashPartitioner
 import org.json4s.JsonDSL._
 import org.json4s._
 import org.json4s.native.JsonMethods._
@@ -489,7 +489,7 @@ object GarbageCollector {
     )
     val sampleFraction = hc.getDouble(LAKEFS_CONF_DEBUG_GC_SAMPLE_FRACTION, 1.0)
 
-    val expiredAddresses = gc
+    val expiredAddressesToWrite = gc
       .getExpiredAddresses(repo,
                            storageNS,
                            runID,
@@ -505,22 +505,31 @@ object GarbageCollector {
       .persist(StorageLevel.MEMORY_AND_DISK_SER)
 
     spark.conf.set("spark.sql.sources.partitionOverwriteMode", "dynamic")
-    expiredAddresses.write
+    expiredAddressesToWrite.write
       .partitionBy(MARK_ID_KEY)
       .mode(SaveMode.Overwrite)
       .parquet(gcAddressesLocation)
 
+    // Read expired addresses as written for further processing.  It may be
+    // too large to hold in memory or even on local disk!
+    val expiredAddresses = spark.read.parquet(gcAddressesLocation)
+
+    println(f"Total expired addresses: ${expiredAddresses.count()}")
     println("Expired addresses:")
     expiredAddresses.show()
 
-    // Enable source for rclone backup and resource
-    // write expired addresses as text - output to '.../addresses_path+".text"'
-    val gcAddressesPath = new Path(gcAddressesLocation)
-    val gcTextAddressesPath = new Path(gcAddressesPath.getParent, gcAddressesPath.getName + ".text")
-    expiredAddresses.write
-      .partitionBy(MARK_ID_KEY)
-      .mode(SaveMode.Overwrite)
-      .text(gcTextAddressesPath.toString)
+    if (hc.getBoolean(LAKEFS_CONF_GC_WRITE_EXPIRED_AS_TEXT, true)) {
+      // Enable source for rclone backup and resource
+      // write expired addresses as text - output to '.../addresses_path+".text"'
+      val gcAddressesPath = new Path(gcAddressesLocation)
+      val gcTextAddressesPath =
+        new Path(gcAddressesPath.getParent, gcAddressesPath.getName + ".text")
+      expiredAddresses.write
+        .partitionBy(MARK_ID_KEY)
+        .mode(SaveMode.Overwrite)
+        .text(gcTextAddressesPath.toString)
+    }
+
     writeAddressesMarkMetadata(runID, markID, gcAddressesLocation, gcCommitsLocation)
 
     (gcAddressesLocation, gcCommitsLocation, expiredAddresses, runID)
@@ -557,21 +566,11 @@ object GarbageCollector {
       configMapper: ConfigMapper
   ) = {
     val reportLogsDst = concatToGCLogsPrefix(storageNSForHadoopFS, "summary")
-    val reportExpiredDst = concatToGCLogsPrefix(storageNSForHadoopFS, "expired_addresses")
     val deletedObjectsDst = concatToGCLogsPrefix(storageNSForHadoopFS, "deleted_objects")
 
     val time = DateTimeFormatter.ISO_INSTANT.format(java.time.Clock.systemUTC.instant())
     writeParquetReport(commitsDF, reportLogsDst, time, "commits.parquet")
-    try {
-      writeParquetReport(expiredAddresses, reportExpiredDst, time)
-      val expiredDF = spark.read.parquet(f"${reportExpiredDst}/dt=${time}/")
-      println(f"Total expired addresses: ${expiredDF.count()}")
-    } catch {
-      case e: Throwable => {
-        println("Error when trying to get expired addresses count, moving on:")
-        e.printStackTrace()
-      }
-    }
+
     try {
       val removedCount = removed.count()
       writeJsonSummary(configMapper, reportLogsDst, removedCount, gcRules, time)

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/LakeFSContext.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/LakeFSContext.scala
@@ -66,6 +66,7 @@ object LakeFSContext {
   val LAKEFS_CONF_GC_NUM_ADDRESS_PARTITIONS = "lakefs.gc.address.num_partitions"
   val LAKEFS_CONF_GC_APPROX_NUM_RANGES_PER_PARTITION =
     "lakefs.gc.address.approx_num_ranges_to_spread_per_partition"
+  val LAKEFS_CONF_GC_WRITE_EXPIRED_AS_TEXT = "lakefs.gc.address.write_as_text"
   val LAKEFS_CONF_DEBUG_GC_MAX_COMMIT_ISO_DATETIME_KEY = "lakefs.debug.gc.max_commit_iso_datetime"
   val LAKEFS_CONF_DEBUG_GC_MAX_COMMIT_EPOCH_SECONDS_KEY = "lakefs.debug.gc.max_commit_epoch_seconds"
   val LAKEFS_CONF_DEBUG_GC_REPRODUCE_RUN_ID_KEY = "lakefs.debug.gc.reproduce_run_id"


### PR DESCRIPTION
Write expired addresses:

* To `STORAGE_NS/_lakefs/retention/gc/addresses/MARK_ID`.
* To `STORAGE_NS/_lakefs/retention/gc/addresses.text/MARK_ID` **UNLESS**
  `lakefs.gc.address.write_as_text` is cleared.  By default the text file is
  written, but allow clearing it.
* Do NOT write to `STORAGE_NS/_lakefs/logs/gc/expired_addresses`.

Also read the written Parquet file for any further processing.  This is
slower when expired_addresses would fit on executors mem+disk caches,
but (much) faster when it does not.

To help a bit more, persist expired addresses after generation and before
writing to local executor mem+disk.

Fixes #5611.