### PR TITLE
Metaclient: fix bucket region check

### DIFF
--- a/clients/spark/core/src/main/scala/io/treeverse/clients/StorageUtils.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/StorageUtils.scala
@@ -99,23 +99,30 @@ object StorageUtils {
 
       require(awsS3ClientBuilder != null)
       require(bucket.nonEmpty)
-
       var client =
-        initializeS3Client(configuration, credentialsProvider, awsS3ClientBuilder, endpoint, region)
-
-      if (!validateClientAndBucketRegionsMatch(client, bucket)) {
-        val bucketRegion = getAWSS3Region(client, bucket)
-        logger.info(
-          s"""Bucket "$bucket" is not in region "$region", discovered it in region "$bucketRegion"""
+        initializeS3Client(configuration, credentialsProvider, awsS3ClientBuilder, endpoint)
+      var bucketRegion =
+        try {
+          getAWSS3Region(client, bucket)
+        } catch {
+          case e: Throwable =>
+            logger.info(f"Could not fetch region for bucket ${bucket}", e)
+            ""
+        }
+      if (bucketRegion == "" && region == "") {
+        throw new IllegalArgumentException(
+          s"""Could not fetch region for bucket "$bucket" and no region was provided"""
         )
-        client = initializeS3Client(configuration,
-                                    credentialsProvider,
-                                    AmazonS3ClientBuilder.standard(),
-                                    endpoint,
-                                    bucketRegion
-                                   )
       }
-      client
+      if (bucketRegion == "") {
+        bucketRegion = region
+      }
+      initializeS3Client(configuration,
+                         credentialsProvider,
+                         awsS3ClientBuilder,
+                         endpoint,
+                         bucketRegion
+                        )
     }
 
     private def initializeS3Client(
@@ -123,38 +130,24 @@ object StorageUtils {
         credentialsProvider: Option[AWSCredentialsProvider],
         awsS3ClientBuilder: AmazonS3ClientBuilder,
         endpoint: String,
-        region: String
+        region: String = null
     ): AmazonS3 = {
       val builder = awsS3ClientBuilder
         .withClientConfiguration(configuration)
-
       val builderWithEndpoint =
         if (endpoint != null)
           builder.withEndpointConfiguration(
             new AwsClientBuilder.EndpointConfiguration(endpoint, region)
           )
-        else
+        else if (region != null)
           builder.withRegion(region)
-
+        else
+          builder
       val builderWithCredentials = credentialsProvider match {
         case Some(cp) => builderWithEndpoint.withCredentials(cp)
         case None     => builderWithEndpoint
       }
       builderWithCredentials.build
-    }
-
-    private def validateClientAndBucketRegionsMatch(client: AmazonS3, bucket: String): Boolean = {
-      try {
-        client.headBucket(new HeadBucketRequest(bucket))
-        true
-      } catch {
-        case e: AmazonServiceException =>
-          logger.info("Bucket \"{}\" isn't reachable with error: {}",
-                      bucket: Any,
-                      e.getMessage: Any
-                     )
-          false
-      }
     }
 
     private def getAWSS3Region(client: AmazonS3, bucket: String): String = {

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/StorageUtils.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/StorageUtils.scala
@@ -4,7 +4,7 @@ import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.client.builder.AwsClientBuilder
 import com.amazonaws.retry.PredefinedRetryPolicies.SDKDefaultRetryCondition
 import com.amazonaws.retry.RetryUtils
-import com.amazonaws.services.s3.model.{HeadBucketRequest, Region, GetBucketLocationRequest}
+import com.amazonaws.services.s3.model.{Region, GetBucketLocationRequest}
 import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
 import com.amazonaws._
 import org.slf4j.{Logger, LoggerFactory}

--- a/clients/spark/core/src/main/scala/io/treeverse/clients/StorageUtils.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/clients/StorageUtils.scala
@@ -4,12 +4,13 @@ import com.amazonaws.auth.AWSCredentialsProvider
 import com.amazonaws.client.builder.AwsClientBuilder
 import com.amazonaws.retry.PredefinedRetryPolicies.SDKDefaultRetryCondition
 import com.amazonaws.retry.RetryUtils
-import com.amazonaws.services.s3.model.{HeadBucketRequest, Region}
+import com.amazonaws.services.s3.model.{HeadBucketRequest, Region, GetBucketLocationRequest}
 import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
 import com.amazonaws._
 import org.slf4j.{Logger, LoggerFactory}
 
 import java.net.URI
+import java.util.concurrent.TimeUnit
 
 object StorageUtils {
   val StorageTypeS3 = "s3"
@@ -151,7 +152,9 @@ object StorageUtils {
     }
 
     private def getAWSS3Region(client: AmazonS3, bucket: String): String = {
-      val bucketRegion = client.getBucketLocation(bucket)
+      var request = new GetBucketLocationRequest(bucket)
+      request = request.withSdkClientExecutionTimeout(TimeUnit.SECONDS.toMillis(15).intValue())
+      val bucketRegion = client.getBucketLocation(request)
       val region = Region.fromValue(bucketRegion)
       // The comparison `region.equals(Region.US_Standard))` is required due to AWS's backward compatibility:
       // https://github.com/aws/aws-sdk-java/issues/1470.

--- a/clients/spark/core/src/main/scala/io/treeverse/gc/GarbageCollection.scala
+++ b/clients/spark/core/src/main/scala/io/treeverse/gc/GarbageCollection.scala
@@ -100,7 +100,7 @@ object GarbageCollection {
 
   def main(args: Array[String]): Unit = {
     val hc = spark.sparkContext.hadoopConfiguration
-    val region = if (args.length == 2) args(1) else null
+    val region = if (args.length == 2) args(1) else ""
     val repo = args(0)
     run(region, repo)
   }

--- a/clients/spark/core/src/test/scala/io/treeverse/clients/StorageUtilsSpec.scala
+++ b/clients/spark/core/src/test/scala/io/treeverse/clients/StorageUtilsSpec.scala
@@ -1,16 +1,17 @@
 package io.treeverse.clients
 
-import com.amazonaws.auth.{
-  AWSCredentialsProvider,
-  AWSStaticCredentialsProvider,
-  BasicAWSCredentials
-}
-import com.amazonaws.services.s3.model.Region
-import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
+import com.amazonaws.ClientConfiguration
+import com.amazonaws.Protocol
+import com.amazonaws.auth.AWSCredentialsProvider
+import com.amazonaws.auth.AWSStaticCredentialsProvider
+import com.amazonaws.auth.BasicAWSCredentials
+import com.amazonaws.services.s3.AmazonS3
+import com.amazonaws.services.s3.AmazonS3ClientBuilder
 import com.amazonaws.thirdparty.apache.http.HttpStatus
-import com.amazonaws.{ClientConfiguration, HttpMethod, Protocol, SdkClientException}
 import okhttp3.HttpUrl
-import okhttp3.mockwebserver.{MockResponse, MockWebServer, RecordedRequest}
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import okhttp3.mockwebserver.RecordedRequest
 import org.scalatest.BeforeAndAfter
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers

--- a/clients/spark/core/src/test/scala/io/treeverse/clients/StorageUtilsSpec.scala
+++ b/clients/spark/core/src/test/scala/io/treeverse/clients/StorageUtilsSpec.scala
@@ -29,6 +29,7 @@ class StorageUtilsSpec extends AnyFunSpec with BeforeAndAfter with MockitoSugar 
   private val ENDPOINT = "http://s3.example.net"
   private val US_STANDARD = "US"
   private val US_WEST_2 = "us-west-2"
+  private val AP_SOUTHEAST_1 = "ap-southeast-1"
   private val BUCKET_NAME = "bucket"
 
   before {
@@ -44,8 +45,12 @@ class StorageUtilsSpec extends AnyFunSpec with BeforeAndAfter with MockitoSugar 
   }
 
   describe("createAndValidateS3Client") {
-    it("should create a client after a successful validation") {
-      server.enqueue(new MockResponse().setResponseCode(200))
+    it("should create a client after fetching the region") {
+      server.enqueue(
+        new MockResponse()
+          .setBody(generateGetBucketLocationResponseWithRegion(US_WEST_2))
+          .setResponseCode(HttpStatus.SC_OK)
+      )
       val initializedClient: AmazonS3 = StorageUtils.S3.createAndValidateS3Client(
         clientConfiguration,
         Some(credentialsProvider),
@@ -60,58 +65,75 @@ class StorageUtilsSpec extends AnyFunSpec with BeforeAndAfter with MockitoSugar 
       initializedClient should not be null
       initializedClient.getRegion.toString should equal(US_WEST_2)
       extractBucketFromRecordedRequest(request) should equal(BUCKET_NAME)
-      request.getMethod should equal(HttpMethod.HEAD.toString)
     }
-
-    it("should create the S3 client successfully with US STANDARD region validation") {
-      server.enqueue(new MockResponse().setBody("successful validation response"))
-      val initializedClient: AmazonS3 = initializeClient()
-
-      server.getRequestCount should equal(1)
-
-      val request: RecordedRequest = server.takeRequest()
-      initializedClient should not be null
-      initializedClient.getRegion.name should equal(Region.US_Standard.name())
-      extractBucketFromRecordedRequest(request) should equal(BUCKET_NAME)
-      request.getMethod should equal(HttpMethod.HEAD.toString)
-    }
-
-    it("should get the correct region for the given bucket and create the S3 client successfully") {
-      server.enqueue(new MockResponse().setResponseCode(HttpStatus.SC_FORBIDDEN))
+    it(
+      "should create the client if the provided region is different from the bucket region"
+    ) {
       server.enqueue(
         new MockResponse()
           .setBody(generateGetBucketLocationResponseWithRegion(US_WEST_2))
           .setResponseCode(HttpStatus.SC_OK)
       )
-      val initializedClient: AmazonS3 = initializeClient()
+      val initializedClient: AmazonS3 = StorageUtils.S3.createAndValidateS3Client(
+        clientConfiguration,
+        Some(credentialsProvider),
+        awsS3ClientBuilder,
+        ENDPOINT,
+        AP_SOUTHEAST_1,
+        BUCKET_NAME
+      )
 
-      server.getRequestCount should equal(2)
-      val headBucketRequest: RecordedRequest = server.takeRequest()
+      server.getRequestCount should equal(1)
+      val request: RecordedRequest = server.takeRequest()
+      initializedClient should not be null
+      initializedClient.getRegion.toString should equal(US_WEST_2)
+      extractBucketFromRecordedRequest(request) should equal(BUCKET_NAME)
+    }
+    it(
+      "should create the client if the provided region is different from the bucket region (US_STANDARD)"
+    ) {
+      server.enqueue(
+        new MockResponse()
+          .setBody(
+            generateGetBucketLocationResponseWithRegion("")
+          ) // buckets on us-east-1 return an empty string here
+          .setResponseCode(HttpStatus.SC_OK)
+      )
+      val initializedClient: AmazonS3 = StorageUtils.S3.createAndValidateS3Client(
+        clientConfiguration,
+        Some(credentialsProvider),
+        awsS3ClientBuilder,
+        ENDPOINT,
+        US_WEST_2,
+        BUCKET_NAME
+      )
+
+      server.getRequestCount should equal(1)
+      val request: RecordedRequest = server.takeRequest()
+      initializedClient should not be null
+      initializedClient.getRegion.toString should be(null)
+      extractBucketFromRecordedRequest(request) should equal(BUCKET_NAME)
+    }
+
+    it("should use provided region is failed to fetch region") {
+      server.enqueue(
+        new MockResponse()
+          .setBody("failed to fetch region")
+          .setResponseCode(HttpStatus.SC_FORBIDDEN)
+      )
+      val initializedClient: AmazonS3 = StorageUtils.S3.createAndValidateS3Client(
+        clientConfiguration,
+        Some(credentialsProvider),
+        awsS3ClientBuilder,
+        ENDPOINT,
+        US_WEST_2,
+        BUCKET_NAME
+      )
+      server.getRequestCount should equal(1)
       val getLocationRequest: RecordedRequest = server.takeRequest()
       initializedClient should not be null
       initializedClient.getRegion.toString should equal(US_WEST_2)
-      extractBucketFromRecordedRequest(headBucketRequest) should equal(BUCKET_NAME)
-      headBucketRequest.getMethod should equal(HttpMethod.HEAD.toString)
-      getLocationRequest.getMethod should equal(HttpMethod.GET.toString)
-    }
-
-    it("should fail creating a client due to failed 'getBucketLocation' request") {
-      server.enqueue(new MockResponse().setResponseCode(HttpStatus.SC_FORBIDDEN))
-      server.enqueue(
-        new MockResponse()
-          .setResponseCode(HttpStatus.SC_NOT_FOUND)
-      )
-
-      assertThrows[SdkClientException] {
-        initializeClient()
-      }
-
-      server.getRequestCount should equal(2)
-      val headBucketRequest: RecordedRequest = server.takeRequest()
-      val getLocationRequest: RecordedRequest = server.takeRequest()
-      extractBucketFromRecordedRequest(headBucketRequest) should equal(BUCKET_NAME)
-      headBucketRequest.getMethod should equal(HttpMethod.HEAD.toString)
-      getLocationRequest.getMethod should equal(HttpMethod.GET.toString)
+      extractBucketFromRecordedRequest(getLocationRequest) should equal(BUCKET_NAME)
     }
   }
 


### PR DESCRIPTION
Resolves #6283.

When the bucket is not in the provided region, GC would fail. Moreover, it would take a long time to fail.
Fixes:
1. Do not use the HeadBucket request, which returned only after a very long while.
2. Check the region using a region-less client, otherwise we got:

> ``` Retry com.amazonaws.services.s3.model.GetBucketLocationRequest@6bbad473 @2023-07-30T13:28:06.548Z: Other client exception: com.amazonaws.services.s3.model.AmazonS3Exception: The authorization header is malformed; the region 'us-west-2' is wrong; expecting 'us-east-1' (Service: Amazon S3; Status Code: 400; Error Code: AuthorizationHeaderMalformed; Request ID: T6BEDTVQBYZG9Y9W; [ommitted]```
3. Added timeout to GetBucketLocation request.
