### PR TITLE
Fix auth get first user should pull at least two users

### DIFF
--- a/pkg/auth/service.go
+++ b/pkg/auth/service.go
@@ -1232,9 +1232,9 @@ func userIDToInt(userID string) (int64, error) {
 
 func (a *APIAuthService) getFirstUser(ctx context.Context, userKey userKey, params *ListUsersParams) (*model.User, error) {
 	return a.cache.GetUser(userKey, func() (*model.User, error) {
-		// fetch single user and make there are no more than one
+		// fetch at least two users to make sure we don't have duplicates
 		if params.Amount == nil {
-			params.Amount = paginationAmount(1)
+			params.Amount = paginationAmount(2)
 		}
 		resp, err := a.apiClient.ListUsersWithResponse(ctx, params)
 		if err != nil {
@@ -1250,7 +1250,7 @@ func (a *APIAuthService) getFirstUser(ctx context.Context, userKey userKey, para
 		if len(results) == 0 {
 			return nil, ErrNotFound
 		}
-		if len(results) > 1 || resp.JSON200.Pagination.HasMore {
+		if len(results) > 1 {
 			// make sure we work with just one user based on 'params'
 			return nil, ErrNonUnique
 		}


### PR DESCRIPTION
Temporary fix for pulling at least 2 users while using list users to pull one unique user.