### PR TITLE
Remove mentions of "DDL" in build, CI infrastructure

### DIFF
--- a/.github/workflows/esti.yaml
+++ b/.github/workflows/esti.yaml
@@ -106,7 +106,6 @@ jobs:
           tags: ${{ steps.login-ecr.outputs.registry }}/lakefs:${{ steps.version.outputs.tag }}
           build-args: VERSION=${{ steps.version.outputs.tag }}
           context: .
-          labels: "db-schema-version=(kv)"
           cache-from: |
             type=s3,region=us-east-1,bucket=lakefs-docker-cache,name=lakefs
           cache-to: |

--- a/.github/workflows/esti.yaml
+++ b/.github/workflows/esti.yaml
@@ -93,10 +93,6 @@ jobs:
         run: echo "tag=sha-$(git rev-parse --short HEAD | sed s/^v//g)" >> $GITHUB_OUTPUT
         id: version
 
-      - name: Extract db schema version from ddl migration files
-        run: echo "dbschema_version=$( (cd pkg/ddl/ && ls -d *.up.sql) | sed -nE '$s/^0*([0-9]+).*/\1/p' )" >> $GITHUB_OUTPUT
-        id: schema
-
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v1
@@ -110,7 +106,7 @@ jobs:
           tags: ${{ steps.login-ecr.outputs.registry }}/lakefs:${{ steps.version.outputs.tag }}
           build-args: VERSION=${{ steps.version.outputs.tag }}
           context: .
-          labels: db-schema-version=${{ steps.schema.outputs.dbschema_version }}
+          labels: "db-schema-version=(kv)"
           cache-from: |
             type=s3,region=us-east-1,bucket=lakefs-docker-cache,name=lakefs
           cache-to: |

--- a/Makefile
+++ b/Makefile
@@ -201,7 +201,7 @@ gofmt:  ## gofmt code formating
 
 validate-fmt:  ## Validate go format
 	@echo checking gofmt...
-	@res=$$($(GOFMT) -d -e -s $$(find . -type d \( -path ./pkg/metastore/hive/gen-go \) -prune -o \( -path ./pkg/ddl \) -prune -o \( -path ./pkg/webui \) -prune -o \( -path ./pkg/api/gen \) -prune -o \( -path ./pkg/permissions/*.gen.go \) -prune -o -name '*.go' -print)); \
+	@res=$$($(GOFMT) -d -e -s $$(find . -type d \( -path ./pkg/metastore/hive/gen-go \) -prune -prune -o \( -path ./pkg/api/gen \) -prune -o \( -path ./pkg/permissions/*.gen.go \) -prune -o -name '*.go' -print)); \
 	if [ -n "$${res}" ]; then \
 		echo checking gofmt fail... ; \
 		echo "$${res}"; \


### PR DESCRIPTION
KV has no DDL.  DDL is gone and will never come back.

Label Docker images "`db-schema-version=(kv)`", although even that's been
missing since we went all KV.

After this change, only test data, documentation, images, and a
Thrift-related file continue to say "ddl".

```sh
❯ git grep -iwl ddl
CHANGELOG.md
clients/spark/core/src/test/resources/pebble-testdata/reader/iter
design/accepted/metadata_kv/lakefs-kv-execution-plan.md
design/open/diagrams/create-repository-2.png
design/open/diagrams/pull-request-dialog.png
design/open/diagrams/wizard-mvp.png
docs/assets/img/graveler2.png
docs/assets/img/iso-env-create-repo.png
docs/assets/img/lakeFS_integration.png
docs/assets/what_is.png
docs/howto/deploy/deploy-on-azure.excalidraw.png
esti/docs/img/lakefs_config.png
pkg/metastore/hive/hive_metastore.thrift
pkg/samplerepo/assets/sample/images/merge01.png
```

-------

Closes #(Insert issue number closed by this PR)

## Change Description

### Background

Share context and relevant information for the PR: offline discussions, considerations, design decisions etc.

### Bug Fix

If this PR is a bug fix, please let us know about:

1. Problem - The reason for opening the bug
2. Root cause - Discovered root cause after investigation
3. Solution - How the bug was fixed
      
### New Feature

If this PR introduces a new feature, describe it here.

### Testing Details

How were the changes tested?

### Breaking Change?

Does this change break any existing functionality? (API, CLI, Clients)

## Additional info

Logs, outputs, screenshots of changes if applicable (CLI / GUI changes)

### Contact Details

How can we get in touch with you if we need more info? (ex. email@example.com)