### PR TITLE
Fix broken redirects & make all others absolute

### DIFF
--- a/cmd/lakectl/cmd/docs.go
+++ b/cmd/lakectl/cmd/docs.go
@@ -18,7 +18,7 @@ parent: Reference
 nav_order: 20
 has_children: false
 redirect_from:
-  - ./commands.html
+  - /reference/commands.html
 ---
 
 {% comment %}

--- a/docs/commitment.md
+++ b/docs/commitment.md
@@ -4,7 +4,7 @@ title: Commitment to OSS
 description: lakeFS is an open-source project under the Apache 2.0 license, committed to fostering the open-source space. 
 nav_order: 100
 has_children: false
-redirect_from: ./understand/licensing.html
+redirect_from: /understand/licensing.html
 ---
 
 # Our commitment to open source

--- a/docs/deploy/aws.md
+++ b/docs/deploy/aws.md
@@ -5,11 +5,11 @@ parent: Deploy and Setup lakeFS
 description: This section will guide you through deploying and setting up a production-suitable lakeFS environment on AWS
 nav_order: 10
 redirect_from:
-   - ../deploying-aws/index.html
-   - ../deploying-aws/install.html
-   - ../deploying-aws/db.html
-   - ../deploying-aws/lb_dns.html
-   - ../setup/storage/s3.html 
+   - /deploying-aws/index.html
+   - /deploying-aws/install.html
+   - /deploying-aws/db.html
+   - /deploying-aws/lb_dns.html
+   - /setup/storage/s3.html 
 next:  ["Import data into your installation", "../howto/import.html"]
 ---
 

--- a/docs/deploy/azure.md
+++ b/docs/deploy/azure.md
@@ -5,7 +5,7 @@ parent: Deploy and Setup lakeFS
 description: This section will guide you through deploying and setting up a production-suitable lakeFS environment on Microsoft Azure
 nav_order: 20
 redirect_from:
-   - ../setup/storage/blob.html 
+   - /setup/storage/blob.html 
 next:  ["Import data into your installation", "../howto/import.html"]
 ---
 

--- a/docs/deploy/gcp.md
+++ b/docs/deploy/gcp.md
@@ -5,7 +5,7 @@ parent: Deploy and Setup lakeFS
 description: This section will guide you through deploying and setting up a production-suitable lakeFS environment on Google Cloud Platform (GCP).
 nav_order: 40
 redirect_from:
-   - ../setup/storage/gcs.html 
+   - /setup/storage/gcs.html 
 next:  ["Import data into your installation", "../howto/import.html"]
 ---
 

--- a/docs/deploy/onprem.md
+++ b/docs/deploy/onprem.md
@@ -5,10 +5,10 @@ parent: Deploy and Setup lakeFS
 description: This section will guide you through deploying and setting up a production-suitable lakeFS environment on-premises (or on other cloud providers)
 nav_order: 50
 redirect_from:
-   - ./k8s.html
-   - ./docker.html 
-   - ../integrations/minio.html
-   - ../using/minio.html
+   - /deploy/k8s.html
+   - /deploy/docker.html 
+   - /integrations/minio.html
+   - /using/minio.html
 next:  ["Import data into your installation", "../howto/import.html"]
 ---
 

--- a/docs/hooks/index.md
+++ b/docs/hooks/index.md
@@ -5,7 +5,7 @@ title: Hooks
 description: Learn about lakeFS hooks
 has_children: true  
 redirect_from:
-  - ./reference/hooks.html
-  - ../hooks.html
+  - /reference/hooks.html
+  - /hooks.html
 ---
 

--- a/docs/howto/copying.md
+++ b/docs/howto/copying.md
@@ -6,8 +6,8 @@ parent: How-To
 nav_order: 50
 has_children: false
 redirect_from: 
-  - ../integrations/distcp.html
-  - ../integrations/rclone.html
+  - /integrations/distcp.html
+  - /integrations/rclone.html
 ---
 
 ## Using DistCp

