### PR TITLE
Ranges cache: add ownership check

### DIFF
--- a/pkg/graveler/committed/value.go
+++ b/pkg/graveler/committed/value.go
@@ -74,8 +74,7 @@ func getBytes(b *[]byte) ([]byte, error) {
 	if l < 0 {
 		return nil, fmt.Errorf("impossible negative length %d: %w", l, ErrBadValueBytes)
 	}
-	ret := make([]byte, l)
-	copy(ret, (*b)[:l])
+	ret := (*b)[:l]
 	*b = (*b)[l:]
 	return ret, nil
 }

--- a/pkg/graveler/sstable/range_manager.go
+++ b/pkg/graveler/sstable/range_manager.go
@@ -92,7 +92,13 @@ func (m *RangeManager) GetValueGE(ctx context.Context, ns committed.Namespace, i
 		}
 		return nil, ErrKeyNotFound
 	}
-	vBytes, _, err := value.Value(nil)
+	vBytes, owned, err := value.Value(nil)
+	if !owned {
+		b := vBytes
+		vBytes = make([]byte, len(b))
+		copy(vBytes, b)
+	}
+
 	if err != nil {
 		return nil, fmt.Errorf("extract value from sstable id %s (key %s): %w", id, key, err)
 	}
@@ -132,7 +138,13 @@ func (m *RangeManager) GetValue(ctx context.Context, ns committed.Namespace, id 
 		// lookup path in range but key not found
 		return nil, ErrKeyNotFound
 	}
-	vBytes, _, err := value.Value(nil)
+	vBytes, owned, err := value.Value(nil)
+	if !owned {
+		b := vBytes
+		vBytes = make([]byte, len(b))
+		copy(vBytes, b)
+	}
+
 	if err != nil {
 		return nil, fmt.Errorf("extract value from sstable id %s (key %s): %w", id, key, err)
 	}


### PR DESCRIPTION
Since we pass `nil` when calling for `Value`, the initialized buffer isn't owned by the calling function. This makes the behavior of the data inside the buffer unexpected. You can read about it [here](https://pkg.go.dev/github.com/cockroachdb/pebble@v0.0.0-20230530230020-1880f18801dd/internal/base#LazyValue) some more ([P1], [P2]).

Closes [1578](https://github.com/treeverse/cloud-controlplane/issues/1578)