### PR TITLE
Remove email authenticator middleware

### DIFF
--- a/cmd/lakefs/cmd/run.go
+++ b/cmd/lakefs/cmd/run.go
@@ -216,8 +216,6 @@ var runCmd = &cobra.Command{
 			middlewareAuthenticator = append(middlewareAuthenticator, remoteAuthenticator)
 		}
 
-		controllerAuthenticator := append(middlewareAuthenticator, auth.NewEmailAuthenticator(authService))
-
 		auditChecker := version.NewDefaultAuditChecker(cfg.Security.AuditCheckURL, metadata.InstallationID, version.NewDefaultVersionSource(cfg.Security.CheckLatestVersionCache))
 		defer auditChecker.Close()
 		if !version.IsVersionUnreleased() {
@@ -243,7 +241,6 @@ var runCmd = &cobra.Command{
 			cfg,
 			c,
 			middlewareAuthenticator,
-			controllerAuthenticator,
 			authService,
 			blockStore,
 			authMetadataManager,

--- a/pkg/api/serve.go
+++ b/pkg/api/serve.go
@@ -42,7 +42,6 @@ func Serve(
 	cfg *config.Config,
 	catalog catalog.Interface,
 	middlewareAuthenticator auth.Authenticator,
-	controllerAuthenticator auth.Authenticator,
 	authService auth.Service,
 	blockAdapter block.Adapter,
 	metadataManager auth.MetadataManager,
@@ -82,7 +81,7 @@ func Serve(
 	controller := NewController(
 		cfg,
 		catalog,
-		controllerAuthenticator,
+		middlewareAuthenticator,
 		authService,
 		blockAdapter,
 		metadataManager,

--- a/pkg/api/serve_test.go
+++ b/pkg/api/serve_test.go
@@ -188,7 +188,6 @@ func setupHandlerWithWalkerFactory(t testing.TB, factory catalog.WalkerFactory) 
 		cfg,
 		c,
 		authenticator,
-		authenticator,
 		authService,
 		c.BlockAdapter,
 		meta,

--- a/pkg/auth/authenticator.go
+++ b/pkg/auth/authenticator.go
@@ -25,12 +25,6 @@ type Credentialler interface {
 	GetCredentials(ctx context.Context, accessKeyID string) (*model.Credential, error)
 }
 
-// NewChainAuthenticator returns an Authenticator that authenticates users
-// by trying each auth in order.
-func NewChainAuthenticator(auth ...Authenticator) Authenticator {
-	return ChainAuthenticator(auth)
-}
-
 // ChainAuthenticator authenticates users by trying each Authenticator in
 // order, returning the last error in case all fail.
 type ChainAuthenticator []Authenticator
@@ -48,30 +42,6 @@ func (ca ChainAuthenticator) AuthenticateUser(ctx context.Context, username, pas
 	}
 	logger.WithError(merr).Info("Failed to authenticate user")
 	return InvalidUserID, merr
-}
-
-type EmailAuthenticator struct {
-	AuthService Service
-}
-
-func NewEmailAuthenticator(service Service) *EmailAuthenticator {
-	return &EmailAuthenticator{AuthService: service}
-}
-
-func (e EmailAuthenticator) AuthenticateUser(ctx context.Context, username, password string) (string, error) {
-	user, err := e.AuthService.GetUserByEmail(ctx, username)
-	if err != nil {
-		return InvalidUserID, err
-	}
-
-	if err := user.Authenticate(password); err != nil {
-		return InvalidUserID, err
-	}
-	return user.Username, nil
-}
-
-func (e EmailAuthenticator) String() string {
-	return "email authenticator"
 }
 
 // BuiltinAuthenticator authenticates users by their access key IDs and

--- a/pkg/loadtest/local_load_test.go
+++ b/pkg/loadtest/local_load_test.go
@@ -90,7 +90,6 @@ func TestLocalLoad(t *testing.T) {
 		conf,
 		c,
 		authenticator,
-		authenticator,
 		authService,
 		blockAdapter,
 		meta,


### PR DESCRIPTION
Reduce the number of check per call by removing deprecated support of authenticate by email.

Close https://github.com/treeverse/lakeFS/issues/5923