### PR TITLE
Fix lua path.Join to handle concatenation of two separators

### DIFF
--- a/pkg/actions/lua/path/path.go
+++ b/pkg/actions/lua/path/path.go
@@ -81,16 +81,19 @@ func join(l *lua.State) int {
 	return 1
 }
 
+// Join joins the parts with the separator.
+// Will keep the first part prefix separator (if found) and the last part suffix separator optional.
 func Join(sep string, parts ...string) string {
-	s := ""
+	var s string
 	for i, part := range parts {
-		s += part // append it
-		isLast := i == len(parts)-1
-		if !isLast {
-			// check if ends with sep, if not, add it
-			if !strings.HasSuffix(part, sep) {
-				s += sep
-			}
+		// remove prefix sep if not first
+		if i != 0 {
+			part = strings.TrimPrefix(part, sep)
+		}
+		s += part
+		// if not last part, make sure we have a suffix sep
+		if i != len(parts)-1 && !strings.HasSuffix(part, sep) {
+			s += sep
 		}
 	}
 	return s

--- a/pkg/actions/lua/path/path_test.go
+++ b/pkg/actions/lua/path/path_test.go
@@ -91,6 +91,10 @@ func TestJoin(t *testing.T) {
 			Expected: "foo/bar/baz",
 		},
 		{
+			Input:    []string{"foo/", "bar", "/baz"},
+			Expected: "foo/bar/baz",
+		},
+		{
 			Input:    []string{"a", "b", "c"},
 			Expected: "a/b/c",
 		},
@@ -104,7 +108,7 @@ func TestJoin(t *testing.T) {
 		t.Run(fmt.Sprintf("join_%d", i), func(t *testing.T) {
 			got := path.Join(path.SEPARATOR, cas.Input...)
 			if got != cas.Expected {
-				t.Errorf("Expected %s got %s", cas.Expected, got)
+				t.Errorf("Expected '%s' got '%s'", cas.Expected, got)
 			}
 		})
 	}
@@ -146,11 +150,13 @@ func TestParse(t *testing.T) {
 	for _, cas := range tbl {
 		t.Run(cas.Input, func(t *testing.T) {
 			got := path.Parse(cas.Input, path.SEPARATOR)
-			if got["base_name"] != cas.ExpectedBasename {
-				t.Errorf("base_name: expected '%s' got '%s'", cas.ExpectedBasename, got["base_name"])
+			baseName := got["base_name"]
+			if baseName != cas.ExpectedBasename {
+				t.Errorf("base_name: expected '%s' got '%s'", cas.ExpectedBasename, baseName)
 			}
-			if got["parent"] != cas.ExpectedParent {
-				t.Errorf("parent: expected '%s' got '%s'", cas.ExpectedParent, got["parent"])
+			parent := got["parent"]
+			if parent != cas.ExpectedParent {
+				t.Errorf("parent: expected '%s' got '%s'", cas.ExpectedParent, parent)
 			}
 		})
 	}


### PR DESCRIPTION
Fix https://github.com/treeverse/lakeFS/issues/6548