### PR TITLE
Ensure merge operations have a metadata field

### DIFF
--- a/pkg/graveler/graveler.go
+++ b/pkg/graveler/graveler.go
@@ -2503,7 +2503,7 @@ func (g *Graveler) Merge(ctx context.Context, repository *RepositoryRecord, dest
 		commitParams.Metadata = make(map[string]string, 1)
 	}
 
-	lg = g.log(ctx).WithFields(logging.Fields{
+	lg := g.log(ctx).WithFields(logging.Fields{
 		"repository":  repository.RepositoryID,
 		"source":      source,
 		"destination": destination,

--- a/pkg/graveler/graveler.go
+++ b/pkg/graveler/graveler.go
@@ -2498,9 +2498,10 @@ func (g *Graveler) Merge(ctx context.Context, repository *RepositoryRecord, dest
 		return "", err
 	}
 
-	if commitParams.Metadata == nil {
-		// Need metadata to place the merge strategy
-		commitParams.Metadata = make(map[string]string, 1)
+	// Ensure a copy of metadata: it will be modified to add the strategy key.
+	metadata := make(map[string]string, len(commitParams.Metadata)+1)
+	for k, v := range commitParams.Metadata {
+		metadata[k] = v
 	}
 
 	lg := g.log(ctx).WithFields(logging.Fields{
@@ -2561,8 +2562,8 @@ func (g *Graveler) Merge(ctx context.Context, repository *RepositoryRecord, dest
 		} else {
 			commit.Generation = fromCommit.Generation + 1
 		}
-		commit.Metadata = commitParams.Metadata
-		commit.Metadata[MergeStrategyMetadataKey] = mergeStrategyString[mergeStrategy]
+		metadata[MergeStrategyMetadataKey] = mergeStrategyString[mergeStrategy]
+		commit.Metadata = metadata
 		preRunID = g.hooks.NewRunID()
 		err = g.hooks.PreMergeHook(ctx, HookRecord{
 			EventType:        EventTypePreMerge,

--- a/pkg/graveler/graveler_test.go
+++ b/pkg/graveler/graveler_test.go
@@ -1827,6 +1827,10 @@ func TestGraveler_PreMergeHook(t *testing.T) {
 	const commitCommitter = "committer"
 	const mergeMessage = "message"
 	mergeMetadata := graveler.Metadata{"key1": "val1"}
+	expectedMergeMetadata := graveler.Metadata{
+		"key1":                   "val1",
+		".lakefs.merge.strategy": "default",
+	}
 	tests := []struct {
 		name string
 		hook bool
@@ -1900,7 +1904,7 @@ func TestGraveler_PreMergeHook(t *testing.T) {
 			if h.Commit.Message != mergeMessage {
 				t.Errorf("Hook merge message '%s', expected '%s'", h.Commit.Message, mergeMessage)
 			}
-			if diff := deep.Equal(h.Commit.Metadata, mergeMetadata); diff != nil {
+			if diff := deep.Equal(h.Commit.Metadata, expectedMergeMetadata); diff != nil {
 				t.Error("Hook merge metadata diff:", diff)
 			}
 		})


### PR DESCRIPTION
Needed to hold the merge strategy.

Fixes #6494.

There are currently no tests for merging at the Graveler level: this code is
actually almost entirely linear.