### PR TITLE
Fix UI pdf viewer by X-Frame-Options set to SAMEORIGIN

### DIFF
--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -3684,7 +3684,7 @@ func (c *Controller) GetObject(w http.ResponseWriter, r *http.Request, repositor
 	w.Header().Set("Cache-Control", "no-store, must-revalidate")
 	w.Header().Set("Expires", "0")
 	w.Header().Set("X-Content-Type-Options", "nosniff")
-	w.Header().Set("X-Frame-Options", "DENY")
+	w.Header().Set("X-Frame-Options", "SAMEORIGIN")
 	w.Header().Set("Content-Security-Policy", "default-src 'none'")
 	_, err = io.Copy(w, reader)
 	if err != nil {

--- a/pkg/gateway/operations/getobject.go
+++ b/pkg/gateway/operations/getobject.go
@@ -113,7 +113,7 @@ func (controller *GetObject) Handle(w http.ResponseWriter, req *http.Request, o 
 	}
 
 	o.SetHeader(w, "X-Content-Type-Options", "nosniff")
-	o.SetHeader(w, "X-Frame-Options", "DENY")
+	o.SetHeader(w, "X-Frame-Options", "SAMEORIGIN")
 	o.SetHeader(w, "Content-Security-Policy", "default-src 'none'")
 
 	defer func() {


### PR DESCRIPTION
The page can only be displayed if all ancestor frames are same origin to the page itself. Enable rendering of pdf in UI.

Closes #6517