### PR TITLE
Python SDK LakeFSClient generated properties per API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ tools: ## Install tools
 client-python: api/swagger.yml  ## Generate SDK for Python client
 	# remove the build folder as it also holds lakefs_client folder which keeps because we skip it during find
 	rm -rf clients/python/build; cd clients/python && \
-		find . -depth -name lakefs_client -prune -o ! \( -name client.py -or -name Gemfile -or -name Gemfile.lock -or -name _config.yml -or -name .openapi-generator-ignore -or -name templates -or -name setup.mustache \) -delete
+		find . -depth -name lakefs_client -prune -o ! \( -name Gemfile -or -name Gemfile.lock -or -name _config.yml -or -name .openapi-generator-ignore -or -name templates -or -name setup.mustache -or -name client.mustache \) -delete
 	$(OPENAPI_GENERATOR) generate \
 		-i /mnt/$< \
 		-g python \
@@ -121,6 +121,7 @@ client-python: api/swagger.yml  ## Generate SDK for Python client
 		--http-user-agent "lakefs-python-sdk/$(PACKAGE_VERSION)" \
 		--git-user-id treeverse --git-repo-id lakeFS \
 		--additional-properties=infoName=Treeverse,infoEmail=services@treeverse.io,packageName=lakefs_client,packageVersion=$(PACKAGE_VERSION),projectName=lakefs-client,packageUrl=https://github.com/treeverse/lakeFS/tree/master/clients/python \
+		-c /mnt/clients/python-codegen-config.yaml \
 		-o /mnt/clients/python
 
 client-java: api/swagger.yml  ## Generate SDK for Java (and Scala) client

--- a/clients/python-codegen-config.yaml
+++ b/clients/python-codegen-config.yaml
@@ -1,0 +1,5 @@
+files:
+  client.mustache:
+    templateType: SupportingFiles
+    folder: lakefs_client
+    destinationFilename: client.py

--- a/clients/python/.openapi-generator-ignore
+++ b/clients/python/.openapi-generator-ignore
@@ -25,7 +25,6 @@
 .gitlab-ci.yml
 git_push.sh
 
-lakefs_client/client.py
 Gemfile.lock
 Gemfile
 _config.yml

--- a/clients/python/.openapi-generator/FILES
+++ b/clients/python/.openapi-generator/FILES
@@ -133,6 +133,7 @@ lakefs_client/api/tags_api.py
 lakefs_client/api/templates_api.py
 lakefs_client/api_client.py
 lakefs_client/apis/__init__.py
+lakefs_client/client.py
 lakefs_client/configuration.py
 lakefs_client/exceptions.py
 lakefs_client/model/__init__.py

--- a/clients/python/lakefs_client/client.py
+++ b/clients/python/lakefs_client/client.py
@@ -1,3 +1,5 @@
+import warnings
+
 from urllib3.util import parse_url, Url
 
 import lakefs_client.apis
@@ -63,25 +65,6 @@ class LakeFSClient:
         self.tags_api = tags_api.TagsApi(self._api)
         self.templates_api = templates_api.TemplatesApi(self._api)
 
-        # Backwards compatibility - keep the old names for now.
-        self.actions = actions_api.ActionsApi(self._api)
-        self.auth = auth_api.AuthApi(self._api)
-        self.branches = branches_api.BranchesApi(self._api)
-        self.commits = commits_api.CommitsApi(self._api)
-        self.config = config_api.ConfigApi(self._api)
-        self.experimental = experimental_api.ExperimentalApi(self._api)
-        self.health_check = health_check_api.HealthCheckApi(self._api)
-        self.metadata = metadata_api.MetadataApi(self._api)
-        self.objects = objects_api.ObjectsApi(self._api)
-        self.otf_diff = otf_diff_api.OtfDiffApi(self._api)
-        self.refs = refs_api.RefsApi(self._api)
-        self.repositories = repositories_api.RepositoriesApi(self._api)
-        self.retention = retention_api.RetentionApi(self._api)
-        self.staging = staging_api.StagingApi(self._api)
-        self.statistics = statistics_api.StatisticsApi(self._api)
-        self.tags = tags_api.TagsApi(self._api)
-        self.templates = templates_api.TemplatesApi(self._api)
-
     @staticmethod
     def _ensure_endpoint(configuration):
         """Normalize lakefs connection endpoint found in configuration's host"""
@@ -102,3 +85,88 @@ class LakeFSClient:
         except ValueError:
             pass
         return configuration
