### PR TITLE
Fix: Add meaningful error on block unsupported operation and check pre-sign capabilities in lakectl local

### DIFF
--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -108,6 +108,12 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/Error"
+    BadRequest:
+      description: Bad Request
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
     Forbidden:
       description: Forbidden
       content:
@@ -1525,11 +1531,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/CredentialsWithSecret"
         400:
-          description: bad request
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
+          $ref: "#/components/responses/BadRequest"
         409:
           description: setup was already called
           content:
@@ -1621,11 +1623,7 @@ paths:
         204:
           description: No content
         400:
-          description: bad request
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
+          $ref: "#/components/responses/BadRequest"
         default:
           $ref: "#/components/responses/ServerError"
 
@@ -3946,10 +3944,12 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         404:
           $ref: "#/components/responses/NotFound"
-        default:
-          $ref: "#/components/responses/ServerError"
+        400:
+          $ref: "#/components/responses/BadRequest"
         410:
           description: object gone (but partial metadata may be available)
+        default:
+          $ref: "#/components/responses/ServerError"
 
   /repositories/{repository}/refs/{ref}/objects/underlyingProperties:
     parameters:
@@ -4629,11 +4629,7 @@ paths:
         204:
           description: reported successfully
         400:
-          description: bad request
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
+          $ref: "#/components/responses/BadRequest"
         401:
           $ref: "#/components/responses/Unauthorized"
         default:

--- a/clients/java/api/openapi.yaml
+++ b/clients/java/api/openapi.yaml
@@ -93,7 +93,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-          description: bad request
+          description: Bad Request
         "409":
           content:
             application/json:
@@ -214,7 +214,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-          description: bad request
+          description: Bad Request
         default:
           content:
             application/json:
@@ -4494,14 +4494,20 @@ paths:
               schema:
                 $ref: '#/components/schemas/Error'
           description: Resource Not Found
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Bad Request
+        "410":
+          description: object gone (but partial metadata may be available)
         default:
           content:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
           description: Internal Server Error
-        "410":
-          description: object gone (but partial metadata may be available)
       summary: get object metadata
       tags:
       - objects
@@ -5626,7 +5632,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
-          description: bad request
+          description: Bad Request
         "401":
           content:
             application/json:
@@ -5734,6 +5740,12 @@ components:
           schema:
             $ref: '#/components/schemas/Error'
       description: Precondition Failed
+    BadRequest:
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+      description: Bad Request
     Forbidden:
       content:
         application/json:

--- a/clients/java/docs/AuthApi.md
+++ b/clients/java/docs/AuthApi.md
@@ -1378,7 +1378,7 @@ No authorization required
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 **204** | No content |  -  |
-**400** | bad request |  -  |
+**400** | Bad Request |  -  |
 **0** | Internal Server Error |  -  |
 
 <a name="getAuthCapabilities"></a>

--- a/clients/java/docs/ConfigApi.md
+++ b/clients/java/docs/ConfigApi.md
@@ -389,7 +389,7 @@ No authorization required
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 **200** | user created successfully |  -  |
-**400** | bad request |  -  |
+**400** | Bad Request |  -  |
 **409** | setup was already called |  -  |
 **0** | Internal Server Error |  -  |
 

--- a/clients/java/docs/ObjectsApi.md
+++ b/clients/java/docs/ObjectsApi.md
@@ -904,6 +904,7 @@ Name | Type | Description  | Notes
 **200** | object metadata |  -  |
 **401** | Unauthorized |  -  |
 **404** | Resource Not Found |  -  |
+**400** | Bad Request |  -  |
 **410** | object gone (but partial metadata may be available) |  -  |
 **0** | Internal Server Error |  -  |
 

--- a/clients/java/docs/StatisticsApi.md
+++ b/clients/java/docs/StatisticsApi.md
@@ -93,7 +93,7 @@ null (empty response body)
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 **204** | reported successfully |  -  |
-**400** | bad request |  -  |
+**400** | Bad Request |  -  |
 **401** | Unauthorized |  -  |
 **0** | Internal Server Error |  -  |
 

