### PR TITLE
docs: airbyte destination to connector

### DIFF
--- a/docs/integrations/airbyte.md
+++ b/docs/integrations/airbyte.md
@@ -39,7 +39,7 @@ You can take advantage of lakeFS consistency guarantees and [Data Lifecycle Mana
 ## S3 Connector
 lakeFS exposes an [S3 Gateway](../understand/architecture.md#s3-gateway) that enables applications to communicate
 with lakeFS the same way they would with Amazon S3.
-You can use Airbyte's [S3 Destination](https://airbyte.io/destinations/s3) to upload data to lakeFS.
+You can use Airbyte's [S3 Connector](https://airbyte.com/connectors/s3) to upload data to lakeFS.
 
 ### Configuring lakeFS using the connector
 Set the following parameters when creating a new Destination of type S3:


### PR DESCRIPTION
Fix the doc page for airbyte - use connector term and link.