### PR TITLE
Use different image for twitter cards

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -26,7 +26,7 @@ defaults:
   - scope:
       path: ""
     values:
-      image: https://docs.lakefs.io/assets/img/lakefs-logo-with-text.png
+      image: https://docs.lakefs.io/assets/img/docs_logo.png
 
 # general config
 repository: treeverse/lakeFS


### PR DESCRIPTION
In #6202 we fixed the page metadata so that twitter would correctly pick up an image (instead of none) when a docs.lakeFS.io page is shared on Twitter. 

However, the image used gets cropped and shows `lakeF` and two-thirds of an axolotl

![image](https://github.com/treeverse/lakeFS/assets/3671582/b83d7254-2225-4469-82e1-3a37ea4f0bb4)

This PR changes the image used to one that is square and should render better. 

![](https://docs.lakefs.io/assets/img/docs_logo.png)