### PR TITLE
Fix: Migration start version

### DIFF
--- a/cmd/lakefs/cmd/migrate.go
+++ b/cmd/lakefs/cmd/migrate.go
@@ -112,7 +112,7 @@ func DoMigration(ctx context.Context, kvStore kv.Store, cfg *config.Config, forc
 			return err
 		}
 		switch {
-		case version >= kv.NextSchemaVersion || version < kv.ACLMigrateVersion:
+		case version >= kv.NextSchemaVersion || version < kv.InitialMigrateVersion:
 			return fmt.Errorf("wrong starting version %d: %w", version, kv.ErrMigrationVersion)
 		case version < kv.ACLNoReposMigrateVersion:
 			err = migrations.MigrateToACL(ctx, kvStore, cfg, logging.Default(), version, force)

--- a/pkg/kv/migrations/rbac_to_acl.go
+++ b/pkg/kv/migrations/rbac_to_acl.go
@@ -216,6 +216,9 @@ func rbacToACL(ctx context.Context, svc auth.Service, doUpdate bool, creationTim
 		if err != nil {
 			return nil, err
 		}
+		if len(users) == 0 { // avoid infinite loop when no users
+			break
+		}
 		for _, user := range users {
 			// get policies attracted to user
 			hasMoreUserPolicy := true


### PR DESCRIPTION
<!-- 
Hello Axolotl!
Thank you for contributing to the lakeFS project.
We appreciate the time invested in this pull request and created this template to help make this process easier.
It's really important to have all the information and context, to ensure we can properly address this PR 
Please use the following references to fill out the pull request.
--> 

### Linked Issue

Closes #6038

---

## Change Description

### Background

Adding initial ACL migration, we forgot to modify the start version for the migration iteration

### Bug Fix

Migration will not start for versions < 0.99
Modified the condition and unit tests
      

