### PR TITLE
GC: return presigned URL together with prepared commits

### DIFF
--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -1207,6 +1207,9 @@ components:
           type: string
           description: location to use for expired addresses parquet table (partitioned by run_id)
           example: s3://my-storage-namespace/_lakefs/retention/addresses
+        gc_commits_presigned_url:
+          type: string
+          description: a presigned url to download the commits csv
       required:
         - run_id
         - gc_commits_location

--- a/clients/java/api/openapi.yaml
+++ b/clients/java/api/openapi.yaml
@@ -6942,6 +6942,7 @@ components:
         run_id: 64eaa103-d726-4a33-bcb8-7c0b4abfe09e
         gc_addresses_location: s3://my-storage-namespace/_lakefs/retention/addresses
         gc_commits_location: s3://my-storage-namespace/_lakefs/retention/commits
+        gc_commits_presigned_url: gc_commits_presigned_url
       properties:
         run_id:
           description: a unique identifier generated for this GC job
@@ -6956,6 +6957,9 @@ components:
           description: location to use for expired addresses parquet table (partitioned
             by run_id)
           example: s3://my-storage-namespace/_lakefs/retention/addresses
+          type: string
+        gc_commits_presigned_url:
+          description: a presigned url to download the commits csv
           type: string
       required:
       - gc_addresses_location

--- a/clients/java/docs/GarbageCollectionPrepareResponse.md
+++ b/clients/java/docs/GarbageCollectionPrepareResponse.md
@@ -10,6 +10,7 @@ Name | Type | Description | Notes
 **runId** | **String** | a unique identifier generated for this GC job | 
 **gcCommitsLocation** | **String** | location of the resulting commits csv table (partitioned by run_id) | 
 **gcAddressesLocation** | **String** | location to use for expired addresses parquet table (partitioned by run_id) | 
+**gcCommitsPresignedUrl** | **String** | a presigned url to download the commits csv |  [optional]
 
 
 