--- a/docs/howto/export.md
+++ b/docs/howto/export.md
@@ -6,7 +6,7 @@ parent: How-To
 nav_order: 40
 has_children: false
 redirect_from: 
-  - ../reference/export.html
+  - /reference/export.html
 ---
 
 # Exporting Data

--- a/docs/howto/import.md
+++ b/docs/howto/import.md
@@ -6,7 +6,7 @@ parent: How-To
 nav_order: 10
 has_children: false
 redirect_from: 
-  - ../setup/import.html
+  - /setup/import.html
 ---
 
 # Import data into lakeFS

--- a/docs/howto/migrate-away.md
+++ b/docs/howto/migrate-away.md
@@ -6,8 +6,8 @@ parent: How-To
 nav_order: 9999
 has_children: false
 redirect_from: 
-  - ../deploying-aws/offboarding.html
-  - ../reference/offboarding.html
+  - /deploying-aws/offboarding.html
+  - /reference/offboarding.html
 ---
 
 # Migrating away from lakeFS

--- a/docs/howto/protect-branches.md
+++ b/docs/howto/protect-branches.md
@@ -6,7 +6,7 @@ parent: How-To
 nav_order: 60
 has_children: false
 redirect_from: 
-  - ../reference/protected_branches.html
+  - /reference/protected_branches.html
 ---
 
 # Branch Protection Rules

--- a/docs/howto/sizing-guide.md
+++ b/docs/howto/sizing-guide.md
@@ -6,8 +6,8 @@ description: This section provides a detailed sizing guide for deploying lakeFS.
 nav_order: 10000  # always last
 has_children: false
 redirect_from:
-    - ../architecture/sizing-guide.html
-    - ../understand/sizing-guide.html
+    - /architecture/sizing-guide.html
+    - /understand/sizing-guide.html
 ---
 # Sizing guide
 {: .no_toc }

--- a/docs/howto/upgrade.md
+++ b/docs/howto/upgrade.md
@@ -6,8 +6,8 @@ parent: How-To
 nav_order: 30
 has_children: false
 redirect_from: 
-  - ../deploying-aws/upgrade.html
-  - ../reference/upgrade.html
+  - /deploying-aws/upgrade.html
+  - /reference/upgrade.html
 ---
 
 # Upgrading lakeFS

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@ layout: default
 title: What is lakeFS
 description: The lakeFS documentation provides guidance on how to use lakeFS to deliver resilience and manageability to data lakes.
 nav_order: 0
-redirect_from: ./downloads.html
+redirect_from: /downloads.html
 ---
 
 ## What is lakeFS

--- a/docs/integrations/airflow.md
+++ b/docs/integrations/airflow.md
@@ -5,7 +5,7 @@ description: Easily build reproducible data pipelines with Airflow and lakeFS us
 parent: Integrations
 nav_order: 40
 has_children: false
-redirect_from: ../using/airflow.html
+redirect_from: /using/airflow.html
 ---
 
 # Using lakeFS with Airflow

--- a/docs/integrations/athena.md
+++ b/docs/integrations/athena.md
@@ -5,7 +5,7 @@ description: This section shows how you can start querying data from lakeFS usin
 parent: Integrations
 nav_order: 80
 has_children: false
-redirect_from: ../using/athena.html
+redirect_from: /using/athena.html
 ---
 
 # Using lakeFS with Amazon Athena

--- a/docs/integrations/aws_cli.md
+++ b/docs/integrations/aws_cli.md
@@ -5,7 +5,7 @@ description: This section shows how to use the AWS CLI for AWS S3 to access lake
 parent: Integrations
 nav_order: 30
 has_children: false
-redirect_from: ../using/aws_cli.html
+redirect_from: /using/aws_cli.html
 ---
 
 # Using lakeFS with AWS CLI

