### PR TITLE
Stats sample data used in create repository as additional event

### DIFF
--- a/pkg/api/errors.go
+++ b/pkg/api/errors.go
@@ -9,4 +9,5 @@ var (
 	ErrAuthenticatingRequest = errors.New("error authenticating request")
 	ErrInvalidAPIEndpoint    = errors.New("invalid API endpoint")
 	ErrRequestSizeExceeded   = errors.New("request size exceeded")
+	ErrStorageNamespaceInUse = errors.New("storage namespace already in use")
 )


### PR DESCRIPTION
An event `repo_sample_data` will be logged in addition to create repository when sample data is used.

Close https://github.com/treeverse/lakeFS/issues/6016