### PR TITLE
Bump docs build to Ruby 3.2

### DIFF
--- a/.github/workflows/check-ui-links.yaml
+++ b/.github/workflows/check-ui-links.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           working-directory: docs
-          ruby-version: '2.7'
+          ruby-version: '3.2'
           bundler-cache: true 
 
       - name: Build latest

--- a/.github/workflows/docs-latest.yaml
+++ b/.github/workflows/docs-latest.yaml
@@ -19,7 +19,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           working-directory: docs
-          ruby-version: '2.7'
+          ruby-version: '3.2'
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
       - name: Build latest

--- a/.github/workflows/docs-pr.yaml
+++ b/.github/workflows/docs-pr.yaml
@@ -20,7 +20,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           working-directory: docs
-          ruby-version: '2.7'
+          ruby-version: '3.2'
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
       - name: Build latest

--- a/.github/workflows/docs-release.yaml
+++ b/.github/workflows/docs-release.yaml
@@ -20,7 +20,7 @@ jobs:
         uses: ruby/setup-ruby@v1
         with:
           working-directory: docs
-          ruby-version: '2.7'
+          ruby-version: '3.2'
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
       - name: Extract version

--- a/docs/Gemfile
+++ b/docs/Gemfile
@@ -1,3 +1,4 @@
 source 'https://rubygems.org'
 gem 'github-pages', group: :jekyll_plugins
 gem 'just-the-docs'
+gem "webrick", "~> 1.8"

--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -254,6 +254,7 @@ GEM
       unf_ext
     unf_ext (0.0.8.2)
     unicode-display_width (1.8.0)
+    webrick (1.8.1)
 
 PLATFORMS
   ruby
@@ -261,6 +262,7 @@ PLATFORMS
 DEPENDENCIES
   github-pages
   just-the-docs
+  webrick (~> 1.8)
 
 BUNDLED WITH
    2.1.4


### PR DESCRIPTION
### Linked Issue

Closes #6122

---

## Change Description

### Background

Docs currently build with Ruby 2.7. 

### New Feature

This PR changes the docs builds to use Ruby 3.2. 

Ruby 3 has been out for 2.5 years now and results in faster site builds (~7 seconds vs. ~30-40 seconds). 

Faster site builds are important for people doing docs dev work to be able to rapidly test their changes locally.

### Testing Details

Tested locally and verified with [results](https://treeverse-lakefs-preview-pr-6253.surge.sh/) of [GitHub Action](https://github.com/treeverse/lakeFS/actions/runs/5654064805/job/15316387808?pr=6253#step:3:21)

### Breaking Change?

No
