### PR TITLE
Import: PrefixIterator

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -1876,11 +1876,15 @@ func (c *Catalog) importAsync(repository *graveler.RepositoryRecord, branchID, i
 		return importError
 	}
 
+	prefixes := make([]graveler.Prefix, 0, len(params.Paths))
+	for _, ip := range params.Paths {
+		prefixes = append(prefixes, graveler.Prefix(ip.Destination))
+	}
 	commitID, err := c.Store.Import(ctx, repository, graveler.BranchID(branchID), metarange.ID, graveler.CommitParams{
 		Committer: params.Commit.Committer,
 		Message:   params.Commit.CommitMessage,
 		Metadata:  map[string]string(params.Commit.Metadata),
-	})
+	}, prefixes)
 	if err != nil {
 		importError := fmt.Errorf("merge import: %w", err)
 		importManager.SetError(importError)

--- a/pkg/graveler/committed/manager.go
+++ b/pkg/graveler/committed/manager.go
@@ -180,7 +180,7 @@ func (c *committedManager) Diff(ctx context.Context, ns graveler.StorageNamespac
 	return NewDiffValueIterator(ctx, leftIt, rightIt), nil
 }
 
-func (c *committedManager) Merge(ctx context.Context, ns graveler.StorageNamespace, destination, source, base graveler.MetaRangeID, strategy graveler.MergeStrategy) (graveler.MetaRangeID, error) {
+func (c *committedManager) Merge(ctx context.Context, ns graveler.StorageNamespace, destination, source, base graveler.MetaRangeID, strategy graveler.MergeStrategy, prefixes []graveler.Prefix) (graveler.MetaRangeID, error) {
 	if source == base {
 		// no changes on source
 		return "", graveler.ErrNoChanges
@@ -199,6 +199,9 @@ func (c *committedManager) Merge(ctx context.Context, ns graveler.StorageNamespa
 	destIt, err := c.metaRangeManager.NewMetaRangeIterator(ctx, ns, destination)
 	if err != nil {
 		return "", fmt.Errorf("get destination iterator: %w", err)
+	}
+	if strategy == graveler.MergeStrategyImport {
+		destIt = NewPrefixIterator(prefixes, destIt)
 	}
 	defer destIt.Close()
 

--- a/pkg/graveler/committed/merge_test.go
+++ b/pkg/graveler/committed/merge_test.go
@@ -1729,7 +1729,7 @@ func runMergeTests(tests testCases, t *testing.T) {
 					metaRangeId := graveler.MetaRangeID("merge")
 					writer.EXPECT().Close().Return(&metaRangeId, nil).AnyTimes()
 					committedManager := committed.NewCommittedManager(metaRangeManager, rangeManager, params)
-					_, err := committedManager.Merge(ctx, "ns", destMetaRangeID, sourceMetaRangeID, baseMetaRangeID, mergeStrategy)
+					_, err := committedManager.Merge(ctx, "ns", destMetaRangeID, sourceMetaRangeID, baseMetaRangeID, mergeStrategy, nil)
 					if err != expectedResult.expectedErr {
 						t.Fatal(err)
 					}

--- a/pkg/graveler/committed/prefix_iterator.go
+++ b/pkg/graveler/committed/prefix_iterator.go
@@ -79,7 +79,7 @@ func (ipi *PrefixIterator) Next() bool {
 			if !ipi.hasNext {
 				return false
 			}
-			vr, r = ipi.updateValue()
+			vr, _ = ipi.updateValue()
 			ipi.updatePath()
 		}
 	}

--- a/pkg/graveler/committed/prefix_iterator.go
+++ b/pkg/graveler/committed/prefix_iterator.go
@@ -1,0 +1,174 @@
+package committed
+
+import (
+	"strings"
+
+	"github.com/treeverse/lakefs/pkg/graveler"
+)
+
+type rangeValue struct {
+	r  *Range
+	vr *graveler.ValueRecord
+}
+
+const done = -1
+
+type ImportIterator interface {
+	IsCurrentRangeBoundedByPath() bool
+	IsCurrentPathIncludedInRange() bool
+}
+
+type PrefixIterator struct {
+	position          int // current path position in the slice or -1 if no prefixes left
+	prefixes          []graveler.Prefix
+	rangeIterator     Iterator
+	currentRangeValue rangeValue
+	hasNext           bool
+}
+
+func (ipi *PrefixIterator) Value() (*graveler.ValueRecord, *Range) {
+	return ipi.currentRangeValue.vr, ipi.currentRangeValue.r
+}
+
+func (ipi *PrefixIterator) updateValue() (*graveler.ValueRecord, *Range) {
+	vr, r := ipi.rangeIterator.Value()
+	ipi.currentRangeValue = rangeValue{
+		r,
+		vr,
+	}
+	return vr, r
+}
+
+func (ipi *PrefixIterator) Err() error {
+	return ipi.rangeIterator.Err()
+}
+func (ipi *PrefixIterator) Close() {
+	ipi.rangeIterator.Close()
+}
+func (ipi *PrefixIterator) SeekGE(id graveler.Key) {
+	ipi.rangeIterator.SeekGE(id)
+}
+
+func (ipi *PrefixIterator) Next() bool {
+	ipi.hasNext = ipi.rangeIterator.Next()
+	if !ipi.hasNext {
+		return false
+	}
+	vr, r := ipi.updateValue()
+	ipi.updatePath()
+
+	if vr == nil && r != nil { // head of range
+		for ipi.IsCurrentRangeBoundedByPath() {
+			if ipi.rangeIterator.Err() != nil {
+				return false
+			}
+			ipi.hasNext = ipi.rangeIterator.NextRange()
+			if !ipi.hasNext {
+				return false
+			}
+			ipi.updateValue()
+			ipi.updatePath()
+		}
+	} else {
+		for vr != nil && ipi.position != done && strings.HasPrefix(vr.Key.String(), string(ipi.prefixes[ipi.position])) {
+			if ipi.rangeIterator.Err() != nil {
+				return false
+			}
+			ipi.hasNext = ipi.rangeIterator.Next()
+			if !ipi.hasNext {
+				return false
+			}
+			vr, r = ipi.updateValue()
+			ipi.updatePath()
+		}
+	}
+	return true
+}
+
+func (ipi *PrefixIterator) NextRange() bool {
+	ipi.hasNext = ipi.rangeIterator.NextRange()
+	if !ipi.hasNext {
+		return false
+	}
+	ipi.updateValue()
+	ipi.updatePath()
+
+	for ipi.IsCurrentRangeBoundedByPath() {
+		if ipi.rangeIterator.Err() != nil {
+			return false
+		}
+		ipi.hasNext = ipi.rangeIterator.NextRange()
+		if !ipi.hasNext {
+			return false
+		}
+		ipi.updateValue()
+		ipi.position = ipi.position + 1
+		if ipi.position >= len(ipi.prefixes) {
+			ipi.position = done
+		}
+		//ipi.updatePath()
+	}
+	// Problem: if the range contains the prefix, yet not bounded by it, it will be returned. This is fine, unless
+	// this range comes before the source range. This will trigger the "write dest before source scenario" which will be
+	// incorrect since we still need to go over the range and ignore all prefixes in it.
+	return true
+}
+
+func NewPrefixIterator(prefixes []graveler.Prefix, rangeIterator Iterator) *PrefixIterator {
+	return &PrefixIterator{prefixes: prefixes, position: 0, rangeIterator: rangeIterator}
+}
+
+func (ipi *PrefixIterator) updatePath() {
+	if ipi.position == done {
+		return
+	}
+	currMinKey := string(ipi.currentRangeValue.r.MinKey)
+	if ipi.currentRangeValue.vr != nil {
+		currMinKey = string(ipi.currentRangeValue.vr.Key)
+	}
+	// If the position is smaller or doesn't have the prefix of the current key, get the next prefix.
+	// At the end of this function we'll have either a path that is a prefix of the current key, or bigger than the key
+	for string(ipi.prefixes[ipi.position]) < currMinKey &&
+		!strings.HasPrefix(currMinKey, string(ipi.prefixes[ipi.position])) {
+		p := ipi.position + 1
+		switch {
+		case p >= len(ipi.prefixes): // No more comparable prefixes
+			ipi.position = done
+			return
+		case string(ipi.prefixes[p]) <= string(ipi.currentRangeValue.r.MaxKey):
+			ipi.position = p
+		default:
+			return
+		}
+	}
+}
+
+func (ipi *PrefixIterator) getPrefix() *graveler.Prefix {
+	if ipi.position == done {
+		return nil
+	}
+	return &ipi.prefixes[ipi.position]
+}
+
+// IsCurrentRangeBoundedByPath returns true if both the range's max and min keys have the current path as their prefix
+func (ipi *PrefixIterator) IsCurrentRangeBoundedByPath() bool {
+	p := ipi.getPrefix()
+	if p == nil {
+		return false
+	}
+	r := ipi.currentRangeValue.r
+	return strings.HasPrefix(string(r.MinKey), string(*p)) && strings.HasPrefix(string(r.MaxKey), string(*p))
+}
+
+// IsCurrentPathIncludedInRange returns true if the examined path is either a prefix of the range's min or max key,
+// or if the path is between the range's min and max keys.
+func (ipi *PrefixIterator) IsCurrentPathIncludedInRange() bool {
+	p := ipi.getPrefix()
+	if p == nil {
+		return false
+	}
+	r := ipi.currentRangeValue.r
+	hasPrefix := strings.HasPrefix(string(r.MinKey), string(*p)) || strings.HasPrefix(string(r.MaxKey), string(*p))
+	intersects := strings.Compare(string(*p), string(r.MinKey)) >= 0 && strings.Compare(string(*p), string(r.MaxKey)) <= 0
+	return hasPrefix || intersects
+}

--- a/pkg/graveler/committed/prefix_iterator.go
+++ b/pkg/graveler/committed/prefix_iterator.go
@@ -1,6 +1,7 @@
 package committed
 
 import (
+	"sort"
 	"strings"
 
 	"github.com/treeverse/lakefs/pkg/graveler"
@@ -111,6 +112,9 @@ func (ipi *PrefixIterator) NextRange() bool {
 }
 
 func NewPrefixIterator(prefixes []graveler.Prefix, rangeIterator Iterator) *PrefixIterator {
+	sort.Slice(prefixes, func(i, j int) bool {
+		return prefixes[i] < prefixes[j]
+	})
 	return &PrefixIterator{prefixes: prefixes, position: 0, rangeIterator: rangeIterator}
 }
 

--- a/pkg/graveler/committed/prefix_iterator.go
+++ b/pkg/graveler/committed/prefix_iterator.go
@@ -106,11 +106,7 @@ func (ipi *PrefixIterator) NextRange() bool {
 		if ipi.position >= len(ipi.prefixes) {
 			ipi.position = done
 		}
-		//ipi.updatePath()
 	}
-	// Problem: if the range contains the prefix, yet not bounded by it, it will be returned. This is fine, unless
-	// this range comes before the source range. This will trigger the "write dest before source scenario" which will be
-	// incorrect since we still need to go over the range and ignore all prefixes in it.
 	return true
 }
 

--- a/pkg/graveler/committed/prefix_iterator.go
+++ b/pkg/graveler/committed/prefix_iterator.go
@@ -145,7 +145,7 @@ func (ipi *PrefixIterator) getPrefix() *graveler.Prefix {
 	return &ipi.prefixes[ipi.currentPrefixIndex]
 }
 
-// IsCurrentRangeBoundedByPrefix returns true if both the range's max and min keys have the current prefix as their prefix
+// IsCurrentRangeBoundedByPrefix returns true if both the range's max and min keys have the current prefix.
 func (ipi *PrefixIterator) IsCurrentRangeBoundedByPrefix() bool {
 	p := ipi.getPrefix()
 	if p == nil {

--- a/pkg/graveler/committed/prefix_iterator.go
+++ b/pkg/graveler/committed/prefix_iterator.go
@@ -103,7 +103,7 @@ func (ipi *PrefixIterator) NextRange() bool {
 			return false
 		}
 		ipi.updateValue()
-		ipi.position = ipi.position + 1
+		ipi.position++
 		if ipi.position >= len(ipi.prefixes) {
 			ipi.position = done
 		}

--- a/pkg/graveler/graveler_v2_test.go
+++ b/pkg/graveler/graveler_v2_test.go
@@ -646,7 +646,7 @@ func TestGravelerImport(t *testing.T) {
 		test.StagingManager.EXPECT().DropAsync(ctx, stagingToken3).Times(1)
 		test.RefManager.EXPECT().SetRepositoryMetadata(ctx, repository, gomock.Any())
 
-		val, err := test.Sut.Import(ctx, repository, branch1ID, commit2.MetaRangeID, graveler.CommitParams{Metadata: graveler.Metadata{}})
+		val, err := test.Sut.Import(ctx, repository, branch1ID, commit2.MetaRangeID, graveler.CommitParams{Metadata: graveler.Metadata{}}, nil)
 		require.NoError(t, err)
 		require.NotNil(t, val)
 		require.Equal(t, commit4ID, graveler.CommitID(val.Ref()))

--- a/pkg/graveler/graveler_v2_test.go
+++ b/pkg/graveler/graveler_v2_test.go
@@ -626,7 +626,7 @@ func TestGravelerImport(t *testing.T) {
 		test.CommittedManager.EXPECT().List(ctx, repository.StorageNamespace, mr1ID).Times(2).Return(testutils.NewFakeValueIterator(nil), nil)
 		test.RefManager.EXPECT().ParseRef(graveler.Ref(branch1ID)).Times(1).Return(rawRefCommit1, nil)
 		test.RefManager.EXPECT().ResolveRawRef(ctx, repository, rawRefCommit1).Times(1).Return(&graveler.ResolvedRef{Type: graveler.ReferenceTypeCommit, BranchRecord: graveler.BranchRecord{Branch: &graveler.Branch{CommitID: commit1ID}}}, nil)
-		test.CommittedManager.EXPECT().Merge(ctx, repository.StorageNamespace, mr1ID, mr2ID, graveler.MetaRangeID(""), graveler.MergeStrategySrc, nil).Times(1).Return(mr4ID, nil)
+		test.CommittedManager.EXPECT().Merge(ctx, repository.StorageNamespace, mr1ID, mr2ID, graveler.MetaRangeID(""), graveler.MergeStrategyImport, nil).Times(1).Return(mr4ID, nil)
 		test.RefManager.EXPECT().AddCommit(ctx, repository, gomock.Any()).DoAndReturn(func(ctx context.Context, repository *graveler.RepositoryRecord, commit graveler.Commit) (graveler.CommitID, error) {
 			require.Equal(t, mr4ID, commit.MetaRangeID)
 			return commit4ID, nil

--- a/pkg/graveler/graveler_v2_test.go
+++ b/pkg/graveler/graveler_v2_test.go
@@ -197,7 +197,7 @@ func TestGravelerMerge(t *testing.T) {
 		test.RefManager.EXPECT().ResolveRawRef(ctx, repository, rawRefCommit1).Times(1).Return(&graveler.ResolvedRef{Type: graveler.ReferenceTypeCommit, BranchRecord: graveler.BranchRecord{Branch: &graveler.Branch{CommitID: commit1ID}}}, nil)
 		test.RefManager.EXPECT().GetCommit(ctx, repository, commit2ID).Times(1).Return(&commit2, nil)
 		test.RefManager.EXPECT().FindMergeBase(ctx, repository, commit2ID, commit1ID).Times(1).Return(&commit3, nil)
-		test.CommittedManager.EXPECT().Merge(ctx, repository.StorageNamespace, mr1ID, mr2ID, mr3ID, graveler.MergeStrategyNone).Times(1).Return(mr4ID, nil)
+		test.CommittedManager.EXPECT().Merge(ctx, repository.StorageNamespace, mr1ID, mr2ID, mr3ID, graveler.MergeStrategyNone, nil).Times(1).Return(mr4ID, nil)
 		test.RefManager.EXPECT().AddCommit(ctx, repository, gomock.Any()).DoAndReturn(func(ctx context.Context, repository *graveler.RepositoryRecord, commit graveler.Commit) (graveler.CommitID, error) {
 			require.Equal(t, mr4ID, commit.MetaRangeID)
 			return commit4ID, nil
@@ -266,7 +266,7 @@ func TestGravelerMerge(t *testing.T) {
 		test.RefManager.EXPECT().ResolveRawRef(ctx, repository, rawRefCommit1).Times(1).Return(&graveler.ResolvedRef{Type: graveler.ReferenceTypeCommit, BranchRecord: graveler.BranchRecord{Branch: &graveler.Branch{CommitID: commit1ID}}}, nil)
 		test.RefManager.EXPECT().GetCommit(ctx, repository, commit2ID).Times(1).Return(&commit2, nil)
 		test.RefManager.EXPECT().FindMergeBase(ctx, repository, commit2ID, commit1ID).Times(1).Return(&commit3, nil)
-		test.CommittedManager.EXPECT().Merge(ctx, repository.StorageNamespace, mr1ID, mr2ID, mr3ID, graveler.MergeStrategyNone).Times(1).Return(mr4ID, nil)
+		test.CommittedManager.EXPECT().Merge(ctx, repository.StorageNamespace, mr1ID, mr2ID, mr3ID, graveler.MergeStrategyNone, nil).Times(1).Return(mr4ID, nil)
 		test.RefManager.EXPECT().AddCommit(ctx, repository, gomock.Any()).DoAndReturn(func(ctx context.Context, repository *graveler.RepositoryRecord, commit graveler.Commit) (graveler.CommitID, error) {
 			require.Equal(t, mr4ID, commit.MetaRangeID)
 			return commit4ID, nil
@@ -362,7 +362,7 @@ func TestGravelerRevert(t *testing.T) {
 		test.RefManager.EXPECT().ResolveRawRef(ctx, repository, rawRefCommit4).Times(1).Return(&graveler.ResolvedRef{Type: graveler.ReferenceTypeCommit, BranchRecord: graveler.BranchRecord{Branch: &graveler.Branch{CommitID: commit4ID}}}, nil)
 		test.RefManager.EXPECT().GetCommit(ctx, repository, commit2ID).Times(1).Return(&commit2, nil)
 		test.RefManager.EXPECT().GetCommit(ctx, repository, commit4ID).Times(1).Return(&commit4, nil)
-		test.CommittedManager.EXPECT().Merge(ctx, repository.StorageNamespace, mr1ID, mr4ID, mr2ID, graveler.MergeStrategyNone).Times(1).Return(mr3ID, nil)
+		test.CommittedManager.EXPECT().Merge(ctx, repository.StorageNamespace, mr1ID, mr4ID, mr2ID, graveler.MergeStrategyNone, nil).Times(1).Return(mr3ID, nil)
 		test.RefManager.EXPECT().AddCommit(ctx, repository, gomock.Any()).DoAndReturn(func(ctx context.Context, repository *graveler.RepositoryRecord, commit graveler.Commit) (graveler.CommitID, error) {
 			require.Equal(t, mr3ID, commit.MetaRangeID)
 			return commit3ID, nil
@@ -455,7 +455,7 @@ func TestGravelerCherryPick(t *testing.T) {
 		test.RefManager.EXPECT().ResolveRawRef(ctx, repository, rawRefCommit4).Times(1).Return(&graveler.ResolvedRef{Type: graveler.ReferenceTypeCommit, BranchRecord: graveler.BranchRecord{Branch: &graveler.Branch{CommitID: commit4ID}}}, nil)
 		test.RefManager.EXPECT().GetCommit(ctx, repository, commit2ID).Times(1).Return(&commit2, nil)
 		test.RefManager.EXPECT().GetCommit(ctx, repository, commit4ID).Times(1).Return(&commit4, nil)
-		test.CommittedManager.EXPECT().Merge(ctx, repository.StorageNamespace, mr1ID, mr2ID, mr4ID, graveler.MergeStrategyNone).Times(1).Return(mr3ID, nil)
+		test.CommittedManager.EXPECT().Merge(ctx, repository.StorageNamespace, mr1ID, mr2ID, mr4ID, graveler.MergeStrategyNone, nil).Times(1).Return(mr3ID, nil)
 		test.RefManager.EXPECT().AddCommit(ctx, repository, gomock.Any()).DoAndReturn(func(ctx context.Context, repository *graveler.RepositoryRecord, commit graveler.Commit) (graveler.CommitID, error) {
 			require.Equal(t, mr3ID, commit.MetaRangeID)
 			return commit3ID, nil
@@ -626,7 +626,7 @@ func TestGravelerImport(t *testing.T) {
 		test.CommittedManager.EXPECT().List(ctx, repository.StorageNamespace, mr1ID).Times(2).Return(testutils.NewFakeValueIterator(nil), nil)
 		test.RefManager.EXPECT().ParseRef(graveler.Ref(branch1ID)).Times(1).Return(rawRefCommit1, nil)
 		test.RefManager.EXPECT().ResolveRawRef(ctx, repository, rawRefCommit1).Times(1).Return(&graveler.ResolvedRef{Type: graveler.ReferenceTypeCommit, BranchRecord: graveler.BranchRecord{Branch: &graveler.Branch{CommitID: commit1ID}}}, nil)
-		test.CommittedManager.EXPECT().Merge(ctx, repository.StorageNamespace, mr1ID, mr2ID, graveler.MetaRangeID(""), graveler.MergeStrategySrc).Times(1).Return(mr4ID, nil)
+		test.CommittedManager.EXPECT().Merge(ctx, repository.StorageNamespace, mr1ID, mr2ID, graveler.MetaRangeID(""), graveler.MergeStrategySrc, nil).Times(1).Return(mr4ID, nil)
 		test.RefManager.EXPECT().AddCommit(ctx, repository, gomock.Any()).DoAndReturn(func(ctx context.Context, repository *graveler.RepositoryRecord, commit graveler.Commit) (graveler.CommitID, error) {
 			require.Equal(t, mr4ID, commit.MetaRangeID)
 			return commit4ID, nil

--- a/pkg/graveler/mock/graveler.go
+++ b/pkg/graveler/mock/graveler.go
@@ -614,18 +614,18 @@ func (mr *MockVersionControllerMockRecorder) GetTag(ctx, repository, tagID inter
 }
 
 // Import mocks base method.
-func (m *MockVersionController) Import(ctx context.Context, repository *graveler.RepositoryRecord, destination graveler.BranchID, source graveler.MetaRangeID, commitParams graveler.CommitParams) (graveler.CommitID, error) {
+func (m *MockVersionController) Import(ctx context.Context, repository *graveler.RepositoryRecord, destination graveler.BranchID, source graveler.MetaRangeID, commitParams graveler.CommitParams, prefixes []graveler.Prefix) (graveler.CommitID, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Import", ctx, repository, destination, source, commitParams)
+	ret := m.ctrl.Call(m, "Import", ctx, repository, destination, source, commitParams, prefixes)
 	ret0, _ := ret[0].(graveler.CommitID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Import indicates an expected call of Import.
-func (mr *MockVersionControllerMockRecorder) Import(ctx, repository, destination, source, commitParams interface{}) *gomock.Call {
+func (mr *MockVersionControllerMockRecorder) Import(ctx, repository, destination, source, commitParams, prefixes interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Import", reflect.TypeOf((*MockVersionController)(nil).Import), ctx, repository, destination, source, commitParams)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Import", reflect.TypeOf((*MockVersionController)(nil).Import), ctx, repository, destination, source, commitParams, prefixes)
 }
 
 // IsLinkAddressExpired mocks base method.
@@ -2471,18 +2471,18 @@ func (mr *MockCommittedManagerMockRecorder) List(ctx, ns, rangeID interface{}) *
 }
 
 // Merge mocks base method.
-func (m *MockCommittedManager) Merge(ctx context.Context, ns graveler.StorageNamespace, destination, source, base graveler.MetaRangeID, strategy graveler.MergeStrategy) (graveler.MetaRangeID, error) {
+func (m *MockCommittedManager) Merge(ctx context.Context, ns graveler.StorageNamespace, destination, source, base graveler.MetaRangeID, strategy graveler.MergeStrategy, prefixes []graveler.Prefix) (graveler.MetaRangeID, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Merge", ctx, ns, destination, source, base, strategy)
+	ret := m.ctrl.Call(m, "Merge", ctx, ns, destination, source, base, strategy, prefixes)
 	ret0, _ := ret[0].(graveler.MetaRangeID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Merge indicates an expected call of Merge.
-func (mr *MockCommittedManagerMockRecorder) Merge(ctx, ns, destination, source, base, strategy interface{}) *gomock.Call {
+func (mr *MockCommittedManagerMockRecorder) Merge(ctx, ns, destination, source, base, strategy, prefixes interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Merge", reflect.TypeOf((*MockCommittedManager)(nil).Merge), ctx, ns, destination, source, base, strategy)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Merge", reflect.TypeOf((*MockCommittedManager)(nil).Merge), ctx, ns, destination, source, base, strategy, prefixes)
 }
 
 // WriteMetaRange mocks base method.

--- a/pkg/graveler/testutil/fakes.go
+++ b/pkg/graveler/testutil/fakes.go
@@ -79,7 +79,7 @@ func (c *CommittedFake) Compare(context.Context, graveler.StorageNamespace, grav
 	return c.DiffIterator, nil
 }
 
-func (c *CommittedFake) Merge(_ context.Context, _ graveler.StorageNamespace, _, _, _ graveler.MetaRangeID, _ graveler.MergeStrategy) (graveler.MetaRangeID, error) {
+func (c *CommittedFake) Merge(_ context.Context, _ graveler.StorageNamespace, _, _, _ graveler.MetaRangeID, _ graveler.MergeStrategy, _ []graveler.Prefix) (graveler.MetaRangeID, error) {
 	if c.Err != nil {
 		return "", c.Err
 	}


### PR DESCRIPTION
This PR introduces a new `PrefixIterator` which will be used for the import functionality, and it works by skipping records that includes a prefix from a prefix list, or complete ranges if they are bounded by one of the prefixes of the list.
The given prefix list is assumed to be sorted (and is being sorted when using the `NewPrefixIterator` constructor function).

The main changes are:
1. `PrefixIterator`: the main addition.
2. Wrapping an iterator with a `PrefixIterator` if the merge strategy is `MergeStrategyImport`
3. Passing a `Prefix`s slice to the `Merge` function.

Tests for the import flow will be added in the next PR.

**Even though this PR contains 8 files, most of them are minor derivatives of the additional `Prefix` slice parameter, so leave those worries aside...**

Closes #6162 