### PR TITLE
docs/quickstart nits 01

### DIFF
--- a/docs/quickstart/rollback.md
+++ b/docs/quickstart/rollback.md
@@ -47,5 +47,5 @@ object          2023-03-21 14:45:38 +0000 UTC    916.4 kB        lakes.parquet
 Once you've finished the quickstart, shut down your local environment with the following command: 
 
 ```bash
-docker-compose down
+docker stop lakefs
 ```

--- a/pkg/samplerepo/assets/sample/README.md.tmpl
+++ b/pkg/samplerepo/assets/sample/README.md.tmpl
@@ -29,7 +29,7 @@ If you're running lakeFS with Docker then all the tools you need (`lakectl`, `du
 ```bash
 docker run --name lakefs \
            --rm --publish 8000:8000 \
-           treeverse/lakefs:0.100.0-duckdb \
+           treeverse/lakefs:latest-duckdb \
              run --local-settings
 ```
 


### PR DESCRIPTION
- bug: docker-compose -> docker
- samplerepo - use latest-duckdb docker image tag

## Change Description

(supersedes #5991)

### Background

Update the Sample repo docs to use new `latest-duckdb` tag for the Docker image instead of hardcoded to a specific version. 

Also fixed erroneous reference to docker-compose in final step. 


### Testing Details

Tested manually - ran the new Docker image and worked through quickstart to make sure it still works. 