+
+    @property
+    def actions(self):
+        warnings.warn("Deprecated property. Use actions_api instead.", DeprecationWarning)
+        return self.actions_api
+
+    @property
+    def auth(self):
+        warnings.warn("Deprecated property. Use auth_api instead.", DeprecationWarning)
+        return self.auth_api
+
+    @property
+    def branches(self):
+        warnings.warn("Deprecated property. Use branches_api instead.", DeprecationWarning)
+        return self.branches_api
+
+    @property
+    def commits(self):
+        warnings.warn("Deprecated property. Use commits_api instead.", DeprecationWarning)
+        return self.commits_api
+
+    @property
+    def config(self):
+        warnings.warn("Deprecated property. Use config_api instead.", DeprecationWarning)
+        return self.config_api
+
+    @property
+    def experimental(self):
+        warnings.warn("Deprecated property. Use experimental_api instead.", DeprecationWarning)
+        return self.experimental_api
+
+    @property
+    def health_check(self):
+        warnings.warn("Deprecated property. Use health_check_api instead.", DeprecationWarning)
+        return self.health_check_api
+
+    @property
+    def metadata(self):
+        warnings.warn("Deprecated property. Use metadata_api instead.", DeprecationWarning)
+        return self.metadata_api
+
+    @property
+    def objects(self):
+        warnings.warn("Deprecated property. Use objects_api instead.", DeprecationWarning)
+        return self.objects_api
+
+    @property
+    def otf_diff(self):
+        warnings.warn("Deprecated property. Use otf_diff_api instead.", DeprecationWarning)
+        return self.otf_diff_api
+
+    @property
+    def refs(self):
+        warnings.warn("Deprecated property. Use refs_api instead.", DeprecationWarning)
+        return self.refs_api
+
+    @property
+    def repositories(self):
+        warnings.warn("Deprecated property. Use repositories_api instead.", DeprecationWarning)
+        return self.repositories_api
+
+    @property
+    def retention(self):
+        warnings.warn("Deprecated property. Use retention_api instead.", DeprecationWarning)
+        return self.retention_api
+
+    @property
+    def staging(self):
+        warnings.warn("Deprecated property. Use staging_api instead.", DeprecationWarning)
+        return self.staging_api
+
+    @property
+    def statistics(self):
+        warnings.warn("Deprecated property. Use statistics_api instead.", DeprecationWarning)
+        return self.statistics_api
+
+    @property
+    def tags(self):
+        warnings.warn("Deprecated property. Use tags_api instead.", DeprecationWarning)
+        return self.tags_api
+
+    @property
+    def templates(self):
+        warnings.warn("Deprecated property. Use templates_api instead.", DeprecationWarning)
+        return self.templates_api

--- a/clients/python/templates/client.mustache
+++ b/clients/python/templates/client.mustache
@@ -1,3 +1,5 @@
+import warnings
+
 from urllib3.util import parse_url, Url
 
 import lakefs_client.apis
@@ -37,25 +39,6 @@ class LakeFSClient:
 {{/apis}}
 {{/apiInfo}}
 
-        # Backwards compatibility - keep the old names for now.
-        self.actions = actions_api.ActionsApi(self._api)
-        self.auth = auth_api.AuthApi(self._api)
-        self.branches = branches_api.BranchesApi(self._api)
-        self.commits = commits_api.CommitsApi(self._api)
-        self.config = config_api.ConfigApi(self._api)
-        self.experimental = experimental_api.ExperimentalApi(self._api)
-        self.health_check = health_check_api.HealthCheckApi(self._api)
-        self.metadata = metadata_api.MetadataApi(self._api)
-        self.objects = objects_api.ObjectsApi(self._api)
-        self.otf_diff = otf_diff_api.OtfDiffApi(self._api)
-        self.refs = refs_api.RefsApi(self._api)
-        self.repositories = repositories_api.RepositoriesApi(self._api)
-        self.retention = retention_api.RetentionApi(self._api)
-        self.staging = staging_api.StagingApi(self._api)
-        self.statistics = statistics_api.StatisticsApi(self._api)
-        self.tags = tags_api.TagsApi(self._api)
-        self.templates = templates_api.TemplatesApi(self._api)
-
     @staticmethod
     def _ensure_endpoint(configuration):
         """Normalize lakefs connection endpoint found in configuration's host"""
@@ -76,3 +59,88 @@ class LakeFSClient:
         except ValueError:
             pass
         return configuration
