### PR TITLE
GC: SaveGarbageCollectionCommits- change the run ID format

### DIFF
--- a/pkg/graveler/retention/garbage_collection_manager.go
+++ b/pkg/graveler/retention/garbage_collection_manager.go
@@ -11,7 +11,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/rs/xid"
 	"github.com/treeverse/lakefs/pkg/block"
 	"github.com/treeverse/lakefs/pkg/graveler"
@@ -229,7 +228,7 @@ func (m *GarbageCollectionManager) SaveGarbageCollectionCommits(ctx context.Cont
 		return "", err
 	}
 	commitsStr := b.String()
-	runID := uuid.New().String()
+	runID := m.NewID()
 	csvLocation, err := m.GetCommitsCSVLocation(runID, repository.StorageNamespace)
 	if err != nil {
 		return "", err


### PR DESCRIPTION
## Change Description

Change the current run ID format to a time-sortable format to be used later by (incremental) GC.

