### PR TITLE
Correctly read command pipes in esti/gc runCommand

### DIFF
--- a/esti/gc_utils_test.go
+++ b/esti/gc_utils_test.go
@@ -49,7 +49,6 @@ func handlePipe(pipe io.ReadCloser, log func(messages ...interface{}), ch chan<-
 			err = nil
 		}
 		ch <- err
-		pipe.Close()
 	}()
 }
 


### PR DESCRIPTION
Fixes #5654.  Uses cmd.Std*Pipe as documented; the previous code might drop some last lines from Spark outputs.

It also ends up reporting the _source_ of each log line from Spark, including the name of the test that ran it.  That's important because all these Sparks run in parallel.  So we now see lines like
```
time="2023-04-09T13:00:10Z" level=info msg="23/04/09 13:00:10 INFO MetricsSystemImpl: Stopping s3a-file-system metrics system..." func=github.com/treeverse/lakefs/esti.handlePipe.func1 file="/home/runner/work/lakeFS/lakeFS/esti/gc_utils_test.go:46" source=gc-gc1 std=err
```
which says that Spark wrote this to **standard error** while running gc-gc1.