### PR TITLE
etag can be passed in the if-none-match in the header on getobject api

### DIFF
--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -3256,6 +3256,13 @@ paths:
           schema:
             type: string
             pattern: '^bytes=((\d*-\d*,? ?)+)$'
+        - in: header
+          name: If-None-Match
+          description: Returns response only if the object does not have a matching ETag
+          example: "abc123efg"
+          required: false
+          schema:
+            type: string
         - in: query
           name: presign
           required: false
@@ -3308,6 +3315,8 @@ paths:
             Location:
               schema:
                 type: string
+        304:
+          description: Content Not modified
         401:
           $ref: "#/components/responses/Unauthorized"
         404:

--- a/clients/java/api/openapi.yaml
+++ b/clients/java/api/openapi.yaml
@@ -3321,6 +3321,16 @@ paths:
           pattern: ^bytes=((\d*-\d*,? ?)+)$
           type: string
         style: simple
+      - description: Returns response only if the object does not have a matching
+          ETag
+        example: abc123efg
+        explode: false
+        in: header
+        name: If-None-Match
+        required: false
+        schema:
+          type: string
+        style: simple
       - explode: true
         in: query
         name: presign
@@ -3391,6 +3401,8 @@ paths:
               schema:
                 type: string
               style: simple
+        "304":
+          description: Content Not modified
         "401":
           content:
             application/json:

--- a/clients/java/docs/ObjectsApi.md
+++ b/clients/java/docs/ObjectsApi.md
@@ -308,7 +308,7 @@ Name | Type | Description  | Notes
 
 <a name="getObject"></a>
 # **getObject**
-> File getObject(repository, ref, path, range, presign)
+> File getObject(repository, ref, path, range, ifNoneMatch, presign)
 
 get object content
 
