### PR TITLE
lakeFS setup for non-external RBAC mode

### DIFF
--- a/cmd/lakefs/cmd/run.go
+++ b/cmd/lakefs/cmd/run.go
@@ -60,7 +60,7 @@ type Shutter interface {
 var errSimplifiedOrExternalAuth = errors.New(`cannot set auth.ui_config.rbac to non-simplified without setting an external auth service`)
 
 func checkAuthModeSupport(cfg *config.Config) error {
-	if !cfg.IsAuthUISimplified() && cfg.Auth.API.Endpoint == "" {
+	if !cfg.IsAuthUISimplified() && !cfg.IsAuthTypeAPI() {
 		return errSimplifiedOrExternalAuth
 	}
 	return nil
@@ -122,7 +122,7 @@ var runCmd = &cobra.Command{
 		if err := checkAuthModeSupport(cfg); err != nil {
 			logger.WithError(err).Fatal("Unsupported auth mode")
 		}
-		if cfg.Auth.API.Endpoint != "" {
+		if cfg.IsAuthTypeAPI() {
 			var apiEmailer *email.Emailer
 			if !cfg.Auth.API.SupportsInvites {
 				// invites not supported by API - delegate it to emailer

--- a/cmd/lakefs/cmd/setup.go
+++ b/cmd/lakefs/cmd/setup.go
@@ -5,13 +5,12 @@ import (
 	"fmt"
 	"os"
 
-	authparams "github.com/treeverse/lakefs/pkg/auth/params"
-	"github.com/treeverse/lakefs/pkg/config"
-
 	"github.com/spf13/cobra"
 	"github.com/treeverse/lakefs/pkg/auth"
 	"github.com/treeverse/lakefs/pkg/auth/crypt"
+	authparams "github.com/treeverse/lakefs/pkg/auth/params"
 	"github.com/treeverse/lakefs/pkg/auth/setup"
+	"github.com/treeverse/lakefs/pkg/config"
 	"github.com/treeverse/lakefs/pkg/kv"
 	"github.com/treeverse/lakefs/pkg/logging"
 	"github.com/treeverse/lakefs/pkg/stats"

--- a/cmd/lakefs/cmd/setup.go
+++ b/cmd/lakefs/cmd/setup.go
@@ -5,6 +5,9 @@ import (
 	"fmt"
 	"os"
 
+	authparams "github.com/treeverse/lakefs/pkg/auth/params"
+	"github.com/treeverse/lakefs/pkg/config"
+
 	"github.com/spf13/cobra"
 	"github.com/treeverse/lakefs/pkg/auth"
 	"github.com/treeverse/lakefs/pkg/auth/crypt"
@@ -37,7 +40,7 @@ var setupCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		if cfg.IsAuthTypeAPI() {
+		if cfg.Auth.UIConfig.RBAC == config.AuthRBACExternal {
 			// nothing to do - users are managed elsewhere
 			return
 		}
@@ -70,7 +73,7 @@ var setupCmd = &cobra.Command{
 		defer kvStore.Close()
 		logger := logging.Default()
 		authLogger := logger.WithField("service", "auth_service")
-		authService = auth.NewAuthService(kvStore, crypt.NewSecretStore(cfg.AuthEncryptionSecret()), nil, cfg.Auth.Cache, authLogger)
+		authService = auth.NewAuthService(kvStore, crypt.NewSecretStore(cfg.AuthEncryptionSecret()), nil, authparams.ServiceCache(cfg.Auth.Cache), authLogger)
 		metadataManager = auth.NewKVMetadataManager(version.Version, cfg.Installation.FixedID, cfg.Database.Type, kvStore)
 
 		cloudMetadataProvider := stats.BuildMetadataProvider(logger, cfg)

--- a/cmd/lakefs/cmd/superuser.go
+++ b/cmd/lakefs/cmd/superuser.go
@@ -10,7 +10,9 @@ import (
 	"github.com/treeverse/lakefs/pkg/auth"
 	"github.com/treeverse/lakefs/pkg/auth/crypt"
 	"github.com/treeverse/lakefs/pkg/auth/model"
+	authparams "github.com/treeverse/lakefs/pkg/auth/params"
 	"github.com/treeverse/lakefs/pkg/auth/setup"
+	"github.com/treeverse/lakefs/pkg/config"
 	"github.com/treeverse/lakefs/pkg/kv"
 	"github.com/treeverse/lakefs/pkg/logging"
 	"github.com/treeverse/lakefs/pkg/stats"
@@ -23,7 +25,7 @@ var superuserCmd = &cobra.Command{
 	Short: "Create additional user with admin credentials",
 	Run: func(cmd *cobra.Command, args []string) {
 		cfg := loadConfig()
-		if cfg.IsAuthTypeAPI() {
+		if cfg.Auth.UIConfig.RBAC == config.AuthRBACExternal {
 			fmt.Printf("Can't create additional admin while using external auth API - auth.api.endpoint is configured.\n")
 			os.Exit(1)
 		}
@@ -56,7 +58,7 @@ var superuserCmd = &cobra.Command{
 			fmt.Printf("Failed to open KV store: %s\n", err)
 			os.Exit(1)
 		}
-		authService := auth.NewAuthService(kvStore, crypt.NewSecretStore(cfg.AuthEncryptionSecret()), nil, cfg.Auth.Cache, logger.WithField("service", "auth_service"))
+		authService := auth.NewAuthService(kvStore, crypt.NewSecretStore(cfg.AuthEncryptionSecret()), nil, authparams.ServiceCache(cfg.Auth.Cache), logger.WithField("service", "auth_service"))
 		authMetadataManager := auth.NewKVMetadataManager(version.Version, cfg.Installation.FixedID, cfg.Database.Type, kvStore)
 
 		metadataProvider := stats.BuildMetadataProvider(logger, cfg)

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -30,7 +30,7 @@ This reference uses `.` to denote the nesting of values.
 * `logging.level` `(one of ["TRACE", "DEBUG", "INFO", "WARN", "ERROR", "NONE"] : "DEBUG")` - Logging level to output
 * `logging.audit_log_level` `(one of ["TRACE", "DEBUG", "INFO", "WARN", "ERROR", "NONE"] : "DEBUG")` - Audit logs level to output.
 
-  **Note:** In case you configure this field to be lower than the main logger level, you won't be able to get the audit logs 
+  **Note:** In case you configure this field to be lower than the main logger level, you won't be able to get the audit logs
   {: .note }
 * `logging.output` `(string : "-")` - A path or paths to write logs to. A `-` means the standard output, `=` means the standard error.
 * `logging.file_max_size_mb` `(int : 100)` - Output file maximum size in megabytes.
@@ -42,19 +42,19 @@ This reference uses `.` to denote the nesting of values.
 * ~~`database.max_idle_connections` `(int : 25)` - Sets the maximum number of connections in the idle connection pool~~
 * ~~`database.connection_max_lifetime` `(duration : 5m)` - Sets the maximum amount of time a connection may be reused~~
 
-  **Note:** Deprecated - See `database` section 
+  **Note:** Deprecated - See `database` section
   {: .note }
 * `database` - Configuration section for the lakeFS key-value store database
-  + `database.type` `(string ["postgres"|"dynamodb"|"local"] : )` - lakeFS database type 
+  + `database.type` `(string ["postgres"|"dynamodb"|"local"] : )` - lakeFS database type
   + `database.postgres` - Configuration section when using `database.type="postgres"`
     + `database.postgres.connection_string` `(string : "postgres://localhost:5432/postgres?sslmode=disable")` - PostgreSQL connection string to use
     + `database.postgres.max_open_connections` `(int : 25)` - Maximum number of open connections to the database
     + `database.postgres.max_idle_connections` `(int : 25)` - Maximum number of connections in the idle connection pool
-    + `database.postgres.connection_max_lifetime` `(duration : 5m)` - Sets the maximum amount of time a connection may be reused `(valid units: ns|us|ms|s|m|h)` 
+    + `database.postgres.connection_max_lifetime` `(duration : 5m)` - Sets the maximum amount of time a connection may be reused `(valid units: ns|us|ms|s|m|h)`
   + `database.dynamodb` - Configuration section when using `database.type="dynamodb"`
     + `database.dynamodb.table_name` `(string : "kvstore")` - Table used to store the data
     + `database.dynamodb.scan_limit` `(int : 1025)` - Maximal number of items per page during scan operation
-    
+
       **Note:** Refer to the following [AWS documentation](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Query.html#Query.Limit) for further information
       {: .note }
     + `database.dynamodb.endpoint` `(string : )` - Endpoint URL for database instance
@@ -76,7 +76,7 @@ This reference uses `.` to denote the nesting of values.
 * `auth.cache.ttl` `(time duration : "20s")` - How long to store an item in the auth cache. Using a higher value reduces load on the database, but will cause changes longer to take effect for cached users.
 * `auth.cache.jitter` `(time duration : "3s")` - A random amount of time between 0 and this value is added to each item's TTL. This is done to avoid a large bulk of keys expiring at once and overwhelming the database.
 * `auth.encrypt.secret_key` `(string : required)` - A random (cryptographically safe) generated string that is used for encryption and HMAC signing
-* `auth.login_duration` `(time duration : "168h")` - The duration the login token is valid for 
+* `auth.login_duration` `(time duration : "168h")` - The duration the login token is valid for
 * `auth.cookie_domain` `(string : "")` - [Domain attribute](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#define_where_cookies_are_sent) to set the access_token cookie on (the default is an empty string which defaults to the same host that sets the cookie)
 * `auth.api.endpoint` `(string: https://external.service/api/v1)` - URL to external Authorization Service described at [authorization.yml](https://github.com/treeverse/lakeFS/blob/master/api/authorization.yml);
 * `auth.api.token` `(string: eyJhbGciOiJIUzI1NiIsInR5...)` - API token used to authenticate requests to api endpoint
@@ -89,20 +89,19 @@ This reference uses `.` to denote the nesting of values.
 * `auth.remote_authenticator.request_timeout` `(duration : 10s)` - If specified, timeout for remote authentication requests.
 * `auth.cookie_auth_verification.validate_id_token_claims` `(map[string]string : )` - When a user tries to access lakeFS, validate that the ID token contains these claims with the corresponding values.
 * `auth.cookie_auth_verification.default_initial_groups` (string[] : [])` - By default, users will be assigned to these groups
-* `auth.cookie_auth_verification.initial_groups_claim_name` `(string[] : [])` - Use this claim from the ID token to provide the initial group for new users. This will take priority if `auth.cookie_auth_verification.default_initial_groups` is also set. 
+* `auth.cookie_auth_verification.initial_groups_claim_name` `(string[] : [])` - Use this claim from the ID token to provide the initial group for new users. This will take priority if `auth.cookie_auth_verification.default_initial_groups` is also set.
 * `auth.cookie_auth_verification.friendly_name_claim_name` `(string[] : )` - If specified, the value from the claim with this name will be used as the user's display name.
 * `auth.cookie_auth_verification.external_user_id_claim_name` - `(string : )` - If specified, the value from the claim with this name will be used as the user's id name.
 * `auth.cookie_auth_verification.auth_source` - `(string : )` - If specified, user will be labeled with this auth source.
 * `auth.oidc.default_initial_groups` `(string[] : [])` - By default, OIDC users will be assigned to these groups
-* `auth.oidc.initial_groups_claim_name` `(string[] : [])` - Use this claim from the ID token to provide the initial group for new users. This will take priority if `auth.oidc.default_initial_groups` is also set. 
+* `auth.oidc.initial_groups_claim_name` `(string[] : [])` - Use this claim from the ID token to provide the initial group for new users. This will take priority if `auth.oidc.default_initial_groups` is also set.
 * `auth.oidc.friendly_name_claim_name` `(string[] : )` - If specified, the value from the claim with this name will be used as the user's display name.
 * `auth.oidc.validate_id_token_claims` `(map[string]string : )` - When a user tries to access lakeFS, validate that the ID token contains these claims with the corresponding values.
-* `auth.ui_config.rbac` `(string: "simplified")` - "simplified" or
-  "external".  In simplified mode, do not display policy in GUI.  If you
-  have configured an external auth server you can set this to "external" to
-  support the policy editor.
+* `auth.ui_config.rbac` `(string: "simplified")` - "simplified", "external" or "internal" (enterprise feature).  In simplified mode, do not display policy in GUI.
+  If you have configured an external auth server you can set this to "external" to support the policy editor.
+  If you are using the enteprrise version of lakeFS, you can set this to "internal" to use the built-in policy editor.
 * `blockstore.type` `(one of ["local", "s3", "gs", "azure", "mem"] : required)`. Block adapter to use. This controls where the underlying data will be stored
-* `blockstore.default_namespace_prefix` `(string : )` - Use this to help your users choose a storage namespace for their repositories. 
+* `blockstore.default_namespace_prefix` `(string : )` - Use this to help your users choose a storage namespace for their repositories.
    If specified, the storage namespace will be filled with this default value as a prefix when creating a repository from the UI.
    The user may still change it to something else.
 * `blockstore.local.path` `(string: "~/lakefs/data")` - When using the local Block Adapter, which directory to store files in
@@ -175,7 +174,7 @@ This reference uses `.` to denote the nesting of values.
 + `email.sender` `(string)` - A string representing the email account which is set as the sender.
 + `email.limit_every_duration` `(duration : 1m)` - The average time between sending emails. If zero is entered, there is no limit to the amount of emails that can be sent.
 + `email.burst` `(int: 10)` - Maximal burst of emails before applying `limit_every_duration`. The zero value means no burst and therefore no emails can be sent.
-+ `email.lakefs_base_url` `(string : "http://localhost:8000")` - A string representing the base lakeFS endpoint to be directed to when emails are sent inviting users, reseting passwords etc. 
++ `email.lakefs_base_url` `(string : "http://localhost:8000")` - A string representing the base lakeFS endpoint to be directed to when emails are sent inviting users, reseting passwords etc.
 * `gateways.s3.domain_name` `(string : "s3.local.lakefs.io")` - a FQDN
   representing the S3 endpoint used by S3 clients to call this server
   (`*.s3.local.lakefs.io` always resolves to 127.0.0.1, useful for
@@ -186,7 +185,7 @@ This reference uses `.` to denote the nesting of values.
 * `stats.flush_interval` `(duration : 30s)` - Interval used to post anonymous statistics collected
 * `stats.flush_size` `(int : 100)` - A size (in records) of anonymous statistics collected in which we post
 * `security.audit_check_interval` `(duration : 24h)` - Duration in which we check for security audit.
-* `ui.enabled` `(bool: true)` - Whether to server the embedded UI from the binary  
+* `ui.enabled` `(bool: true)` - Whether to server the embedded UI from the binary
 {: .ref-list }
 
 ## Using Environment Variables
@@ -337,4 +336,3 @@ blockstore:
     storage_access_key: ExampleAcessKeyMD7nkPOWgV7d4BUjzLw==
 
 ```
-

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -97,7 +97,7 @@ This reference uses `.` to denote the nesting of values.
 * `auth.oidc.initial_groups_claim_name` `(string[] : [])` - Use this claim from the ID token to provide the initial group for new users. This will take priority if `auth.oidc.default_initial_groups` is also set. 
 * `auth.oidc.friendly_name_claim_name` `(string[] : )` - If specified, the value from the claim with this name will be used as the user's display name.
 * `auth.oidc.validate_id_token_claims` `(map[string]string : )` - When a user tries to access lakeFS, validate that the ID token contains these claims with the corresponding values.
-* `auth.ui_config.RBAC` `(string: "simplified")` - "simplified" or
+* `auth.ui_config.rbac` `(string: "simplified")` - "simplified" or
   "external".  In simplified mode, do not display policy in GUI.  If you
   have configured an external auth server you can set this to "external" to
   support the policy editor.

--- a/docs/reference/rbac.md
+++ b/docs/reference/rbac.md
@@ -385,6 +385,6 @@ Policy                                                  | Admins | SuperUsers | 
 
 ## Pluggable Authentication and Authorization
 
-Authorization and authentication is pluggable in lakeFS. If lakeFS is attached to a [remote authentication server](remote-authenticator.html) (or you are using lakeFS Cloud) then the [role-based access control](rbac.html) user interface can be used. If you are using RBAC with your self-managed lakeFS then the lakeFS configuration element `auth.ui_config.RBAC` should be set to `external`.
+Authorization and authentication is pluggable in lakeFS. If lakeFS is attached to a [remote authentication server](remote-authenticator.html) (or you are using lakeFS Cloud) then the [role-based access control](rbac.html) user interface can be used. If you are using RBAC with your self-managed lakeFS then the lakeFS configuration element `auth.ui_config.rbac` should be set to `external`.
 
-If you are using self-managed lakeFS and do not have a [remote authentication server](remote-authenticator.html) then you should set `auth.ui_config.RBAC` to `simplified` and refer to the [access control list](access-control-lists.html) documentation instead.
+If you are using self-managed lakeFS and do not have a [remote authentication server](remote-authenticator.html) then you should set `auth.ui_config.rbac` to `simplified` and refer to the [access control list](access-control-lists.html) documentation instead.

--- a/docs/reference/rbac.md
+++ b/docs/reference/rbac.md
@@ -23,7 +23,7 @@ lakeFS Enterprise
 {: .note}
 > RBAC is available on [lakeFS Cloud](../cloud/) and [lakeFS Enterprise](../enterprise/).
 >
-> If you're using the open source version of lakeFS then the [ACL-based authorization mechanism](access-control-lists.html) is an alternative to RBAC. 
+> If you're using the open source version of lakeFS then the [ACL-based authorization mechanism](access-control-lists.html) is an alternative to RBAC.
 
 {% include toc.html %}
 
@@ -307,7 +307,7 @@ The following Policies are created during initial setup:
 
 ## Additional Policies
 
-You can create additional policies to further limit user access. Use the web UI or the [lakectl auth](./cli.md#lakectl-auth-policies-create) command to create policies. Here is an example to define read/write access for a specific repository: 
+You can create additional policies to further limit user access. Use the web UI or the [lakectl auth](./cli.md#lakectl-auth-policies-create) command to create policies. Here is an example to define read/write access for a specific repository:
 
 ```json
 {
@@ -364,20 +364,20 @@ You can create additional policies to further limit user access. Use the web UI 
 
 ## Preconfigured Groups
 
-lakeFS has four preconfigured groups: 
+lakeFS has four preconfigured groups:
 
 * Admins
 * SuperUsers
 * Developers
 * Viewers
 
-They have the following policies granted to them: 
+They have the following policies granted to them:
 
 Policy                                                  | Admins | SuperUsers | Developers| Viewers |
 --------------------------------------------------------|--------|------------|-----------|---------|
 [`FSFullAccess`](#fsfullaccess)                         |   ✅   |     ✅     |           |         |
-[`AuthFullAccess`](#authfullaccess)                     |   ✅   |            |           |         | 
-[`RepoManagementFullAccess`](#repomanagementfullaccess) |   ✅   |            |           |         | 
+[`AuthFullAccess`](#authfullaccess)                     |   ✅   |            |           |         |
+[`RepoManagementFullAccess`](#repomanagementfullaccess) |   ✅   |            |           |         |
 [`AuthManageOwnCredentials`](#authmanageowncredentials) |        |     ✅     |    ✅     |   ✅    |
 [`RepoManagementReadAll`](#repomanagementreadall)       |        |     ✅     |    ✅     |         |
 [`FSReadWriteAll`](#fsreadwriteall)                     |        |            |    ✅     |         |
@@ -385,6 +385,6 @@ Policy                                                  | Admins | SuperUsers | 
 
 ## Pluggable Authentication and Authorization
 
-Authorization and authentication is pluggable in lakeFS. If lakeFS is attached to a [remote authentication server](remote-authenticator.html) (or you are using lakeFS Cloud) then the [role-based access control](rbac.html) user interface can be used. If you are using RBAC with your self-managed lakeFS then the lakeFS configuration element `auth.ui_config.rbac` should be set to `external`.
+Authorization and authentication is pluggable in lakeFS. If lakeFS is attached to a [remote authentication server](remote-authenticator.html) (or you are using lakeFS Cloud) then the [role-based access control](rbac.html) user interface can be used. If you are using RBAC with your self-managed lakeFS then the lakeFS configuration element `auth.ui_config.rbac` should be set to `external`. An enterprise (paid) solution of lakeFS should set `auth.ui_config.rbac` as `internal`.
 
 If you are using self-managed lakeFS and do not have a [remote authentication server](remote-authenticator.html) then you should set `auth.ui_config.rbac` to `simplified` and refer to the [access control list](access-control-lists.html) documentation instead.

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -587,17 +587,17 @@ func (c *Controller) GetGroupACL(w http.ResponseWriter, r *http.Request, groupID
 		return
 	}
 
-	var acl model.ACL
+	var groupACL model.ACL
 	switch len(policies) {
 	case 0: // Blank ACL is valid and allows nothing
 		break
 	case 1:
-		acl = policies[0].ACL
-		if len(acl.Permission) == 0 {
+		groupACL = policies[0].ACL
+		if len(groupACL.Permission) == 0 {
 			c.Logger.
 				WithContext(ctx).
 				WithField("policy", fmt.Sprintf("%+v", policies[0])).
-				WithField("acl", fmt.Sprintf("%+v", acl)).
+				WithField("acl", fmt.Sprintf("%+v", groupACL)).
 				WithField("group", groupID).
 				Warn("Policy attached to group has no ACL")
 			response := NotFoundOrNoACL{
@@ -622,7 +622,7 @@ func (c *Controller) GetGroupACL(w http.ResponseWriter, r *http.Request, groupID
 	}
 
 	response := ACL{
-		Permission: string(acl.Permission),
+		Permission: string(groupACL.Permission),
 	}
 
 	writeResponse(w, r, http.StatusOK, response)
@@ -3829,7 +3829,7 @@ func (c *Controller) GetSetupState(w http.ResponseWriter, r *http.Request) {
 
 	state := string(savedState)
 	// no need to create an admin user if users are managed externally
-	if c.Config.IsAuthTypeAPI() {
+	if c.Config.Auth.UIConfig.RBAC == config.AuthRBACExternal {
 		state = string(auth.SetupStateInitialized)
 	} else if savedState == auth.SetupStateNotInitialized {
 		c.Collector.CollectEvent(stats.Event{Class: "global", Name: "preinit", Client: httputil.GetRequestLakeFSClient(r)})
@@ -3872,7 +3872,7 @@ func (c *Controller) Setup(w http.ResponseWriter, r *http.Request, body SetupJSO
 		return
 	}
 
-	if c.Config.IsAuthTypeAPI() {
+	if c.Config.Auth.UIConfig.RBAC == config.AuthRBACExternal {
 		// nothing to do - users are managed elsewhere
 		writeResponse(w, r, http.StatusOK, CredentialsWithSecret{})
 		return
@@ -3926,7 +3926,7 @@ func (c *Controller) SetupCommPrefs(w http.ResponseWriter, r *http.Request, body
 	// this is the "natural" next step in the setup process
 	nextStep := auth.SetupStateCommPrefsDone
 	// if users are managed externally, we can skip the admin user creation step
-	if c.Config.IsAuthTypeAPI() {
+	if c.Config.Auth.UIConfig.RBAC == config.AuthRBACExternal {
 		nextStep = auth.SetupStateInitialized
 	}
 	response := NextStep{

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -1206,6 +1206,9 @@ func TestController_ListTagsHandler(t *testing.T) {
 			})
 			testutil.Must(t, err)
 			payload := resp.JSON200
+			if payload == nil {
+				t.Fatal("ListTags missing response, got", resp.Status())
+			}
 			results = append(results, payload.Results...)
 			if !payload.Pagination.HasMore {
 				break

--- a/pkg/api/serve_test.go
+++ b/pkg/api/serve_test.go
@@ -126,9 +126,8 @@ func setupHandlerWithWalkerFactory(t testing.TB, factory catalog.WalkerFactory) 
 		viper.Set(config.BlockstoreTypeKey, block.BlockstoreTypeMem)
 	}
 	viper.Set("database.type", mem.DriverName)
-	// Fake external mode using the internal service (this only works in
-	// tests).
-	viper.Set("auth.ui_config.rbac", "external")
+	// Use 'internal' mode in order to have access to policies
+	viper.Set("auth.ui_config.rbac", "internal")
 
 	collector := &memCollector{}
 

--- a/pkg/auth/setup/setup.go
+++ b/pkg/auth/setup/setup.go
@@ -115,9 +115,7 @@ func attachPolicies(ctx context.Context, authService auth.Service, groupID strin
 }
 
 func SetupRBACBaseGroups(ctx context.Context, authService auth.Service, ts time.Time) error {
-	var err error
-
-	err = createGroups(ctx, authService, []*model.Group{
+	err := createGroups(ctx, authService, []*model.Group{
 		{CreatedAt: ts, DisplayName: AdminsGroup},
 		{CreatedAt: ts, DisplayName: SuperUsersGroup},
 		{CreatedAt: ts, DisplayName: DevelopersGroup},
@@ -187,7 +185,7 @@ func SetupACLBaseGroups(ctx context.Context, authService auth.Service, ts time.T
 func SetupAdminUser(ctx context.Context, authService auth.Service, cfg *config.Config, superuser *model.SuperuserConfiguration) (*model.Credential, error) {
 	now := time.Now()
 
-	// Setup the basic groups and policies
+	// Set up the basic groups and policies
 	err := SetupBaseGroups(ctx, authService, cfg, now)
 	if err != nil {
 		return nil, err

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -629,6 +629,10 @@ func (c *Config) IsAuthUISimplified() bool {
 	return c.Auth.UIConfig.RBAC == AuthRBACSimplified
 }
 
+func (c *Config) IsAuthTypeAPI() bool {
+	return c.Auth.API.Endpoint != ""
+}
+
 func (c *Config) UISnippets() []apiparams.CodeSnippet {
 	snippets := make([]apiparams.CodeSnippet, 0, len(c.UI.Snippets))
 	for _, item := range c.UI.Snippets {


### PR DESCRIPTION
Currently lakeFS do not setup initial user and groups in case `auth.api.endpoint` is configured.
It assumes that the service will manage the creation and the users for lakeFS.
This PR changes check to be based on `auth.ui_config.rbac` value.
- simplified: setup acl authorizations and initial user
- external: skip setup - assume the remote service managed the data
- internal: will setup rbac authorizations and initial user as the remote service share the  same data source.

Close https://github.com/treeverse/lakeFS/issues/5866