### PR TITLE
Fix API LinkPhysicalAddress twice should fail with status code 400

### DIFF
--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -2495,8 +2495,9 @@ func TestController_LinkPhysicalAddressHandler(t *testing.T) {
 			},
 		})
 		testutil.Must(t, err)
-		if resp.HTTPResponse.StatusCode != http.StatusNotFound {
-			t.Fatalf("expected error linking the same physical address twice")
+		expectedStatusCode := http.StatusBadRequest
+		if resp.HTTPResponse.StatusCode != expectedStatusCode {
+			t.Fatalf("LinkPhysicalAddress status code: %d, expected: %d", resp.HTTPResponse.StatusCode, expectedStatusCode)
 		}
 	})
 }


### PR DESCRIPTION
- Fix validation time expiration.
- Fix status code returned by error.
- Fix test code to match expected status code 400 - bad request.

Fix #5599