--- a/clients/java/src/main/java/io/lakefs/clients/api/AuthApi.java
+++ b/clients/java/src/main/java/io/lakefs/clients/api/AuthApi.java
@@ -1844,7 +1844,7 @@ public class AuthApi {
      <table summary="Response Details" border="1">
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 204 </td><td> No content </td><td>  -  </td></tr>
-        <tr><td> 400 </td><td> bad request </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
      */
@@ -1901,7 +1901,7 @@ public class AuthApi {
      <table summary="Response Details" border="1">
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 204 </td><td> No content </td><td>  -  </td></tr>
-        <tr><td> 400 </td><td> bad request </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
      */
@@ -1919,7 +1919,7 @@ public class AuthApi {
      <table summary="Response Details" border="1">
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 204 </td><td> No content </td><td>  -  </td></tr>
-        <tr><td> 400 </td><td> bad request </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
      */
@@ -1939,7 +1939,7 @@ public class AuthApi {
      <table summary="Response Details" border="1">
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 204 </td><td> No content </td><td>  -  </td></tr>
-        <tr><td> 400 </td><td> bad request </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
      */

--- a/clients/java/src/main/java/io/lakefs/clients/api/ConfigApi.java
+++ b/clients/java/src/main/java/io/lakefs/clients/api/ConfigApi.java
@@ -495,7 +495,7 @@ public class ConfigApi {
      <table summary="Response Details" border="1">
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 200 </td><td> user created successfully </td><td>  -  </td></tr>
-        <tr><td> 400 </td><td> bad request </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> setup was already called </td><td>  -  </td></tr>
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
@@ -554,7 +554,7 @@ public class ConfigApi {
      <table summary="Response Details" border="1">
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 200 </td><td> user created successfully </td><td>  -  </td></tr>
-        <tr><td> 400 </td><td> bad request </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> setup was already called </td><td>  -  </td></tr>
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
@@ -574,7 +574,7 @@ public class ConfigApi {
      <table summary="Response Details" border="1">
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 200 </td><td> user created successfully </td><td>  -  </td></tr>
-        <tr><td> 400 </td><td> bad request </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> setup was already called </td><td>  -  </td></tr>
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
@@ -596,7 +596,7 @@ public class ConfigApi {
      <table summary="Response Details" border="1">
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 200 </td><td> user created successfully </td><td>  -  </td></tr>
-        <tr><td> 400 </td><td> bad request </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 409 </td><td> setup was already called </td><td>  -  </td></tr>
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>

--- a/clients/java/src/main/java/io/lakefs/clients/api/ObjectsApi.java
+++ b/clients/java/src/main/java/io/lakefs/clients/api/ObjectsApi.java
@@ -1367,6 +1367,7 @@ public class ObjectsApi {
         <tr><td> 200 </td><td> object metadata </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Resource Not Found </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 410 </td><td> object gone (but partial metadata may be available) </td><td>  -  </td></tr>
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
@@ -1455,6 +1456,7 @@ public class ObjectsApi {
         <tr><td> 200 </td><td> object metadata </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Resource Not Found </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 410 </td><td> object gone (but partial metadata may be available) </td><td>  -  </td></tr>
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
@@ -1480,6 +1482,7 @@ public class ObjectsApi {
         <tr><td> 200 </td><td> object metadata </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Resource Not Found </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 410 </td><td> object gone (but partial metadata may be available) </td><td>  -  </td></tr>
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
@@ -1507,6 +1510,7 @@ public class ObjectsApi {
         <tr><td> 200 </td><td> object metadata </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Resource Not Found </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 410 </td><td> object gone (but partial metadata may be available) </td><td>  -  </td></tr>
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>

--- a/clients/java/src/main/java/io/lakefs/clients/api/StatisticsApi.java
+++ b/clients/java/src/main/java/io/lakefs/clients/api/StatisticsApi.java
@@ -65,7 +65,7 @@ public class StatisticsApi {
      <table summary="Response Details" border="1">
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 204 </td><td> reported successfully </td><td>  -  </td></tr>
-        <tr><td> 400 </td><td> bad request </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized </td><td>  -  </td></tr>
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
@@ -123,7 +123,7 @@ public class StatisticsApi {
      <table summary="Response Details" border="1">
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 204 </td><td> reported successfully </td><td>  -  </td></tr>
-        <tr><td> 400 </td><td> bad request </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized </td><td>  -  </td></tr>
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
@@ -142,7 +142,7 @@ public class StatisticsApi {
      <table summary="Response Details" border="1">
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 204 </td><td> reported successfully </td><td>  -  </td></tr>
-        <tr><td> 400 </td><td> bad request </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized </td><td>  -  </td></tr>
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
@@ -163,7 +163,7 @@ public class StatisticsApi {
      <table summary="Response Details" border="1">
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 204 </td><td> reported successfully </td><td>  -  </td></tr>
-        <tr><td> 400 </td><td> bad request </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Bad Request </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized </td><td>  -  </td></tr>
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>

--- a/clients/python/docs/AuthApi.md
+++ b/clients/python/docs/AuthApi.md
@@ -1619,7 +1619,7 @@ No authorization required
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 **204** | No content |  -  |
-**400** | bad request |  -  |
+**400** | Bad Request |  -  |
 **0** | Internal Server Error |  -  |
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)

--- a/clients/python/docs/ConfigApi.md
+++ b/clients/python/docs/ConfigApi.md
@@ -451,7 +451,7 @@ No authorization required
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 **200** | user created successfully |  -  |
-**400** | bad request |  -  |
+**400** | Bad Request |  -  |
 **409** | setup was already called |  -  |
 **0** | Internal Server Error |  -  |
 

--- a/clients/python/docs/ObjectsApi.md
+++ b/clients/python/docs/ObjectsApi.md
@@ -1096,6 +1096,7 @@ Name | Type | Description  | Notes
 **200** | object metadata |  -  |
 **401** | Unauthorized |  -  |
 **404** | Resource Not Found |  -  |
+**400** | Bad Request |  -  |
 **410** | object gone (but partial metadata may be available) |  -  |
 **0** | Internal Server Error |  -  |
 

--- a/clients/python/docs/StatisticsApi.md
+++ b/clients/python/docs/StatisticsApi.md
@@ -115,7 +115,7 @@ void (empty response body)
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 **204** | reported successfully |  -  |
-**400** | bad request |  -  |
+**400** | Bad Request |  -  |
 **401** | Unauthorized |  -  |
 **0** | Internal Server Error |  -  |
 

--- a/cmd/lakectl/cmd/local_clone.go
+++ b/cmd/lakectl/cmd/local_clone.go
@@ -26,8 +26,9 @@ var localCloneCmd = &cobra.Command{
 	Short: "Clone a path from a lakeFS repository into a new directory.",
 	Args:  cobra.RangeArgs(localCloneMinArgs, localCloneMaxArgs),
 	Run: func(cmd *cobra.Command, args []string) {
+		client := getClient()
 		remote, localPath := getLocalArgs(args, true, false)
-		syncFlags := getLocalSyncFlags(cmd)
+		syncFlags := getLocalSyncFlags(cmd, client)
 		updateIgnore := Must(cmd.Flags().GetBool(localGitIgnoreFlagName))
 		empty, err := fileutil.IsDirEmpty(localPath)
 		if err != nil {
@@ -43,7 +44,6 @@ var localCloneCmd = &cobra.Command{
 			DieErr(err)
 		}
 		stableRemote := remote.WithRef(head)
-		client := getClient()
 		// Dynamically construct changes
 		c := make(chan *local.Change, filesChanSize)
 		go func() {

--- a/cmd/lakectl/cmd/local_commit.go
+++ b/cmd/lakectl/cmd/local_commit.go
@@ -34,8 +34,9 @@ var localCommitCmd = &cobra.Command{
 	Short: "Commit changes from local directory to the lakeFS branch it tracks.",
 	Args:  localDefaultArgsRange,
 	Run: func(cmd *cobra.Command, args []string) {
+		client := getClient()
 		_, localPath := getLocalArgs(args, false, false)
-		syncFlags := getLocalSyncFlags(cmd)
+		syncFlags := getLocalSyncFlags(cmd, client)
 		message := Must(cmd.Flags().GetString(localCommitMessageFlagName))
 		allowEmptyMessage := Must(cmd.Flags().GetBool(localCommitAllowEmptyMessage))
 		if message == "" && !allowEmptyMessage {
@@ -52,7 +53,6 @@ var localCommitCmd = &cobra.Command{
 		}
 
 		fmt.Printf("\nGetting branch: %s\n", remote.Ref)
-		client := getClient()
 		resp, err := client.GetBranchWithResponse(cmd.Context(), remote.Repository, remote.Ref)
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusOK)
 

--- a/cmd/lakectl/cmd/local_pull.go
+++ b/cmd/lakectl/cmd/local_pull.go
@@ -17,9 +17,10 @@ var localPullCmd = &cobra.Command{
 	Short: "Fetch latest changes from lakeFS.",
 	Args:  localDefaultArgsRange,
 	Run: func(cmd *cobra.Command, args []string) {
+		client := getClient()
 		_, localPath := getLocalArgs(args, false, false)
 		force := Must(cmd.Flags().GetBool(localForceFlagName))
-		syncFlags := getLocalSyncFlags(cmd)
+		syncFlags := getLocalSyncFlags(cmd, client)
 		idx, err := local.ReadIndex(localPath)
 		if err != nil {
 			DieErr(err)
@@ -31,7 +32,6 @@ var localPullCmd = &cobra.Command{
 		}
 
 		currentBase := remote.WithRef(idx.AtHead)
-		client := getClient()
 		// make sure no local changes
 		localChange := localDiff(cmd.Context(), client, currentBase, idx.LocalPath())
 		if len(localChange) > 0 && !force {

--- a/docs/assets/js/swagger.yml
+++ b/docs/assets/js/swagger.yml
@@ -108,6 +108,12 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/Error"
+    BadRequest:
+      description: Bad Request
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/Error"
     Forbidden:
       description: Forbidden
       content:
@@ -1525,11 +1531,7 @@ paths:
               schema:
                 $ref: "#/components/schemas/CredentialsWithSecret"
         400:
-          description: bad request
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
+          $ref: "#/components/responses/BadRequest"
         409:
           description: setup was already called
           content:
@@ -1621,11 +1623,7 @@ paths:
         204:
           description: No content
         400:
-          description: bad request
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
+          $ref: "#/components/responses/BadRequest"
         default:
           $ref: "#/components/responses/ServerError"
 
@@ -3946,10 +3944,12 @@ paths:
           $ref: "#/components/responses/Unauthorized"
         404:
           $ref: "#/components/responses/NotFound"
-        default:
-          $ref: "#/components/responses/ServerError"
+        400:
+          $ref: "#/components/responses/BadRequest"
         410:
           description: object gone (but partial metadata may be available)
+        default:
+          $ref: "#/components/responses/ServerError"
 
   /repositories/{repository}/refs/{ref}/objects/underlyingProperties:
     parameters:
@@ -4629,11 +4629,7 @@ paths:
         204:
           description: reported successfully
         400:
-          description: bad request
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/Error"
+          $ref: "#/components/responses/BadRequest"
         401:
           $ref: "#/components/responses/Unauthorized"
         default:

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -2073,7 +2073,8 @@ func (c *Controller) handleAPIErrorCallback(ctx context.Context, w http.Response
 		errors.Is(err, graveler.ErrParentOutOfRange),
 		errors.Is(err, graveler.ErrCherryPickMergeNoParent),
 		errors.Is(err, graveler.ErrInvalidMergeStrategy),
-		errors.Is(err, block.ErrInvalidAddress):
+		errors.Is(err, block.ErrInvalidAddress),
+		errors.Is(err, block.ErrOperationNotSupported):
 		log.Debug("Bad request")
 		cb(w, r, http.StatusBadRequest, err)
 

--- a/pkg/block/local/adapter.go
+++ b/pkg/block/local/adapter.go
@@ -101,7 +101,7 @@ func NewAdapter(path string, opts ...func(a *Adapter)) (*Adapter, error) {
 }
 
 func (l *Adapter) GetPreSignedURL(_ context.Context, _ block.ObjectPointer, _ block.PreSignMode) (string, time.Time, error) {
-	return "", time.Time{}, fmt.Errorf("local adapter: %w", block.ErrOperationNotSupported)
+	return "", time.Time{}, fmt.Errorf("local adapter presigned URL: %w", block.ErrOperationNotSupported)
 }
 
 // verifyRelPath ensures that p is under the directory controlled by this adapter.  It does not


### PR DESCRIPTION
Closes #6405

## Change Description

### Background

Ensure lakeFS returns an appropriate status code on block unsupported operation.
Check block adapter supoort for pre-signed URLs and modify default flag accordingly
Print error message on lakectl local commands to reflect the error

### Testing Details

Manually tested
