### PR TITLE
Fix links broken by changes to samples repo

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -164,7 +164,7 @@ implement this logic yourself.
 
 Instead, make updates to the desired data assets on a branch and then utilize a lakeFS merge to atomically expose the data to downstream consumers.
 
-To learn more about atomic cross-collection updates, check out [this video](https://www.youtube.com/watch?v=9OsjUvk5UJU) which describes the concept in more detail, along with [this notebook](https://github.com/treeverse/lakeFS-samples/blob/main/01-multi-table-transaction-consistency-deltalake-lakefs/lakeFS-DeltaLake-multi-table-transaction-consistency.ipynb).
+To learn more about atomic cross-collection updates, check out [this video](https://www.youtube.com/watch?v=9OsjUvk5UJU) which describes the concept in more detail, along with [this notebook](https://github.com/treeverse/lakeFS-samples/blob/main/notebooks/write-audit-publish/wap-lakefs.ipynb) in the [lakeFS samples repository](https://github.com/treeverse/lakeFS-samples/).
 
 
 

--- a/docs/use_cases/cicd_for_data.md
+++ b/docs/use_cases/cicd_for_data.md
@@ -118,7 +118,7 @@ Next step is to configure the custom logic for your hooks server and configuring
 
 ## Set up your first lakeFS webhook under 10 minutes
 
-To configure and set up a pre-merge lakeFS hook that validates file format of your data on staging branch before promoting it to production, refer to the [sample](https://github.com/treeverse/lakeFS-samples/tree/main/04-data-quality-checks-with-lakeFS-hooks) demo notebook and actions.yaml here. 
+To configure and set up a pre-merge lakeFS hook that validates file format of your data on staging branch before promoting it to production, refer to [this notebook](https://github.com/treeverse/lakeFS-samples/blob/main/notebooks/hooks-demo.ipynb) in the [lakeFS samples repository](https://github.com/treeverse/lakeFS-samples).
 
 To explore different checks and validations on your data, refer to [pre-built hooks config](https://github.com/treeverse/lakeFS-hooks#included-webhooks) by the lakeFS team. 
 


### PR DESCRIPTION
The lakeFS samples repo [changed recently](https://github.com/treeverse/lakeFS-samples/pull/74) and some stuff moved around. This fixes the links that changed. 