### PR TITLE
Fix: quickstart validation

### DIFF
--- a/cmd/lakefs/cmd/root.go
+++ b/cmd/lakefs/cmd/root.go
@@ -49,7 +49,7 @@ func init() {
 }
 
 func validateQuickstartEnv(cfg *config.Config) {
-	if !((cfg.Database.Type == local.DriverName || cfg.Database.Type == mem.DriverName) && cfg.Blockstore.Type == block.BlockstoreTypeLocal) {
+	if ((cfg.Database.Type != local.DriverName && cfg.Database.Type != mem.DriverName) || cfg.Blockstore.Type != block.BlockstoreTypeLocal) {
 		fmt.Println("quickstart mode can only run with local settings")
 		os.Exit(1)
 	}

--- a/cmd/lakefs/cmd/root.go
+++ b/cmd/lakefs/cmd/root.go
@@ -57,7 +57,7 @@ func validateQuickstartEnv(cfg *config.Config) {
 	if cfg.Installation.UserName != config.DefaultQuickstartUsername ||
 		cfg.Installation.AccessKeyID != config.DefaultQuickstartKeyID ||
 		cfg.Installation.SecretAccessKey != config.DefaultQuickstartSecretKey {
-		fmt.Println("installation parameters must not be changed in quickstart mode")
+		_, _ = fmt.Fprint(os.Stderr, "\nFATAL: installation parameters must not be changed in quickstart mode\n")
 		os.Exit(1)
 	}
 }

--- a/cmd/lakefs/cmd/root.go
+++ b/cmd/lakefs/cmd/root.go
@@ -60,8 +60,6 @@ func validateQuickstartEnv(cfg *config.Config) {
 		fmt.Println("installation parameters must not be changed in quickstart mode")
 		os.Exit(1)
 	}
-	fmt.Printf("Access Key ID    : %s\n", config.DefaultQuickstartKeyID)
-	fmt.Printf("Secret Access Key: %s\n", config.DefaultQuickstartSecretKey)
 }
 
 func useConfig(flagName string) bool {

--- a/cmd/lakefs/cmd/root.go
+++ b/cmd/lakefs/cmd/root.go
@@ -50,7 +50,7 @@ func init() {
 
 func validateQuickstartEnv(cfg *config.Config) {
 	if (cfg.Database.Type != local.DriverName && cfg.Database.Type != mem.DriverName) || cfg.Blockstore.Type != block.BlockstoreTypeLocal {
-		_, _ = fmt.Fprint(os.Stderr, "\nERROR: quickstart mode can only run with local settings\n")
+		_, _ = fmt.Fprint(os.Stderr, "\nFATAL: quickstart mode can only run with local settings\n")
 		os.Exit(1)
 	}
 

--- a/cmd/lakefs/cmd/root.go
+++ b/cmd/lakefs/cmd/root.go
@@ -49,15 +49,15 @@ func init() {
 }
 
 func validateQuickstartEnv(cfg *config.Config) {
-	if !((cfg.Database.Type == local.DriverName || cfg.Database.Type == mem.DriverName) && cfg.Blockstore.Type != block.BlockstoreTypeLocal) {
-		fmt.Printf("quickstart mode can only run with local settings\n")
+	if !((cfg.Database.Type == local.DriverName || cfg.Database.Type == mem.DriverName) && cfg.Blockstore.Type == block.BlockstoreTypeLocal) {
+		fmt.Println("quickstart mode can only run with local settings")
 		os.Exit(1)
 	}
 
 	if cfg.Installation.UserName != config.DefaultQuickstartUsername ||
 		cfg.Installation.AccessKeyID != config.DefaultQuickstartKeyID ||
 		cfg.Installation.SecretAccessKey != config.DefaultQuickstartSecretKey {
-		fmt.Printf("installation parameters must not be changed in quickstart mode\n")
+		fmt.Println("installation parameters must not be changed in quickstart mode")
 		os.Exit(1)
 	}
 	fmt.Printf("Access Key ID    : %s\n", config.DefaultQuickstartKeyID)

--- a/cmd/lakefs/cmd/root.go
+++ b/cmd/lakefs/cmd/root.go
@@ -49,8 +49,8 @@ func init() {
 }
 
 func validateQuickstartEnv(cfg *config.Config) {
-	if ((cfg.Database.Type != local.DriverName && cfg.Database.Type != mem.DriverName) || cfg.Blockstore.Type != block.BlockstoreTypeLocal) {
-		fmt.Println("quickstart mode can only run with local settings")
+	if (cfg.Database.Type != local.DriverName && cfg.Database.Type != mem.DriverName) || cfg.Blockstore.Type != block.BlockstoreTypeLocal {
+		_, _ = fmt.Fprint(os.Stderr, "\nERROR: quickstart mode can only run with local settings\n")
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
Closes #6400

## Change Description

Bug fix - logical error in condition which checks the supported refstore and blockstore for quickstart mode

### Testing Details

Manual testing

