### PR TITLE
Fix uncommitted gc to handle no uncommitted location

### DIFF
--- a/clients/spark/build.sbt
+++ b/clients/spark/build.sbt
@@ -299,6 +299,6 @@ ThisBuild / organizationName := "Treeverse Labs"
 ThisBuild / organizationHomepage := Some(url("http://treeverse.io"))
 ThisBuild / description := "Spark client for lakeFS object metadata."
 ThisBuild / licenses := List(
-  "Apache 2" -> new URL("http://www.apache.org/licenses/LICENSE-2.0.txt")
+  "Apache 2" -> url("http://www.apache.org/licenses/LICENSE-2.0.txt")
 )
 ThisBuild / homepage := Some(url("https://lakefs.io"))


### PR DESCRIPTION
Skip translate URI in case there is no uncommitted data.

Using `StorageUtils.AzureBlob.uriToStorageAccountName` with empty URL will throw java.lang.NullPointerException while trying to split host name. 

Fix https://github.com/treeverse/lakeFS/issues/5816
