### PR TITLE
Display buttons to open (Airflow) metadata from UI

### DIFF
--- a/webui/src/pages/repositories/repository/commits/commit/index.tsx
+++ b/webui/src/pages/repositories/repository/commits/commit/index.tsx
@@ -14,6 +14,7 @@ import {Link} from "../../../../../lib/components/nav";
 import {useRouter} from "../../../../../lib/hooks/router";
 import {URINavigator} from "../../../../../lib/components/repository/tree";
 import {appendMoreResults} from "../../changes";
+import {MetadataRow, MetadataUIButton} from "./metadata";
 
 const ChangeList = ({ repo, commit, prefix, onNavigate }) => {
     const [actionError, setActionError] = useState(null);
@@ -88,11 +89,16 @@ const CommitActions = ({ repo, commit }) => {
     );
 };
 
+const getKeysOrNull = (metadata: Record<string>): Array<string> | null => {
+    if (!metadata) return null;
+    const keys = Object.getOwnPropertyNames(metadata);
+    if (keys.length === 0) return null;
+    return keys;
+};
 
 const CommitMetadataTable = ({ commit }) => {
-    if (!commit.metadata) return <></>
-    const keys = Object.getOwnPropertyNames(commit.metadata)
-    if (keys.length === 0) return <></>
+    const keys = getKeysOrNull(commit.metadata);
+    if (!keys) return null;
 
     return (
         <>
@@ -104,15 +110,22 @@ const CommitMetadataTable = ({ commit }) => {
                 </tr>
             </thead>
             <tbody>
-            {keys.map(key => (
-                <tr key={key}>
-                    <td><code>{key}</code></td>
-                    <td><code>{commit.metadata[key]}</code></td>
-                </tr>
-            ))}
+                {keys.map(key =>
+                    <MetadataRow metadata_key={key} metadata_value={commit.metadata[key]}/>)}
             </tbody>
         </Table>
         </>
+    );
+};
+
+const CommitMetadataUIButtons = ({ commit }) => {
+    const keys = getKeysOrNull(commit.metadata);
+    if (!keys) return null;
+
+    return (
+        <>{
+            keys.map((key) => <MetadataUIButton metadata_key={key} metadata_value={commit.metadata[key]}/>)
+        }</>
     );
 };
 
@@ -192,6 +205,7 @@ const CommitView = ({ repo, commitId, onNavigate, view, prefix }) => {
 
                     <div className="mt-4">
                         <CommitInfo repo={repo} commit={commit}/>
+                        <CommitMetadataUIButtons commit={commit}/>
                         <CommitMetadataTable commit={commit}/>
                     </div>
                 </Card.Body>

--- a/webui/src/pages/repositories/repository/commits/commit/metadata.tsx
+++ b/webui/src/pages/repositories/repository/commits/commit/metadata.tsx
@@ -1,0 +1,23 @@
+import React from "react";
+import Button from 'react-bootstrap/Button';
+
+const keyIsClickableUrl = /::lakefs::(.*)::url\[url:ui\]$/;
+
+export const MetadataRow = ({ metadata_key, metadata_value }) => {
+    return <tr>
+               <td><code>{metadata_key}</code></td>
+               <td><code>{metadata_value}</code></td>
+           </tr>;
+};
+
+export const MetadataUIButton = ({ metadata_key, metadata_value }) => {
+    const m = metadata_key.match(keyIsClickableUrl);
+    if (!m) {
+        return null;
+    }
+    return <tr key={metadata_key}>
+               <td colSpan={2}>
+                   <Button variant="success" href={metadata_value}>Open {m[1]} UI</Button>
+               </td>
+           </tr>;
+};


### PR DESCRIPTION
Add a button "Open something something UI" for every metadata value whose
key looks like as "`::lakefs::something something::url\[url:ui\]`".

This matches the display metadata design.

Tested end-to-end.

Fixes #5765.