### PR TITLE
Add work dir for jupyter

### DIFF
--- a/deployments/compose/docker-compose.yml
+++ b/deployments/compose/docker-compose.yml
@@ -216,6 +216,7 @@ services:
     volumes:
       - ./etc/jupyter_notebook_config.py:/home/jovyan/.jupyter/jupyter_notebook_config.py
       - ./etc/hive-site.xml:/usr/local/spark/conf/hive-site.xml
+      - ./jupyter/work:/home/jovyan/work
 
 networks:
   default:


### PR DESCRIPTION
This adds a work directory to Jupyter so that user's notebooks are preserved locally when the container is removed. In the future we could ship sample notebooks in this folder too.