@@ -359,9 +359,10 @@ public class Example {
     String ref = "ref_example"; // String | a reference (could be either a branch or a commit ID)
     String path = "path_example"; // String | relative to the ref
     String range = "bytes=0-1023"; // String | Byte range to retrieve
+    String ifNoneMatch = "abc123efg"; // String | Returns response only if the object does not have a matching ETag
     Boolean presign = true; // Boolean | 
     try {
-      File result = apiInstance.getObject(repository, ref, path, range, presign);
+      File result = apiInstance.getObject(repository, ref, path, range, ifNoneMatch, presign);
       System.out.println(result);
     } catch (ApiException e) {
       System.err.println("Exception when calling ObjectsApi#getObject");
@@ -382,6 +383,7 @@ Name | Type | Description  | Notes
  **ref** | **String**| a reference (could be either a branch or a commit ID) |
  **path** | **String**| relative to the ref |
  **range** | **String**| Byte range to retrieve | [optional]
+ **ifNoneMatch** | **String**| Returns response only if the object does not have a matching ETag | [optional]
  **presign** | **Boolean**|  | [optional]
 
 ### Return type
@@ -403,6 +405,7 @@ Name | Type | Description  | Notes
 **200** | object content |  * Content-Length -  <br>  * Last-Modified -  <br>  * ETag -  <br>  |
 **206** | partial object content |  * Content-Length -  <br>  * Content-Range -  <br>  * Last-Modified -  <br>  * ETag -  <br>  |
 **302** | Redirect to a pre-signed URL for the object |  * Location - redirect to S3 <br>  |
+**304** | Content Not modified |  -  |
 **401** | Unauthorized |  -  |
 **404** | Resource Not Found |  -  |
 **410** | object expired |  -  |

--- a/clients/java/src/main/java/io/lakefs/clients/api/ObjectsApi.java
+++ b/clients/java/src/main/java/io/lakefs/clients/api/ObjectsApi.java
@@ -522,6 +522,7 @@ public class ObjectsApi {
      * @param ref a reference (could be either a branch or a commit ID) (required)
      * @param path relative to the ref (required)
      * @param range Byte range to retrieve (optional)
+     * @param ifNoneMatch Returns response only if the object does not have a matching ETag (optional)
      * @param presign  (optional)
      * @param _callback Callback for upload/download progress
      * @return Call to execute
@@ -532,6 +533,7 @@ public class ObjectsApi {
         <tr><td> 200 </td><td> object content </td><td>  * Content-Length -  <br>  * Last-Modified -  <br>  * ETag -  <br>  </td></tr>
         <tr><td> 206 </td><td> partial object content </td><td>  * Content-Length -  <br>  * Content-Range -  <br>  * Last-Modified -  <br>  * ETag -  <br>  </td></tr>
         <tr><td> 302 </td><td> Redirect to a pre-signed URL for the object </td><td>  * Location - redirect to S3 <br>  </td></tr>
+        <tr><td> 304 </td><td> Content Not modified </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Resource Not Found </td><td>  -  </td></tr>
         <tr><td> 410 </td><td> object expired </td><td>  -  </td></tr>
@@ -539,7 +541,7 @@ public class ObjectsApi {
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call getObjectCall(String repository, String ref, String path, String range, Boolean presign, final ApiCallback _callback) throws ApiException {
+    public okhttp3.Call getObjectCall(String repository, String ref, String path, String range, String ifNoneMatch, Boolean presign, final ApiCallback _callback) throws ApiException {
         Object localVarPostBody = null;
 
         // create path and map variables
@@ -565,6 +567,10 @@ public class ObjectsApi {
             localVarHeaderParams.put("Range", localVarApiClient.parameterToString(range));
         }
 
+        if (ifNoneMatch != null) {
+            localVarHeaderParams.put("If-None-Match", localVarApiClient.parameterToString(ifNoneMatch));
+        }
+
         final String[] localVarAccepts = {
             "application/octet-stream", "application/json"
         };
@@ -584,7 +590,7 @@ public class ObjectsApi {
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call getObjectValidateBeforeCall(String repository, String ref, String path, String range, Boolean presign, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call getObjectValidateBeforeCall(String repository, String ref, String path, String range, String ifNoneMatch, Boolean presign, final ApiCallback _callback) throws ApiException {
         
         // verify the required parameter 'repository' is set
         if (repository == null) {
@@ -602,7 +608,7 @@ public class ObjectsApi {
         }
         
 
-        okhttp3.Call localVarCall = getObjectCall(repository, ref, path, range, presign, _callback);
+        okhttp3.Call localVarCall = getObjectCall(repository, ref, path, range, ifNoneMatch, presign, _callback);
         return localVarCall;
 
     }
@@ -614,6 +620,7 @@ public class ObjectsApi {
      * @param ref a reference (could be either a branch or a commit ID) (required)
      * @param path relative to the ref (required)
      * @param range Byte range to retrieve (optional)
+     * @param ifNoneMatch Returns response only if the object does not have a matching ETag (optional)
      * @param presign  (optional)
      * @return File
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
@@ -623,6 +630,7 @@ public class ObjectsApi {
         <tr><td> 200 </td><td> object content </td><td>  * Content-Length -  <br>  * Last-Modified -  <br>  * ETag -  <br>  </td></tr>
         <tr><td> 206 </td><td> partial object content </td><td>  * Content-Length -  <br>  * Content-Range -  <br>  * Last-Modified -  <br>  * ETag -  <br>  </td></tr>
         <tr><td> 302 </td><td> Redirect to a pre-signed URL for the object </td><td>  * Location - redirect to S3 <br>  </td></tr>
+        <tr><td> 304 </td><td> Content Not modified </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Resource Not Found </td><td>  -  </td></tr>
         <tr><td> 410 </td><td> object expired </td><td>  -  </td></tr>
@@ -630,8 +638,8 @@ public class ObjectsApi {
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
      */
-    public File getObject(String repository, String ref, String path, String range, Boolean presign) throws ApiException {
-        ApiResponse<File> localVarResp = getObjectWithHttpInfo(repository, ref, path, range, presign);
+    public File getObject(String repository, String ref, String path, String range, String ifNoneMatch, Boolean presign) throws ApiException {
+        ApiResponse<File> localVarResp = getObjectWithHttpInfo(repository, ref, path, range, ifNoneMatch, presign);
         return localVarResp.getData();
     }
 
@@ -642,6 +650,7 @@ public class ObjectsApi {
      * @param ref a reference (could be either a branch or a commit ID) (required)
      * @param path relative to the ref (required)
      * @param range Byte range to retrieve (optional)
+     * @param ifNoneMatch Returns response only if the object does not have a matching ETag (optional)
      * @param presign  (optional)
      * @return ApiResponse&lt;File&gt;
      * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
@@ -651,6 +660,7 @@ public class ObjectsApi {
         <tr><td> 200 </td><td> object content </td><td>  * Content-Length -  <br>  * Last-Modified -  <br>  * ETag -  <br>  </td></tr>
         <tr><td> 206 </td><td> partial object content </td><td>  * Content-Length -  <br>  * Content-Range -  <br>  * Last-Modified -  <br>  * ETag -  <br>  </td></tr>
         <tr><td> 302 </td><td> Redirect to a pre-signed URL for the object </td><td>  * Location - redirect to S3 <br>  </td></tr>
+        <tr><td> 304 </td><td> Content Not modified </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Resource Not Found </td><td>  -  </td></tr>
         <tr><td> 410 </td><td> object expired </td><td>  -  </td></tr>
@@ -658,8 +668,8 @@ public class ObjectsApi {
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
      */
-    public ApiResponse<File> getObjectWithHttpInfo(String repository, String ref, String path, String range, Boolean presign) throws ApiException {
-        okhttp3.Call localVarCall = getObjectValidateBeforeCall(repository, ref, path, range, presign, null);
+    public ApiResponse<File> getObjectWithHttpInfo(String repository, String ref, String path, String range, String ifNoneMatch, Boolean presign) throws ApiException {
+        okhttp3.Call localVarCall = getObjectValidateBeforeCall(repository, ref, path, range, ifNoneMatch, presign, null);
         Type localVarReturnType = new TypeToken<File>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
@@ -671,6 +681,7 @@ public class ObjectsApi {
      * @param ref a reference (could be either a branch or a commit ID) (required)
      * @param path relative to the ref (required)
      * @param range Byte range to retrieve (optional)
+     * @param ifNoneMatch Returns response only if the object does not have a matching ETag (optional)
      * @param presign  (optional)
      * @param _callback The callback to be executed when the API call finishes
      * @return The request call
@@ -681,6 +692,7 @@ public class ObjectsApi {
         <tr><td> 200 </td><td> object content </td><td>  * Content-Length -  <br>  * Last-Modified -  <br>  * ETag -  <br>  </td></tr>
         <tr><td> 206 </td><td> partial object content </td><td>  * Content-Length -  <br>  * Content-Range -  <br>  * Last-Modified -  <br>  * ETag -  <br>  </td></tr>
         <tr><td> 302 </td><td> Redirect to a pre-signed URL for the object </td><td>  * Location - redirect to S3 <br>  </td></tr>
+        <tr><td> 304 </td><td> Content Not modified </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Resource Not Found </td><td>  -  </td></tr>
         <tr><td> 410 </td><td> object expired </td><td>  -  </td></tr>
@@ -688,9 +700,9 @@ public class ObjectsApi {
         <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
      </table>
      */
-    public okhttp3.Call getObjectAsync(String repository, String ref, String path, String range, Boolean presign, final ApiCallback<File> _callback) throws ApiException {
+    public okhttp3.Call getObjectAsync(String repository, String ref, String path, String range, String ifNoneMatch, Boolean presign, final ApiCallback<File> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = getObjectValidateBeforeCall(repository, ref, path, range, presign, _callback);
+        okhttp3.Call localVarCall = getObjectValidateBeforeCall(repository, ref, path, range, ifNoneMatch, presign, _callback);
         Type localVarReturnType = new TypeToken<File>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;

--- a/clients/java/src/test/java/io/lakefs/clients/api/ObjectsApiTest.java
+++ b/clients/java/src/test/java/io/lakefs/clients/api/ObjectsApiTest.java
@@ -106,8 +106,9 @@ public class ObjectsApiTest {
         String ref = null;
         String path = null;
         String range = null;
+        String ifNoneMatch = null;
         Boolean presign = null;
-                File response = api.getObject(repository, ref, path, range, presign);
+                File response = api.getObject(repository, ref, path, range, ifNoneMatch, presign);
         // TODO: test validations
     }
     

--- a/clients/python/docs/ObjectsApi.md
+++ b/clients/python/docs/ObjectsApi.md
@@ -429,6 +429,7 @@ with lakefs_client.ApiClient(configuration) as api_client:
     ref = "ref_example" # str | a reference (could be either a branch or a commit ID)
     path = "path_example" # str | relative to the ref
     range = "bytes=0-1023" # str | Byte range to retrieve (optional)
+    if_none_match = "abc123efg" # str | Returns response only if the object does not have a matching ETag (optional)
     presign = True # bool |  (optional)
 
     # example passing only required values which don't have defaults set
@@ -443,7 +444,7 @@ with lakefs_client.ApiClient(configuration) as api_client:
     # and optional values
     try:
         # get object content
-        api_response = api_instance.get_object(repository, ref, path, range=range, presign=presign)
+        api_response = api_instance.get_object(repository, ref, path, range=range, if_none_match=if_none_match, presign=presign)
         pprint(api_response)
     except lakefs_client.ApiException as e:
         print("Exception when calling ObjectsApi->get_object: %s\n" % e)
@@ -458,6 +459,7 @@ Name | Type | Description  | Notes
  **ref** | **str**| a reference (could be either a branch or a commit ID) |
  **path** | **str**| relative to the ref |
  **range** | **str**| Byte range to retrieve | [optional]
+ **if_none_match** | **str**| Returns response only if the object does not have a matching ETag | [optional]
  **presign** | **bool**|  | [optional]
 
 ### Return type
@@ -481,6 +483,7 @@ Name | Type | Description  | Notes
 **200** | object content |  * Content-Length -  <br>  * Last-Modified -  <br>  * ETag -  <br>  |
 **206** | partial object content |  * Content-Length -  <br>  * Content-Range -  <br>  * Last-Modified -  <br>  * ETag -  <br>  |
 **302** | Redirect to a pre-signed URL for the object |  * Location - redirect to S3 <br>  |
+**304** | Content Not modified |  -  |
 **401** | Unauthorized |  -  |
 **404** | Resource Not Found |  -  |
 **410** | object expired |  -  |

--- a/clients/python/lakefs_client/api/objects_api.py
+++ b/clients/python/lakefs_client/api/objects_api.py
@@ -273,6 +273,7 @@ class ObjectsApi(object):
                     'ref',
                     'path',
                     'range',
+                    'if_none_match',
                     'presign',
                 ],
                 'required': [
@@ -308,6 +309,8 @@ class ObjectsApi(object):
                         (str,),
                     'range':
                         (str,),
+                    'if_none_match':
+                        (str,),
                     'presign':
                         (bool,),
                 },
@@ -316,6 +319,7 @@ class ObjectsApi(object):
                     'ref': 'ref',
                     'path': 'path',
                     'range': 'Range',
+                    'if_none_match': 'If-None-Match',
                     'presign': 'presign',
                 },
                 'location_map': {
@@ -323,6 +327,7 @@ class ObjectsApi(object):
                     'ref': 'path',
                     'path': 'query',
                     'range': 'header',
+                    'if_none_match': 'header',
                     'presign': 'query',
                 },
                 'collection_format_map': {
@@ -1133,6 +1138,7 @@ class ObjectsApi(object):
 
         Keyword Args:
             range (str): Byte range to retrieve. [optional]
+            if_none_match (str): Returns response only if the object does not have a matching ETag. [optional]
             presign (bool): [optional]
             _return_http_data_only (bool): response data without head status
                 code and headers. Default is True.

--- a/docs/assets/js/swagger.yml
+++ b/docs/assets/js/swagger.yml
@@ -3256,6 +3256,13 @@ paths:
           schema:
             type: string
             pattern: '^bytes=((\d*-\d*,? ?)+)$'
+        - in: header
+          name: If-None-Match
+          description: Returns response only if the object does not have a matching ETag
+          example: "abc123efg"
+          required: false
+          schema:
+            type: string
         - in: query
           name: presign
           required: false
@@ -3308,6 +3315,8 @@ paths:
             Location:
               schema:
                 type: string
+        304:
+          description: Content Not modified
         401:
           $ref: "#/components/responses/Unauthorized"
         404:

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -3611,6 +3611,16 @@ func (c *Controller) GetObject(w http.ResponseWriter, r *http.Request, repositor
 		return
 	}
 
+	// check ETag if not modified
+	etag := httputil.ETag(entry.Checksum)
+	fmt.Println(r.Header.Get("If-None-Match"))
+	fmt.Println(etag)
+
+	if r.Header.Get("If-None-Match") == etag {
+		w.WriteHeader(http.StatusNotModified)
+		return
+	}
+
 	// setup response
 	var reader io.ReadCloser
 
@@ -3642,7 +3652,6 @@ func (c *Controller) GetObject(w http.ResponseWriter, r *http.Request, repositor
 		w.Header().Set("Content-Length", fmt.Sprint(entry.Size))
 	}
 
-	etag := httputil.ETag(entry.Checksum)
 	w.Header().Set("ETag", etag)
 	lastModified := httputil.HeaderTimestamp(entry.CreationDate)
 	w.Header().Set("Last-Modified", lastModified)

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -2399,6 +2399,20 @@ func TestController_ObjectsGetObjectHandler(t *testing.T) {
 			t.Errorf("expected to get \"%s\" storage class, got %#v", expensiveString, properties)
 		}
 	})
+
+	t.Run("get object not modified", func(t *testing.T) {
+		etag_input := "\"" + blob.Checksum + "\""
+		resp, err := clt.GetObjectWithResponse(ctx, repo, "main", &api.GetObjectParams{
+			Path:        "foo/bar",
+			IfNoneMatch: &etag_input,
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if resp.HTTPResponse.StatusCode != http.StatusNotModified {
+			t.Errorf("GetObject() status code %d, expected %d", resp.HTTPResponse.StatusCode, http.StatusNotModified)
+		}
+	})
 }
 
 func TestController_ObjectsUploadObjectHandler(t *testing.T) {


### PR DESCRIPTION
Closes #5967

## Change Description

Add an optional [If-None-Match: "ETag"](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/If-None-Match#syntax) header to getObject requests. When an ETag is passed, if that ETag is current for the object on that path then return 304 Not Modified.

If the ETag is not current, return the object as it was being originally done. This ensures that this is not a breaking change.

### Testing Details

Added a unit test that checks if a 304 is returned (pkg/api/controller_test.go)

### Breaking Change?

If-None-Match is an optional parameter and existing clients will need to be updated to pass this parameter. So, it should not be a breaking change.

