### PR TITLE
Experimental unified GC

### DIFF
--- a/clients/spark/core/src/main/scala/io/treeverse/clients/LakeFSContext.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/LakeFSContext.scala
@@ -19,6 +19,16 @@ object LakeFSJobParams {
     new LakeFSJobParams(repoName = repoName, commitIDs = Seq(commitID), sourceName = sourceName)
   }
 
+  /** Use these parameters to list all entries from the given commits.
+   */
+  def forCommits(
+      repoName: String,
+      commitIDs: Iterable[String],
+      sourceName: String = ""
+  ): LakeFSJobParams = {
+    new LakeFSJobParams(repoName = repoName, commitIDs = commitIDs, sourceName = sourceName)
+  }
+
   /** Use these parameters to list all entries for in all ranges found in the storage namespace.
    *  The same entry may be listed multiple times if it is found in multiple ranges.
    */
@@ -83,6 +93,7 @@ object LakeFSContext {
   val LAKEFS_CONF_GC_INCREMENTAL = "lakefs.gc.incremental"
   val LAKEFS_CONF_GC_INCREMENTAL_FALLBACK_TO_FULL = "lakefs.gc.incremental.fallback_to_full"
   val LAKEFS_CONF_GC_INCREMENTAL_NTH_PREVIOUS_RUN = "lakefs.gc.incremental.use-nth-previous-run"
+  val LAKEFS_CONF_GC_EXPERIMENTAL_UNIFIED_GC = "lakefs.gc.experimental.unified_gc"
   val LAKEFS_CONF_DEBUG_GC_NO_DELETE_KEY = "lakefs.debug.gc.no_delete"
 
   val MARK_ID_KEY = "mark_id"

--- a/clients/spark/core/src/main/scala/io/treeverse/gc/ActiveCommitsAddressLister.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/gc/ActiveCommitsAddressLister.scala
@@ -29,3 +29,14 @@ class ActiveCommitsAddressLister(val apiClient: ApiClient, val repoName: String)
                        )
   }
 }
+
+object ActiveCommitsAddressLister {
+  def main(args: Array[String]): Unit = {
+    // val apiClient = new ApiClient("http://localhost:8000/api/v1", "lakefs", "secret")
+    // val repoName = "lakefs"
+    // val lister = new ActiveCommitsAddressLister(apiClient, repoName)
+    // val spark = SparkSession.builder().appName("ActiveCommitsAddressLister").getOrCreate()
+    // val df = lister.listCommittedAddresses(spark, "", "")
+    // df.show()
+  }
+}

--- a/clients/spark/core/src/main/scala/io/treeverse/gc/ActiveCommitsAddressLister.scala.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/gc/ActiveCommitsAddressLister.scala.scala
@@ -1,0 +1,31 @@
+package io.treeverse.gc
+
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.DataFrame
+import io.treeverse.clients.ApiClient
+import io.treeverse.clients.LakeFSContext
+import io.treeverse.clients.LakeFSJobParams
+
+class ActiveCommitsAddressLister(val apiClient: ApiClient, val repoName: String)
+    extends CommittedAddressLister {
+
+  override def listCommittedAddresses(
+      spark: SparkSession,
+      storageNamespace: String,
+      clientStorageNamespace: String
+  ): DataFrame = {
+
+    val prepareResult = apiClient.prepareGarbageCollectionCommits(repoName, "")
+    var commitsDF = spark.read
+      .option("header", value = true)
+      .option("inferSchema", value = true)
+      .csv(prepareResult.getGcCommitsLocation)
+    commitsDF = commitsDF.filter(commitsDF("expired") === true).select("commit_id")
+    LakeFSContext.newDF(spark,
+                        LakeFSJobParams.forCommits(repoName,
+                                                   commitsDF.collect().map(_.getString(0)),
+                                                   "experimental-unified-gc"
+                                                  )
+                       )
+  }
+}

--- a/clients/spark/core/src/main/scala/io/treeverse/gc/ActiveCommitsAddressLister.scala.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/gc/ActiveCommitsAddressLister.scala.scala
@@ -20,7 +20,7 @@ class ActiveCommitsAddressLister(val apiClient: ApiClient, val repoName: String)
       .option("header", value = true)
       .option("inferSchema", value = true)
       .csv(prepareResult.getGcCommitsLocation)
