### PR TITLE
Fix credentials list GUI sort

### DIFF
--- a/pkg/auth/service.go
+++ b/pkg/auth/service.go
@@ -356,9 +356,6 @@ func (s *AuthService) ListUserCredentials(ctx context.Context, username string, 
 	if err != nil {
 		return nil, nil, err
 	}
-	sort.Slice(creds, func(i, j int) bool {
-		return creds[i].IssuedDate.After(creds[j].IssuedDate)
-	})
 	return creds, paginator, nil
 }
 

--- a/pkg/auth/service.go
+++ b/pkg/auth/service.go
@@ -356,6 +356,9 @@ func (s *AuthService) ListUserCredentials(ctx context.Context, username string, 
 	if err != nil {
 		return nil, nil, err
 	}
+	sort.Slice(creds, func(i, j int) bool {
+		return creds[i].IssuedDate.After(creds[j].IssuedDate)
+	})
 	return creds, paginator, nil
 }
 

--- a/webui/src/lib/components/auth/credentials.jsx
+++ b/webui/src/lib/components/auth/credentials.jsx
@@ -28,7 +28,7 @@ export const CredentialsTable = ({userId, currentAccessKey, refresh, after, onPa
             <DataTable
                 keyFn={row => row.access_key_id}
                 emptyState={'No credentials found'}
-                results={results}
+                results={results.sort((a, b) => b.creation_date - a.creation_date)}
                 headers={['Access Key ID', 'Creation Date', '']}
                 rowFn={row => [
                     <>


### PR DESCRIPTION
### Linked Issue

Closes #3691

---

## Change Description

### Background

On the Administration tab, the credentials are auto sorted by their ID. This change sorts the credentials by date, with the newest credentials on top

### Additional info
Administration Tab GUI with credentials sorted by creation date
![image](https://github.com/treeverse/lakeFS/assets/77828327/80dea54f-9cd5-4958-9bfc-2d1c913f282d)


---

### Contact Details

rishiravi.k98@gmail.com
