### PR TITLE
test: fix local flakiness while keeping unique identifiers

### DIFF
--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -1514,7 +1514,7 @@ func (c *Controller) CreateRepository(w http.ResponseWriter, r *http.Request, bo
 		defaultBranch = "main"
 	}
 
-	if params.Bare != nil && *params.Bare {
+	if swag.BoolValue(params.Bare) {
 		// create a bare repository. This is useful in conjunction with refs-restore to create a copy
 		// of another repository by e.g. copying the _lakefs/ directory and restoring its refs
 		repo, err := c.Catalog.CreateBareRepository(ctx,
@@ -1536,9 +1536,11 @@ func (c *Controller) CreateRepository(w http.ResponseWriter, r *http.Request, bo
 
 	err := c.ensureStorageNamespace(ctx, body.StorageNamespace)
 	if err != nil {
-		reason := "unknown"
-		var retErr error
-		var urlErr *url.Error
+		var (
+			reason string
+			retErr error
+			urlErr *url.Error
+		)
 		switch {
 		case errors.As(err, &urlErr) && urlErr.Op == "parse":
 			retErr = err
@@ -1551,6 +1553,7 @@ func (c *Controller) CreateRepository(w http.ResponseWriter, r *http.Request, bo
 			reason = "already_in_use"
 		default:
 			retErr = ErrFailedToAccessStorage
+			reason = "unknown"
 		}
 		c.Logger.
 			WithError(err).

--- a/pkg/block/mem/adapter.go
+++ b/pkg/block/mem/adapter.go
@@ -111,7 +111,12 @@ func (a *Adapter) Get(_ context.Context, obj block.ObjectPointer, _ int64) (io.R
 }
 
 func verifyObjectPointer(obj block.ObjectPointer) error {
-	if !strings.HasPrefix(obj.StorageNamespace, "mem://") {
+	const prefix = "mem://"
+	if obj.StorageNamespace == "" {
+		if !strings.HasPrefix(obj.Identifier, prefix) {
+			return fmt.Errorf("mem block adapter: %w identifier: %s", block.ErrInvalidAddress, obj.Identifier)
+		}
+	} else if !strings.HasPrefix(obj.StorageNamespace, prefix) {
 		return fmt.Errorf("mem block adapter: %w storage namespace: %s", block.ErrInvalidAddress, obj.StorageNamespace)
 	}
 	return nil

--- a/pkg/block/mem/adapter.go
+++ b/pkg/block/mem/adapter.go
@@ -11,6 +11,7 @@ import (
 	"net/http"
 	"net/url"
 	"sort"
+	"strings"
 	"sync"
 
 	"github.com/google/uuid"
@@ -80,6 +81,9 @@ func getKey(obj block.ObjectPointer) string {
 }
 
 func (a *Adapter) Put(_ context.Context, obj block.ObjectPointer, _ int64, reader io.Reader, opts block.PutOpts) error {
+	if err := verifyObjectPointer(obj); err != nil {
+		return err
+	}
 	a.mutex.Lock()
 	defer a.mutex.Unlock()
 	data, err := io.ReadAll(reader)
@@ -93,6 +97,9 @@ func (a *Adapter) Put(_ context.Context, obj block.ObjectPointer, _ int64, reade
 }
 
 func (a *Adapter) Get(_ context.Context, obj block.ObjectPointer, _ int64) (io.ReadCloser, error) {
+	if err := verifyObjectPointer(obj); err != nil {
+		return nil, err
+	}
 	a.mutex.RLock()
 	defer a.mutex.RUnlock()
 	key := getKey(obj)
@@ -103,15 +110,28 @@ func (a *Adapter) Get(_ context.Context, obj block.ObjectPointer, _ int64) (io.R
 	return io.NopCloser(bytes.NewReader(data)), nil
 }
 
+func verifyObjectPointer(obj block.ObjectPointer) error {
+	if !strings.HasPrefix(obj.StorageNamespace, "mem://") {
+		return fmt.Errorf("mem block adapter: %w storage namespace: %s", block.ErrInvalidAddress, obj.StorageNamespace)
+	}
+	return nil
+}
+
 func (a *Adapter) GetWalker(_ *url.URL) (block.Walker, error) {
 	return nil, fmt.Errorf("mem block adapter: %w", block.ErrOperationNotSupported)
 }
 
-func (a *Adapter) GetPreSignedURL(_ context.Context, _ block.ObjectPointer, _ block.PreSignMode) (string, error) {
+func (a *Adapter) GetPreSignedURL(_ context.Context, obj block.ObjectPointer, _ block.PreSignMode) (string, error) {
+	if err := verifyObjectPointer(obj); err != nil {
+		return "", err
+	}
 	return "", fmt.Errorf("mem block adapter: %w", block.ErrOperationNotSupported)
 }
 
 func (a *Adapter) Exists(_ context.Context, obj block.ObjectPointer) (bool, error) {
+	if err := verifyObjectPointer(obj); err != nil {
+		return false, err
+	}
 	a.mutex.RLock()
 	defer a.mutex.RUnlock()
 	_, ok := a.data[getKey(obj)]
@@ -119,6 +139,9 @@ func (a *Adapter) Exists(_ context.Context, obj block.ObjectPointer) (bool, erro
 }
 
 func (a *Adapter) GetRange(_ context.Context, obj block.ObjectPointer, startPosition int64, endPosition int64) (io.ReadCloser, error) {
+	if err := verifyObjectPointer(obj); err != nil {
+		return nil, err
+	}
 	a.mutex.RLock()
 	defer a.mutex.RUnlock()
 	data, ok := a.data[getKey(obj)]
@@ -129,6 +152,9 @@ func (a *Adapter) GetRange(_ context.Context, obj block.ObjectPointer, startPosi
 }
 
 func (a *Adapter) GetProperties(_ context.Context, obj block.ObjectPointer) (block.Properties, error) {
+	if err := verifyObjectPointer(obj); err != nil {
+		return block.Properties{}, err
+	}
 	a.mutex.RLock()
 	defer a.mutex.RUnlock()
 	props, ok := a.properties[getKey(obj)]
@@ -139,6 +165,9 @@ func (a *Adapter) GetProperties(_ context.Context, obj block.ObjectPointer) (blo
 }
 
 func (a *Adapter) Remove(_ context.Context, obj block.ObjectPointer) error {
+	if err := verifyObjectPointer(obj); err != nil {
+		return err
+	}
 	a.mutex.Lock()
 	defer a.mutex.Unlock()
 	delete(a.data, getKey(obj))
@@ -146,6 +175,12 @@ func (a *Adapter) Remove(_ context.Context, obj block.ObjectPointer) error {
 }
 
 func (a *Adapter) Copy(_ context.Context, sourceObj, destinationObj block.ObjectPointer) error {
+	if err := verifyObjectPointer(sourceObj); err != nil {
+		return err
+	}
+	if err := verifyObjectPointer(destinationObj); err != nil {
+		return err
+	}
 	a.mutex.Lock()
 	defer a.mutex.Unlock()
 	destinationKey := getKey(destinationObj)
@@ -156,6 +191,9 @@ func (a *Adapter) Copy(_ context.Context, sourceObj, destinationObj block.Object
 }
 
 func (a *Adapter) UploadCopyPart(ctx context.Context, sourceObj, _ block.ObjectPointer, uploadID string, partNumber int) (*block.UploadPartResponse, error) {
+	if err := verifyObjectPointer(sourceObj); err != nil {
+		return nil, err
+	}
 	a.mutex.Lock()
 	defer a.mutex.Unlock()
 	mpu, ok := a.mpu[uploadID]
@@ -184,6 +222,9 @@ func (a *Adapter) UploadCopyPart(ctx context.Context, sourceObj, _ block.ObjectP
 }
 
 func (a *Adapter) UploadCopyPartRange(_ context.Context, sourceObj, _ block.ObjectPointer, uploadID string, partNumber int, startPosition, endPosition int64) (*block.UploadPartResponse, error) {
+	if err := verifyObjectPointer(sourceObj); err != nil {
+		return nil, err
+	}
 	a.mutex.Lock()
 	defer a.mutex.Unlock()
 	mpu, ok := a.mpu[uploadID]
@@ -212,7 +253,10 @@ func (a *Adapter) UploadCopyPartRange(_ context.Context, sourceObj, _ block.Obje
 	}, nil
 }
 
-func (a *Adapter) CreateMultiPartUpload(_ context.Context, _ block.ObjectPointer, _ *http.Request, _ block.CreateMultiPartUploadOpts) (*block.CreateMultiPartUploadResponse, error) {
+func (a *Adapter) CreateMultiPartUpload(_ context.Context, obj block.ObjectPointer, _ *http.Request, _ block.CreateMultiPartUploadOpts) (*block.CreateMultiPartUploadResponse, error) {
+	if err := verifyObjectPointer(obj); err != nil {
+		return nil, err
+	}
 	a.mutex.Lock()
 	defer a.mutex.Unlock()
 	mpu := newMPU()
@@ -222,7 +266,10 @@ func (a *Adapter) CreateMultiPartUpload(_ context.Context, _ block.ObjectPointer
 	}, nil
 }
 
-func (a *Adapter) UploadPart(_ context.Context, _ block.ObjectPointer, _ int64, reader io.Reader, uploadID string, partNumber int) (*block.UploadPartResponse, error) {
+func (a *Adapter) UploadPart(_ context.Context, obj block.ObjectPointer, _ int64, reader io.Reader, uploadID string, partNumber int) (*block.UploadPartResponse, error) {
+	if err := verifyObjectPointer(obj); err != nil {
+		return nil, err
+	}
 	a.mutex.Lock()
 	defer a.mutex.Unlock()
 	mpu, ok := a.mpu[uploadID]
@@ -246,7 +293,10 @@ func (a *Adapter) UploadPart(_ context.Context, _ block.ObjectPointer, _ int64, 
 	}, nil
 }
 
-func (a *Adapter) AbortMultiPartUpload(_ context.Context, _ block.ObjectPointer, uploadID string) error {
+func (a *Adapter) AbortMultiPartUpload(_ context.Context, obj block.ObjectPointer, uploadID string) error {
+	if err := verifyObjectPointer(obj); err != nil {
+		return err
+	}
 	a.mutex.Lock()
 	defer a.mutex.Unlock()
 	_, ok := a.mpu[uploadID]
@@ -258,6 +308,9 @@ func (a *Adapter) AbortMultiPartUpload(_ context.Context, _ block.ObjectPointer,
 }
 
 func (a *Adapter) CompleteMultiPartUpload(_ context.Context, obj block.ObjectPointer, uploadID string, _ *block.MultipartUploadCompletion) (*block.CompleteMultiPartUploadResponse, error) {
+	if err := verifyObjectPointer(obj); err != nil {
+		return nil, err
+	}
 	a.mutex.Lock()
 	defer a.mutex.Unlock()
 	mpu, ok := a.mpu[uploadID]

--- a/pkg/catalog/uncommitted_iterator_test.go
+++ b/pkg/catalog/uncommitted_iterator_test.go
@@ -13,19 +13,30 @@ import (
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
-var now = time.Now()
-var uncommittedBranchRecords = []*graveler.ValueRecord{
-	{Key: graveler.Key("file1"), Value: catalog.MustEntryToValue(&catalog.Entry{Address: "file1", LastModified: timestamppb.New(now), Size: 1, ETag: "01"})},
-	{Key: graveler.Key("file2"), Value: catalog.MustEntryToValue(&catalog.Entry{Address: "file2", LastModified: timestamppb.New(now), Size: 2, ETag: "02"})},
-	{Key: graveler.Key("file3"), Value: catalog.MustEntryToValue(&catalog.Entry{Address: "file3", LastModified: timestamppb.New(now), Size: 3, ETag: "03"})},
-	{Key: graveler.Key("h/file1"), Value: catalog.MustEntryToValue(&catalog.Entry{Address: "h/file1", LastModified: timestamppb.New(now), Size: 1, ETag: "01"})},
-	{Key: graveler.Key("h/file2"), Value: catalog.MustEntryToValue(&catalog.Entry{Address: "h/file2", LastModified: timestamppb.New(now), Size: 2, ETag: "02"})},
-}
+var (
+	now                      = time.Now()
+	uncommittedBranchRecords = []*graveler.ValueRecord{
+		{Key: graveler.Key("file1"), Value: catalog.MustEntryToValue(&catalog.Entry{Address: "file1", LastModified: timestamppb.New(now), Size: 1, ETag: "01"})},
+		{Key: graveler.Key("file2"), Value: catalog.MustEntryToValue(&catalog.Entry{Address: "file2", LastModified: timestamppb.New(now), Size: 2, ETag: "02"})},
+		{Key: graveler.Key("file3"), Value: catalog.MustEntryToValue(&catalog.Entry{Address: "file3", LastModified: timestamppb.New(now), Size: 3, ETag: "03"})},
+		{Key: graveler.Key("h/file1"), Value: catalog.MustEntryToValue(&catalog.Entry{Address: "h/file1", LastModified: timestamppb.New(now), Size: 1, ETag: "01"})},
+		{Key: graveler.Key("h/file2"), Value: catalog.MustEntryToValue(&catalog.Entry{Address: "h/file2", LastModified: timestamppb.New(now), Size: 2, ETag: "02"})},
+	}
+)
 
 func TestUncommittedIterator(t *testing.T) {
 	ctx := context.Background()
 	gravelerMock := &catalog.FakeGraveler{
 		ListIteratorFactory: catalog.NewFakeValueIteratorFactory(uncommittedBranchRecords),
+	}
+	const repoID = "uncommitted-iterator"
+	repository := &graveler.RepositoryRecord{
+		RepositoryID: repoID,
+		Repository: &graveler.Repository{
+			StorageNamespace: "mem://" + repoID,
+			CreationDate:     time.Now(),
+			DefaultBranchID:  "main",
+		},
 	}
 	tests := []struct {
 		name     string
@@ -113,6 +124,16 @@ func TestUncommittedIterator_SeekGE(t *testing.T) {
 	gravelerMock := &catalog.FakeGraveler{
 		ListIteratorFactory: catalog.NewFakeValueIteratorFactory(uncommittedBranchRecords),
 	}
+	const repoID = "uncommitted-iter-seek-ge"
+	repository := &graveler.RepositoryRecord{
+		RepositoryID: repoID,
+		Repository: &graveler.Repository{
+			StorageNamespace: "mem://" + repoID,
+			CreationDate:     time.Now(),
+			DefaultBranchID:  "main",
+		},
+	}
+
 	tests := []struct {
 		name          string
 		branches      []*graveler.BranchRecord

--- a/pkg/graveler/retention/garbage_collection_manager_test.go
+++ b/pkg/graveler/retention/garbage_collection_manager_test.go
@@ -20,11 +20,9 @@ import (
 func TestGarbageCollectionManager_GetUncommittedLocation(t *testing.T) {
 	blockAdapter := mem.New()
 	refMgr := &testutil.RefsFake{}
-	prefix := "test_prefix"
-	runID := "my_test_runID"
-	namespace := "test-namespace"
-	repo := "my-repo"
-	ns := graveler.StorageNamespace(fmt.Sprintf("%s://%s/%s", block.BlockstoreTypeMem, namespace, repo))
+	const prefix = "test_prefix"
+	const runID = "my_test_runID"
+	ns := graveler.StorageNamespace("mem://test-namespace/my-repo")
 	path := fmt.Sprintf("%s/%s/retention/gc/uncommitted/%s/uncommitted/", ns, prefix, runID)
 	gc := retention.NewGarbageCollectionManager(blockAdapter, refMgr, prefix)
 	location, err := gc.GetUncommittedLocation(runID, ns)
@@ -47,11 +45,10 @@ func TestGarbageCollectionManager_SaveGarbageCollectionUncommitted(t *testing.T)
 	ctx := context.Background()
 	blockAdapter := mem.New()
 	refMgr := &testutil.RefsFake{}
-	prefix := "test_prefix"
-	runID := "my_test_runID"
-	namespace := "test-namespace"
-	repoID := graveler.RepositoryID("my-repo")
-	ns := graveler.StorageNamespace(fmt.Sprintf("%s://%s/%s", block.BlockstoreTypeMem, namespace, repoID))
+	const prefix = "test_prefix"
+	const runID = "my_test_runID"
+	const repoID = "my-repo"
+	ns := graveler.StorageNamespace("mem://test-namespace/" + repoID)
 	repositoryRec := graveler.RepositoryRecord{
 		RepositoryID: repoID,
 		Repository: &graveler.Repository{

--- a/pkg/pyramid/tier_fs_test.go
+++ b/pkg/pyramid/tier_fs_test.go
@@ -38,7 +38,7 @@ func TestSimpleWriteRead(t *testing.T) {
 
 func TestReadFailDuringWrite(t *testing.T) {
 	ctx := context.Background()
-	namespace := uuid.New().String()
+	namespace := uniqueNamespace()
 	filename := "file1"
 	f, err := fs.Create(ctx, namespace)
 	require.NoError(t, err)
@@ -87,7 +87,8 @@ func TestStartup(t *testing.T) {
 		}
 	}()
 
-	uniquePath := path.Join(baseDir, uuid.New().String())
+	namespaceID := uuid.New().String()
+	uniquePath := path.Join(baseDir, namespaceID)
 	workspacePath := path.Join(uniquePath, workspaceDir)
 	if err := os.MkdirAll(workspacePath, os.ModePerm); err != nil {
 		t.Fatal("make dir under", workspacePath, err)
@@ -126,7 +127,7 @@ func TestStartup(t *testing.T) {
 	// package os this does not matter.
 	assert.Error(t, err, os.ErrNotExist, "expected %s not to exist", workspacePath)
 
-	f, err := localFS.Open(ctx, uniqueNamespace(), filename)
+	f, err := localFS.Open(ctx, "mem://"+namespaceID, filename)
 	defer func() { _ = f.Close() }()
 	assert.NoError(t, err)
 

--- a/pkg/pyramid/tier_fs_test.go
+++ b/pkg/pyramid/tier_fs_test.go
@@ -28,7 +28,7 @@ const (
 
 func TestSimpleWriteRead(t *testing.T) {
 	ctx := context.Background()
-	namespace := uuid.New().String()
+	namespace := uniqueNamespace()
 	filename := "1/2/file1.txt"
 
 	content := []byte("hello world!")
@@ -57,20 +57,24 @@ func TestReadFailDuringWrite(t *testing.T) {
 }
 
 func TestEvictionSingleNamespace(t *testing.T) {
-	testEviction(t, uuid.New().String())
+	testEviction(t, uniqueNamespace())
+}
+
+func uniqueNamespace() string {
+	return "mem://" + uuid.New().String()
 }
 
 func TestEvictionMultipleNamespaces(t *testing.T) {
-	testEviction(t, uuid.New().String(),
-		uuid.New().String(),
-		uuid.New().String())
+	testEviction(t,
+		uniqueNamespace(),
+		uniqueNamespace(),
+		uniqueNamespace(),
+	)
 }
 
 func TestStartup(t *testing.T) {
 	ctx := context.Background()
-	fsName := uuid.New().String()
-	namespace := uuid.New().String()
-
+	fsName := uniqueNamespace()
 	// cleanup
 	baseDir := path.Join(os.TempDir(), fsName)
 	defer func() {
@@ -83,15 +87,15 @@ func TestStartup(t *testing.T) {
 		}
 	}()
 
-	namespacePath := path.Join(baseDir, namespace)
-	workspacePath := path.Join(namespacePath, workspaceDir)
+	uniquePath := path.Join(baseDir, uuid.New().String())
+	workspacePath := path.Join(uniquePath, workspaceDir)
 	if err := os.MkdirAll(workspacePath, os.ModePerm); err != nil {
 		t.Fatal("make dir under", workspacePath, err)
 	}
 
 	filename := "ThisShouldStay"
 	content := []byte("This Should Stay - I'm telling You!!!!")
-	if err := os.WriteFile(path.Join(namespacePath, filename), content, os.ModePerm); err != nil {
+	if err := os.WriteFile(path.Join(uniquePath, filename), content, os.ModePerm); err != nil {
 		t.Fatal("write file", filename, err)
 	}
 
@@ -122,7 +126,7 @@ func TestStartup(t *testing.T) {
 	// package os this does not matter.
 	assert.Error(t, err, os.ErrNotExist, "expected %s not to exist", workspacePath)
 
-	f, err := localFS.Open(ctx, namespace, filename)
+	f, err := localFS.Open(ctx, uniqueNamespace(), filename)
 	defer func() { _ = f.Close() }()
 	assert.NoError(t, err)
 
@@ -165,7 +169,7 @@ func TestMultipleConcurrentReads(t *testing.T) {
 	defer func() { _ = os.RemoveAll(baseDir) }()
 
 	// write a single file to lookup later
-	namespace := uuid.New().String()
+	namespace := uniqueNamespace()
 	filename := "1/2/file1.txt"
 	content := []byte("hello world!")
 	writeToFile(t, ctx, namespace, filename, content)


### PR DESCRIPTION
Fix https://github.com/treeverse/lakeFS/issues/4736
Fix https://github.com/treeverse/lakeFS/issues/5100

Also updated mem block adapter to verify the storage namespace - align the behaviour as other block adapters.