### PR TITLE
UGC prepare configurable max file size and produce time

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -189,6 +189,8 @@ This reference uses `.` to denote the nesting of values.
 * `stats.flush_size` `(int : 100)` - A size (in records) of anonymous statistics collected in which we post
 * `security.audit_check_interval` `(duration : 24h)` - Duration in which we check for security audit.
 * `ui.enabled` `(bool: true)` - Whether to server the embedded UI from the binary
+* `ugc.prepare_max_file_size` `(int: 125829120)` - Uncommitted garbage collection prepare request, limit the produced file maximum size
+* `ugc.prepare_interval` `(duraction: 1m)` - Uncommitted garbage collection prepare request, limit produce time to interval
 {: .ref-list }
 
 ## Using Environment Variables

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -147,7 +147,6 @@ type Catalog struct {
 	KVStoreLimited        kv.Store
 	addressProvider       *ident.HexAddressProvider
 	UGCPrepareMaxFileSize int64
-	UGCPrepareInterval    time.Duration
 }
 
 const (
@@ -289,7 +288,6 @@ func New(ctx context.Context, cfg Config) (*Catalog, error) {
 		BlockAdapter:          tierFSParams.Adapter,
 		Store:                 gStore,
 		UGCPrepareMaxFileSize: cfg.Config.UGC.PrepareMaxFileSize,
-		UGCPrepareInterval:    cfg.Config.UGC.PrepareInterval,
 		PathProvider:          cfg.PathProvider,
 		BackgroundLimiter:     cfg.Limiter,
 		log:                   logging.Default().WithField("service_name", "entry_catalog"),
@@ -2187,7 +2185,7 @@ func (c *Catalog) PrepareGCUncommitted(ctx context.Context, repositoryID string,
 	uw := NewUncommittedWriter(fd)
 
 	// Write parquet to local storage
-	newMark, hasData, err := gcWriteUncommitted(ctx, c.Store, repository, uw, mark, runID, c.UGCPrepareMaxFileSize, c.UGCPrepareInterval)
+	newMark, hasData, err := gcWriteUncommitted(ctx, c.Store, repository, uw, mark, runID, c.UGCPrepareMaxFileSize)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -147,6 +147,7 @@ type Catalog struct {
 	KVStoreLimited        kv.Store
 	addressProvider       *ident.HexAddressProvider
 	UGCPrepareMaxFileSize int64
+	UGCPrepareInterval    time.Duration
 }
 
 const (
@@ -288,6 +289,7 @@ func New(ctx context.Context, cfg Config) (*Catalog, error) {
 		BlockAdapter:          tierFSParams.Adapter,
 		Store:                 gStore,
 		UGCPrepareMaxFileSize: cfg.Config.UGC.PrepareMaxFileSize,
+		UGCPrepareInterval:    cfg.Config.UGC.PrepareInterval,
 		PathProvider:          cfg.PathProvider,
 		BackgroundLimiter:     cfg.Limiter,
 		log:                   logging.Default().WithField("service_name", "entry_catalog"),
@@ -2185,7 +2187,7 @@ func (c *Catalog) PrepareGCUncommitted(ctx context.Context, repositoryID string,
 	uw := NewUncommittedWriter(fd)
 
 	// Write parquet to local storage
-	newMark, hasData, err := gcWriteUncommitted(ctx, c.Store, repository, uw, mark, runID, c.UGCPrepareMaxFileSize)
+	newMark, hasData, err := gcWriteUncommitted(ctx, c.Store, repository, uw, mark, runID, c.UGCPrepareMaxFileSize, c.UGCPrepareInterval)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/catalog/catalog_test.go
+++ b/pkg/catalog/catalog_test.go
@@ -565,10 +565,10 @@ func TestCatalog_PrepareGCUncommitted(t *testing.T) {
 			g, expectedRecords := createPrepareUncommittedTestScenario(t, repositoryID, tt.numBranch, tt.numRecords, tt.expectedCalls)
 			blockAdapter := testutil.NewBlockAdapterByType(t, block.BlockstoreTypeMem)
 			c := &catalog.Catalog{
-				Store:                    g.Sut,
-				BlockAdapter:             blockAdapter,
-				GCMaxUncommittedFileSize: 500 * 1024,
-				KVStore:                  g.KVStore,
+				Store:                 g.Sut,
+				BlockAdapter:          blockAdapter,
+				UGCPrepareMaxFileSize: 500 * 1024,
+				KVStore:               g.KVStore,
 			}
 
 			var (

--- a/pkg/catalog/gc_write_uncommitted.go
+++ b/pkg/catalog/gc_write_uncommitted.go
@@ -3,14 +3,13 @@ package catalog
 import (
 	"context"
 	"strings"
-	"time"
 
 	"github.com/treeverse/lakefs/pkg/graveler"
 	"github.com/xitongsys/parquet-go/parquet"
 	"github.com/xitongsys/parquet-go/writer"
 )
 
-func gcWriteUncommitted(ctx context.Context, store Store, repository *graveler.RepositoryRecord, w *UncommittedWriter, mark *GCUncommittedMark, runID string, maxFileSize int64, prepareDuration time.Duration) (*GCUncommittedMark, bool, error) {
+func gcWriteUncommitted(ctx context.Context, store Store, repository *graveler.RepositoryRecord, w *UncommittedWriter, mark *GCUncommittedMark, runID string, maxFileSize int64) (*GCUncommittedMark, bool, error) {
 	pw, err := writer.NewParquetWriterFromWriter(w, new(UncommittedParquetObject), gcParquetParallelNum)
 	if err != nil {
 		return nil, false, err
@@ -34,7 +33,6 @@ func gcWriteUncommitted(ctx context.Context, store Store, repository *graveler.R
 	}
 
 	count := 0
-	startTime := time.Now()
 	var nextMark *GCUncommittedMark
 	for it.Next() {
 		entry := it.Value()
@@ -57,7 +55,7 @@ func gcWriteUncommitted(ctx context.Context, store Store, repository *graveler.R
 				return nil, false, err
 			}
 		}
-		if w.Size() > maxFileSize || (prepareDuration > 0 && time.Since(startTime) > prepareDuration) {
+		if w.Size() > maxFileSize {
 			nextMark = &GCUncommittedMark{
 				RunID:    runID,
 				BranchID: entry.branchID,

--- a/pkg/catalog/gc_write_uncommitted.go
+++ b/pkg/catalog/gc_write_uncommitted.go
@@ -57,6 +57,10 @@ func gcWriteUncommitted(ctx context.Context, store Store, repository *graveler.R
 				return nil, false, err
 			}
 		}
+		// check if we need to stop - based on max file size or prepare duration.
+		// prepare duration is optional, if 0 it will be ignored.
+		// prepare duration is used to stop the process in cases we scan a lot of data, and we want to stop
+		// so the api call will not time out.
 		if w.Size() > maxFileSize || (prepareDuration > 0 && time.Since(startTime) > prepareDuration) {
 			nextMark = &GCUncommittedMark{
 				RunID:    runID,

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -292,7 +292,8 @@ type Config struct {
 		} `mapstructure:"sstable"`
 	} `mapstructure:"committed"`
 	UGC struct {
-		PrepareMaxFileSize int64 `mapstructure:"prepare_max_file_size"`
+		PrepareMaxFileSize int64         `mapstructure:"prepare_max_file_size"`
+		PrepareInterval    time.Duration `mapstructure:"prepare_interval"`
 	} `mapstructure:"ugc"`
 	Graveler struct {
 		RepositoryCache struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -291,6 +291,10 @@ type Config struct {
 			} `mapstructure:"memory"`
 		} `mapstructure:"sstable"`
 	} `mapstructure:"committed"`
+	UGC struct {
+		PrepareMaxFileSize int64         `mapstructure:"prepare_max_file_size"`
+		PrepareInterval    time.Duration `mapstructure:"prepare_interval"`
+	} `mapstructure:"ugc"`
 	Graveler struct {
 		RepositoryCache struct {
 			Size   int           `mapstructure:"size"`

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -292,8 +292,7 @@ type Config struct {
 		} `mapstructure:"sstable"`
 	} `mapstructure:"committed"`
 	UGC struct {
-		PrepareMaxFileSize int64         `mapstructure:"prepare_max_file_size"`
-		PrepareInterval    time.Duration `mapstructure:"prepare_interval"`
+		PrepareMaxFileSize int64 `mapstructure:"prepare_max_file_size"`
 	} `mapstructure:"ugc"`
 	Graveler struct {
 		RepositoryCache struct {

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -116,6 +116,5 @@ func setDefaults(local bool) {
 
 	viper.SetDefault("plugins.default_path", "~/.lakefs/plugins")
 
-	viper.SetDefault("ugc.prepare_interval", time.Minute)
 	viper.SetDefault("ugc.prepare_max_file_size", 20*1024*1024)
 }

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -116,5 +116,6 @@ func setDefaults(local bool) {
 
 	viper.SetDefault("plugins.default_path", "~/.lakefs/plugins")
 
+	viper.SetDefault("ugc.prepare_interval", time.Minute)
 	viper.SetDefault("ugc.prepare_max_file_size", 20*1024*1024)
 }

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -115,4 +115,7 @@ func setDefaults(local bool) {
 	viper.SetDefault("graveler.commit_cache.jitter", 2*time.Second)
 
 	viper.SetDefault("plugins.default_path", "~/.lakefs/plugins")
+
+	viper.SetDefault("ugc.prepare_interval", time.Minute)
+	viper.SetDefault("ugc.prepare_max_file_size", 20*1024*1024)
 }


### PR DESCRIPTION
Uncommitted garbage collector configurable file size limit to enable reducing the time for a single request.

Close https://github.com/treeverse/lakeFS/issues/5968