--- a/docs/integrations/dbt.md
+++ b/docs/integrations/dbt.md
@@ -5,7 +5,7 @@ description: This guide covers maintaining environments with dbt and lakeFS.
 parent: Integrations
 nav_order: 110
 has_children: false
-redirect_from: ../using/dbt.html
+redirect_from: /using/dbt.html
 ---
 
 ## Maintaining environments with dbt and lakeFS

--- a/docs/integrations/dremio.md
+++ b/docs/integrations/dremio.md
@@ -5,7 +5,7 @@ description: This section shows how you can start using lakeFS with Dremio, a ne
 parent: Integrations
 nav_order: 150
 has_children: false
-redirect_from: ../using/dremio.html
+redirect_from: /using/dremio.html
 ---
 
 # Using lakeFS with Dremio

--- a/docs/integrations/glue_hive_metastore.md
+++ b/docs/integrations/glue_hive_metastore.md
@@ -5,7 +5,7 @@ description: This section explains how to query data from lakeFS branches in ser
 parent: Integrations
 nav_order: 60
 has_children: false
-redirect_from: ../using/glue_hive_metastore.html
+redirect_from: /using/glue_hive_metastore.html
 ---
 
 {% include toc.html %}

--- a/docs/integrations/hive.md
+++ b/docs/integrations/hive.md
@@ -5,7 +5,7 @@ description: This section covers how you can start using lakeFS with Apache Hive
 parent: Integrations
 nav_order: 140
 has_children: false
-redirect_from: ../using/hive.html
+redirect_from: /using/hive.html
 ---
 
 # Using lakeFS with Hive

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -4,5 +4,5 @@ title: Integrations
 description: You can integrate lakeFS with all modern data frameworks such as Spark, Hive, AWS Athena, Presto, etc.
 nav_order: 20
 has_children: true
-redirect_from: ../using
+redirect_from: /using
 ---

--- a/docs/integrations/kafka.md
+++ b/docs/integrations/kafka.md
@@ -5,7 +5,9 @@ description: This section explains how you can start using lakeFS with Kafka usi
 parent: Integrations
 nav_order: 120
 has_children: false
-redirect_from: ../using/kakfa.html
+redirect_from: 
+    - /using/kakfa.html
+    - /integrations/kakfa.html
 ---
 
 # Using lakeFS with Kafka

--- a/docs/integrations/python.md
+++ b/docs/integrations/python.md
@@ -6,9 +6,9 @@ parent: Integrations
 nav_order: 50
 has_children: false
 redirect_from: 
-  - ../using/python.html
-  - ../using/boto.html
-  - ./boto.html
+  - /using/python.html
+  - /using/boto.html
+  - /integrations/boto.html
 ---
 
 {% include toc.html %}

--- a/docs/integrations/sagemaker.md
+++ b/docs/integrations/sagemaker.md
@@ -5,7 +5,7 @@ description: This section explains how to integrate your SageMaker installation 
 parent: Integrations
 nav_order: 130
 has_children: false
-redirect_from: ../using/sagemaker.html
+redirect_from: /using/sagemaker.html
 ---
 
 # Using lakeFS with SageMaker 

--- a/docs/integrations/spark.md
+++ b/docs/integrations/spark.md
@@ -425,7 +425,7 @@ io.lakefs:hadoop-lakefs-assembly:0.1.13
 
 Once installed, it should look something like this:
 
-![Databricks - Adding the lakeFS client Jar](./integrations/assets/img/databricks-install-package.png)
+![Databricks - Adding the lakeFS client Jar](/assets/img/databricks-install-package.png)
 
   </div>
 </div>

--- a/docs/integrations/spark.md
+++ b/docs/integrations/spark.md
@@ -6,13 +6,13 @@ parent: Integrations
 nav_order: 10
 has_children: false
 redirect_from: 
