### PR TITLE
Remove auth API pass and use username with credentials

### DIFF
--- a/api/authorization.yml
+++ b/api/authorization.yml
@@ -218,6 +218,10 @@ components:
         user_id:
           type: integer
           format: int64
+          deprecated: true
+        user_name:
+          type: string
+          description: A unique identifier for the user. In password-based authentication should be the email.
 
     Group:
       type: object

--- a/cmd/lakefs-loadtest/cmd/root.go
+++ b/cmd/lakefs-loadtest/cmd/root.go
@@ -19,9 +19,7 @@ const (
 	DefaultServerEndpointURL = "http://localhost:8000"
 )
 
-var (
-	cfgFile string
-)
+var cfgFile string
 
 // rootCmd represents the base command when called without any sub-commands
 var rootCmd = &cobra.Command{

--- a/pkg/auth/errors.go
+++ b/pkg/auth/errors.go
@@ -19,4 +19,5 @@ var (
 	ErrInvalidToken            = errors.New("invalid token")
 	ErrInvalidRequest          = errors.New("invalid request")
 	ErrUserNotFound            = errors.New("user not found")
+	ErrInvalidResponse         = errors.New("invalid response")
 )

--- a/pkg/auth/service.go
+++ b/pkg/auth/service.go
@@ -14,7 +14,6 @@ import (
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
-
 	"github.com/deepmap/oapi-codegen/pkg/securityprovider"
 	"github.com/getkin/kin-openapi/openapi3filter"
 	"github.com/go-openapi/swag"
@@ -1680,7 +1679,6 @@ func (a *APIAuthService) GetCredentials(ctx context.Context, accessKeyID string)
 		}
 		username := aws.StringValue(credentials.UserName)
 		if username == "" {
-			// TODO(Guys): return username instead of this call
 			user, err := a.GetUserByID(ctx, model.ConvertDBID(credentials.UserId))
 			if err != nil {
 				return nil, err


### PR DESCRIPTION
As part of using username (string) instead of user id (int) as identifier - enable passing user name in get suer credentials.

Close https://github.com/treeverse/lakeFS/issues/5844