### PR TITLE
Fix broken Onboarding link

### DIFF
--- a/docs/hooks/index.md
+++ b/docs/hooks/index.md
@@ -8,6 +8,7 @@ nav_order: 29
 redirect_from:
   - /reference/hooks.html
   - /hooks.html
+  - /hooks/overview.html
 ---
 
 # lakeFS Hooks

--- a/webui/src/lib/onboarding/repoOnboardingService.tsx
+++ b/webui/src/lib/onboarding/repoOnboardingService.tsx
@@ -176,7 +176,7 @@ export const getRepoOnboardingSteps = (
       "Create simple hooks to validate new data meets certain requirements: schema validation, metadata registration, and more.",
     cta: "Configure",
     onClick: () =>
-      window.open("https://docs.lakefs.io/hooks/overview.html", "_blank"),
+      window.open("https://docs.lakefs.io/hooks/", "_blank"),
     showStep: () => true,
     isCompleted: async () => {
       try {


### PR DESCRIPTION
### Linked Issue

Closes #6119

---

## Change Description

### Background

In-product Onboarding links to /hooks/overview.html which doesn't exist.


### Bug Fix

1. Create a redirect for /hooks/overview.html to /hooks/index.html
2. Fix the link in the onboarding code
      
(1) will fix the immediate issue until (2) is published in the next release


### Testing Details

Manually

