### PR TITLE
GC: Read provided mark ID's run id in case that the run is a sweep-only run

### DIFF
--- a/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
@@ -416,6 +416,7 @@ object GarbageCollector {
           gcAddressesLocation = getAddressesLocation(storageNSForHadoopFS)
           expiredAddresses = readExpiredAddresses(gcAddressesLocation, markID)
           runID = readRunIDFromMarkIDMetadata(gcAddressesLocation, markID)
+          println(s"Sweep only run: using addresses from location '$gcAddressesLocation' and run ID '$runID'")
         }
 
         remove(

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
@@ -439,7 +439,15 @@ object GarbageCollector {
     }
 
     val commitsDF = gc.getCommitsDF(gcCommitsLocation)
-    writeReports(shouldSweep, storageNSForHadoopFS, gcRules, runID, markID, commitsDF, removed, configMapper)
+    writeReports(shouldSweep,
+                 storageNSForHadoopFS,
+                 gcRules,
+                 runID,
+                 markID,
+                 commitsDF,
+                 removed,
+                 configMapper
+                )
     spark.close()
   }
 
@@ -666,7 +674,7 @@ object GarbageCollector {
 
     val removedCount = removed.count()
     println(s"Total objects to delete (some may already have been deleted): $removedCount")
-    if(isSweep) {
+    if (isSweep) {
       logRunID(storageNSForHadoopFS, runID, configMapper)
     }
     writeJsonSummary(configMapper, reportLogsDst, removedCount, gcRules, time)

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
@@ -416,7 +416,9 @@ object GarbageCollector {
           gcAddressesLocation = getAddressesLocation(storageNSForHadoopFS)
           expiredAddresses = readExpiredAddresses(gcAddressesLocation, markID)
           runID = readRunIDFromMarkIDMetadata(gcAddressesLocation, markID)
-          println(s"Sweep only run: using addresses from location '$gcAddressesLocation' and run ID '$runID'")
+          println(
+            s"Sweep only run: using addresses from location '$gcAddressesLocation' and run ID '$runID'"
+          )
         }
 
         remove(

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/GarbageCollector.scala
@@ -412,10 +412,10 @@ object GarbageCollector {
     val removed = {
       if (shouldSweep) {
         // If a mark didn't happen in this run, gcAddressesLocation, runID, and expiredAddresses will be empty.
-        if(!shouldMark) {
-            gcAddressesLocation = getAddressesLocation(storageNSForHadoopFS)
-            expiredAddresses = readExpiredAddresses(gcAddressesLocation, markID)
-            runID = readRunIDFromMarkIDMetadata(gcAddressesLocation, markID)
+        if (!shouldMark) {
+          gcAddressesLocation = getAddressesLocation(storageNSForHadoopFS)
+          expiredAddresses = readExpiredAddresses(gcAddressesLocation, markID)
+          runID = readRunIDFromMarkIDMetadata(gcAddressesLocation, markID)
         }
 
         val removed = remove(


### PR DESCRIPTION
If the current run is a sweep-only run, a run ID isn't generated since the run relies on a previously marked run ID.
The current fix reads the run ID from the metadata of the previously marked run (according to the provided mark ID) and uses it with the sweep.
It didn't affect us this far, but since incremental GC relies on logging the run ID when it finishes, the run ID fetching is crucial for sweep-only runs.

* I also changed the location of logging the run ID (before this change it was logged before sweep completed)