### PR TITLE
Add check for broken outbound links from the UI 

### DIFF
--- a/.github/workflows/check-ui-links.yaml
+++ b/.github/workflows/check-ui-links.yaml
@@ -2,9 +2,6 @@ name: Check links from the UI
 
 on:
   pull_request:
-    # paths:
-    #   - "webui/**"
-    #   - "docs/**"
     branches:
       - master
 

--- a/.github/workflows/check-ui-links.yaml
+++ b/.github/workflows/check-ui-links.yaml
@@ -56,7 +56,7 @@ jobs:
       - name: Check Lychee output
         run: |
           if grep "Errors per input" /tmp/lychee/results.md; then
-            echo "## 🙀 Links found in the lakeFS UI that are broken" > $GITHUB_STEP_SUMMARY
+            echo "## 🙀 Outbuond links found in the lakeFS UI that are broken" > $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
 
             while IFS= read -r line; do
@@ -74,6 +74,6 @@ jobs:
 
             exit 1
           else
-            echo "## ✅ All links found in the lakeFS UI are working" > $GITHUB_STEP_SUMMARY
+            echo "## ✅ All outbound links found in the lakeFS UI are working" > $GITHUB_STEP_SUMMARY
             exit 0
           fi

--- a/.github/workflows/check-ui-links.yaml
+++ b/.github/workflows/check-ui-links.yaml
@@ -6,7 +6,6 @@ on:
       - master
 
 jobs:
-  # This job name kept short because it's used in the preview URL
   preview:
     name: Check links from UI
     runs-on: ubuntu-20.04
@@ -19,7 +18,7 @@ jobs:
         with:
           working-directory: docs
           ruby-version: '2.7'
-          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+          bundler-cache: true 
 
       - name: Build latest
         working-directory: docs
@@ -47,8 +46,6 @@ jobs:
           jobSummary: false
           format: markdown
           output: /tmp/lychee/results.md
-        # env:
-        #   GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Check Lychee output
         run: |

--- a/.github/workflows/check-ui-links.yaml
+++ b/.github/workflows/check-ui-links.yaml
@@ -58,9 +58,22 @@ jobs:
           if grep "Errors per input" /tmp/lychee/results.md; then
             echo "## 🙀 Links found in the lakeFS UI that are broken" > $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-            sed 's/^.*docs\/_site//g' /tmp/lychee/results.md >> $GITHUB_STEP_SUMMARY
 
-            for a in 
+            # sed 's/^.*docs\/_site//g' 
+
+            sed -e '/## Errors per input/,$d' /tmp/lychee/results.md >> $GITHUB_STEP_SUMMARY
+
+            echo "## Broken links found" >> $GITHUB_STEP_SUMMARY
+            while IFS= read -r line; do
+              if [[ $line =~ .*docs/_site(.*)\].* ]]; then
+                  search_phrase="${BASH_REMATCH[1]}"
+                  matching_files=$(grep -lr "$search_phrase" "webui/src")
+                  echo "🚨 Broken reference to \`$search_phrase\` found in \`$matching_files\`"
+                  echo
+              fi
+            done < /tmp/lychee/results.md        
+            
+            cat $GITHUB_STEP_SUMMARY
 
             exit 1
           else

--- a/.github/workflows/check-ui-links.yaml
+++ b/.github/workflows/check-ui-links.yaml
@@ -4,7 +4,9 @@ on:
   pull_request:
     branches:
       - master
-
+  schedule:
+    - cron: '0 1 * * *' # once a day at 1 am
+    
 jobs:
   preview:
     name: Check links from UI

--- a/.github/workflows/check-ui-links.yaml
+++ b/.github/workflows/check-ui-links.yaml
@@ -30,9 +30,11 @@ jobs:
 
       - name: Get links to check
         id: get-links
-        working-directory: /
         run: |
           escaped_pwd=$(pwd | sed 's/[\/&]/\\&/g')
+          echo $pwd
+          echo $escaped_pwd
+          ls -l 
 
           find webui/src -type f ! -name "*.js" -exec grep -Eo 'href="([^"]*)"' {} \; | \
             cut -d'"' -f2 | \

