### PR TITLE
Add lakeFS Cloud note to top of deploy docs

### DIFF
--- a/docs/deploy/aws.md
+++ b/docs/deploy/aws.md
@@ -15,13 +15,14 @@ next:  ["Import data into your installation", "../howto/import.html"]
 
 # Deploy lakeFS on AWS
 
-
-⏰ Expected deployment time: 25 min
+These instructions are for a self-managed deployment of lakeFS on AWS.<br/> 
+For a hosted lakeFS service with guaranteed SLAs, try [lakeFS Cloud](https://lakefs.cloud/).
 {: .note }
 
 {% include toc.html %}
 
-{% include_relative includes/prerequisites.md %}
+⏰ Expected deployment time: 25 min
+{: .note }
 
 ## Grant lakeFS permissions to DynamoDB
 

--- a/docs/deploy/azure.md
+++ b/docs/deploy/azure.md
@@ -11,7 +11,8 @@ next:  ["Import data into your installation", "../howto/import.html"]
 
 # Deploy lakeFS on Azure
 
-⏰ Expected deployment time: 25 min
+These instructions are for a self-managed deployment of lakeFS on Azure. <br/> 
+For a hosted lakeFS service with guaranteed SLAs, try [lakeFS Cloud](https://lakefs.cloud/).
 {: .note }
 
 lakeFS has several dependencies for which you need to select and configure a technology or interface: 
@@ -20,11 +21,10 @@ lakeFS has several dependencies for which you need to select and configure a tec
 
 This guide walks you through the options available and how to configure them, finishing with configuring and running lakeFS itself and creating your first repository. 
 
-
-
 {% include toc.html %}
 
-{% include_relative includes/prerequisites.md %}
+⏰ Expected deployment time: 25 min
+{: .note }
 
 ## 1. Object Storage
 

--- a/docs/deploy/gcp.md
+++ b/docs/deploy/gcp.md
@@ -11,12 +11,14 @@ next:  ["Import data into your installation", "../howto/import.html"]
 
 # Deploy lakeFS on GCP
 
-⏰ Expected deployment time: 25 min
+These instructions are for a self-managed deployment of lakeFS on GCP. <br/> 
+For a hosted lakeFS service with guaranteed SLAs, try [lakeFS Cloud](https://lakefs.cloud/).
 {: .note }
 
 {% include toc.html %}
 
-{% include_relative includes/prerequisites.md %}
+⏰ Expected deployment time: 25 min
+{: .note }
 
 ## Create a Database
 

--- a/docs/deploy/index.md
+++ b/docs/deploy/index.md
@@ -12,5 +12,5 @@ redirect_from:
 
 # Deploy and setup lakeFS
 
-Note: Optionally, for a hosted lakeFS service with guaranteed SLAs, try [lakeFS Cloud](https://lakefs.cloud)
+For a hosted lakeFS service with guaranteed SLAs, try [lakeFS Cloud](https://lakefs.cloud)
 {: .note }

--- a/docs/deploy/onprem.md
+++ b/docs/deploy/onprem.md
@@ -14,12 +14,13 @@ next:  ["Import data into your installation", "../howto/import.html"]
 
 # On-Premises deployment
 
-⏰ Expected deployment time: 25 min
+For a hosted lakeFS service with guaranteed SLAs, try [lakeFS Cloud](https://lakefs.cloud)
 {: .note }
 
 {% include toc.html %}
 
-{% include_relative includes/prerequisites.md %}
+⏰ Expected deployment time: 25 min
+{: .note }
 
 ## Prerequisites
 


### PR DESCRIPTION
- pre-reqs is empty and just make editing the pages that include it confusing
- Add lakeFS Cloud note to top of deploy docs

closes https://github.com/treeverse/devex-internal/issues/146
