### PR TITLE
[Docs] Bump just-the-docs to 0.6.0

### DIFF
--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -31,7 +31,7 @@ defaults:
 # general config
 repository: treeverse/lakeFS
 
-remote_theme: pmarsceill/just-the-docs@v0.5.0
+remote_theme: pmarsceill/just-the-docs@v0.6.0
 
 plugins:
   - jekyll-redirect-from

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -114,7 +114,7 @@ layout: table_wrappers
                 });
             </script>
 
-            {% include nav.html pages=site.html_pages %}
+            {% include_cached nav.html pages=site.html_pages %}
             <div class="mobile-menu">
                 {% include header_menu.html %}
             </div>


### PR DESCRIPTION
Closes #6451

## Change Description

### Background

We use just-the-docs theme for docs. There is a new version of JtD which this PR implements. 

### New Feature

There are no new features, this is just a maintenance bump to keep us current with the theme to avoid big leaps in the future. 

Note https://github.com/just-the-docs/just-the-docs/issues/1323 - as a result of this the PR also includes a modification to `_layouts/default.html` to use `include_cached`. With this in place the build time remains the same as 0.5.0 (~11 seconds). 

### Testing Details

Tested manually. 

