### PR TITLE
Everything Bagel: Switch back to Spark 3.3.2

### DIFF
--- a/deployments/compose/jupyter/Dockerfile
+++ b/deployments/compose/jupyter/Dockerfile
@@ -1,4 +1,4 @@
-FROM jupyter/pyspark-notebook:notebook-6.5.4
+FROM jupyter/pyspark-notebook:spark-3.3.2
 
 ENV HADOOP_AWS_VERSION=3.3.1
 ENV AWS_SDK_VERSION=1.11.901

--- a/deployments/compose/jupyter/Dockerfile
+++ b/deployments/compose/jupyter/Dockerfile
@@ -1,4 +1,13 @@
-FROM jupyter/pyspark-notebook:spark-3.3.2
+# This image includes Apache Spark 3.3.2
+# Be aware of version compatibility issues if bumping it.
+# For example, the latest version of Delta Lake doesn't work with Apache Spark 3.4
+#
+# To determine the version of Spark in the base image, see the relevant information
+# on Docker Hub (https://hub.docker.com/r/jupyter/pyspark-notebook/tags?page=1&name=notebook)
+#
+# For example https://hub.docker.com/layers/jupyter/pyspark-notebook/notebook-6.5.3/images/sha256-661613756e04df5ec9f00e49fe202b25a0f992c05f575d9608820528fa1db369?context=explore 
+# has `spark_version=3.3.2`
+FROM jupyter/pyspark-notebook:notebook-6.5.3
 
 ENV HADOOP_AWS_VERSION=3.3.1
 ENV AWS_SDK_VERSION=1.11.901


### PR DESCRIPTION
Previous bumped version of the base image (notebook-6.5.4) includes Apache Spark 3.4. 
The latest version of Spark that Delta Lake works with is 3.3.x (https://docs.delta.io/latest/releases.html#compatibility-with-apache-spark)

Therefore, switch back to this version and pin to a clearer tag (spark-) in the base image. 

Tested manually. 
