### PR TITLE
Update quickstart URL

### DIFF
--- a/cmd/lakefs/cmd/run.go
+++ b/cmd/lakefs/cmd/run.go
@@ -440,7 +440,7 @@ const runBanner = `
 
 │
 │ For more information on how to use lakeFS,
-│     check out the docs at https://docs.lakefs.io/quickstart/repository
+│     check out the docs at https://docs.lakefs.io/quickstart/
 │
 
 │


### PR DESCRIPTION
The current quickstart URL shown on the boot screen is out of date. This PR fixes that. 

### Testing

Built locally and manually tested to confirm updated URL is displayed at boot time.


```
lakeFS dev-ae419ffc6.with.local.changes - Up and running (^C to shutdown)...


     ██╗      █████╗ ██╗  ██╗███████╗███████╗███████╗
     ██║     ██╔══██╗██║ ██╔╝██╔════╝██╔════╝██╔════╝
     ██║     ███████║█████╔╝ █████╗  █████╗  ███████╗
     ██║     ██╔══██║██╔═██╗ ██╔══╝  ██╔══╝  ╚════██║
     ███████╗██║  ██║██║  ██╗███████╗██║     ███████║
     ╚══════╝╚═╝  ╚═╝╚═╝  ╚═╝╚══════╝╚═╝     ╚══════╝

│
│ If you're running lakeFS locally for the first time,
│     complete the setup process at http://127.0.0.1:8000/setup
│

│
│ For more information on how to use lakeFS,
│     check out the docs at https://docs.lakefs.io/quickstart/
│

│
│ For support or any other question,                            >(.＿.)<
│     join our Slack channel https://docs.lakefs.io/slack         (  )_
│

Version dev-ae419ffc6.with.local.changes
```