### PR TITLE
Fix UI rename Error control to AlertError fixing conflict with class

### DIFF
--- a/webui/src/lib/components/auth/credentials.jsx
+++ b/webui/src/lib/components/auth/credentials.jsx
@@ -6,7 +6,7 @@ import Alert from "react-bootstrap/Alert";
 
 import {auth} from "../../api";
 import {useAPIWithPagination} from "../../hooks/api";
-import {ClipboardButton, DataTable, Error, FormattedDate, Loading} from "../controls";
+import {ClipboardButton, DataTable, AlertError, FormattedDate, Loading} from "../controls";
 import {ConfirmationButton} from "../modals";
 import {Paginator} from "../pagination";
 
@@ -19,8 +19,8 @@ export const CredentialsTable = ({userId, currentAccessKey, refresh, after, onPa
         return auth.listCredentials(userId, after);
     }, [refresh, internalRefresh, userId, after]);
 
-    if (error) return <Error error={error}/>;
-    if (revokeError) return <Error error={revokeError}/>;
+    if (error) return <AlertError error={error}/>;
+    if (revokeError) return <AlertError error={revokeError}/>;
     if (loading) return <Loading/>;
 
     return (

--- a/webui/src/lib/components/auth/forms.jsx
+++ b/webui/src/lib/components/auth/forms.jsx
@@ -7,7 +7,7 @@ import {FormControl, InputGroup} from "react-bootstrap";
 import {SearchIcon} from "@primer/octicons-react";
 
 import {useAPI} from "../../hooks/api";
-import {Checkbox, DataTable, DebouncedFormControl, Error, Loading} from "../controls";
+import {Checkbox, DataTable, DebouncedFormControl, AlertError, Loading} from "../controls";
 
 const isEmptyString = (str) => (!str?.length);
 
@@ -30,7 +30,7 @@ export const AttachModal = ({ show, searchFn, onAttach, onHide, addText = "Add",
 
     let content;
     if (loading) content = <Loading/>;
-    else if (error) content = <Error error={error}/>;
+    else if (error) content = <AlertError error={error}/>;
     else content = (
             <>
                 <DataTable
@@ -127,7 +127,7 @@ export const EntityActionModal = ({ show, onHide, onAction, title, placeholder, 
                     <FormControl ref={idField} autoFocus placeholder={placeholder} type="text"/>
                 </Form>
 
-                {(!!error) && <Error className="mt-3" error={error}/>}
+                {(!!error) && <AlertError className="mt-3" error={error}/>}
 
             </Modal.Body>
 

--- a/webui/src/lib/components/controls.jsx
+++ b/webui/src/lib/components/controls.jsx
@@ -75,7 +75,7 @@ export const Na = () => {
     );
 };
 
-export const Error = ({error, onDismiss = null, className = null}) => {
+export const AlertError = ({error, onDismiss = null, className = null}) => {
     let content = React.isValidElement(error) ? error : error.toString();
     // handle wrapped errors
     let err = error;

--- a/webui/src/lib/components/policy.jsx
+++ b/webui/src/lib/components/policy.jsx
@@ -5,7 +5,7 @@ import Modal from "react-bootstrap/Modal";
 import Form from "react-bootstrap/Form";
 import {FormControl} from "react-bootstrap";
 import Button from "react-bootstrap/Button";
-import {Error, FormattedDate} from "./controls";
+import {AlertError, FormattedDate} from "./controls";
 
 export const PolicyEditor = ({ show, onHide, onSubmit, policy = null, noID = false, isCreate = false, validationFunction = null, externalError = null }) => {
     const [error, setError] = useState(null);
@@ -93,8 +93,8 @@ export const PolicyEditor = ({ show, onHide, onSubmit, policy = null, noID = fal
                     </Form.Group>
                 </Form>
 
-                {(!!error) && <Error className="mt-3" error={error}/>}
-                {(!!externalError) && <Error className="mt-3" error={externalError}/>}
+                {(!!error) && <AlertError className="mt-3" error={error}/>}
+                {(!!externalError) && <AlertError className="mt-3" error={externalError}/>}
 
             </Modal.Body>
 

--- a/webui/src/lib/components/repository/ObjectsDiff.jsx
+++ b/webui/src/lib/components/repository/ObjectsDiff.jsx
@@ -2,7 +2,7 @@ import React from "react";
 import {useAPI} from "../../hooks/api";
 import {objects} from "../../api";
 import ReactDiffViewer, {DiffMethod} from "react-diff-viewer-continued";
-import {Error, Loading} from "../controls";
+import {AlertError, Loading} from "../controls";
 import {humanSize} from "./tree";
 import Alert from "react-bootstrap/Alert";
 import {InfoIcon} from "@primer/octicons-react";
@@ -31,12 +31,12 @@ export const ObjectsDiff = ({diffType, repoId, leftRef, rightRef, path}) => {
                 [repoId, leftRef, path]);
             break;
         default:
-            return <Error error={"Unsupported diff type " + diffType}/>;
+            return <AlertError error={"Unsupported diff type " + diffType}/>;
     }
 
     if ((left && left.loading) || (right && right.loading)) return <Loading/>;
     const err = (left && left.error) || (right && right.err);
-    if (err) return <Error error={err}/>;
+    if (err) return <AlertError error={err}/>;
 
     const leftStat = left && left.response;
     const rightStat = right && right.response;
@@ -45,7 +45,7 @@ export const ObjectsDiff = ({diffType, repoId, leftRef, rightRef, path}) => {
     }
     const objectTooBig = (leftStat && leftStat.size_bytes > maxDiffSizeBytes) || (rightStat && rightStat.size_bytes > maxDiffSizeBytes);
     if (objectTooBig) {
-        return <Error error={path + " is too big (> " + humanSize(maxDiffSizeBytes)+ "). To view its diff please download" +
+        return <AlertError error={path + " is too big (> " + humanSize(maxDiffSizeBytes)+ "). To view its diff please download" +
         " the objects and use an external diff tool."}/>
     }
     const leftSize = leftStat && leftStat.size_bytes;
@@ -78,7 +78,7 @@ const ContentDiff = ({repoId, path, leftRef, rightRef, leftSize, rightSize, diff
 
     if ((left && left.loading) || (right && right.loading)) return <Loading/>;
     const err = (left && left.error) || (right && right.err);
-    if (err) return <Error error={err}/>;
+    if (err) return <AlertError error={err}/>;
 
     return <div>
         <span><DiffSizeReport leftSize={leftSize} rightSize={rightSize} diffType={diffType}/></span>
@@ -93,18 +93,18 @@ const ContentDiff = ({repoId, path, leftRef, rightRef, leftSize, rightSize, diff
 function validateDiffInput(left, right, diffType) {
     switch (diffType) {
         case 'changed':
-            if (!left && !right) return <Error error={"Invalid diff input"}/>;
+            if (!left && !right) return <AlertError error={"Invalid diff input"}/>;
             break;
         case 'added':
-            if (!right) return <Error error={"Invalid diff input: right hand-side is missing"}/>;
+            if (!right) return <AlertError error={"Invalid diff input: right hand-side is missing"}/>;
             break;
         case 'removed':
-            if (!left) return <Error error={"Invalid diff input: left hand-side is missing"}/>;
+            if (!left) return <AlertError error={"Invalid diff input: left hand-side is missing"}/>;
             break;
         case 'conflict':
             break;
         default:
-            return <Error error={"Unknown diff type: " + diffType}/>;
+            return <AlertError error={"Unknown diff type: " + diffType}/>;
     }
 }
 
@@ -154,7 +154,7 @@ const DiffSizeReport = ({leftSize, rightSize, diffType}) => {
             size = leftSize;
             break;
         default:
-            return <Error error={"Unknown diff type: " + diffType}/>;
+            return <AlertError error={"Unknown diff type: " + diffType}/>;
     }
 
 

--- a/webui/src/lib/components/repository/TableDiff.jsx
+++ b/webui/src/lib/components/repository/TableDiff.jsx
@@ -6,14 +6,14 @@ import Tooltip from "react-bootstrap/Tooltip";
 import {OtfDiffType, OtfType} from "../../../constants";
 import {useAPI} from "../../hooks/api";
 import {repositories} from "../../api";
-import {Error, Loading} from "../controls";
+import {AlertError, Loading} from "../controls";
 import Alert from "react-bootstrap/Alert";
 import Button from "react-bootstrap/Button";
 
 export const DeltaLakeDiff = ({repo, leftRef, rightRef, tablePath}) => {
     let { error, loading, response } = useAPI(() => repositories.otfDiff(repo.id, leftRef, rightRef, tablePath, OtfType.Delta), [])
     if (loading) return <Loading style={{margin: 0+"px"}}/>;
-    if (!loading && error) return <Error error={error}/>;
+    if (!loading && error) return <AlertError error={error}/>;
 
     const otfDiffs = response.results;
     const diffType = response.diff_type;

--- a/webui/src/lib/components/repository/changes.jsx
+++ b/webui/src/lib/components/repository/changes.jsx
@@ -3,7 +3,7 @@ import React, {useCallback, useState} from "react";
 import {ArrowLeftIcon, ClockIcon, InfoIcon, PlusIcon, XIcon} from "@primer/octicons-react";
 
 import {useAPI, useAPIWithPagination} from "../../hooks/api";
-import {Error, Loading} from "../controls";
+import {AlertError, Loading} from "../controls";
 import {ObjectsDiff} from "./ObjectsDiff";
 import {TreeItemType} from "../../../constants";
 import * as otfUtils from "../../../util/otfUtil";
@@ -59,7 +59,7 @@ export const TreeItemRow = ({ entry, repo, reference, leftDiffRefID, rightDiffRe
 
     const results = resultsState.results
     if (error)
-        return <tr><td><Error error={error}/></td></tr>
+        return <tr><td><AlertError error={error}/></td></tr>
 
     if (itemType.loading || (loading && results.length === 0)) {
         return <ObjectTreeEntryRow key={entry.path + "entry-row"} entry={entry} loading={true} relativeTo={relativeTo}

--- a/webui/src/lib/components/repository/tree.jsx
+++ b/webui/src/lib/components/repository/tree.jsx
@@ -30,7 +30,7 @@ import { ConfirmationModal } from "../modals";
 import { Paginator } from "../pagination";
 import { Link } from "../nav";
 import { RefTypeBranch, RefTypeCommit } from "../../../constants";
-import {ClipboardButton, copyTextToClipboard, Error, Loading} from "../controls";
+import {ClipboardButton, copyTextToClipboard, AlertError, Loading} from "../controls";
 import Modal from "react-bootstrap/Modal";
 import { useAPI } from "../../hooks/api";
 import noop from "lodash/noop";
@@ -271,7 +271,7 @@ const OriginModal = ({ show, onHide, entry, repo, reference }) => {
   let content = <Loading />;
 
   if (error) {
-    content = <Error error={error} />;
+    content = <AlertError error={error} />;
   }
   if (!loading && !error && commit) {
     content = (

--- a/webui/src/pages/auth/credentials.jsx
+++ b/webui/src/pages/auth/credentials.jsx
@@ -4,7 +4,7 @@ import {AuthLayout} from "../../lib/components/auth/layout";
 import {
     ActionGroup,
     ActionsBar,
-    Error,
+    AlertError,
     RefreshButton
 } from "../../lib/components/controls";
 import {ConfirmationButton} from "../../lib/components/modals";
@@ -59,7 +59,7 @@ const CredentialsContainer = () => {
                 An access key-pair is the set of credentials used to access lakeFS. <a href="https://docs.lakefs.io/reference/authorization.html#authentication" target="_blank" rel="noopener noreferrer">Learn more.</a>
             </div>
 
-            {(!!createError) && <Error error={createError}/>}
+            {(!!createError) && <AlertError error={createError}/>}
 
             <CredentialsShowModal
                 credentials={createdKey}

--- a/webui/src/pages/auth/groups/group/members.jsx
+++ b/webui/src/pages/auth/groups/group/members.jsx
@@ -15,7 +15,7 @@ import {
     DataTable,
     FormattedDate,
     Loading,
-    Error,
+    AlertError,
     RefreshButton
 } from "../../../../lib/components/controls";
 import {useRouter} from "../../../../lib/hooks/router";
@@ -37,10 +37,10 @@ const GroupMemberList = ({ groupId, after, onPaginate }) => {
 
     let content;
     if (loading) content = <Loading/>;
-    else if (error) content=  <Error error={error}/>;
+    else if (error) content=  <AlertError error={error}/>;
     else content = (
             <>
-                {attachError && <Error error={attachError}/>}
+                {attachError && <AlertError error={attachError}/>}
 
                 <DataTable
                     keyFn={user => user.id}

--- a/webui/src/pages/auth/groups/group/policies.jsx
+++ b/webui/src/pages/auth/groups/group/policies.jsx
@@ -15,7 +15,7 @@ import {
     DataTable,
     FormattedDate,
     Loading,
-    Error,
+    AlertError,
     RefreshButton
 } from "../../../../lib/components/controls";
 import {Link} from "../../../../lib/components/nav";
@@ -35,10 +35,10 @@ const GroupPoliciesList = ({ groupId, after, onPaginate }) => {
 
     let content;
     if (loading) content = <Loading/>;
-    else if (error) content=  <Error error={error}/>;
+    else if (error) content=  <AlertError error={error}/>;
     else content = (
             <>
-                {attachError && <Error error={attachError}/>}
+                {attachError && <AlertError error={attachError}/>}
 
                 <DataTable
                     keyFn={policy => policy.id}

--- a/webui/src/pages/auth/groups/index.tsx
+++ b/webui/src/pages/auth/groups/index.tsx
@@ -13,7 +13,8 @@ import {
     ActionsBar,
     Checkbox,
     DataTable,
-    Error, FormattedDate,
+    AlertError,
+    FormattedDate,
     Loading,
     RefreshButton
 } from "../../../lib/components/controls";
@@ -94,7 +95,7 @@ const GroupsContainer = () => {
         setSelected([]);
     }, [after, refresh]);
 
-    if (error) return <Error error={error}/>;
+    if (error) return <AlertError error={error}/>;
     if (loading) return <Loading/>;
     const headers = simplified ? ['', 'Group ID', 'Permission', 'Created At'] : ['', 'Group ID', 'Created At'];
 
@@ -132,8 +133,8 @@ const GroupsContainer = () => {
             </div>
 
 
-            {(!!deleteError) && <Error error={deleteError}/>}
-            {(!!putACLError) && <Error error={putACLError}/>}
+            {(!!deleteError) && <AlertError error={deleteError}/>}
+            {(!!putACLError) && <AlertError error={putACLError}/>}
 
             <EntityActionModal
                 show={showCreate}

--- a/webui/src/pages/auth/login.tsx
+++ b/webui/src/pages/auth/login.tsx
@@ -6,7 +6,7 @@ import Form from "react-bootstrap/Form";
 import Col from "react-bootstrap/Col";
 import Button from "react-bootstrap/Button";
 import {auth, AuthenticationError, setup, SETUP_STATE_INITIALIZED} from "../../lib/api";
-import {Error} from "../../lib/components/controls"
+import {AlertError} from "../../lib/components/controls"
 import {useRouter} from "../../lib/hooks/router";
 import {useAPI} from "../../lib/hooks/api";
 
@@ -60,7 +60,7 @@ const LoginForm = ({loginConfig}: {loginConfig: LoginConfig}) => {
                                 <Form.Control type="password" placeholder={passwordPlaceholder}/>
                             </Form.Group>
 
-                            {(!!loginError) && <Error error={loginError}/>}
+                            {(!!loginError) && <AlertError error={loginError}/>}
 
                             <Button variant="primary" type="submit">Login</Button>
                         </Form>

--- a/webui/src/pages/auth/policies/index.jsx
+++ b/webui/src/pages/auth/policies/index.jsx
@@ -13,7 +13,8 @@ import {
     ActionsBar,
     Checkbox,
     DataTable,
-    Error, FormattedDate,
+    AlertError,
+    FormattedDate,
     Loading,
     RefreshButton,
     Warning,
@@ -43,7 +44,7 @@ const PoliciesContainer = () => {
 
     const {RBAC: rbac} = useLoginConfigContext();
 
-    if (error) return <Error error={error}/>;
+    if (error) return <AlertError error={error}/>;
     if (loading) return <Loading/>;
 
     return (
@@ -85,7 +86,7 @@ const PoliciesContainer = () => {
                 A policy defines the permissions of a user or a group. <a href="https://docs.lakefs.io/reference/authorization.html#authorization" target="_blank" rel="noopener noreferrer">Learn more.</a>
             </div>
 
-            {(!!deleteError) && <Error error={deleteError}/>}
+            {(!!deleteError) && <AlertError error={deleteError}/>}
 
             <PolicyEditor
                 onSubmit={(policyId, policyBody) => {

--- a/webui/src/pages/auth/policies/policy.jsx
+++ b/webui/src/pages/auth/policies/policy.jsx
@@ -13,7 +13,7 @@ import {
     ActionGroup,
     ActionsBar,
     Loading,
-    Error,
+    AlertError,
 } from "../../../lib/components/controls";
 import {useRouter} from "../../../lib/hooks/router";
 
@@ -31,7 +31,7 @@ const PolicyView = ({ policyId }) => {
 
     let content;
     if (loading) content = <Loading/>;
-    else if (error) content=  <Error error={error}/>;
+    else if (error) content=  <AlertError error={error}/>;
     else content = (
         <PolicyDisplay policy={policy} asJSON={jsonView}/>
     );

--- a/webui/src/pages/auth/reset-password.jsx
+++ b/webui/src/pages/auth/reset-password.jsx
@@ -6,7 +6,7 @@ import Form from "react-bootstrap/Form";
 import Col from "react-bootstrap/Col";
 import Button from "react-bootstrap/Button";
 import {MailIcon} from "@primer/octicons-react";
-import {Error} from "../../lib/components/controls";
+import {AlertError} from "../../lib/components/controls";
 import {auth} from "../../lib/api";
 import validator from "validator/es";
 import {useRouter} from "../../lib/hooks/router";
@@ -60,7 +60,7 @@ const RequestResetPasswordForm = () => {
                                     }
                                 </Form.Group>
 
-                                {(!!reqResetPwdError) && <Error error={reqResetPwdError}/>}
+                                {(!!reqResetPwdError) && <AlertError error={reqResetPwdError}/>}
 
                                 <Button variant="primary" type="submit" className="reset-pwd" disabled={!formValid}>Reset Password</Button>
                             </Form>
@@ -133,7 +133,7 @@ const ResetPasswordForm = ({token}) => {
                                 }
                             </Form.Group>
 
-                            {(!!resetPwdError) && <Error error={resetPwdError}/>}
+                            {(!!resetPwdError) && <AlertError error={resetPwdError}/>}
 
                             <Button variant="primary" type="submit" className="reset-pwd" disabled={!formValid}>Reset</Button>
                         </Form>

--- a/webui/src/pages/auth/users/create-user-with-password.jsx
+++ b/webui/src/pages/auth/users/create-user-with-password.jsx
@@ -6,7 +6,7 @@ import Col from "react-bootstrap/Col";
 import Card from "react-bootstrap/Card";
 import Form from "react-bootstrap/Form";
 import {auth} from "../../../lib/api";
-import {ActionGroup, ActionsBar, Error} from "../../../lib/components/controls";
+import {ActionGroup, ActionsBar, AlertError} from "../../../lib/components/controls";
 import Button from "react-bootstrap/Button";
 import {useRouter} from "../../../lib/hooks/router";
 
@@ -75,7 +75,7 @@ const CreateUserWithPasswordForm = ({token, email}) => {
                                 }
                             </Form.Group>
 
-                            {(!!reqActivateUserError) && <Error error={reqActivateUserError}/>}
+                            {(!!reqActivateUserError) && <AlertError error={reqActivateUserError}/>}
                         </Form>
                     </Card.Body>
                 </Card>

--- a/webui/src/pages/auth/users/index.jsx
+++ b/webui/src/pages/auth/users/index.jsx
@@ -17,7 +17,8 @@ import {
     ActionsBar,
     Checkbox,
     DataTable,
-    Error, FormattedDate,
+    AlertError,
+    FormattedDate,
     Loading,
     RefreshButton
 } from "../../../lib/components/controls";
@@ -45,7 +46,7 @@ const UsersContainer = ({nextPage, refresh, setRefresh, error, loading, userList
     useEffect(() => { setSelected([]); }, [refresh, after]);
 
     const authCapabilities = useAPI(() => auth.getAuthCapabilities());
-    if (error) return <Error error={error}/>;
+    if (error) return <AlertError error={error}/>;
     if (loading) return <Loading/>;
     if (authCapabilities.loading) return <Loading/>;
 
@@ -71,7 +72,7 @@ const UsersContainer = ({nextPage, refresh, setRefresh, error, loading, userList
                 Users are entities that access and use lakeFS. <a href="https://docs.lakefs.io/reference/authentication.html" target="_blank" rel="noopener noreferrer">Learn more.</a>
             </div>
 
-            {(!!deleteError) && <Error error={deleteError}/>}
+            {(!!deleteError) && <AlertError error={deleteError}/>}
 
             <EntityActionModal
                 show={showCreate}

--- a/webui/src/pages/auth/users/user/credentials.jsx
+++ b/webui/src/pages/auth/users/user/credentials.jsx
@@ -9,7 +9,7 @@ import {ConfirmationButtonWithContext} from "../../../../lib/components/modals";
 import {
     ActionGroup,
     ActionsBar,
-    Error,
+    AlertError,
     RefreshButton
 } from "../../../../lib/components/controls";
 import {useRouter} from "../../../../lib/hooks/router";
@@ -33,7 +33,7 @@ const UserCredentialsList = ({ userId, after, onPaginate }) => {
     };
     const content = (
             <>
-                {createError && <Error error={createError}/>}
+                {createError && <AlertError error={createError}/>}
                 <CredentialsTable
                     userId={userId}
                     currentAccessKey={(user) ? user.accessKeyId : ""}

--- a/webui/src/pages/auth/users/user/effectivePolicies.jsx
+++ b/webui/src/pages/auth/users/user/effectivePolicies.jsx
@@ -11,7 +11,7 @@ import {
     DataTable,
     FormattedDate,
     Loading,
-    Error,
+    AlertError,
     RefreshButton
 } from "../../../../lib/components/controls";
 import {Link} from "../../../../lib/components/nav";
@@ -28,7 +28,7 @@ const UserEffectivePoliciesList = ({ userId, after, onPaginate }) => {
 
     let content;
     if (loading) content = <Loading/>;
-    else if (error) content=  <Error error={error}/>;
+    else if (error) content=  <AlertError error={error}/>;
     else content = (
             <>
                <DataTable

--- a/webui/src/pages/auth/users/user/groups.jsx
+++ b/webui/src/pages/auth/users/user/groups.jsx
@@ -8,7 +8,7 @@ import {
     DataTable,
     FormattedDate,
     Loading,
-    Error,
+    AlertError,
     RefreshButton
 } from "../../../../lib/components/controls";
 import Button from "react-bootstrap/Button";
@@ -33,10 +33,10 @@ const UserGroupsList = ({ userId, after, onPaginate }) => {
 
     let content;
     if (loading) content = <Loading/>;
-    else if (error) content=  <Error error={error}/>;
+    else if (error) content=  <AlertError error={error}/>;
     else content = (
         <>
-            {attachError && <Error error={attachError}/>}
+            {attachError && <AlertError error={attachError}/>}
 
             <DataTable
                 keyFn={group => group.id}

--- a/webui/src/pages/auth/users/user/policies.jsx
+++ b/webui/src/pages/auth/users/user/policies.jsx
@@ -8,7 +8,7 @@ import {
     DataTable,
     FormattedDate,
     Loading,
-    Error,
+    AlertError,
     RefreshButton
 } from "../../../../lib/components/controls";
 import Button from "react-bootstrap/Button";
@@ -33,10 +33,10 @@ const UserPoliciesList = ({ userId, after, onPaginate }) => {
 
     let content;
     if (loading) content = <Loading/>;
-    else if (error) content=  <Error error={error}/>;
+    else if (error) content=  <AlertError error={error}/>;
     else content = (
             <>
-                {attachError && <Error error={attachError}/>}
+                {attachError && <AlertError error={attachError}/>}
                 <DataTable
                     keyFn={policy => policy.id}
                     rowFn={policy => [

--- a/webui/src/pages/repositories/index.jsx
+++ b/webui/src/pages/repositories/index.jsx
@@ -14,7 +14,7 @@ import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
 
 import Layout from "../../lib/components/layout";
-import {ActionsBar, Error, Loading, useDebouncedState} from "../../lib/components/controls";
+import {ActionsBar, AlertError, Loading, useDebouncedState} from "../../lib/components/controls";
 import {config, repositories} from '../../lib/api';
 import {RepositoryCreateForm} from "../../lib/components/repositoryCreateForm";
 import {useAPI, useAPIWithPagination} from "../../lib/hooks/api";
@@ -112,7 +112,7 @@ const RepositoryList = ({ onPaginate, prefix, after, refresh, onCreateSampleRepo
     }, [refresh, prefix, after]);
 
     if (loading) return <Loading/>;
-    if (error) return <Error error={error}/>;
+    if (error) return <AlertError error={error}/>;
     if (!after && !prefix && results.length === 0) {
         return <GetStarted onCreateSampleRepo={onCreateSampleRepo} onCreateEmptyRepo={onCreateEmptyRepo} creatingRepo={creatingRepo} />;
     }

--- a/webui/src/pages/repositories/repository/actions/index.jsx
+++ b/webui/src/pages/repositories/repository/actions/index.jsx
@@ -3,7 +3,7 @@ import {RepositoryPageLayout} from "../../../../lib/components/repository/layout
 import {
     ActionGroup,
     ActionsBar,
-    Error,
+    AlertError,
     FormattedDate,
     Loading, Na, RefreshButton,
     TooltipButton
@@ -123,7 +123,7 @@ const ActionsList = ({ repo, after, onPaginate, branch, commit, onFilterBranch, 
     const doRefresh = () => setRefresh(!refresh)
 
     let content;
-    if (error) content = <Error error={error}/>
+    if (error) content = <AlertError error={error}/>
 
     else if (loading) content = <Loading/>
     else if (results.length === 0 && !nextPage) content = <Alert variant="info" className={"mt-3"}>No action runs have been logged yet.</Alert>

--- a/webui/src/pages/repositories/repository/actions/run/index.jsx
+++ b/webui/src/pages/repositories/repository/actions/run/index.jsx
@@ -1,7 +1,7 @@
 import React, {useState} from "react";
 
 import {RepositoryPageLayout} from "../../../../../lib/components/repository/layout";
-import {Error, FormattedDate, Loading, Na} from "../../../../../lib/components/controls";
+import {AlertError, FormattedDate, Loading, Na} from "../../../../../lib/components/controls";
 import {RefContextProvider, useRefs} from "../../../../../lib/hooks/repo";
 import {useAPI} from "../../../../../lib/hooks/api";
 import {actions} from "../../../../../lib/api";
@@ -91,7 +91,7 @@ const HookLog = ({ repo, run, execution }) => {
         if (loading) {
             content = <pre>Loading...</pre>;
         } else if (error) {
-            content = <Error error={error}/>;
+            content = <AlertError error={error}/>;
         } else {
             content = <pre>{response}</pre>;
         }
@@ -206,7 +206,7 @@ const RunContainer = ({ repo, runId, onSelectAction, selectedAction }) => {
     }, [repo.id, runId]);
 
     if (loading) return <Loading/>;
-    if (error) return <Error error={error}/>;
+    if (error) return <AlertError error={error}/>;
 
     return (
         <ActionBrowser
@@ -226,7 +226,7 @@ const ActionContainer = () => {
     const {loading, error, repo} = useRefs();
 
     if (loading) return <Loading/>;
-    if (error) return <Error error={error}/>;
+    if (error) return <AlertError error={error}/>;
 
     const params = {repoId: repo.id, runId};
 

--- a/webui/src/pages/repositories/repository/branches.jsx
+++ b/webui/src/pages/repositories/repository/branches.jsx
@@ -16,7 +16,7 @@ import {branches} from "../../../lib/api";
 import {
     ActionGroup,
     ActionsBar, ClipboardButton,
-    Error, LinkButton,
+    AlertError, LinkButton,
     Loading, PrefixSearchWidget, RefreshButton
 } from "../../../lib/components/controls";
 import {RepositoryPageLayout} from "../../../lib/components/repository/layout";
@@ -182,7 +182,7 @@ const CreateBranchButton = ({ repo, variant = "success", onCreate = null, childr
                         </Form.Group>
                     </Form>
 
-                    {!!error && <Error error={error}/>}
+                    {!!error && <AlertError error={error}/>}
                 </Modal.Body>
                 <Modal.Footer>
                     <Button variant="secondary" disabled={disabled} onClick={hide}>
@@ -211,7 +211,7 @@ const BranchList = ({ repo, prefix, after, onPaginate }) => {
     let content;
 
     if (loading) content = <Loading/>;
-    else if (error) content = <Error error={error}/>;
+    else if (error) content = <AlertError error={error}/>;
     else content = (
         <>
             <Card>

--- a/webui/src/pages/repositories/repository/changes.jsx
+++ b/webui/src/pages/repositories/repository/changes.jsx
@@ -12,7 +12,7 @@ import {branches, commits, refs} from "../../../lib/api";
 import {useAPIWithPagination} from "../../../lib/hooks/api";
 import {RefContextProvider, useRefs} from "../../../lib/hooks/repo";
 import {ConfirmationModal} from "../../../lib/components/modals";
-import {ActionGroup, ActionsBar, Error, Loading, RefreshButton} from "../../../lib/components/controls";
+import {ActionGroup, ActionsBar, AlertError, Loading, RefreshButton} from "../../../lib/components/controls";
 import RefDropdown from "../../../lib/components/repository/refDropdown";
 import {RepositoryPageLayout} from "../../../lib/components/repository/layout";
 import {formatAlertText} from "../../../lib/components/repository/errors";
@@ -147,7 +147,7 @@ const ChangesBrowser = ({repo, reference, prefix, onSelectRef, }) => {
     }
 
 
-    if (error) return <Error error={error}/>
+    if (error) return <AlertError error={error}/>
     if (loading) return <Loading/>
 
     let onReset = async (entry) => {
@@ -182,7 +182,7 @@ const ChangesBrowser = ({repo, reference, prefix, onSelectRef, }) => {
     const uncommittedRef = reference.id
 
    const actionErrorDisplay = (actionError) ?
-        <Error error={actionError} onDismiss={() => setActionError(null)}/> : <></>
+        <AlertError error={actionError} onDismiss={() => setActionError(null)}/> : <></>
 
     return (
         <>

--- a/webui/src/pages/repositories/repository/commits/commit/index.tsx
+++ b/webui/src/pages/repositories/repository/commits/commit/index.tsx
@@ -1,6 +1,6 @@
 import React, {useState} from "react";
 import {RepositoryPageLayout} from "../../../../../lib/components/repository/layout";
-import {ClipboardButton,Error, LinkButton, Loading} from "../../../../../lib/components/controls";
+import {ClipboardButton, AlertError, LinkButton, Loading} from "../../../../../lib/components/controls";
 import {RefContextProvider, useRefs} from "../../../../../lib/hooks/repo";
 import Card from "react-bootstrap/Card";
 import {useAPI, useAPIWithPagination} from "../../../../../lib/hooks/api";
@@ -33,11 +33,11 @@ const ChangeList = ({ repo, commit, prefix, onNavigate }) => {
 
     const results = resultsState.results
 
-    if (error) return <Error error={error}/>
+    if (error) return <AlertError error={error}/>
     if (loading) return <Loading/>
 
     const actionErrorDisplay = (actionError) ?
-        <Error error={actionError} onDismiss={() => setActionError(null)}/> : <></>
+        <AlertError error={actionError} onDismiss={() => setActionError(null)}/> : <></>
 
     const commitSha = commit.id.substring(0, 12);
     const uriNavigator = <URINavigator path={prefix} reference={commit} repo={repo}
@@ -186,7 +186,7 @@ const CommitView = ({ repo, commitId, onNavigate, view, prefix }) => {
     }, [repo.id, commitId]);
 
     if (loading) return <Loading/>;
-    if (error) return <Error error={error}/>;
+    if (error) return <AlertError error={error}/>;
 
     const commit = response;
 
@@ -231,7 +231,7 @@ const CommitContainer = () => {
     const { commitId } = router.params;
 
     if (loading) return <Loading/>;
-    if (error) return <Error error={error}/>;
+    if (error) return <AlertError error={error}/>;
 
     return (
         <CommitView

--- a/webui/src/pages/repositories/repository/commits/index.jsx
+++ b/webui/src/pages/repositories/repository/commits/index.jsx
@@ -12,7 +12,7 @@ import {
     ActionGroup,
     ActionsBar,
     ClipboardButton,
-    Error,
+    AlertError,
     LinkButton,
     Loading, RefreshButton
 } from "../../../../lib/components/controls";
@@ -92,7 +92,7 @@ const CommitsBrowser = ({ repo, reference, after, onPaginate, onSelectRef }) => 
     }, [repo.id, reference.id, refresh, after])
 
     if (loading) return <Loading/>
-    if (error) return <Error error={error}/>
+    if (error) return <AlertError error={error}/>
 
     return (
         <div className="mb-5">

--- a/webui/src/pages/repositories/repository/compare.jsx
+++ b/webui/src/pages/repositories/repository/compare.jsx
@@ -1,7 +1,7 @@
 import React, {useCallback, useState} from "react";
 
 import {RepositoryPageLayout} from "../../../lib/components/repository/layout";
-import {ActionGroup, ActionsBar, Error, Loading, RefreshButton} from "../../../lib/components/controls";
+import {ActionGroup, ActionsBar, AlertError, Loading, RefreshButton} from "../../../lib/components/controls";
 import {RefContextProvider, useRefs} from "../../../lib/hooks/repo";
 import RefDropdown from "../../../lib/components/repository/refDropdown";
 import {ArrowLeftIcon, ArrowSwitchIcon, GitMergeIcon} from "@primer/octicons-react";
@@ -101,7 +101,7 @@ const CompareList = ({ repo, reference, compareReference, prefix, onSelectRef, o
     if (loading) {
         content = <Loading/>
     }
-    else if (error) content = <Error error={error}/>
+    else if (error) content = <AlertError error={error}/>
     else if (compareReference.id === reference.id) {
         content = (
             <Alert variant="warning">
@@ -256,7 +256,7 @@ const MergeButton = ({repo, onDone, source, dest, disabled = false, isTableMerge
                         to automatically favor changes from <b>{dest}</b> (&rdquo;dest-wins&rdquo;) or
                         from <b>{source}</b> (&rdquo;source-wins&rdquo;). In case no selection is made,
                         the merge process will fail in case of a conflict.</FormHelperText>
-                    {(mergeState.err) ? (<Error error={mergeState.err}/>) : (<></>)}
+                    {(mergeState.err) ? (<AlertError error={mergeState.err}/>) : (<></>)}
                 </Modal.Body>
                 <Modal.Footer>
                     <Button variant="secondary" disabled={mergeState.merging} onClick={hide}>

--- a/webui/src/pages/repositories/repository/error.jsx
+++ b/webui/src/pages/repositories/repository/error.jsx
@@ -4,7 +4,7 @@ import Button from "react-bootstrap/Button";
 import {repositories, RepositoryDeletionError} from "../../../lib/api";
 import {TrashIcon} from "@primer/octicons-react";
 import React from "react";
-import {Error} from "../../../lib/components/controls";
+import {AlertError} from "../../../lib/components/controls";
 
 const RepositoryInDeletionContainer = ({repoId}) => {
     const router = useRouter();
@@ -34,5 +34,5 @@ export const RepoError = ({error}) => {
     if (error instanceof RepositoryDeletionError) {
         return <RepositoryInDeletionContainer repoId={error.repoId}/>;
     }
-    return <Error error={error}/>;
+    return <AlertError error={error}/>;
 };

--- a/webui/src/pages/repositories/repository/fileRenderers/data.tsx
+++ b/webui/src/pages/repositories/repository/fileRenderers/data.tsx
@@ -10,7 +10,7 @@ import Table from "react-bootstrap/Table";
 
 import {SQLEditor} from "./editor";
 import {RendererComponent} from "./types";
-import {Error, Loading} from "../../../../lib/components/controls";
+import {AlertError, Loading} from "../../../../lib/components/controls";
 
 
 const MAX_RESULTS_RETURNED = 1000;
@@ -85,7 +85,7 @@ LIMIT 20`
     );
 
     if (error) {
-        content = <Error error={error}/>
+        content = <AlertError error={error}/>
     } else if (data === null) {
         content = <DataLoader/>
     } else {

--- a/webui/src/pages/repositories/repository/fileRenderers/simple.tsx
+++ b/webui/src/pages/repositories/repository/fileRenderers/simple.tsx
@@ -3,7 +3,7 @@ import Alert from "react-bootstrap/Alert";
 import { humanSize } from "../../../../lib/components/repository/tree";
 import { useAPI } from "../../../../lib/hooks/api";
 import { objects, qs } from "../../../../lib/api";
-import { Error, Loading } from "../../../../lib/components/controls";
+import { AlertError, Loading } from "../../../../lib/components/controls";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import remarkHtml from "remark-html";
@@ -61,7 +61,7 @@ export const TextDownloader: FC<RendererComponentWithTextCallback> = ({
     return <Loading />;
   }
   if (error) {
-    return <Error error={error} />;
+    return <AlertError error={error} />;
   }
 
   // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/webui/src/pages/repositories/repository/objectViewer.tsx
+++ b/webui/src/pages/repositories/repository/objectViewer.tsx
@@ -8,7 +8,7 @@ import { useAPI } from "../../../lib/hooks/api";
 import { useQuery } from "../../../lib/hooks/router";
 import { objects } from "../../../lib/api";
 import { ObjectRenderer } from "./fileRenderers";
-import { Error } from "../../../lib/components/controls";
+import { AlertError } from "../../../lib/components/controls";
 import { URINavigator } from "../../../lib/components/repository/tree";
 import { RefTypeCommit } from "../../../constants";
 import { RepositoryPageLayout } from "../../../lib/components/repository/layout";
@@ -69,7 +69,7 @@ const FileObjectsViewerPage = () => {
   if (loading) {
     content = <Loading />;
   } else if (error) {
-    content = <Error error={error} />;
+    content = <AlertError error={error} />;
   } else {
     const fileExtension = getFileExtension(path);
     // We'll need to convert the API service to get rid of this any

--- a/webui/src/pages/repositories/repository/objects.jsx
+++ b/webui/src/pages/repositories/repository/objects.jsx
@@ -6,7 +6,7 @@ import RefDropdown from "../../../lib/components/repository/refDropdown";
 import {
     ActionGroup,
     ActionsBar,
-    Error,
+    AlertError,
     Loading,
     PrefixSearchWidget,
     RefreshButton,
@@ -279,7 +279,7 @@ const UploadButton = ({config, repo, reference, path, onDone, onClick, onHide, s
                             />
                         </Form.Group>
                     </Form>
-                    {(uploadState.error) ? (<Error error={uploadState.error}/>) : (<></>)}
+                    {(uploadState.error) ? (<AlertError error={uploadState.error}/>) : (<></>)}
 
                 </Modal.Body>
                 <Modal.Footer>
@@ -327,11 +327,11 @@ const TreeContainer = ({
     const [deleteState, setDeleteState] = useState(initialState)
 
     if (loading) return <Loading/>;
-    if (error) return <Error error={error}/>;
+    if (error) return <AlertError error={error}/>;
 
     return (
         <>
-            {deleteState.error && <Error error={deleteState.error} onDismiss={() => setDeleteState(initialState)}/>}
+            {deleteState.error && <AlertError error={deleteState.error} onDismiss={() => setDeleteState(initialState)}/>}
             <Tree
                 config={{config}}
                 repo={repo}

--- a/webui/src/pages/repositories/repository/settings/branches.jsx
+++ b/webui/src/pages/repositories/repository/settings/branches.jsx
@@ -1,6 +1,6 @@
 import React, {useRef, useState} from "react";
 import {RepositoryPageLayout} from "../../../../lib/components/repository/layout";
-import {Error, Loading, RefreshButton} from "../../../../lib/components/controls";
+import {AlertError, Loading, RefreshButton} from "../../../../lib/components/controls";
 import {RefContextProvider, useRefs} from "../../../../lib/hooks/repo";
 import Card from "react-bootstrap/Card";
 import {SettingsLayout} from "./layout";
@@ -22,9 +22,9 @@ const SettingsContainer = () => {
     const {response: rules, error: rulesError, loading: rulesLoading} = useAPI(async () => {
         return branchProtectionRules.getRules(repo.id)
     }, [repo, refresh])
-    if (error) return <Error error={error}/>;
-    if (rulesError) return <Error error={rulesError}/>;
-    if (actionError) return <Error error={actionError}/>;
+    if (error) return <AlertError error={error}/>;
+    if (rulesError) return <AlertError error={rulesError}/>;
+    if (actionError) return <AlertError error={actionError}/>;
     return (<>
         <div className="mt-3 mb-5">
             <div className={"section-title"}>
@@ -113,7 +113,7 @@ const CreateRuleModal = ({show, hideFn, onSuccess, repoID}) => {
                     </Col>
                 </Form.Group>
             </Form>
-            {error && <Error error={error}/>}
+            {error && <AlertError error={error}/>}
         </Modal.Body>
         <Modal.Footer>
             <Button disabled={createButtonDisabled} onClick={() => createRule(patternField.current.value)}

--- a/webui/src/pages/repositories/repository/settings/general.jsx
+++ b/webui/src/pages/repositories/repository/settings/general.jsx
@@ -7,7 +7,7 @@ import Button from "react-bootstrap/Button";
 import Form from "react-bootstrap/Form";
 import {TrashIcon} from "@primer/octicons-react";
 import Col from "react-bootstrap/Col";
-import {Error, Loading} from "../../../../lib/components/controls";
+import {AlertError, Loading} from "../../../../lib/components/controls";
 import Modal from "react-bootstrap/Modal";
 import {repositories} from "../../../../lib/api";
 import {useRouter} from "../../../../lib/hooks/router";
@@ -60,8 +60,8 @@ const SettingsContainer = () => {
     const [ deletionError, setDeletionError ] = useState(null);
 
     if (loading) return <Loading/>;
-    if (error) return <Error error={error}/>;
-    if (deletionError) return <Error error={deletionError}/>;
+    if (error) return <AlertError error={error}/>;
+    if (deletionError) return <AlertError error={deletionError}/>;
 
     return (
         <div className="mt-3 mb-5">

--- a/webui/src/pages/repositories/repository/settings/retention.jsx
+++ b/webui/src/pages/repositories/repository/settings/retention.jsx
@@ -3,7 +3,7 @@ import {RepositoryPageLayout} from "../../../../lib/components/repository/layout
 import {
     ActionGroup,
     ActionsBar,
-    Error,
+    AlertError,
     Loading,
     RefreshButton,
     ToggleSwitch
@@ -78,7 +78,7 @@ const GCPolicy = ({repo}) => {
     if (loading) {
         content = <Loading/>;
     } else if (error) {
-        content = isPolicyNotSet ? <Alert variant="info" className={"mt-3"}>A garbage collection policy is not set yet.</Alert> :  <Error error={error}/>;
+        content = isPolicyNotSet ? <Alert variant="info" className={"mt-3"}>A garbage collection policy is not set yet.</Alert> : <AlertError error={error}/>;
     } else if (jsonView) {
         content = <>
             <pre className={"policy-body"}>{JSON.stringify(policy, null, 4)}</pre>
@@ -160,7 +160,7 @@ const GCPolicy = ({repo}) => {
 const RetentionContainer = () => {
     const {repo, loading, error} = useRefs();
     if (loading) return <Loading/>;
-    if (error) return <Error error={error}/>;
+    if (error) return <AlertError error={error}/>;
 
     return (
         <GCPolicy repo={repo}/>

--- a/webui/src/pages/repositories/repository/tags.jsx
+++ b/webui/src/pages/repositories/repository/tags.jsx
@@ -16,7 +16,7 @@ import {tags} from "../../../lib/api";
 import {
     ActionGroup,
     ActionsBar, ClipboardButton,
-    Error, LinkButton,
+    AlertError, LinkButton,
     Loading, PrefixSearchWidget, RefreshButton
 } from "../../../lib/components/controls";
 import { RepositoryPageLayout } from "../../../lib/components/repository/layout";
@@ -155,7 +155,7 @@ const CreateTagButton = ({ repo, variant = "success", onCreate = null, children 
                         </Form.Group>
                     </Form>
 
-                    {!!error && <Error error={error} />}
+                    {!!error && <AlertError error={error} />}
 
                 </Modal.Body>
                 <Modal.Footer>
@@ -185,7 +185,7 @@ const TagList = ({ repo, after, prefix, onPaginate }) => {
     let content;
 
     if (loading) content = <Loading />;
-    else if (error) content = <Error error={error} />;
+    else if (error) content = <AlertError error={error} />;
     else content = ( results && !!results.length  ?
         <>
             <Card>

--- a/webui/src/pages/setup/userConfiguration.tsx
+++ b/webui/src/pages/setup/userConfiguration.tsx
@@ -5,7 +5,7 @@ import Card from "react-bootstrap/Card";
 import Col from "react-bootstrap/Col";
 import Form from "react-bootstrap/Form";
 import Row from "react-bootstrap/Row";
-import {Error} from "../../lib/components/controls";
+import {AlertError} from "../../lib/components/controls";
 
 interface UserConfigurationProps {
     onSubmit: (email: string, admin: string, updatesCheck: boolean, securityCheck: boolean) => Promise<void>;
@@ -76,7 +76,7 @@ export const UserConfiguration: FC<UserConfigurationProps> = ({
                                 <Form.Check type="checkbox" checked={securityCheck} onChange={handleSecurityChange} label="I'd like to receive security updates (recommended)" />
                             </Form.Group>
 
-                            {!!setupError && <Error error={setupError}/>}
+                            {!!setupError && <AlertError error={setupError}/>}
                             <Button variant="primary" disabled={disabled} type="submit">
                                 {disabled ? <Spinner as="span"
                                                      animation="border"


### PR DESCRIPTION
Import component Error and using the Error class as exception conflicts.
Renamed Error control to be AlertError (as it is a type of Alert) will help prevent any future bugs while trying to throw errors.

Fix #5906