### PR TITLE
Add content to index pages of /understand

### DIFF
--- a/cmd/lakectl/cmd/docs.go
+++ b/cmd/lakectl/cmd/docs.go
@@ -11,7 +11,6 @@ import (
 
 // language=markdown
 var cliReferenceHeader = `---
-layout: default
 title: lakectl (lakeFS command-line tool)
 description: lakeFS comes with its own native CLI client. Here you can see the complete command reference.
 parent: Reference

--- a/docs/404.md
+++ b/docs/404.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 permalink: /404.html
 nav_exclude: true
 ---

--- a/docs/cloud/auditing.md
+++ b/docs/cloud/auditing.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Auditing
 parent: lakeFS Cloud
 description: Auditing is a solution for lakeFS Cloud which enables tracking of events and activities performed within the solution. These logs capture information such as who accessed the solution, what actions were taken, and when they occurred.

--- a/docs/cloud/index.md
+++ b/docs/cloud/index.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: lakeFS Cloud
 description: This section includes lakeFS Cloud documentation
 nav_order: 80

--- a/docs/cloud/managed-gc.md
+++ b/docs/cloud/managed-gc.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Managed Garbage Collection
 description: Reduce the operational overhead of running garbage collection manually.
 parent: lakeFS Cloud

--- a/docs/cloud/private-link.md
+++ b/docs/cloud/private-link.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Private Link
 description: Private Link enables lakeFS Cloud to interact with your infrastructure using private networking.
 parent: lakeFS Cloud

--- a/docs/cloud/sso.md
+++ b/docs/cloud/sso.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Single Sign On (SSO)
 description: How to configure Single Sign On (SSO) for lakeFS Cloud.
 parent: lakeFS Cloud

--- a/docs/cloud/unity-delta-sharing.md
+++ b/docs/cloud/unity-delta-sharing.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Unity Delta Sharing
 parent: lakeFS Cloud
 description: The lakeFS Delta Sharing service lets you export DeltaLake and HMS-style tables stored on lakeFS over the Delta Sharing protocol. This is particularly useful with DataBricks Unity.

--- a/docs/enterprise/index.md
+++ b/docs/enterprise/index.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: lakeFS Enterprise
 description: lakeFS Enterprise is an enterprise-ready lakeFS solution providing additional features including RBAC, SSO and Support SLA.
 nav_order: 81

--- a/docs/enterprise/sso.md
+++ b/docs/enterprise/sso.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Single Sign On (SSO) in lakeFS Enterprise
 description: How to configure Single Sign On in lakeFS Enterprise.
 parent: lakeFS Enterprise

--- a/docs/howto/copying.md
+++ b/docs/howto/copying.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Copying data to/from lakeFS
 description: 
 parent: How-To

--- a/docs/howto/deploy/aws.md
+++ b/docs/howto/deploy/aws.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: AWS
 grand_parent: How-To
 parent: Install lakeFS

--- a/docs/howto/deploy/azure.md
+++ b/docs/howto/deploy/azure.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Azure
 grand_parent: How-To
 parent: Install lakeFS

--- a/docs/howto/deploy/gcp.md
+++ b/docs/howto/deploy/gcp.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: GCP
 grand_parent: How-To
 parent: Install lakeFS

--- a/docs/howto/deploy/index.md
+++ b/docs/howto/deploy/index.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Install lakeFS
 parent: How-To
 description: This section will guide you through deploying and setting up a production lakeFS environment.

--- a/docs/howto/deploy/index.md
+++ b/docs/howto/deploy/index.md
@@ -16,3 +16,7 @@ redirect_from:
 
 For a hosted lakeFS service with guaranteed SLAs, try [lakeFS Cloud](https://lakefs.cloud)
 {: .note }
+
+lakeFS releases include [binaries](https://github.com/treeverse/lakeFS/releases) for common operating systems, a [containerized option](https://hub.docker.com/r/treeverse/lakefs) or a [Helm chart](https://artifacthub.io/packages/helm/lakefs/lakefs).
+
+Check out our guides for running lakeFS on [AWS]({{ site.baseurl }}/howto/deploy/aws.md), [GCP]({{ site.baseurl }}/howto/deploy/gcp.md) and [more]({{ site.baseurl }}/howto/deploy).

--- a/docs/howto/deploy/onprem.md
+++ b/docs/howto/deploy/onprem.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: On-Premises Deployment of lakeFS
 grand_parent: How-To
 parent: Install lakeFS

--- a/docs/howto/deploy/upgrade.md
+++ b/docs/howto/deploy/upgrade.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Upgrade lakeFS
 description: A guide to upgrading lakeFS to the latest version.
 grand_parent: How-To

--- a/docs/howto/export.md
+++ b/docs/howto/export.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Export Data
 description: Use the lakeFS Spark client or RClone inside Docker to export a lakeFS commit to the object store.
 parent: How-To

--- a/docs/howto/garbage-collection-committed.md
+++ b/docs/howto/garbage-collection-committed.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: (deprecated) Committed Objects
 description: Clean up unnecessary objects using the garbage collection feature in lakeFS.
 parent: Garbage Collection

--- a/docs/howto/garbage-collection-index.md
+++ b/docs/howto/garbage-collection-index.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Garbage Collection
 description: Clean up unnecessary objects using the garbage collection feature in lakeFS.
 parent: How-To

--- a/docs/howto/garbage-collection-uncommitted.md
+++ b/docs/howto/garbage-collection-uncommitted.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: (deprecated) Uncommitted Objects
 description: Clean up uncommitted objects that are no longer needed.
 parent: Garbage Collection

--- a/docs/howto/garbage-collection.md
+++ b/docs/howto/garbage-collection.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Garbage Collection
 description: Clean up expired objects using the garbage collection feature in lakeFS.
 parent: Garbage Collection

--- a/docs/howto/gc-internals.md
+++ b/docs/howto/gc-internals.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: "Internals: Committed GC"
 description: How Garbage Collection in lakeFS works
 parent: Garbage Collection

--- a/docs/howto/hooks/airflow.md
+++ b/docs/howto/hooks/airflow.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Airflow Hooks
 parent: Actions and Hooks
 grand_parent: How-To

--- a/docs/howto/hooks/index.md
+++ b/docs/howto/hooks/index.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Actions and Hooks
 description: Overview of lakeFS Actions and Hooks
 has_children: true  

--- a/docs/howto/hooks/lua.md
+++ b/docs/howto/hooks/lua.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Lua Hooks
 parent: Actions and Hooks
 grand_parent: How-To

--- a/docs/howto/hooks/webhooks.md
+++ b/docs/howto/hooks/webhooks.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Webhooks
 parent: Actions and Hooks
 grand_parent: How-To

--- a/docs/howto/import.md
+++ b/docs/howto/import.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Import data
 description: Import existing data into a lakeFS repository
 parent: How-To

--- a/docs/howto/index.md
+++ b/docs/howto/index.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: How-To
 description: How to perform various tasks in lakeFS
 nav_order: 5

--- a/docs/howto/migrate-away.md
+++ b/docs/howto/migrate-away.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Migrating away from lakeFS
 description: The simplest way to migrate away from lakeFS is by copying data from a lakeFS repository to an S3 bucket.
 parent: How-To

--- a/docs/howto/protect-branches.md
+++ b/docs/howto/protect-branches.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Protect Branches
 description: Branch protection rules prevent direct changes from being applied to your important branches.
 parent: How-To

--- a/docs/howto/sizing-guide.md
+++ b/docs/howto/sizing-guide.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Sizing Guide
 parent: How-To
 description: This section provides a detailed sizing guide for deploying lakeFS.

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Welcome to lakeFS 👋🏻
 description: The lakeFS documentation provides guidance on how to use lakeFS to deliver resilience and manageability to data lakes.
 nav_order: 0

--- a/docs/integrations/airbyte.md
+++ b/docs/integrations/airbyte.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Airbyte
 description: Use Airbyte with lakeFS to easily sync data between applications and S3 with lakeFS version control.
 parent: Integrations

--- a/docs/integrations/airflow.md
+++ b/docs/integrations/airflow.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Airflow
 description: Easily build reproducible data pipelines with Airflow and lakeFS using commits, without modifying the code or logic of your job.
 parent: Integrations

--- a/docs/integrations/athena.md
+++ b/docs/integrations/athena.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Amazon Athena
 description: This section shows how you can start querying data from lakeFS using Amazon Athena.
 parent: Integrations

--- a/docs/integrations/aws_cli.md
+++ b/docs/integrations/aws_cli.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: AWS CLI
 description: This section shows how to use the AWS CLI for AWS S3 to access lakeFS.
 parent: Integrations

--- a/docs/integrations/cloudera.md
+++ b/docs/integrations/cloudera.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Cloudera
 description: Accessing data in lakeFS from Cloudera Spark works the same as accessing S3 data from Apache Spark.
 parent: Integrations

--- a/docs/integrations/dbt.md
+++ b/docs/integrations/dbt.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: dbt
 description: This guide covers maintaining environments with dbt and lakeFS.
 parent: Integrations

--- a/docs/integrations/delta.md
+++ b/docs/integrations/delta.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Delta Lake
 description: This section explains how to use Delta Lake with lakeFS.
 parent: Integrations

--- a/docs/integrations/dremio.md
+++ b/docs/integrations/dremio.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Dremio
 description: This section shows how you can start using lakeFS with Dremio, a next-generation data lake engine.
 parent: Integrations

--- a/docs/integrations/duckdb.md
+++ b/docs/integrations/duckdb.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: DuckDB
 description: How to use lakeFS with DuckDB, an open-source SQL OLAP database management system.
 parent: Integrations

--- a/docs/integrations/glue_hive_metastore.md
+++ b/docs/integrations/glue_hive_metastore.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Glue / Hive metastore
 description: This section explains how to query data from lakeFS branches in services backed by Glue/Hive Metastore.
 parent: Integrations

--- a/docs/integrations/hive.md
+++ b/docs/integrations/hive.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Hive
 description: This section covers how you can start using lakeFS with Apache Hive, a distributed data warehouse system that enables analytics at a massive scale.
 parent: Integrations

--- a/docs/integrations/iceberg.md
+++ b/docs/integrations/iceberg.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Apache Iceberg
 description: How to integrate lakeFS with Apache Iceberg
 parent: Integrations

--- a/docs/integrations/index.md
+++ b/docs/integrations/index.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Integrations
 description: Integrate lakeFS with all modern data frameworks such as Spark, Apache Iceberg, Hive, AWS Athena, Presto, and more.
 nav_order: 10

--- a/docs/integrations/kafka.md
+++ b/docs/integrations/kafka.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Kafka
 description: This section explains how you can start using lakeFS with Kafka using Confluent’s S3 Sink Connector.
 parent: Integrations

--- a/docs/integrations/kubeflow.md
+++ b/docs/integrations/kubeflow.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Kubeflow
 description: Easily build reproducible data pipelines with Kubeflow and lakeFS using commits, without modifying the code or logic of your job.
 parent: Integrations

--- a/docs/integrations/presto_trino.md
+++ b/docs/integrations/presto_trino.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Presto/Trino
 description: This section explains how you can start using lakeFS with Presto/Trino, an open-source distributed SQL query engine.
 parent: Integrations

--- a/docs/integrations/python.md
+++ b/docs/integrations/python.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Python
 description: Use Python to interact with your objects on lakeFS
 parent: Integrations

--- a/docs/integrations/r.md
+++ b/docs/integrations/r.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: R
 description: How to use lakeFS from R including creating branches, committing changes, and merging.
 parent: Integrations

--- a/docs/integrations/sagemaker.md
+++ b/docs/integrations/sagemaker.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: SageMaker
 description: This section explains how to integrate your SageMaker installation to work with lakeFS.
 parent: Integrations

--- a/docs/integrations/spark.md
+++ b/docs/integrations/spark.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Spark
 description: Accessing data in lakeFS from Apache Spark works the same as accessing S3 data from Apache Spark.
 parent: Integrations

--- a/docs/posts/index.md
+++ b/docs/posts/index.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 has_children: true
 search_exclude: true
 ---

--- a/docs/posts/security_update.md
+++ b/docs/posts/security_update.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 parent: posts
 has_children: false
 date: 2023-01-31

--- a/docs/project/contributing.md
+++ b/docs/project/contributing.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Contributing to lakeFS
 description: lakeFS community welcomes your contribution. To make the process as seamless as possible, we recommend reading this contribution guide first.
 parent: The lakeFS Project

--- a/docs/project/docs/callouts.md
+++ b/docs/project/docs/callouts.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Callouts
 description: Using and Customising Callouts in lakeFS Documentation
 parent: Documentation

--- a/docs/project/index.md
+++ b/docs/project/index.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: The lakeFS Project
 description: lakeFS is an open-source project under the Apache 2.0 license, committed to fostering the open-source space. 
 nav_order: 100

--- a/docs/quickstart/learning-more-lakefs.md
+++ b/docs/quickstart/learning-more-lakefs.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: 🧑🏻‍🎓 Learn more about lakeFS
 description: Learn more about lakeFS here with links to resources including quickstart, samples, installation guides, and more. 
 parent: ⭐ Quickstart ⭐

--- a/docs/reference/access-control-lists.md
+++ b/docs/reference/access-control-lists.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Access Control Lists (ACLs)
 parent: Reference
 description: Access control lists (ACLs) are one of the resource-based options that you can use to manage access to your repositories and objects. There are limits to managing permissions using ACLs.

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: API Reference
 description: This section includes the reference documentation for the lakeFS platform's various APIs.
 parent: Reference

--- a/docs/reference/authentication.md
+++ b/docs/reference/authentication.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Authentication 
 description: This section covers Authentication of your lakeFS server.
 parent: Reference

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: lakectl (lakeFS command-line tool)
 description: lakeFS comes with its own native CLI client. Here you can see the complete command reference.
 parent: Reference

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Configuration
 description: Configuring lakeFS is done using a YAML configuration file. This reference uses `.` to denote the nesting of values.
 parent: Reference

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Reference
 description: Reference documentation for the lakeFS platform's various APIs, CLIs, and file formats.
 nav_order: 20

--- a/docs/reference/monitor.md
+++ b/docs/reference/monitor.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Monitoring using Prometheus
 description: A guide to monitoring your lakeFS Installation with Prometheus.
 parent: Reference

--- a/docs/reference/presigned-url.md
+++ b/docs/reference/presigned-url.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Presigned URL
 description: Configuring lakeFS to use presigned URLs
 parent: Reference

--- a/docs/reference/rbac.md
+++ b/docs/reference/rbac.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Role-Based Access Control (RBAC)
 description: This section covers authorization (using RBAC) of your lakeFS server.
 parent: Reference

--- a/docs/reference/remote-authenticator.md
+++ b/docs/reference/remote-authenticator.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Remote Authenticator
 description: Create a pluggable remote authenticator to integrate lakeFS with your existing security infrastructure.
 parent: Reference

--- a/docs/reference/s3.md
+++ b/docs/reference/s3.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: S3 Supported API
 description: "S3-supported API. lakeFS supports the following API operations: Identity and authorization, Bucket operations, Object operations and listing"
 parent: Reference

--- a/docs/reference/spark-client.md
+++ b/docs/reference/spark-client.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Spark Client
 description: The lakeFS Spark client performs operations on lakeFS committed metadata stored in the object store. 
 parent: Reference

--- a/docs/slack/index.md
+++ b/docs/slack/index.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Slack
 nav_order: 100
 description: Redirect page for lakeFS slack joining url

--- a/docs/understand/architecture.md
+++ b/docs/understand/architecture.md
@@ -2,48 +2,35 @@
 title: Architecture
 parent: Understanding lakeFS
 description: lakeFS architecture overview. Learn more about lakeFS components, including its S3 API gateway.
-nav_order: 10
 has_children: false
 redirect_from:
     - /architecture/index.html
     - /architecture/overview.html
 ---
-# Architecture Overview
+# lakeFS Architecture
 
-
-{% include toc_2-3.html %}
-
-## Overview
-
-lakeFS is distributed as a single binary encapsulating several logical services:
+lakeFS is distributed as a single binary encapsulating several logical services.
 
 The server itself is stateless, meaning you can easily add more instances to handle a bigger load.
 
-The following underlying object stores (or any S3-compatible store) can be used by lakeFS to store data:
+![Architecture]({{ site.baseurl }}/assets/img/architecture.png)
 
+{% include toc_2-3.html %}
+### Object Storage
+
+lakeFS stores data in object stores. Those supported include: 
+
+- AWS S3
 - Google Cloud Storage
 - Azure Blob Storage
-- AWS S3
 - MinIO
 - Ceph
 
-In additional a Key Value storage is used for storing metadata:
+### Metadata Storage
 
-- [PostgreSQL](https://www.postgresql.org/){:target="_blank"}
-- [DynamoDB](https://aws.amazon.com/dynamodb/){:target="_blank"}
+In additional a Key Value storage is used for storing metadata, with supported databases including PostgreSQL, DynamoDB, and CosmosDB Instructions of how to deploy such database on AWS can be found [here]({{ site.baseurl }}/howto/deploy/aws.md#grant-dynamodb-permissions-to-lakefs).
 
-Instructions of how to deploy such database on AWS can be found [here]({{ site.baseurl }}/howto/deploy/aws.md#grant-dynamodb-permissions-to-lakefs).
-
-Additional information on the data format can be found in [Versioning internals]({{ site.baseurl }}/understand/how/versioning-internals.md).
-
-
-![Architecture]({{ site.baseurl }}/assets/img/architecture.png)
-
-## Ways to deploy lakeFS
-
-lakeFS releases include [binaries](https://github.com/treeverse/lakeFS/releases) for common operating systems, a [containerized option](https://hub.docker.com/r/treeverse/lakefs) or 
-a [Helm chart](https://artifacthub.io/packages/helm/lakefs/lakefs).
-Check out our guides for running lakeFS on [AWS]({{ site.baseurl }}/howto/deploy/aws.md), [GCP]({{ site.baseurl }}/howto/deploy/gcp.md) and [more]({{ site.baseurl }}/howto/deploy).
+Additional information on the data format can be found in [Versioning internals](./how/versioning-internals.md) and [Internal database structure](./how/kv.md)
 
 ### Load Balancing
 
@@ -74,7 +61,7 @@ See the [roadmap]({{ site.baseurl }}/project/index.md#roadmap) for information o
 ### Graveler
 
 The Graveler handles lakeFS versioning by translating lakeFS addresses to the actual stored objects.
-To learn about the data model used to store lakeFS metadata, see the [data model section]({{ site.baseurl }}/understand/how/versioning-internals.md).
+To learn about the data model used to store lakeFS metadata, see the [versioning internals page]({{ site.baseurl }}/understand/how/versioning-internals.md).
 
 ### Authentication & Authorization Service
 

--- a/docs/understand/architecture.md
+++ b/docs/understand/architecture.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Architecture
 parent: Understanding lakeFS
 description: lakeFS architecture overview. Learn more about lakeFS components, including its S3 API gateway.

--- a/docs/understand/data_lifecycle_management/ci.md
+++ b/docs/understand/data_lifecycle_management/ci.md
@@ -3,7 +3,6 @@ title: During Deployment
 parent: Data Lifecycle Management
 grand_parent: Understanding lakeFS
 description: lakeFS enables to continuously test newly ingested data to ensure data quality requirements are met
-nav_order: 35
 redirect_from:
   - /data_lifecycle_management/ci.html
 ---

--- a/docs/understand/data_lifecycle_management/ci.md
+++ b/docs/understand/data_lifecycle_management/ci.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: During Deployment
 parent: Data Lifecycle Management
 grand_parent: Understanding lakeFS

--- a/docs/understand/data_lifecycle_management/data-devenv.md
+++ b/docs/understand/data_lifecycle_management/data-devenv.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: In Test
 parent: Data Lifecycle Management
 grand_parent: Understanding lakeFS

--- a/docs/understand/data_lifecycle_management/data-devenv.md
+++ b/docs/understand/data_lifecycle_management/data-devenv.md
@@ -3,7 +3,6 @@ title: In Test
 parent: Data Lifecycle Management
 grand_parent: Understanding lakeFS
 description: lakeFS enables a safe test environment on your data lake without the need to copy or mock data
-nav_order: 25
 redirect_from:
   - /data_lifecycle_management/data-devenv.html
 ---

--- a/docs/understand/data_lifecycle_management/index.md
+++ b/docs/understand/data_lifecycle_management/index.md
@@ -1,10 +1,18 @@
 ---
 title: Data Lifecycle Management
 description: Learn how lakeFS enables data lifecycle management.
-nav_order: 50
 parent: Understanding lakeFS
 has_children: true
+has_toc: false
 redirect_from:
     - /branching/recommendations.html
     - /using_lakefs.html
 ---
+
+# Data Lifecycle Management in lakeFS
+
+lakeFS provides full support for Data Lifecycle Management through all stages: 
+
+* [In Test](./data-devenv.md)
+* [During Deployment](./ci.md)
+* [In Production](./production.md)

--- a/docs/understand/data_lifecycle_management/index.md
+++ b/docs/understand/data_lifecycle_management/index.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Data Lifecycle Management
 description: Learn how lakeFS enables data lifecycle management.
 nav_order: 50

--- a/docs/understand/data_lifecycle_management/production.md
+++ b/docs/understand/data_lifecycle_management/production.md
@@ -3,7 +3,6 @@ title: In Production
 parent: Data Lifecycle Management
 grand_parent: Understanding lakeFS
 description: lakeFS helps recover from errors and find root case in production.
-nav_order: 55
 redirect_from:
   - /data_lifecycle_management/production.html
 ---

--- a/docs/understand/data_lifecycle_management/production.md
+++ b/docs/understand/data_lifecycle_management/production.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: In Production
 parent: Data Lifecycle Management
 grand_parent: Understanding lakeFS

--- a/docs/understand/faq.md
+++ b/docs/understand/faq.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: FAQ
 parent: Understanding lakeFS
 description: Have a question about lakeFS? Check out this list of Frequently Asked Questions

--- a/docs/understand/glossary.md
+++ b/docs/understand/glossary.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Glossary
 description: Glossary of all terms related to lakeFS technical internals and the architecture.
 parent: Understanding lakeFS

--- a/docs/understand/glossary.md
+++ b/docs/understand/glossary.md
@@ -2,7 +2,6 @@
 title: Glossary
 description: Glossary of all terms related to lakeFS technical internals and the architecture.
 parent: Understanding lakeFS
-nav_order: 60
 has_children: false
 redirect_from:
     - /reference/glossary.html

--- a/docs/understand/how/index.md
+++ b/docs/understand/how/index.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: How lakeFS Works
 description: This section includes all the details about the lakeFS open source project. 
 parent: Understanding lakeFS

--- a/docs/understand/how/index.md
+++ b/docs/understand/how/index.md
@@ -2,9 +2,16 @@
 title: How lakeFS Works
 description: This section includes all the details about the lakeFS open source project. 
 parent: Understanding lakeFS
-nav_order: 40
 has_children: true
-
+has_toc: false
 ---
 
-This section includes all the details about lakeFS internals and implementation details
+# How lakeFS Works
+
+The [Architecture]({{ site.baseurl }}/understand/architecture.html) page includes a logical overview of lakeFS and its components. 
+
+For deep-dive content about lakeFS see: 
+
+* [Internal database structure](./kv.md)
+* [Merges in lakeFS](./merge.md)
+* [Versioning Internals](./versioning-internals.md)

--- a/docs/understand/how/kv.md
+++ b/docs/understand/how/kv.md
@@ -3,7 +3,6 @@ title: Internal database structure
 parent: How lakeFS Works
 grand_parent: Understanding lakeFS
 description: Brief introduction to lakeFS over KV
-nav_order: 20
 has_children: false
 redirect_from:
   - /understand/kv-in-a-nutshell.html

--- a/docs/understand/how/kv.md
+++ b/docs/understand/how/kv.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Internal database structure
 parent: How lakeFS Works
 grand_parent: Understanding lakeFS

--- a/docs/understand/how/merge.md
+++ b/docs/understand/how/merge.md
@@ -3,14 +3,13 @@ title: Merge
 description: Using lakeFS, you can merge different commits and references into a branch. The purpose of this document is to explain how to use this feature.
 parent: How lakeFS Works
 grand_parent: Understanding lakeFS
-nav_order: 9999
 has_children: false
 redirect_from:
   - /reference/merge.html
   - /understand/merge.html
 ---
 
-# Merge
+# Merges in lakeFS
 
 The merge operation in lakeFS is similar to Git. It incorporates changes from a _merge source_ (a commit/reference) into a _merge destination_ (a **branch**). 
 

--- a/docs/understand/how/merge.md
+++ b/docs/understand/how/merge.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Merge
 description: Using lakeFS, you can merge different commits and references into a branch. The purpose of this document is to explain how to use this feature.
 parent: How lakeFS Works

--- a/docs/understand/how/versioning-internals.md
+++ b/docs/understand/how/versioning-internals.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Versioning Internals
 parent: How lakeFS Works
 grand_parent: Understanding lakeFS

--- a/docs/understand/how/versioning-internals.md
+++ b/docs/understand/how/versioning-internals.md
@@ -3,7 +3,6 @@ title: Versioning Internals
 parent: How lakeFS Works
 grand_parent: Understanding lakeFS
 description: This section explains how versioning works in lakeFS.
-nav_order: 10
 has_children: false
 redirect_from: 
   - /understand/architecture/data-model.html

--- a/docs/understand/index.md
+++ b/docs/understand/index.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Understanding lakeFS
 description: Details about lakeFS Concepts and Design
 nav_order: 15

--- a/docs/understand/index.md
+++ b/docs/understand/index.md
@@ -3,4 +3,46 @@ title: Understanding lakeFS
 description: Details about lakeFS Concepts and Design
 nav_order: 15
 has_children: true
+has_toc: false
 ---
+
+# Understanding lakeFS
+
+<img src="/assets/img/docs_logo.png" alt="lakeFS Docs" width=200 style="float: right; margin: 0 0 10px 10px;"/>
+
+## Architecture and Internals
+
+The [Architecture](./architecture.html) page includes a logical overview of lakeFS and its components. 
+
+For deep-dive content about lakeFS see: 
+
+* [Internal database structure](./how/kv.md)
+* [Merges in lakeFS](./how/merge.md)
+* [Versioning Internals](./how/versioning-internals.md)
+
+## lakeFS Use Cases
+
+lakeFS has many uses in the data world, including
+
+* [CI/CD for Data Lakes](./use_cases/cicd_for_data.md)
+* [ETL Testing Environment](./use_cases/etl_testing.md)
+* [Reproducibility](./use_cases/reproducibility.md)
+* [Rollback](./use_cases/rollback.md)
+
+One of the important things that lakeFS provides is full support for [Data Lifecycle Management](./data_lifecycle_management/) through all stages: 
+
+* [In Test](./data_lifecycle_management/data-devenv.md)
+* [During Deployment](./data_lifecycle_management/ci.md)
+* [In Production](./data_lifecycle_management/production.md)
+
+## lakeFS Concepts and Model 
+
+lakeFS adopts many of the terms and concepts from git. [This page](./model.html) goes into details on the similarities and differences, and provides a good background to the concepts used in lakeFS. 
+
+## Performance
+
+Check out the [Performance best practices](./performance-best-practices.html) guide for useful hints and tips on ensuring high performance from lakeFS. 
+
+## FAQ and Glossary
+
+The [FAQ](./faq.html) covers many common questions around lakeFS, and the [glossary](./glossary.html) provides a useful reference for the terms used in lakeFS. 

--- a/docs/understand/model.md
+++ b/docs/understand/model.md
@@ -1,8 +1,7 @@
 ---
-title: Model 
+title: Concepts and  Model 
 description: The lakeFS object model blends the object models of Git and of object stores such as S3. Read this page to learn more.
 parent: Understanding lakeFS
-nav_order: 20
 has_children: false
 redirect_from: 
   - /reference/object-model.html
@@ -10,7 +9,7 @@ redirect_from:
   - /understand/object-model.html
 ---
 
-# Model
+# lakeFS Concepts and Model
 
 {% include toc_2-3.html %}
 
@@ -21,9 +20,9 @@ defines the common concepts of lakeFS.
 
 lakeFS is an interface to manage objects in an object store.
 
-The actual data itself is not stored inside lakeFS directly but in an [underlying object store](#concepts-unique-to-lakefs).
-lakeFS manages pointers and additional metadata about these objects. 
-{: .note }
+{: .tip }
+> The actual data itself is not stored inside lakeFS directly but in an [underlying object store](#concepts-unique-to-lakefs).
+> lakeFS manages pointers and additional metadata about these objects. 
 
 ## Version Control
 

--- a/docs/understand/model.md
+++ b/docs/understand/model.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Model 
 description: The lakeFS object model blends the object models of Git and of object stores such as S3. Read this page to learn more.
 parent: Understanding lakeFS

--- a/docs/understand/performance-best-practices.md
+++ b/docs/understand/performance-best-practices.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Performance Best Practices
 parent: Understanding lakeFS
 description: This section suggests performance best practices to work with lakeFS.

--- a/docs/understand/performance-best-practices.md
+++ b/docs/understand/performance-best-practices.md
@@ -2,7 +2,6 @@
 title: Performance Best Practices
 parent: Understanding lakeFS
 description: This section suggests performance best practices to work with lakeFS.
-nav_order: 26
 has_children: false
 --- 
 # Performance Best Practices

--- a/docs/understand/use_cases/etl_testing.md
+++ b/docs/understand/use_cases/etl_testing.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: ETL Testing Environment
 description: In this tutorial, we will explore how to safely run ETL testing using lakeFS to create isolated dev/test data environments to run data pipelines.
 parent: Use Cases

--- a/docs/understand/use_cases/index.md
+++ b/docs/understand/use_cases/index.md
@@ -1,5 +1,4 @@
 ---
-layout: default
 title: Use Cases
 description: Better understand how to use the features of lakeFS for specific use cases.
 parent: Understanding lakeFS

--- a/docs/understand/use_cases/index.md
+++ b/docs/understand/use_cases/index.md
@@ -2,9 +2,24 @@
 title: Use Cases
 description: Better understand how to use the features of lakeFS for specific use cases.
 parent: Understanding lakeFS
-nav_order: 30
 has_children: true
+has_toc: false
 redirect_from:
    - /use_cases/
    - /use_cases/index.html
 ---
+
+# lakeFS Use Cases
+
+lakeFS has many uses in the data world, including
+
+* [CI/CD for Data Lakes](./cicd_for_data.md)
+* [ETL Testing Environment](./etl_testing.md)
+* [Reproducibility](./reproducibility.md)
+* [Rollback](./rollback.md)
+
+One of the important things that lakeFS provides is full support for [Data Lifecycle Management](../data_lifecycle_management/) through all stages: 
+
+* [In Test](../data_lifecycle_management/data-devenv.md)
+* [During Deployment](../data_lifecycle_management/ci.md)
+* [In Production](../data_lifecycle_management/production.md)


### PR DESCRIPTION
- Remove default layout metadata 
	- It's the only layout 
	- It's the default anyway 
	- It adds unnecessary content to the front page matter metadata for pages, making it more likely to make a mistake editing what is there
- Add content to index pages of /understand, fix a few page nits
