### PR TITLE
UI: Allow writing to lakeFS from duckdb-wasm

### DIFF
--- a/cmd/lakefs/cmd/run.go
+++ b/cmd/lakefs/cmd/run.go
@@ -300,6 +300,7 @@ var runCmd = &cobra.Command{
 			cfg.Logging.AuditLogLevel,
 			cfg.Logging.TraceRequestHeaders,
 		)
+		s3gatewayHandler = apiAuthenticator(s3gatewayHandler)
 
 		bufferedCollector.Start(ctx)
 		defer bufferedCollector.Close()
@@ -315,8 +316,7 @@ var runCmd = &cobra.Command{
 				if httputil.HostMatches(request, cfg.Gateways.S3.DomainNames) ||
 					httputil.HostSubdomainOf(request, cfg.Gateways.S3.DomainNames) ||
 					sig.IsAWSSignedRequest(request) {
-					h := apiAuthenticator(s3gatewayHandler)
-					h.ServeHTTP(writer, request)
+					s3gatewayHandler.ServeHTTP(writer, request)
 					return
 				}
 

--- a/cmd/lakefs/cmd/run.go
+++ b/cmd/lakefs/cmd/run.go
@@ -277,11 +277,12 @@ var runCmd = &cobra.Command{
 		}
 
 		// setup authenticator for s3 gateway to also support swagger auth
-		apiAuthenticator, err := api.MakeAuthMiddleware(
-			logger.WithField("service", "api_gateway"),
-			cfg,
+		apiAuthenticator, err := api.GenericAuthMiddleware(
+			logger.WithField("service", "s3_gateway"),
 			middlewareAuthenticator,
 			authService,
+			&cfg.Auth.OIDC,
+			&cfg.Auth.CookieAuthVerification,
 		)
 		if err != nil {
 			logger.WithError(err).Fatal("could not initialize authenticator for S3 gateway")

--- a/pkg/api/serve.go
+++ b/pkg/api/serve.go
@@ -37,16 +37,6 @@ const (
 	extensionValidationExcludeBody = "x-validation-exclude-body"
 )
 
-func MakeAuthMiddleware(logger logging.Logger, cfg *config.Config, middlewareAuthenticator auth.Authenticator, authService auth.Service) (func(next http.Handler) http.Handler, error) {
-	swagger, err := GetSwagger()
-	if err != nil {
-		return nil, err
-	}
-	sessionStore := sessions.NewCookieStore(authService.SecretStore().SharedSecret())
-	mw := AuthMiddleware(logger, swagger, middlewareAuthenticator, authService, sessionStore, &cfg.Auth.OIDC, &cfg.Auth.CookieAuthVerification)
-	return mw, nil
-}
-
 func Serve(
 	cfg *config.Config,
 	catalog catalog.Interface,

--- a/pkg/gateway/handler.go
+++ b/pkg/gateway/handler.go
@@ -241,9 +241,9 @@ func authorize(w http.ResponseWriter, req *http.Request, authService auth.Gatewa
 	o := ctx.Value(ContextKeyOperation).(*operations.Operation)
 	user, _ := auth.GetUser(ctx)
 	username := user.Username
-	var accessKeyId string
+	var accessKeyID string
 	if authContext, ok := ctx.Value(ContextKeyAuthContext).(sig.SigContext); ok {
-		accessKeyId = authContext.GetAccessKeyID()
+		accessKeyID = authContext.GetAccessKeyID()
 	}
 
 	if len(perms.Nodes) == 0 && len(perms.Permission.Action) == 0 {
@@ -265,8 +265,8 @@ func authorize(w http.ResponseWriter, req *http.Request, authService auth.Gatewa
 	}
 	if authResp.Error != nil || !authResp.Allowed {
 		l := o.Log(req).WithError(authResp.Error)
-		if accessKeyId != "" {
-			l = l.WithField("key", accessKeyId)
+		if accessKeyID != "" {
+			l = l.WithField("key", accessKeyID)
 		}
 		l.Warn("no permission")
 		_ = o.EncodeError(w, req, gatewayerrors.ErrAccessDenied.ToAPIErr())

--- a/pkg/gateway/sig/sig.go
+++ b/pkg/gateway/sig/sig.go
@@ -134,6 +134,11 @@ func IsAWSSignedRequest(req *http.Request) bool {
 	if strings.HasPrefix(v2Value, "AWS ") {
 		return true
 	}
+	// unauthenticated requests might still pass X-Amz-Date
+	dateHeader := headers.Get("X-Amz-Date")
+	if dateHeader != "" {
+		return true
+	}
 
 	// then request params
 	queryParams := req.URL.Query()

--- a/pkg/gateway/sig/sig.go
+++ b/pkg/gateway/sig/sig.go
@@ -134,11 +134,6 @@ func IsAWSSignedRequest(req *http.Request) bool {
 	if strings.HasPrefix(v2Value, "AWS ") {
 		return true
 	}
-	// unauthenticated requests might still pass X-Amz-Date
-	dateHeader := headers.Get("X-Amz-Date")
-	if dateHeader != "" {
-		return true
-	}
 
 	// then request params
 	queryParams := req.URL.Query()

--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -8,7 +8,7 @@
       "name": "lakefs-ui",
       "version": "0.1.0",
       "dependencies": {
-        "@duckdb/duckdb-wasm": "^1.24.0",
+        "@duckdb/duckdb-wasm": "^1.26.0",
         "@emotion/react": "^11.10.5",
         "@emotion/styled": "^11.10.5",
         "@mui/material": "^5.11.1",
@@ -448,9 +448,9 @@
       }
     },
     "node_modules/@duckdb/duckdb-wasm": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@duckdb/duckdb-wasm/-/duckdb-wasm-1.24.0.tgz",
-      "integrity": "sha512-ow3y5kNV5saNd9dK1PkoKq7I0yqOJsnuRA15p92/gIl37wsNq/hI1R5m1HBe02CAEBQPi14w7+EV9xzvduSfZA==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@duckdb/duckdb-wasm/-/duckdb-wasm-1.26.0.tgz",
+      "integrity": "sha512-Tpw/0E4O9QYDhpneIY2e0yPxK11VZ+IL13eomy8adlutVohiF1P/T/pa99lqV5Ku4lQMkl2kfNNNHhSj33Jfng==",
       "dependencies": {
         "apache-arrow": "^11.0.0"
       }
@@ -10288,9 +10288,9 @@
       }
     },
     "@duckdb/duckdb-wasm": {
-      "version": "1.24.0",
-      "resolved": "https://registry.npmjs.org/@duckdb/duckdb-wasm/-/duckdb-wasm-1.24.0.tgz",
-      "integrity": "sha512-ow3y5kNV5saNd9dK1PkoKq7I0yqOJsnuRA15p92/gIl37wsNq/hI1R5m1HBe02CAEBQPi14w7+EV9xzvduSfZA==",
+      "version": "1.26.0",
+      "resolved": "https://registry.npmjs.org/@duckdb/duckdb-wasm/-/duckdb-wasm-1.26.0.tgz",
+      "integrity": "sha512-Tpw/0E4O9QYDhpneIY2e0yPxK11VZ+IL13eomy8adlutVohiF1P/T/pa99lqV5Ku4lQMkl2kfNNNHhSj33Jfng==",
       "requires": {
         "apache-arrow": "^11.0.0"
       }

--- a/webui/package.json
+++ b/webui/package.json
@@ -14,7 +14,7 @@
     "typesync": "npx typesync"
   },
   "dependencies": {
-    "@duckdb/duckdb-wasm": "^1.24.0",
+    "@duckdb/duckdb-wasm": "^1.26.0",
     "@emotion/react": "^11.10.5",
     "@emotion/styled": "^11.10.5",
     "@mui/material": "^5.11.1",

--- a/webui/src/pages/repositories/repository/fileRenderers/duckdb.tsx
+++ b/webui/src/pages/repositories/repository/fileRenderers/duckdb.tsx
@@ -1,31 +1,12 @@
 import * as duckdb from '@duckdb/duckdb-wasm';
+import * as arrow from 'apache-arrow';
+import {AsyncDuckDB, AsyncDuckDBConnection, DuckDBDataProtocol} from '@duckdb/duckdb-wasm';
 import duckdb_wasm from '@duckdb/duckdb-wasm/dist/duckdb-mvp.wasm?url';
 import mvp_worker from '@duckdb/duckdb-wasm/dist/duckdb-browser-mvp.worker.js?url';
 import duckdb_wasm_eh from '@duckdb/duckdb-wasm/dist/duckdb-eh.wasm?url';
 import eh_worker from '@duckdb/duckdb-wasm/dist/duckdb-browser-eh.worker.js?url';
-import {AsyncDuckDB, AsyncDuckDBConnection} from "@duckdb/duckdb-wasm";
 
 
-// based on the replacement rules on the percent-encoding MDN page:
-// https://developer.mozilla.org/en-US/docs/Glossary/Percent-encoding
-// also, I tried doing something nicer with list comprehensions and printf('%x') to convert
-//  from unicode code point to hex - DuckDB didn't seem to evaluate lambdas and list comprehensions
-// Issue: https://github.com/duckdb/duckdb/issues/5821
-// when padding a macro to a table function such as read_parquet() or read_csv().
-// so - string replacements it is.
-const DUCKDB_SEED_SQL = `
-CREATE MACRO p_encode(s) AS 
-    list_aggregate([
-        case when x in (':', '/', '?', '#', '[', ']', '@', '!', '$', '&', '''', '(', ')', '*', '+', ',', ';', '=', '%', ' ') 
-            then printf('%%%X', unicode(x))  else x end
-        for x 
-        in string_split(s, '')
-    ], 'string_agg', '');
-    
-CREATE MACRO lakefs_object(repoId, refId, path) AS
-    '${document.location.protocol}//${document.location.host}/api/v1/repositories/' ||
-    p_encode(repoId) || '/refs/' || p_encode(refId) || '/objects?path=' || p_encode(path);
-`
 
 const MANUAL_BUNDLES: duckdb.DuckDBBundles = {
     mvp: {
@@ -53,18 +34,72 @@ async function getDuckDB(): Promise<duckdb.AsyncDuckDB> {
     const db = new duckdb.AsyncDuckDB(logger, worker)
     await db.instantiate(bundle.mainModule, bundle.pthreadWorker)
     const conn = await db.connect()
-    await conn.query(DUCKDB_SEED_SQL)
     await conn.close()
     _db = db
     return _db
 }
 
-export async function getDuckDBConnection(): Promise<duckdb.AsyncDuckDBConnection> {
-    const db = await getDuckDB()
-    return db.connect()
+
+// taken from @duckdb/duckdb-wasm/dist/types/src/bindings/tokens.d.ts
+// which, unfortunately, we cannot import.
+const DUCKDB_STRING_CONSTANT = 2;
+const LAKEFS_URI_PATTERN = /^(['"]?)(lakefs:\/\/(.*))(['"])$/;
+
+// returns a mapping of `lakefs://..` URIs to their `s3://...` equivalent
+async function extractFiles(conn: AsyncDuckDBConnection, sql: string): Promise<{ [name: string]: string }> {
+    const tokenized = await conn.bindings.tokenize(sql)
+    let prev = 0;
+    const fileMap: { [name: string]: string } = {};
+    tokenized.offsets.forEach((offset, i) => {
+        let currentToken = sql.length;
+        if (i < tokenized.offsets.length - 1) {
+            currentToken = tokenized.offsets[i+1];
+        }
+        const part = sql.substring(prev, currentToken);
+        prev = currentToken;
+        if (tokenized.types[i] === DUCKDB_STRING_CONSTANT) {
+            const matches = part.match(LAKEFS_URI_PATTERN)
+            if (matches !== null) {
+                fileMap[matches[2]] = `s3://${matches[3]}`;
+            }
+        }
+    })
+    return fileMap
 }
 
-export async function closeDuckDBConnection(conn: AsyncDuckDBConnection | null) {
+/* eslint-disable  @typescript-eslint/no-explicit-any */
+export async function runDuckDBQuery(sql: string):  Promise<arrow.Table<any>> {
+    const db = await getDuckDB()
+    /* eslint-disable  @typescript-eslint/no-explicit-any */
+    let result: arrow.Table<any>
+    const conn  = await db.connect()
+    try {
+        // TODO (ozk): read this from the server's configuration?
+        await conn.query(`SET s3_region='us-east-1';`)
+        // set the example values (used to make sure the S3 gateway picks up the request)
+        // real authentication is done using the existing swagger cookie or token
+        await conn.query(`SET s3_access_key_id='use_swagger_credentials';`)
+        await conn.query(`SET s3_secret_access_key='these_are_meaningless_but_must_be_set';`)
+        await conn.query(`SET s3_endpoint='${document.location.protocol}//${document.location.host}'`)
+
+        // register lakefs uri-ed files as s3 files
+        const fileMap = await extractFiles(conn, sql)
+        const fileNames = Object.getOwnPropertyNames(fileMap)
+        await Promise.all(fileNames.map(
+            fileName => db.registerFileURL(fileName, fileMap[fileName], DuckDBDataProtocol.S3, true)
+        ))
+        // execute the query
+        result = await conn.query(sql)
+
+        // remove registrations
+        await Promise.all(fileNames.map(fileName => db.dropFile(fileName)))
+    } finally {
+        await closeDuckDBConnection(conn)
+    }
+    return result
+}
+
+async function closeDuckDBConnection(conn: AsyncDuckDBConnection | null) {
     if (conn !== null) {
         await conn.close()
     }


### PR DESCRIPTION
This solves the underlying cause for #6001. closes #6043 
Included in the PR:

1. Upgrade [duckdb-wasm](https://duckdb.org/docs/api/wasm/overview.html) to include recent fixes for s3 path-style access
1. Allow lakeFS to authenticate s3 gateway requests using the OpenAPI authentication mechanisms (allowing reading/writing using S3 protocol for signed-in users using existing cookies/jwt tokens)
1. dynamically register `lakefs://...` URIs to corresponding S3 URIs, abstracting the S3 protocol usage from the end user
1. Remove the `lakefs_object()` macro in favor of "native" `lakefs://` URIs

Not included in the PR but should be done to close #6001 :
- [ ] Adapt the quickstart guide to use the UI instead of the duckdb command line
- [ ] Remove the image that includes duckdb both from documentation and from Docker Hub
- [ ] Remove any existing build steps that create such an image from lakeFS repos