+
+    @property
+    def actions(self):
+        warnings.warn("Deprecated property. Use actions_api instead.", DeprecationWarning)
+        return self.actions_api
+
+    @property
+    def auth(self):
+        warnings.warn("Deprecated property. Use auth_api instead.", DeprecationWarning)
+        return self.auth_api
+
+    @property
+    def branches(self):
+        warnings.warn("Deprecated property. Use branches_api instead.", DeprecationWarning)
+        return self.branches_api
+
+    @property
+    def commits(self):
+        warnings.warn("Deprecated property. Use commits_api instead.", DeprecationWarning)
+        return self.commits_api
+
+    @property
+    def config(self):
+        warnings.warn("Deprecated property. Use config_api instead.", DeprecationWarning)
+        return self.config_api
+
+    @property
+    def experimental(self):
+        warnings.warn("Deprecated property. Use experimental_api instead.", DeprecationWarning)
+        return self.experimental_api
+
+    @property
+    def health_check(self):
+        warnings.warn("Deprecated property. Use health_check_api instead.", DeprecationWarning)
+        return self.health_check_api
+
+    @property
+    def metadata(self):
+        warnings.warn("Deprecated property. Use metadata_api instead.", DeprecationWarning)
+        return self.metadata_api
+
+    @property
+    def objects(self):
+        warnings.warn("Deprecated property. Use objects_api instead.", DeprecationWarning)
+        return self.objects_api
+
+    @property
+    def otf_diff(self):
+        warnings.warn("Deprecated property. Use otf_diff_api instead.", DeprecationWarning)
+        return self.otf_diff_api
+
+    @property
+    def refs(self):
+        warnings.warn("Deprecated property. Use refs_api instead.", DeprecationWarning)
+        return self.refs_api
+
+    @property
+    def repositories(self):
+        warnings.warn("Deprecated property. Use repositories_api instead.", DeprecationWarning)
+        return self.repositories_api
+
+    @property
+    def retention(self):
+        warnings.warn("Deprecated property. Use retention_api instead.", DeprecationWarning)
+        return self.retention_api
+
+    @property
+    def staging(self):
+        warnings.warn("Deprecated property. Use staging_api instead.", DeprecationWarning)
+        return self.staging_api
+
+    @property
+    def statistics(self):
+        warnings.warn("Deprecated property. Use statistics_api instead.", DeprecationWarning)
+        return self.statistics_api
+
+    @property
+    def tags(self):
+        warnings.warn("Deprecated property. Use tags_api instead.", DeprecationWarning)
+        return self.tags_api
+
+    @property
+    def templates(self):
+        warnings.warn("Deprecated property. Use templates_api instead.", DeprecationWarning)
+        return self.templates_api

--- a/clients/python/templates/client.mustache
+++ b/clients/python/templates/client.mustache
@@ -1,24 +1,11 @@
 from urllib3.util import parse_url, Url
 
 import lakefs_client.apis
-from lakefs_client.api import actions_api
-from lakefs_client.api import auth_api
-from lakefs_client.api import branches_api
-from lakefs_client.api import commits_api
-from lakefs_client.api import config_api
-from lakefs_client.api import experimental_api
-from lakefs_client.api import health_check_api
-from lakefs_client.api import import_api
-from lakefs_client.api import metadata_api
-from lakefs_client.api import objects_api
-from lakefs_client.api import otf_diff_api
-from lakefs_client.api import refs_api
-from lakefs_client.api import repositories_api
-from lakefs_client.api import retention_api
-from lakefs_client.api import staging_api
-from lakefs_client.api import statistics_api
-from lakefs_client.api import tags_api
-from lakefs_client.api import templates_api
+{{#apiInfo}}
+{{#apis}}
+from {{apiPackage}} import {{classFilename}}
+{{/apis}}
+{{/apiInfo}}
 
 
 class _WrappedApiClient(lakefs_client.ApiClient):
@@ -44,24 +31,11 @@ class LakeFSClient:
         configuration = LakeFSClient._ensure_endpoint(configuration)
         self._api = _WrappedApiClient(configuration=configuration, header_name=header_name,
                                           header_value=header_value, cookie=cookie, pool_threads=pool_threads)
-        self.actions_api = actions_api.ActionsApi(self._api)
-        self.auth_api = auth_api.AuthApi(self._api)
-        self.branches_api = branches_api.BranchesApi(self._api)
-        self.commits_api = commits_api.CommitsApi(self._api)
-        self.config_api = config_api.ConfigApi(self._api)
-        self.experimental_api = experimental_api.ExperimentalApi(self._api)
-        self.health_check_api = health_check_api.HealthCheckApi(self._api)
-        self.import_api = import_api.ImportApi(self._api)
-        self.metadata_api = metadata_api.MetadataApi(self._api)
-        self.objects_api = objects_api.ObjectsApi(self._api)
-        self.otf_diff_api = otf_diff_api.OtfDiffApi(self._api)
-        self.refs_api = refs_api.RefsApi(self._api)
-        self.repositories_api = repositories_api.RepositoriesApi(self._api)
-        self.retention_api = retention_api.RetentionApi(self._api)
-        self.staging_api = staging_api.StagingApi(self._api)
-        self.statistics_api = statistics_api.StatisticsApi(self._api)
-        self.tags_api = tags_api.TagsApi(self._api)
-        self.templates_api = templates_api.TemplatesApi(self._api)
+{{#apiInfo}}
+{{#apis}}
+        self.{{classFilename}} = {{classFilename}}.{{{classname}}}(self._api)
+{{/apis}}
+{{/apiInfo}}
 
         # Backwards compatibility - keep the old names for now.
         self.actions = actions_api.ActionsApi(self._api)


### PR DESCRIPTION
Deprecate old properties - tag name (ex: objects, refs and etc.)
Generate per api class member (ex: objects_api, refs_api and etc.)

**Update changelog** add note that we depracte python client old members 

Fix https://github.com/treeverse/lakeFS/issues/6262