### PR TITLE
Support .text as a text file extension in the Web UI

### DIFF
--- a/webui/src/lib/components/repository/ObjectsDiff.jsx
+++ b/webui/src/lib/components/repository/ObjectsDiff.jsx
@@ -8,7 +8,7 @@ import Alert from "react-bootstrap/Alert";
 import {InfoIcon} from "@primer/octicons-react";
 
 const maxDiffSizeBytes = 120 << 10;
-const supportedReadableFormats = ["txt", "csv", "tsv", "text"];
+const supportedReadableFormats = ["txt", "text", "csv", "tsv", "yaml", "yml", "json"];
 
 export const ObjectsDiff = ({diffType, repoId, leftRef, rightRef, path}) => {
     const readable = readableObject(path);
@@ -64,9 +64,13 @@ function readableObject(path) {
 }
 
 const NoContentDiff = ({left, right, diffType}) => {
+    const supportedFileExtensions = supportedReadableFormats.map((fileType) => `.${fileType}`);
+    // use the list formatter in place of manual formatting
+    // ref: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/ListFormat
+    const formatter = new Intl.ListFormat('en', { style: "long", type: "conjunction" });
     return <div>
         <span><StatDiff left={left} right={right} diffType={diffType}/></span>
-        <span><Alert variant="light"><InfoIcon/> lakeFS supports content diff for .tsv, .csv, and .txt file formats only</Alert></span>
+        <span><Alert variant="light"><InfoIcon/> {`lakeFS supports content diff for ${formatter.format(supportedFileExtensions)} file formats only`}</Alert></span>
     </div>;
 }
 

--- a/webui/src/pages/repositories/repository/fileRenderers/index.tsx
+++ b/webui/src/pages/repositories/repository/fileRenderers/index.tsx
@@ -138,6 +138,9 @@ export function guessType(contentType: string | null, fileExtension: string | nu
             return FileType.PDF
         case 'txt':
         case 'text':
+        case 'yaml':
+        case 'yml':
+        case 'json':
             return FileType.TEXT
     }
     if (guessLanguage(fileExtension, contentType))


### PR DESCRIPTION
## Change Description

### Background

The lakeFS web UI supports `.txt` as a text file extension, but not `.text`. The latter is still a text file and used by, amongst other things, Apache Iceberg in its metadata. 

This fix adds support for `.text` to the web UI.
      
### New Feature

`.text` files are also supported for viewing and diff'ing.

### Testing Details

Locally built and tested the change. 

#### Object viewer

![image](https://github.com/treeverse/lakeFS/assets/3671582/2fcc7839-be62-44aa-8efe-b77faad1c8b1)

#### Diff

![image](https://github.com/treeverse/lakeFS/assets/3671582/3194472b-af08-41f5-9750-762e7ac564f0)


### Breaking Change?

No