--- a/clients/java/src/main/java/io/lakefs/clients/api/model/GarbageCollectionPrepareResponse.java
+++ b/clients/java/src/main/java/io/lakefs/clients/api/model/GarbageCollectionPrepareResponse.java
@@ -41,6 +41,10 @@ public class GarbageCollectionPrepareResponse {
   @SerializedName(SERIALIZED_NAME_GC_ADDRESSES_LOCATION)
   private String gcAddressesLocation;
 
+  public static final String SERIALIZED_NAME_GC_COMMITS_PRESIGNED_URL = "gc_commits_presigned_url";
+  @SerializedName(SERIALIZED_NAME_GC_COMMITS_PRESIGNED_URL)
+  private String gcCommitsPresignedUrl;
+
 
   public GarbageCollectionPrepareResponse runId(String runId) {
     
@@ -111,6 +115,29 @@ public class GarbageCollectionPrepareResponse {
   }
 
 
+  public GarbageCollectionPrepareResponse gcCommitsPresignedUrl(String gcCommitsPresignedUrl) {
+    
+    this.gcCommitsPresignedUrl = gcCommitsPresignedUrl;
+    return this;
+  }
+
+   /**
+   * a presigned url to download the commits csv
+   * @return gcCommitsPresignedUrl
+  **/
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "a presigned url to download the commits csv")
+
+  public String getGcCommitsPresignedUrl() {
+    return gcCommitsPresignedUrl;
+  }
+
+
+  public void setGcCommitsPresignedUrl(String gcCommitsPresignedUrl) {
+    this.gcCommitsPresignedUrl = gcCommitsPresignedUrl;
+  }
+
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {
@@ -122,12 +149,13 @@ public class GarbageCollectionPrepareResponse {
     GarbageCollectionPrepareResponse garbageCollectionPrepareResponse = (GarbageCollectionPrepareResponse) o;
     return Objects.equals(this.runId, garbageCollectionPrepareResponse.runId) &&
         Objects.equals(this.gcCommitsLocation, garbageCollectionPrepareResponse.gcCommitsLocation) &&
-        Objects.equals(this.gcAddressesLocation, garbageCollectionPrepareResponse.gcAddressesLocation);
+        Objects.equals(this.gcAddressesLocation, garbageCollectionPrepareResponse.gcAddressesLocation) &&
+        Objects.equals(this.gcCommitsPresignedUrl, garbageCollectionPrepareResponse.gcCommitsPresignedUrl);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(runId, gcCommitsLocation, gcAddressesLocation);
+    return Objects.hash(runId, gcCommitsLocation, gcAddressesLocation, gcCommitsPresignedUrl);
   }
 
   @Override
@@ -137,6 +165,7 @@ public class GarbageCollectionPrepareResponse {
     sb.append("    runId: ").append(toIndentedString(runId)).append("\n");
     sb.append("    gcCommitsLocation: ").append(toIndentedString(gcCommitsLocation)).append("\n");
     sb.append("    gcAddressesLocation: ").append(toIndentedString(gcAddressesLocation)).append("\n");
+    sb.append("    gcCommitsPresignedUrl: ").append(toIndentedString(gcCommitsPresignedUrl)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/clients/java/src/test/java/io/lakefs/clients/api/model/GarbageCollectionPrepareResponseTest.java
+++ b/clients/java/src/test/java/io/lakefs/clients/api/model/GarbageCollectionPrepareResponseTest.java
@@ -64,4 +64,12 @@ public class GarbageCollectionPrepareResponseTest {
         // TODO: test gcAddressesLocation
     }
 
+    /**
+     * Test the property 'gcCommitsPresignedUrl'
+     */
+    @Test
+    public void gcCommitsPresignedUrlTest() {
+        // TODO: test gcCommitsPresignedUrl
+    }
+
 }

--- a/clients/python/docs/GarbageCollectionPrepareResponse.md
+++ b/clients/python/docs/GarbageCollectionPrepareResponse.md
@@ -7,6 +7,7 @@ Name | Type | Description | Notes
 **run_id** | **str** | a unique identifier generated for this GC job | 
 **gc_commits_location** | **str** | location of the resulting commits csv table (partitioned by run_id) | 
 **gc_addresses_location** | **str** | location to use for expired addresses parquet table (partitioned by run_id) | 
+**gc_commits_presigned_url** | **str** | a presigned url to download the commits csv | [optional] 
 **any string name** | **bool, date, datetime, dict, float, int, list, str, none_type** | any string name can be used but the value must be the correct type | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/clients/python/lakefs_client/model/garbage_collection_prepare_response.py
+++ b/clients/python/lakefs_client/model/garbage_collection_prepare_response.py
@@ -85,6 +85,7 @@ class GarbageCollectionPrepareResponse(ModelNormal):
             'run_id': (str,),  # noqa: E501
             'gc_commits_location': (str,),  # noqa: E501
             'gc_addresses_location': (str,),  # noqa: E501
+            'gc_commits_presigned_url': (str,),  # noqa: E501
         }
 
     @cached_property
@@ -96,6 +97,7 @@ class GarbageCollectionPrepareResponse(ModelNormal):
         'run_id': 'run_id',  # noqa: E501
         'gc_commits_location': 'gc_commits_location',  # noqa: E501
         'gc_addresses_location': 'gc_addresses_location',  # noqa: E501
+        'gc_commits_presigned_url': 'gc_commits_presigned_url',  # noqa: E501
     }
 
     read_only_vars = {
@@ -144,6 +146,7 @@ class GarbageCollectionPrepareResponse(ModelNormal):
                                 Animal class but this time we won't travel
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
+            gc_commits_presigned_url (str): a presigned url to download the commits csv. [optional]  # noqa: E501
         """
 
         _check_type = kwargs.pop('_check_type', True)
@@ -233,6 +236,7 @@ class GarbageCollectionPrepareResponse(ModelNormal):
                                 Animal class but this time we won't travel
                                 through its discriminator because we passed in
                                 _visited_composed_classes = (Animal,)
+            gc_commits_presigned_url (str): a presigned url to download the commits csv. [optional]  # noqa: E501
         """
 
         _check_type = kwargs.pop('_check_type', True)

--- a/docs/assets/js/swagger.yml
+++ b/docs/assets/js/swagger.yml
@@ -1207,6 +1207,9 @@ components:
           type: string
           description: location to use for expired addresses parquet table (partitioned by run_id)
           example: s3://my-storage-namespace/_lakefs/retention/addresses
+        gc_commits_presigned_url:
+          type: string
+          description: a presigned url to download the commits csv
       required:
         - run_id
         - gc_commits_location

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -2781,10 +2781,18 @@ func (c *Controller) PrepareGarbageCollectionCommits(w http.ResponseWriter, r *h
 	if c.handleAPIError(ctx, w, r, err) {
 		return
 	}
+	presignedUrl, err := c.BlockAdapter.GetPreSignedURL(ctx, block.ObjectPointer{
+		Identifier:     gcRunMetadata.CommitsCSVLocation,
+		IdentifierType: block.IdentifierTypeFull,
+	}, block.PreSignModeRead)
+	if err != nil {
+		c.Logger.Warn("Failed to presign url for GC commits")
+	}
 	writeResponse(w, r, http.StatusCreated, GarbageCollectionPrepareResponse{
-		GcCommitsLocation:   gcRunMetadata.CommitsCSVLocation,
-		GcAddressesLocation: gcRunMetadata.AddressLocation,
-		RunId:               gcRunMetadata.RunID,
+		GcCommitsLocation:     gcRunMetadata.CommitsCSVLocation,
+		GcAddressesLocation:   gcRunMetadata.AddressLocation,
+		RunId:                 gcRunMetadata.RunID,
+		GcCommitsPresignedUrl: &presignedUrl,
 	})
 }
 

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -2781,7 +2781,7 @@ func (c *Controller) PrepareGarbageCollectionCommits(w http.ResponseWriter, r *h
 	if c.handleAPIError(ctx, w, r, err) {
 		return
 	}
-	presignedUrl, err := c.BlockAdapter.GetPreSignedURL(ctx, block.ObjectPointer{
+	presignedURL, err := c.BlockAdapter.GetPreSignedURL(ctx, block.ObjectPointer{
 		Identifier:     gcRunMetadata.CommitsCSVLocation,
 		IdentifierType: block.IdentifierTypeFull,
 	}, block.PreSignModeRead)
@@ -2792,7 +2792,7 @@ func (c *Controller) PrepareGarbageCollectionCommits(w http.ResponseWriter, r *h
 		GcCommitsLocation:     gcRunMetadata.CommitsCSVLocation,
 		GcAddressesLocation:   gcRunMetadata.AddressLocation,
 		RunId:                 gcRunMetadata.RunID,
-		GcCommitsPresignedUrl: &presignedUrl,
+		GcCommitsPresignedUrl: &presignedURL,
 	})
 }
 

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -2786,7 +2786,7 @@ func (c *Controller) PrepareGarbageCollectionCommits(w http.ResponseWriter, r *h
 		IdentifierType: block.IdentifierTypeFull,
 	}, block.PreSignModeRead)
 	if err != nil {
-		c.Logger.Warn("Failed to presign url for GC commits")
+		c.Logger.WithError(err).Warn("Failed to presign url for GC commits")
 	}
 	writeResponse(w, r, http.StatusCreated, GarbageCollectionPrepareResponse{
 		GcCommitsLocation:     gcRunMetadata.CommitsCSVLocation,


### PR DESCRIPTION
On the lakeFS server, after preparing the list of expired and active commits for GC, also return a presigned URL to download the CSV file.