### PR TITLE
Docs: fix broken redirect

### DIFF
--- a/docs/howto/garbage-collection/committed.md
+++ b/docs/howto/garbage-collection/committed.md
@@ -5,7 +5,7 @@ parent: Garbage Collection
 grand_parent: How-To
 nav_order: 98
 has_children: false
-redirect:
+redirect_from: 
     - /howto/garbage-collection-committed.html
 ---
 

--- a/docs/howto/garbage-collection/internals.md
+++ b/docs/howto/garbage-collection/internals.md
@@ -5,7 +5,7 @@ parent: Garbage Collection
 grand_parent: How-To
 nav_order: 1
 has_children: false
-redirect:
+redirect_from: 
     - /howto/gc-internals.html
 ---
 

--- a/docs/howto/garbage-collection/uncommitted.md
+++ b/docs/howto/garbage-collection/uncommitted.md
@@ -5,7 +5,7 @@ parent: Garbage Collection
 grand_parent: How-To
 nav_order: 99
 has_children: false
-redirect:
+redirect_from: 
     - /howto/garbage-collection-uncommitted.html
 ---
 


### PR DESCRIPTION
## Change Description

Docs check https://github.com/treeverse/docs-lakeFS/actions/runs/5872973146 identified some missing files. 

```
howto/garbage-collection-committed.html
howto/garbage-collection-uncommitted.html
howto/gc-internals.html
```
These were as a result of moving docs in https://github.com/treeverse/lakeFS/pull/6264 and the redirect metadata being wrong

This PR fixes it. 

## Testing

Built docs locally and verified that redirect pages are created: 

```
$ ls -l _site/howto/garbage-collection-*commit*
-rw-r--r--  1 rmoff  staff  589 16 Aug 17:50 _site/howto/garbage-collection-committed.html
-rw-r--r--  1 rmoff  staff  597 16 Aug 17:50 _site/howto/garbage-collection-uncommitted.html

$ ls -l _site/howto/gc-internals.html
-rw-r--r--  1 rmoff  staff  589 16 Aug 17:50 _site/howto/gc-internals.html
```