### PR TITLE
Lua optional net http request

### DIFF
--- a/cmd/lakefs/cmd/lua.go
+++ b/cmd/lakefs/cmd/lua.go
@@ -28,7 +28,7 @@ var luaRunCmd = &cobra.Command{
 
 		ctx := cmd.Context()
 		l := lua.NewStateEx()
-		lualibs.OpenSafe(l, ctx, os.Stdout)
+		lualibs.OpenSafe(l, ctx, lualibs.OpenSafeConfig{NetHTTPEnabled: true}, os.Stdout)
 		luautil.DeepPush(l, args)
 		l.SetGlobal("args") // add cmd line args as lua args
 		if err := lua.DoFile(l, filename); err != nil {

--- a/cmd/lakefs/cmd/run.go
+++ b/cmd/lakefs/cmd/run.go
@@ -195,7 +195,7 @@ var runCmd = &cobra.Command{
 			catalog.NewActionsOutputWriter(c.BlockAdapter),
 			idGen,
 			bufferedCollector,
-			cfg.Actions.Enabled,
+			actions.Config(cfg.Actions),
 		)
 
 		// wire actions into entry catalog

--- a/docs/hooks/lua.md
+++ b/docs/hooks/lua.md
@@ -340,8 +340,10 @@ Returns a code (number), body (string), headers (table) and status (string).
  - headers - table with the response request headers (key/value or table of values)
  - status - status code text
 
-The first form of the call will perform GET request or POST in case body passed to the request.
-The second form allows to customize the specific method and the request headers by passing a table with request information.
+The first form of the call will perform GET requests or POST requests if the body parameter is passed.
+
+The second form accepts a table and allows you to customize the request method and headers.
+
 
 Example of a GET request
 

--- a/docs/hooks/lua.md
+++ b/docs/hooks/lua.md
@@ -321,6 +321,7 @@ Returns a new 128-bit [RFC 4122 UUID](https://www.rfc-editor.org/rfc/rfc4122){: 
 
 Provides a `request` function that performs an HTTP request.
 For security reasons, this package is not available by default. This enables http requests to be sent out from the lakeFS instance network. The feature should be enabled under `actions.lua.net_http_enabled` [configuration](../reference/configuration.md).
+Request will time out after 30 seconds.
 
 ```lua
 http.request(url [, body])

--- a/docs/hooks/lua.md
+++ b/docs/hooks/lua.md
@@ -320,7 +320,7 @@ Returns a new 128-bit [RFC 4122 UUID](https://www.rfc-editor.org/rfc/rfc4122){: 
 ### `net/http` (optional)
 
 Provides a `request` function that performs an HTTP request.
-For security reasons, this package is not available by default. This enables http requests to be sent out from the lakeFS instance network. The feature should be enabled under `actions.lua.net_http_enabled` [configuration](../reference/configuration.md).
+For security reasons, this package is not available by default as it enables http requests to be sent out from the lakeFS instance network. The feature should be enabled under `actions.lua.net_http_enabled` [configuration](../reference/configuration.md).
 Request will time out after 30 seconds.
 
 ```lua

--- a/docs/hooks/lua.md
+++ b/docs/hooks/lua.md
@@ -320,7 +320,7 @@ Returns a new 128-bit [RFC 4122 UUID](https://www.rfc-editor.org/rfc/rfc4122){: 
 ### `net/http` (optional)
 
 Provides a `request` function that performs an HTTP request.
-Note that this package is not enabled by default for security reasons. It enables http request coming out from lakeFS instance network. The feature should be enabled under `actions.lua.net_http_enabled` [configuration](../reference/configuration.md).
+For security reasons, this package is not available by default. This enables http requests to be sent out from the lakeFS instance network. The feature should be enabled under `actions.lua.net_http_enabled` [configuration](../reference/configuration.md).
 
 ```lua
 http.request(url [, body])

--- a/docs/hooks/lua.md
+++ b/docs/hooks/lua.md
@@ -317,6 +317,62 @@ The `value` string should be in [ISO8601](https://en.wikipedia.org/wiki/ISO_8601
 
 Returns a new 128-bit [RFC 4122 UUID](https://www.rfc-editor.org/rfc/rfc4122){: target="_blank" } in string representation.
 
+### `net/http` (optional)
+
+Provides a `request` function that performs an HTTP request.
+Note that this package is not enabled by default for security reasons. It enables http request coming out from lakeFS instance network. The feature should be enabled under `actions.lua.net_http_enabled` [configuration](../reference/configuration.md).
+
+```lua
+http.request(url [, body])
+http.request{
+  url = string,
+  [method = string,]
+  [headers = header-table,]
+  [body = string,]
+}
+```
+
+Returns a code (number), body (string), headers (table) and status (string).
+
+ - code - status code number
+ - body - string with the response body
+ - headers - table with the response request headers (key/value or table of values)
+ - status - status code text
+
+The first form of the call will perform GET request or POST in case body passed to the request.
+The second form allows to customize the specific method and the request headers by passing a table with request information.
+
+Example of a GET request
+
+```lua
+local http = require("net/http")
+local code, body = http.request("https://example.com")
+if code == 200 then
+    print(body)
+else
+    print("Failed to get example.com - status code: " .. code)
+end
+
+```
+
+Example of a POST request
+
+```lua
+local http = require("net/http")
+local code, body = http.request{
+    url="https://httpbin.org/post",
+    method="POST",
+    body="custname=tester",
+    headers={["Content-Type"]="application/x-www-form-urlencoded"},
+}
+if code == 200 then
+    print(body)
+else
+    print("Failed to post data - status code: " .. code)
+end
+```
+
+
 ## Example Hooks
 
 This example will simply print out a JSON representation of the event that occurred:

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -35,7 +35,8 @@ This reference uses `.` to denote the nesting of values.
 * `logging.output` `(string : "-")` - A path or paths to write logs to. A `-` means the standard output, `=` means the standard error.
 * `logging.file_max_size_mb` `(int : 100)` - Output file maximum size in megabytes.
 * `logging.files_keep` `(int : 0)` - Number of log files to keep, default is all.
-* `actions.enabled` `(bool : true)` - Setting this to false will block hooks from being executed
+* `actions.enabled` `(bool : true)` - Setting this to false will block hooks from being executed.
+* `actions.lua.net_http_enabled` `(bool : false)` - Setting this to true will load the `net/http` package.
 * ~~`database.connection_string` `(string : "postgres://localhost:5432/postgres?sslmode=disable")` - PostgreSQL connection string to use~~
 * ~~`database.max_open_connections` `(int : 25)` - Maximum number of open connections to the database~~
 * ~~`database.max_idle_connections` `(int : 25)` - Sets the maximum number of connections in the idle connection pool~~

--- a/pkg/actions/airflow.go
+++ b/pkg/actions/airflow.go
@@ -55,11 +55,12 @@ var (
 	errAirflowHookDAGFailed     = errors.New("airflow hook DAG failed")
 )
 
-func NewAirflowHook(h ActionHook, action *Action, endpoint *http.Server) (Hook, error) {
+func NewAirflowHook(h ActionHook, action *Action, cfg Config, endpoint *http.Server) (Hook, error) {
 	airflowHook := Airflow{
 		HookBase: HookBase{
 			ID:         h.ID,
 			ActionName: action.Name,
+			Config:     cfg,
 			Endpoint:   endpoint,
 		},
 		DAGConf: map[string]interface{}{},

--- a/pkg/actions/hook.go
+++ b/pkg/actions/hook.go
@@ -23,11 +23,12 @@ type Hook interface {
 	Run(ctx context.Context, record graveler.HookRecord, buf *bytes.Buffer) error
 }
 
-type NewHookFunc func(ActionHook, *Action, *http.Server) (Hook, error)
+type NewHookFunc func(ActionHook, *Action, Config, *http.Server) (Hook, error)
 
 type HookBase struct {
 	ID         string
 	ActionName string
+	Config     Config
 	Endpoint   *http.Server
 }
 
@@ -39,10 +40,10 @@ var hooks = map[HookType]NewHookFunc{
 
 var ErrUnknownHookType = errors.New("unknown hook type")
 
-func NewHook(h ActionHook, a *Action, e *http.Server) (Hook, error) {
-	f := hooks[h.Type]
+func NewHook(hook ActionHook, action *Action, cfg Config, server *http.Server) (Hook, error) {
+	f := hooks[hook.Type]
 	if f == nil {
-		return nil, fmt.Errorf("%w (%s)", ErrUnknownHookType, h.Type)
+		return nil, fmt.Errorf("%w (%s)", ErrUnknownHookType, hook.Type)
 	}
-	return f(h, a, e)
+	return f(hook, action, cfg, server)
 }

--- a/pkg/actions/kv_run_results_iterator_test.go
+++ b/pkg/actions/kv_run_results_iterator_test.go
@@ -138,7 +138,7 @@ func createTestData(t *testing.T, ctx context.Context, kvStore kv.Store) (map[st
 	writer := mock.NewMockOutputWriter(ctrl)
 	mockStatsCollector := NewActionStatsMockCollector()
 	testSource := mock.NewMockSource(ctrl)
-	actionService := actions.NewService(ctx, actions.NewActionsKVStore(kvStore), testSource, writer, &TestDecreasingIDGenerator{num: math.MaxInt32}, &mockStatsCollector, false)
+	actionService := actions.NewService(ctx, actions.NewActionsKVStore(kvStore), testSource, writer, &TestDecreasingIDGenerator{num: math.MaxInt32}, &mockStatsCollector, actions.Config{})
 	msgIdx := 0
 	run := actions.RunResultData{
 		RunId:     "",

--- a/pkg/actions/lua.go
+++ b/pkg/actions/lua.go
@@ -84,7 +84,7 @@ func (h *LuaHook) Run(ctx context.Context, record graveler.HookRecord, buf *byte
 		return err
 	}
 	l := lua.NewState()
-	lualibs.OpenSafe(l, ctx, &loggingBuffer{buf: buf, ctx: ctx})
+	lualibs.OpenSafe(l, ctx, h.Config.Lua, &loggingBuffer{buf: buf, ctx: ctx})
 	injectHookContext(l, ctx, user, h.Endpoint, h.Args)
 	applyRecord(l, h.ActionName, h.ID, record)
 
@@ -165,7 +165,7 @@ func DescendArgs(args interface{}) (descended interface{}, err error) {
 	}
 }
 
-func NewLuaHook(h ActionHook, action *Action, e *http.Server) (Hook, error) {
+func NewLuaHook(h ActionHook, action *Action, cfg Config, e *http.Server) (Hook, error) {
 	// optional args
 	args := make(map[string]interface{})
 	argsVal, hasArgs := h.Properties["args"]
@@ -197,6 +197,7 @@ func NewLuaHook(h ActionHook, action *Action, e *http.Server) (Hook, error) {
 			HookBase: HookBase{
 				ID:         h.ID,
 				ActionName: action.Name,
+				Config:     cfg,
 				Endpoint:   e,
 			},
 			Script: script,
@@ -219,6 +220,7 @@ func NewLuaHook(h ActionHook, action *Action, e *http.Server) (Hook, error) {
 		HookBase: HookBase{
 			ID:         h.ID,
 			ActionName: action.Name,
+			Config:     cfg,
 			Endpoint:   e,
 		},
 		ScriptPath: scriptFile,

--- a/pkg/actions/lua/encoding/parquet/parquet_test.go
+++ b/pkg/actions/lua/encoding/parquet/parquet_test.go
@@ -6,25 +6,22 @@ import (
 	"os"
 	"testing"
 
-	"github.com/treeverse/lakefs/pkg/actions/lua/encoding/parquet"
-
-	"github.com/treeverse/lakefs/pkg/actions/lua/encoding/json"
-
 	"github.com/Shopify/go-lua"
-
 	lualibs "github.com/treeverse/lakefs/pkg/actions/lua"
+	"github.com/treeverse/lakefs/pkg/actions/lua/encoding/json"
+	"github.com/treeverse/lakefs/pkg/actions/lua/encoding/parquet"
 )
 
-var parquetSchemaRead = `
+const parquetSchemaRead = `
 parquet = require("encoding/parquet")
-schema = parquet.get_schema(paruqet_content)
+schema = parquet.get_schema(parquet_content)
 
 for _, col in pairs(schema) do
 	print(col.name .. "\t" .. col.type)
 end
 `
 
-var expected = `geoname_id	BYTE_ARRAY
+const expected = `geoname_id	BYTE_ARRAY
 name	BYTE_ARRAY
 ascii_name	BYTE_ARRAY
 alternate_names	BYTE_ARRAY
@@ -42,7 +39,7 @@ coordinates	BYTE_ARRAY
 func TestOpen(t *testing.T) {
 	out := bytes.Buffer{}
 	l := lua.NewState()
-	lualibs.OpenSafe(l, context.Background(), &out)
+	lualibs.OpenSafe(l, context.Background(), lualibs.OpenSafeConfig{}, &out)
 	parquet.Open(l)
 	json.Open(l)
 
@@ -51,7 +48,7 @@ func TestOpen(t *testing.T) {
 		t.Fatal(err)
 	}
 	l.PushString(string(parquetBytes))
-	l.SetGlobal("paruqet_content")
+	l.SetGlobal("parquet_content")
 
 	err = lua.DoString(l, parquetSchemaRead)
 	if err != nil {

--- a/pkg/actions/lua/net/http/client.go
+++ b/pkg/actions/lua/net/http/client.go
@@ -1,0 +1,117 @@
+package http
+
+import (
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/Shopify/go-lua"
+	"github.com/treeverse/lakefs/pkg/actions/lua/util"
+)
+
+func Open(l *lua.State) {
+	open := func(l *lua.State) int {
+		lua.NewLibrary(l, httpLibrary)
+		return 1
+	}
+	lua.Require(l, "net/http", open, false)
+	l.Pop(1)
+}
+
+var httpLibrary = []lua.RegistryFunction{
+	{Name: "request", Function: httpRequest},
+}
+
+// httpRequest - perform http request
+//
+//		Accepts arguments (url, body) or table with url, method, body, headers. Value for url is required. method is by default GET.
+//	 Returns code, body, headers, status.
+func httpRequest(l *lua.State) int {
+	var (
+		reqMethod  = http.MethodGet
+		reqURL     string
+		reqBody    io.Reader
+		reqHeaders map[string]interface{}
+	)
+	switch l.TypeOf(1) {
+	case lua.TypeString:
+		reqURL = lua.CheckString(l, 1)
+		// get optional body as string
+		if s, ok := l.ToString(2); ok {
+			reqBody = strings.NewReader(s)
+		}
+	case lua.TypeTable:
+		// extract request params from table
+		value, err := util.PullTable(l, 1)
+		check(l, err)
+		tbl := value.(map[string]interface{})
+		if s, ok := tbl["url"].(string); ok {
+			reqURL = s
+		}
+		if s, ok := tbl["method"].(string); ok {
+			reqMethod = s
+		}
+		if s, ok := tbl["body"].(string); ok {
+			reqBody = strings.NewReader(s)
+		}
+		if m, ok := tbl["headers"].(map[string]interface{}); ok {
+			reqHeaders = m
+		}
+	default:
+		lua.Errorf(l, "first argument can be url or request table (invalid type: %d)", l.TypeOf(1))
+		panic("unreachable")
+	}
+	if reqURL == "" {
+		lua.Errorf(l, "missing request url")
+		panic("unreachable")
+	}
+	req, err := http.NewRequest(reqMethod, reqURL, reqBody)
+	check(l, err)
+	requestAddHeader(reqHeaders, req)
+	resp, err := http.DefaultClient.Do(req)
+	check(l, err)
+	defer func() { _ = resp.Body.Close() }()
+	body, err := io.ReadAll(resp.Body)
+	check(l, err)
+	l.PushInteger(resp.StatusCode)
+	l.PushString(string(body))
+	pushResponseHeader(l, resp.Header)
+	l.PushString(resp.Status)
+	return 4
+}
+
+// requestAddHeader add headers to request. each table value can be single a string or array(table) of strings
+func requestAddHeader(reqHeaders map[string]interface{}, req *http.Request) {
+	for k, v := range reqHeaders {
+		switch vv := v.(type) {
+		case string:
+			req.Header.Add(k, vv)
+		case map[string]interface{}:
+			for _, val := range vv {
+				if s, ok := val.(string); ok {
+					req.Header.Add(k, s)
+				}
+			}
+		}
+	}
+}
+
+// pushResponseHeader response headers as table. the result table will include single value or table of values for multiple values
+func pushResponseHeader(l *lua.State, header http.Header) {
+	m := make(map[string]interface{}, len(header))
+	for k, v := range header {
+		if len(v) == 1 {
+			m[k] = v[0]
+		} else {
+			m[k] = v
+		}
+	}
+	util.DeepPush(l, m)
+}
+
+func check(l *lua.State, err error) {
+	if err != nil {
+		lua.Errorf(l, err.Error())
+		panic("unreachable")
+	}
+}

--- a/pkg/actions/lua/net/http/request.go
+++ b/pkg/actions/lua/net/http/request.go
@@ -24,8 +24,9 @@ var httpLibrary = []lua.RegistryFunction{
 
 // httpRequest - perform http request
 //
-//		Accepts arguments (url, body) or table with url, method, body, headers. Value for url is required. method is by default GET.
-//	 Returns code, body, headers, status.
+//	Accepts arguments (url, body) or table with url, method, body, headers. Value for url is required.
+//		method is by default GET or POST in case body is set.
+//	Returns code, body, headers, status.
 func httpRequest(l *lua.State) int {
 	var (
 		reqMethod  = http.MethodGet
@@ -35,24 +36,26 @@ func httpRequest(l *lua.State) int {
 	)
 	switch l.TypeOf(1) {
 	case lua.TypeString:
+		// url and optional body
 		reqURL = lua.CheckString(l, 1)
-		// get optional body as string
 		if s, ok := l.ToString(2); ok {
 			reqBody = strings.NewReader(s)
+			reqMethod = http.MethodPost
 		}
 	case lua.TypeTable:
-		// extract request params from table
+		// extract request parameters from table
 		value, err := util.PullTable(l, 1)
 		check(l, err)
 		tbl := value.(map[string]interface{})
 		if s, ok := tbl["url"].(string); ok {
 			reqURL = s
 		}
-		if s, ok := tbl["method"].(string); ok {
-			reqMethod = s
-		}
 		if s, ok := tbl["body"].(string); ok {
 			reqBody = strings.NewReader(s)
+			reqMethod = http.MethodPost
+		}
+		if s, ok := tbl["method"].(string); ok {
+			reqMethod = s
 		}
 		if m, ok := tbl["headers"].(map[string]interface{}); ok {
 			reqHeaders = m

--- a/pkg/actions/lua/net/http/request.go
+++ b/pkg/actions/lua/net/http/request.go
@@ -31,7 +31,7 @@ var httpLibrary = []lua.RegistryFunction{
 //		method is by default GET or POST in case body is set.
 //	Returns code, body, headers, status.
 func httpRequest(l *lua.State) int {
-	req, err := prepareRequest(l)
+	req := prepareRequest(l)
 	client := http.Client{
 		Timeout: defaultRequestTimeout,
 	}
@@ -49,7 +49,7 @@ func httpRequest(l *lua.State) int {
 	return 4
 }
 
-func prepareRequest(l *lua.State) (*http.Request, error) {
+func prepareRequest(l *lua.State) *http.Request {
 	var (
 		reqMethod  = http.MethodGet
 		reqURL     string
@@ -93,7 +93,7 @@ func prepareRequest(l *lua.State) (*http.Request, error) {
 	req, err := http.NewRequest(reqMethod, reqURL, reqBody)
 	check(l, err)
 	requestAddHeader(reqHeaders, req)
-	return req, err
+	return req
 }
 
 // requestAddHeader add headers to request. each table value can be single a string or array(table) of strings

--- a/pkg/actions/lua/net/http/request.go
+++ b/pkg/actions/lua/net/http/request.go
@@ -28,7 +28,7 @@ var httpLibrary = []lua.RegistryFunction{
 // httpRequest - perform http request
 //
 //	Accepts arguments (url, body) or table with url, method, body, headers. Value for url is required.
-//		method is by default GET or POST in case body is set.
+//	The `method` is by default GET or POST in case body is set.
 //	Returns code, body, headers, status.
 func httpRequest(l *lua.State) int {
 	req := prepareRequest(l)

--- a/pkg/actions/lua/open.go
+++ b/pkg/actions/lua/open.go
@@ -23,7 +23,7 @@ import (
 // most classes here are taken from: https://github.com/Shopify/goluago
 // See the original MIT license with copyright at ./LICENSE.md
 
-func Open(l *lua.State, ctx context.Context) {
+func Open(l *lua.State, ctx context.Context, cfg OpenSafeConfig) {
 	regexp.Open(l)
 	strings.Open(l)
 	json.Open(l)
@@ -37,5 +37,7 @@ func Open(l *lua.State, ctx context.Context) {
 	parquet.Open(l)
 	path.Open(l)
 	aws.Open(l, ctx)
-	http.Open(l)
+	if cfg.NetHTTPEnabled {
+		http.Open(l)
+	}
 }

--- a/pkg/actions/lua/open.go
+++ b/pkg/actions/lua/open.go
@@ -11,6 +11,7 @@ import (
 	"github.com/treeverse/lakefs/pkg/actions/lua/encoding/hex"
 	"github.com/treeverse/lakefs/pkg/actions/lua/encoding/json"
 	"github.com/treeverse/lakefs/pkg/actions/lua/encoding/parquet"
+	"github.com/treeverse/lakefs/pkg/actions/lua/net/http"
 	"github.com/treeverse/lakefs/pkg/actions/lua/path"
 	"github.com/treeverse/lakefs/pkg/actions/lua/regexp"
 	"github.com/treeverse/lakefs/pkg/actions/lua/storage/aws"
@@ -36,4 +37,5 @@ func Open(l *lua.State, ctx context.Context) {
 	parquet.Open(l)
 	path.Open(l)
 	aws.Open(l, ctx)
+	http.Open(l)
 }

--- a/pkg/actions/lua/stdlib.go
+++ b/pkg/actions/lua/stdlib.go
@@ -348,7 +348,11 @@ func BaseOpen(buf io.StringWriter) glua.Function {
 	}
 }
 
-func OpenSafe(l *glua.State, ctx context.Context, buf io.StringWriter) {
+type OpenSafeConfig struct {
+	NetHTTPEnabled bool
+}
+
+func OpenSafe(l *glua.State, ctx context.Context, cfg OpenSafeConfig, buf io.StringWriter) {
 	// a thin version of the standard library that doesn't include 'io'
 	//  along with a set of globals that omit anything that loads something external or reaches out to OS.
 	libs := []glua.RegistryFunction{
@@ -367,6 +371,5 @@ func OpenSafe(l *glua.State, ctx context.Context, buf io.StringWriter) {
 
 	// utils adapted from goluago, skipping anything that allows network or storage access.
 	// additionally, the "goluago" namespace is removed from import tokens
-
-	Open(l, ctx)
+	Open(l, ctx, cfg)
 }

--- a/pkg/actions/lua_test.go
+++ b/pkg/actions/lua_test.go
@@ -176,7 +176,7 @@ func TestLuaRun_NetHttp(t *testing.T) {
 	tests := []struct {
 		Name        string
 		Script      string
-		ExpectError bool
+		ExpectedErr bool
 		Expected    string
 	}{
 		{
@@ -193,7 +193,8 @@ print(code .. " " .. body .. " " .. status)
 local code, body, headers, status = http.request("https://invalid.place.com")
 print(code .. " " .. body .. " " .. status)
 `,
-			Expected: "no such host",
+			ExpectedErr: true,
+			Expected:    "no such host",
 		},
 		{
 			Name: "simple_post",
@@ -299,7 +300,7 @@ print(code .. " " .. body .. " " .. status)
 				PreRunID: "3498032432",
 				TagID:    "",
 			}, out)
-			if tt.ExpectError {
+			if tt.ExpectedErr {
 				if err == nil {
 					t.Fatal("Expected error - got none.")
 				}

--- a/pkg/actions/lua_test.go
+++ b/pkg/actions/lua_test.go
@@ -118,10 +118,6 @@ func TestLuaRun_NetHttpDisabled(t *testing.T) {
 			Description: "na",
 			Properties: map[string]interface{}{
 				"script": `local http = require("net/http")`,
-
-				//local code, body = http.request("https://example.com")
-				//print(code, body)
-				//`,
 			},
 		},
 		&actions.Action{

--- a/pkg/actions/service.go
+++ b/pkg/actions/service.go
@@ -35,6 +35,13 @@ var (
 	ErrNilValue = errors.New("nil value")
 )
 
+type Config struct {
+	Enabled bool
+	Lua     struct {
+		NetHTTPEnabled bool
+	}
+}
+
 // StoreService is an implementation of actions.Service that saves
 // the run data to the blockstore and to the actions.Store (which is a
 // fancy name for a DB - kv style or postgres directly)
@@ -47,8 +54,7 @@ type StoreService struct {
 	cancel   context.CancelFunc
 	wg       sync.WaitGroup
 	stats    stats.Collector
-	runHooks bool
-
+	cfg      Config
 	endpoint *http.Server
 }
 
@@ -204,18 +210,18 @@ type Service interface {
 	graveler.HooksHandler
 }
 
-func NewService(ctx context.Context, store Store, source Source, writer OutputWriter, idGen IDGenerator, stats stats.Collector, runHooks bool) *StoreService {
+func NewService(ctx context.Context, store Store, source Source, writer OutputWriter, idGen IDGenerator, stats stats.Collector, cfg Config) *StoreService {
 	ctx, cancel := context.WithCancel(ctx)
 	return &StoreService{
-		Store:    store,
-		Source:   source,
-		Writer:   writer,
-		ctx:      ctx,
-		idGen:    idGen,
-		cancel:   cancel,
-		wg:       sync.WaitGroup{},
-		stats:    stats,
-		runHooks: runHooks,
+		Store:  store,
+		Source: source,
+		Writer: writer,
+		ctx:    ctx,
+		idGen:  idGen,
+		cancel: cancel,
+		wg:     sync.WaitGroup{},
+		stats:  stats,
+		cfg:    cfg,
 	}
 }
 
@@ -255,7 +261,7 @@ func (s *StoreService) asyncRun(ctx context.Context, record graveler.HookRecord)
 
 // Run load and run actions based on the event information
 func (s *StoreService) Run(ctx context.Context, record graveler.HookRecord) error {
-	if !s.runHooks {
+	if !s.cfg.Enabled {
 		logging.FromContext(ctx).WithField("record", record).Debug("Hooks are disabled, skipping hooks execution")
 		return nil
 	}
@@ -301,7 +307,7 @@ func (s *StoreService) allocateTasks(runID string, actions []*Action) ([][]*Task
 	for actionIdx, action := range actions {
 		var actionTasks []*Task
 		for hookIdx, hook := range action.Hooks {
-			h, err := NewHook(hook, action, s.endpoint)
+			h, err := NewHook(hook, action, s.cfg, s.endpoint)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/actions/service_test.go
+++ b/pkg/actions/service_test.go
@@ -59,7 +59,9 @@ type getService func(t *testing.T, ctx context.Context, source actions.Source, w
 func GetKVService(t *testing.T, ctx context.Context, source actions.Source, writer actions.OutputWriter, stats stats.Collector, runHooks bool) actions.Service {
 	t.Helper()
 	kvStore := kvtest.GetStore(ctx, t)
-	return actions.NewService(ctx, actions.NewActionsKVStore(kvStore), source, writer, &actions.DecreasingIDGenerator{}, stats, runHooks)
+	cfg := actions.Config{Enabled: runHooks}
+	cfg.Lua.NetHTTPEnabled = true
+	return actions.NewService(ctx, actions.NewActionsKVStore(kvStore), source, writer, &actions.DecreasingIDGenerator{}, stats, cfg)
 }
 
 func TestServiceRun(t *testing.T) {

--- a/pkg/actions/webhook.go
+++ b/pkg/actions/webhook.go
@@ -35,7 +35,7 @@ var (
 	errWebhookWrongFormat   = errors.New("webhook wrong format")
 )
 
-func NewWebhook(h ActionHook, action *Action, e *http.Server) (Hook, error) {
+func NewWebhook(h ActionHook, action *Action, cfg Config, e *http.Server) (Hook, error) {
 	url, ok := h.Properties[webhookURLPropertyKey]
 	if !ok {
 		return nil, fmt.Errorf("missing url: %w", errWebhookWrongFormat)
@@ -70,6 +70,7 @@ func NewWebhook(h ActionHook, action *Action, e *http.Server) (Hook, error) {
 		HookBase: HookBase{
 			ID:         h.ID,
 			ActionName: action.Name,
+			Config:     cfg,
 			Endpoint:   e,
 		},
 		Timeout:     requestTimeout,

--- a/pkg/api/serve_test.go
+++ b/pkg/api/serve_test.go
@@ -154,6 +154,8 @@ func setupHandlerWithWalkerFactory(t testing.TB, factory catalog.WalkerFactory) 
 	testutil.MustDo(t, "build catalog", err)
 
 	// wire actions
+	actionsConfig := actions.Config{Enabled: true}
+	actionsConfig.Lua.NetHTTPEnabled = true
 	actionsService := actions.NewService(
 		ctx,
 		actionsStore,
@@ -161,7 +163,7 @@ func setupHandlerWithWalkerFactory(t testing.TB, factory catalog.WalkerFactory) 
 		catalog.NewActionsOutputWriter(c.BlockAdapter),
 		idGen,
 		collector,
-		true,
+		actionsConfig,
 	)
 
 	c.SetHooksHandler(actionsService)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -108,6 +108,9 @@ type Config struct {
 	Actions struct {
 		// ActionsEnabled set to false will block any hook execution
 		Enabled bool `mapstructure:"enabled"`
+		Lua     struct {
+			NetHTTPEnabled bool `mapstructure:"net_http_enabled"`
+		} `mapstructure:"lua"`
 	}
 
 	Logging struct {

--- a/pkg/loadtest/local_load_test.go
+++ b/pkg/loadtest/local_load_test.go
@@ -70,7 +70,7 @@ func TestLocalLoad(t *testing.T) {
 	outputWriter := catalog.NewActionsOutputWriter(c.BlockAdapter)
 
 	// wire actions
-	actionsService := actions.NewService(ctx, actions.NewActionsKVStore(kvStore), source, outputWriter, &actions.DecreasingIDGenerator{}, &stats.NullCollector{}, true)
+	actionsService := actions.NewService(ctx, actions.NewActionsKVStore(kvStore), source, outputWriter, &actions.DecreasingIDGenerator{}, &stats.NullCollector{}, actions.Config{Enabled: true})
 	c.SetHooksHandler(actionsService)
 
 	credentials, err := setup.SetupAdminUser(ctx, authService, conf, superuser)


### PR DESCRIPTION
Lua net/http package with `request` capability.
By default we do not load the module for security reasons - control by `actions.lua.net_http_enabled`.

Close #5649