### PR TITLE
Add back the copy URI button + add cache-control header to GET objects

### DIFF
--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -3295,6 +3295,9 @@ func (c *Controller) HeadObject(w http.ResponseWriter, r *http.Request, reposito
 	w.Header().Set("Last-Modified", lastModified)
 	w.Header().Set("Accept-Ranges", "bytes")
 	w.Header().Set("Content-Type", entry.ContentType)
+	// for security, make sure the browser and any proxies en route don't cache the response
+	w.Header().Set("Cache-Control", "no-store, must-revalidate")
+	w.Header().Set("Expires", "0")
 
 	// calculate possible byte range, if any.
 	if params.Range != nil {

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -3391,6 +3391,9 @@ func (c *Controller) GetObject(w http.ResponseWriter, r *http.Request, repositor
 	lastModified := httputil.HeaderTimestamp(entry.CreationDate)
 	w.Header().Set("Last-Modified", lastModified)
 	w.Header().Set("Content-Type", entry.ContentType)
+	// for security, make sure the browser and any proxies en route don't cache the response
+	w.Header().Set("Cache-Control", "no-store, must-revalidate")
+	w.Header().Set("Expires", "0")
 	_, err = io.Copy(w, reader)
 	if err != nil {
 		c.Logger.

--- a/webui/src/pages/repositories/repository/objectViewer.tsx
+++ b/webui/src/pages/repositories/repository/objectViewer.tsx
@@ -1,147 +1,166 @@
-import React, {  FC } from "react";
+import React, { FC } from "react";
 import { useParams } from "react-router-dom";
 import { Box } from "@mui/material";
 import Alert from "react-bootstrap/Alert";
-import Card from "react-bootstrap/Card"
+import Card from "react-bootstrap/Card";
 
 import { useAPI } from "../../../lib/hooks/api";
 import { useQuery } from "../../../lib/hooks/router";
 import { objects } from "../../../lib/api";
-import { ObjectRenderer} from "./fileRenderers";
-import {Error} from "../../../lib/components/controls";
+import { ObjectRenderer } from "./fileRenderers";
+import { Error } from "../../../lib/components/controls";
 import { URINavigator } from "../../../lib/components/repository/tree";
 import { RefTypeCommit } from "../../../constants";
-import {RepositoryPageLayout} from "../../../lib/components/repository/layout";
-import {RefContextProvider} from "../../../lib/hooks/repo";
-import {linkToPath} from "../../../lib/api";
+import { RepositoryPageLayout } from "../../../lib/components/repository/layout";
+import { RefContextProvider } from "../../../lib/hooks/repo";
+import { linkToPath } from "../../../lib/api";
 
 import "../../../styles/ipynb.css";
 
-
 type ObjectViewerPathParams = {
-    objectName: string;
-    repoId: string;
-}
+  objectName: string;
+  repoId: string;
+};
 
 interface ObjectViewerQueryString {
-    ref: string;
-    path: string;
+  ref: string;
+  path: string;
 }
 
 interface FileContentsProps {
-    repoId: string;
-    refId: string;
-    path: string;
-    loading: boolean;
-    error: Error | null;
-    contentType?: string | null;
-    fileExtension: string;
-    sizeBytes: number;
-    showFullNavigator?: boolean;
-    presign?: boolean;
+  repoId: string;
+  refId: string;
+  path: string;
+  loading: boolean;
+  error: Error | null;
+  contentType?: string | null;
+  fileExtension: string;
+  sizeBytes: number;
+  showFullNavigator?: boolean;
+  presign?: boolean;
 }
 
-
 export const Loading: FC = () => {
-    return (
-        <Alert variant={"info"}>Loading...</Alert>
-    );
+  return <Alert variant={"info"}>Loading...</Alert>;
 };
 
 export const getFileExtension = (objectName: string): string => {
-    const objectNameParts = objectName.split(".");
-    return objectNameParts[objectNameParts.length - 1];
-}
+  const objectNameParts = objectName.split(".");
+  return objectNameParts[objectNameParts.length - 1];
+};
 
 export const getContentType = (headers: Headers): string | null => {
-    if (!headers) return null;
+  if (!headers) return null;
 
-    return headers.get("Content-Type") ?? null;
-}
+  return headers.get("Content-Type") ?? null;
+};
 
 const FileObjectsViewerPage = () => {
-    const { repoId } = useParams<ObjectViewerPathParams>();
-    const queryString = useQuery<ObjectViewerQueryString>();
-    const refId = queryString["ref"] ?? "";
-    const path = queryString["path"] ?? "";
-    const {response, error, loading} = useAPI( () => {
-            return objects.head(repoId, refId, path)
-        },
-        [repoId, refId, path]);
+  const { repoId } = useParams<ObjectViewerPathParams>();
+  const queryString = useQuery<ObjectViewerQueryString>();
+  const refId = queryString["ref"] ?? "";
+  const path = queryString["path"] ?? "";
+  const { response, error, loading } = useAPI(() => {
+    return objects.head(repoId, refId, path);
+  }, [repoId, refId, path]);
 
-    let content;
-    if (loading) {
-        content  = <Loading/>;
-    } else if (error) {
-        content = <Error error={error}/>
-    } else {
-        const fileExtension = getFileExtension(path);
-        // We'll need to convert the API service to get rid of this any
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const contentType = getContentType((response as any)?.headers);
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        const sizeBytes = parseInt((response as any)?.headers.get('Content-Length'))
-        content = <FileContents
-            repoId={repoId || ''}
+  let content;
+  if (loading) {
+    content = <Loading />;
+  } else if (error) {
+    content = <Error error={error} />;
+  } else {
+    const fileExtension = getFileExtension(path);
+    // We'll need to convert the API service to get rid of this any
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const contentType = getContentType((response as any)?.headers);
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const sizeBytes = parseInt(
+      (response as any)?.headers.get("Content-Length")
+    );
+    content = (
+      <FileContents
+        repoId={repoId || ""}
+        refId={refId}
+        path={path}
+        fileExtension={fileExtension}
+        contentType={contentType}
+        sizeBytes={sizeBytes}
+        error={error}
+        loading={loading}
+      />
+    );
+  }
+
+  return (
+    <RefContextProvider>
+      <RepositoryPageLayout activePage={"objects"}>
+        {content}
+      </RepositoryPageLayout>
+    </RefContextProvider>
+  );
+};
+
+export const FileContents: FC<FileContentsProps> = ({
+  repoId,
+  refId,
+  path,
+  loading,
+  error,
+  contentType = null,
+  fileExtension = "",
+  sizeBytes = -1,
+  showFullNavigator = true,
+  presign = false,
+}) => {
+  const objectUrl = linkToPath(repoId, refId, path, presign);
+
+  if (loading || error) {
+    return <></>;
+  }
+
+  const repo = {
+    id: repoId,
+  };
+
+  const reference = {
+    id: refId,
+    type: RefTypeCommit,
+  };
+
+  const titleComponent = showFullNavigator ? (
+    <URINavigator
+      path={path}
+      repo={repo}
+      reference={reference}
+      isPathToFile={true}
+      downloadUrl={objectUrl}
+      hasCopyButton={true}
+    />
+  ) : (
+    <span>{path}</span>
+  );
+
+  return (
+    <Card className={"file-content-card"}>
+      <Card.Header className={"file-content-heading"}>
+        {titleComponent}
+      </Card.Header>
+      <Card.Body className={"file-content-body"}>
+        <Box sx={{ mx: 1 }}>
+          <ObjectRenderer
+            repoId={repoId}
             refId={refId}
             path={path}
             fileExtension={fileExtension}
             contentType={contentType}
             sizeBytes={sizeBytes}
-            error={error}
-            loading={loading}
-        />
-    }
-
-    return (
-        <RefContextProvider>
-            <RepositoryPageLayout activePage={'objects'}>
-                {content}
-            </RepositoryPageLayout>
-        </RefContextProvider>
-    );
-};
-
-export const FileContents: FC<FileContentsProps> = ({repoId, refId, path, loading, error, contentType = null, fileExtension='', sizeBytes = -1, showFullNavigator = true, presign= false}) => {
-
-    const objectUrl = linkToPath(repoId, refId, path, presign);
-
-    if (loading || error) {
-        return <></>;
-    }
-
-    const repo = {
-        id: repoId,
-    };
-
-    const reference = {
-        id: refId,
-        type: RefTypeCommit,
-    }
-
-    const titleComponent = showFullNavigator ?
-        (<URINavigator path={path} repo={repo} reference={reference} isPathToFile={true} downloadUrl={objectUrl} />) :
-        (<span>{path}</span>);
-    
-    return (
-            <Card className={'file-content-card'}>
-                <Card.Header className={'file-content-heading'}>
-                    {titleComponent}
-                </Card.Header>
-                <Card.Body className={'file-content-body'}>
-                    <Box sx={{mx: 1}}>
-                        <ObjectRenderer
-                            repoId={repoId}
-                            refId={refId}
-                            path={path}
-                            fileExtension={fileExtension}
-                            contentType={contentType}
-                            sizeBytes={sizeBytes}
-                            presign={presign}/>
-                    </Box>
-                </Card.Body>
-            </Card>
-    );
+            presign={presign}
+          />
+        </Box>
+      </Card.Body>
+    </Card>
+  );
 };
 
 export default FileObjectsViewerPage;

--- a/webui/src/pages/repositories/repository/objectViewer.tsx
+++ b/webui/src/pages/repositories/repository/objectViewer.tsx
@@ -74,8 +74,8 @@ const FileObjectsViewerPage = () => {
     // We'll need to convert the API service to get rid of this any
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const contentType = getContentType((response as any)?.headers);
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
     const sizeBytes = parseInt(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
       (response as any)?.headers.get("Content-Length")
     );
     content = (


### PR DESCRIPTION
Resolves #5580 - show the copy URI button in object viewer