### PR TITLE
GC - enable incremental run id

### DIFF
--- a/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
@@ -205,9 +205,7 @@ class GarbageCollector(val rangeGetter: RangeGetter) extends Serializable {
   def getExpiredAddresses(
       repo: String,
       storageNS: String,
-      runID: String,
       commitDFLocation: String,
-      numCommitPartitions: Int,
       numRangePartitions: Int,
       numAddressPartitions: Int,
       approxNumRangesToSpreadPerPartition: Double,
@@ -311,7 +309,7 @@ object GarbageCollector {
 
     val markID = hc.get(LAKEFS_CONF_GC_MARK_ID, UUID.randomUUID().toString)
 
-    if (!maxCommitIsoDatetime.isEmpty) {
+    if (maxCommitIsoDatetime.nonEmpty) {
       hc.setLong(
         LAKEFS_CONF_DEBUG_GC_MAX_COMMIT_EPOCH_SECONDS_KEY,
         LocalDateTime
@@ -445,8 +443,7 @@ object GarbageCollector {
       storageNSForHadoopFS: String
   ): (String, String, DataFrame, String) = {
     val runIDToReproduce = hc.get(LAKEFS_CONF_DEBUG_GC_REPRODUCE_RUN_ID_KEY, "")
-    val previousRunID =
-      "" //args(2) // TODO(Guys): get previous runID from arguments or from storage
+    val previousRunID = hc.get(LAKEFS_CONF_GC_PREV_RUN_ID, "")
 
     var prepareResult: GarbageCollectionPrepareResponse = null
     var runID = ""
@@ -492,9 +489,7 @@ object GarbageCollector {
     val expiredAddresses = gc
       .getExpiredAddresses(repo,
                            storageNS,
-                           runID,
                            gcCommitsLocation,
-                           numCommitPartitions,
                            numRangePartitions,
                            numAddressPartitions,
                            approxNumRangesToSpreadPerPartition,

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/LakeFSContext.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/LakeFSContext.scala
@@ -80,7 +80,7 @@ object LakeFSContext {
   val LAKEFS_CONF_GC_MARK_ID = "lakefs.gc.mark_id"
   val LAKEFS_CONF_GC_S3_MIN_BACKOFF_SECONDS = "lakefs.gc.s3.min_backoff_secs"
   val LAKEFS_CONF_GC_S3_MAX_BACKOFF_SECONDS = "lakefs.gc.s3.max_backoff_secs"
-  val LAKEFS_CONF_GC_PREV_RUN_ID = "lakefs.gc.incremental.run_id"
+  val LAKEFS_CONF_GC_PREV_RUN_ID = "lakefs.gc.incremental.previous_run_id"
   val LAKEFS_CONF_DEBUG_GC_NO_DELETE_KEY = "lakefs.debug.gc.no_delete"
 
   val MARK_ID_KEY = "mark_id"

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/LakeFSContext.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/LakeFSContext.scala
@@ -78,6 +78,7 @@ object LakeFSContext {
   val LAKEFS_CONF_GC_DO_MARK = "lakefs.gc.do_mark"
   val LAKEFS_CONF_GC_DO_SWEEP = "lakefs.gc.do_sweep"
   val LAKEFS_CONF_GC_MARK_ID = "lakefs.gc.mark_id"
+  val LAKEFS_CONF_GC_PREV_RUN_ID = "lakefs.gc.incremental.run_id"
   val LAKEFS_CONF_DEBUG_GC_NO_DELETE_KEY = "lakefs.debug.gc.no_delete"
 
   val MARK_ID_KEY = "mark_id"


### PR DESCRIPTION
## Change Description

### Background

- Enable running GC starting from the point where it previously stopped commit-wise, meaning that commits that were already processed and were determined as expired won't be returned from lakeFS for further processing.
- This PR also contains some minor refactor updates such as removing unused function parameters and simplifying code. 

## How was this tested?

Using a test running over the following commit graph:
```bash
-main--<A-3 days old>--<C-3 days old>--<D-2 days old>--<F-2 days old>--<G-2 days old>-<H-merge commit>--<I-0 days old>
	        |                                                                          /
	        -branch1--<B-3 days old>--<E-2 days old>----------------------------------/
```
and the following GC rules:
```json
{ 
    "default_retention_days": 1, 
    "branches": [ 
        { 
            "branch_id": "branch1",
            "retention_days": 4
        } 
    ] 
}
```
1. GC full run resulted in the `commits.csv` containing 10 commits (the 9 above + repo creation commit) of which 3 were marked as expired: C, D, F (G isn't supposed to be deleted because this is where the head was a day ago) as expected.
2. Change the GC rules to:
```json
{ 
    "default_retention_days": 1, 
    "branches": [ 
        { 
            "branch_id": "branch1",
            "retention_days": 2
        } 
    ] 
}
```
3. GC incremental run resulted in the `commits.csv` containing **7 commits** (the 10 explained above minus the 3 that were expired in the previous run) of which 3 were marked as expired: A, B, and repo creation commit, as expected.