### PR TITLE
Use logging.FromContext instead of logging.Default where possible

### DIFF
--- a/cmd/lakectl/cmd/config/config.go
+++ b/cmd/lakectl/cmd/config/config.go
@@ -67,7 +67,7 @@ func ReadConfig() (c *Config) {
 
 	setDefaults()
 	c.err = viper.ReadInConfig()
-	logger := logging.Default().WithField("file", viper.ConfigFileUsed())
+	logger := logging.ContextUnavailable().WithField("file", viper.ConfigFileUsed())
 
 	if errors.Is(c.err, viper.ConfigFileNotFoundError{}) {
 		logger.WithError(c.err).Fatal("failed to read config file")

--- a/cmd/lakectl/cmd/metastore_copy.go
+++ b/cmd/lakectl/cmd/metastore_copy.go
@@ -38,7 +38,7 @@ var metastoreCopyCmd = &cobra.Command{
 		if len(serde) == 0 {
 			serde = toTable
 		}
-		logging.Default().WithFields(logging.Fields{
+		logging.ContextUnavailable().WithFields(logging.Fields{
 			"form_client_type": fromClientType,
 			"from_schema":      fromDB,
 			"from_table":       fromTable,

--- a/cmd/lakectl/cmd/metastore_copy_schema.go
+++ b/cmd/lakectl/cmd/metastore_copy_schema.go
@@ -29,7 +29,7 @@ var metastoreCopySchemaCmd = &cobra.Command{
 			toDB = toBranch
 		}
 
-		logging.Default().WithFields(logging.Fields{
+		logging.ContextUnavailable().WithFields(logging.Fields{
 			"form_client_type": fromClientType,
 			"from_db":          fromDB,
 			"to_client_type":   toClientType,

--- a/cmd/lakectl/cmd/root.go
+++ b/cmd/lakectl/cmd/root.go
@@ -88,7 +88,7 @@ var rootCmd = &cobra.Command{
 		}
 
 		if cfg.Err() == nil {
-			logging.Default().
+			logging.ContextUnavailable().
 				WithField("file", viper.ConfigFileUsed()).
 				Debug("loaded configuration from file")
 		}

--- a/cmd/lakefs-loadtest/cmd/entry.go
+++ b/cmd/lakefs-loadtest/cmd/entry.go
@@ -63,11 +63,11 @@ var entryCmd = &cobra.Command{
 
 		kvParams, err := conf.DatabaseParams()
 		if err != nil {
-			logging.Default().WithError(err).Fatal("Get KV params")
+			logging.ContextUnavailable().WithError(err).Fatal("Get KV params")
 		}
 		kvStore, err := kv.Open(ctx, kvParams)
 		if err != nil {
-			logging.Default().WithError(err).Fatal("failed to open KV store")
+			logging.ContextUnavailable().WithError(err).Fatal("failed to open KV store")
 		}
 		defer kvStore.Close()
 

--- a/cmd/lakefs/cmd/migrate.go
+++ b/cmd/lakefs/cmd/migrate.go
@@ -115,7 +115,7 @@ func DoMigration(ctx context.Context, kvStore kv.Store, cfg *config.Config, forc
 		case version >= kv.NextSchemaVersion || version < kv.InitialMigrateVersion:
 			return fmt.Errorf("wrong starting version %d: %w", version, kv.ErrMigrationVersion)
 		case version < kv.ACLNoReposMigrateVersion:
-			err = migrations.MigrateToACL(ctx, kvStore, cfg, logging.Default(), version, force)
+			err = migrations.MigrateToACL(ctx, kvStore, cfg, logging.ContextUnavailable(), version, force)
 		case version < kv.ACLImportMigrateVersion:
 			err = migrations.MigrateImportPermissions(ctx, kvStore, cfg)
 		}

--- a/cmd/lakefs/cmd/root.go
+++ b/cmd/lakefs/cmd/root.go
@@ -75,7 +75,7 @@ func loadConfig() *config.Config {
 
 // initConfig reads in config file and ENV variables if set.
 func initConfig() {
-	logger := logging.Default().WithField("phase", "startup")
+	logger := logging.ContextUnavailable().WithField("phase", "startup")
 	if cfgFile != "" {
 		logger.WithField("file", cfgFile).Info("Configuration file")
 		// Use config file from the flag.

--- a/cmd/lakefs/cmd/run.go
+++ b/cmd/lakefs/cmd/run.go
@@ -71,7 +71,7 @@ var runCmd = &cobra.Command{
 	Use:   "run",
 	Short: "Run lakeFS",
 	Run: func(cmd *cobra.Command, args []string) {
-		logger := logging.Default()
+		logger := logging.ContextUnavailable()
 		cfg := loadConfig()
 		viper.WatchConfig()
 		viper.OnConfigChange(func(in fsnotify.Event) {

--- a/cmd/lakefs/cmd/setup.go
+++ b/cmd/lakefs/cmd/setup.go
@@ -71,7 +71,7 @@ var setupCmd = &cobra.Command{
 			os.Exit(1)
 		}
 		defer kvStore.Close()
-		logger := logging.Default()
+		logger := logging.ContextUnavailable()
 		authLogger := logger.WithField("service", "auth_service")
 		authService = auth.NewAuthService(kvStore, crypt.NewSecretStore(cfg.AuthEncryptionSecret()), nil, authparams.ServiceCache(cfg.Auth.Cache), authLogger)
 		metadataManager = auth.NewKVMetadataManager(version.Version, cfg.Installation.FixedID, cfg.Database.Type, kvStore)

--- a/cmd/lakefs/cmd/superuser.go
+++ b/cmd/lakefs/cmd/superuser.go
@@ -46,7 +46,7 @@ var superuserCmd = &cobra.Command{
 			os.Exit(1)
 		}
 
-		logger := logging.Default()
+		logger := logging.ContextUnavailable()
 		ctx := cmd.Context()
 		kvParams, err := cfg.DatabaseParams()
 		if err != nil {

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -4597,7 +4597,7 @@ func writeResponse(w http.ResponseWriter, r *http.Request, code int, response in
 	w.WriteHeader(code)
 	err := json.NewEncoder(w).Encode(response)
 	if err != nil {
-		logging.Default().WithError(err).WithField("code", code).Debug("Failed to write encoded json response")
+		logging.FromContext(r.Context()).WithError(err).WithField("code", code).Info("Failed to write encoded json response")
 	}
 }
 

--- a/pkg/api/serve_test.go
+++ b/pkg/api/serve_test.go
@@ -165,7 +165,7 @@ func setupHandlerWithWalkerFactory(t testing.TB, factory catalog.WalkerFactory) 
 	idGen := &actions.DecreasingIDGenerator{}
 	authService := auth.NewAuthService(kvStore, crypt.NewSecretStore([]byte("some secret")), nil, authparams.ServiceCache{
 		Enabled: false,
-	}, logging.Default())
+	}, logging.ContextUnavailable())
 	meta := auth.NewKVMetadataManager("serve_test", cfg.Installation.FixedID, cfg.Database.Type, kvStore)
 
 	// Do not validate invalid config (missing required fields).
@@ -223,7 +223,7 @@ func setupHandlerWithWalkerFactory(t testing.TB, factory catalog.WalkerFactory) 
 		nil,
 		actionsService,
 		auditChecker,
-		logging.Default(),
+		logging.ContextUnavailable(),
 		emailer,
 		tmpl,
 		nil,

--- a/pkg/auth/service.go
+++ b/pkg/auth/service.go
@@ -1959,7 +1959,7 @@ func NewAPIAuthService(apiEndpoint, token string, secretStore crypt.SecretStore,
 		cache:       cache,
 	}
 	if emailer != nil {
-		res.delegatedInviteHandler = NewEmailInviteHandler(res, logging.Default(), emailer)
+		res.delegatedInviteHandler = NewEmailInviteHandler(res, logging.ContextUnavailable(), emailer)
 	}
 	return res, nil
 }
@@ -1978,7 +1978,7 @@ func generateAuthAPIJWT(secret []byte) (string, error) {
 		ExpiresAt: jwt.NewNumericDate(exp),
 	}
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
-	logging.Default().WithField("id", id).Info("generated auth api token")
+	logging.ContextUnavailable().WithField("id", id).Info("generated auth api token")
 	return token.SignedString(secret)
 }
 

--- a/pkg/auth/service.go
+++ b/pkg/auth/service.go
@@ -1017,7 +1017,7 @@ func interpolateUser(resource string, username string) string {
 	return strings.ReplaceAll(resource, "${user}", username)
 }
 
-func checkPermissions(node permissions.Node, username string, policies []*model.Policy) CheckResult {
+func checkPermissions(ctx context.Context, node permissions.Node, username string, policies []*model.Policy) CheckResult {
 	allowed := CheckNeutral
 	switch node.Type {
 	case permissions.NodeTypeNode:
@@ -1049,7 +1049,7 @@ func checkPermissions(node permissions.Node, username string, policies []*model.
 		// Denied - one of the permissions is Deny
 		// Natural - otherwise
 		for _, node := range node.Nodes {
-			result := checkPermissions(node, username, policies)
+			result := checkPermissions(ctx, node, username, policies)
 			if result == CheckDeny {
 				return CheckDeny
 			}
@@ -1064,7 +1064,7 @@ func checkPermissions(node permissions.Node, username string, policies []*model.
 		// Denied - one of the permissions is Deny
 		// Natural - otherwise
 		for _, node := range node.Nodes {
-			result := checkPermissions(node, username, policies)
+			result := checkPermissions(ctx, node, username, policies)
 			if result == CheckNeutral || result == CheckDeny {
 				return result
 			}
@@ -1072,7 +1072,7 @@ func checkPermissions(node permissions.Node, username string, policies []*model.
 		return CheckAllow
 
 	default:
-		logging.Default().Error("unknown permission node type")
+		logging.FromContext(ctx).Error("unknown permission node type")
 		return CheckDeny
 	}
 	return allowed
@@ -1087,7 +1087,7 @@ func (s *AuthService) Authorize(ctx context.Context, req *AuthorizationRequest) 
 		return nil, err
 	}
 
-	allowed := checkPermissions(req.RequiredPermissions, req.Username, policies)
+	allowed := checkPermissions(ctx, req.RequiredPermissions, req.Username, policies)
 
 	if allowed != CheckAllow {
 		return &AuthorizationResponse{
@@ -1892,7 +1892,7 @@ func (a *APIAuthService) Authorize(ctx context.Context, req *AuthorizationReques
 		return nil, err
 	}
 
-	allowed := checkPermissions(req.RequiredPermissions, req.Username, policies)
+	allowed := checkPermissions(ctx, req.RequiredPermissions, req.Username, policies)
 
 	if allowed != CheckAllow {
 		return &AuthorizationResponse{

--- a/pkg/auth/service_test.go
+++ b/pkg/auth/service_test.go
@@ -107,7 +107,7 @@ func TestAuthService_ListUsers_PagedWithPrefix(t *testing.T) {
 	kvStore := kvtest.GetStore(ctx, t)
 	s := auth.NewAuthService(kvStore, crypt.NewSecretStore(someSecret), nil, authparams.ServiceCache{
 		Enabled: false,
-	}, logging.Default())
+	}, logging.ContextUnavailable())
 
 	users := []string{"bar", "barn", "baz", "foo", "foobar", "foobaz"}
 	for _, u := range users {
@@ -157,7 +157,7 @@ func TestAuthService_ListPaged(t *testing.T) {
 	kvStore := kvtest.GetStore(ctx, t)
 	s := auth.NewAuthService(kvStore, crypt.NewSecretStore(someSecret), nil, authparams.ServiceCache{
 		Enabled: false,
-	}, logging.Default())
+	}, logging.ContextUnavailable())
 
 	const chars = "abcdefghijklmnopqrstuvwxyz"
 	for _, c := range chars {
@@ -540,19 +540,19 @@ func BenchmarkKVAuthService_ListEffectivePolicies(b *testing.B) {
 
 	serviceWithoutCache := auth.NewAuthService(kvStore, crypt.NewSecretStore(someSecret), nil, authparams.ServiceCache{
 		Enabled: false,
-	}, logging.Default())
+	}, logging.ContextUnavailable())
 	serviceWithCache := auth.NewAuthService(kvStore, crypt.NewSecretStore(someSecret), nil, authparams.ServiceCache{
 		Enabled: true,
 		Size:    1024,
 		TTL:     20 * time.Second,
 		Jitter:  3 * time.Second,
-	}, logging.Default())
+	}, logging.ContextUnavailable())
 	serviceWithCacheLowTTL := auth.NewAuthService(kvStore, crypt.NewSecretStore(someSecret), nil, authparams.ServiceCache{
 		Enabled: true,
 		Size:    1024,
 		TTL:     1 * time.Millisecond,
 		Jitter:  1 * time.Millisecond,
-	}, logging.Default())
+	}, logging.ContextUnavailable())
 	userName := userWithPolicies(b, serviceWithoutCache, userPoliciesForTesting)
 
 	b.Run("without_cache", func(b *testing.B) {
@@ -1124,7 +1124,7 @@ func NewTestApiService(t *testing.T, withCache bool) (*mock.MockClientWithRespon
 		cacheParams.TTL = time.Minute
 		cacheParams.Jitter = time.Minute
 	}
-	s, err := auth.NewAPIAuthServiceWithClient(mockClient, secretStore, cacheParams, logging.Default())
+	s, err := auth.NewAPIAuthServiceWithClient(mockClient, secretStore, cacheParams, logging.ContextUnavailable())
 	if err != nil {
 		t.Fatalf("failed initiating API service with mock")
 	}

--- a/pkg/auth/setup/setup.go
+++ b/pkg/auth/setup/setup.go
@@ -252,7 +252,7 @@ func CreateInitialAdminUserWithKeys(ctx context.Context, authService auth.Servic
 
 	// update setup timestamp
 	if err := metadataManger.UpdateSetupTimestamp(ctx, time.Now()); err != nil {
-		logging.Default().WithError(err).Error("Failed the update setup timestamp")
+		logging.ContextUnavailable().WithError(err).Error("Failed the update setup timestamp")
 	}
 	return cred, err
 }

--- a/pkg/auth/testutil/service.go
+++ b/pkg/auth/testutil/service.go
@@ -17,5 +17,5 @@ func SetupService(t *testing.T, ctx context.Context, secret []byte) (*auth.AuthS
 	kvStore := kvtest.GetStore(ctx, t)
 	return auth.NewAuthService(kvStore, crypt.NewSecretStore(secret), nil, authparams.ServiceCache{
 		Enabled: false,
-	}, logging.Default()), kvStore
+	}, logging.ContextUnavailable()), kvStore
 }

--- a/pkg/batch/executor_test.go
+++ b/pkg/batch/executor_test.go
@@ -54,7 +54,7 @@ func (d *db) GetAccessCount() int32 {
 
 func testReadAfterWrite(t *testing.T) {
 	// Setup executor
-	exec := batch.NewExecutor(logging.Default())
+	exec := batch.NewExecutor(logging.ContextUnavailable())
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	go exec.Run(ctx)
@@ -141,7 +141,7 @@ func testReadAfterWrite(t *testing.T) {
 
 func testBatchExpiration(t *testing.T) {
 	// Setup executor
-	exec := batch.NewExecutor(logging.Default())
+	exec := batch.NewExecutor(logging.ContextUnavailable())
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	go exec.Run(ctx)
@@ -182,7 +182,7 @@ func testBatchExpiration(t *testing.T) {
 
 func testBatchByKey(t *testing.T) {
 	// Setup executor
-	exec := batch.NewExecutor(logging.Default())
+	exec := batch.NewExecutor(logging.ContextUnavailable())
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	go exec.Run(ctx)

--- a/pkg/block/azure/adapter.go
+++ b/pkg/block/azure/adapter.go
@@ -42,8 +42,8 @@ type Adapter struct {
 	disablePreSignedUI bool
 }
 
-func NewAdapter(params params.Azure) (*Adapter, error) {
-	logging.Default().WithField("type", "azure").Info("initialized blockstore adapter")
+func NewAdapter(ctx context.Context, params params.Azure) (*Adapter, error) {
+	logging.FromContext(ctx).WithField("type", "azure").Info("initialized blockstore adapter")
 	preSignedExpiry := params.PreSignedExpiry
 	if preSignedExpiry == 0 {
 		preSignedExpiry = block.DefaultPreSignExpiryDuration

--- a/pkg/block/azure/adapter_test.go
+++ b/pkg/block/azure/adapter_test.go
@@ -1,6 +1,7 @@
 package azure_test
 
 import (
+	"context"
 	"net/url"
 	"regexp"
 	"testing"
@@ -19,7 +20,7 @@ func TestAzureAdapter(t *testing.T) {
 	externalPath, err := url.JoinPath(basePath, "external")
 	require.NoError(t, err)
 
-	adapter, err := azure.NewAdapter(params.Azure{
+	adapter, err := azure.NewAdapter(context.Background(), params.Azure{
 		StorageAccount:   accountName,
 		StorageAccessKey: accountKey,
 		TestEndpointURL:  blockURL,
@@ -29,7 +30,7 @@ func TestAzureAdapter(t *testing.T) {
 }
 
 func TestAdapterNamespace(t *testing.T) {
-	adapter, err := azure.NewAdapter(params.Azure{
+	adapter, err := azure.NewAdapter(context.Background(), params.Azure{
 		StorageAccount:   accountName,
 		StorageAccessKey: accountKey,
 		TestEndpointURL:  blockURL,

--- a/pkg/block/azure/multipart_block_writer.go
+++ b/pkg/block/azure/multipart_block_writer.go
@@ -135,7 +135,7 @@ func getMultipartIDs(ctx context.Context, container container.Client, objName st
 	// remove
 	_, err = blobURL.Delete(ctx, nil)
 	if err != nil {
-		logging.Default().WithContext(ctx).WithField("blob_url", blobURL.URL()).WithError(err).Warn("Failed to delete multipart ids data file")
+		logging.FromContext(ctx).WithField("blob_url", blobURL.URL()).WithError(err).Warn("Failed to delete multipart ids data file")
 	}
 	return ids, nil
 }
@@ -169,7 +169,7 @@ func getMultipartSize(ctx context.Context, container container.Client, objName s
 	// remove
 	_, err = blobURL.Delete(ctx, nil)
 	if err != nil {
-		logging.Default().WithContext(ctx).WithField("blob_url", blobURL.URL()).WithError(err).Warn("Failed to delete multipart size data file")
+		logging.FromContext(ctx).WithField("blob_url", blobURL.URL()).WithError(err).Warn("Failed to delete multipart size data file")
 	}
 	return int64(size), nil
 }

--- a/pkg/block/gs/stream.go
+++ b/pkg/block/gs/stream.go
@@ -47,7 +47,7 @@ func (s *StreamingReader) GetLastChunk() []byte {
 func ReadAllWithTimeout(r io.Reader, buf []byte, timeout time.Duration) (n int, err error) {
 	desired := len(buf)
 
-	lg := logging.Default().WithFields(logging.Fields{
+	lg := logging.ContextUnavailable().WithFields(logging.Fields{
 		"timeout":      timeout,
 		"desired_size": desired,
 	})

--- a/pkg/block/mem/adapter.go
+++ b/pkg/block/mem/adapter.go
@@ -59,7 +59,7 @@ type Adapter struct {
 	mutex      *sync.RWMutex
 }
 
-func New(opts ...func(a *Adapter)) *Adapter {
+func New(_ context.Context, opts ...func(a *Adapter)) *Adapter {
 	a := &Adapter{
 		data:       make(map[string][]byte),
 		mpu:        make(map[string]*mpu),

--- a/pkg/block/s3/inventory.go
+++ b/pkg/block/s3/inventory.go
@@ -40,12 +40,12 @@ func (a *Adapter) GenerateInventory(ctx context.Context, logger logging.Logger, 
 		return nil, err
 	}
 	svc := a.clients.Get(ctx, m.inventoryBucket)
-	return GenerateInventory(logger, m, s3inventory.NewReader(ctx, svc, logger), shouldSort, prefixes)
+	return GenerateInventory(ctx, logger, m, s3inventory.NewReader(ctx, svc, logger), shouldSort, prefixes)
 }
 
-func GenerateInventory(logger logging.Logger, m *Manifest, inventoryReader s3inventory.IReader, shouldSort bool, prefixes []string) (block.Inventory, error) {
+func GenerateInventory(ctx context.Context, logger logging.Logger, m *Manifest, inventoryReader s3inventory.IReader, shouldSort bool, prefixes []string) (block.Inventory, error) {
 	if logger == nil {
-		logger = logging.Default()
+		logger = logging.FromContext(ctx)
 	}
 	if shouldSort || len(prefixes) > 0 {
 		if err := sortManifest(m, logger, inventoryReader); err != nil {

--- a/pkg/block/s3/inventory_test.go
+++ b/pkg/block/s3/inventory_test.go
@@ -212,7 +212,7 @@ func TestIterator(t *testing.T) {
 			for _, filename := range test.InventoryFiles {
 				inventoryFiles = append(inventoryFiles, s3.InventoryFile{Key: filename})
 			}
-			inv, err := s3.GenerateInventory(context.Background(), logging.Default(), &s3.Manifest{
+			inv, err := s3.GenerateInventory(context.Background(), logging.ContextUnavailable(), &s3.Manifest{
 				URL:                manifestURL,
 				InventoryBucketArn: "arn:aws:s3:::example-bucket",
 				SourceBucket:       "lakefs-example-data",

--- a/pkg/block/s3/inventory_test.go
+++ b/pkg/block/s3/inventory_test.go
@@ -1,6 +1,7 @@
 package s3_test
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"testing"
@@ -211,7 +212,7 @@ func TestIterator(t *testing.T) {
 			for _, filename := range test.InventoryFiles {
 				inventoryFiles = append(inventoryFiles, s3.InventoryFile{Key: filename})
 			}
-			inv, err := s3.GenerateInventory(logging.Default(), &s3.Manifest{
+			inv, err := s3.GenerateInventory(context.Background(), logging.Default(), &s3.Manifest{
 				URL:                manifestURL,
 				InventoryBucketArn: "arn:aws:s3:::example-bucket",
 				SourceBucket:       "lakefs-example-data",

--- a/pkg/block/s3/stream.go
+++ b/pkg/block/s3/stream.go
@@ -51,7 +51,7 @@ func (s *StreamingReader) GetLastChunk() []byte {
 func ReadAllWithTimeout(r io.Reader, buf []byte, timeout time.Duration, minSize int) (n int, err error) {
 	desired := len(buf)
 
-	lg := logging.Default().WithFields(logging.Fields{
+	lg := logging.ContextUnavailable().WithFields(logging.Fields{
 		"timeout":      timeout,
 		"desired_size": desired,
 	})

--- a/pkg/block/transient/adapter.go
+++ b/pkg/block/transient/adapter.go
@@ -19,7 +19,7 @@ var ErrInventoryNotImplemented = errors.New("inventory feature not implemented f
 
 type Adapter struct{}
 
-func New() *Adapter {
+func New(_ context.Context) *Adapter {
 	return &Adapter{}
 }
 

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -137,7 +137,6 @@ type Config struct {
 type Catalog struct {
 	BlockAdapter          block.Adapter
 	Store                 Store
-	log                   logging.Logger
 	walkerFactory         WalkerFactory
 	managers              []io.Closer
 	workPool              *pond.WorkerPool
@@ -292,7 +291,6 @@ func New(ctx context.Context, cfg Config) (*Catalog, error) {
 		UGCPrepareInterval:    cfg.Config.UGC.PrepareInterval,
 		PathProvider:          cfg.PathProvider,
 		BackgroundLimiter:     cfg.Limiter,
-		log:                   logging.Default().WithField("service_name", "entry_catalog"),
 		walkerFactory:         cfg.WalkerFactory,
 		workPool:              workPool,
 		KVStore:               cfg.KVStore,
@@ -304,6 +302,10 @@ func New(ctx context.Context, cfg Config) (*Catalog, error) {
 
 func (c *Catalog) SetHooksHandler(hooks graveler.HooksHandler) {
 	c.Store.SetHooksHandler(hooks)
+}
+
+func (c *Catalog) log(ctx context.Context) logging.Logger {
+	return logging.FromContext(ctx).WithField("service_name", "entry_catalog")
 }
 
 // CreateRepository create a new repository pointing to 'storageNamespace' (ex: s3://bucket1/repo) with default branch name 'branch'
@@ -1925,7 +1927,7 @@ func (c *Catalog) Import(ctx context.Context, repositoryID, branchID string, par
 	id := xid.New().String()
 	// Run import
 	go func() {
-		logger := c.log.WithField("import_id", id)
+		logger := c.log(ctx).WithField("import_id", id)
 		err = c.importAsync(repository, branchID, id, params, logger)
 		if err != nil {
 			logger.WithError(err).Error("import failure")
@@ -1945,7 +1947,7 @@ func (c *Catalog) CancelImport(ctx context.Context, repositoryID, importID strin
 		return err
 	}
 	if importStatus.Completed {
-		c.log.WithFields(logging.Fields{
+		c.log(ctx).WithFields(logging.Fields{
 			"import_id": importID,
 			"completed": importStatus.Completed,
 			"error":     importStatus.Error,
@@ -2009,7 +2011,7 @@ func (c *Catalog) WriteRange(ctx context.Context, repositoryID string, params Wr
 	stagingToken := params.StagingToken
 	skipped := it.GetSkippedEntries()
 	if len(skipped) > 0 {
-		c.log.Warning("Skipped count:", len(skipped))
+		c.log(ctx).Warning("Skipped count:", len(skipped))
 		if stagingToken == "" {
 			stagingToken = graveler.GenerateStagingToken("import", "ingest_range").String()
 		}
@@ -2174,7 +2176,7 @@ func (c *Catalog) PrepareGCUncommitted(ctx context.Context, repositoryID string,
 	defer func() {
 		_ = fd.Close()
 		if err := os.Remove(fd.Name()); err != nil {
-			c.log.WithField("filename", fd.Name()).Warn("Failed to delete temporary gc uncommitted data file")
+			c.log(ctx).WithField("filename", fd.Name()).Warn("Failed to delete temporary gc uncommitted data file")
 		}
 	}()
 
@@ -2282,14 +2284,14 @@ func (c *Catalog) VerifyLinkAddress(ctx context.Context, repository, token strin
 func (c *Catalog) DeleteExpiredLinkAddresses(ctx context.Context) {
 	repos, err := c.listRepositoriesHelper(ctx)
 	if err != nil {
-		c.log.WithError(err).Warn("Failed list repositories during delete expired addresses")
+		c.log(ctx).WithError(err).Warn("Failed list repositories during delete expired addresses")
 		return
 	}
 
 	for _, repo := range repos {
 		err := c.Store.DeleteExpiredLinkAddresses(ctx, repo)
 		if err != nil {
-			c.log.WithError(err).WithField("repository", repo.RepositoryID).Warn("Delete expired address tokens failed")
+			c.log(ctx).WithError(err).WithField("repository", repo.RepositoryID).Warn("Delete expired address tokens failed")
 		}
 	}
 }
@@ -2297,14 +2299,14 @@ func (c *Catalog) DeleteExpiredLinkAddresses(ctx context.Context) {
 func (c *Catalog) DeleteExpiredImports(ctx context.Context) {
 	repos, err := c.listRepositoriesHelper(ctx)
 	if err != nil {
-		c.log.WithError(err).Warn("Delete expired imports: failed to list repositories")
+		c.log(ctx).WithError(err).Warn("Delete expired imports: failed to list repositories")
 		return
 	}
 
 	for _, repo := range repos {
 		err = c.Store.DeleteExpiredImports(ctx, repo)
 		if err != nil {
-			c.log.WithError(err).WithField("repository", repo.RepositoryID).Warn("Delete expired imports failed")
+			c.log(ctx).WithError(err).WithField("repository", repo.RepositoryID).Warn("Delete expired imports failed")
 		}
 	}
 }

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -258,7 +258,7 @@ func New(ctx context.Context, cfg Config) (*Catalog, error) {
 	}
 	committedManager := committed.NewCommittedManager(sstableMetaRangeManager, sstableManager, committedParams)
 
-	executor := batch.NewConditionalExecutor(logging.Default())
+	executor := batch.NewConditionalExecutor(logging.ContextUnavailable())
 	go executor.Run(ctx)
 
 	storeLimiter := kv.NewStoreLimiter(cfg.KVStore, cfg.Limiter)

--- a/pkg/cloud/aws/s3inventory/reader_test.go
+++ b/pkg/cloud/aws/s3inventory/reader_test.go
@@ -256,7 +256,7 @@ func TestReaders(t *testing.T) {
 					localFile = generateParquet(t, objs(test.ObjectNum, lastModified), test.ExcludeField)
 				}
 				uploadFile(t, svc, inventoryBucketName, "myFile.inv", localFile)
-				reader := NewReader(context.Background(), svc, logging.Default())
+				reader := NewReader(context.Background(), svc, logging.ContextUnavailable())
 				fileReader, err := reader.GetFileReader(format, inventoryBucketName, "myFile.inv")
 				if err != nil {
 					t.Fatalf("failed to create file reader: %v", err)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -501,7 +501,7 @@ func (c *Config) DatabaseParams() (kvparams.Config, error) {
 }
 
 func (c *Config) GetAwsConfig() *aws.Config {
-	logger := logging.Default().WithField("sdk", "aws")
+	logger := logging.ContextUnavailable().WithField("sdk", "aws")
 	cfg := &aws.Config{
 		Logger: &logging.AWSAdapter{Logger: logger},
 	}
@@ -521,7 +521,7 @@ func (c *Config) GetAwsConfig() *aws.Config {
 	if c.Blockstore.S3.Credentials != nil {
 		secretAccessKey := c.Blockstore.S3.Credentials.SecretAccessKey
 		if secretAccessKey == "" {
-			logging.Default().Warn("blockstore.s3.credentials.access_secret_key is deprecated. Use instead: blockstore.s3.credentials.secret_access_key.")
+			logging.ContextUnavailable().Warn("blockstore.s3.credentials.access_secret_key is deprecated. Use instead: blockstore.s3.credentials.secret_access_key.")
 			secretAccessKey = c.Blockstore.S3.Credentials.AccessSecretKey
 		}
 		cfg.Credentials = credentials.NewStaticCredentials(
@@ -590,7 +590,7 @@ func (c *Config) BlockstoreGSParams() (blockparams.GS, error) {
 
 func (c *Config) BlockstoreAzureParams() (blockparams.Azure, error) {
 	if c.Blockstore.Azure.AuthMethod != "" {
-		logging.Default().Warn("blockstore.azure.auth_method is deprecated. Value is no longer used.")
+		logging.ContextUnavailable().Warn("blockstore.azure.auth_method is deprecated. Value is no longer used.")
 	}
 	return blockparams.Azure{
 		StorageAccount:     c.Blockstore.Azure.StorageAccount,
@@ -628,7 +628,7 @@ func (c *Config) GetCommittedTierFSParams(adapter block.Adapter) (*pyramidparams
 		return nil, fmt.Errorf("expand %s: %w", c.Committed.LocalCache.Dir, err)
 	}
 
-	logger := logging.Default().WithField("module", "pyramid")
+	logger := logging.ContextUnavailable().WithField("module", "pyramid")
 	return &pyramidparams.ExtParams{
 		RangeAllocationProportion:     rangePro,
 		MetaRangeAllocationProportion: metaRangePro,

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -144,7 +144,7 @@ func TestConfig_JSONLogger(t *testing.T) {
 	_, err := newConfigFromFile("testdata/valid_json_logger_config.yaml")
 	testutil.Must(t, err)
 
-	logging.Default().Info("some message that I should be looking for")
+	logging.ContextUnavailable().Info("some message that I should be looking for")
 
 	content, err := os.Open(logfile)
 	if err != nil {

--- a/pkg/gateway/handler.go
+++ b/pkg/gateway/handler.go
@@ -118,7 +118,7 @@ func NewHandler(region string, catalog catalog.Interface, multipartTracker multi
 				EnrichWithRepositoryOrFallback(catalog, authService, fallbackHandler,
 					OperationLookupHandler(
 						h))))))
-	logging.Default().WithFields(logging.Fields{
+	logging.ContextUnavailable().WithFields(logging.Fields{
 		"s3_bare_domain": bareDomains,
 		"s3_region":      region,
 	}).Info("initialized S3 Gateway handler")

--- a/pkg/gateway/middleware.go
+++ b/pkg/gateway/middleware.go
@@ -36,7 +36,7 @@ func AuthenticationHandler(authService auth.GatewayService, next http.Handler) h
 		authenticator := sig.ChainedAuthenticator(
 			sig.NewV4Authenticator(req),
 			sig.NewV2SigAuthenticator(req))
-		authContext, err := authenticator.Parse()
+		authContext, err := authenticator.Parse(req.Context())
 		if err != nil {
 			o.Log(req).WithError(err).Warn("failed to parse signature")
 			_ = o.EncodeError(w, req, getAPIErrOrDefault(err, gatewayerrors.ErrAccessDenied))

--- a/pkg/gateway/operations/putobject.go
+++ b/pkg/gateway/operations/putobject.go
@@ -42,7 +42,7 @@ func (controller *PutObject) RequiredPermissions(req *http.Request, repoID, _, d
 	// this is a copy operation
 	p, err := getPathFromSource(copySource)
 	if err != nil {
-		logging.Default().WithError(err).Error("could not parse copy source path")
+		logging.FromContext(req.Context()).WithError(err).Error("could not parse copy source path")
 		return permissions.Node{}, gatewayErrors.ErrInvalidCopySource
 	}
 

--- a/pkg/gateway/sig/sig_test.go
+++ b/pkg/gateway/sig/sig_test.go
@@ -82,7 +82,7 @@ func MakeV4Signer(keyID, secretKey, location string) Signer {
 func MakeV2Verifier(keyID, secretKey, bareDomain string) Verifier {
 	return func(req *http.Request) error {
 		authenticator := sig.NewV2SigAuthenticator(req)
-		_, err := authenticator.Parse()
+		_, err := authenticator.Parse(req.Context())
 		if err != nil {
 			return fmt.Errorf("sigV2 parse failed: %w", err)
 		}
@@ -96,7 +96,7 @@ func MakeV2Verifier(keyID, secretKey, bareDomain string) Verifier {
 func MakeV4Verifier(keyID, secretKey, bareDomain string) Verifier {
 	return func(req *http.Request) error {
 		authenticator := sig.NewV4Authenticator(req)
-		_, err := authenticator.Parse()
+		_, err := authenticator.Parse(req.Context())
 		if err != nil {
 			return fmt.Errorf("sigV4 parse failed: %w", err)
 		}

--- a/pkg/gateway/sig/v2.go
+++ b/pkg/gateway/sig/v2.go
@@ -52,7 +52,7 @@ func init() {
 	var sortedArray []string
 	for _, word := range interestingResourcesContainer {
 		if _, ok := tempMap[word]; ok {
-			logging.Default().
+			logging.ContextUnavailable().
 				WithField("word", word).
 				Warn("appears twice in sig\v2.go array interestingResourcesContainer. a programmer error")
 		} else {
@@ -214,7 +214,7 @@ func buildPath(host string, bareDomain string, path string) string {
 		return "/" + prePath + path
 	}
 	// bareDomain is not suffix of the path probably a bug
-	logging.Default().
+	logging.ContextUnavailable().
 		WithFields(logging.Fields{"request_host": host, "bare_domain": bareDomain}).
 		Error("request host mismatch")
 	return ""

--- a/pkg/gateway/sig/v4.go
+++ b/pkg/gateway/sig/v4.go
@@ -2,6 +2,7 @@ package sig
 
 import (
 	"bufio"
+	"context"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
@@ -380,7 +381,7 @@ type V4Authenticator struct {
 	ctx     V4Auth
 }
 
-func (a *V4Authenticator) Parse() (SigContext, error) {
+func (a *V4Authenticator) Parse(_ context.Context) (SigContext, error) {
 	var ctx V4Auth
 	var err error
 	ctx, err = ParseV4AuthContext(a.request)

--- a/pkg/gateway/sig/v4_test.go
+++ b/pkg/gateway/sig/v4_test.go
@@ -90,7 +90,7 @@ func TestDoesPolicySignatureMatch(t *testing.T) {
 			// Do the same for the headers.
 			req.Header = tc.Header
 			authenticator := sig.NewV4Authenticator(req)
-			_, err := authenticator.Parse()
+			_, err := authenticator.Parse(req.Context())
 			if err != nil {
 				if !tc.ExpectedParseError {
 					t.Fatal(err)
@@ -159,7 +159,7 @@ func TestSingleChunkPut(t *testing.T) {
 			// verify request with our authenticator
 
 			authenticator := sig.NewV4Authenticator(req)
-			_, err = authenticator.Parse()
+			_, err = authenticator.Parse(req.Context())
 			if err != nil {
 				t.Errorf("expect not no error, got %v", err)
 			}
@@ -221,7 +221,7 @@ func TestStreaming(t *testing.T) {
 
 	// now test it
 	authenticator := sig.NewV4Authenticator(req)
-	_, err = authenticator.Parse()
+	_, err = authenticator.Parse(req.Context())
 	if err != nil {
 		t.Errorf("expect not no error, got %v", err)
 	}
@@ -279,7 +279,7 @@ func TestStreamingLastByteWrong(t *testing.T) {
 
 	// now test it
 	authenticator := sig.NewV4Authenticator(req)
-	_, err = authenticator.Parse()
+	_, err = authenticator.Parse(req.Context())
 	if err != nil {
 		t.Errorf("expect not no error, got %v", err)
 	}
@@ -326,7 +326,7 @@ func TestUnsignedPayload(t *testing.T) {
 	}
 
 	authenticator := sig.NewV4Authenticator(req)
-	_, err = authenticator.Parse()
+	_, err = authenticator.Parse(req.Context())
 	if err != nil {
 		t.Errorf("expect not no error, got %v", err)
 	}

--- a/pkg/gateway/testutil/gateway_setup.go
+++ b/pkg/gateway/testutil/gateway_setup.go
@@ -94,7 +94,7 @@ type FakeAuthService struct {
 
 func (m *FakeAuthService) GetCredentials(_ context.Context, accessKey string) (*model.Credential, error) {
 	if accessKey != m.AccessKeyID {
-		logging.Default().Fatal("access key in recording different than configuration")
+		logging.ContextUnavailable().Fatal("access key in recording different than configuration")
 	}
 	aCred := new(model.Credential)
 	aCred.AccessKeyID = accessKey

--- a/pkg/graveler/committed/import_test.go
+++ b/pkg/graveler/committed/import_test.go
@@ -368,7 +368,7 @@ func Test_import(t *testing.T) {
 
 				writer.EXPECT().Abort().AnyTimes()
 				metaRangeId := graveler.MetaRangeID("import")
-				writer.EXPECT().Close().Return(&metaRangeId, nil).AnyTimes()
+				writer.EXPECT().Close(gomock.Any()).Return(&metaRangeId, nil).AnyTimes()
 				committedManager := committed.NewCommittedManager(metaRangeManager, rangeManager, params)
 				_, err := committedManager.Import(ctx, "ns", destMetaRangeID, sourceMetaRangeID, tst.prefixes)
 				if err != expectedResult.expectedErr {

--- a/pkg/graveler/committed/manager.go
+++ b/pkg/graveler/committed/manager.go
@@ -15,7 +15,6 @@ type committedManager struct {
 	metaRangeManager MetaRangeManager
 	RangeManager     RangeManager
 	params           *Params
-	logger           logging.Logger
 }
 
 func NewCommittedManager(m MetaRangeManager, r RangeManager, p Params) graveler.CommittedManager {
@@ -23,7 +22,6 @@ func NewCommittedManager(m MetaRangeManager, r RangeManager, p Params) graveler.
 		metaRangeManager: m,
 		RangeManager:     r,
 		params:           &p,
-		logger:           logging.Default(),
 	}
 }
 
@@ -72,7 +70,7 @@ func (c *committedManager) WriteRange(ctx context.Context, ns graveler.StorageNa
 
 	defer func() {
 		if err := writer.Abort(); err != nil {
-			c.logger.WithError(err).Error("Aborting write to range")
+			logging.FromContext(ctx).WithError(err).Error("Aborting write to range")
 		}
 	}()
 
@@ -112,7 +110,7 @@ func (c *committedManager) WriteMetaRange(ctx context.Context, ns graveler.Stora
 	writer := c.metaRangeManager.NewWriter(ctx, ns, nil)
 	defer func() {
 		if err := writer.Abort(); err != nil {
-			c.logger.WithError(err).Error("Aborting write to meta range")
+			logging.FromContext(ctx).WithError(err).Error("Aborting write to meta range")
 		}
 	}()
 
@@ -129,12 +127,12 @@ func (c *committedManager) WriteMetaRange(ctx context.Context, ns graveler.Stora
 			Count:         int64(r.Count),
 			Tombstone:     false,
 		}); err != nil {
-			c.logger.WithError(err).Error("Aborting writing range to meta range")
+			logging.FromContext(ctx).WithError(err).Error("Aborting writing range to meta range")
 			return nil, fmt.Errorf("writing range: %w", err)
 		}
 	}
 
-	id, err := writer.Close()
+	id, err := writer.Close(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("closing metarange: %w", err)
 	}
@@ -148,7 +146,7 @@ func (c *committedManager) WriteMetaRangeByIterator(ctx context.Context, ns grav
 	writer := c.metaRangeManager.NewWriter(ctx, ns, metadata)
 	defer func() {
 		if err := writer.Abort(); err != nil {
-			c.logger.WithError(err).Error("Aborting write to meta range")
+			logging.FromContext(ctx).WithError(err).Error("Aborting write to meta range")
 		}
 	}()
 
@@ -160,7 +158,7 @@ func (c *committedManager) WriteMetaRangeByIterator(ctx context.Context, ns grav
 	if err := it.Err(); err != nil {
 		return nil, fmt.Errorf("getting value from iterator: %w", err)
 	}
-	id, err := writer.Close()
+	id, err := writer.Close(ctx)
 	if err != nil {
 		return nil, fmt.Errorf("closing writer: %w", err)
 	}
@@ -261,7 +259,7 @@ func (c *committedManager) merge(ctx context.Context, mctx mergeContext) (gravel
 	defer func() {
 		err = mwWriter.Abort()
 		if err != nil {
-			c.logger.WithError(err).Error("Abort failed after Merge")
+			logging.FromContext(ctx).WithError(err).Error("Abort failed after Merge")
 		}
 	}()
 
@@ -272,7 +270,7 @@ func (c *committedManager) merge(ctx context.Context, mctx mergeContext) (gravel
 		}
 		return "", err
 	}
-	newID, err := mwWriter.Close()
+	newID, err := mwWriter.Close(ctx)
 	if newID == nil {
 		return "", fmt.Errorf("close writer ns=%s id=%s: %w", mctx.ns, mctx.destinationID, err)
 	}
@@ -284,7 +282,7 @@ func (c *committedManager) Commit(ctx context.Context, ns graveler.StorageNamesp
 	defer func() {
 		err := mwWriter.Abort()
 		if err != nil {
-			c.logger.WithError(err).Error("Abort failed after Commit")
+			logging.FromContext(ctx).WithError(err).Error("Abort failed after Commit")
 		}
 	}()
 	metaRangeIterator, err := c.metaRangeManager.NewMetaRangeIterator(ctx, ns, baseMetaRangeID)
@@ -302,7 +300,7 @@ func (c *committedManager) Commit(ctx context.Context, ns graveler.StorageNamesp
 		}
 		return "", summary, err
 	}
-	newID, err := mwWriter.Close()
+	newID, err := mwWriter.Close(ctx)
 	if newID == nil {
 		return "", summary, fmt.Errorf("close writer ns=%s metarange id=%s: %w", ns, baseMetaRangeID, err)
 	}

--- a/pkg/graveler/committed/manager_test.go
+++ b/pkg/graveler/committed/manager_test.go
@@ -126,7 +126,7 @@ func TestManager_WriteMetaRange(t *testing.T) {
 					minKey = string(info.MinKey)
 					return nil
 				}).Times(len(tt.records))
-			metarangeWriter.EXPECT().Close().Return(&expectedMetarangeID, nil)
+			metarangeWriter.EXPECT().Close(gomock.Any()).Return(&expectedMetarangeID, nil)
 			metarangeWriter.EXPECT().Abort().Return(nil)
 			sut := committed.NewCommittedManager(metarangeManager, rangeManager, params)
 

--- a/pkg/graveler/committed/merge_test.go
+++ b/pkg/graveler/committed/merge_test.go
@@ -1727,7 +1727,7 @@ func runMergeTests(tests testCases, t *testing.T) {
 
 					writer.EXPECT().Abort().AnyTimes()
 					metaRangeId := graveler.MetaRangeID("merge")
-					writer.EXPECT().Close().Return(&metaRangeId, nil).AnyTimes()
+					writer.EXPECT().Close(gomock.Any()).Return(&metaRangeId, nil).AnyTimes()
 					committedManager := committed.NewCommittedManager(metaRangeManager, rangeManager, params)
 					_, err := committedManager.Merge(ctx, "ns", destMetaRangeID, sourceMetaRangeID, baseMetaRangeID, mergeStrategy)
 					if err != expectedResult.expectedErr {

--- a/pkg/graveler/committed/meta_range.go
+++ b/pkg/graveler/committed/meta_range.go
@@ -111,7 +111,7 @@ type MetaRangeWriter interface {
 	// Close finalizes the MetaRange creation. It's invalid to add records after calling this method.
 	// During MetaRange writing, ranges are closed asynchronously and copied by tierFS
 	// while writing continues. Close waits until closing and copying all ranges.
-	Close() (*graveler.MetaRangeID, error)
+	Close(context.Context) (*graveler.MetaRangeID, error)
 
 	Abort() error
 }

--- a/pkg/graveler/committed/meta_range_writer_test.go
+++ b/pkg/graveler/committed/meta_range_writer_test.go
@@ -89,7 +89,7 @@ func TestWriter_WriteRecords(t *testing.T) {
 		t.Errorf("expected ErrUnsorted got = %s", err)
 	}
 
-	_, err = w.Close()
+	_, err = w.Close(ctx)
 	if err != nil {
 		t.Errorf("failed to close: %s", err)
 	}
@@ -174,7 +174,7 @@ func TestWriter_RecordRangeAndClose(t *testing.T) {
 		t.Fatalf("unexpected error %s", err)
 	}
 
-	_, err = w.Close()
+	_, err = w.Close(ctx)
 	if err != nil {
 		t.Fatalf("unexpected error %s", err)
 	}

--- a/pkg/graveler/committed/mock/meta_range.go
+++ b/pkg/graveler/committed/mock/meta_range.go
@@ -386,18 +386,18 @@ func (mr *MockMetaRangeWriterMockRecorder) Abort() *gomock.Call {
 }
 
 // Close mocks base method.
-func (m *MockMetaRangeWriter) Close() (*graveler.MetaRangeID, error) {
+func (m *MockMetaRangeWriter) Close(arg0 context.Context) (*graveler.MetaRangeID, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Close")
+	ret := m.ctrl.Call(m, "Close", arg0)
 	ret0, _ := ret[0].(*graveler.MetaRangeID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Close indicates an expected call of Close.
-func (mr *MockMetaRangeWriterMockRecorder) Close() *gomock.Call {
+func (mr *MockMetaRangeWriterMockRecorder) Close(arg0 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockMetaRangeWriter)(nil).Close))
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Close", reflect.TypeOf((*MockMetaRangeWriter)(nil).Close), arg0)
 }
 
 // WriteRange mocks base method.

--- a/pkg/graveler/graveler.go
+++ b/pkg/graveler/graveler.go
@@ -1035,7 +1035,7 @@ func NewGraveler(committedManager CommittedManager, stagingManager StagingManage
 		StagingManager:           stagingManager,
 		protectedBranchesManager: protectedBranchesManager,
 		garbageCollectionManager: gcManager,
-		logger:                   logging.Default().WithField("service_name", "graveler_graveler"),
+		logger:                   logging.ContextUnavailable().WithField("service_name", "graveler_graveler"),
 	}
 }
 

--- a/pkg/graveler/ref/manager.go
+++ b/pkg/graveler/ref/manager.go
@@ -704,7 +704,7 @@ func (m *Manager) DeleteExpiredImports(ctx context.Context, repository *graveler
 		}
 		if status.UpdatedAt.AsTime().Before(expiry) {
 			if !status.Completed && status.Error == "" {
-				logging.Default().WithFields(logging.Fields{"import_id": status.Id}).Warning("removing stale import")
+				logging.FromContext(ctx).WithFields(logging.Fields{"import_id": status.Id}).Warning("removing stale import")
 			}
 			err = m.kvStoreLimited.Delete(ctx, []byte(repoPartition), entry.Key)
 			if err != nil {

--- a/pkg/graveler/retention/garbage_collection_manager_test.go
+++ b/pkg/graveler/retention/garbage_collection_manager_test.go
@@ -18,7 +18,7 @@ import (
 )
 
 func TestGarbageCollectionManager_GetUncommittedLocation(t *testing.T) {
-	blockAdapter := mem.New()
+	blockAdapter := mem.New(context.Background())
 	refMgr := &testutil.RefsFake{}
 	const prefix = "test_prefix"
 	const runID = "my_test_runID"
@@ -43,7 +43,7 @@ func createTestFile(t *testing.T, filename, testLine string, count int) {
 
 func TestGarbageCollectionManager_SaveGarbageCollectionUncommitted(t *testing.T) {
 	ctx := context.Background()
-	blockAdapter := mem.New()
+	blockAdapter := mem.New(context.Background())
 	refMgr := &testutil.RefsFake{}
 	const prefix = "test_prefix"
 	const runID = "my_test_runID"

--- a/pkg/graveler/settings/manager.go
+++ b/pkg/graveler/settings/manager.go
@@ -142,7 +142,7 @@ func (m *Manager) Update(ctx context.Context, repository *graveler.RepositoryRec
 		}
 		err = kv.SetMsgIf(ctx, m.store, graveler.RepoPartition(repository), []byte(graveler.SettingsPath(key)), newData, pred)
 		if errors.Is(err, kv.ErrPredicateFailed) {
-			logging.Default().WithError(err).Warn("Predicate failed on settings update. Retrying")
+			logging.FromContext(ctx).WithError(err).Warn("Predicate failed on settings update. Retrying")
 			return graveler.ErrPreconditionFailed
 		} else if err != nil {
 			return backoff.Permanent(err)

--- a/pkg/graveler/settings/manager_test.go
+++ b/pkg/graveler/settings/manager_test.go
@@ -235,7 +235,7 @@ func prepareTest(t *testing.T, ctx context.Context, refCache cache.Cache, branch
 	ctrl := gomock.NewController(t)
 	refManager := mock.NewMockRefManager(ctrl)
 
-	blockAdapter := mem.New()
+	blockAdapter := mem.New(context.Background())
 	branchLock := mock.NewMockBranchLocker(ctrl)
 	cb := func(_ context.Context, _ *graveler.RepositoryRecord, _ graveler.BranchID, f func() (interface{}, error)) (interface{}, error) {
 		return f()

--- a/pkg/kv/import.go
+++ b/pkg/kv/import.go
@@ -91,7 +91,7 @@ func Import(ctx context.Context, reader io.Reader, store Store) error {
 		return fmt.Errorf("bad header format: %w", ErrInvalidFormat)
 	}
 	// TODO(niro): Add validation to the header in the future
-	log := logging.Default().WithFields(logging.Fields{
+	log := logging.FromContext(ctx).WithFields(logging.Fields{
 		"package_name":      header.PackageName,
 		"lakefs_version":    header.LakeFSVersion,
 		"db_schema_version": header.DBSchemaVersion,

--- a/pkg/kv/migration.go
+++ b/pkg/kv/migration.go
@@ -65,6 +65,6 @@ func ValidateSchemaVersion(ctx context.Context, store Store) (int, error) {
 		return kvVersion, fmt.Errorf("ACL migration required. Please run 'lakefs migrate up': %w", ErrMigrationRequired)
 	}
 
-	logging.Default().WithField("version", kvVersion).Info("KV valid")
+	logging.FromContext(ctx).WithField("version", kvVersion).Info("KV valid")
 	return kvVersion, nil
 }

--- a/pkg/loadtest/loader.go
+++ b/pkg/loadtest/loader.go
@@ -93,7 +93,7 @@ func (t *Loader) Run() error {
 		if errors.Is(err, io.ErrClosedPipe) {
 			continue
 		}
-		logging.Default().WithError(err).Error("error during request pipeline")
+		logging.ContextUnavailable().WithError(err).Error("error during request pipeline")
 		return err
 	}
 	err = printResults(t.Metrics, t.TotalMetrics)
@@ -162,7 +162,7 @@ func (t *Loader) doAttack() (hasErrors bool) {
 	for res := range attacker.Attack(targeter, rate, t.Config.Duration, "lakeFS loadtest test") {
 		typ := GetRequestType(*res)
 		if len(res.Error) > 0 {
-			logging.Default().Debugf("Error in request type %s, error: %s, status: %d", typ, res.Error, res.Code)
+			logging.ContextUnavailable().Debugf("Error in request type %s, error: %s, status: %d", typ, res.Error, res.Code)
 			hasErrors = true
 		}
 		typeMetrics := t.Metrics[typ]

--- a/pkg/loadtest/local_load_test.go
+++ b/pkg/loadtest/local_load_test.go
@@ -49,7 +49,7 @@ func TestLocalLoad(t *testing.T) {
 	}
 
 	kvStore := kvtest.GetStore(ctx, t)
-	authService := auth.NewAuthService(kvStore, crypt.NewSecretStore([]byte("some secret")), nil, authparams.ServiceCache{}, logging.Default().WithField("service", "auth"))
+	authService := auth.NewAuthService(kvStore, crypt.NewSecretStore([]byte("some secret")), nil, authparams.ServiceCache{}, logging.ContextUnavailable().WithField("service", "auth"))
 	meta := auth.NewKVMetadataManager("local_load_test", conf.Installation.FixedID, conf.Database.Type, kvStore)
 
 	blockstoreType := os.Getenv(testutil.EnvKeyUseBlockAdapter)
@@ -98,7 +98,7 @@ func TestLocalLoad(t *testing.T) {
 		nil,
 		actionsService,
 		auditChecker,
-		logging.Default(),
+		logging.ContextUnavailable(),
 		emailer,
 		nil,
 		nil,

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -326,7 +326,10 @@ func (lf logrusCallerFormatter) Format(e *logrus.Entry) ([]byte, error) {
 	return lf.f.Format(e)
 }
 
-func Default() Logger {
+// ContextUnavailable returns a Logger when no context is available.  It
+// should be used only in code during startup, teardown, or tests.  Prefer
+// to use Default().
+func ContextUnavailable() Logger {
 	// wrap formatter with our own formatter that overrides caller
 	formatterInitOnce.Do(func() {
 		defaultLogger.SetReportCaller(true)
@@ -347,8 +350,10 @@ func addFromContext(log Logger, ctx context.Context) Logger {
 	return log.WithFields(loggerFields)
 }
 
+// FromContext returns a Logger for reporting logs during ctx.  This logger
+// will typically include request IDs from the context.
 func FromContext(ctx context.Context) Logger {
-	return addFromContext(Default(), ctx)
+	return addFromContext(ContextUnavailable(), ctx)
 }
 
 func AddFields(ctx context.Context, fields Fields) context.Context {

--- a/pkg/metastore/metastore.go
+++ b/pkg/metastore/metastore.go
@@ -1,6 +1,7 @@
 package metastore
 
 import (
+	"context"
 	"strings"
 	"time"
 
@@ -17,8 +18,8 @@ const (
 	sparkSQLProviderLocationKey = "path"
 )
 
-func (m *Table) Update(db, table, serde string, setSymlink bool, transformLocation func(location string) (string, error), isSparkSQLTable, fixSparkPlaceHolder bool) error {
-	log := logging.Default().WithFields(logging.Fields{
+func (m *Table) Update(ctx context.Context, db, table, serde string, setSymlink bool, transformLocation func(location string) (string, error), isSparkSQLTable, fixSparkPlaceHolder bool) error {
+	log := logging.FromContext(ctx).WithFields(logging.Fields{
 		"db":         db,
 		"table":      table,
 		"serde":      serde,
@@ -43,8 +44,8 @@ func (m *Table) isSparkSQLTable() (res bool) {
 	return
 }
 
-func (m *Partition) Update(db, table, serde string, setSymlink bool, transformLocation func(location string) (string, error), isSparkSQLTable, fixSparkPlaceHolder bool) error {
-	log := logging.Default().WithFields(logging.Fields{
+func (m *Partition) Update(ctx context.Context, db, table, serde string, setSymlink bool, transformLocation func(location string) (string, error), isSparkSQLTable, fixSparkPlaceHolder bool) error {
+	log := logging.FromContext(ctx).WithFields(logging.Fields{
 		"db":         db,
 		"table":      table,
 		"serde":      serde,

--- a/pkg/plugins/diff/service.go
+++ b/pkg/plugins/diff/service.go
@@ -177,7 +177,7 @@ func registerDefaultPlugins(service *Service, pluginsPath string) {
 	_, err := os.Stat(deltaPath)
 	if err != nil {
 		if !os.IsNotExist(err) {
-			logging.Default().WithError(err).Error("failed to access delta lake diff plugin")
+			logging.ContextUnavailable().WithError(err).Error("failed to access delta lake diff plugin")
 		}
 		return
 	}
@@ -194,7 +194,7 @@ func registerPlugin(service *Service, pluginProps config.Plugins, rf registratio
 	if props, ok := pluginProps.Properties[pluginName]; ok {
 		pp, err := homedir.Expand(props.Path)
 		if err != nil {
-			logging.Default().Errorf("failed to register a plugin for an invalid path: '%s'", props.Path)
+			logging.ContextUnavailable().Errorf("failed to register a plugin for an invalid path: '%s'", props.Path)
 			return
 		}
 		pluginPath = pp
@@ -207,7 +207,7 @@ func registerPlugin(service *Service, pluginProps config.Plugins, rf registratio
 	pa := plugins.PluginHandshake{}
 	rf(service, pid, pa)
 
-	logging.Default().Infof("successfully registered a plugin for diff type: '%s'", diffType)
+	logging.ContextUnavailable().Infof("successfully registered a plugin for diff type: '%s'", diffType)
 }
 
 type registrationFunc func(ds *Service, pid plugins.PluginIdentity, handshake plugins.PluginHandshake)

--- a/pkg/plugins/internal/manager.go
+++ b/pkg/plugins/internal/manager.go
@@ -89,7 +89,7 @@ func newPluginClient(name string, p plugin.Plugin, hc plugin.HandshakeConfig, cm
 		Output: os.Stdout,
 		Level:  hclog.Debug,
 	})
-	l := logging.Default()
+	l := logging.Default().WithField("plugin_name", name)
 	hcl := NewHClogger(hl, l)
 	clientConfig.Logger = hcl
 	return plugin.NewClient(&clientConfig)

--- a/pkg/plugins/internal/manager.go
+++ b/pkg/plugins/internal/manager.go
@@ -89,7 +89,7 @@ func newPluginClient(name string, p plugin.Plugin, hc plugin.HandshakeConfig, cm
 		Output: os.Stdout,
 		Level:  hclog.Debug,
 	})
-	l := logging.Default().WithField("plugin_name", name)
+	l := logging.ContextUnavailable().WithField("plugin_name", name)
 	hcl := NewHClogger(hl, l)
 	clientConfig.Logger = hcl
 	return plugin.NewClient(&clientConfig)

--- a/pkg/pyramid/file_test.go
+++ b/pkg/pyramid/file_test.go
@@ -29,7 +29,7 @@ func TestPyramidWriteFile(t *testing.T) {
 	var storeCtx context.Context
 	sut := WRFile{
 		File:   fh,
-		logger: logging.Default(),
+		logger: logging.ContextUnavailable(),
 		store: func(innerCtx context.Context, _ string) error {
 			storeCalled = true
 			storeCtx = innerCtx
@@ -77,7 +77,7 @@ func TestWriteValidate(t *testing.T) {
 
 	sut := WRFile{
 		File:   fh,
-		logger: logging.Default(),
+		logger: logging.ContextUnavailable(),
 		store: func(context.Context, string) error {
 			storeCalled = true
 			return nil
@@ -111,7 +111,7 @@ func TestMultipleWriteCalls(t *testing.T) {
 
 	sut := WRFile{
 		File:   fh,
-		logger: logging.Default(),
+		logger: logging.ContextUnavailable(),
 		store: func(context.Context, string) error {
 			storeCalled = true
 			return nil
@@ -146,7 +146,7 @@ func TestAbort(t *testing.T) {
 
 	sut := WRFile{
 		File:   fh,
-		logger: logging.Default(),
+		logger: logging.ContextUnavailable(),
 		store: func(context.Context, string) error {
 			storeCalled = true
 			return nil

--- a/pkg/pyramid/main_test.go
+++ b/pkg/pyramid/main_test.go
@@ -45,7 +45,7 @@ func createFSWithEviction(ev params.Eviction) (FS, string) {
 	baseDir := path.Join(os.TempDir(), fsName)
 
 	// starting adapter with closed channel so all Gets pass
-	adapter = &memAdapter{Adapter: mem.New(), wait: make(chan struct{})}
+	adapter = &memAdapter{Adapter: mem.New(context.Background()), wait: make(chan struct{})}
 	close(adapter.wait)
 
 	var err error

--- a/pkg/pyramid/tier_fs_test.go
+++ b/pkg/pyramid/tier_fs_test.go
@@ -108,7 +108,7 @@ func TestStartup(t *testing.T) {
 		FSName:              fsName,
 		DiskAllocProportion: 1.0,
 		SharedParams: params.SharedParams{
-			Logger:             logging.Default(),
+			Logger:             logging.ContextUnavailable(),
 			Adapter:            mem.New(context.Background()),
 			BlockStoragePrefix: blockStoragePrefix,
 			Local: params.LocalDiskParams{

--- a/pkg/pyramid/tier_fs_test.go
+++ b/pkg/pyramid/tier_fs_test.go
@@ -109,7 +109,7 @@ func TestStartup(t *testing.T) {
 		DiskAllocProportion: 1.0,
 		SharedParams: params.SharedParams{
 			Logger:             logging.Default(),
-			Adapter:            mem.New(),
+			Adapter:            mem.New(context.Background()),
 			BlockStoragePrefix: blockStoragePrefix,
 			Local: params.LocalDiskParams{
 				BaseDir:             os.TempDir(),

--- a/pkg/testutil/db.go
+++ b/pkg/testutil/db.go
@@ -183,7 +183,7 @@ func NewBlockAdapterByType(t testing.TB, blockstoreType string) block.Adapter {
 		return lakefsS3.NewAdapter(sess)
 
 	default:
-		return mem.New()
+		return mem.New(context.Background())
 	}
 }
 

--- a/pkg/testutil/setup.go
+++ b/pkg/testutil/setup.go
@@ -33,7 +33,7 @@ type SetupTestingEnvParams struct {
 }
 
 func SetupTestingEnv(params *SetupTestingEnvParams) (logging.Logger, api.ClientWithResponsesInterface, *s3.S3, string) {
-	logger := logging.Default()
+	logger := logging.ContextUnavailable()
 	viper.AddConfigPath(".")
 	viper.SetEnvKeyReplacer(strings.NewReplacer(".", "_")) // support nested config
 	viper.SetEnvPrefix(strings.ToUpper(params.Name))
@@ -59,7 +59,7 @@ func SetupTestingEnv(params *SetupTestingEnvParams) (logging.Logger, api.ClientW
 	ctx := context.Background()
 
 	// initialize the env/repo
-	logger = logging.Default()
+	logger = logging.ContextUnavailable()
 	logger.WithField("settings", viper.AllSettings()).Info(fmt.Sprintf("Starting %s", params.Name))
 
 	endpointURL := ParseEndpointURL(logger, viper.GetString("endpoint_url"))


### PR DESCRIPTION
Loggers created using `logging.FromContext` include a request ID field,
allowing readers to thread together actions performed for the same request.
Also in future they allow us to add _additional_ fields, for example to
distinguish S3 from lakeFS API operations deep inside the call tree.

Rename `logging.Default` to something more descriptive but perhaps less
pleasant, to encourage calling `logging.FromContext`.

Fixes #2682.