### PR TITLE
Incremental GC: Keep reachable previously expired GC commits

### DIFF
--- a/pkg/graveler/retention/expired_commits.go
+++ b/pkg/graveler/retention/expired_commits.go
@@ -120,7 +120,7 @@ func GetGarbageCollectionCommits(ctx context.Context, startingPointIterator *GCS
 				// If the parent commit was expired in a previous GC run (incremental GC case) we can stop because it's
 				// both expired in this run and the previous (in this path)
 				if nextCommitChildren, ok := prevExpiredCommitsToChildrenMap[nextCommitID]; ok {
-					// Get the previously expired commit's list of known children and add the current commit to it.
+					// Add current commit to previously expired commit's list of known children if it's not there.
 					if _, ok := nextCommitChildren[currentCommitID]; !ok {
 						nextCommitChildren[currentCommitID] = struct{}{}
 						prevExpiredCommitsToChildrenMap[nextCommitID] = nextCommitChildren

--- a/pkg/graveler/retention/expired_commits_test.go
+++ b/pkg/graveler/retention/expired_commits_test.go
@@ -266,6 +266,15 @@ func TestExpiredCommits(t *testing.T) {
 			expectedActiveIDs:  []string{"B", "D", "E", "F", "HEAD1", "HEAD2"},
 			expectedExpiredIDs: []string{},
 		},
+		/*
+			<ep1- 8 days>
+				\
+				  <e4- 7 days> -- <e1- 7 days> -- <h1- 1 day>        (5-day-retention)
+				/
+			<ep2- 8 days> -- <e2- 7 days> -- <h2- 1 day>             (5-day-retention)
+				\
+				  <e5- 6 days> -- <e3- 6 days> -- <h3- 1 day>        (5-day-retention)
+		*/
 		"reachable_previously_expired": {
 			commits: map[string]testCommit{
 				"ep1": newTestCommit(8),
@@ -274,7 +283,7 @@ func TestExpiredCommits(t *testing.T) {
 				"e4":  newTestCommit(7, "ep1", "ep2"),
 				"e3":  newTestCommit(6, "e5"),  // expired yet active
 				"e2":  newTestCommit(6, "ep2"), // expired yet active
-				"e1":  newTestCommit(6, "e4"),  // expired yet active
+				"e1":  newTestCommit(7, "e4"),  // expired yet active
 				"h3":  newTestCommit(1, "e3"),
 				"h2":  newTestCommit(1, "e2"),
 				"h1":  newTestCommit(1, "e1"),

--- a/pkg/graveler/retention/expired_commits_test.go
+++ b/pkg/graveler/retention/expired_commits_test.go
@@ -119,13 +119,13 @@ func TestExpiredCommits(t *testing.T) {
 				"b": newTestCommit(10, "a"),
 				"c": newTestCommit(10, "a"),
 				"d": newTestCommit(5, "c"),
-				"e": newTestCommit(5, "b"),
+				"e": newTestCommit(7, "b"),
 				"f": newTestCommit(1, "e"),
 			},
 			headsRetentionDays: map[string]int32{"f": 7, "d": 3},
 			previouslyExpired:  []string{"a"},
-			expectedActiveIDs:  []string{"b", "d", "e", "f"},
-			expectedExpiredIDs: []string{"c"},
+			expectedActiveIDs:  []string{"d", "e", "f"},
+			expectedExpiredIDs: []string{"c", "b"},
 		},
 		"many_previously_expired": {
 			commits: map[string]testCommit{
@@ -205,15 +205,15 @@ func TestExpiredCommits(t *testing.T) {
 				"b": newTestCommit(10, "a"),
 				"c": newTestCommit(10, "a"),
 				"d": newTestCommit(5, "c"),
-				"e": newTestCommit(5, "b"),
+				"e": newTestCommit(8, "b"),
 				"f": newTestCommit(1, "e"),
 				"g": newTestCommit(10, "a"), // dangling
 				"h": newTestCommit(6, "g"),  // dangling
 			},
 			headsRetentionDays: map[string]int32{"f": 7, "d": 3},
 			previouslyExpired:  []string{"a"},
-			expectedActiveIDs:  []string{"b", "d", "e", "f"},
-			expectedExpiredIDs: []string{"c", "g", "h"},
+			expectedActiveIDs:  []string{"e", "d", "f"},
+			expectedExpiredIDs: []string{"c", "g", "h", "b"},
 		},
 		"dangling_from_before_expired": {
 			commits: map[string]testCommit{
@@ -223,15 +223,15 @@ func TestExpiredCommits(t *testing.T) {
 				"b":           newTestCommit(10, "e1"),
 				"c":           newTestCommit(10, "e1"),
 				"d":           newTestCommit(5, "c"),
-				"e":           newTestCommit(5, "b"),
+				"e":           newTestCommit(8, "b"),
 				"f":           newTestCommit(1, "e"),
 				"g":           newTestCommit(10, "root"), // dangling
 				"h":           newTestCommit(6, "g"),     // dangling
 			},
 			headsRetentionDays: map[string]int32{"f": 7, "d": 3},
 			previouslyExpired:  []string{"e1"},
-			expectedActiveIDs:  []string{"b", "d", "e", "f"},
-			expectedExpiredIDs: []string{"c", "g", "root", "h"},
+			expectedActiveIDs:  []string{"d", "e", "f"},
+			expectedExpiredIDs: []string{"c", "b", "g", "root", "h"},
 		},
 		"retained_by_non_leaf_head": {
 			// commit x is retained because of the rule of head2, and not the rule of head1.
@@ -264,7 +264,7 @@ func TestExpiredCommits(t *testing.T) {
 			headsRetentionDays: map[string]int32{"HEAD1": 3, "HEAD2": 3},
 			previouslyExpired:  []string{"A", "B", "C", "E"},
 			expectedActiveIDs:  []string{"B", "D", "E", "F", "HEAD1", "HEAD2"},
-			expectedExpiredIDs: []string{},
+			expectedExpiredIDs: []string{"A", "C"},
 		},
 		/*
 			<ep1- 8 days>


### PR DESCRIPTION
### Linked Issue

Examine it for more details:
Closes #5889

---

## Change Description

If previously expired commits (i.e. commits that expired on a previous GC run) have at least one active child commit, keep the previously expired commits in the commits CSV output for successive GC runs.
