### PR TITLE
Split treeverse/lakefs into 2 images, without duckdb by default

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@
 FROM --platform=$BUILDPLATFORM golang:1.19.2-alpine3.16 AS build
 
 ARG VERSION=dev
-ARG DUCKDB_RELEASE_TAG=v0.7.1
 
 WORKDIR /build
 
@@ -55,14 +54,13 @@ RUN RUSTFLAGS=-Ctarget-feature=-crt-static cargo build --release
 
 # Build DuckDB
 FROM --platform=$BUILDPLATFORM alpine:3.16.0 AS build-duckdb
+ARG DUCKDB_RELEASE_TAG=v0.7.1
 
 RUN apk add --no-cache git
 WORKDIR /
-RUN git clone --depth 1 https://github.com/duckdb/duckdb.git
+RUN git clone --depth 1 --branch ${DUCKDB_RELEASE_TAG} https://github.com/duckdb/duckdb.git
 
 WORKDIR /duckdb
-RUN git checkout ${DUCKDB_RELEASE_TAG}
-
 RUN apk add --no-cache build-base cmake openssl-dev ninja
 RUN GEN=ninja BUILD_HTTPFS=1 make 
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -122,6 +122,11 @@ WORKDIR /home/lakefs
 
 RUN mkdir -p /home/lakefs/.lakefs/plugins/diff && ln -s /app/delta_diff /home/lakefs/.lakefs/plugins/diff/delta
 
+ENTRYPOINT ["/app/lakefs"]
+CMD ["run"]
+
+FROM --platform=$BUILDPLATFORM lakefs-plugins AS lakefs-with-duckdb
+
 # Add DuckDB
 USER root
 WORKDIR /app
@@ -130,6 +135,3 @@ COPY --from=build-duckdb /duckdb/build/release/duckdb  ./
 USER lakefs
 # Create ~/.duckdbrc file to customise the prompt 🦆
 RUN echo ".prompt '⚫◗ '" > $HOME/.duckdbrc
-
-ENTRYPOINT ["/app/lakefs"]
-CMD ["run"]

--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,8 @@ UI_DIR=webui
 UI_BUILD_DIR=$(UI_DIR)/dist
 
 DOCKER_IMAGE=lakefs
-DOCKER_WITH_DUCKDB_IMAGE=lakefs-with-duckdb
 DOCKER_TAG=dev
+DOCKER_WITH_DUCKDB_TAG=$(DOCKER_TAG)-duckdb
 VERSION=dev
 export VERSION
 
@@ -194,8 +194,8 @@ system-tests: # Run system tests locally
 	./esti/scripts/runner.sh -r all
 
 build-docker: build ## Build Docker image file (Docker required)
-	$(DOCKER) buildx build --target lakefs-lakectl -t treeverse/$(DOCKER_IMAGE):$(DOCKER_TAG) .
-	$(DOCKER) buildx build -t treeverse/$(DOCKER_WITH_DUCKDB_IMAGE):$(DOCKER_TAG) .
+	$(DOCKER) buildx build --target lakefs-plugins -t treeverse/$(DOCKER_IMAGE):$(DOCKER_TAG) .
+	$(DOCKER) buildx build -t treeverse/$(DOCKER_IMAGE):$(DOCKER_WITH_DUCKDB_TAG) .
 
 gofmt:  ## gofmt code formating
 	@echo Running go formating with the following command:

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ UI_DIR=webui
 UI_BUILD_DIR=$(UI_DIR)/dist
 
 DOCKER_IMAGE=lakefs
+DOCKER_WITH_DUCKDB_IMAGE=lakefs-with-duckdb
 DOCKER_TAG=dev
 VERSION=dev
 export VERSION
@@ -193,7 +194,8 @@ system-tests: # Run system tests locally
 	./esti/scripts/runner.sh -r all
 
 build-docker: build ## Build Docker image file (Docker required)
-	$(DOCKER) buildx build -t treeverse/$(DOCKER_IMAGE):$(DOCKER_TAG) .
+	$(DOCKER) buildx build --target lakefs-lakectl -t treeverse/$(DOCKER_IMAGE):$(DOCKER_TAG) .
+	$(DOCKER) buildx build -t treeverse/$(DOCKER_WITH_DUCKDB_IMAGE):$(DOCKER_TAG) .
 
 gofmt:  ## gofmt code formating
 	@echo Running go formating with the following command:


### PR DESCRIPTION
* treeverse/lakefs will *not* include duckdb
* treeverse/lakefs-with-duckdb *will* include duckdb

Fixes #5836.

Tested _manually_ by examining the images treeverse/lakefs and
treeverse/lakefs-with-duckdb after `make build-docker`.

Releasing with this PR will push treeverse/lakefs to Docker Hub, and we can
push treeverse/lakefs-with-duckdb there manually.  We will automate this
later.