### PR TITLE
remove import iterator debug log

### DIFF
--- a/pkg/catalog/import.go
+++ b/pkg/catalog/import.go
@@ -96,7 +96,6 @@ func (i *Import) Ingest(it *walkEntryIterator) error {
 		return ErrImportClosed
 	}
 
-	i.logger.WithField("itr", it).Debug("Ingest start")
 	for it.Next() {
 		if err := i.set(*it.Value()); err != nil {
 			return err
@@ -105,7 +104,6 @@ func (i *Import) Ingest(it *walkEntryIterator) error {
 		i.status.Progress += 1
 		i.mu.Unlock()
 	}
-	i.logger.WithField("itr", it).Debug("Ingest finished")
 	return nil
 }
 


### PR DESCRIPTION
Remove debug log which capture iterator as field. log dump a list of pointers and `import_id`.
If we think we should still capture these log message I'll update the log call. Or approve to remove.

```
time="2023-07-03T14:33:41Z" level=debug msg="Ingest finished" func="pkg/catalog.(*Import).Ingest" file="build/pkg/catalog/import.go:108" import_id=cihdogv31pdmv82jh2tg itr="&***0xc00add23c0 0xc00b0039f8 0xc00b0d9a40 0xc00b0ec300 0xc00b003a10 *** <nil>*** ***  false*** ***" service_name=entry_catalog
```