### PR TITLE
docs: update python integration ssl ca configuration

### DIFF
--- a/docs/integrations/python.md
+++ b/docs/integrations/python.md
@@ -60,6 +60,7 @@ production setting.
 Optionally, to enable communication via proxies, simply set the proxy configuration:
 
 ```python
+configuration.ssl_ca_cert = <ssl CA certificate path>
 configuration.proxy = <proxy server URL>
 ``` 
 

--- a/docs/integrations/python.md
+++ b/docs/integrations/python.md
@@ -60,7 +60,7 @@ production setting.
 Optionally, to enable communication via proxies, simply set the proxy configuration:
 
 ```python
-configuration.ssl_ca_cert = <ssl CA certificate path>
+configuration.ssl_ca_cert = <path to a file of concatenated CA certificates in PEM format> # Set this to customize the certificate file to verify the peer
 configuration.proxy = <proxy server URL>
 ``` 
 


### PR DESCRIPTION
Added the configuration of configuration.ssl_ca_cert for proxy configuration

Closes #6482 

## Change Description
Added a single documentation line for adding SSL CA Certification when configuring the python client with a proxy.

### Background

Documenting an issue observed in the field. 
