### PR TITLE
[Docs] Fix surge.sh preview teardowns when PR is closed

### DIFF
--- a/.github/workflows/docs-pr.yaml
+++ b/.github/workflows/docs-pr.yaml
@@ -2,6 +2,7 @@ name: Docs Preview and Link Check
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, closed]
     paths:
       - "docs/**"
     branches:


### PR DESCRIPTION
The surge.sh preview deployment should be [torn down](https://github.com/afc163/surge-preview/#teardown) when the PR is closed. The flag is currently set for this in the action but the action doesn't fire for PR closures and so teardown doesn't happen. 