### PR TITLE
Update lakefs rclone export to v1.62

### DIFF
--- a/.github/workflows/docker-publish-lakefs-rclone-export.yaml
+++ b/.github/workflows/docker-publish-lakefs-rclone-export.yaml
@@ -55,7 +55,7 @@ jobs:
         with:
           context: deployments/tools/export
           push: true
-          platforms: linux/amd64,linux/arm64,darwin/amd64,darwin/arm64
+          platforms: linux/amd64,linux/arm64
           tags: |
             ${{ steps.login-ecr.outputs.registry }}/lakefs-rclone-export:${{ steps.version.outputs.tag }}
             treeverse/lakefs-rclone-export:${{ steps.version.outputs.tag }}

--- a/deployments/tools/export/Dockerfile
+++ b/deployments/tools/export/Dockerfile
@@ -1,4 +1,4 @@
-FROM rclone/rclone:1.57 AS rclone
+FROM rclone/rclone:1.62 AS rclone
 
 FROM python:3.11-slim-buster
 


### PR DESCRIPTION
Hope this is the last fix/update on the subject for now.

- limit the target platforms based on rclone image
- upgrade from v1.57 which supported only one target

Tested export manually using the new version
