### PR TITLE
feat: add `diff_branch` to Lua hook

### DIFF
--- a/docs/howto/hooks/lua.md
+++ b/docs/howto/hooks/lua.md
@@ -231,6 +231,10 @@ Returns 2 values:
 1. The HTTP status code returned by the lakeFS API
 1. The content of the specified object as a lua string
 
+### `lakefs/diff_branch(repository_id, branch_id [, after, amount, prefix, delimiter])`
+
+Returns an object-wise diff of uncommitted changes on `branch_id`.
+
 ### `path/parse(path_string)`
 
 Returns a table for the given path string with the following structure:

--- a/pkg/actions/lua/lakefs/client.go
+++ b/pkg/actions/lua/lakefs/client.go
@@ -170,6 +170,31 @@ func OpenClient(l *lua.State, ctx context.Context, user *model.User, server *htt
 				l.PushString(rr.Body.String())
 				return 2
 			}},
+			{Name: "diff_branch", Function: func(state *lua.State) int {
+				repo := lua.CheckString(l, 1)
+				branch := lua.CheckString(l, 2)
+				reqURL := fmt.Sprintf("/repositories/%s/branches/%s/diff", url.PathEscape(repo), url.PathEscape(branch))
+				req, err := newLakeFSJSONRequest(ctx, user, http.MethodGet, reqURL, nil)
+				if err != nil {
+					check(l, err)
+				}
+				// query params
+				q := req.URL.Query()
+				if !l.IsNone(3) {
+					q.Add("after", lua.CheckString(l, 3))
+				}
+				if !l.IsNone(4) {
+					q.Add("amount", fmt.Sprintf("%d", lua.CheckInteger(l, 4)))
+				}
+				if !l.IsNone(5) {
+					q.Add("prefix", lua.CheckString(l, 5))
+				}
+				if !l.IsNone(6) {
+					q.Add("delimiter", lua.CheckString(l, 6))
+				}
+				req.URL.RawQuery = q.Encode()
+				return getLakeFSJSONResponse(l, server, req)
+			}},
 		})
 		return 1
 	}


### PR DESCRIPTION
## Change Description

### Background

Add functionality to find which objects are currently uncommitted on a given branch.  Using `diff_refs` hook in Lua does not provide uncommitted objects in reference branch, however the `/repositories/{repository}/branches/{branch}/diff` path returns this information.

### New Feature

Adding `diff_branch` to Lua hook in order to obtain uncommitted objects.
