### PR TITLE
Fix: UI object information slide outside the modal dialog

### DIFF
--- a/webui/src/lib/components/repository/tree.jsx
+++ b/webui/src/lib/components/repository/tree.jsx
@@ -165,12 +165,12 @@ const EntryRowActions = ({ repo, reference, entry, onDelete, presign = false }) 
 
 const StatModal = ({ show, onHide, entry }) => {
   return (
-    <Modal show={show} onHide={onHide} size={"lg"}>
+    <Modal show={show} onHide={onHide} size={"xl"}>
       <Modal.Header closeButton>
         <Modal.Title>Object Information</Modal.Title>
       </Modal.Header>
       <Modal.Body>
-        <Table hover>
+        <Table responsive hover>
           <tbody>
             <tr>
               <td>


### PR DESCRIPTION
Fix https://github.com/treeverse/lakeFS/issues/6502

Before:
<img width="994" alt="image" src="https://github.com/treeverse/lakeFS/assets/8110/66805ea4-8d43-4525-9f9d-71d24865e550">


After:
<img width="1162" alt="image" src="https://github.com/treeverse/lakeFS/assets/8110/c3364e71-7cc0-40ab-994a-400b9e28f113">

