### PR TITLE
Use filepath join to format local path

### DIFF
--- a/pkg/pyramid/tier_fs.go
+++ b/pkg/pyramid/tier_fs.go
@@ -38,7 +38,7 @@ const workspaceDir = "workspace"
 // It will traverse the existing local folders and will update
 // the local disk cache to reflect existing files.
 func NewFS(c *params.InstanceParams) (FS, error) {
-	fsLocalBaseDir := filepath.Clean(path.Join(c.Local.BaseDir, c.FSName))
+	fsLocalBaseDir := filepath.Join(c.Local.BaseDir, c.FSName)
 	if err := os.MkdirAll(fsLocalBaseDir, os.ModePerm); err != nil {
 		return nil, fmt.Errorf("creating base dir: %s - %w", fsLocalBaseDir, err)
 	}


### PR DESCRIPTION
- No need to call clean as join already uses internally.
- Use `filepath` insterad of `path` for working with local files.