--- a/.github/workflows/check-ui-links.yaml
+++ b/.github/workflows/check-ui-links.yaml
@@ -54,6 +54,7 @@ jobs:
         #   GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Check Lychee output
+        shell: bash
         run: |
           if grep "Errors per input" /tmp/lychee/results.md; then
             echo "## 🙀 Links found in the lakeFS UI that are broken" > $GITHUB_STEP_SUMMARY

--- a/.github/workflows/check-ui-links.yaml
+++ b/.github/workflows/check-ui-links.yaml
@@ -46,8 +46,21 @@ jobs:
         uses: lycheeverse/lychee-action@v1.7.0
         with:
           args: /tmp/links_to_check.txt
-          fail: true
-          jobSummary: true
+          fail: false
+          jobSummary: false
           format: markdown
-        env:
-          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          output: /tmp/lychee/results.md
+        # env:
+        #   GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+
+      - name: Check Lychee output
+        run: |
+          if grep "Errors per input" /tmp/lychee.md; then
+            echo "## 🙀 Links found in the lakeFS UI that are broken" > $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            sed 's/^.*docs\/_site//g' /tmp/lychee.md >> $GITHUB_STEP_SUMMARY
+            exit 1
+          else
+            echo "## ✅ All links found in the lakeFS UI are working" > $GITHUB_STEP_SUMMARY
+            exit 0
+          fi

--- a/.github/workflows/check-ui-links.yaml
+++ b/.github/workflows/check-ui-links.yaml
@@ -55,10 +55,13 @@ jobs:
 
       - name: Check Lychee output
         run: |
-          if grep "Errors per input" /tmp/lychee.md; then
+          if grep "Errors per input" /tmp/lychee/results.md; then
             echo "## 🙀 Links found in the lakeFS UI that are broken" > $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
-            sed 's/^.*docs\/_site//g' /tmp/lychee.md >> $GITHUB_STEP_SUMMARY
+            sed 's/^.*docs\/_site//g' /tmp/lychee/results.md >> $GITHUB_STEP_SUMMARY
+
+            for a in 
+
             exit 1
           else
             echo "## ✅ All links found in the lakeFS UI are working" > $GITHUB_STEP_SUMMARY

--- a/.github/workflows/check-ui-links.yaml
+++ b/.github/workflows/check-ui-links.yaml
@@ -54,25 +54,21 @@ jobs:
         #   GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
 
       - name: Check Lychee output
-        shell: bash
         run: |
           if grep "Errors per input" /tmp/lychee/results.md; then
             echo "## 🙀 Links found in the lakeFS UI that are broken" > $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
 
-            # sed 's/^.*docs\/_site//g' 
-
-            sed -e '/## Errors per input/,$d' /tmp/lychee/results.md >> $GITHUB_STEP_SUMMARY
-
-            echo "## Broken links found" >> $GITHUB_STEP_SUMMARY
             while IFS= read -r line; do
               if [[ $line =~ .*docs/_site(.*)\].* ]]; then
                   search_phrase="${BASH_REMATCH[1]}"
                   matching_files=$(grep -lr "$search_phrase" "webui/src")
-                  echo "🚨 Broken reference to \`$search_phrase\` found in \`$matching_files\`"
-                  echo
+                  echo "* 🚨 Broken reference to \`$search_phrase\` found in \`$matching_files\`" >> $GITHUB_STEP_SUMMARY
               fi
             done < /tmp/lychee/results.md        
+            echo "" >> $GITHUB_STEP_SUMMARY
+
+            sed -e '/## Errors per input/,$d' /tmp/lychee/results.md >> $GITHUB_STEP_SUMMARY
             
             cat $GITHUB_STEP_SUMMARY
 

