### PR TITLE
Quote asterisk in YAML config file in lDS docs

### DIFF
--- a/docs/howto/unity-delta-sharing.md
+++ b/docs/howto/unity-delta-sharing.md
@@ -63,8 +63,10 @@ repositories:
     - id: repo2
       share_name: share_two
       branches:
-      - *
+      - "*"
 ```
+
+Note that a plain "*" line must be quoted in YAML.
 
 Upload it to your config URL.  For instance if the config URL is `lakefs://repo/main/lakefs_delta_sharing.yaml`, you might use:
 


### PR DESCRIPTION
Existing sample does not actually work: a _leading_ `*` in YAML breaks
parsing as a label, so a string has to be `"*"` not `*`.