### PR TITLE
Pebble: Copy not owned data in all places

### DIFF
--- a/pkg/graveler/committed/value.go
+++ b/pkg/graveler/committed/value.go
@@ -91,9 +91,3 @@ func UnmarshalValue(b []byte) (*graveler.Value, error) {
 	}
 	return ret, nil
 }
-
-// UnmarshalIdentity returns *only* the Identity field encoded by b.  It does not even examine
-// any bytes beyond the prefix of b holding Identity.
-func UnmarshalIdentity(b []byte) ([]byte, []byte, error) {
-	return splitBytes(&b)
-}

--- a/pkg/graveler/committed/value.go
+++ b/pkg/graveler/committed/value.go
@@ -76,19 +76,19 @@ func splitBytes(b []byte) ([]byte, []byte, error) {
 	if l < 0 {
 		return nil, nil, fmt.Errorf("impossible negative length %d: %w", l, ErrBadValueBytes)
 	}
-	left := remainedBuf[:l]
-	right := remainedBuf[l:]
-	return left, right, nil
+	value := remainedBuf[:l]
+	rest := remainedBuf[l:]
+	return value, rest, nil
 }
 
 func UnmarshalValue(b []byte) (*graveler.Value, error) {
 	ret := &graveler.Value{}
 	var err error
-	var right []byte
-	if ret.Identity, right, err = splitBytes(b); err != nil {
+	data := b
+	if ret.Identity, data, err = splitBytes(b); err != nil {
 		return nil, fmt.Errorf("identity field: %w", err)
 	}
-	if ret.Data, _, err = splitBytes(right); err != nil {
+	if ret.Data, _, err = splitBytes(data); err != nil {
 		return nil, fmt.Errorf("data field: %w", err)
 	}
 	return ret, nil

--- a/pkg/graveler/committed/value.go
+++ b/pkg/graveler/committed/value.go
@@ -85,7 +85,7 @@ func UnmarshalValue(b []byte) (*graveler.Value, error) {
 	ret := &graveler.Value{}
 	var err error
 	data := b
-	if ret.Identity, data, err = splitBytes(b); err != nil {
+	if ret.Identity, data, err = splitBytes(data); err != nil {
 		return nil, fmt.Errorf("identity field: %w", err)
 	}
 	if ret.Data, _, err = splitBytes(data); err != nil {

--- a/pkg/graveler/committed/value.go
+++ b/pkg/graveler/committed/value.go
@@ -64,12 +64,12 @@ func MustMarshalValue(v *graveler.Value) []byte {
 
 // splitBytes splits a given byte slice into two: the first part defined by the interpreted length (provided in the
 // slice), and the second part is the remainder of bytes from the slice
-func splitBytes(b *[]byte) ([]byte, []byte, error) {
-	l, o := binary.Varint(*b)
+func splitBytes(b []byte) ([]byte, []byte, error) {
+	l, o := binary.Varint(b)
 	if o < 0 {
 		return nil, nil, fmt.Errorf("read length: %w", ErrBadValueBytes)
 	}
-	remainedBuf := (*b)[o:]
+	remainedBuf := b[o:]
 	if len(remainedBuf) < int(l) {
 		return nil, nil, fmt.Errorf("not enough bytes to read %d bytes: %w", l, ErrBadValueBytes)
 	}
@@ -85,10 +85,10 @@ func UnmarshalValue(b []byte) (*graveler.Value, error) {
 	ret := &graveler.Value{}
 	var err error
 	var right []byte
-	if ret.Identity, right, err = splitBytes(&b); err != nil {
+	if ret.Identity, right, err = splitBytes(b); err != nil {
 		return nil, fmt.Errorf("identity field: %w", err)
 	}
-	if ret.Data, _, err = splitBytes(&right); err != nil {
+	if ret.Data, _, err = splitBytes(right); err != nil {
 		return nil, fmt.Errorf("data field: %w", err)
 	}
 	return ret, nil

--- a/pkg/graveler/committed/value.go
+++ b/pkg/graveler/committed/value.go
@@ -62,30 +62,31 @@ func MustMarshalValue(v *graveler.Value) []byte {
 	return val
 }
 
-func getBytes(b *[]byte) ([]byte, error) {
+func splitBytes(b *[]byte) ([]byte, []byte, error) {
 	l, o := binary.Varint(*b)
 	if o < 0 {
-		return nil, fmt.Errorf("read length: %w", ErrBadValueBytes)
+		return nil, nil, fmt.Errorf("read length: %w", ErrBadValueBytes)
 	}
-	*b = (*b)[o:]
-	if len(*b) < int(l) {
-		return nil, fmt.Errorf("not enough bytes to read %d bytes: %w", l, ErrBadValueBytes)
+	remainedBuf := (*b)[o:]
+	if len(remainedBuf) < int(l) {
+		return nil, nil, fmt.Errorf("not enough bytes to read %d bytes: %w", l, ErrBadValueBytes)
 	}
 	if l < 0 {
-		return nil, fmt.Errorf("impossible negative length %d: %w", l, ErrBadValueBytes)
+		return nil, nil, fmt.Errorf("impossible negative length %d: %w", l, ErrBadValueBytes)
 	}
-	ret := (*b)[:l]
-	*b = (*b)[l:]
-	return ret, nil
+	left := remainedBuf[:l]
+	right := remainedBuf[l:]
+	return left, right, nil
 }
 
 func UnmarshalValue(b []byte) (*graveler.Value, error) {
 	ret := &graveler.Value{}
 	var err error
-	if ret.Identity, err = getBytes(&b); err != nil {
+	var right []byte
+	if ret.Identity, right, err = splitBytes(&b); err != nil {
 		return nil, fmt.Errorf("identity field: %w", err)
 	}
-	if ret.Data, err = getBytes(&b); err != nil {
+	if ret.Data, _, err = splitBytes(&right); err != nil {
 		return nil, fmt.Errorf("data field: %w", err)
 	}
 	return ret, nil
@@ -93,6 +94,6 @@ func UnmarshalValue(b []byte) (*graveler.Value, error) {
 
 // UnmarshalIdentity returns *only* the Identity field encoded by b.  It does not even examine
 // any bytes beyond the prefix of b holding Identity.
-func UnmarshalIdentity(b []byte) ([]byte, error) {
-	return getBytes(&b)
+func UnmarshalIdentity(b []byte) ([]byte, []byte, error) {
+	return splitBytes(&b)
 }

--- a/pkg/graveler/committed/value.go
+++ b/pkg/graveler/committed/value.go
@@ -62,6 +62,8 @@ func MustMarshalValue(v *graveler.Value) []byte {
 	return val
 }
 
+// splitBytes splits a given byte slice into two: the first part defined by the interpreted length (provided in the
+// slice), and the second part is the remainder of bytes from the slice
 func splitBytes(b *[]byte) ([]byte, []byte, error) {
 	l, o := binary.Varint(*b)
 	if o < 0 {

--- a/pkg/graveler/committed/value_test.go
+++ b/pkg/graveler/committed/value_test.go
@@ -95,7 +95,7 @@ func TestGravelerValueIdentityUnmarshal(t *testing.T) {
 			c.id = make([]byte, 0)
 		}
 		t.Run(c.name, func(t *testing.T) {
-			id, err := committed.UnmarshalIdentity(c.b)
+			id, _, err := committed.UnmarshalIdentity(c.b)
 			if !errors.Is(err, c.err) {
 				t.Errorf("got error %s != %s", err, c.err)
 			}

--- a/pkg/graveler/committed/value_test.go
+++ b/pkg/graveler/committed/value_test.go
@@ -71,39 +71,3 @@ func TestGravelerValueUnmarshal(t *testing.T) {
 		})
 	}
 }
-
-func TestGravelerValueIdentityUnmarshal(t *testing.T) {
-	cases := []struct {
-		name string
-		id   []byte
-		b    []byte
-		err  error
-	}{
-		{name: "empty", b: []byte{0, 0}},
-		{name: "identity", id: []byte("foo"), b: []byte{6, 102, 111, 111, 0}},
-		{name: "data", b: []byte{0, 38, 116, 104, 101, 32, 113, 117, 105, 99, 107, 32, 98, 114, 111, 119, 110, 32, 102, 111, 120}},
-		{name: "identityAndData", id: []byte("foo"), b: []byte{6, 102, 111, 111, 38, 116, 104, 101, 32, 113, 117, 105, 99, 107, 32, 98, 114, 111, 119, 110, 32, 102, 111, 120}},
-		{name: "failIdentityNegativeLength", b: []byte{3, 102, 111, 111, 0}, err: committed.ErrBadValueBytes},
-		{name: "okIdentityTooShort", id: []byte("fo"), b: []byte{4, 102, 111, 111, 0}},
-		{name: "failIdentityTooLong", b: []byte{16, 102, 111, 111, 0}, err: committed.ErrBadValueBytes},
-		{name: "okIdentityDataNegativeLength", id: []byte("foo"), b: []byte{6, 102, 111, 111, 17, 116, 104, 101, 32, 113, 117, 105, 99, 107, 32, 98, 114, 111, 119, 110, 32, 102, 111, 120}},
-		{name: "okIdentityDataTooLong", id: []byte("foo"), b: []byte{6, 102, 111, 111, 250, 116, 104, 101, 32, 113, 117, 105, 99, 107, 32, 98, 114, 111, 119, 110, 32, 102, 111, 120}},
-	}
-
-	for _, c := range cases {
-		if c.id == nil {
-			c.id = make([]byte, 0)
-		}
-		t.Run(c.name, func(t *testing.T) {
-			id, _, err := committed.UnmarshalIdentity(c.b)
-			if !errors.Is(err, c.err) {
-				t.Errorf("got error %s != %s", err, c.err)
-			}
-			if err == nil {
-				if diffs := deep.Equal(id, c.id); diffs != nil {
-					t.Errorf("bad value %+v: %s", id, diffs)
-				}
-			}
-		})
-	}
-}

--- a/pkg/graveler/sstable/helpers.go
+++ b/pkg/graveler/sstable/helpers.go
@@ -1,0 +1,16 @@
+package sstable
+
+import "github.com/cockroachdb/pebble"
+
+func retrieveValue(lazyValue pebble.LazyValue) ([]byte, error) {
+	val, owned, err := lazyValue.Value(nil)
+	if err != nil {
+		return []byte{}, err
+	}
+	if owned || val == nil {
+		return val, nil
+	}
+	var copiedVal = make([]byte, len(val))
+	copy(copiedVal, val)
+	return copiedVal, nil
+}

--- a/pkg/graveler/sstable/helpers.go
+++ b/pkg/graveler/sstable/helpers.go
@@ -5,7 +5,7 @@ import "github.com/cockroachdb/pebble"
 func retrieveValue(lazyValue pebble.LazyValue) ([]byte, error) {
 	val, owned, err := lazyValue.Value(nil)
 	if err != nil {
-		return []byte{}, err
+		return nil, err
 	}
 	if owned || val == nil {
 		return val, nil

--- a/pkg/graveler/sstable/iterator.go
+++ b/pkg/graveler/sstable/iterator.go
@@ -28,7 +28,7 @@ func NewIterator(it sstable.Iterator, derefer func() error) *Iterator {
 
 func (iter *Iterator) SeekGE(lookup committed.Key) {
 	key, value := iter.it.SeekGE(lookup, sstable.SeekGEFlags(0))
-	val, _, err := value.Value(nil)
+	val, err := retrieveValue(value)
 	iter.currKey = key
 	iter.currValue = val
 	iter.err = err
@@ -39,7 +39,7 @@ func (iter *Iterator) Next() bool {
 	if !iter.postSeek {
 		key, value := iter.it.Next()
 		iter.currKey = key
-		val, _, err := value.Value(nil)
+		val, err := retrieveValue(value)
 		iter.err = err
 		iter.currValue = val
 	}

--- a/pkg/graveler/sstable/range_manager.go
+++ b/pkg/graveler/sstable/range_manager.go
@@ -92,12 +92,7 @@ func (m *RangeManager) GetValueGE(ctx context.Context, ns committed.Namespace, i
 		}
 		return nil, ErrKeyNotFound
 	}
-	vBytes, owned, err := value.Value(nil)
-	if !owned {
-		b := vBytes
-		vBytes = make([]byte, len(b))
-		copy(vBytes, b)
-	}
+	vBytes, err := retrieveValue(value)
 
 	if err != nil {
 		return nil, fmt.Errorf("extract value from sstable id %s (key %s): %w", id, key, err)
@@ -138,12 +133,7 @@ func (m *RangeManager) GetValue(ctx context.Context, ns committed.Namespace, id 
 		// lookup path in range but key not found
 		return nil, ErrKeyNotFound
 	}
-	vBytes, owned, err := value.Value(nil)
-	if !owned {
-		b := vBytes
-		vBytes = make([]byte, len(b))
-		copy(vBytes, b)
-	}
+	vBytes, err := retrieveValue(value)
 
 	if err != nil {
 		return nil, fmt.Errorf("extract value from sstable id %s (key %s): %w", id, key, err)


### PR DESCRIPTION
* Changed `getBytes` to `splitBytes` which takes a byte buffer pointer as a parameter and splits it into two parts according to the size that is read from it. Another change is that the function will not modify the buffer that is passed but rather return two buffers that represent the first part and the remainder.
* Once a value is read and not owned by the caller (to pebble's `LazyValue.Value()`), it's copied and returned to the caller. This was implemented partially, and this PR completes the implementation.

Closes [#1663](https://github.com/treeverse/cloud-controlplane/issues/1663)