### PR TITLE
Make the login box a bit wider

### DIFF
--- a/webui/src/pages/auth/login.tsx
+++ b/webui/src/pages/auth/login.tsx
@@ -34,7 +34,7 @@ const LoginForm = ({loginConfig}: {loginConfig: LoginConfig}) => {
 
     return (
         <Row>
-            <Col md={{offset: 5, span: 2}}>
+            <Col md={{offset: 4, span: 4}}>
                 <Card className="login-widget">
                     <Card.Header>Login</Card.Header>
                     <Card.Body>


### PR DESCRIPTION
<!-- 
Hello Axolotl!
Thank you for contributing to the lakeFS project.
We appreciate the time invested in this pull request and created this template to help make this process easier.
It's really important to have all the information and context, to ensure we can properly address this PR 
Please use the following references to fill out the pull request.
--> 

### Linked Issue

Closes #6088

---

## Change Description

### Background

The login box doesn't make much use of the horizontal space, which is a shame given the typical length of an access key. It also feels out of proportion with the rest of the page. 

![image](https://github.com/treeverse/lakeFS/assets/3671582/073662c6-55c6-4546-aece-afdc02ecec7f)

     
### New Feature

This PR makes it wider

![image](https://github.com/treeverse/lakeFS/assets/3671582/508d0db1-6e91-4145-a878-cfda9a0e7431)

### Testing Details

Tested manually, see screenshot above