### PR TITLE
Bump Just the Docs from 0.4.1 to 0.5.0

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -10,7 +10,7 @@ search_tokenizer_separator: /[\s/]+/
 logo: '/assets/logo.svg'
 logo_link: 'https://lakefs.io'
 
-remote_theme: pmarsceill/just-the-docs@v0.4.1
+remote_theme: pmarsceill/just-the-docs@v0.5.0
 
 
 


### PR DESCRIPTION
Just the Docs [v0.5.0](https://github.com/just-the-docs/just-the-docs/releases/tag/v0.5.0) was released recently. This PR updates our docs to use it. No driver other than to keep current lest there's a version we want in the future and want to avoid a big version leap. 
