### PR TITLE
Fix brew tap to use the right token

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -85,3 +85,4 @@ brews:
   tap:
     owner: treeverse
     name: homebrew-lakefs
+    token: "{{ .Env.TAP_GITHUB_TOKEN }}"


### PR DESCRIPTION
Need to specify which token to use - the default will not work.