### PR TITLE
lakectl: validate fs upload path is not empty

### DIFF
--- a/cmd/lakectl/cmd/fs.go
+++ b/cmd/lakectl/cmd/fs.go
@@ -252,6 +252,9 @@ var fsUploadCmd = &cobra.Command{
 		ctx := cmd.Context()
 		transport := transportMethodFromFlags(direct, preSignMode)
 		if !recursive {
+			if pathURI.GetPath() == "" {
+				Die("target path is not a valid URI", 1)
+			}
 			stat, err := upload(ctx, client, source, pathURI, contentType, transport)
 			if err != nil {
 				DieErr(err)
@@ -259,6 +262,7 @@ var fsUploadCmd = &cobra.Command{
 			Write(fsStatTemplate, stat)
 			return
 		}
+
 		// copy recursively
 		var totals struct {
 			Bytes int64


### PR DESCRIPTION
Fix https://github.com/treeverse/lakeFS/issues/5531

Validate upload parameter is not empty.
Error "target path is not a valid URI" in case it is missing.
