### PR TITLE
Remove metrics dynamo_{request_duration_seconds,failures_total}

### DIFF
--- a/pkg/kv/dynamodb/stats.go
+++ b/pkg/kv/dynamodb/stats.go
@@ -5,26 +5,9 @@ import (
 	"github.com/prometheus/client_golang/prometheus/promauto"
 )
 
-const (
-	dynamoRequestDurationStart  = 0.001
-	dynamoRequestDurationFactor = 4
-	dynamoRequestDurationCount  = 9 // use 9 buckets from 1ms to just over 1 minute (65s).
-)
-
 var (
-	dynamoRequestDuration = promauto.NewHistogramVec(prometheus.HistogramOpts{
-		Name:    "dynamo_request_duration_seconds",
-		Help:    "Time spent doing DynamoDB requests.",
-		Buckets: prometheus.ExponentialBuckets(dynamoRequestDurationStart, dynamoRequestDurationFactor, dynamoRequestDurationCount),
-	}, []string{"operation"})
-
 	dynamoConsumedCapacity = promauto.NewCounterVec(prometheus.CounterOpts{
 		Name: "dynamo_consumed_capacity_total",
 		Help: "The capacity units consumed by operation.",
-	}, []string{"operation"})
-
-	dynamoFailures = promauto.NewCounterVec(prometheus.CounterOpts{
-		Name: "dynamo_failures_total",
-		Help: "The total number of errors while working for kv store.",
 	}, []string{"operation"})
 )

--- a/pkg/kv/dynamodb/store.go
+++ b/pkg/kv/dynamodb/store.go
@@ -122,7 +122,7 @@ func isTableExist(ctx context.Context, svc *dynamodb.DynamoDB, table string) (bo
 		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == dynamodb.ErrCodeResourceNotFoundException {
 			return false, nil
 		}
-		return false, handleClientError(operation, err)
+		return false, handleClientError(err)
 	}
 	return true, nil
 }
@@ -216,7 +216,7 @@ func (s *Store) Get(ctx context.Context, partitionKey, key []byte) (*kv.ValueWit
 	})
 	const operation = "GetItem"
 	if err != nil {
-		return nil, fmt.Errorf("get item: %w", handleClientError(operation, err))
+		return nil, fmt.Errorf("get item: %w", handleClientError(err))
 	}
 	if result.ConsumedCapacity != nil {
 		dynamoConsumedCapacity.WithLabelValues(operation).Add(*result.ConsumedCapacity.CapacityUnits)
@@ -299,7 +299,7 @@ func (s *Store) setWithOptionalPredicate(ctx context.Context, partitionKey, key,
 		if _, ok := err.(*dynamodb.ConditionalCheckFailedException); ok && usePredicate {
 			return kv.ErrPredicateFailed
 		}
-		return fmt.Errorf("put item: %w", handleClientError(operation, err))
+		return fmt.Errorf("put item: %w", handleClientError(err))
 	}
 	if resp.ConsumedCapacity != nil {
 		dynamoConsumedCapacity.WithLabelValues(operation).Add(*resp.ConsumedCapacity.CapacityUnits)
@@ -322,7 +322,7 @@ func (s *Store) Delete(ctx context.Context, partitionKey, key []byte) error {
 	})
 	const operation = "DeleteItem"
 	if err != nil {
-		return fmt.Errorf("delete item: %w", handleClientError(operation, err))
+		return fmt.Errorf("delete item: %w", handleClientError(err))
 	}
 	if resp.ConsumedCapacity != nil {
 		dynamoConsumedCapacity.WithLabelValues(operation).Add(*resp.ConsumedCapacity.CapacityUnits)
@@ -392,7 +392,7 @@ func (s *Store) scanInternal(ctx context.Context, keyConditionExpression string,
 	queryOutput, err := s.svc.QueryWithContext(ctx, queryInput)
 	const operation = "Query"
 	if err != nil {
-		return nil, fmt.Errorf("query: %w", handleClientError(operation, err))
+		return nil, fmt.Errorf("query: %w", handleClientError(err))
 	}
 	dynamoConsumedCapacity.WithLabelValues(operation).Add(*queryOutput.ConsumedCapacity.CapacityUnits)
 
@@ -497,7 +497,7 @@ func (s *Store) StopPeriodicCheck() {
 	}
 }
 
-func handleClientError(operation string, err error) error {
+func handleClientError(err error) error {
 	// extract original error if needed
 	var reqErr awserr.Error
 	if errors.As(err, &reqErr) && errors.Is(reqErr.OrigErr(), context.Canceled) {

--- a/pkg/kv/dynamodb/store.go
+++ b/pkg/kv/dynamodb/store.go
@@ -117,7 +117,6 @@ func isTableExist(ctx context.Context, svc *dynamodb.DynamoDB, table string) (bo
 	_, err := svc.DescribeTableWithContext(ctx, &dynamodb.DescribeTableInput{
 		TableName: aws.String(table),
 	})
-	const operation = "DescribeTable"
 	if err != nil {
 		if awsErr, ok := err.(awserr.Error); ok && awsErr.Code() == dynamodb.ErrCodeResourceNotFoundException {
 			return false, nil

--- a/pkg/kv/metrics.go
+++ b/pkg/kv/metrics.go
@@ -12,7 +12,7 @@ var (
 		prometheus.HistogramOpts{
 			Name:    "kv_request_duration_seconds",
 			Help:    "request durations for the kv Store",
-			Buckets: []float64{0.01, 0.05, 0.1, 0.2, 0.25, 0.5, 1, 2.5, 5, 10},
+			Buckets: []float64{0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10},
 		},
 		[]string{"type", "operation"})
 


### PR DESCRIPTION
They are already covered by kv_request_duration_seconds,
kv_request_failures_total.  The first in particular is a histogram, so many
data streams.

Fixes #6125.