### PR TITLE
test: local KV seek past end suggest

### DIFF
--- a/pkg/kv/kvtest/iterators.go
+++ b/pkg/kv/kvtest/iterators.go
@@ -31,9 +31,6 @@ func (swc *StoreWithCounter) Scan(ctx context.Context, partitionKey []byte, opti
 	return swc.Store.Scan(ctx, partitionKey, options)
 }
 
-func setupTestPartitionIterator(t *testing.T) {
-}
-
 func testPartitionIterator(t *testing.T, ms MakeStore) {
 	ctx := context.Background()
 	store := ms(t, ctx)

--- a/pkg/kv/kvtest/iterators.go
+++ b/pkg/kv/kvtest/iterators.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"errors"
+	"sync/atomic"
 	"testing"
 
 	"github.com/go-test/deep"
@@ -18,40 +19,34 @@ const (
 
 type StoreWithCounter struct {
 	kv.Store
-	calls map[string]int
+	ScanCalls int64
 }
 
 func NewStoreWithCounter(store kv.Store) *StoreWithCounter {
-	return &StoreWithCounter{Store: store, calls: make(map[string]int)}
+	return &StoreWithCounter{Store: store}
 }
 
 func (swc *StoreWithCounter) Scan(ctx context.Context, partitionKey []byte, options kv.ScanOptions) (kv.EntriesIterator, error) {
-	// TODO lock
-	swc.calls["Scan"]++
+	atomic.AddInt64(&swc.ScanCalls, 1)
 	return swc.Store.Scan(ctx, partitionKey, options)
+}
+
+func setupTestPartitionIterator(t *testing.T) {
 }
 
 func testPartitionIterator(t *testing.T, ms MakeStore) {
 	ctx := context.Background()
 	store := ms(t, ctx)
-	m := []TestModel{
-		{Name: []byte("a")},
-		{Name: []byte("aa")},
-		{Name: []byte("b")},
-		{Name: []byte("c")},
-		{Name: []byte("d")},
-	}
 
 	// prepare data
-	for i := 0; i < len(m); i++ {
-		err := kv.SetMsg(ctx, store, firstPartitionKey, m[i].Name, &m[i])
-		if err != nil {
-			t.Fatal("failed to set model", err)
-		}
-
-		err = kv.SetMsg(ctx, store, secondPartitionKey, m[i].Name, &m[i])
-		if err != nil {
-			t.Fatal("failed to set model", err)
+	modelNames := []string{"a", "aa", "b", "c", "d"}
+	for _, name := range modelNames {
+		model := TestModel{Name: []byte(name)}
+		for _, partitionKey := range []string{firstPartitionKey, secondPartitionKey} {
+			err := kv.SetMsg(ctx, store, partitionKey, model.Name, &model)
+			if err != nil {
+				t.Fatalf("failed to set model (partition %s, name %s): %s", partitionKey, name, err)
+			}
 		}
 	}
 
@@ -64,14 +59,11 @@ func testPartitionIterator(t *testing.T, ms MakeStore) {
 		names := make([]string, 0)
 		for itr.Next() {
 			e := itr.Entry()
-			model, ok := e.Value.(*TestModel)
-			if !ok {
-				t.Fatalf("Failed to cast entry to TestModel")
-			}
+			model := e.Value.(*TestModel)
 			names = append(names, string(model.Name))
 		}
-		if itr.Err() != nil {
-			t.Fatalf("unexpected error: %v", itr.Err())
+		if err := itr.Err(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
 		}
 
 		if diffs := deep.Equal(names, []string{"a", "aa", "b", "c", "d"}); diffs != nil {
@@ -90,20 +82,18 @@ func testPartitionIterator(t *testing.T, ms MakeStore) {
 			names := make([]string, 0)
 			for itr.Next() {
 				e := itr.Entry()
-				model, ok := e.Value.(*TestModel)
-				if !ok {
-					t.Fatalf("Failed to cast entry to TestModel")
-				}
+				model := e.Value.(*TestModel)
 				names = append(names, string(model.Name))
 			}
-			if itr.Err() != nil {
-				t.Fatalf("unexpected error: %v", itr.Err())
+			if err := itr.Err(); err != nil {
+				t.Fatalf("unexpected error: %v", err)
 			}
 			if diffs := deep.Equal(names, []string{"b", "c", "d"}); diffs != nil {
 				t.Fatalf("got wrong list of names: %v", diffs)
 			}
 		}
 	})
+
 	t.Run("count scans on successive SeekGE operations", func(t *testing.T) {
 		store := NewStoreWithCounter(store)
 		itr := kv.NewPartitionIterator(ctx, store, (&TestModel{}).ProtoReflect().Type(), secondPartitionKey, 0)
@@ -116,16 +106,17 @@ func testPartitionIterator(t *testing.T, ms MakeStore) {
 			if !itr.Next() {
 				t.Fatalf("Expected iterator to have a value")
 			}
-			if itr.Err() != nil {
-				t.Fatalf("unexpected error: %v", itr.Err())
+			if err := itr.Err(); err != nil {
+				t.Fatalf("unexpected error: %v", err)
 			}
 			k := itr.Entry().Key
 			if string(k) != seekValue {
 				t.Fatalf("Expected to find value %s. Found %s", seekValue, k)
 			}
 		}
-		if store.calls["Scan"] != 1 {
-			t.Fatalf("Expected exactly 1 call to Scan. got: %d", store.calls["Scan"])
+		scanCalls := atomic.LoadInt64(&store.ScanCalls)
+		if scanCalls != 1 {
+			t.Fatalf("Expected exactly 1 call to Scan. got: %d", scanCalls)
 		}
 	})
 
@@ -145,12 +136,12 @@ func testPartitionIterator(t *testing.T, ms MakeStore) {
 			t.Fatalf("next after seekGE expected to be false")
 		}
 
-		if !errors.Is(itr.Err(), kv.ErrMissingPartitionKey) {
-			t.Fatalf("expected error: %s, got %v", kv.ErrMissingPartitionKey, itr.Err())
+		if err := itr.Err(); !errors.Is(err, kv.ErrMissingPartitionKey) {
+			t.Fatalf("expected error: %s, got %v", kv.ErrMissingPartitionKey, err)
 		}
 	})
 
-	t.Run("seekGE past end", func(t *testing.T) {
+	t.Run("SeekGE past end", func(t *testing.T) {
 		itr := kv.NewPartitionIterator(ctx, store, (&TestModel{}).ProtoReflect().Type(), firstPartitionKey, 0)
 		if itr == nil {
 			t.Fatalf("failed to create partition iterator")
@@ -161,10 +152,7 @@ func testPartitionIterator(t *testing.T, ms MakeStore) {
 			t.Fatal("expected Next to be true")
 		}
 		e := itr.Entry()
-		model, ok := e.Value.(*TestModel)
-		if !ok {
-			t.Fatalf("Failed to cast entry to TestModel")
-		}
+		model := e.Value.(*TestModel)
 		if string(model.Name) != "b" {
 			t.Fatalf("expected value b from iterator")
 		}
@@ -172,8 +160,8 @@ func testPartitionIterator(t *testing.T, ms MakeStore) {
 		if itr.Next() {
 			t.Fatalf("expected Next to be false")
 		}
-		if itr.Err() != nil {
-			t.Fatalf("unexpected error: %v", itr.Err())
+		if err := itr.Err(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
 		}
 	})
 }
@@ -181,24 +169,16 @@ func testPartitionIterator(t *testing.T, ms MakeStore) {
 func testPrimaryIterator(t *testing.T, ms MakeStore) {
 	ctx := context.Background()
 	store := ms(t, ctx)
-	m := []TestModel{
-		{Name: []byte("a")},
-		{Name: []byte("aa")},
-		{Name: []byte("b")},
-		{Name: []byte("c")},
-		{Name: []byte("d")},
-	}
 
 	// prepare data
-	for i := 0; i < len(m); i++ {
-		err := kv.SetMsg(ctx, store, firstPartitionKey, m[i].Name, &m[i])
-		if err != nil {
-			t.Fatal("failed to set model", err)
-		}
-
-		err = kv.SetMsg(ctx, store, secondPartitionKey, m[i].Name, &m[i])
-		if err != nil {
-			t.Fatal("failed to set model", err)
+	modelNames := []string{"a", "aa", "b", "c", "d"}
+	for _, name := range modelNames {
+		model := TestModel{Name: []byte(name)}
+		for _, partitionKey := range []string{firstPartitionKey, secondPartitionKey} {
+			err := kv.SetMsg(ctx, store, partitionKey, model.Name, &model)
+			if err != nil {
+				t.Fatalf("failed to set model (partition %s, name %s): %s", partitionKey, name, err)
+			}
 		}
 	}
 
@@ -212,14 +192,11 @@ func testPrimaryIterator(t *testing.T, ms MakeStore) {
 		names := make([]string, 0)
 		for itr.Next() {
 			e := itr.Entry()
-			model, ok := e.Value.(*TestModel)
-			if !ok {
-				t.Fatalf("Failed to cast entry to TestModel")
-			}
+			model := e.Value.(*TestModel)
 			names = append(names, string(model.Name))
 		}
-		if itr.Err() != nil {
-			t.Fatalf("unexpected error: %v", itr.Err())
+		if err := itr.Err(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
 		}
 
 		if diffs := deep.Equal(names, []string{"a", "aa", "b", "c", "d"}); diffs != nil {
@@ -237,14 +214,11 @@ func testPrimaryIterator(t *testing.T, ms MakeStore) {
 		names := make([]string, 0)
 		for itr.Next() {
 			e := itr.Entry()
-			model, ok := e.Value.(*TestModel)
-			if !ok {
-				t.Fatalf("Failed to cast entry to TestModel")
-			}
+			model := e.Value.(*TestModel)
 			names = append(names, string(model.Name))
 		}
-		if itr.Err() != nil {
-			t.Fatalf("unexpected error: %v", itr.Err())
+		if err := itr.Err(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
 		}
 
 		if diffs := deep.Equal(names, []string{"a", "aa"}); diffs != nil {
@@ -263,8 +237,8 @@ func testPrimaryIterator(t *testing.T, ms MakeStore) {
 		if itr.Next() {
 			t.Fatalf("next should return false")
 		}
-		if itr.Err() != nil {
-			t.Fatalf("unexpected error: %v", itr.Err())
+		if err := itr.Err(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
 		}
 	})
 
@@ -278,14 +252,11 @@ func testPrimaryIterator(t *testing.T, ms MakeStore) {
 		names := make([]string, 0)
 		for itr.Next() {
 			e := itr.Entry()
-			model, ok := e.Value.(*TestModel)
-			if !ok {
-				t.Fatalf("Failed to cast entry to TestModel")
-			}
+			model := e.Value.(*TestModel)
 			names = append(names, string(model.Name))
 		}
-		if itr.Err() != nil {
-			t.Fatalf("unexpected error: %v", itr.Err())
+		if err := itr.Err(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
 		}
 
 		if diffs := deep.Equal(names, []string{"b", "c", "d"}); diffs != nil {
@@ -303,14 +274,11 @@ func testPrimaryIterator(t *testing.T, ms MakeStore) {
 		names := make([]string, 0)
 		for itr.Next() {
 			e := itr.Entry()
-			model, ok := e.Value.(*TestModel)
-			if !ok {
-				t.Fatalf("Failed to cast entry to TestModel")
-			}
+			model := e.Value.(*TestModel)
 			names = append(names, string(model.Name))
 		}
-		if itr.Err() != nil {
-			t.Fatalf("unexpected error: %v", itr.Err())
+		if err := itr.Err(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
 		}
 
 		if diffs := deep.Equal(names, []string{"c", "d"}); diffs != nil {
@@ -321,9 +289,9 @@ func testPrimaryIterator(t *testing.T, ms MakeStore) {
 
 func testSecondaryIterator(t *testing.T, ms MakeStore) {
 	ctx := context.Background()
+	store := ms(t, ctx)
 
 	// prepare data
-	store := ms(t, ctx)
 	m := []TestModel{
 		{Name: []byte("a"), JustAString: "one"},
 		{Name: []byte("b"), JustAString: "two"},
@@ -331,17 +299,16 @@ func testSecondaryIterator(t *testing.T, ms MakeStore) {
 		{Name: []byte("d"), JustAString: "four"},
 		{Name: []byte("e"), JustAString: "five"},
 	}
-
 	for i := 0; i < len(m); i++ {
 		primaryKey := append([]byte("name/"), m[i].Name...)
 		err := kv.SetMsg(ctx, store, firstPartitionKey, primaryKey, &m[i])
 		if err != nil {
-			t.Fatal("failed to set model", err)
+			t.Fatal("failed to set model (primary key)", err)
 		}
 		secondaryKey := append([]byte("just_a_string/"), m[i].JustAString...)
 		err = kv.SetMsg(ctx, store, firstPartitionKey, secondaryKey, &kv.SecondaryIndex{PrimaryKey: primaryKey})
 		if err != nil {
-			t.Fatal("failed to set model", err)
+			t.Fatal("failed to set model (secondary key)", err)
 		}
 	}
 	err := kv.SetMsg(ctx, store, secondPartitionKey, []byte("just_a_string/e"), &kv.SecondaryIndex{})
@@ -363,18 +330,15 @@ func testSecondaryIterator(t *testing.T, ms MakeStore) {
 		var msgs []*TestModel
 		for itr.Next() {
 			e := itr.Entry()
-			model, ok := e.Value.(*TestModel)
-			if !ok {
-				t.Fatalf("Failed to cast entry to TestModel")
-			}
+			model := e.Value.(*TestModel)
 			expectedKey := append([]byte("just_a_string/"), model.JustAString...)
 			if !bytes.Equal(e.Key, expectedKey) {
 				t.Fatalf("Iterator key=%s, expected=%s", e.Key, expectedKey)
 			}
 			msgs = append(msgs, model)
 		}
-		if itr.Err() != nil {
-			t.Fatalf("unexpected error: %v", itr.Err())
+		if err := itr.Err(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
 		}
 		expectedMsgs := []*TestModel{
 			{Name: []byte("e"), JustAString: "five"},
@@ -398,14 +362,11 @@ func testSecondaryIterator(t *testing.T, ms MakeStore) {
 		var msgs []*TestModel
 		for itr.Next() {
 			e := itr.Entry()
-			model, ok := e.Value.(*TestModel)
-			if !ok {
-				t.Fatalf("Failed to cast entry to TestModel")
-			}
+			model := e.Value.(*TestModel)
 			msgs = append(msgs, model)
 		}
-		if itr.Err() != nil {
-			t.Fatalf("unexpected error: %v", itr.Err())
+		if err := itr.Err(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
 		}
 
 		expectedMsgs := []*TestModel{
@@ -427,14 +388,11 @@ func testSecondaryIterator(t *testing.T, ms MakeStore) {
 		var msgs []*TestModel
 		for itr.Next() {
 			e := itr.Entry()
-			model, ok := e.Value.(*TestModel)
-			if !ok {
-				t.Fatalf("Failed to cast entry to TestModel")
-			}
+			model := e.Value.(*TestModel)
 			msgs = append(msgs, model)
 		}
-		if itr.Err() != nil {
-			t.Fatalf("unexpected error: %v", itr.Err())
+		if err := itr.Err(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
 		}
 
 		expectedMsgs := []*TestModel{


### PR DESCRIPTION
Suggestions over https://github.com/treeverse/lakeFS/pull/6434:
- Invalid cast will break the test instead of test - reduce the code complexity
- Capture error before log the iterator error (in case calling twice Err() will produce different error)
- Handle atomic counter