### PR TITLE
Fix UI validate repository name while validate storage namespace

### DIFF
--- a/webui/src/lib/components/repositoryCreateForm.jsx
+++ b/webui/src/lib/components/repositoryCreateForm.jsx
@@ -39,9 +39,9 @@ export const RepositoryCreateForm = ({ config, onSubmit, onCancel, error = null,
     };
 
     const checkStorageNamespaceValidity = () => {
-        const isStorageNamespaceValid = storageNamespaceValidityRegex.test(storageNamespaceField.current.value)
+        const isStorageNamespaceValid = storageNamespaceValidityRegex.test(storageNamespaceField.current.value);
         setStorageNamespaceValid(isStorageNamespaceValid);
-        setFormValid(isStorageNamespaceValid && defaultBranchValid && repoValid);
+        setFormValid(isStorageNamespaceValid && defaultBranchValid && repoValidityRegex.test(repoNameField.current.value));
     };
 
     const checkDefaultBranchValidity = () => {


### PR DESCRIPTION
The repository name validation should be re-tested while validating schema namespace as it is verified while repo name and storage namespace changes.
Need to check the current value and not the value from the current state when we validate the storage namespace.

Fix #5801