### PR TITLE
duckdb: handle line breaks after a string constant

### DIFF
--- a/webui/src/pages/repositories/repository/fileRenderers/duckdb.tsx
+++ b/webui/src/pages/repositories/repository/fileRenderers/duckdb.tsx
@@ -43,7 +43,7 @@ async function getDuckDB(): Promise<duckdb.AsyncDuckDB> {
 // taken from @duckdb/duckdb-wasm/dist/types/src/bindings/tokens.d.ts
 // which, unfortunately, we cannot import.
 const DUCKDB_STRING_CONSTANT = 2;
-const LAKEFS_URI_PATTERN = /^(['"]?)(lakefs:\/\/(.*))(['"])$/;
+const LAKEFS_URI_PATTERN = /^(['"]?)(lakefs:\/\/(.*))(['"])\s*$/;
 
 // returns a mapping of `lakefs://..` URIs to their `s3://...` equivalent
 async function extractFiles(conn: AsyncDuckDBConnection, sql: string): Promise<{ [name: string]: string }> {
@@ -94,16 +94,7 @@ export async function runDuckDBQuery(sql: string):  Promise<arrow.Table<any>> {
         // remove registrations
         await Promise.all(fileNames.map(fileName => db.dropFile(fileName)))
     } finally {
-        await closeDuckDBConnection(conn)
-    }
-    return result
-}
-
-async function closeDuckDBConnection(conn: AsyncDuckDBConnection | null) {
-    if (conn !== null) {
         await conn.close()
     }
-    const db = await getDuckDB()
-    await db.flushFiles()
-    await db.dropFiles()
+    return result
 }


### PR DESCRIPTION
Fixes #6107

DuckDB's tokenizer returns only starting offsets, not ending ones. since whitespaces are meaningless in SQL, the next token might only appear after line breaks or spaces.

This fixes handling of trailing whitespaces.

Additionally, this PR removes the unnecessary cleanup done after closing the connection - calling `dropFiles` when there are no files to drop returns a promise that never rejects nor accepts - resulting in a query browser that appears stuck (potentially, closes #6095 together with #6101)