### PR TITLE
Split and publish lakefs duckdb build and images

### DIFF
--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -91,3 +91,15 @@ jobs:
             ${{ steps.login-ecr.outputs.registry }}/lakefs:${{ steps.version.outputs.tag }}
             treeverse/lakefs:${{ steps.version.outputs.tag }}
             treeverse/lakefs:latest
+
+      - name: Build and push lakefs-duckdb
+        uses: docker/build-push-action@v3
+        with:
+          context: .
+          file: Dockerfile.duckdb
+          push: true
+          platforms: linux/amd64,linux/arm64,darwin/amd64,darwin/arm64
+          build-args: LAKEFS_RELEASE_TAG=$${ steps.version.outputs.tag }}
+          tags: |
+            ${{ steps.login-ecr.outputs.registry }}/lakefs:${{ steps.version.outputs.tag }}-duckdb
+            treeverse/lakefs:${{ steps.version.outputs.tag }}-duckdb

--- a/Dockerfile
+++ b/Dockerfile
@@ -52,18 +52,6 @@ COPY ./pkg/plugins/diff/delta_diff_server/src ./src
 RUN rm ./target/release/deps/delta_diff*
 RUN RUSTFLAGS=-Ctarget-feature=-crt-static cargo build --release
 
-# Build DuckDB
-FROM --platform=$BUILDPLATFORM alpine:3.16.0 AS build-duckdb
-ARG DUCKDB_RELEASE_TAG=v0.7.1
-
-RUN apk add --no-cache git
-WORKDIR /
-RUN git clone --depth 1 --branch ${DUCKDB_RELEASE_TAG} https://github.com/duckdb/duckdb.git
-
-WORKDIR /duckdb
-RUN apk add --no-cache build-base cmake openssl-dev ninja
-RUN GEN=ninja BUILD_HTTPFS=1 make 
-
 # Just lakectl
 FROM --platform=$BUILDPLATFORM alpine:3.16.0 AS lakectl
 RUN apk add -U --no-cache ca-certificates
@@ -75,8 +63,8 @@ USER lakefs
 WORKDIR /home/lakefs
 ENTRYPOINT ["/app/lakectl"]
 
-# Add lakefs
-FROM --platform=$BUILDPLATFORM alpine:3.16.0 AS lakefs-lakectl
+# lakefs with lakectl
+FROM --platform=$BUILDPLATFORM alpine:3.16.0 AS lakefs
 
 RUN apk add -U --no-cache ca-certificates
 # Be Docker compose friendly (i.e. support wait-for)
@@ -122,14 +110,3 @@ RUN mkdir -p /home/lakefs/.lakefs/plugins/diff && ln -s /app/delta_diff /home/la
 
 ENTRYPOINT ["/app/lakefs"]
 CMD ["run"]
-
-FROM --platform=$BUILDPLATFORM lakefs-plugins AS lakefs-with-duckdb
-
-# Add DuckDB
-USER root
-WORKDIR /app
-COPY --from=build-duckdb /duckdb/build/release/duckdb  ./
-
-USER lakefs
-# Create ~/.duckdbrc file to customise the prompt 🦆
-RUN echo ".prompt '⚫◗ '" > $HOME/.duckdbrc

--- a/Dockerfile.duckdb
+++ b/Dockerfile.duckdb
@@ -1,0 +1,12 @@
+ARG LAKEFS_RELEASE_TAG=latest
+ARG DUCKDB_RELEASE_TAG=v0.7.1
+
+FROM --platform=$BUILDPLATFORM alpine:3.16.0 AS build-duckdb
+ARG DUCKDB_RELEASE_TAG
+RUN apk add --no-cache git build-base cmake openssl-dev ninja
+RUN git clone --depth 1 --branch ${DUCKDB_RELEASE_TAG} https://github.com/duckdb/duckdb.git
+WORKDIR /duckdb
+RUN GEN=ninja BUILD_HTTPFS=1 make 
+
+FROM --platform=$BUILDPLATFORM treeverse/lakefs:${LAKEFS_RELEASE_TAG} AS lakefs-duckdb
+COPY --from=build-duckdb /duckdb/build/release/duckdb /usr/local/bin/duckdb


### PR DESCRIPTION
Build and publish lakefs with duckdb as part of release.

- Extract duckdb from the main Dockerfile to Dockerfile.duckdb
- Use build arg to select which lakeFS build tag to use as base
- Update docker image publish to publish lakefs+duckdb

Close https://github.com/treeverse/lakeFS/issues/5837