### PR TITLE
Bump docs platform versions: Jekyll 3.9.3 / Just The Docs 0.5.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -94,7 +94,7 @@ docs-serve-docker: ### Serve local docs from Docker
 			--volume="$$PWD/docs:/srv/jekyll:Z" \
 			--volume="$$PWD/docs/.jekyll-bundle-cache:/usr/local/bundle:Z" \
 			--interactive --tty \
-			jekyll/jekyll:3.8 \
+			jekyll/jekyll:3.9.3 \
 			jekyll serve --livereload
 
 gen-docs: ## Generate CLI docs automatically

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 gem 'github-pages', group: :jekyll_plugins
 gem 'just-the-docs'
+gem "webrick", "~> 1.8"

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -196,7 +196,7 @@ GEM
       gemoji (~> 3.0)
       html-pipeline (~> 2.2)
       jekyll (>= 3.0, < 5.0)
-    just-the-docs (0.5.1)
+    just-the-docs (0.5.2)
       jekyll (>= 3.8.5)
       jekyll-seo-tag (>= 2.0)
       rake (>= 12.3.1)
@@ -254,6 +254,7 @@ GEM
       unf_ext
     unf_ext (0.0.8.2)
     unicode-display_width (1.8.0)
+    webrick (1.8.1)
 
 PLATFORMS
   ruby
@@ -261,6 +262,7 @@ PLATFORMS
 DEPENDENCIES
   github-pages
   just-the-docs
+  webrick (~> 1.8)
 
 BUNDLED WITH
    2.1.4

--- a/docs/README.md
+++ b/docs/README.md
@@ -57,7 +57,7 @@ The alternative is to use Docker which has the benefit of handling all the depen
               --volume="$PWD/docs:/srv/jekyll:Z" \
               --volume="$PWD/docs/.jekyll-bundle-cache:/usr/local/bundle:Z" \
               --interactive --tty \
-              jekyll/jekyll:3.8 \
+              jekyll/jekyll:3.9.3 \
               jekyll serve --livereload
    ```
 

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -10,7 +10,7 @@ search_tokenizer_separator: /[\s/]+/
 logo: '/assets/logo.svg'
 logo_link: 'https://lakefs.io'
 
-remote_theme: pmarsceill/just-the-docs@v0.5.0
+remote_theme: pmarsceill/just-the-docs@v0.5.2
 
 
 


### PR DESCRIPTION
Bumping Jekyll and Just The Docs versions to their latest. 
No specific driver other than to keep current and avoid big-bang migrations in the future. 

Tested manually. 
