### PR TITLE
Presign S3 URLs using fresh credentials and cap their TTL

### DIFF
--- a/pkg/block/factory/build.go
+++ b/pkg/block/factory/build.go
@@ -5,7 +5,6 @@ import (
 	"crypto/tls"
 	"fmt"
 	"net/http"
-	"time"
 
 	"cloud.google.com/go/storage"
 	"github.com/aws/aws-sdk-go/aws"
@@ -29,8 +28,6 @@ import (
 const (
 	// googleAuthCloudPlatform - Cloud Storage authentication https://cloud.google.com/storage/docs/authentication
 	googleAuthCloudPlatform = "https://www.googleapis.com/auth/cloud-platform"
-	// renewWebIdentity is the time to try to renew web credentials.
-	renewWebIdentity = 5 * time.Minute
 )
 
 func BuildBlockAdapter(ctx context.Context, statsCollector stats.Collector, c params.AdapterConfig) (block.Adapter, error) {
@@ -88,7 +85,7 @@ func buildLocalAdapter(ctx context.Context, params params.Local) (*local.Adapter
 	return adapter, nil
 }
 
-func BuildS3Client(params *aws.Config, skipVerifyCertificateTestOnly bool) (*session.Session, error) {
+func BuildS3Client(awsConfig *aws.Config, webIdentity *params.S3WebIdentity, skipVerifyCertificateTestOnly bool) (*session.Session, error) {
 	client := http.DefaultClient
 	if skipVerifyCertificateTestOnly {
 		tr := &http.Transport{
@@ -97,11 +94,19 @@ func BuildS3Client(params *aws.Config, skipVerifyCertificateTestOnly bool) (*ses
 		client = &http.Client{Transport: tr}
 	}
 	opts := session.Options{}
-	opts.Config.MergeIn(params, aws.NewConfig().WithHTTPClient(client))
-	opts.CredentialsProviderOptions = &session.CredentialsProviderOptions{
-		WebIdentityRoleProviderOptions: func(wirp *stscreds.WebIdentityRoleProvider) {
-			wirp.ExpiryWindow = renewWebIdentity
-		},
+	opts.Config.MergeIn(awsConfig, aws.NewConfig().WithHTTPClient(client))
+	if webIdentity != nil {
+		wi := *webIdentity // Copy WebIdentity: it will be used asynchronously.
+		opts.CredentialsProviderOptions = &session.CredentialsProviderOptions{
+			WebIdentityRoleProviderOptions: func(wirp *stscreds.WebIdentityRoleProvider) {
+				if wi.SessionDuration > 0 {
+					wirp.Duration = wi.SessionDuration
+				}
+				if wi.SessionExpiryWindow > 0 {
+					wirp.ExpiryWindow = wi.SessionExpiryWindow
+				}
+			},
+		}
 	}
 	sess, err := session.NewSessionWithOptions(opts)
 	if err != nil {
@@ -112,7 +117,7 @@ func BuildS3Client(params *aws.Config, skipVerifyCertificateTestOnly bool) (*ses
 }
 
 func buildS3Adapter(ctx context.Context, statsCollector stats.Collector, params params.S3) (*s3a.Adapter, error) {
-	sess, err := BuildS3Client(params.AwsConfig, params.SkipVerifyCertificateTestOnly)
+	sess, err := BuildS3Client(params.AwsConfig, params.WebIdentity, params.SkipVerifyCertificateTestOnly)
 	if err != nil {
 		return nil, err
 	}
@@ -130,6 +135,9 @@ func buildS3Adapter(ctx context.Context, statsCollector stats.Collector, params 
 	}
 	if params.ServerSideEncryptionKmsKeyID != "" {
 		opts = append(opts, s3a.WithServerSideEncryptionKmsKeyID(params.ServerSideEncryptionKmsKeyID))
+	}
+	if params.WebIdentity != nil && params.WebIdentity.SessionExpiryWindow > 0 {
+		opts = append(opts, s3a.WithPreSignedRefreshWindow(params.WebIdentity.SessionExpiryWindow))
 	}
 	adapter := s3a.NewAdapter(sess, opts...)
 	logging.FromContext(ctx).WithField("type", "s3").Info("initialized blockstore adapter")

--- a/pkg/block/params/block.go
+++ b/pkg/block/params/block.go
@@ -24,6 +24,19 @@ type Local struct {
 	AllowedExternalPrefixes []string
 }
 
+// S3WebIdentity contains parameters for customizing S3 web identity.  This
+// is also used when configuring S3 with IRSA in EKS (Kubernetes).
+type S3WebIdentity struct {
+	// SessionDuration is the duration WebIdentityRoleProvider will
+	// request for a token for its assumed role.  It can be 1 hour or
+	// more, but its maximum is configurable on AWS.
+	SessionDuration time.Duration
+
+	// SessionExpiryWindow is the time before credentials expiry that
+	// the WebIdentityRoleProvider may request a fresh token.
+	SessionExpiryWindow time.Duration
+}
+
 type S3 struct {
 	AwsConfig                     *aws.Config
 	StreamingChunkSize            int
@@ -35,6 +48,7 @@ type S3 struct {
 	PreSignedExpiry               time.Duration
 	DisablePreSigned              bool
 	DisablePreSignedUI            bool
+	WebIdentity                   *S3WebIdentity
 }
 
 type GS struct {

--- a/pkg/block/s3/client_cache.go
+++ b/pkg/block/s3/client_cache.go
@@ -134,7 +134,7 @@ func (c *ClientCache) Get(ctx context.Context, bucket string) (ret S3APIWithExpi
 			return
 		}
 		if err != nil {
-			l = l.WithField("error", err)
+			l = l.WithError(err)
 		} else if !expiry.IsZero() {
 			l = l.WithFields(logging.Fields{
 				"expiry": expiry,

--- a/pkg/block/s3/client_cache_test.go
+++ b/pkg/block/s3/client_cache_test.go
@@ -31,6 +31,10 @@ func (f FakeS3APIWithExpirer) ExpiresAt() (time.Time, error) {
 	return time.Time{}, errFakeExpires
 }
 
+func (f FakeS3APIWithExpirer) Refresh() (time.Time, error) {
+	return f.ExpiresAt()
+}
+
 func TestClientCache(t *testing.T) {
 	defaultRegion := "us-west-2"
 	sess, err := session.NewSession(&aws.Config{Region: &defaultRegion})

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -259,6 +259,10 @@ type Config struct {
 			PreSignedExpiry               time.Duration `mapstructure:"pre_signed_expiry"`
 			DisablePreSigned              bool          `mapstructure:"disable_pre_signed"`
 			DisablePreSignedUI            bool          `mapstructure:"disable_pre_signed_ui"`
+			WebIdentity                   *struct {
+				SessionDuration     time.Duration `mapstructure:"session_duration"`
+				SessionExpiryWindow time.Duration `mapstructure:"session_expiry_window"`
+			} `mapstructure:"web_identity"`
 		} `mapstructure:"s3"`
 		Azure *struct {
 			TryTimeout       time.Duration `mapstructure:"try_timeout"`
@@ -547,6 +551,13 @@ func (c *Config) BlockstoreType() string {
 }
 
 func (c *Config) BlockstoreS3Params() (blockparams.S3, error) {
+	var webIdentity *blockparams.S3WebIdentity
+	if c.Blockstore.S3.WebIdentity != nil {
+		webIdentity = &blockparams.S3WebIdentity{
+			SessionDuration:     c.Blockstore.S3.WebIdentity.SessionDuration,
+			SessionExpiryWindow: c.Blockstore.S3.WebIdentity.SessionExpiryWindow,
+		}
+	}
 	return blockparams.S3{
 		AwsConfig:                     c.GetAwsConfig(),
 		StreamingChunkSize:            c.Blockstore.S3.StreamingChunkSize,
@@ -558,6 +569,7 @@ func (c *Config) BlockstoreS3Params() (blockparams.S3, error) {
 		PreSignedExpiry:               c.Blockstore.S3.PreSignedExpiry,
 		DisablePreSigned:              c.Blockstore.S3.DisablePreSigned,
 		DisablePreSignedUI:            c.Blockstore.S3.DisablePreSignedUI,
+		WebIdentity:                   webIdentity,
 	}, nil
 }
 

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -67,6 +67,7 @@ func setDefaults(cfgType string) {
 	viper.SetDefault("blockstore.s3.max_retries", 5)
 	viper.SetDefault("blockstore.s3.discover_bucket_region", true)
 	viper.SetDefault("blockstore.s3.pre_signed_expiry", 15*time.Minute)
+	viper.SetDefault("blockstore.s3.web_identity.session_expiry_window", 5*time.Minute)
 	viper.SetDefault("blockstore.s3.disable_pre_signed_ui", true)
 
 	viper.SetDefault("committed.local_cache.size_bytes", 1*1024*1024*1024)

--- a/pkg/ingest/store/factory.go
+++ b/pkg/ingest/store/factory.go
@@ -66,7 +66,7 @@ func (f *WalkerFactory) buildS3Walker(opts WalkerOptions) (*s3.Walker, error) {
 		if err != nil {
 			return nil, err
 		}
-		sess, err = factory.BuildS3Client(s3params.AwsConfig, s3params.SkipVerifyCertificateTestOnly)
+		sess, err = factory.BuildS3Client(s3params.AwsConfig, s3params.WebIdentity, s3params.SkipVerifyCertificateTestOnly)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
## Periodically refresh S3 credentials before presigning S3 URLs

When running with IRSA, EKS provides the lakeFS server process with fresh
"web identity" credentials in a file.  The AWS SDK re-reads these
credentials when signing requests, but _not_ re-read presigning a URL.

Ensure that credentials are refreshed to have at least 5 minutes on them.
In particular this ensures that after a lakeFS server has seen no traffic
and its credentials have expired, a presigned URL that it generates will use
valid credentials.

We see evidence of this occurring with Unity Delta Sharing, and I have
manually reproduced this.

## Cap expiration time of S3 presigned URLs by the lifetime of their signing credentials

The AWS SDK copies the request expiration time for a presigned URL onto that
URL (and signs it).  If the signing credentials expire before the URL, the
URL becomes invalid and using it yields "Token Expired".

Unity Delta Sharing appears to believe the URL validity period rather than the reported "expirationTimestamp", and it uses such URLs.

## A race condition remains

It is of course impossible to provide Unity Delta Sharing with a URL that
will be valid when it chooses to use it.  But an additional race condition
remains that is entirely within lakeFS!  The server uses its clock to
determine and report credentials lifetimes.  This clock is necessarily
unsynchronized with the AWS cluster infrastructure, so a race is always
possible in any program that believes these timestamps.  The only solution
is of course not to rely on timestamps: to work correctly, programs will
have to understand "Token Expired" error messages and request a new URL.  Or
they can assume clock synchronization + S3 latency is within 5 seconds, say,
and require a URL to expire after that time period.

Closes #6391.
