### PR TITLE
show object's user metadata in UI and CLI

### DIFF
--- a/cmd/lakectl/cmd/fs.go
+++ b/cmd/lakectl/cmd/fs.go
@@ -28,7 +28,12 @@ Size: {{ .SizeBytes }} bytes
 Human Size: {{ .SizeBytes|human_bytes }}
 Physical Address: {{ .PhysicalAddress }}
 Checksum: {{ .Checksum }}
-Content-Type: {{ .ContentType }}
+Content-Type: {{ .ContentType }} {{ if $.Metadata }}
+Metadata:
+	{{ range $key, $value := .Metadata.AdditionalProperties }}
+	{{ $key | printf "%-18s" }} = {{ $value }}
+	{{- end }}
+{{- end }}
 `
 
 const fsRecursiveTemplate = `Files: {{.Count}}
@@ -56,8 +61,9 @@ var fsStatCmd = &cobra.Command{
 		preSign := MustBool(cmd.Flags().GetBool("pre-sign"))
 		client := getClient()
 		resp, err := client.StatObjectWithResponse(cmd.Context(), pathURI.Repository, pathURI.Ref, &api.StatObjectParams{
-			Path:    *pathURI.Path,
-			Presign: swag.Bool(preSign),
+			Path:         *pathURI.Path,
+			Presign:      swag.Bool(preSign),
+			UserMetadata: swag.Bool(true),
 		})
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusOK)
 		if resp.JSON200 == nil {

--- a/cmd/lakectl/cmd/fs.go
+++ b/cmd/lakectl/cmd/fs.go
@@ -28,7 +28,7 @@ Size: {{ .SizeBytes }} bytes
 Human Size: {{ .SizeBytes|human_bytes }}
 Physical Address: {{ .PhysicalAddress }}
 Checksum: {{ .Checksum }}
-Content-Type: {{ .ContentType }}{{ if $.Metadata }}
+Content-Type: {{ .ContentType }}{{ if and $.Metadata $.Metadata.AdditionalProperties }}
 Metadata:
 	{{ range $key, $value := .Metadata.AdditionalProperties }}
 	{{ $key | printf "%-18s" }} = {{ $value }}

--- a/cmd/lakectl/cmd/fs.go
+++ b/cmd/lakectl/cmd/fs.go
@@ -28,7 +28,7 @@ Size: {{ .SizeBytes }} bytes
 Human Size: {{ .SizeBytes|human_bytes }}
 Physical Address: {{ .PhysicalAddress }}
 Checksum: {{ .Checksum }}
-Content-Type: {{ .ContentType }} {{ if $.Metadata }}
+Content-Type: {{ .ContentType }}{{ if $.Metadata }}
 Metadata:
 	{{ range $key, $value := .Metadata.AdditionalProperties }}
 	{{ $key | printf "%-18s" }} = {{ $value }}

--- a/webui/src/lib/components/repository/tree.jsx
+++ b/webui/src/lib/components/repository/tree.jsx
@@ -220,12 +220,44 @@ const StatModal = ({ show, onHide, entry }) => {
                 </td>
               </tr>
             )}
+            {entry.metadata && (
+                <tr>
+                  <td>
+                    <strong>Metadata</strong>
+                  </td>
+                  <td>
+                    <EntryMetadata metadata={entry.metadata}/>
+                  </td>
+                </tr>
+            )}
           </tbody>
         </Table>
       </Modal.Body>
     </Modal>
   );
 };
+
+const EntryMetadata = ({ metadata }) => {
+    return (
+        <Table hover striped>
+          <thead>
+          <tr>
+            <th>Key</th>
+            <th>Value</th>
+          </tr>
+          </thead>
+          <tbody>
+          {Object.getOwnPropertyNames(metadata).map(key =>
+              <tr key={`metadata:${key}`}>
+                <td><code>{key}</code></td>
+                <td><code>{metadata[key]}</code></td>
+              </tr>
+          )}
+          </tbody>
+        </Table>
+    )
+};
+
 
 const CommitMetadata = ({ metadata }) => {
   const entries = Object.entries(metadata);


### PR DESCRIPTION
Closes #6037 (user requested enhancement).

This PR shows user metadata in the UI under "Object Info": 

![image](https://github.com/treeverse/lakeFS/assets/205955/bd165e72-86d6-44d6-b7cf-298f72a1d6bc)

And in the CLI when running `lakectl fs stats <object uri>`


