### PR TITLE
Fix: URI parse with whitespace

### DIFF
--- a/.github/workflows/esti.yaml
+++ b/.github/workflows/esti.yaml
@@ -594,7 +594,7 @@ jobs:
           cache: "sbt"
       - name: Build lakeFS HadoopFS
         working-directory: clients/hadoopfs
-        run: mvn -Passembly -DfinalName=client --batch-mode --update-snapshots package
+        run: mvn -Passembly -DfinalName=client --batch-mode --update-snapshots package -DskipTests
       - name: Store lakeFS HadoopFS
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/esti.yaml
+++ b/.github/workflows/esti.yaml
@@ -594,7 +594,7 @@ jobs:
           cache: "sbt"
       - name: Build lakeFS HadoopFS
         working-directory: clients/hadoopfs
-        run: mvn -Passembly -DfinalName=client --batch-mode --update-snapshots package -DskipTests
+        run: mvn -Passembly -DfinalName=client --batch-mode --update-snapshots package
       - name: Store lakeFS HadoopFS
         uses: actions/upload-artifact@v3
         with:

--- a/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileSystem.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileSystem.java
@@ -162,7 +162,7 @@ public class LakeFSFileSystem extends FileSystem {
             Repository repository = repositoriesApi.getRepository(objectLoc.getRepository());
             String storageNamespace = repository.getStorageNamespace();
             URI storageURI = URI.create(storageNamespace);
-            Path physicalPath = new Path(physicalAddressTranslator.translate(storageURI));
+            Path physicalPath = physicalAddressTranslator.translate(storageNamespace);
             fsForConfig = physicalPath.getFileSystem(conf);
         } catch (ApiException | URISyntaxException | IOException e) {
             failedFSForConfig = true;

--- a/clients/hadoopfs/src/main/java/io/lakefs/storage/PresignedStorageAccessStrategy.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/storage/PresignedStorageAccessStrategy.java
@@ -3,7 +3,6 @@ package io.lakefs.storage;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
 import java.net.URL;
 
 import org.apache.hadoop.fs.FSDataInputStream;
@@ -50,7 +49,7 @@ public class PresignedStorageAccessStrategy implements StorageAccessStrategy {
 
     @Override
     public FSDataInputStream createDataInputStream(ObjectLocation objectLocation, int bufSize)
-            throws ApiException, MalformedURLException, IOException {
+            throws ApiException, IOException {
         ObjectsApi objectsApi = lfsClient.getObjectsApi();
         ObjectStats stats = objectsApi.statObject(objectLocation.getRepository(),
                 objectLocation.getRef(), objectLocation.getPath(), false, true);

--- a/clients/hadoopfs/src/test/java/io/lakefs/LakeFSFileSystemTest.java
+++ b/clients/hadoopfs/src/test/java/io/lakefs/LakeFSFileSystemTest.java
@@ -167,16 +167,13 @@ public abstract class LakeFSFileSystemTest {
         when(repositoriesApi.getRepository("repo"))
             .thenReturn(new Repository().storageNamespace(s3Url("/repo-base")));
 
-        fs.initializeWithClientFactory(new URI("lakefs://repo/main/file.txt"), conf,
-                                       new LakeFSFileSystem.ClientFactory() {
-                public LakeFSClient newClient() { return lfsClient; }
-            });
+        fs.initializeWithClientFactory(new URI("lakefs://repo/main/file.txt"), conf, () -> lfsClient);
     }
 
     /**
      * @return all pathnames under s3Prefix that start with prefix.  (Obvious not scalable!)
      */
-    protected List<String> getS3FilesByPrefix(String prefix) throws IOException {
+    protected List<String> getS3FilesByPrefix(String prefix) {
         final int maxKeys = 1500;
 
         ListObjectsRequest req = new ListObjectsRequest()
@@ -192,7 +189,7 @@ public abstract class LakeFSFileSystemTest {
     }
 
     @Test
-    public void getUri() throws URISyntaxException, IOException {
+    public void getUri() {
         URI u = fs.getUri();
         Assert.assertNotNull(u);
     }
@@ -215,7 +212,7 @@ public abstract class LakeFSFileSystemTest {
     }
 
     @Test
-    public void testGetFileStatus_NoFile() throws ApiException, IOException {
+    public void testGetFileStatus_NoFile() throws ApiException {
         Path noFilePath = new Path("lakefs://repo/main/no.file");
 
         when(objectsApi.statObject("repo", "main", "no.file", false, false))
@@ -274,7 +271,7 @@ public abstract class LakeFSFileSystemTest {
     }
 
     @Test
-    public void testExists_ExistsAsDirectoryInSecondList() throws ApiException, IOException {
+    public void testExists_ExistsAsDirectoryInSecondList() {
         // TODO(ariels)
     }
 
@@ -288,12 +285,12 @@ public abstract class LakeFSFileSystemTest {
     }
 
     @Test
-    public void testExists_NotExistsPrefixWithNoSlash() throws ApiException, IOException {
+    public void testExists_NotExistsPrefixWithNoSlash() {
         // TODO(ariels)
     }
 
     @Test
-    public void testExists_NotExistsPrefixWithNoSlashTwoLists() throws ApiException, IOException {
+    public void testExists_NotExistsPrefixWithNoSlashTwoLists() {
         // TODO(ariels)
     }
 
@@ -560,9 +557,9 @@ public abstract class LakeFSFileSystemTest {
         do {
             when(objectsApi.statObject("repo", "main", testPath.toString(), false, false))
                     .thenThrow(noSuchFile);
-            when(objectsApi.statObject("repo", "main", testPath.toString()+"/", false, false))
+            when(objectsApi.statObject("repo", "main", testPath+"/", false, false))
                     .thenThrow(noSuchFile);
-            when(objectsApi.listObjects(eq("repo"), eq("main"), eq(false), eq(false), eq(""), any(), eq(""), eq(testPath.toString()+"/")))
+            when(objectsApi.listObjects(eq("repo"), eq("main"), eq(false), eq(false), eq(""), any(), eq(""), eq(testPath+"/")))
                     .thenReturn(new ObjectStatsList().results(Collections.emptyList()).pagination(new Pagination().hasMore(false)));
             testPath = testPath.getParent();
         } while(testPath != null && !testPath.isRoot());
@@ -610,22 +607,29 @@ public abstract class LakeFSFileSystemTest {
     }
 
     @Test
-    public void testOpenWithSpace() throws IOException, ApiException {
+    public void testOpenWithInvalidUriChars() throws IOException, ApiException {
         String contents = "The quick brown fox jumps over the lazy dog.";
         byte[] contentsBytes = contents.getBytes();
-        String physicalKey = "/repo-base/with space/open";
         int readBufferSize = 5;
 
-        // Write physical file to S3.
-        ObjectMetadata s3Metadata = new ObjectMetadata();
-        s3Metadata.setContentLength(contentsBytes.length);
-        s3Client.putObject(new PutObjectRequest(s3Bucket, physicalKey, new ByteArrayInputStream(contentsBytes), s3Metadata));
+        String[] keys = {
+                "/repo-base/with space/open",
+                "/repo-base/wi:th$cha&rs#/%op;e?n",
+                "/repo-base/עכשיו/בעברית/open",
+                "/repo-base/\uD83E\uDD2F/imoji/open",
+        };
+        for (String key : keys) {
+            // Write physical file to S3.
+            ObjectMetadata s3Metadata = new ObjectMetadata();
+            s3Metadata.setContentLength(contentsBytes.length);
+            s3Client.putObject(new PutObjectRequest(s3Bucket, key, new ByteArrayInputStream(contentsBytes), s3Metadata));
 
-        Path p = new Path("lakefs://repo/main/read.me");
-        mockStatObject("repo", "main", "read.me", physicalKey, (long)contentsBytes.length);
-        try (InputStream in = fs.open(p, readBufferSize)) {
-            String actual = IOUtils.toString(in);
-            Assert.assertEquals(contents, actual);
+            Path p = new Path("lakefs://repo/main/read.me");
+            mockStatObject("repo", "main", "read.me", key, (long) contentsBytes.length);
+            try (InputStream in = fs.open(p, readBufferSize)) {
+                String actual = IOUtils.toString(in);
+                Assert.assertEquals(contents, actual);
+            }
         }
     }
     


### PR DESCRIPTION
<!-- 
Hello Axolotl!
Thank you for contributing to the lakeFS project.
We appreciate the time invested in this pull request and created this template to help make this process easier.
It's really important to have all the information and context, to ensure we can properly address this PR 
Please use the following references to fill out the pull request.
--> 

### Linked Issue

Closes #5827
---

## Change Description

### Background

Fix instances where we try to create a URI from a string with illegal characters.
Re-introduce hadoopfs unit tests to github pipeline

### Bug Fix

The solution was to pass through a hadoop Path object which knows how to deal with illegal characters and provide a valid URI object
      
### Testing Details

Added unit test for open with the appropriate scenario.
Note that we cannot use junit parameterization due to how we built our test class and the fact that static methods are not supported for inner classes in java 8
