### PR TITLE
Add content to Reference index page, remove nav_order for child pages

### DIFF
--- a/docs/reference/access-control-lists.md
+++ b/docs/reference/access-control-lists.md
@@ -2,7 +2,6 @@
 title: Access Control Lists (ACLs)
 parent: Reference
 description: Access control lists (ACLs) are one of the resource-based options that you can use to manage access to your repositories and objects. There are limits to managing permissions using ACLs.
-nav_order: 100
 has_children: false
 redirect_from: /reference/access-control-list.html
 ---

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -2,7 +2,6 @@
 title: API Reference
 description: This section includes the reference documentation for the lakeFS platform's various APIs.
 parent: Reference
-nav_order: 30
 has_children: false
 ---
 

--- a/docs/reference/authentication.md
+++ b/docs/reference/authentication.md
@@ -2,7 +2,6 @@
 title: Authentication 
 description: This section covers Authentication of your lakeFS server.
 parent: Reference
-nav_order: 60
 has_children: false
 ---
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2,7 +2,6 @@
 title: lakectl (lakeFS command-line tool)
 description: lakeFS comes with its own native CLI client. Here you can see the complete command reference.
 parent: Reference
-nav_order: 20
 has_children: false
 redirect_from:
   - /reference/commands.html

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -1,12 +1,11 @@
 ---
-title: Configuration
-description: Configuring lakeFS is done using a YAML configuration file. This reference uses `.` to denote the nesting of values.
+title: lakeFS Server Configuration
+description: Configuration reference for lakeFS Server
 parent: Reference
-nav_order: 10
 has_children: false
 ---
 
-# Configuration Reference
+# lakeFS Server Configuration
 
 {% include toc.html %}
 
@@ -217,7 +216,9 @@ To set an environment variable, prepend `LAKEFS_` to its name, convert it to upp
 For example, `logging.format` becomes `LAKEFS_LOGGING_FORMAT`, `blockstore.s3.region` becomes `LAKEFS_BLOCKSTORE_S3_REGION`, etc.
 
 
-## Example: Local Development with PostgreSQL database
+## Example Configurations
+
+### Local Development with PostgreSQL database
 
 ```yaml
 ---
@@ -248,7 +249,7 @@ gateways:
 ```
 
 
-## Example: AWS Deployment with DynamoDB database
+### AWS Deployment with DynamoDB database
 
 ```yaml
 ---
@@ -275,10 +276,7 @@ blockstore:
 
 ```
 
-[aws-s3-batch-permissions]: https://docs.aws.amazon.com/AmazonS3/latest/dev/batch-ops-iam-role-policies.html
-
-
-## Example: Google Storage
+### Google Storage
 
 ```yaml
 ---
@@ -303,7 +301,7 @@ blockstore:
 
 ```
 
-## Example: MinIO
+### MinIO
 
 ```yaml
 ---
@@ -332,7 +330,7 @@ blockstore:
       secret_access_key: minioadmin
 
 ```
-## Example: Azure blob storage
+### Azure blob storage
 
 ```yaml
 ---

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,6 +1,39 @@
 ---
 title: Reference
 description: Reference documentation for the lakeFS platform's various APIs, CLIs, and file formats.
-nav_order: 20
 has_children: true
+has_toc: false
+nav_order: 20
 ---
+
+# lakeFS Reference
+
+<img src="/assets/img/docs_logo.png" alt="lakeFS Docs" width=200 style="float: right; margin: 0 0 10px 10px;"/>
+
+## Components
+
+- [Server Configuration]({% link reference/configuration.md %})
+- lakeFS command-line tool [lakectl]({% link reference/cli.md %})
+
+## Clients
+
+- [Spark Metadata Client]({% link reference/spark-client.md %})
+- [lakeFS Hadoop FileSystem]({% link integrations/spark.md%}#lakefs-hadoop-filesystem)
+- [Python Client](https://pydocs.lakefs.io/)
+
+## Security
+
+- [Authentication]({% link reference/authentication.md %})
+- [Remote Authenticator]({% link reference/remote-authenticator.md %})
+- [Role-Based Access Control (RBAC)]({% link reference/rbac.md %})
+- [Presigned URL]({% link reference/presigned-url.md %})
+- [Access Control Lists (ACLs)]({% link reference/access-control-lists.md %})
+
+## Monitoring
+
+- [Monitoring using Prometheus]({% link reference/monitor.md %})
+
+## API
+
+- [lakeFS API]({% link reference/api.md %})
+- [S3 Gateway API]({% link reference/s3.md %})

--- a/docs/reference/monitor.md
+++ b/docs/reference/monitor.md
@@ -2,7 +2,6 @@
 title: Monitoring using Prometheus
 description: A guide to monitoring your lakeFS Installation with Prometheus.
 parent: Reference
-nav_order: 90
 has_children: false
 redirect_from: /deploying-aws/monitor.md
 ---

--- a/docs/reference/presigned-url.md
+++ b/docs/reference/presigned-url.md
@@ -2,7 +2,6 @@
 title: Presigned URL
 description: Configuring lakeFS to use presigned URLs
 parent: Reference
-nav_order: 100
 has_children: false
 ---
 

--- a/docs/reference/rbac.md
+++ b/docs/reference/rbac.md
@@ -2,7 +2,6 @@
 title: Role-Based Access Control (RBAC)
 description: This section covers authorization (using RBAC) of your lakeFS server.
 parent: Reference
-nav_order: 65
 has_children: false
 redirect_from:
   - /reference/authorization.html

--- a/docs/reference/remote-authenticator.md
+++ b/docs/reference/remote-authenticator.md
@@ -2,7 +2,6 @@
 title: Remote Authenticator
 description: Create a pluggable remote authenticator to integrate lakeFS with your existing security infrastructure.
 parent: Reference
-nav_order: 62
 has_children: false
 ---
 

--- a/docs/reference/s3.md
+++ b/docs/reference/s3.md
@@ -2,7 +2,6 @@
 title: S3 Supported API
 description: "S3-supported API. lakeFS supports the following API operations: Identity and authorization, Bucket operations, Object operations and listing"
 parent: Reference
-nav_order: 50
 has_children: false
 ---
 # S3-Supported API

--- a/docs/reference/spark-client.md
+++ b/docs/reference/spark-client.md
@@ -3,7 +3,6 @@ title: Spark Client
 description: The lakeFS Spark client performs operations on lakeFS committed metadata stored in the object store. 
 parent: Reference
 has_children: false
-nav_order: 40
 ---
 
 


### PR DESCRIPTION
Closes #6427

## Change Description

### Background

See #5470

### New Feature

- Adds content to Reference index page
- Remove nav_order from child pages
- Remove orphan markdown link
