### PR TITLE
Depracate lakectl fs --direct flag

### DIFF
--- a/cmd/lakectl/cmd/fs_cat.go
+++ b/cmd/lakectl/cmd/fs_cat.go
@@ -57,6 +57,10 @@ var fsCatCmd = &cobra.Command{
 //nolint:gochecknoinits
 func init() {
 	fsCatCmd.Flags().BoolP("direct", "d", false, "read directly from backing store (faster but requires more credentials)")
+	err := fsCatCmd.Flags().MarkDeprecated("direct", "use --pre-sign instead")
+	if err != nil {
+		DieErr(err)
+	}
 	fsCatCmd.Flags().Bool("pre-sign", false, "Use pre-sign link to access the data")
 
 	fsCmd.AddCommand(fsCatCmd)

--- a/cmd/lakectl/cmd/fs_download.go
+++ b/cmd/lakectl/cmd/fs_download.go
@@ -182,6 +182,10 @@ func getObjectHelper(ctx context.Context, client *api.ClientWithResponses, metho
 //nolint:gochecknoinits
 func init() {
 	fsDownloadCmd.Flags().BoolP("direct", "d", false, "read directly from backing store (requires credentials)")
+	err := fsDownloadCmd.Flags().MarkDeprecated("direct", "use --pre-sign instead")
+	if err != nil {
+		DieErr(err)
+	}
 	fsDownloadCmd.Flags().BoolP("recursive", "r", false, "recursively all objects under path")
 	fsDownloadCmd.Flags().IntP("parallel", "p", fsDownloadParallelDefault, "max concurrent downloads")
 	fsDownloadCmd.Flags().Bool("pre-sign", false, "Request pre-sign link to access the data")

--- a/cmd/lakectl/cmd/fs_upload.go
+++ b/cmd/lakectl/cmd/fs_upload.go
@@ -103,6 +103,10 @@ func init() {
 	fsUploadCmd.Flags().StringP("source", "s", "", "local file to upload, or \"-\" for stdin")
 	fsUploadCmd.Flags().BoolP("recursive", "r", false, "recursively copy all files under local source")
 	fsUploadCmd.Flags().BoolP("direct", "d", false, "write directly to backing store (faster but requires more credentials)")
+	err := fsUploadCmd.Flags().MarkDeprecated("direct", "use --pre-sign instead")
+	if err != nil {
+		DieErr(err)
+	}
 	_ = fsUploadCmd.MarkFlagRequired("source")
 	fsUploadCmd.Flags().StringP("content-type", "", "", "MIME type of contents")
 	fsUploadCmd.Flags().Bool("pre-sign", false, "Use pre-sign link to access the data")

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2205,7 +2205,6 @@ lakectl fs cat <path uri> [flags]
 {:.no_toc}
 
 ```
-  -d, --direct     read directly from backing store (faster but requires more credentials)
   -h, --help       help for cat
       --pre-sign   Use pre-sign link to access the data
 ```
@@ -2224,7 +2223,6 @@ lakectl fs download <path uri> [<destination path>] [flags]
 {:.no_toc}
 
 ```
-  -d, --direct         read directly from backing store (requires credentials)
   -h, --help           help for download
   -p, --parallel int   max concurrent downloads (default 6)
       --pre-sign       Request pre-sign link to access the data
@@ -2350,7 +2348,6 @@ lakectl fs upload <path uri> [flags]
 
 ```
       --content-type string   MIME type of contents
-  -d, --direct                write directly to backing store (faster but requires more credentials)
   -h, --help                  help for upload
       --pre-sign              Use pre-sign link to access the data
   -r, --recursive             recursively copy all files under local source

--- a/docs/understand/performance-best-practices.md
+++ b/docs/understand/performance-best-practices.md
@@ -34,7 +34,7 @@ For more information, see [how uncommitted data is managed in lakeFS][representi
 Sometimes, storage operations can become a bottleneck. For example, when your data pipelines upload many big objects.
 In such cases, it can be beneficial to perform only versioning operations on lakeFS, while performing storage reads/writes directly on the object store.
 lakeFS offers multiple ways to do that:
-* The [`lakectl fs upload --direct`][lakectl-upload] command (or [download][lakectl-download]).
+* The [`lakectl fs upload --pre-sign`][lakectl-upload] command (or [download][lakectl-download]).
 * The lakeFS [Hadoop Filesystem][hadoopfs].
 * The [staging API][api-staging] which can be used to add lakeFS references to objects after having written them to the storage.
 


### PR DESCRIPTION
Closes #6463

## Change Description

### Background

With the introduction of --pre-sign url flag, the --direct flag is no longer required as well as in the current state is not supported by most configurations 

### Testing Details

Manual

### Breaking Change?

Not yet
