### PR TITLE
Re-run Surge on pushes

### DIFF
--- a/.github/workflows/docs-pr.yaml
+++ b/.github/workflows/docs-pr.yaml
@@ -6,6 +6,9 @@ on:
       - "docs/**"
     branches:
       - master
+  push:
+    paths:
+      - "docs/**"
 
 jobs:
   # This job name kept short because it's used in the preview URL


### PR DESCRIPTION
This makes Surge try harder and run more often.  Discovered while I was
working on #6305, where it ran once after creating the PR but then stopped.
Admittedly GitHub was not particularly responsive to running actions at the
time.