### PR TITLE
Uncommitted gc always read deleted addresses for bulk remove

### DIFF
--- a/clients/spark/core/src/main/scala/io/treeverse/gc/UncommittedGarbageCollector.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/gc/UncommittedGarbageCollector.scala
@@ -186,15 +186,6 @@ object UncommittedGarbageCollector {
         uncommittedDF.unpersist()
       }
 
-      // write addresses to delete
-      if (shouldMark) {
-        val reportDst = formatRunPath(storageNamespace, runID)
-        println(s"Report for mark_id=$runID path=$reportDst")
-
-        addressesToDelete.write.parquet(s"$reportDst/deleted")
-        addressesToDelete.write.text(s"$reportDst/deleted.text")
-      }
-
       // delete marked addresses
       if (shouldSweep) {
         val markedAddresses = if (shouldMark) {
@@ -267,6 +258,10 @@ object UncommittedGarbageCollector {
   ): Unit = {
     val reportDst = formatRunPath(storageNamespace, runID)
     println(s"Report for mark_id=$runID path=$reportDst")
+
+    expiredAddresses.write.parquet(s"$reportDst/deleted")
+    expiredAddresses.write.text(s"$reportDst/deleted.text")
+
     val summary =
       writeJsonSummary(reportDst,
                        runID,

--- a/clients/spark/core/src/main/scala/io/treeverse/gc/UncommittedGarbageCollector.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/gc/UncommittedGarbageCollector.scala
@@ -194,11 +194,16 @@ object UncommittedGarbageCollector {
         addressesToDelete.write.parquet(s"$reportDst/deleted")
         addressesToDelete.write.text(s"$reportDst/deleted.text")
       }
+
       // delete marked addresses
       if (shouldSweep) {
-        val jobID = if (shouldMark) runID else markID
-        println("deleting marked addresses from job ID: " + jobID)
-        val markedAddresses = readMarkedAddresses(storageNamespace, jobID)
+        val markedAddresses = if (shouldMark) {
+          println("deleting marked addresses from run ID: " + runID)
+          addressesToDelete
+        } else {
+          println("deleting marked addresses from mark ID: " + markID)
+          readMarkedAddresses(storageNamespace, markID)
+        }
 
         val storageNSForSdkClient = getStorageNSForSdkClient(apiClient: ApiClient, repo)
         val region = getRegion(args)


### PR DESCRIPTION
Fix #5421 

- The dataset addressesToDelete holds the cached results and unpersist the uncommitted and committed datasets to free memory/disk space.
- Instead using GarbageCollector.bulkRemove - `bulkRemove` implemented. We loop by taking chunk of items from the `addressesToDelete` (size is based on the bulk remover getMaxBulkSize) and calling the `bulkRemover` deleteObjects.

_Note_ work done related to the cache probably helped the out-of-disk and not working with a local iterator.
More data to delete over time will probably help us more to understand which changes need to be made to distribute the bulk delete without abuse or throttle the API.