### PR TITLE
Don't run checks that we don't need to for Docs

### DIFF
--- a/.github/workflows/changelog.yaml
+++ b/.github/workflows/changelog.yaml
@@ -3,6 +3,8 @@ name: changelog
 on:
   pull_request:
     types: [labeled, unlabeled, opened, edited, synchronize]
+    paths-ignore:
+      - 'docs/**'
 
 jobs:
   enforce-label:

--- a/.github/workflows/codeql-analysis.yaml
+++ b/.github/workflows/codeql-analysis.yaml
@@ -5,6 +5,8 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+    paths-ignore:
+      - 'docs/**'
   schedule:
     - cron: '42 10 * * 3'
 

--- a/.github/workflows/esti.yaml
+++ b/.github/workflows/esti.yaml
@@ -1,6 +1,8 @@
 name: Esti
 on:
   pull_request:
+    paths-ignore:
+      - 'docs/**'
   push:
     branches:
       - master

--- a/.github/workflows/spark.yaml
+++ b/.github/workflows/spark.yaml
@@ -6,6 +6,8 @@ on:
     branches:
       - master
   pull_request:
+    paths-ignore:
+      - 'docs/**'
 jobs:
   spark-metadata-client:
     name: Unit test Spark metadata client

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -4,6 +4,8 @@ on:
     branches:
       - master
   pull_request:
+    paths-ignore:
+      - 'docs/**'
 jobs:
   validator:
     name: Run Linters and Checkers


### PR DESCRIPTION
## Change Description

Disable code-related checks if a pull request is for files *only* under `docs/`. 

If there are files in `docs/` *and* elsewhere the checks will still run as currently. 

### Background

Currently, we run a lot of checks for any `pull_request` event.

This has two costs: 

1. Compute: GitHub charges for some workflows where they use more resources
2. Productivity: it takes longer for checks to complete and a PR to be mergeable without overriding (which is generally bad practice). 
      
### Costs: Compute

[A run of the `esti` workflow](https://github.com/treeverse/lakeFS/actions/runs/5242017357) costs in the region of $1.38 (based on the `billable minutes` in the workflow and [documented charges](https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions#per-minute-rates)). 

Many steps have zero billing cost; here are the ones that do have billing cost:

| Job | Billable time (minutes) | runs-on | Cost |
|---|---|---|---|
| Test committed gc (3.2.1, -hadoop3, false) | 9 | ubuntu-latest-8-cores | $0.288 |
| Test committed gc (3.1.2, false) | 9 | ubuntu-latest-8-cores | $0.288 |
| Test committed gc (3.0.2, false) | 8 | ubuntu-latest-8-cores | $0.256 |
| Test committed gc on Azure (3.2.1, -hadoop3) | 7 | ubuntu-latest-8-cores | $0.224 |
| Build and push Docker image | 4 | ubuntu-latest-16-cores | $0.256 |
| Build metadata client for Spark 3.x (core3, 301) | 1 | ubuntu-latest-8-cores | $0.032 |
| Build metadata client for Spark 3.x (core312, 312-hadoop3, -hadoop3) | 1 | ubuntu-latest-8-cores | $0.032 |
|  |  |  | $1.376 |

Some PRs will go through multiple interactions; this one which updates some Azure deployment docs had four changes made to it, costing roughly $5.50.

### Costs: Productivity

[A run of `esti`](https://github.com/treeverse/lakeFS/actions/runs/5242017357) takes around 17 minutes walltime elapsed. During this time the PR cannot be merged: 

<img width="345" alt="CleanShot_2023-06-12_at_11 19 18@2x" src="https://github.com/treeverse/lakeFS/assets/3671582/3998fba6-da82-48d4-943b-42296130deac">

The user can opt-in (each time) to enable auto-merge, and they can also ignore the checks and force the merge. The former is an additional manual step which is tedious. The latter is bad practice and could easily lead to valid check failures being ignored.  

### Testing Details

This will have to be tested by visual inspection and review; by definition this PR will trigger checks because it impacts files outside of `docs`!

It can also be tested by observation post-merge and fixed/reverted if necessary. 
