### PR TITLE
Fix: s3 gateway returning 200 instead of 206 for range requests

### DIFF
--- a/pkg/gateway/operations/getobject.go
+++ b/pkg/gateway/operations/getobject.go
@@ -61,9 +61,9 @@ func (controller *GetObject) Handle(w http.ResponseWriter, req *http.Request, o 
 		_ = o.EncodeError(w, req, gatewayerrors.Codes.ToAPIErr(gatewayerrors.ErrInternalError))
 		return
 	}
-
 	o.SetHeader(w, "Last-Modified", httputil.HeaderTimestamp(entry.CreationDate))
 	o.SetHeader(w, "ETag", httputil.ETag(entry.Checksum))
+	o.SetHeader(w, "Content-Type", entry.ContentType)
 	o.SetHeader(w, "Accept-Ranges", "bytes")
 	amzMetaWriteHeaders(w, entry.Metadata)
 	// TODO: the rest of https://docs.aws.amazon.com/en_pv/AmazonS3/latest/API/API_GetObject.html
@@ -97,8 +97,6 @@ func (controller *GetObject) Handle(w http.ResponseWriter, req *http.Request, o 
 			return
 		}
 	} else {
-		o.SetHeader(w, "Content-Type", entry.ContentType)
-		o.SetHeader(w, "X-AMZ-Content-Range", "yes")
 		contentRange := fmt.Sprintf("bytes %d-%d/%d", rng.StartOffset, rng.EndOffset, entry.Size)
 		o.SetHeader(w, "Content-Range", contentRange)
 		o.SetHeader(w, "Content-Length", fmt.Sprintf("%d", rng.Size()))

--- a/pkg/gateway/operations/getobject.go
+++ b/pkg/gateway/operations/getobject.go
@@ -88,6 +88,7 @@ func (controller *GetObject) Handle(w http.ResponseWriter, req *http.Request, o 
 			Identifier:       entry.PhysicalAddress,
 		}, entry.Size)
 	} else {
+		w.WriteHeader(http.StatusPartialContent)
 		expected = rng.EndOffset - rng.StartOffset + 1 // both range ends are inclusive
 		data, err = o.BlockStore.GetRange(req.Context(), block.ObjectPointer{
 			StorageNamespace: o.Repository.StorageNamespace,

--- a/pkg/gateway/operations/headobject.go
+++ b/pkg/gateway/operations/headobject.go
@@ -44,7 +44,6 @@ func (controller *HeadObject) Handle(w http.ResponseWriter, req *http.Request, o
 	}
 
 	// range query
-	var expected int64
 	var rng httputil.Range
 	var rngErr error
 	// range query
@@ -59,18 +58,18 @@ func (controller *HeadObject) Handle(w http.ResponseWriter, req *http.Request, o
 			}
 		}
 	}
-	if rangeSpec != "" && rngErr == nil {
-		expected = rng.Size()
-		w.WriteHeader(http.StatusPartialContent)
-		o.SetHeader(w, "Content-Range", fmt.Sprintf("bytes %d-%d/%d", rng.StartOffset, rng.EndOffset, entry.Size))
-	} else {
-		expected = entry.Size
-	}
 
 	o.SetHeader(w, "Accept-Ranges", "bytes")
 	o.SetHeader(w, "Last-Modified", httputil.HeaderTimestamp(entry.CreationDate))
 	o.SetHeader(w, "ETag", httputil.ETag(entry.Checksum))
-	o.SetHeader(w, "Content-Length", fmt.Sprintf("%d", expected))
 	o.SetHeader(w, "Content-Type", entry.ContentType)
+
 	amzMetaWriteHeaders(w, entry.Metadata)
+	if rangeSpec != "" && rngErr == nil {
+		o.SetHeader(w, "Content-Length", fmt.Sprintf("%d", rng.Size()))
+		o.SetHeader(w, "Content-Range", fmt.Sprintf("bytes %d-%d/%d", rng.StartOffset, rng.EndOffset, entry.Size))
+		w.WriteHeader(http.StatusPartialContent)
+	} else {
+		o.SetHeader(w, "Content-Length", fmt.Sprintf("%d", entry.Size))
+	}
 }