--- a/.github/workflows/check-ui-links.yaml
+++ b/.github/workflows/check-ui-links.yaml
@@ -1,0 +1,67 @@
+name: Docs Preview and Link Check
+
+on:
+  pull_request:
+    paths:
+      - "docs/**"
+    branches:
+      - master
+
+jobs:
+  # This job name kept short because it's used in the preview URL
+  preview:
+    name: Docs PR - Publish preview and check links
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Check-out
+        uses: actions/checkout@v3
+
+      - name: Setup Ruby
+        uses: ruby/setup-ruby@v1
+        with:
+          working-directory: docs
+          ruby-version: '2.7'
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
+
+      - name: Build latest
+        id: build-latest
+        working-directory: docs
+        run: bundle exec jekyll build --config _config.yml -d _site/ --verbose
+
+      - name: Overlay PR message on each page
+        working-directory: docs/_site
+        run: |
+          PR_URL=${{ github.event.pull_request.html_url }}
+          PR_NUMBER=${{ github.event.pull_request.number }}
+
+          html_files=$(find . -name '*.html')
+
+          for file in $html_files; do
+            sed -i -e "s|\(.*\)\(</body>\)|<div style=\"position: fixed; top: 5px; left: 5px; padding: 3px; background-color: #e8ac07; font-weight: bold; z-index: 9999; box-shadow: 0 0 10px rgba(0,0,0,0.5);\">ℹ️ This is a preview of PR <a href=\"$PR_URL\" style=\"color: black;\">#$PR_NUMBER</a></div>\n\1\2|" $file
+          done
+       
+      - name: Publish preview site
+        uses: afc163/surge-preview@v1
+        id: preview_step
+        with:
+          surge_token: ${{ secrets.SURGE_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          dist: docs/_site
+          failOnError: true
+          teardown: true
+          build: |
+            echo Deploying preview to surge.sh
+
+      - name: Get the preview_url
+        run: echo "url => https://${{ steps.preview_step.outputs.preview_url }}"
+
+      - name: Check links
+        id: lychee
+        uses: lycheeverse/lychee-action@v1.7.0
+        with:
+          args: docs/_site --no-progress --exclude-file=docs/.lycheeignore
+          fail: true
+          jobSummary: true
+          format: markdown
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/check-ui-links.yaml
+++ b/.github/workflows/check-ui-links.yaml
@@ -2,9 +2,9 @@ name: Check links from the UI
 
 on:
   pull_request:
-    paths:
-      - "webui/**"
-      - "docs/**"
+    # paths:
+    #   - "webui/**"
+    #   - "docs/**"
     branches:
       - master
 

--- a/.github/workflows/check-ui-links.yaml
+++ b/.github/workflows/check-ui-links.yaml
@@ -32,18 +32,10 @@ jobs:
         id: get-links
         working-directory: /
         run: |
-          function search_links_in_files() {
-              local folder_path="webui/src"
-              find "$folder_path" -type f ! -name "*.js" -print0 | while IFS= read -r -d '' file; do
-                grep -Eo 'href="([^"]*)"' "$file" | cut -d'"' -f2 | while IFS= read -r link; do
-                  # echo "$link\tis linked to from\t$file"
-                  echo $link
-                done
-              done
-          }
-
           escaped_pwd=$(pwd | sed 's/[\/&]/\\&/g')
-          search_links_in_files | \
+
+          find webui/src -type f ! -name "*.js" -exec grep -Eo 'href="([^"]*)"' {} \; | \
+            cut -d'"' -f2 | \
             grep -v -e "^/" -e "^#" | \
             sed "s/https:\/\/docs.lakefs.io/file:\/\/$escaped_pwd\/docs\/_site/" > /tmp/links_to_check.txt
 

--- a/.github/workflows/check-ui-links.yaml
+++ b/.github/workflows/check-ui-links.yaml
@@ -1,8 +1,9 @@
-name: Docs Preview and Link Check
+name: Check links from the UI
 
 on:
   pull_request:
     paths:
+      - "webui/**"
       - "docs/**"
     branches:
       - master
@@ -10,7 +11,7 @@ on:
 jobs:
   # This job name kept short because it's used in the preview URL
   preview:
-    name: Docs PR - Publish preview and check links
+    name: Check links from UI
     runs-on: ubuntu-20.04
     steps:
       - name: Check-out
@@ -24,42 +25,33 @@ jobs:
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
       - name: Build latest
-        id: build-latest
         working-directory: docs
         run: bundle exec jekyll build --config _config.yml -d _site/ --verbose
 
-      - name: Overlay PR message on each page
-        working-directory: docs/_site
+      - name: Get links to check
+        id: get-links
+        working-directory: /
         run: |
-          PR_URL=${{ github.event.pull_request.html_url }}
-          PR_NUMBER=${{ github.event.pull_request.number }}
+          function search_links_in_files() {
+              local folder_path="webui/src"
+              find "$folder_path" -type f ! -name "*.js" -print0 | while IFS= read -r -d '' file; do
+                grep -Eo 'href="([^"]*)"' "$file" | cut -d'"' -f2 | while IFS= read -r link; do
+                  # echo "$link\tis linked to from\t$file"
+                  echo $link
+                done
+              done
+          }
 
-          html_files=$(find . -name '*.html')
-
-          for file in $html_files; do
-            sed -i -e "s|\(.*\)\(</body>\)|<div style=\"position: fixed; top: 5px; left: 5px; padding: 3px; background-color: #e8ac07; font-weight: bold; z-index: 9999; box-shadow: 0 0 10px rgba(0,0,0,0.5);\">ℹ️ This is a preview of PR <a href=\"$PR_URL\" style=\"color: black;\">#$PR_NUMBER</a></div>\n\1\2|" $file
-          done
-       
-      - name: Publish preview site
-        uses: afc163/surge-preview@v1
-        id: preview_step
-        with:
-          surge_token: ${{ secrets.SURGE_TOKEN }}
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          dist: docs/_site
-          failOnError: true
-          teardown: true
-          build: |
-            echo Deploying preview to surge.sh
-
-      - name: Get the preview_url
-        run: echo "url => https://${{ steps.preview_step.outputs.preview_url }}"
+          escaped_pwd=$(pwd | sed 's/[\/&]/\\&/g')
+          search_links_in_files | \
+            grep -v -e "^/" -e "^#" | \
+            sed "s/https:\/\/docs.lakefs.io/file:\/\/$escaped_pwd\/docs\/_site/" > /tmp/links_to_check.txt
 
       - name: Check links
         id: lychee
         uses: lycheeverse/lychee-action@v1.7.0
         with:
-          args: docs/_site --no-progress --exclude-file=docs/.lycheeignore
+          args: /tmp/links_to_check.txt
           fail: true
           jobSummary: true
           format: markdown

--- a/webui/src/pages/repositories/repository/actions/index.jsx
+++ b/webui/src/pages/repositories/repository/actions/index.jsx
@@ -165,7 +165,7 @@ const ActionsList = ({ repo, after, onPaginate, branch, commit, onFilterBranch, 
             {content}
             <div>
                 {/* eslint-disable-next-line react/jsx-no-target-blank */}
-                Actions can be configured to run when predefined events occur. <a href="https://docs.lakefs.io/setup/hooks.html" target="_blank">Learn more.</a>
+                Actions can be configured to run when predefined events occur. <a href="https://docs.lakefs.io/hooks.html" target="_blank">Learn more.</a>
             </div>
         </div>
     )


### PR DESCRIPTION
Nothing's going to upset a user more than wanting to **Learn more**:

![CleanShot_2023-06-29_at_17 48 27](https://github.com/treeverse/lakeFS/assets/3671582/c7e5161c-fb8a-4f5b-b16a-d2ceb20418cf)

and not being able to

![CleanShot_2023-06-29_at_17 48 48](https://github.com/treeverse/lakeFS/assets/3671582/816c2021-a122-4504-8f1e-9d36e5db00dc)

---

This new workflow scrapes the `webui/src` folder for any outbound links, builds the docs site, and then checks those links. 

[Here's](https://github.com/treeverse/lakeFS/actions/runs/5414711446) a test run in which it successfully identifies a broken link

![CleanShot_2023-06-29_at_17 50 07](https://github.com/treeverse/lakeFS/assets/3671582/e01ff41a-12c3-4abb-b418-652499e91d9b)

and [here is a successful run](https://github.com/treeverse/lakeFS/actions/runs/5414774722)