### PR TITLE
Fix lakefs export docker image to use python 3.11

### DIFF
--- a/deployments/tools/export/Dockerfile
+++ b/deployments/tools/export/Dockerfile
@@ -1,6 +1,6 @@
 FROM rclone/rclone:1.57 AS rclone
 
-FROM python:3.8-slim-buster
+FROM python:3.9-slim-buster
 
 WORKDIR /lakefs
 

--- a/deployments/tools/export/Dockerfile
+++ b/deployments/tools/export/Dockerfile
@@ -1,6 +1,6 @@
 FROM rclone/rclone:1.57 AS rclone
 
-FROM python:3.9-slim-buster
+FROM python:3.11-slim-buster
 
 WORKDIR /lakefs
 


### PR DESCRIPTION
Fix #5744