### PR TITLE
Remove "S3 with local API key" Esti test

### DIFF
--- a/.github/workflows/esti.yaml
+++ b/.github/workflows/esti.yaml
@@ -1175,19 +1175,6 @@ jobs:
             docker-compose exec -T postgres pg_dumpall --username=lakefs | gzip | aws s3 cp - s3://esti-system-testing/${{ github.run_number }}/${{ steps.unique.outputs.value }}/dump.gz
           fi
 
-      - name: Run lakeFS S3 to use with local API key
-        env:
-          LAKEFS_STATS_ENABLED: "false"
-          LAKEFS_BLOCKSTORE_TYPE: s3
-          LAKEFS_DATABASE_TYPE: postgres
-          DOCKER_REG: ${{ steps.login-ecr.outputs.registry }}
-          ESTI_TEST_DATA_ACCESS: true,false
-          ESTI_BLOCKSTORE_TYPE: s3
-          ESTI_STORAGE_NAMESPACE: s3://esti-system-testing/${{ github.run_number }}-local-api-key/${{ steps.unique.outputs.value }}
-        run: |
-          docker-compose -f esti/ops/docker-compose.yaml down -v
-          docker-compose -f esti/ops/docker-compose.yaml up --quiet-pull --exit-code-from=esti
-
   run-system-gcp-gs:
     name: Run latest lakeFS app on Google Cloud Platform and Google Cloud Storage
     needs: [gen-code, deploy-image]


### PR DESCRIPTION
This no longer does anything useful.  I added it way back in
[#927](https://github.com/treeverse/lakeFS/pull/927/files#diff-9f6b0e6a618e2cd31c41c6d5a3a0ffd9fe0bc64deca0e656acadf4f818f78906R140-R157).
The system test was called "Nessie" back then :-)
At the time we had no auth tests or anything.  We now go through these codes
_all the time_, both on Esti and on Cloud integration tests.  No point in
this test.

Also it usually ends _last_, so we may gain ~1 min wall-clock time per Esti
run..