--- a/pkg/httputil/range.go
+++ b/pkg/httputil/range.go
@@ -19,6 +19,7 @@ type Range struct {
 func (r Range) String() string {
 	return fmt.Sprintf("start=%d, end=%d (total=%d)", r.StartOffset, r.EndOffset, r.EndOffset-r.StartOffset+1)
 }
+
 func (r Range) Size() int64 {
 	return r.EndOffset - r.StartOffset + 1
 }
@@ -48,10 +49,9 @@ func ParseRange(spec string, length int64) (Range, error) {
 		if err != nil {
 			return r, ErrBadRange
 		}
+		r.StartOffset = length - endOffset
 		if length-endOffset < 0 {
 			r.StartOffset = 0
-		} else {
-			r.StartOffset = length - endOffset
 		}
 		r.EndOffset = length - 1
 		return r, nil

--- a/pkg/httputil/range.go
+++ b/pkg/httputil/range.go
@@ -1,12 +1,14 @@
 package httputil
 
 import (
+	"errors"
 	"fmt"
 	"strconv"
 	"strings"
 )
 
-var ErrBadRange = fmt.Errorf("unsatisfiable range")
+var ErrBadRange = errors.New("invalid range")
+var ErrUnsatisfiableRange = errors.New("unsatisfiable range")
 
 // Range represents an RFC 2616 HTTP Range
 type Range struct {
@@ -16,6 +18,9 @@ type Range struct {
 
 func (r Range) String() string {
 	return fmt.Sprintf("start=%d, end=%d (total=%d)", r.StartOffset, r.EndOffset, r.EndOffset-r.StartOffset+1)
+}
+func (r Range) Size() int64 {
+	return r.EndOffset - r.StartOffset + 1
 }
 
 // ParseRange parses an HTTP RFC 2616 Range header value and returns an Range object for the given object length
@@ -40,18 +45,24 @@ func ParseRange(spec string, length int64) (Range, error) {
 	// negative only
 	if len(fromString) == 0 {
 		endOffset, err := strconv.ParseInt(toString, 10, 64) //nolint: gomnd
-		if err != nil || endOffset > length {
+		if err != nil {
 			return r, ErrBadRange
 		}
-		r.StartOffset = length - endOffset
+		if length-endOffset < 0 {
+			r.StartOffset = 0
+		} else {
+			r.StartOffset = length - endOffset
+		}
 		r.EndOffset = length - 1
 		return r, nil
 	}
 	// positive only
 	if len(toString) == 0 {
 		beginOffset, err := strconv.ParseInt(fromString, 10, 64) //nolint: gomnd
-		if err != nil || beginOffset > length-1 {
+		if err != nil {
 			return r, ErrBadRange
+		} else if beginOffset > length-1 {
+			return r, ErrUnsatisfiableRange
 		}
 		r.StartOffset = beginOffset
 		r.EndOffset = length - 1
@@ -70,8 +81,9 @@ func ParseRange(spec string, length int64) (Range, error) {
 	if endOffset > length-1 {
 		endOffset = length - 1
 	}
+	// if the beginning offset is after the size, it is unsatisfiable
 	if beginOffset > length-1 || endOffset > length-1 {
-		return r, ErrBadRange
+		return r, ErrUnsatisfiableRange
 	}
 	r.StartOffset = beginOffset
 	r.EndOffset = endOffset

--- a/pkg/httputil/range_test.go
+++ b/pkg/httputil/range_test.go
@@ -1,6 +1,7 @@
 package httputil_test
 
 import (
+	"errors"
 	"fmt"
 	"testing"
 
@@ -11,40 +12,54 @@ func TestParseRange(t *testing.T) {
 	cases := []struct {
 		Spec          string
 		Length        int
-		ExpectedError bool
+		ExpectedError error
 		ExpectedStart int
 		ExpectedEnd   int
+		ExpectedSize  int
 	}{
-		{"bytes=0-20", 50, false, 0, 20},
-		{"bytes=0-20", 10, false, 0, 9},
-		{"bytes=-20", 50, false, 30, 49},
-		{"bytes=20-", 50, false, 20, 49},
-		{"bytes=-20", 10, true, 0, 0},
-		{"bytes=0-20", 20, false, 0, 19},
-		{"bytes=0-19", 20, false, 0, 19},
-		{"bytes=-0-19", 20, true, 0, 0},
-		{"bytess=0-19", 20, true, 0, 0},
-		{"0-19", 20, true, 0, 0},
-		{"bytes=-", 20, true, 0, 0},
-		{"bytes=0-foo", 20, true, 0, 0},
-		{"bytes=foo-19", 20, true, 0, 0},
-		{"bytes=21-", 20, true, 0, 0},
+		{"bytes=0-20", 50, nil, 0, 20, 21},
+		{"bytes=0-20", 10, nil, 0, 9, 10},
+		{"bytes=-20", 50, nil, 30, 49, 20},
+		{"bytes=20-", 50, nil, 20, 49, 30},
+		{"bytes=-20", 10, nil, 0, 9, 10},
+		{"bytes=0-20", 20, nil, 0, 19, 20},
+		{"bytes=0-19", 20, nil, 0, 19, 20},
+		{"bytes=1-300", 20, nil, 1, 19, 19},
+		{"bytes=-0-19", 20, httputil.ErrBadRange, 0, 0, 0},
+		{"bytess=0-19", 20, httputil.ErrBadRange, 0, 0, 0},
+		{"0-19", 20, httputil.ErrBadRange, 0, 0, 0},
+		{"bytes=-", 20, httputil.ErrBadRange, 0, 0, 0},
+		{"bytes=0-foo", 20, httputil.ErrBadRange, 0, 0, 0},
+		{"bytes=foo-19", 20, httputil.ErrBadRange, 0, 0, 0},
+		{"bytes=20-", 20, httputil.ErrUnsatisfiableRange, 0, 0, 0},
+		{"bytes=21-", 20, httputil.ErrUnsatisfiableRange, 0, 0, 0},
+		{"bytes=19-", 20, nil, 19, 19, 1},
 	}
 
 	for _, c := range cases {
 		t.Run(fmt.Sprintf("%s_length_%d", c.Spec, c.Length), func(t *testing.T) {
 			r, err := httputil.ParseRange(c.Spec, int64(c.Length))
-			if (err != nil) != c.ExpectedError {
-				t.Fatalf("got err=%s, expected error %t", err, c.ExpectedError)
+			if c.ExpectedError != nil && err == nil {
+				t.Fatalf("epxected error: %s, got nil!", c.ExpectedError)
+			}
+			if c.ExpectedError == nil && err != nil {
+				t.Fatalf("unepxected error: %s!", err)
+			}
+			if c.ExpectedError != nil && err != nil && !errors.Is(err, c.ExpectedError) {
+				t.Fatalf("epxected error: %s, got %s!", c.ExpectedError, err)
 			}
 			if err != nil {
 				return
 			}
+
 			if r.EndOffset != int64(c.ExpectedEnd) {
 				t.Fatalf("expected end offset: %d, got %d", c.ExpectedEnd, r.EndOffset)
 			}
 			if r.StartOffset != int64(c.ExpectedStart) {
 				t.Fatalf("expected start offset: %d, got %d", c.ExpectedStart, r.StartOffset)
+			}
+			if r.Size() != int64(c.ExpectedSize) {
+				t.Fatalf("expected size: %d, got %d", c.ExpectedSize, r.Size())
 			}
 		})
 	}

--- a/pkg/httputil/range_test.go
+++ b/pkg/httputil/range_test.go
@@ -39,14 +39,8 @@ func TestParseRange(t *testing.T) {
 	for _, c := range cases {
 		t.Run(fmt.Sprintf("%s_length_%d", c.Spec, c.Length), func(t *testing.T) {
 			r, err := httputil.ParseRange(c.Spec, int64(c.Length))
-			if c.ExpectedError != nil && err == nil {
-				t.Fatalf("epxected error: %s, got nil!", c.ExpectedError)
-			}
-			if c.ExpectedError == nil && err != nil {
-				t.Fatalf("unepxected error: %s!", err)
-			}
-			if c.ExpectedError != nil && err != nil && !errors.Is(err, c.ExpectedError) {
-				t.Fatalf("epxected error: %s, got %s!", c.ExpectedError, err)
+			if !errors.Is(err, c.ExpectedError) {
+				t.Fatalf("epxected error: %v, got %v!", c.ExpectedError, err)
 			}
 			if err != nil {
 				return


### PR DESCRIPTION
Fixes #6100 
Notably, this bug currently impacts duckdb-wasm - the browser itself might cache a range request's response and reuse the response when responding to requests to the same file on another range (ouch).

@rmoff  - this should also unblock the improved quickstart from using duckdb-wasm to write.