### PR TITLE
Delta Diff fails on certain operations

### DIFF
--- a/docs/integrations/delta.md
+++ b/docs/integrations/delta.md
@@ -39,7 +39,7 @@ The diff is available as long as the table history in Delta is retained ([30 day
 
 To enable the Delta Lake diff feature, you need to install a plugin on the lakeFS server. You will find the plugin binary in the
 [release](https://github.com/treeverse/lakeFS/releases/latest) tarball (versions >= 0.97.3).
-Put the `delta_diff` binary under `~/.lakefs/plugins/diff` on the machine where lakeFS is running. 
+Rename the `delta_diff` binary to `delta` and put it under `~/.lakefs/plugins/diff` on the machine where lakeFS is running. 
 
 You can customize the location of the Delta Lake diff plugin by changing the `diff.delta.plugin` and 
 `plugin.properties.<plugin name>.path` configurations in the [`.lakefs.yaml`](../reference/configuration.html#plugins) file.

--- a/pkg/plugins/diff/delta_diff_server/src/delta_ops.rs
+++ b/pkg/plugins/diff/delta_diff_server/src/delta_ops.rs
@@ -53,6 +53,12 @@ lazy_static! {
         hm.insert("INSERT", OperationType::Update as i32);
         hm.insert("DELETE", OperationType::Delete as i32);
         hm.insert("CREATE", OperationType::Create as i32);
+        hm.insert("ALTER", OperationType::Update as i32);
+        hm.insert("SYNC", OperationType::Update as i32);
+        hm.insert("LOAD", OperationType::Update as i32);
+        hm.insert("COMMENT ON", OperationType::Update as i32);
+        hm.insert("GENERATE", OperationType::Create as i32);
+        hm.insert("DROP", OperationType::Delete as i32);
         hm.insert("CREATE TABLE AS SELECT", OperationType::Create as i32);
         hm.insert("REPLACE TABLE AS SELECT", OperationType::Update as i32);
         hm.insert("COPY INTO", OperationType::Update as i32);

--- a/pkg/plugins/diff/delta_diff_server/src/delta_ops.rs
+++ b/pkg/plugins/diff/delta_diff_server/src/delta_ops.rs
@@ -52,6 +52,7 @@ lazy_static! {
         hm.insert("WRITE", OperationType::Update as i32);
         hm.insert("INSERT", OperationType::Update as i32);
         hm.insert("DELETE", OperationType::Delete as i32);
+        hm.insert("CREATE", OperationType::Create as i32);
         hm.insert("CREATE TABLE AS SELECT", OperationType::Create as i32);
         hm.insert("REPLACE TABLE AS SELECT", OperationType::Update as i32);
         hm.insert("COPY INTO", OperationType::Update as i32);


### PR DESCRIPTION
Closes #5862

In this code, after the initial None check, the code filters the `OP_TYPES` hashmap to find all key-value pairs where the key is a prefix of op_name. These prefix matches are collected into a vector of tuples (key, value).

Then, based on the number of prefix matches, the code handles different cases:

- If no prefix matches are found, an error is returned.
- If only one prefix match is found, the corresponding value is returned.
- If multiple prefix matches are found, the code chooses the longest matching prefix and retrieves the corresponding value from `OP_TYPES`.

It was tested manually by executing delta query's.