### PR TITLE
Setup lakefs on startup using predefined setup parameters

### DIFF
--- a/cmd/lakefs/cmd/run.go
+++ b/cmd/lakefs/cmd/run.go
@@ -190,9 +190,12 @@ var runCmd = &cobra.Command{
 
 		// initial setup if needed, do not fail on error
 		if cfg.Setup.UserName != "" && cfg.Setup.AccessKeyID.SecureValue() != "" && cfg.Setup.SecretAccessKey.SecureValue() != "" {
-			_, err := setupLakeFS(ctx, cfg, authMetadataManager, authService, cfg.Setup.UserName, cfg.Setup.AccessKeyID.SecureValue(), cfg.Setup.SecretAccessKey.SecureValue())
+			setupCreds, err := setupLakeFS(ctx, cfg, authMetadataManager, authService, cfg.Setup.UserName, cfg.Setup.AccessKeyID.SecureValue(), cfg.Setup.SecretAccessKey.SecureValue())
 			if err != nil {
-				logger.WithError(err).Warn("Failed to run initial setup")
+				logger.WithError(err).WithField("admin", cfg.Setup.UserName).Fatal("Failed to initial setup environment")
+			}
+			if setupCreds != nil {
+				logger.WithField("admin", cfg.Setup.UserName).Info("Initial setup completed successfully")
 			}
 		}
 

--- a/cmd/lakefs/cmd/run.go
+++ b/cmd/lakefs/cmd/run.go
@@ -188,6 +188,14 @@ var runCmd = &cobra.Command{
 		}
 		deleteScheduler.StartAsync()
 
+		// initial setup if needed, do not fail on error
+		if cfg.Setup.UserName != "" && cfg.Setup.AccessKeyID.SecureValue() != "" && cfg.Setup.SecretAccessKey.SecureValue() != "" {
+			_, err := setupLakeFS(ctx, cfg, authMetadataManager, authService, cfg.Setup.UserName, cfg.Setup.AccessKeyID.SecureValue(), cfg.Setup.SecretAccessKey.SecureValue())
+			if err != nil {
+				logger.WithError(err).Warn("Failed to run initial setup")
+			}
+		}
+
 		templater := templater.NewService(templates.Content, cfg, authService)
 
 		actionsService := actions.NewService(

--- a/cmd/lakefs/cmd/run.go
+++ b/cmd/lakefs/cmd/run.go
@@ -191,14 +191,14 @@ var runCmd = &cobra.Command{
 		// initial setup - support only when a local database is configured.
 		// local database lock will make sure that only one instance will run the setup.
 		if kvParams.Type == local.DriverName &&
-			cfg.Setup.UserName != "" && cfg.Setup.AccessKeyID.SecureValue() != "" && cfg.Setup.SecretAccessKey.SecureValue() != "" {
-			setupCreds, err := setupLakeFS(ctx, cfg, authMetadataManager, authService, cfg.Setup.UserName,
-				cfg.Setup.AccessKeyID.SecureValue(), cfg.Setup.SecretAccessKey.SecureValue())
+			cfg.Installation.UserName != "" && cfg.Installation.AccessKeyID.SecureValue() != "" && cfg.Installation.SecretAccessKey.SecureValue() != "" {
+			setupCreds, err := setupLakeFS(ctx, cfg, authMetadataManager, authService, cfg.Installation.UserName,
+				cfg.Installation.AccessKeyID.SecureValue(), cfg.Installation.SecretAccessKey.SecureValue())
 			if err != nil {
-				logger.WithError(err).WithField("admin", cfg.Setup.UserName).Fatal("Failed to initial setup environment")
+				logger.WithError(err).WithField("admin", cfg.Installation.UserName).Fatal("Failed to initial setup environment")
 			}
 			if setupCreds != nil {
-				logger.WithField("admin", cfg.Setup.UserName).Info("Initial setup completed successfully")
+				logger.WithField("admin", cfg.Installation.UserName).Info("Initial setup completed successfully")
 			}
 		}
 

--- a/cmd/lakefs/cmd/setup.go
+++ b/cmd/lakefs/cmd/setup.go
@@ -5,11 +5,10 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/treeverse/lakefs/pkg/auth/model"
-
 	"github.com/spf13/cobra"
 	"github.com/treeverse/lakefs/pkg/auth"
 	"github.com/treeverse/lakefs/pkg/auth/crypt"
+	"github.com/treeverse/lakefs/pkg/auth/model"
 	authparams "github.com/treeverse/lakefs/pkg/auth/params"
 	"github.com/treeverse/lakefs/pkg/auth/setup"
 	"github.com/treeverse/lakefs/pkg/config"

--- a/cmd/lakefs/cmd/setup.go
+++ b/cmd/lakefs/cmd/setup.go
@@ -107,11 +107,9 @@ var setupCmd = &cobra.Command{
 
 func setupLakeFS(ctx context.Context, cfg *config.Config, metadataManager auth.MetadataManager, authService auth.Service, userName string, accessKeyID string, secretAccessKey string) (*model.Credential, error) {
 	initialized, err := metadataManager.IsInitialized(ctx)
-	if err != nil {
+	if err != nil || initialized {
+		// return on error or if already initialized
 		return nil, err
-	}
-	if initialized {
-		return nil, nil
 	}
 	credentials, err := setup.CreateInitialAdminUserWithKeys(ctx, authService, cfg, metadataManager, userName, &accessKeyID, &secretAccessKey)
 	if err != nil {

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -204,7 +204,7 @@ This reference uses `.` to denote the nesting of values.
 * `plugins.default_path` `(string : ~/.lakefs/plugins)` - Absolute path to the root of lakeFS's plugins location.
 * `plugins.properties.<plugin name>.path` `(string : )` - Absolute path to the location of `<plugin name>`'s binary location.
 * `plugins.properties.<plugin name>.version` `(uint : )` - Version of the `<plugin name>` plugin. The version must be > 0.
-* `setup.user_name` `(string : )` - Admin username used to setup lakeFS on startup. Limited to working only with local database. The initial admin `setup.access_key_id` and `setup.secret_access_key` are required for the setup. 
+* `setup.user_name` `(string : )` - When specified, an initial admin user will be created when the server is first run. Works only when `database.type` is set to local. Requires `setup.access_key_id` and `setup.secret_access_key`. 
 * `setup.access_key_id` `(string : )` - Admin's initial access key id (used once in the initial setup process)
 * `setup.secret_access_key` `(string : )` - Admin's initial secret access key (used once in the initial setup process)
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -204,9 +204,9 @@ This reference uses `.` to denote the nesting of values.
 * `plugins.default_path` `(string : ~/.lakefs/plugins)` - Absolute path to the root of lakeFS's plugins location.
 * `plugins.properties.<plugin name>.path` `(string : )` - Absolute path to the location of `<plugin name>`'s binary location.
 * `plugins.properties.<plugin name>.version` `(uint : )` - Version of the `<plugin name>` plugin. The version must be > 0.
-* `setup.user_name` `(string : )` - When specified, an initial admin user will be created when the server is first run. Works only when `database.type` is set to local. Requires `setup.access_key_id` and `setup.secret_access_key`. 
-* `setup.access_key_id` `(string : )` - Admin's initial access key id (used once in the initial setup process)
-* `setup.secret_access_key` `(string : )` - Admin's initial secret access key (used once in the initial setup process)
+* `installation.user_name` `(string : )` - When specified, an initial admin user will be created when the server is first run. Works only when `database.type` is set to local. Requires `setup.access_key_id` and `setup.secret_access_key`. 
+* `installation.access_key_id` `(string : )` - Admin's initial access key id (used once in the initial setup process)
+* `installation.secret_access_key` `(string : )` - Admin's initial secret access key (used once in the initial setup process)
 
 {: .ref-list }
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -204,6 +204,9 @@ This reference uses `.` to denote the nesting of values.
 * `plugins.default_path` `(string : ~/.lakefs/plugins)` - Absolute path to the root of lakeFS's plugins location.
 * `plugins.properties.<plugin name>.path` `(string : )` - Absolute path to the location of `<plugin name>`'s binary location.
 * `plugins.properties.<plugin name>.version` `(uint : )` - Version of the `<plugin name>` plugin. The version must be > 0.
+* `setup.user_name` `(string : )` - Admin username used to setup lakeFS on startup. Limited to working only with local database. The initial admin `setup.access_key_id` and `setup.secret_access_key` are required for the setup. 
+* `setup.access_key_id` `(string : )` - Admin's initial access key id (used once in the initial setup process)
+* `setup.secret_access_key` `(string : )` - Admin's initial secret access key (used once in the initial setup process)
 
 {: .ref-list }
 

--- a/pkg/auth/setup/setup.go
+++ b/pkg/auth/setup/setup.go
@@ -185,6 +185,8 @@ func SetupACLBaseGroups(ctx context.Context, authService auth.Service, ts time.T
 func SetupAdminUser(ctx context.Context, authService auth.Service, cfg *config.Config, superuser *model.SuperuserConfiguration) (*model.Credential, error) {
 	now := time.Now()
 
+	// TODO(barak): Make sure one setup is done
+
 	// Set up the basic groups and policies
 	err := SetupBaseGroups(ctx, authService, cfg, now)
 	if err != nil {
@@ -235,14 +237,17 @@ func CreateInitialAdminUser(ctx context.Context, authService auth.Service, cfg *
 }
 
 func CreateInitialAdminUserWithKeys(ctx context.Context, authService auth.Service, cfg *config.Config, metadataManger auth.MetadataManager, username string, accessKeyID *string, secretAccessKey *string) (*model.Credential, error) {
-	adminUser := &model.SuperuserConfiguration{User: model.User{
-		CreatedAt: time.Now(),
-		Username:  username,
-	}}
+	adminUser := &model.SuperuserConfiguration{
+		User: model.User{
+			CreatedAt: time.Now(),
+			Username:  username,
+		},
+	}
 	if accessKeyID != nil && secretAccessKey != nil {
 		adminUser.AccessKeyID = *accessKeyID
 		adminUser.SecretAccessKey = *secretAccessKey
 	}
+
 	// create first admin user
 	cred, err := SetupAdminUser(ctx, authService, cfg, adminUser)
 	if err != nil {

--- a/pkg/auth/setup/setup.go
+++ b/pkg/auth/setup/setup.go
@@ -182,12 +182,10 @@ func SetupACLBaseGroups(ctx context.Context, authService auth.Service, ts time.T
 	return nil
 }
 
+// SetupAdminUser setup base groups, policies and create admin user
 func SetupAdminUser(ctx context.Context, authService auth.Service, cfg *config.Config, superuser *model.SuperuserConfiguration) (*model.Credential, error) {
-	now := time.Now()
-
-	// TODO(barak): Make sure one setup is done
-
 	// Set up the basic groups and policies
+	now := time.Now()
 	err := SetupBaseGroups(ctx, authService, cfg, now)
 	if err != nil {
 		return nil, err
@@ -197,10 +195,8 @@ func SetupAdminUser(ctx context.Context, authService auth.Service, cfg *config.C
 }
 
 func AddAdminUser(ctx context.Context, authService auth.Service, user *model.SuperuserConfiguration) (*model.Credential, error) {
-	const adminGroupName = "Admins"
-
-	// verify admin group exists
-	_, err := authService.GetGroup(ctx, adminGroupName)
+	// verify the admin group exists
+	_, err := authService.GetGroup(ctx, AdminsGroup)
 	if err != nil {
 		return nil, fmt.Errorf("admin group - %w", err)
 	}
@@ -211,7 +207,7 @@ func AddAdminUser(ctx context.Context, authService auth.Service, user *model.Sup
 	if err != nil {
 		return nil, fmt.Errorf("create user - %w", err)
 	}
-	err = authService.AddUserToGroup(ctx, user.Username, adminGroupName)
+	err = authService.AddUserToGroup(ctx, user.Username, AdminsGroup)
 	if err != nil {
 		return nil, fmt.Errorf("add user to group - %w", err)
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -366,6 +366,11 @@ type Config struct {
 	} `mapstructure:"ui"`
 	Diff    DiffProps `mapstructure:"diff"`
 	Plugins Plugins   `mapstructure:"plugins"`
+	Setup   struct {
+		UserName        string       `mapstructure:"user_name"`
+		AccessKeyID     SecureString `mapstructure:"access_key_id"`
+		SecretAccessKey SecureString `mapstructure:"secret_access_key"`
+	} `mapstructure:"setup"`
 }
 
 func NewConfig() (*Config, error) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -335,7 +335,10 @@ type Config struct {
 		Enabled bool `mapstructure:"enabled"`
 	} `mapstructure:"email_subscription"`
 	Installation struct {
-		FixedID string `mapstructure:"fixed_id"`
+		FixedID         string       `mapstructure:"fixed_id"`
+		UserName        string       `mapstructure:"user_name"`
+		AccessKeyID     SecureString `mapstructure:"access_key_id"`
+		SecretAccessKey SecureString `mapstructure:"secret_access_key"`
 	} `mapstructure:"installation"`
 	Security struct {
 		CheckLatestVersion      bool          `mapstructure:"check_latest_version"`
@@ -366,11 +369,6 @@ type Config struct {
 	} `mapstructure:"ui"`
 	Diff    DiffProps `mapstructure:"diff"`
 	Plugins Plugins   `mapstructure:"plugins"`
-	Setup   struct {
-		UserName        string       `mapstructure:"user_name"`
-		AccessKeyID     SecureString `mapstructure:"access_key_id"`
-		SecretAccessKey SecureString `mapstructure:"secret_access_key"`
-	} `mapstructure:"setup"`
 }
 
 func NewConfig() (*Config, error) {


### PR DESCRIPTION
Using configuration setup initial admin user with predefined key/secret.
In order to use for testing, demo and preventing parallel setup at the same time - limited to use only with local database.

Close https://github.com/treeverse/lakeFS/issues/5947