### PR TITLE
Fix hooks docs URL in index.jsx

### DIFF
--- a/webui/src/pages/repositories/repository/actions/index.jsx
+++ b/webui/src/pages/repositories/repository/actions/index.jsx
@@ -165,7 +165,7 @@ const ActionsList = ({ repo, after, onPaginate, branch, commit, onFilterBranch, 
             {content}
             <div>
                 {/* eslint-disable-next-line react/jsx-no-target-blank */}
-                Actions can be configured to run when predefined events occur. <a href="https://docs.lakefs.io/setup/hooks.html" target="_blank">Learn more.</a>
+                Actions can be configured to run when predefined events occur. <a href="https://docs.lakefs.io/hooks/" target="_blank">Learn more.</a>
             </div>
         </div>
     )

--- a/webui/src/pages/repositories/repository/actions/index.jsx
+++ b/webui/src/pages/repositories/repository/actions/index.jsx
@@ -165,7 +165,7 @@ const ActionsList = ({ repo, after, onPaginate, branch, commit, onFilterBranch, 
             {content}
             <div>
                 {/* eslint-disable-next-line react/jsx-no-target-blank */}
-                Actions can be configured to run when predefined events occur. <a href="https://docs.lakefs.io/hooks/" target="_blank">Learn more.</a>
+                Actions can be configured to run when predefined events occur. <a href="https://docs.lakefs.io/hooks/overview.html" target="_blank">Learn more.</a>
             </div>
         </div>
     )


### PR DESCRIPTION
Currently, the hooks page points to a dead link if no hooks have been pre-configured. This PR updates the URL to use https://docs.lakefs.io/hooks/ instead.

<!-- 
Hello Axolotl!
Thank you for contributing to the lakeFS project.
We appreciate the time invested in this pull request and created this template to help make this process easier.
It's really important to have all the information and context, to ensure we can properly address this PR 
Please use the following references to fill out the pull request.

### Linked Issue

Closes #(Insert issue number closed by this PR)

---

## Change Description

### Background

Share context and relevant information for the PR: offline discussions, considerations, design decisions etc.

### Bug Fix

1. Problem - The reason for opening the bug
2. Root cause - Discovered root cause after investigation
3. solution - How was the bug fixed
      
### New Feature

Description of new feature

### Testing Details

How were the changes tested?
Added new unit tests / integration tests

### Breaking Change?

Does this change break any existing functionality? (API, CLI, Clients)

---

## Additional info

Logs, outputs, screenshots of changes if applicable (CLI / GUI changes)

---

### Contact Details

How can we get in touch with you if we need more info? (ex. email@example.com)
--> 
