### PR TITLE
Implement lakectl local checkout

### DIFF
--- a/cmd/lakectl/cmd/diff.go
+++ b/cmd/lakectl/cmd/diff.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/treeverse/lakefs/pkg/api"
 	"github.com/treeverse/lakefs/pkg/diff"
+	"github.com/treeverse/lakefs/pkg/uri"
 )
 
 const (
@@ -65,7 +66,7 @@ var diffCmd = &cobra.Command{
 		if leftRefURI.Repository != rightRefURI.Repository {
 			Die("both references must belong to the same repository", 1)
 		}
-		printDiffRefs(cmd.Context(), client, leftRefURI.Repository, leftRefURI.Ref, rightRefURI.Ref, twoWay)
+		printDiffRefs(cmd.Context(), client, leftRefURI, rightRefURI, twoWay)
 	},
 }
 
@@ -106,9 +107,9 @@ func printDiffBranch(ctx context.Context, client api.ClientWithResponsesInterfac
 	}
 }
 
-func printDiffRefs(ctx context.Context, client api.ClientWithResponsesInterface, repository string, leftRef string, rightRef string, twoDot bool) {
+func printDiffRefs(ctx context.Context, client api.ClientWithResponsesInterface, left, right *uri.URI, twoDot bool) {
 	diffs := make(chan api.Diff, maxDiffPageSize)
-	err := diff.StreamRepositoryDiffs(ctx, client, repository, leftRef, rightRef, "", diffs, twoDot)
+	err := diff.StreamRepositoryDiffs(ctx, client, left, right, "", diffs, twoDot)
 	if err != nil {
 		DieErr(err)
 	}

--- a/cmd/lakectl/cmd/local.go
+++ b/cmd/lakectl/cmd/local.go
@@ -50,7 +50,7 @@ func getLocalSyncFlags(cmd *cobra.Command) syncFlags {
 func getLocalArgs(args []string, requireRemote bool) (remote *uri.URI, localPath string) {
 	idx := 0
 	if requireRemote {
-		remote = MustParsePathURI("path", args[0])
+		remote = MustParseRefURI("path", args[0])
 		idx += 1
 	}
 

--- a/cmd/lakectl/cmd/local_checkout.go
+++ b/cmd/lakectl/cmd/local_checkout.go
@@ -1,0 +1,113 @@
+package cmd
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"strings"
+
+	"github.com/go-openapi/swag"
+	"github.com/spf13/cobra"
+	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/diff"
+	"github.com/treeverse/lakefs/pkg/local"
+	"golang.org/x/sync/errgroup"
+)
+
+var localCheckoutCmd = &cobra.Command{
+	Use:   "checkout [directory]",
+	Short: "Sync local directory with the remote state.",
+	Args:  localDefaultArgsRange,
+	Run: func(cmd *cobra.Command, args []string) {
+		_, localPath := getLocalArgs(args, false)
+		syncFlags := getLocalSyncFlags(cmd)
+		specifiedRef := Must(cmd.Flags().GetString("ref"))
+		idx, err := local.ReadIndex(localPath)
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				DieFmt("directory %s is not linked to a lakeFS path", localPath)
+			}
+			DieErr(err)
+		}
+
+		remote, err := idx.GetCurrentURI()
+		if err != nil {
+			DieErr(err)
+		}
+
+		currentBase := remote.WithRef(idx.AtHead)
+		client := getClient()
+		diffs := localDiff(cmd.Context(), client, currentBase, idx.LocalPath())
+		syncMgr := local.NewSyncManager(cmd.Context(), client, syncFlags.parallelism, syncFlags.presign)
+		// confirm on local changes
+		if len(diffs) > 0 {
+			fmt.Println("Uncommitted changes exist, the operation will revert all changes on local directory.")
+			confirmation, err := Confirm(cmd.Flags(), "Proceed")
+			if err != nil || !confirmation {
+				Die("command aborted", 1)
+			}
+
+			c := make(chan *local.Change, filesChanSize)
+			// revert changes!
+			go func() {
+				defer close(c)
+				for _, change := range local.Undo(diffs) {
+					c <- change
+				}
+			}()
+			err = syncMgr.Sync(idx.LocalPath(), currentBase, c)
+			if err != nil {
+				DieErr(err)
+			}
+		}
+
+		if specifiedRef != "" {
+			newRemote := remote.WithRef(specifiedRef)
+			newHead := resolveCommitOrDie(cmd.Context(), client, newRemote.Repository, newRemote.Ref)
+			newBase := newRemote.WithRef(newHead)
+			// write new index
+			_, err = local.WriteIndex(idx.LocalPath(), newRemote, newHead)
+			if err != nil {
+				DieErr(err)
+			}
+
+			var wg errgroup.Group
+			d := make(chan api.Diff, maxDiffPageSize)
+			wg.Go(func() error {
+				return diff.StreamRepositoryDiffs(cmd.Context(), client, currentBase, newBase, swag.StringValue(currentBase.Path), d, true)
+			})
+
+			c := make(chan *local.Change, filesChanSize)
+			wg.Go(func() error {
+				defer close(c)
+				for dif := range d {
+					c <- &local.Change{
+						Source: local.ChangeSourceRemote,
+						Path:   strings.TrimPrefix(dif.Path, currentBase.GetPath()),
+						Type:   local.ChangeTypeFromString(dif.Type),
+					}
+				}
+				return nil
+			})
+
+			err = syncMgr.Sync(idx.LocalPath(), newBase, c)
+			if err != nil {
+				DieErr(err)
+			}
+			err = wg.Wait()
+			if err != nil {
+				DieErr(err)
+			}
+		}
+		summary := syncMgr.Summary()
+		fmt.Printf("Checkout Summary:\nDownloaded:\t%d\nRemoved:\t%d\n", summary.Downloaded, summary.Removed)
+	},
+}
+
+//nolint:gochecknoinits
+func init() {
+	localCheckoutCmd.Flags().StringP("ref", "r", "", "Checkout the given source branch or reference")
+	AssignAutoConfirmFlag(localCheckoutCmd.Flags())
+	withLocalSyncFlags(localCheckoutCmd)
+	localCmd.AddCommand(localCheckoutCmd)
+}

--- a/cmd/lakectl/cmd/local_clone.go
+++ b/cmd/lakectl/cmd/local_clone.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"io/fs"
 	"net/http"
-	"path/filepath"
 	"strings"
 
 	"github.com/go-openapi/swag"
@@ -27,16 +26,8 @@ var localCloneCmd = &cobra.Command{
 	Short: "Clone a path from a lakeFS repository into a new directory.",
 	Args:  cobra.RangeArgs(localCloneMinArgs, localCloneMaxArgs),
 	Run: func(cmd *cobra.Command, args []string) {
-		remote := MustParsePathURI("path", args[0])
-		dir := "."
-		if len(args) == localCloneMaxArgs {
-			dir = args[1]
-		}
+		remote, localPath := getLocalArgs(args, true)
 		syncFlags := getLocalSyncFlags(cmd)
-		localPath, err := filepath.Abs(dir)
-		if err != nil {
-			DieErr(err)
-		}
 
 		empty, err := fileutil.IsDirEmpty(localPath)
 		if err != nil {

--- a/cmd/lakectl/cmd/local_init.go
+++ b/cmd/lakectl/cmd/local_init.go
@@ -53,21 +53,13 @@ var localInitCmd = &cobra.Command{
 	Short: "set a local directory to sync with a lakeFS path.",
 	Args:  cobra.RangeArgs(localInitMinArgs, localInitMaxArgs),
 	Run: func(cmd *cobra.Command, args []string) {
-		remote := MustParsePathURI("path", args[0])
-		dir := "."
-		if len(args) == localInitMaxArgs {
-			dir = args[1]
-		}
-		localPath, err := filepath.Abs(dir)
-		if err != nil {
-			DieErr(err)
-		}
+		remote, localPath := getLocalArgs(args, true)
 		force := Must(cmd.Flags().GetBool("force"))
 
-		_, err = localInit(cmd.Context(), localPath, remote, force)
+		_, err := localInit(cmd.Context(), localPath, remote, force)
 		if err != nil {
 			if errors.Is(err, fs.ErrExist) {
-				DieFmt("directory '%s' already linked to a lakeFS path, run command with --force to overwrite", dir)
+				DieFmt("directory '%s' already linked to a lakeFS path, run command with --force to overwrite", localPath)
 			}
 			DieErr(err)
 		}

--- a/cmd/lakectl/cmd/local_status.go
+++ b/cmd/lakectl/cmd/local_status.go
@@ -65,7 +65,7 @@ var localStatusCmd = &cobra.Command{
 				DieErr(err)
 			}
 
-			c = c.MergeWith(changes)
+			c = c.MergeWith(changes, local.MergeStrategyNone)
 		}
 
 		if len(c) == 0 {

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2574,6 +2574,27 @@ BETA: sync local directories with lakeFS paths
 
 
 
+### lakectl local checkout
+
+Sync local directory with the remote state.
+
+```
+lakectl local checkout [directory] [flags]
+```
+
+#### Options
+{:.no_toc}
+
+```
+  -h, --help              help for checkout
+  -p, --parallelism int   Max concurrent operations to perform (default 25)
+      --presign           Use pre-signed URLs when downloading/uploading data (recommended) (default true)
+  -r, --ref string        Checkout the given source branch or reference
+  -y, --yes               Automatically say yes to all confirmations
+```
+
+
+
 ### lakectl local clone
 
 Clone a path from a lakeFS repository into a new directory.

--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -9,12 +9,13 @@ import (
 	"github.com/jedib0t/go-pretty/v6/text"
 	"github.com/treeverse/lakefs/pkg/api"
 	"github.com/treeverse/lakefs/pkg/local"
+	"github.com/treeverse/lakefs/pkg/uri"
 )
 
 const diffTypeTwoDot = "two_dot"
 
-// StreamRepositoryDiffs fetches differences between 'left' and 'right' references in a repository
-func StreamRepositoryDiffs(ctx context.Context, client api.ClientWithResponsesInterface, repository, left, right, prefix string, diffs chan<- api.Diff, twoDot bool) error {
+// StreamRepositoryDiffs fetches differences between 'left' and 'right' references, assumes both are in the same repository
+func StreamRepositoryDiffs(ctx context.Context, client api.ClientWithResponsesInterface, left, right *uri.URI, prefix string, diffs chan<- api.Diff, twoDot bool) error {
 	defer func() {
 		close(diffs)
 	}()
@@ -26,7 +27,7 @@ func StreamRepositoryDiffs(ctx context.Context, client api.ClientWithResponsesIn
 	hasMore := true
 	var after string
 	for hasMore {
-		diffResp, err := client.DiffRefsWithResponse(ctx, repository, left, right, &api.DiffRefsParams{
+		diffResp, err := client.DiffRefsWithResponse(ctx, left.Repository, left.Ref, right.Ref, &api.DiffRefsParams{
 			After:  (*api.PaginationAfter)(swag.String(after)),
 			Prefix: (*api.PaginationPrefix)(&prefix),
 			Type:   diffType,

--- a/pkg/local/sync.go
+++ b/pkg/local/sync.go
@@ -234,7 +234,7 @@ func (s *SyncManager) upload(rootPath string, remote *uri.URI, change *Change) e
 }
 
 func (s *SyncManager) deleteLocal(rootPath string, change *Change) error {
-	b := s.progressBar.AddSpinner(fmt.Sprintf("delete local path: %s", change.Path))
+	b := s.progressBar.AddSpinner(fmt.Sprintf("delete local: %s", change.Path))
 	source := filepath.Join(rootPath, change.Path)
 	err := fileutil.RemoveFile(source)
 	if err != nil {


### PR DESCRIPTION
Closes #6348

## Change Description

### Background

Implement lakectl local command to sync local directory with the remote state, overwriting any local change
      
### New Feature

Part of task https://github.com/treeverse/lakeFS/issues/6239

### Testing Details

Unit testing for tools, lakectl tests will be added for esti upon feature completion. SyncManager will be tested as part of the command (was tested manually)

### Breaking Change?

No
