### PR TITLE
Graveler Import interface + Minor merger refactor

### DIFF
--- a/esti/import_test.go
+++ b/esti/import_test.go
@@ -308,7 +308,7 @@ func TestImportNew(t *testing.T) {
 		paths := []api.ImportLocation{{
 			Destination: importTargetPrefix,
 			Path:        importPath,
-			Type:        catalog.ImportPathTypePrefix,
+			Type:        graveler.ImportPathTypePrefix,
 		}}
 		importID := testImportNew(t, ctx, repoName, branch, paths, nil)
 		verifyImportObjects(t, ctx, repoName, importTargetPrefix, branch, importFilesToCheck, expectedContentLength)
@@ -352,7 +352,7 @@ func TestImportNew(t *testing.T) {
 		paths := []api.ImportLocation{{
 			Destination: importTargetPrefix,
 			Path:        importPathParent,
-			Type:        catalog.ImportPathTypePrefix,
+			Type:        graveler.ImportPathTypePrefix,
 		}}
 		_ = testImportNew(t, ctx, repoName, branch, paths, &metadata)
 		verifyImportObjects(t, ctx, repoName, importTargetPrefix+"import-test-data/", branch, importFilesToCheck, expectedContentLength)
@@ -368,13 +368,13 @@ func TestImportNew(t *testing.T) {
 			paths = append(paths, api.ImportLocation{
 				Destination: importTargetPrefix + prefix,
 				Path:        importPath + prefix,
-				Type:        catalog.ImportPathTypePrefix,
+				Type:        graveler.ImportPathTypePrefix,
 			})
 		}
 		paths = append(paths, api.ImportLocation{
 			Destination: importTargetPrefix + "nested",
 			Path:        importPath + "nested/",
-			Type:        catalog.ImportPathTypePrefix,
+			Type:        graveler.ImportPathTypePrefix,
 		})
 
 		_ = testImportNew(t, ctx, repoName, branch, paths, &metadata)
@@ -391,7 +391,7 @@ func TestImportNew(t *testing.T) {
 			paths = append(paths, api.ImportLocation{
 				Destination: importTargetPrefix + prefix,
 				Path:        importPath + prefix,
-				Type:        catalog.ImportPathTypePrefix,
+				Type:        graveler.ImportPathTypePrefix,
 			})
 		}
 		for _, p := range importFilesToCheck {
@@ -399,7 +399,7 @@ func TestImportNew(t *testing.T) {
 				paths = append(paths, api.ImportLocation{
 					Destination: importTargetPrefix + p,
 					Path:        importPath + p,
-					Type:        catalog.ImportPathTypeObject,
+					Type:        graveler.ImportPathTypeObject,
 				})
 			}
 		}
@@ -480,7 +480,7 @@ func TestImportCancel(t *testing.T) {
 		Paths: []api.ImportLocation{{
 			Destination: importTargetPrefix,
 			Path:        importPath,
-			Type:        catalog.ImportPathTypePrefix,
+			Type:        graveler.ImportPathTypePrefix,
 		}},
 	})
 	require.NoError(t, err)

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -2192,19 +2192,18 @@ func (c *Controller) ImportStart(w http.ResponseWriter, r *http.Request, body Im
 	if body.Commit.Metadata != nil {
 		metadata = body.Commit.Metadata.AdditionalProperties
 	}
-	paths := make([]catalog.ImportPath, 0, len(body.Paths))
+	paths := make([]graveler.ImportPath, 0, len(body.Paths))
 	for _, p := range body.Paths {
 		pathType, err := catalog.GetImportPathType(p.Type)
 		if c.handleAPIError(ctx, w, r, err) {
 			return
 		}
-		paths = append(paths, catalog.ImportPath{
+		paths = append(paths, graveler.ImportPath{
 			Destination: p.Destination,
 			Path:        p.Path,
 			Type:        pathType,
 		})
 	}
-
 	committer := user.Username
 	importID, err := c.Catalog.Import(r.Context(), repository, branch, catalog.ImportRequest{
 		Paths: paths,

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -161,24 +161,11 @@ const (
 	workersMaxDrainDuration  = 5 * time.Second
 )
 
-type ImportPathType string
-
-const (
-	ImportPathTypePrefix = "common_prefix"
-	ImportPathTypeObject = "object"
-)
-
-type ImportPath struct {
-	Path        string
-	Destination string
-	Type        ImportPathType
-}
-
-func GetImportPathType(t string) (ImportPathType, error) {
+func GetImportPathType(t string) (graveler.ImportPathType, error) {
 	switch t {
-	case ImportPathTypePrefix,
-		ImportPathTypeObject:
-		return ImportPathType(t), nil
+	case graveler.ImportPathTypePrefix,
+		graveler.ImportPathTypeObject:
+		return graveler.ImportPathType(t), nil
 	default:
 		return "", fmt.Errorf("invalid import type: %w", graveler.ErrInvalidValue)
 	}
@@ -191,7 +178,7 @@ type ImportCommit struct {
 }
 
 type ImportRequest struct {
-	Paths  []ImportPath
+	Paths  []graveler.ImportPath
 	Commit ImportCommit
 }
 
@@ -1880,7 +1867,7 @@ func (c *Catalog) importAsync(repository *graveler.RepositoryRecord, branchID, i
 		Committer: params.Commit.Committer,
 		Message:   params.Commit.CommitMessage,
 		Metadata:  map[string]string(params.Commit.Metadata),
-	})
+	}, params.Paths)
 	if err != nil {
 		importError := fmt.Errorf("merge import: %w", err)
 		importManager.SetError(importError)
@@ -1991,7 +1978,7 @@ func (c *Catalog) WriteRange(ctx context.Context, repositoryID string, params Wr
 		return nil, nil, fmt.Errorf("creating object-store walker: %w", err)
 	}
 
-	it, err := NewWalkEntryIterator(ctx, walker, ImportPathTypePrefix, params.Prepend, params.After, params.ContinuationToken)
+	it, err := NewWalkEntryIterator(ctx, walker, graveler.ImportPathTypePrefix, params.Prepend, params.After, params.ContinuationToken)
 	if err != nil {
 		return nil, nil, fmt.Errorf("creating walk iterator: %w", err)
 	}

--- a/pkg/catalog/walk_entry_iterator.go
+++ b/pkg/catalog/walk_entry_iterator.go
@@ -3,6 +3,7 @@ package catalog
 import (
 	"context"
 	"errors"
+	"github.com/treeverse/lakefs/pkg/graveler"
 	"strings"
 
 	"github.com/treeverse/lakefs/pkg/block"
@@ -42,7 +43,7 @@ type WalkerFactory interface {
 	GetWalker(ctx context.Context, opts store.WalkerOptions) (*store.WalkerWrapper, error)
 }
 
-func NewWalkEntryIterator(ctx context.Context, walker *store.WalkerWrapper, sourceType ImportPathType, destination, after, continuationToken string) (*walkEntryIterator, error) {
+func NewWalkEntryIterator(ctx context.Context, walker *store.WalkerWrapper, sourceType graveler.ImportPathType, destination, after, continuationToken string) (*walkEntryIterator, error) {
 	prepend := destination
 	if prepend != "" && !strings.HasSuffix(prepend, "/") {
 		prepend += "/"
@@ -67,7 +68,7 @@ func NewWalkEntryIterator(ctx context.Context, walker *store.WalkerWrapper, sour
 				return ErrItClosed
 			}
 			p := prepend + e.RelativeKey
-			if sourceType == ImportPathTypeObject {
+			if sourceType == graveler.ImportPathTypeObject {
 				p = destination
 			}
 			record := objectStoreEntryToEntryRecord(e, p)

--- a/pkg/catalog/walk_entry_iterator.go
+++ b/pkg/catalog/walk_entry_iterator.go
@@ -3,8 +3,9 @@ package catalog
 import (
 	"context"
 	"errors"
-	"github.com/treeverse/lakefs/pkg/graveler"
 	"strings"
+
+	"github.com/treeverse/lakefs/pkg/graveler"
 
 	"github.com/treeverse/lakefs/pkg/block"
 	"github.com/treeverse/lakefs/pkg/ingest/store"

--- a/pkg/catalog/walk_entry_iterator_test.go
+++ b/pkg/catalog/walk_entry_iterator_test.go
@@ -2,6 +2,7 @@ package catalog_test
 
 import (
 	"context"
+	"github.com/treeverse/lakefs/pkg/graveler"
 	"net/url"
 	"testing"
 
@@ -41,7 +42,7 @@ func TestWalkEntryIterator(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			w := testutils.NewFakeWalker(iteratorTestCount, tt.max, uriPrefix, after, continuationToken, fromSourceURIWithPrefix, nil)
 			parsedURL, _ := url.Parse(fromSourceURIWithPrefix)
-			sut, err := catalog.NewWalkEntryIterator(context.Background(), store.NewWrapper(w, parsedURL), catalog.ImportPathTypePrefix, prepend, after, continuationToken)
+			sut, err := catalog.NewWalkEntryIterator(context.Background(), store.NewWrapper(w, parsedURL), graveler.ImportPathTypePrefix, prepend, after, continuationToken)
 			require.NoError(t, err, "creating walk entry iterator")
 			require.NotNil(t, sut)
 

--- a/pkg/catalog/walk_entry_iterator_test.go
+++ b/pkg/catalog/walk_entry_iterator_test.go
@@ -2,9 +2,10 @@ package catalog_test
 
 import (
 	"context"
-	"github.com/treeverse/lakefs/pkg/graveler"
 	"net/url"
 	"testing"
+
+	"github.com/treeverse/lakefs/pkg/graveler"
 
 	"github.com/stretchr/testify/require"
 	"github.com/treeverse/lakefs/pkg/block"

--- a/pkg/graveler/committed/manager.go
+++ b/pkg/graveler/committed/manager.go
@@ -293,3 +293,7 @@ func (c *committedManager) GetRangeIDByKey(ctx context.Context, ns graveler.Stor
 	}
 	return graveler.RangeID(r.ID), nil
 }
+
+func (c *committedManager) Import(ctx context.Context, ns graveler.StorageNamespace, destination, source graveler.MetaRangeID) (graveler.MetaRangeID, error) {
+	return "", nil
+}

--- a/pkg/graveler/committed/manager.go
+++ b/pkg/graveler/committed/manager.go
@@ -294,6 +294,6 @@ func (c *committedManager) GetRangeIDByKey(ctx context.Context, ns graveler.Stor
 	return graveler.RangeID(r.ID), nil
 }
 
-func (c *committedManager) Import(ctx context.Context, ns graveler.StorageNamespace, destination, source graveler.MetaRangeID) (graveler.MetaRangeID, error) {
+func (c *committedManager) Import(ctx context.Context, ns graveler.StorageNamespace, destination, source graveler.MetaRangeID, importPaths []graveler.ImportPath) (graveler.MetaRangeID, error) {
 	return "", nil
 }

--- a/pkg/graveler/committed/merge.go
+++ b/pkg/graveler/committed/merge.go
@@ -321,11 +321,10 @@ func (m *merger) handleConflict(sourceValue *graveler.ValueRecord, destValue *gr
 
 // handleBothKeys handles the case where both source and dest iterators are inside range
 func (m *merger) handleBothKeys(sourceValue *graveler.ValueRecord, destValue *graveler.ValueRecord) error {
-	c := bytes.Compare(sourceValue.Key, destValue.Key)
 	switch {
-	case c < 0: // source before dest
+	case isValue1BeforeValue2(sourceValue, destValue): // source before dest
 		return m.sourceBeforeDest(sourceValue)
-	case c > 0: // dest before source
+	case isValue1BeforeValue2(destValue, sourceValue): // dest before source
 		return m.destBeforeSource(destValue)
 
 	default: // identical keys
@@ -516,4 +515,8 @@ func sameBoundRanges(range1, range2 *Range) bool {
 
 func range1BeforeRange2(range1, range2 *Range) bool {
 	return bytes.Compare(range1.MaxKey, range2.MinKey) < 0
+}
+
+func isValue1BeforeValue2(v1, v2 *graveler.ValueRecord) bool {
+	return bytes.Compare(v1.Key, v2.Key) < 0
 }

--- a/pkg/graveler/committed/range.go
+++ b/pkg/graveler/committed/range.go
@@ -1,6 +1,9 @@
 package committed
 
-import "google.golang.org/protobuf/proto"
+import (
+	"bytes"
+	"google.golang.org/protobuf/proto"
+)
 
 // Range represents a range of sorted Keys
 type Range struct {
@@ -21,6 +24,14 @@ func (r Range) Copy() *Range {
 		Count:         r.Count,
 		Tombstone:     r.Tombstone,
 	}
+}
+
+func (r Range) IsBefore(o *Range) bool {
+	return bytes.Compare(r.MaxKey, o.MinKey) < 0
+}
+
+func (r Range) SameBounds(o *Range) bool {
+	return bytes.Equal(r.MinKey, o.MinKey) && bytes.Equal(r.MaxKey, o.MaxKey)
 }
 
 func MarshalRange(r Range) ([]byte, error) {

--- a/pkg/graveler/committed/range.go
+++ b/pkg/graveler/committed/range.go
@@ -2,6 +2,7 @@ package committed
 
 import (
 	"bytes"
+
 	"google.golang.org/protobuf/proto"
 )
 

--- a/pkg/graveler/graveler.go
+++ b/pkg/graveler/graveler.go
@@ -299,6 +299,10 @@ func (v *ValueRecord) IsTombstone() bool {
 	return v.Value == nil
 }
 
+func (v *ValueRecord) IsBefore(o *ValueRecord) bool {
+	return bytes.Compare(v.Key, o.Key) < 0
+}
+
 func (cp CommitParents) Identity() []byte {
 	commits := make([]string, len(cp))
 	for i, v := range cp {

--- a/pkg/graveler/graveler.go
+++ b/pkg/graveler/graveler.go
@@ -912,6 +912,11 @@ type CommittedManager interface {
 
 	// GetRangeIDByKey returns the RangeID that contains the given key.
 	GetRangeIDByKey(ctx context.Context, ns StorageNamespace, id MetaRangeID, key Key) (RangeID, error)
+
+	// Import applies changes from 'source' to 'destination' and returns the ID of the new metarange.
+	// This is similar to the Merge operation, but it will override existing prefixes in the destination
+	// if they also exist in the source.
+	Import(ctx context.Context, ns StorageNamespace, destination, source MetaRangeID) (MetaRangeID, error)
 }
 
 // StagingManager manages entries in a staging area, denoted by a staging token

--- a/pkg/graveler/graveler.go
+++ b/pkg/graveler/graveler.go
@@ -917,9 +917,7 @@ type CommittedManager interface {
 	// GetRangeIDByKey returns the RangeID that contains the given key.
 	GetRangeIDByKey(ctx context.Context, ns StorageNamespace, id MetaRangeID, key Key) (RangeID, error)
 
-	// Import applies changes from 'source' to 'destination' and returns the ID of the new metarange.
-	// This is similar to the Merge operation, but it will override existing prefixes in the destination
-	// if they also exist in the provided import paths.
+	// Import sync changes from 'source' to 'destination' and returns the ID of the new metarange.
 	Import(ctx context.Context, ns StorageNamespace, destination, source MetaRangeID, importPaths []ImportPath) (MetaRangeID, error)
 }
 

--- a/pkg/graveler/graveler_v2_test.go
+++ b/pkg/graveler/graveler_v2_test.go
@@ -646,7 +646,7 @@ func TestGravelerImport(t *testing.T) {
 		test.StagingManager.EXPECT().DropAsync(ctx, stagingToken3).Times(1)
 		test.RefManager.EXPECT().SetRepositoryMetadata(ctx, repository, gomock.Any())
 
-		val, err := test.Sut.Import(ctx, repository, branch1ID, commit2.MetaRangeID, graveler.CommitParams{Metadata: graveler.Metadata{}})
+		val, err := test.Sut.Import(ctx, repository, branch1ID, commit2.MetaRangeID, graveler.CommitParams{Metadata: graveler.Metadata{}}, nil)
 		require.NoError(t, err)
 		require.NotNil(t, val)
 		require.Equal(t, commit4ID, graveler.CommitID(val.Ref()))

--- a/pkg/graveler/mock/graveler.go
+++ b/pkg/graveler/mock/graveler.go
@@ -2970,3 +2970,7 @@ func (mr *MockProtectedBranchesManagerMockRecorder) IsBlocked(ctx, repository, b
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsBlocked", reflect.TypeOf((*MockProtectedBranchesManager)(nil).IsBlocked), ctx, repository, branchID, action)
 }
+
+func (mr *MockProtectedBranchesManagerMockRecorder) Import(ctx context.Context, ns graveler.StorageNamespace, destination, source graveler.MetaRangeID) (graveler.MetaRangeID, error) {
+	return "", nil
+}

--- a/pkg/graveler/mock/graveler.go
+++ b/pkg/graveler/mock/graveler.go
@@ -614,7 +614,7 @@ func (mr *MockVersionControllerMockRecorder) GetTag(ctx, repository, tagID inter
 }
 
 // Import mocks base method.
-func (m *MockVersionController) Import(ctx context.Context, repository *graveler.RepositoryRecord, destination graveler.BranchID, source graveler.MetaRangeID, commitParams graveler.CommitParams) (graveler.CommitID, error) {
+func (m *MockVersionController) Import(ctx context.Context, repository *graveler.RepositoryRecord, destination graveler.BranchID, source graveler.MetaRangeID, commitParams graveler.CommitParams, importPaths []graveler.ImportPath) (graveler.CommitID, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "Import", ctx, repository, destination, source, commitParams)
 	ret0, _ := ret[0].(graveler.CommitID)
@@ -2530,7 +2530,7 @@ func (mr *MockCommittedManagerMockRecorder) WriteRange(ctx, ns, it interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteRange", reflect.TypeOf((*MockCommittedManager)(nil).WriteRange), ctx, ns, it)
 }
 
-func (mr *MockCommittedManager) Import(ctx context.Context, ns graveler.StorageNamespace, destination, source graveler.MetaRangeID) (graveler.MetaRangeID, error) {
+func (mr *MockCommittedManager) Import(ctx context.Context, ns graveler.StorageNamespace, destination, source graveler.MetaRangeID, importPaths []graveler.ImportPath) (graveler.MetaRangeID, error) {
 	return "", nil
 }
 

--- a/pkg/graveler/mock/graveler.go
+++ b/pkg/graveler/mock/graveler.go
@@ -2530,6 +2530,10 @@ func (mr *MockCommittedManagerMockRecorder) WriteRange(ctx, ns, it interface{}) 
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteRange", reflect.TypeOf((*MockCommittedManager)(nil).WriteRange), ctx, ns, it)
 }
 
+func (mr *MockCommittedManager) Import(ctx context.Context, ns graveler.StorageNamespace, destination, source graveler.MetaRangeID) (graveler.MetaRangeID, error) {
+	return "", nil
+}
+
 // MockStagingManager is a mock of StagingManager interface.
 type MockStagingManager struct {
 	ctrl     *gomock.Controller
@@ -2969,8 +2973,4 @@ func (m *MockProtectedBranchesManager) IsBlocked(ctx context.Context, repository
 func (mr *MockProtectedBranchesManagerMockRecorder) IsBlocked(ctx, repository, branchID, action interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "IsBlocked", reflect.TypeOf((*MockProtectedBranchesManager)(nil).IsBlocked), ctx, repository, branchID, action)
-}
-
-func (mr *MockProtectedBranchesManagerMockRecorder) Import(ctx context.Context, ns graveler.StorageNamespace, destination, source graveler.MetaRangeID) (graveler.MetaRangeID, error) {
-	return "", nil
 }

--- a/pkg/graveler/mock/graveler.go
+++ b/pkg/graveler/mock/graveler.go
@@ -616,16 +616,16 @@ func (mr *MockVersionControllerMockRecorder) GetTag(ctx, repository, tagID inter
 // Import mocks base method.
 func (m *MockVersionController) Import(ctx context.Context, repository *graveler.RepositoryRecord, destination graveler.BranchID, source graveler.MetaRangeID, commitParams graveler.CommitParams, importPaths []graveler.ImportPath) (graveler.CommitID, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Import", ctx, repository, destination, source, commitParams)
+	ret := m.ctrl.Call(m, "Import", ctx, repository, destination, source, commitParams, importPaths)
 	ret0, _ := ret[0].(graveler.CommitID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Import indicates an expected call of Import.
-func (mr *MockVersionControllerMockRecorder) Import(ctx, repository, destination, source, commitParams interface{}) *gomock.Call {
+func (mr *MockVersionControllerMockRecorder) Import(ctx, repository, destination, source, commitParams, importPaths interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Import", reflect.TypeOf((*MockVersionController)(nil).Import), ctx, repository, destination, source, commitParams)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Import", reflect.TypeOf((*MockVersionController)(nil).Import), ctx, repository, destination, source, commitParams, importPaths)
 }
 
 // IsLinkAddressExpired mocks base method.
@@ -2455,6 +2455,21 @@ func (mr *MockCommittedManagerMockRecorder) GetRangeIDByKey(ctx, ns, id, key int
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRangeIDByKey", reflect.TypeOf((*MockCommittedManager)(nil).GetRangeIDByKey), ctx, ns, id, key)
 }
 
+// Import mocks base method.
+func (m *MockCommittedManager) Import(ctx context.Context, ns graveler.StorageNamespace, destination, source graveler.MetaRangeID, importPaths []graveler.ImportPath) (graveler.MetaRangeID, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Import", ctx, ns, destination, source, importPaths)
+	ret0, _ := ret[0].(graveler.MetaRangeID)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Import indicates an expected call of Import.
+func (mr *MockCommittedManagerMockRecorder) Import(ctx, ns, destination, source, importPaths interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Import", reflect.TypeOf((*MockCommittedManager)(nil).Import), ctx, ns, destination, source, importPaths)
+}
+
 // List mocks base method.
 func (m *MockCommittedManager) List(ctx context.Context, ns graveler.StorageNamespace, rangeID graveler.MetaRangeID) (graveler.ValueIterator, error) {
 	m.ctrl.T.Helper()
@@ -2528,10 +2543,6 @@ func (m *MockCommittedManager) WriteRange(ctx context.Context, ns graveler.Stora
 func (mr *MockCommittedManagerMockRecorder) WriteRange(ctx, ns, it interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteRange", reflect.TypeOf((*MockCommittedManager)(nil).WriteRange), ctx, ns, it)
-}
-
-func (mr *MockCommittedManager) Import(ctx context.Context, ns graveler.StorageNamespace, destination, source graveler.MetaRangeID, importPaths []graveler.ImportPath) (graveler.MetaRangeID, error) {
-	return "", nil
 }
 
 // MockStagingManager is a mock of StagingManager interface.

--- a/pkg/graveler/testutil/fakes.go
+++ b/pkg/graveler/testutil/fakes.go
@@ -118,6 +118,10 @@ func (c *CommittedFake) GetRange(_ context.Context, _ graveler.StorageNamespace,
 	return graveler.RangeAddress(fmt.Sprintf("fake://prefix/%s(range)", rangeID)), nil
 }
 
+func (c *CommittedFake) Import(ctx context.Context, ns graveler.StorageNamespace, destination, source graveler.MetaRangeID) (graveler.MetaRangeID, error) {
+	return "", nil
+}
+
 // Backwards compatibility for test pre-KV
 const defaultKey = "key"
 

--- a/pkg/graveler/testutil/fakes.go
+++ b/pkg/graveler/testutil/fakes.go
@@ -118,7 +118,7 @@ func (c *CommittedFake) GetRange(_ context.Context, _ graveler.StorageNamespace,
 	return graveler.RangeAddress(fmt.Sprintf("fake://prefix/%s(range)", rangeID)), nil
 }
 
-func (c *CommittedFake) Import(ctx context.Context, ns graveler.StorageNamespace, destination, source graveler.MetaRangeID) (graveler.MetaRangeID, error) {
+func (c *CommittedFake) Import(ctx context.Context, ns graveler.StorageNamespace, destination, source graveler.MetaRangeID, importPaths []graveler.ImportPath) (graveler.MetaRangeID, error) {
 	return "", nil
 }
 


### PR DESCRIPTION
Add in `Import` interface to graveler.
* This PR includes only the interface of Import (i.e. no implementation details yet).
* This PR also include minor refactoring to the `merger` code. It's not a functional refactor.

**Don't be alarmed by the number of files. Most are very minor changes...**
The important file is `pkg/graveler/graveler.go` which states the Import interface.

Related to #6162 