-    commitsDF = commitsDF.filter(commitsDF("expired") === true).select("commit_id")
+    commitsDF = commitsDF.filter(commitsDF("expired") === false).select("commit_id")
     LakeFSContext.newDF(spark,
                         LakeFSJobParams.forCommits(repoName,
                                                    commitsDF.collect().map(_.getString(0)),

--- a/clients/spark/core/src/main/scala/io/treeverse/gc/CommittedAddressLister.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/gc/CommittedAddressLister.scala
@@ -11,29 +11,6 @@ trait CommittedAddressLister {
       storageNamespace: String,
       clientStorageNamespace: String
   ): DataFrame
-}
-
-class NaiveCommittedAddressLister extends CommittedAddressLister {
-
-  override def listCommittedAddresses(
-      spark: SparkSession,
-      storageNamespace: String,
-      clientStorageNamespace: String
-  ): DataFrame = {
-    val normalizedStorageNamespace =
-      if (storageNamespace.endsWith("/")) storageNamespace else storageNamespace + "/"
-    val params = LakeFSJobParams.forStorageNamespace(
-      normalizedStorageNamespace,
-      UncommittedGarbageCollector.UNCOMMITTED_GC_SOURCE_NAME
-    )
-    val df = LakeFSContext.newDF(spark, params)
-
-    val normalizedClientStorageNamespace =
-      if (clientStorageNamespace.endsWith("/")) clientStorageNamespace
-      else clientStorageNamespace + "/"
-
-    filterAddresses(spark, df, normalizedClientStorageNamespace)
-  }
 
   def filterAddresses(
       spark: SparkSession,
@@ -76,5 +53,27 @@ class NaiveCommittedAddressLister extends CommittedAddressLister {
     addressesDF
       .repartition(addressesDF.col("address"))
       .distinct()
+  }
+}
+
+class NaiveCommittedAddressLister extends CommittedAddressLister {
+  override def listCommittedAddresses(
+      spark: SparkSession,
+      storageNamespace: String,
+      clientStorageNamespace: String
+  ): DataFrame = {
+    val normalizedStorageNamespace =
+      if (storageNamespace.endsWith("/")) storageNamespace else storageNamespace + "/"
+    val params = LakeFSJobParams.forStorageNamespace(
+      normalizedStorageNamespace,
+      UncommittedGarbageCollector.UNCOMMITTED_GC_SOURCE_NAME
+    )
+    val df = LakeFSContext.newDF(spark, params)
+
+    val normalizedClientStorageNamespace =
+      if (clientStorageNamespace.endsWith("/")) clientStorageNamespace
+      else clientStorageNamespace + "/"
+
+    filterAddresses(spark, df, normalizedClientStorageNamespace)
   }
 }

--- a/clients/spark/core/src/main/scala/io/treeverse/gc/UncommittedGarbageCollector.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/gc/UncommittedGarbageCollector.scala
@@ -128,6 +128,7 @@ object UncommittedGarbageCollector {
 
     val shouldMark = hc.getBoolean(LAKEFS_CONF_GC_DO_MARK, true)
     val experimentalUnifiedGC = hc.getBoolean(LAKEFS_CONF_GC_EXPERIMENTAL_UNIFIED_GC, false)
+    // Unified GC does not support sweep mode: it only marks objects for deletion
     var shouldSweep = hc.getBoolean(LAKEFS_CONF_GC_DO_SWEEP, true) && !experimentalUnifiedGC
     val markID = hc.get(LAKEFS_CONF_GC_MARK_ID, "")
 

--- a/clients/spark/core/src/main/scala/io/treeverse/gc/UncommittedGarbageCollector.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/gc/UncommittedGarbageCollector.scala
@@ -179,7 +179,7 @@ object UncommittedGarbageCollector {
         val clientStorageNamespace =
           apiClient.getStorageNamespace(repo, StorageClientType.SDKClient)
         val committedLister =
-          if (experimentalUnifiedGC) new ActiveCommitsAddressLister(apiClient, repo)
+          if (experimentalUnifiedGC) new ActiveCommitsAddressLister(apiClient, repo, storageType)
           else new NaiveCommittedAddressLister()
         val committedDF =
           committedLister.listCommittedAddresses(spark, storageNamespace, clientStorageNamespace)

--- a/clients/spark/core/src/main/scala/io/treeverse/gc/UncommittedGarbageCollector.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/gc/UncommittedGarbageCollector.scala
@@ -81,6 +81,7 @@ object UncommittedGarbageCollector {
   def validateRunModeConfigs(
       shouldMark: Boolean,
       shouldSweep: Boolean,
+      experimentalUnifiedGC: Boolean,
       markID: String
   ): Unit = {
     if (!shouldMark && !shouldSweep) {
@@ -95,6 +96,11 @@ object UncommittedGarbageCollector {
     }
     if (shouldMark && markID.nonEmpty) {
       throw new ParameterValidationException("Can't provide mark ID for mark mode. Exiting...")
+    }
+    if (experimentalUnifiedGC && (!shouldMark || shouldSweep)) {
+      throw new ParameterValidationException(
+        "Unified GC is an experimental feature and can only be used in mark-only mode. Exiting..."
+      )
     }
   }
 
@@ -121,11 +127,11 @@ object UncommittedGarbageCollector {
     val startTime = java.time.Clock.systemUTC.instant()
 
     val shouldMark = hc.getBoolean(LAKEFS_CONF_GC_DO_MARK, true)
-    val shouldSweep = hc.getBoolean(LAKEFS_CONF_GC_DO_SWEEP, true)
+    val experimentalUnifiedGC = hc.getBoolean(LAKEFS_CONF_GC_EXPERIMENTAL_UNIFIED_GC, false)
+    var shouldSweep = hc.getBoolean(LAKEFS_CONF_GC_DO_SWEEP, true) && !experimentalUnifiedGC
     val markID = hc.get(LAKEFS_CONF_GC_MARK_ID, "")
 
-    validateRunModeConfigs(shouldMark, shouldSweep, markID)
-
+    validateRunModeConfigs(shouldMark, shouldSweep, experimentalUnifiedGC, markID)
     val apiConf =
       APIConfigurations(apiURL,
                         accessKey,
@@ -172,8 +178,11 @@ object UncommittedGarbageCollector {
         // Process committed
         val clientStorageNamespace =
           apiClient.getStorageNamespace(repo, StorageClientType.SDKClient)
-        val committedDF = new NaiveCommittedAddressLister()
-          .listCommittedAddresses(spark, storageNamespace, clientStorageNamespace)
+        val committedLister =
+          if (experimentalUnifiedGC) new ActiveCommitsAddressLister(apiClient, repo)
+          else new NaiveCommittedAddressLister()
+        val committedDF =
+          committedLister.listCommittedAddresses(spark, storageNamespace, clientStorageNamespace)
 
         addressesToDelete = dataDF
           .select("address")

--- a/clients/spark/core/src/test/scala/io/treeverse/gc/UncommittedGarbageCollectorSpec.scala
+++ b/clients/spark/core/src/test/scala/io/treeverse/gc/UncommittedGarbageCollectorSpec.scala
@@ -315,14 +315,15 @@ class UncommittedGarbageCollectorSpec
       val markID = "markID"
 
       it("should succeed mark & sweep") {
-        UncommittedGarbageCollector.validateRunModeConfigs(true, true, "")
+        UncommittedGarbageCollector.validateRunModeConfigs(true, true, false, "")
       }
       it("should succeed when sweep with mark ID") {
-        UncommittedGarbageCollector.validateRunModeConfigs(false, true, markID)
+        UncommittedGarbageCollector.validateRunModeConfigs(false, true, false, markID)
       }
       it("should fail when no options provided") {
         try {
           UncommittedGarbageCollector.validateRunModeConfigs(false,
+                                                             false,
                                                              false,
                                                              markID
                                                             ) // Should throw an exception
@@ -341,6 +342,7 @@ class UncommittedGarbageCollectorSpec
           try {
             UncommittedGarbageCollector.validateRunModeConfigs(true,
                                                                sweepVal,
+                                                               false,
                                                                markID
                                                               ) // Should throw an exception
             // Fail test if no exception was thrown
@@ -356,6 +358,7 @@ class UncommittedGarbageCollectorSpec
         try {
           UncommittedGarbageCollector.validateRunModeConfigs(false,
                                                              true,
+                                                             false,
                                                              ""
                                                             ) // Should throw an exception
           // Fail test if no exception was thrown


### PR DESCRIPTION
Resolves #5639.

This is an experimental feature: use the current UGC mechanism to do both GCs in one run.

### Algorithm
(credit: @itaiad200)
1. List all objects in the object store.
2. Deduct uncommitted entries.
3. Deduct entries from _active_ commits.
4. Mark the resulting set.

### Notes

1. Will not delete any objects: perform only mark stage.
2. Currently the naming is strange, because this still falls under "uncommitted" classes. This is in order to reduce the amount of code written. If we move on with this feature, we will change that.
3. Still needs lots of testing, of course.