### PR TITLE
Make sure that the feedback buttons are always clickable

### DIFF
--- a/docs/_sass/custom/custom.scss
+++ b/docs/_sass/custom/custom.scss
@@ -974,6 +974,7 @@ div.highlighter-rouge{
 	}
 	position: sticky;
 	top: 180px;
+	z-index: 9999;
 	.feedback-buttons {
 		position: absolute;
 		right: 70px;


### PR DESCRIPTION
<!-- 
Hello Axolotl!
Thank you for contributing to the lakeFS project.
We appreciate the time invested in this pull request and created this template to help make this process easier.
It's really important to have all the information and context, to ensure we can properly address this PR 
Please use the following references to fill out the pull request.
--> 

### Linked Issue

Closes #6198

---

## Change Description

Docs feedback buttons cannot be clicked

https://github.com/treeverse/lakeFS/assets/3671582/6f01d30f-21c0-4143-95ba-27fa09c92813


### Bug Fix

Set the Z-index so that they will always be on top
      
### Testing Details

Tested manually

https://github.com/treeverse/lakeFS/assets/3671582/edb1fe1a-00e7-42b2-ab19-98d13577b5e6

Can also be seen in action in preview here: https://treeverse-lakefs-preview-pr-6215.surge.sh/