-  - ../using/spark.html
-  - ../using/databricks.html
-  - ./databricks.html
-  - ./emr.html
-  - ../using/emr.html
-  - ./glue_etl.html
-  - ../using/glue_etl.html
+  - /integrations/databricks.html
+  - /integrations/emr.html
+  - /integrations/glue_etl.html
+  - /using/databricks.html
+  - /using/emr.html
+  - /using/glue_etl.html
+  - /using/spark.html
 ---
 
 # Using lakeFS with Spark
@@ -425,7 +425,7 @@ io.lakefs:hadoop-lakefs-assembly:0.1.13
 
 Once installed, it should look something like this:
 
-![Databricks - Adding the lakeFS client Jar](../assets/img/databricks-install-package.png)
+![Databricks - Adding the lakeFS client Jar](./integrations/assets/img/databricks-install-package.png)
 
   </div>
 </div>

--- a/docs/quickstart/index.md
+++ b/docs/quickstart/index.md
@@ -6,14 +6,14 @@ has_children: true
 has_toc: false
 next: ["Launch the quickstart environment", "./launch.html"]
 redirect_from: 
-    - "./installing.html"
-    - "./try.html"
-    - "/quickstart.html"
-    - "./add_data.html"
-    - "./more_quickstart_options.html"
-    - "./repository.html"
-    - "./run.html"
-    - "./first_commit.html"
+  - /quickstart.html
+  - /quickstart/installing.html
+  - /quickstart/try.html
+  - /quickstart/add_data.html
+  - /quickstart/more_quickstart_options.html
+  - /quickstart/repository.html
+  - /quickstart/run.html
+  - /quickstart/first_commit.html
 ---
 
 # lakeFS Quickstart

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -6,7 +6,7 @@ parent: Reference
 nav_order: 20
 has_children: false
 redirect_from:
-  - ./commands.html
+  - /reference/commands.html
 ---
 
 {% comment %}

--- a/docs/reference/monitor.md
+++ b/docs/reference/monitor.md
@@ -5,7 +5,7 @@ description: A guide to monitoring your lakeFS Installation with Prometheus.
 parent: Reference
 nav_order: 90
 has_children: false
-redirect_from: ../deploying-aws/monitor.md
+redirect_from: /deploying-aws/monitor.md
 ---
 
 # Monitoring using Prometheus

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -5,7 +5,7 @@ description: New features and improvements lined-up for lakeFS. Become part of b
 nav_order: 95
 has_children: false
 redirect_from: 
-  - ../understand/roadmap.html
+  - /understand/roadmap.html
 ---
 
 # Roadmap

--- a/docs/understand/architecture.md
+++ b/docs/understand/architecture.md
@@ -6,8 +6,8 @@ description: lakeFS architecture overview. Learn more about lakeFS components, i
 nav_order: 10
 has_children: false
 redirect_from:
-    - ../architecture/index.html
-    - ../architecture/overview.html
+    - /architecture/index.html
+    - /architecture/overview.html
 ---
 # Architecture Overview
 {: .no_toc }

--- a/docs/understand/data_lifecycle_management/ci.md
+++ b/docs/understand/data_lifecycle_management/ci.md
@@ -6,7 +6,7 @@ grand_parent: Understanding lakeFS
 description: lakeFS enables to continuously test newly ingested data to ensure data quality requirements are met
 nav_order: 35
 redirect_from:
-  - ../../data_lifecycle_management/ci.html
+  - /data_lifecycle_management/ci.html
 ---
 
 ## During Deployment

--- a/docs/understand/data_lifecycle_management/data-devenv.md
+++ b/docs/understand/data_lifecycle_management/data-devenv.md
@@ -6,7 +6,7 @@ grand_parent: Understanding lakeFS
 description: lakeFS enables a safe test environment on your data lake without the need to copy or mock data
 nav_order: 25
 redirect_from:
-  - ../../data_lifecycle_management/data-devenv.html
+  - /data_lifecycle_management/data-devenv.html
 ---
 
 

--- a/docs/understand/data_lifecycle_management/index.md
+++ b/docs/understand/data_lifecycle_management/index.md
@@ -6,6 +6,6 @@ nav_order: 50
 parent: Understanding lakeFS
 has_children: true
 redirect_from:
-    - ../branching/recommendations.html
-    - ../using_lakefs.html
+    - /branching/recommendations.html
+    - /using_lakefs.html
 ---

--- a/docs/understand/data_lifecycle_management/production.md
+++ b/docs/understand/data_lifecycle_management/production.md
@@ -6,7 +6,7 @@ grand_parent: Understanding lakeFS
 description: lakeFS helps recover from errors and find root case in production.
 nav_order: 55
 redirect_from:
-  - ../../data_lifecycle_management/production.html
+  - /data_lifecycle_management/production.html
 ---
 
 ## In Production

--- a/docs/understand/glossary.md
+++ b/docs/understand/glossary.md
@@ -6,7 +6,7 @@ parent: Understanding lakeFS
 nav_order: 60
 has_children: false
 redirect_from:
-    - ../reference/glossary.html
+    - /reference/glossary.html
     - /glossary.html
 ---
 

--- a/docs/understand/how/kv.md
+++ b/docs/understand/how/kv.md
@@ -7,7 +7,7 @@ description: Brief introduction to lakeFS over KV
 nav_order: 20
 has_children: false
 redirect_from:
-  - ../kv-in-a-nutshell.html
+  - /understand/kv-in-a-nutshell.html
 ---
 # Internal database structure
 {: .no_toc }

--- a/docs/understand/how/merge.md
+++ b/docs/understand/how/merge.md
@@ -7,8 +7,8 @@ grand_parent: Understanding lakeFS
 nav_order: 9999
 has_children: false
 redirect_from:
-  - ../reference/merge.html
-  - understand/merge.html
+  - /reference/merge.html
+  - /understand/merge.html
 ---
 
 # Merge

--- a/docs/understand/how/versioning-internals.md
+++ b/docs/understand/how/versioning-internals.md
@@ -7,9 +7,9 @@ description: This section explains how versioning works in lakeFS.
 nav_order: 10
 has_children: false
 redirect_from: 
-  - ../architecture/data-model.html
-  - ../understand/data-model.html
-  - ../versioning-internals.html
+  - /understand/architecture/data-model.html
+  - /understand/understand/data-model.html
+  - /understand/versioning-internals.html
 --- 
 
 

--- a/docs/understand/model.md
+++ b/docs/understand/model.md
@@ -5,7 +5,10 @@ description: The lakeFS object model blends the object models of Git and of obje
 parent: Understanding lakeFS
 nav_order: 20
 has_children: false
-redirect_from: ["../reference/object-model.html","../understand/branching-model.html","../understand/object-model.html"]
+redirect_from: 
+  - /reference/object-model.html
+  - /understand/branching-model.html
+  - /understand/object-model.html
 ---
 
 # Model


### PR DESCRIPTION
- Kakfa -> Kafka
- Change all redirects to absolute paths


### Linked Issue

Closes #5630

---

## Change Description

### Background

Many existing redirects are broken. See #5630 for analysis and details


### Bug Fix

1. Change all `redirect_from` values to absolute paths
      

### Testing Details

How were the changes tested? Manually

#### Are redirects now working? 

* ✅ [`/quickstart/run.html`](https://treeverse-lakefs-preview-pr-5633.surge.sh/quickstart/run.html)
* ✅ [`/reference/commands.html`](https://treeverse-lakefs-preview-pr-5633.surge.sh/reference/commands.html)

#### `lychee` linkchecker Summary

https://github.com/treeverse/lakeFS/actions/runs/4608679010#summary-12510074854

```
| Status        | Count |
|---------------|-------|
| 🔍 Total      | 2522  |
| ✅ Successful | 1756  |
| ⏳ Timeouts   | 0     |
| 🔀 Redirected | 0     |
| 👻 Excluded   | 766   |
| ❓ Unknown    | 0     |
| 🚫 Errors     | 0     |
```

### Breaking Change?

No

