### PR TITLE
OpenAPI generated code in a separate package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,6 @@ clean:
 		$(LAKEFS_BINARY_NAME) \
 		$(UI_BUILD_DIR) \
 		$(UI_DIR)/node_modules \
-		pkg/api/api/lakefs.gen.go \
 		pkg/api/apigen/lakefs.gen.go \
 		pkg/auth/client.gen.go
 
@@ -146,6 +145,7 @@ package: package-python
 
 .PHONY: gen-api
 gen-api: docs/assets/js/swagger.yml ## Run the swagger code generator
+	rm -f pkg/api/lakefs.gen.go
 	$(GOGENERATE) \
 		./pkg/api \
 		./pkg/auth

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,7 @@ clean:
 		$(LAKEFS_BINARY_NAME) \
 		$(UI_BUILD_DIR) \
 		$(UI_DIR)/node_modules \
+		pkg/api/api/lakefs.gen.go \
 		pkg/api/apigen/lakefs.gen.go \
 		pkg/auth/client.gen.go
 

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ clean:
 		$(LAKEFS_BINARY_NAME) \
 		$(UI_BUILD_DIR) \
 		$(UI_DIR)/node_modules \
-		pkg/api/lakefs.gen.go \
+		pkg/api/apigen/lakefs.gen.go \
 		pkg/auth/client.gen.go
 
 check-licenses: check-licenses-go-mod check-licenses-npm

--- a/Makefile
+++ b/Makefile
@@ -147,7 +147,7 @@ package: package-python
 gen-api: docs/assets/js/swagger.yml ## Run the swagger code generator
 	rm -f pkg/api/lakefs.gen.go
 	$(GOGENERATE) \
-		./pkg/api \
+		./pkg/api/apigen \
 		./pkg/auth
 
 .PHONY: gen-code

--- a/cmd/lakectl/cmd/abuse_commit.go
+++ b/cmd/lakectl/cmd/abuse_commit.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 	"github.com/treeverse/lakefs/pkg/api/helpers"
 	"github.com/treeverse/lakefs/pkg/testutil/stress"
 )
@@ -52,8 +52,8 @@ var abuseCommitCmd = &cobra.Command{
 			client := getClient()
 			for work := range input {
 				start := time.Now()
-				resp, err := client.CommitWithResponse(ctx, u.Repository, u.Ref, &api.CommitParams{},
-					api.CommitJSONRequestBody(api.CommitCreation{Message: work}))
+				resp, err := client.CommitWithResponse(ctx, u.Repository, u.Ref, &apigen.CommitParams{},
+					apigen.CommitJSONRequestBody(apigen.CommitCreation{Message: work}))
 				if err == nil && resp.StatusCode() != http.StatusOK {
 					err = helpers.ResponseAsError(resp)
 				}

--- a/cmd/lakectl/cmd/abuse_create_branches.go
+++ b/cmd/lakectl/cmd/abuse_create_branches.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 	"github.com/treeverse/lakefs/pkg/api/helpers"
 	"github.com/treeverse/lakefs/pkg/testutil/stress"
 )
@@ -34,10 +34,10 @@ var abuseCreateBranchesCmd = &cobra.Command{
 
 		const paginationAmount = 1000
 		deleteGen.Setup(func(add stress.GeneratorAddFn) {
-			currentOffset := api.PaginationAfter(branchPrefix)
-			amount := api.PaginationAmount(paginationAmount)
+			currentOffset := apigen.PaginationAfter(branchPrefix)
+			amount := apigen.PaginationAmount(paginationAmount)
 			for {
-				resp, err := client.ListBranchesWithResponse(cmd.Context(), u.Repository, &api.ListBranchesParams{
+				resp, err := client.ListBranchesWithResponse(cmd.Context(), u.Repository, &apigen.ListBranchesParams{
 					After:  &currentOffset,
 					Amount: &amount,
 				})
@@ -56,7 +56,7 @@ var abuseCreateBranchesCmd = &cobra.Command{
 				if !pagination.HasMore {
 					return
 				}
-				currentOffset = api.PaginationAfter(pagination.NextOffset)
+				currentOffset = apigen.PaginationAfter(pagination.NextOffset)
 			}
 		})
 
@@ -91,7 +91,7 @@ var abuseCreateBranchesCmd = &cobra.Command{
 			for branch := range input {
 				start := time.Now()
 				resp, err := client.CreateBranchWithResponse(
-					ctx, u.Repository, api.CreateBranchJSONRequestBody{
+					ctx, u.Repository, apigen.CreateBranchJSONRequestBody{
 						Name:   branch,
 						Source: u.Ref,
 					})

--- a/cmd/lakectl/cmd/abuse_link_same_object.go
+++ b/cmd/lakectl/cmd/abuse_link_same_object.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 	"github.com/treeverse/lakefs/pkg/api/helpers"
 	"github.com/treeverse/lakefs/pkg/testutil/stress"
 )
@@ -43,7 +43,7 @@ var abuseLinkSameObjectCmd = &cobra.Command{
 			for work := range input {
 				start := time.Now()
 
-				getResponse, err := client.GetPhysicalAddressWithResponse(ctx, u.Repository, u.Ref, &api.GetPhysicalAddressParams{Path: work})
+				getResponse, err := client.GetPhysicalAddressWithResponse(ctx, u.Repository, u.Ref, &apigen.GetPhysicalAddressParams{Path: work})
 				if err == nil && getResponse.JSON200 == nil {
 					err = helpers.ResponseAsError(getResponse)
 				}
@@ -57,12 +57,12 @@ var abuseLinkSameObjectCmd = &cobra.Command{
 
 				stagingLocation := getResponse.JSON200
 				linkResponse, err := client.LinkPhysicalAddressWithResponse(ctx, u.Repository, u.Ref,
-					&api.LinkPhysicalAddressParams{
+					&apigen.LinkPhysicalAddressParams{
 						Path: work,
 					},
-					api.LinkPhysicalAddressJSONRequestBody{
+					apigen.LinkPhysicalAddressJSONRequestBody{
 						Checksum: "00695c7307b0480c7b6bdc873cf05c15",
-						Staging: api.StagingLocation{
+						Staging: apigen.StagingLocation{
 							PhysicalAddress: stagingLocation.PhysicalAddress,
 							Token:           stagingLocation.Token,
 						},

--- a/cmd/lakectl/cmd/abuse_list.go
+++ b/cmd/lakectl/cmd/abuse_list.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 	"github.com/treeverse/lakefs/pkg/api/helpers"
 	"github.com/treeverse/lakefs/pkg/testutil/stress"
 )
@@ -36,14 +36,14 @@ var abuseListCmd = &cobra.Command{
 			}
 		})
 
-		listPrefix := api.PaginationPrefix(prefix)
+		listPrefix := apigen.PaginationPrefix(prefix)
 		// execute the things!
 		generator.Run(func(input chan string, output chan stress.Result) {
 			ctx := cmd.Context()
 			client := getClient()
 			for range input {
 				start := time.Now()
-				resp, err := client.ListObjectsWithResponse(ctx, u.Repository, u.Ref, &api.ListObjectsParams{
+				resp, err := client.ListObjectsWithResponse(ctx, u.Repository, u.Ref, &apigen.ListObjectsParams{
 					Prefix: &listPrefix,
 				})
 				if err == nil && resp.StatusCode() != http.StatusOK {

--- a/cmd/lakectl/cmd/abuse_random_read.go
+++ b/cmd/lakectl/cmd/abuse_random_read.go
@@ -10,7 +10,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 	"github.com/treeverse/lakefs/pkg/api/helpers"
 	"github.com/treeverse/lakefs/pkg/testutil/stress"
 )
@@ -52,7 +52,7 @@ var abuseRandomReadsCmd = &cobra.Command{
 			client := getClient()
 			for work := range input {
 				start := time.Now()
-				resp, err := client.StatObjectWithResponse(ctx, u.Repository, u.Ref, &api.StatObjectParams{
+				resp, err := client.StatObjectWithResponse(ctx, u.Repository, u.Ref, &apigen.StatObjectParams{
 					Path: work,
 				})
 				if err == nil && resp.StatusCode() != http.StatusOK {

--- a/cmd/lakectl/cmd/abuse_random_writes.go
+++ b/cmd/lakectl/cmd/abuse_random_writes.go
@@ -9,7 +9,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 	"github.com/treeverse/lakefs/pkg/api/helpers"
 	"github.com/treeverse/lakefs/pkg/testutil/stress"
 )
@@ -49,7 +49,7 @@ var abuseRandomWritesCmd = &cobra.Command{
 		var size int64
 		checksum := "00695c7307b0480c7b6bdc873cf05c15"
 		addr := storagePrefix + "/random-write"
-		creationInfo := api.ObjectStageCreation{
+		creationInfo := apigen.ObjectStageCreation{
 			Checksum:        checksum,
 			PhysicalAddress: addr,
 			SizeBytes:       size,
@@ -61,8 +61,8 @@ var abuseRandomWritesCmd = &cobra.Command{
 			client := getClient()
 			for work := range input {
 				start := time.Now()
-				resp, err := client.StageObjectWithResponse(ctx, u.Repository, u.Ref, &api.StageObjectParams{Path: work},
-					api.StageObjectJSONRequestBody(creationInfo))
+				resp, err := client.StageObjectWithResponse(ctx, u.Repository, u.Ref, &apigen.StageObjectParams{Path: work},
+					apigen.StageObjectJSONRequestBody(creationInfo))
 				if err == nil && resp.StatusCode() != http.StatusOK {
 					err = helpers.ResponseAsError(resp)
 				}

--- a/cmd/lakectl/cmd/actions_runs_describe.go
+++ b/cmd/lakectl/cmd/actions_runs_describe.go
@@ -8,6 +8,7 @@ import (
 	"github.com/jedib0t/go-pretty/v6/text"
 	"github.com/spf13/cobra"
 	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 	"github.com/treeverse/lakefs/pkg/api/helpers"
 )
 
@@ -29,7 +30,7 @@ var actionsRunsDescribeCmd = &cobra.Command{
 		amount := Must(cmd.Flags().GetInt("amount"))
 		after := Must(cmd.Flags().GetString("after"))
 		u := MustParseRepoURI("repository", args[0])
-		pagination := api.Pagination{HasMore: true}
+		pagination := apigen.Pagination{HasMore: true}
 
 		fmt.Println("Repository:", u)
 		runID := args[1]
@@ -52,7 +53,7 @@ var actionsRunsDescribeCmd = &cobra.Command{
 				amountForPagination = internalPageSize
 			}
 			// iterator over hooks - print information and output
-			runHooksRes, err := client.ListRunHooksWithResponse(ctx, u.Repository, runID, &api.ListRunHooksParams{
+			runHooksRes, err := client.ListRunHooksWithResponse(ctx, u.Repository, runID, &apigen.ListRunHooksParams{
 				After:  api.PaginationAfterPtr(after),
 				Amount: api.PaginationAmountPtr(amountForPagination),
 			})
@@ -62,7 +63,7 @@ var actionsRunsDescribeCmd = &cobra.Command{
 			}
 			pagination = runHooksRes.JSON200.Pagination
 			data := struct {
-				Hooks      []api.HookRun
+				Hooks      []apigen.HookRun
 				HooksTable []*Table
 				HookLog    func(hookRunID string) (string, error)
 				Pagination *Pagination
@@ -86,7 +87,7 @@ var actionsRunsDescribeCmd = &cobra.Command{
 	},
 }
 
-func makeHookLog(ctx context.Context, client api.ClientWithResponsesInterface, repositoryID string, runID string) func(hookRunID string) (string, error) {
+func makeHookLog(ctx context.Context, client apigen.ClientWithResponsesInterface, repositoryID string, runID string) func(hookRunID string) (string, error) {
 	return func(hookRunID string) (string, error) {
 		resp, err := client.GetRunHookOutputWithResponse(ctx, repositoryID, runID, hookRunID)
 		if err != nil {
@@ -99,7 +100,7 @@ func makeHookLog(ctx context.Context, client api.ClientWithResponsesInterface, r
 	}
 }
 
-func convertRunResultTable(r *api.ActionRun) *Table {
+func convertRunResultTable(r *apigen.ActionRun) *Table {
 	runID := text.FgYellow.Sprint(r.RunId)
 	statusColor := text.FgRed
 	if r.Status == "completed" {
@@ -114,7 +115,7 @@ func convertRunResultTable(r *api.ActionRun) *Table {
 	}
 }
 
-func convertHookResultsTables(results []api.HookRun) []*Table {
+func convertHookResultsTables(results []apigen.HookRun) []*Table {
 	tables := make([]*Table, len(results))
 	for i, r := range results {
 		hookRunID := text.FgYellow.Sprint(r.HookRunId)

--- a/cmd/lakectl/cmd/actions_runs_describe.go
+++ b/cmd/lakectl/cmd/actions_runs_describe.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/jedib0t/go-pretty/v6/text"
 	"github.com/spf13/cobra"
-	"github.com/treeverse/lakefs/pkg/api"
 	"github.com/treeverse/lakefs/pkg/api/apigen"
+	"github.com/treeverse/lakefs/pkg/api/apiutil"
 	"github.com/treeverse/lakefs/pkg/api/helpers"
 )
 
@@ -54,8 +54,8 @@ var actionsRunsDescribeCmd = &cobra.Command{
 			}
 			// iterator over hooks - print information and output
 			runHooksRes, err := client.ListRunHooksWithResponse(ctx, u.Repository, runID, &apigen.ListRunHooksParams{
-				After:  api.PaginationAfterPtr(after),
-				Amount: api.PaginationAmountPtr(amountForPagination),
+				After:  apiutil.Ptr(apigen.PaginationAfter(after)),
+				Amount: apiutil.Ptr(apigen.PaginationAmount(amountForPagination)),
 			})
 			DieOnErrorOrUnexpectedStatusCode(runHooksRes, err, http.StatusOK)
 			if runHooksRes.JSON200 == nil {

--- a/cmd/lakectl/cmd/actions_runs_list.go
+++ b/cmd/lakectl/cmd/actions_runs_list.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 
 	"github.com/spf13/cobra"
-	"github.com/treeverse/lakefs/pkg/api"
 	"github.com/treeverse/lakefs/pkg/api/apigen"
+	"github.com/treeverse/lakefs/pkg/api/apiutil"
 )
 
 const actionsRunsListTemplate = `{{.ActionsRunsTable | table -}}
@@ -43,8 +43,8 @@ var actionsRunsListCmd = &cobra.Command{
 		}
 
 		resp, err := client.ListRepositoryRunsWithResponse(ctx, u.Repository, &apigen.ListRepositoryRunsParams{
-			After:  api.PaginationAfterPtr(after),
-			Amount: api.PaginationAmountPtr(amount),
+			After:  apiutil.Ptr(apigen.PaginationAfter(after)),
+			Amount: apiutil.Ptr(apigen.PaginationAmount(amount)),
 			Branch: optionalBranch,
 			Commit: optionalCommit,
 		})

--- a/cmd/lakectl/cmd/actions_runs_list.go
+++ b/cmd/lakectl/cmd/actions_runs_list.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 )
 
 const actionsRunsListTemplate = `{{.ActionsRunsTable | table -}}
@@ -41,7 +42,7 @@ var actionsRunsListCmd = &cobra.Command{
 			optionalCommit = &commit
 		}
 
-		resp, err := client.ListRepositoryRunsWithResponse(ctx, u.Repository, &api.ListRepositoryRunsParams{
+		resp, err := client.ListRepositoryRunsWithResponse(ctx, u.Repository, &apigen.ListRepositoryRunsParams{
 			After:  api.PaginationAfterPtr(after),
 			Amount: api.PaginationAmountPtr(amount),
 			Branch: optionalBranch,

--- a/cmd/lakectl/cmd/annotate.go
+++ b/cmd/lakectl/cmd/annotate.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 )
 
 const (
@@ -17,7 +18,7 @@ const (
 
 type objectCommitData struct {
 	Object        string
-	Commit        api.Commit
+	Commit        apigen.Commit
 	CommitMessage string
 }
 
@@ -32,21 +33,21 @@ var annotateCmd = &cobra.Command{
 		recursive := Must(cmd.Flags().GetBool("recursive"))
 		firstParent := Must(cmd.Flags().GetBool("first-parent"))
 		client := getClient()
-		pfx := api.PaginationPrefix(*pathURI.Path)
+		pfx := apigen.PaginationPrefix(*pathURI.Path)
 		context := cmd.Context()
-		resp, err := client.ListObjectsWithResponse(context, pathURI.Repository, pathURI.Ref, &api.ListObjectsParams{Prefix: &pfx})
+		resp, err := client.ListObjectsWithResponse(context, pathURI.Repository, pathURI.Ref, &apigen.ListObjectsParams{Prefix: &pfx})
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusOK)
 		if resp.JSON200 == nil {
 			Die("Bad response from server", 1)
 		}
-		var listObjectsDelimiter api.PaginationDelimiter
+		var listObjectsDelimiter apigen.PaginationDelimiter
 		if !recursive {
 			listObjectsDelimiter = PathDelimiter
 		}
 		var from string
 		limit := true
 		for {
-			params := &api.ListObjectsParams{
+			params := &apigen.ListObjectsParams{
 				Prefix:    &pfx,
 				After:     api.PaginationAfterPtr(from),
 				Delimiter: &listObjectsDelimiter,
@@ -57,7 +58,7 @@ var annotateCmd = &cobra.Command{
 				Die("Bad response from server", 1)
 			}
 			for _, obj := range listObjectsResp.JSON200.Results {
-				logCommitsParams := &api.LogCommitsParams{
+				logCommitsParams := &apigen.LogCommitsParams{
 					Amount:      api.PaginationAmountPtr(1),
 					Limit:       &limit,
 					FirstParent: &firstParent,

--- a/cmd/lakectl/cmd/annotate.go
+++ b/cmd/lakectl/cmd/annotate.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"github.com/treeverse/lakefs/pkg/api"
 	"github.com/treeverse/lakefs/pkg/api/apigen"
+	"github.com/treeverse/lakefs/pkg/api/apiutil"
 )
 
 const (
@@ -49,7 +49,7 @@ var annotateCmd = &cobra.Command{
 		for {
 			params := &apigen.ListObjectsParams{
 				Prefix:    &pfx,
-				After:     api.PaginationAfterPtr(from),
+				After:     apiutil.Ptr(apigen.PaginationAfter(from)),
 				Delimiter: &listObjectsDelimiter,
 			}
 			listObjectsResp, err := client.ListObjectsWithResponse(context, pathURI.Repository, pathURI.Ref, params)
@@ -59,7 +59,7 @@ var annotateCmd = &cobra.Command{
 			}
 			for _, obj := range listObjectsResp.JSON200.Results {
 				logCommitsParams := &apigen.LogCommitsParams{
-					Amount:      api.PaginationAmountPtr(1),
+					Amount:      apiutil.Ptr(apigen.PaginationAmount(1)),
 					Limit:       &limit,
 					FirstParent: &firstParent,
 				}

--- a/cmd/lakectl/cmd/auth_groups_acl_set.go
+++ b/cmd/lakectl/cmd/auth_groups_acl_set.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 
 	"github.com/spf13/cobra"
-	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 )
 
 var authGroupsACLSet = &cobra.Command{
@@ -17,7 +17,7 @@ var authGroupsACLSet = &cobra.Command{
 
 		clt := getClient()
 
-		acl := api.SetGroupACLJSONRequestBody{
+		acl := apigen.SetGroupACLJSONRequestBody{
 			Permission: permission,
 		}
 

--- a/cmd/lakectl/cmd/auth_groups_create.go
+++ b/cmd/lakectl/cmd/auth_groups_create.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 
 	"github.com/spf13/cobra"
-	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 )
 
 const groupCreatedTemplate = `{{ "Group created successfully." | green }}
@@ -19,7 +19,7 @@ var authGroupsCreateCmd = &cobra.Command{
 		id := Must(cmd.Flags().GetString("id"))
 		clt := getClient()
 
-		resp, err := clt.CreateGroupWithResponse(cmd.Context(), api.CreateGroupJSONRequestBody{
+		resp, err := clt.CreateGroupWithResponse(cmd.Context(), apigen.CreateGroupJSONRequestBody{
 			Id: id,
 		})
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusCreated)

--- a/cmd/lakectl/cmd/auth_groups_list.go
+++ b/cmd/lakectl/cmd/auth_groups_list.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 )
 
 var authGroupsListCmd = &cobra.Command{
@@ -17,7 +18,7 @@ var authGroupsListCmd = &cobra.Command{
 
 		clt := getClient()
 
-		resp, err := clt.ListGroupsWithResponse(cmd.Context(), &api.ListGroupsParams{
+		resp, err := clt.ListGroupsWithResponse(cmd.Context(), &apigen.ListGroupsParams{
 			After:  api.PaginationAfterPtr(after),
 			Amount: api.PaginationAmountPtr(amount),
 		})

--- a/cmd/lakectl/cmd/auth_groups_list.go
+++ b/cmd/lakectl/cmd/auth_groups_list.go
@@ -5,8 +5,8 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/treeverse/lakefs/pkg/api"
 	"github.com/treeverse/lakefs/pkg/api/apigen"
+	"github.com/treeverse/lakefs/pkg/api/apiutil"
 )
 
 var authGroupsListCmd = &cobra.Command{
@@ -19,8 +19,8 @@ var authGroupsListCmd = &cobra.Command{
 		clt := getClient()
 
 		resp, err := clt.ListGroupsWithResponse(cmd.Context(), &apigen.ListGroupsParams{
-			After:  api.PaginationAfterPtr(after),
-			Amount: api.PaginationAmountPtr(amount),
+			After:  apiutil.Ptr(apigen.PaginationAfter(after)),
+			Amount: apiutil.Ptr(apigen.PaginationAmount(amount)),
 		})
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusOK)
 		if resp.JSON200 == nil {

--- a/cmd/lakectl/cmd/auth_groups_members_list.go
+++ b/cmd/lakectl/cmd/auth_groups_members_list.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 
 	"github.com/spf13/cobra"
-	"github.com/treeverse/lakefs/pkg/api"
 	"github.com/treeverse/lakefs/pkg/api/apigen"
+	"github.com/treeverse/lakefs/pkg/api/apiutil"
 )
 
 var authGroupsMembersList = &cobra.Command{
@@ -19,8 +19,8 @@ var authGroupsMembersList = &cobra.Command{
 		clt := getClient()
 
 		resp, err := clt.ListGroupMembersWithResponse(cmd.Context(), id, &apigen.ListGroupMembersParams{
-			After:  api.PaginationAfterPtr(after),
-			Amount: api.PaginationAmountPtr(amount),
+			After:  apiutil.Ptr(apigen.PaginationAfter(after)),
+			Amount: apiutil.Ptr(apigen.PaginationAmount(amount)),
 		})
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusOK)
 		if resp.JSON200 == nil {

--- a/cmd/lakectl/cmd/auth_groups_members_list.go
+++ b/cmd/lakectl/cmd/auth_groups_members_list.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 )
 
 var authGroupsMembersList = &cobra.Command{
@@ -17,7 +18,7 @@ var authGroupsMembersList = &cobra.Command{
 
 		clt := getClient()
 
-		resp, err := clt.ListGroupMembersWithResponse(cmd.Context(), id, &api.ListGroupMembersParams{
+		resp, err := clt.ListGroupMembersWithResponse(cmd.Context(), id, &apigen.ListGroupMembersParams{
 			After:  api.PaginationAfterPtr(after),
 			Amount: api.PaginationAmountPtr(amount),
 		})

--- a/cmd/lakectl/cmd/auth_groups_policies_list.go
+++ b/cmd/lakectl/cmd/auth_groups_policies_list.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 )
 
 var authGroupsPoliciesList = &cobra.Command{
@@ -19,7 +20,7 @@ var authGroupsPoliciesList = &cobra.Command{
 
 		clt := getClient()
 
-		resp, err := clt.ListGroupPoliciesWithResponse(cmd.Context(), id, &api.ListGroupPoliciesParams{
+		resp, err := clt.ListGroupPoliciesWithResponse(cmd.Context(), id, &apigen.ListGroupPoliciesParams{
 			After:  api.PaginationAfterPtr(after),
 			Amount: api.PaginationAmountPtr(amount),
 		})

--- a/cmd/lakectl/cmd/auth_groups_policies_list.go
+++ b/cmd/lakectl/cmd/auth_groups_policies_list.go
@@ -6,8 +6,8 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/treeverse/lakefs/pkg/api"
 	"github.com/treeverse/lakefs/pkg/api/apigen"
+	"github.com/treeverse/lakefs/pkg/api/apiutil"
 )
 
 var authGroupsPoliciesList = &cobra.Command{
@@ -21,8 +21,8 @@ var authGroupsPoliciesList = &cobra.Command{
 		clt := getClient()
 
 		resp, err := clt.ListGroupPoliciesWithResponse(cmd.Context(), id, &apigen.ListGroupPoliciesParams{
-			After:  api.PaginationAfterPtr(after),
-			Amount: api.PaginationAmountPtr(amount),
+			After:  apiutil.Ptr(apigen.PaginationAfter(after)),
+			Amount: apiutil.Ptr(apigen.PaginationAmount(amount)),
 		})
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusOK)
 		if resp.JSON200 == nil {

--- a/cmd/lakectl/cmd/auth_policies_create.go
+++ b/cmd/lakectl/cmd/auth_policies_create.go
@@ -7,7 +7,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 )
 
 const policyCreatedTemplate = `{{ "Policy created successfully." | green }}
@@ -40,7 +40,7 @@ var authPoliciesCreate = &cobra.Command{
 		if err != nil {
 			DieFmt("could not parse statement JSON document: %v", err)
 		}
-		resp, err := clt.CreatePolicyWithResponse(cmd.Context(), api.CreatePolicyJSONRequestBody{
+		resp, err := clt.CreatePolicyWithResponse(cmd.Context(), apigen.CreatePolicyJSONRequestBody{
 			Id:        id,
 			Statement: doc.Statement,
 		})

--- a/cmd/lakectl/cmd/auth_policies_list.go
+++ b/cmd/lakectl/cmd/auth_policies_list.go
@@ -5,8 +5,8 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/treeverse/lakefs/pkg/api"
 	"github.com/treeverse/lakefs/pkg/api/apigen"
+	"github.com/treeverse/lakefs/pkg/api/apiutil"
 )
 
 var authPoliciesList = &cobra.Command{
@@ -19,8 +19,8 @@ var authPoliciesList = &cobra.Command{
 		clt := getClient()
 
 		resp, err := clt.ListPoliciesWithResponse(cmd.Context(), &apigen.ListPoliciesParams{
-			After:  api.PaginationAfterPtr(after),
-			Amount: api.PaginationAmountPtr(amount),
+			After:  apiutil.Ptr(apigen.PaginationAfter(after)),
+			Amount: apiutil.Ptr(apigen.PaginationAmount(amount)),
 		})
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusOK)
 		if resp.JSON200 == nil {

--- a/cmd/lakectl/cmd/auth_policies_list.go
+++ b/cmd/lakectl/cmd/auth_policies_list.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 )
 
 var authPoliciesList = &cobra.Command{
@@ -17,7 +18,7 @@ var authPoliciesList = &cobra.Command{
 
 		clt := getClient()
 
-		resp, err := clt.ListPoliciesWithResponse(cmd.Context(), &api.ListPoliciesParams{
+		resp, err := clt.ListPoliciesWithResponse(cmd.Context(), &apigen.ListPoliciesParams{
 			After:  api.PaginationAfterPtr(after),
 			Amount: api.PaginationAmountPtr(amount),
 		})

--- a/cmd/lakectl/cmd/auth_policies_show.go
+++ b/cmd/lakectl/cmd/auth_policies_show.go
@@ -4,11 +4,11 @@ import (
 	"net/http"
 
 	"github.com/spf13/cobra"
-	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 )
 
 type StatementDoc struct {
-	Statement []api.Statement `json:"statement"`
+	Statement []apigen.Statement `json:"statement"`
 }
 
 const policyDetailsTemplate = `

--- a/cmd/lakectl/cmd/auth_users_create.go
+++ b/cmd/lakectl/cmd/auth_users_create.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 
 	"github.com/spf13/cobra"
-	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 )
 
 const userCreatedTemplate = `{{ "User created successfully." | green }}
@@ -19,7 +19,7 @@ var authUsersCreate = &cobra.Command{
 		id := Must(cmd.Flags().GetString("id"))
 		clt := getClient()
 
-		resp, err := clt.CreateUserWithResponse(cmd.Context(), api.CreateUserJSONRequestBody{
+		resp, err := clt.CreateUserWithResponse(cmd.Context(), apigen.CreateUserJSONRequestBody{
 			Id: id,
 		})
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusCreated)

--- a/cmd/lakectl/cmd/auth_users_credentials_list.go
+++ b/cmd/lakectl/cmd/auth_users_credentials_list.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 )
 
 var authUsersCredentialsList = &cobra.Command{
@@ -26,7 +27,7 @@ var authUsersCredentialsList = &cobra.Command{
 			id = resp.JSON200.User.Id
 		}
 
-		resp, err := clt.ListUserCredentialsWithResponse(cmd.Context(), id, &api.ListUserCredentialsParams{
+		resp, err := clt.ListUserCredentialsWithResponse(cmd.Context(), id, &apigen.ListUserCredentialsParams{
 			After:  api.PaginationAfterPtr(after),
 			Amount: api.PaginationAmountPtr(amount),
 		})

--- a/cmd/lakectl/cmd/auth_users_credentials_list.go
+++ b/cmd/lakectl/cmd/auth_users_credentials_list.go
@@ -5,8 +5,8 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/treeverse/lakefs/pkg/api"
 	"github.com/treeverse/lakefs/pkg/api/apigen"
+	"github.com/treeverse/lakefs/pkg/api/apiutil"
 )
 
 var authUsersCredentialsList = &cobra.Command{
@@ -28,8 +28,8 @@ var authUsersCredentialsList = &cobra.Command{
 		}
 
 		resp, err := clt.ListUserCredentialsWithResponse(cmd.Context(), id, &apigen.ListUserCredentialsParams{
-			After:  api.PaginationAfterPtr(after),
-			Amount: api.PaginationAmountPtr(amount),
+			After:  apiutil.Ptr(apigen.PaginationAfter(after)),
+			Amount: apiutil.Ptr(apigen.PaginationAmount(amount)),
 		})
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusOK)
 		if resp.JSON200 == nil {

--- a/cmd/lakectl/cmd/auth_users_groups_list.go
+++ b/cmd/lakectl/cmd/auth_users_groups_list.go
@@ -5,8 +5,8 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/treeverse/lakefs/pkg/api"
 	"github.com/treeverse/lakefs/pkg/api/apigen"
+	"github.com/treeverse/lakefs/pkg/api/apiutil"
 )
 
 var authUsersGroupsList = &cobra.Command{
@@ -20,8 +20,8 @@ var authUsersGroupsList = &cobra.Command{
 		clt := getClient()
 
 		resp, err := clt.ListUserGroupsWithResponse(cmd.Context(), id, &apigen.ListUserGroupsParams{
-			After:  api.PaginationAfterPtr(after),
-			Amount: api.PaginationAmountPtr(amount),
+			After:  apiutil.Ptr(apigen.PaginationAfter(after)),
+			Amount: apiutil.Ptr(apigen.PaginationAmount(amount)),
 		})
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusOK)
 		if resp.JSON200 == nil {

--- a/cmd/lakectl/cmd/auth_users_groups_list.go
+++ b/cmd/lakectl/cmd/auth_users_groups_list.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 )
 
 var authUsersGroupsList = &cobra.Command{
@@ -18,7 +19,7 @@ var authUsersGroupsList = &cobra.Command{
 
 		clt := getClient()
 
-		resp, err := clt.ListUserGroupsWithResponse(cmd.Context(), id, &api.ListUserGroupsParams{
+		resp, err := clt.ListUserGroupsWithResponse(cmd.Context(), id, &apigen.ListUserGroupsParams{
 			After:  api.PaginationAfterPtr(after),
 			Amount: api.PaginationAmountPtr(amount),
 		})

--- a/cmd/lakectl/cmd/auth_users_list.go
+++ b/cmd/lakectl/cmd/auth_users_list.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 )
 
 var authUsersList = &cobra.Command{
@@ -17,7 +18,7 @@ var authUsersList = &cobra.Command{
 
 		clt := getClient()
 
-		resp, err := clt.ListUsersWithResponse(cmd.Context(), &api.ListUsersParams{
+		resp, err := clt.ListUsersWithResponse(cmd.Context(), &apigen.ListUsersParams{
 			After:  api.PaginationAfterPtr(after),
 			Amount: api.PaginationAmountPtr(amount),
 		})

--- a/cmd/lakectl/cmd/auth_users_list.go
+++ b/cmd/lakectl/cmd/auth_users_list.go
@@ -5,8 +5,8 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/treeverse/lakefs/pkg/api"
 	"github.com/treeverse/lakefs/pkg/api/apigen"
+	"github.com/treeverse/lakefs/pkg/api/apiutil"
 )
 
 var authUsersList = &cobra.Command{
@@ -19,8 +19,8 @@ var authUsersList = &cobra.Command{
 		clt := getClient()
 
 		resp, err := clt.ListUsersWithResponse(cmd.Context(), &apigen.ListUsersParams{
-			After:  api.PaginationAfterPtr(after),
-			Amount: api.PaginationAmountPtr(amount),
+			After:  apiutil.Ptr(apigen.PaginationAfter(after)),
+			Amount: apiutil.Ptr(apigen.PaginationAmount(amount)),
 		})
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusOK)
 		if resp.JSON200 == nil {

--- a/cmd/lakectl/cmd/auth_users_policies_list.go
+++ b/cmd/lakectl/cmd/auth_users_policies_list.go
@@ -6,8 +6,8 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/treeverse/lakefs/pkg/api"
 	"github.com/treeverse/lakefs/pkg/api/apigen"
+	"github.com/treeverse/lakefs/pkg/api/apiutil"
 )
 
 var authUsersPoliciesList = &cobra.Command{
@@ -22,8 +22,8 @@ var authUsersPoliciesList = &cobra.Command{
 		clt := getClient()
 
 		resp, err := clt.ListUserPoliciesWithResponse(cmd.Context(), id, &apigen.ListUserPoliciesParams{
-			After:     api.PaginationAfterPtr(after),
-			Amount:    api.PaginationAmountPtr(amount),
+			After:     apiutil.Ptr(apigen.PaginationAfter(after)),
+			Amount:    apiutil.Ptr(apigen.PaginationAmount(amount)),
 			Effective: &effective,
 		})
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusOK)

--- a/cmd/lakectl/cmd/auth_users_policies_list.go
+++ b/cmd/lakectl/cmd/auth_users_policies_list.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 )
 
 var authUsersPoliciesList = &cobra.Command{
@@ -20,7 +21,7 @@ var authUsersPoliciesList = &cobra.Command{
 
 		clt := getClient()
 
-		resp, err := clt.ListUserPoliciesWithResponse(cmd.Context(), id, &api.ListUserPoliciesParams{
+		resp, err := clt.ListUserPoliciesWithResponse(cmd.Context(), id, &apigen.ListUserPoliciesParams{
 			After:     api.PaginationAfterPtr(after),
 			Amount:    api.PaginationAmountPtr(amount),
 			Effective: &effective,

--- a/cmd/lakectl/cmd/bisect.go
+++ b/cmd/lakectl/cmd/bisect.go
@@ -13,6 +13,7 @@ import (
 	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 )
 
 const bisectCommitTemplate = `{{ range $val := . }}
@@ -49,16 +50,16 @@ var bisectCmd = &cobra.Command{
 }
 
 type Bisect struct {
-	Created    time.Time     `json:"created"`
-	Repository string        `json:"repository"`
-	BadCommit  string        `json:"badCommit,omitempty"`
-	GoodCommit string        `json:"goodCommit,omitempty"`
-	Commits    []*api.Commit `json:"commits,omitempty"`
+	Created    time.Time        `json:"created"`
+	Repository string           `json:"repository"`
+	BadCommit  string           `json:"badCommit,omitempty"`
+	GoodCommit string           `json:"goodCommit,omitempty"`
+	Commits    []*apigen.Commit `json:"commits,omitempty"`
 }
 
 const bisectStartCmdArgs = 2
 
-func resolveCommitOrDie(ctx context.Context, client api.ClientWithResponsesInterface, repository, ref string) string {
+func resolveCommitOrDie(ctx context.Context, client apigen.ClientWithResponsesInterface, repository, ref string) string {
 	response, err := client.GetCommitWithResponse(ctx, repository, ref)
 	DieOnErrorOrUnexpectedStatusCode(response, err, http.StatusOK)
 	if response.JSON200 == nil {
@@ -138,7 +139,7 @@ func (b *Bisect) Save() error {
 	return os.WriteFile(expand, data, fileMode)
 }
 
-func (b *Bisect) Update(ctx context.Context, client api.ClientWithResponsesInterface) error {
+func (b *Bisect) Update(ctx context.Context, client apigen.ClientWithResponsesInterface) error {
 	if b.GoodCommit == "" || b.BadCommit == "" {
 		b.Commits = nil
 		return nil
@@ -147,10 +148,10 @@ func (b *Bisect) Update(ctx context.Context, client api.ClientWithResponsesInter
 	// scan commit log from bad to good (not included) and save them into state
 	b.Commits = nil
 	const amountPerCall = 500
-	params := &api.LogCommitsParams{
+	params := &apigen.LogCommitsParams{
 		Amount: api.PaginationAmountPtr(amountPerCall),
 	}
-	var commits []*api.Commit
+	var commits []*apigen.Commit
 	for {
 		logResponse, err := client.LogCommitsWithResponse(ctx, b.Repository, b.BadCommit, params)
 		DieOnErrorOrUnexpectedStatusCode(logResponse, err, http.StatusOK)

--- a/cmd/lakectl/cmd/bisect.go
+++ b/cmd/lakectl/cmd/bisect.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
-	"github.com/treeverse/lakefs/pkg/api"
 	"github.com/treeverse/lakefs/pkg/api/apigen"
+	"github.com/treeverse/lakefs/pkg/api/apiutil"
 )
 
 const bisectCommitTemplate = `{{ range $val := . }}
@@ -149,7 +149,7 @@ func (b *Bisect) Update(ctx context.Context, client apigen.ClientWithResponsesIn
 	b.Commits = nil
 	const amountPerCall = 500
 	params := &apigen.LogCommitsParams{
-		Amount: api.PaginationAmountPtr(amountPerCall),
+		Amount: apiutil.Ptr(apigen.PaginationAmount(amountPerCall)),
 	}
 	var commits []*apigen.Commit
 	for {
@@ -169,7 +169,7 @@ func (b *Bisect) Update(ctx context.Context, client apigen.ClientWithResponsesIn
 		if !logResponse.JSON200.Pagination.HasMore {
 			break
 		}
-		params.After = api.PaginationAfterPtr(logResponse.JSON200.Pagination.NextOffset)
+		params.After = apiutil.Ptr(apigen.PaginationAfter(logResponse.JSON200.Pagination.NextOffset))
 	}
 	return fmt.Errorf("good %w", ErrCommitNotFound)
 }

--- a/cmd/lakectl/cmd/bisect_run.go
+++ b/cmd/lakectl/cmd/bisect_run.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 )
 
 var bisectRunCmd = &cobra.Command{
@@ -44,7 +44,7 @@ var bisectRunCmd = &cobra.Command{
 	},
 }
 
-func bisectRunCommand(ctx context.Context, commit *api.Commit, name string, args []string) *exec.Cmd {
+func bisectRunCommand(ctx context.Context, commit *apigen.Commit, name string, args []string) *exec.Cmd {
 	// prepare args
 	replacer := strings.NewReplacer(
 		":BISECT_ID:", commit.Id,

--- a/cmd/lakectl/cmd/branch_create.go
+++ b/cmd/lakectl/cmd/branch_create.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 
 	"github.com/spf13/cobra"
-	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 	"github.com/treeverse/lakefs/pkg/uri"
 )
 
@@ -28,7 +28,7 @@ var branchCreateCmd = &cobra.Command{
 			Die("source branch must be in the same repository", 1)
 		}
 
-		resp, err := client.CreateBranchWithResponse(cmd.Context(), u.Repository, api.CreateBranchJSONRequestBody{
+		resp, err := client.CreateBranchWithResponse(cmd.Context(), u.Repository, apigen.CreateBranchJSONRequestBody{
 			Name:   u.Ref,
 			Source: sourceURI.Ref,
 		})

--- a/cmd/lakectl/cmd/branch_list.go
+++ b/cmd/lakectl/cmd/branch_list.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 )
 
 var branchListCmd = &cobra.Command{
@@ -18,7 +19,7 @@ var branchListCmd = &cobra.Command{
 		after := Must(cmd.Flags().GetString("after"))
 		u := MustParseRepoURI("repository", args[0])
 		client := getClient()
-		resp, err := client.ListBranchesWithResponse(cmd.Context(), u.Repository, &api.ListBranchesParams{
+		resp, err := client.ListBranchesWithResponse(cmd.Context(), u.Repository, &apigen.ListBranchesParams{
 			After:  api.PaginationAfterPtr(after),
 			Amount: api.PaginationAmountPtr(amount),
 		})

--- a/cmd/lakectl/cmd/branch_list.go
+++ b/cmd/lakectl/cmd/branch_list.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 
 	"github.com/spf13/cobra"
-	"github.com/treeverse/lakefs/pkg/api"
 	"github.com/treeverse/lakefs/pkg/api/apigen"
+	"github.com/treeverse/lakefs/pkg/api/apiutil"
 )
 
 var branchListCmd = &cobra.Command{
@@ -20,8 +20,8 @@ var branchListCmd = &cobra.Command{
 		u := MustParseRepoURI("repository", args[0])
 		client := getClient()
 		resp, err := client.ListBranchesWithResponse(cmd.Context(), u.Repository, &apigen.ListBranchesParams{
-			After:  api.PaginationAfterPtr(after),
-			Amount: api.PaginationAmountPtr(amount),
+			After:  apiutil.Ptr(apigen.PaginationAfter(after)),
+			Amount: apiutil.Ptr(apigen.PaginationAmount(amount)),
 		})
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusOK)
 		if resp.JSON200 == nil {

--- a/cmd/lakectl/cmd/branch_protect.go
+++ b/cmd/lakectl/cmd/branch_protect.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 
 	"github.com/spf13/cobra"
-	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 )
 
 const (
@@ -37,7 +37,7 @@ var branchProtectListCmd = &cobra.Command{
 		for i, rule := range *resp.JSON200 {
 			patterns[i] = []interface{}{rule.Pattern}
 		}
-		PrintTable(patterns, []interface{}{"Branch Name Pattern"}, &api.Pagination{
+		PrintTable(patterns, []interface{}{"Branch Name Pattern"}, &apigen.Pagination{
 			HasMore: false,
 			Results: len(patterns),
 		}, len(patterns))
@@ -54,7 +54,7 @@ var branchProtectAddCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getClient()
 		u := MustParseRepoURI("repository", args[0])
-		resp, err := client.CreateBranchProtectionRuleWithResponse(cmd.Context(), u.Repository, api.CreateBranchProtectionRuleJSONRequestBody{
+		resp, err := client.CreateBranchProtectionRuleWithResponse(cmd.Context(), u.Repository, apigen.CreateBranchProtectionRuleJSONRequestBody{
 			Pattern: args[1],
 		})
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusNoContent)
@@ -72,7 +72,7 @@ var branchProtectDeleteCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getClient()
 		u := MustParseRepoURI("repository", args[0])
-		resp, err := client.DeleteBranchProtectionRuleWithResponse(cmd.Context(), u.Repository, api.DeleteBranchProtectionRuleJSONRequestBody{
+		resp, err := client.DeleteBranchProtectionRuleWithResponse(cmd.Context(), u.Repository, apigen.DeleteBranchProtectionRuleJSONRequestBody{
 			Pattern: args[1],
 		})
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusNoContent)

--- a/cmd/lakectl/cmd/branch_reset.go
+++ b/cmd/lakectl/cmd/branch_reset.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 
 	"github.com/spf13/cobra"
-	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 )
 
 // lakectl branch reset lakefs://myrepo/main --commit commitId --prefix path --object path
@@ -32,24 +32,24 @@ var branchResetCmd = &cobra.Command{
 			DieErr(err)
 		}
 
-		var reset api.ResetCreation
+		var reset apigen.ResetCreation
 		var confirmationMsg string
 		switch {
 		case len(prefix) > 0:
 			confirmationMsg = fmt.Sprintf("Are you sure you want to reset all uncommitted changes from path: %s", prefix)
-			reset = api.ResetCreation{
+			reset = apigen.ResetCreation{
 				Path: &prefix,
 				Type: "common_prefix",
 			}
 		case len(object) > 0:
 			confirmationMsg = fmt.Sprintf("Are you sure you want to reset all uncommitted changes for object: %s", object)
-			reset = api.ResetCreation{
+			reset = apigen.ResetCreation{
 				Path: &object,
 				Type: "object",
 			}
 		default:
 			confirmationMsg = "Are you sure you want to reset all uncommitted changes"
-			reset = api.ResetCreation{
+			reset = apigen.ResetCreation{
 				Type: "reset",
 			}
 		}
@@ -59,7 +59,7 @@ var branchResetCmd = &cobra.Command{
 			Die("Reset aborted", 1)
 			return
 		}
-		resp, err := clt.ResetBranchWithResponse(cmd.Context(), u.Repository, u.Ref, api.ResetBranchJSONRequestBody(reset))
+		resp, err := clt.ResetBranchWithResponse(cmd.Context(), u.Repository, u.Ref, apigen.ResetBranchJSONRequestBody(reset))
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusNoContent)
 	},
 }

--- a/cmd/lakectl/cmd/branch_revert.go
+++ b/cmd/lakectl/cmd/branch_revert.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 )
 
 const (
@@ -43,7 +43,7 @@ var branchRevertCmd = &cobra.Command{
 		clt := getClient()
 		for i := 1; i < len(args); i++ {
 			commitRef := args[i]
-			resp, err := clt.RevertBranchWithResponse(cmd.Context(), u.Repository, u.Ref, api.RevertBranchJSONRequestBody{
+			resp, err := clt.RevertBranchWithResponse(cmd.Context(), u.Repository, u.Ref, apigen.RevertBranchJSONRequestBody{
 				ParentNumber: parentNumber,
 				Ref:          commitRef,
 			})

--- a/cmd/lakectl/cmd/branch_tools.go
+++ b/cmd/lakectl/cmd/branch_tools.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"net/http"
 
-	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 	"github.com/treeverse/lakefs/pkg/metastore"
 )
 
@@ -30,7 +30,7 @@ func ExtractRepoAndBranchFromDBName(ctx context.Context, dbName string, client m
 // CreateBranch creates a new branch with the given repository, and source and destination branch names
 func CreateBranch(ctx context.Context, repository, sourceBranch, destinationBranch string) {
 	client := getClient()
-	resp, err := client.CreateBranchWithResponse(ctx, repository, api.CreateBranchJSONRequestBody{
+	resp, err := client.CreateBranchWithResponse(ctx, repository, apigen.CreateBranchJSONRequestBody{
 		Name:   destinationBranch,
 		Source: sourceBranch,
 	})

--- a/cmd/lakectl/cmd/cherry_pick.go
+++ b/cmd/lakectl/cmd/cherry_pick.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 
 	"github.com/spf13/cobra"
-	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 	"github.com/treeverse/lakefs/pkg/uri"
 )
 
@@ -44,7 +44,7 @@ var cherryPick = &cobra.Command{
 		}
 
 		clt := getClient()
-		resp, err := clt.CherryPickWithResponse(cmd.Context(), branch.Repository, branch.Ref, api.CherryPickJSONRequestBody{
+		resp, err := clt.CherryPickWithResponse(cmd.Context(), branch.Repository, branch.Ref, apigen.CherryPickJSONRequestBody{
 			Ref:          ref.Ref,
 			ParentNumber: &parentNumber,
 		})
@@ -52,7 +52,7 @@ var cherryPick = &cobra.Command{
 
 		Write(commitCreateTemplate, struct {
 			Branch *uri.URI
-			Commit *api.Commit
+			Commit *apigen.Commit
 		}{Branch: branch, Commit: resp.JSON201})
 	},
 }

--- a/cmd/lakectl/cmd/commit.go
+++ b/cmd/lakectl/cmd/commit.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 	"github.com/treeverse/lakefs/pkg/uri"
 )
 
@@ -59,11 +59,11 @@ var commitCmd = &cobra.Command{
 		fmt.Println("Branch:", branchURI)
 
 		// do commit
-		metadata := api.CommitCreation_Metadata{
+		metadata := apigen.CommitCreation_Metadata{
 			AdditionalProperties: kvPairs,
 		}
 		client := getClient()
-		resp, err := client.CommitWithResponse(cmd.Context(), branchURI.Repository, branchURI.Ref, &api.CommitParams{}, api.CommitJSONRequestBody{
+		resp, err := client.CommitWithResponse(cmd.Context(), branchURI.Repository, branchURI.Ref, &apigen.CommitParams{}, apigen.CommitJSONRequestBody{
 			Message:  message,
 			Metadata: &metadata,
 			Date:     datePtr,
@@ -76,7 +76,7 @@ var commitCmd = &cobra.Command{
 		commit := resp.JSON201
 		Write(commitCreateTemplate, struct {
 			Branch *uri.URI
-			Commit *api.Commit
+			Commit *apigen.Commit
 		}{Branch: branchURI, Commit: commit})
 	},
 }

--- a/cmd/lakectl/cmd/common_helpers.go
+++ b/cmd/lakectl/cmd/common_helpers.go
@@ -18,7 +18,7 @@ import (
 	"github.com/jedib0t/go-pretty/v6/text"
 	"github.com/manifoldco/promptui"
 	"github.com/spf13/pflag"
-	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 	"github.com/treeverse/lakefs/pkg/api/helpers"
 	"github.com/treeverse/lakefs/pkg/uri"
 	"golang.org/x/term"
@@ -184,7 +184,7 @@ func DieFmt(msg string, args ...interface{}) {
 }
 
 type APIError interface {
-	GetPayload() *api.Error
+	GetPayload() *apigen.Error
 }
 
 func DieErr(err error) {
@@ -250,7 +250,7 @@ func DieOnHTTPError(httpResponse *http.Response) {
 	}
 }
 
-func PrintTable(rows [][]interface{}, headers []interface{}, paginator *api.Pagination, amount int) {
+func PrintTable(rows [][]interface{}, headers []interface{}, paginator *apigen.Pagination, amount int) {
 	ctx := struct {
 		Table      *Table
 		Pagination *Pagination

--- a/cmd/lakectl/cmd/diff.go
+++ b/cmd/lakectl/cmd/diff.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 	"github.com/treeverse/lakefs/pkg/diff"
 	"github.com/treeverse/lakefs/pkg/uri"
 	"golang.org/x/sync/errgroup"
@@ -83,11 +84,11 @@ func (p *pageSize) Next() int {
 	return p.Value()
 }
 
-func printDiffBranch(ctx context.Context, client api.ClientWithResponsesInterface, repository string, branch string) {
+func printDiffBranch(ctx context.Context, client apigen.ClientWithResponsesInterface, repository string, branch string) {
 	var after string
 	pageSize := pageSize(minDiffPageSize)
 	for {
-		resp, err := client.DiffBranchWithResponse(ctx, repository, branch, &api.DiffBranchParams{
+		resp, err := client.DiffBranchWithResponse(ctx, repository, branch, &apigen.DiffBranchParams{
 			After:  api.PaginationAfterPtr(after),
 			Amount: api.PaginationAmountPtr(int(pageSize)),
 		})
@@ -108,8 +109,8 @@ func printDiffBranch(ctx context.Context, client api.ClientWithResponsesInterfac
 	}
 }
 
-func printDiffRefs(ctx context.Context, client api.ClientWithResponsesInterface, left, right *uri.URI, twoDot bool) {
-	diffs := make(chan api.Diff, maxDiffPageSize)
+func printDiffRefs(ctx context.Context, client apigen.ClientWithResponsesInterface, left, right *uri.URI, twoDot bool) {
+	diffs := make(chan apigen.Diff, maxDiffPageSize)
 	var wg errgroup.Group
 	wg.Go(func() error {
 		return diff.StreamRepositoryDiffs(ctx, client, left, right, "", diffs, twoDot)
@@ -122,7 +123,7 @@ func printDiffRefs(ctx context.Context, client api.ClientWithResponsesInterface,
 	}
 }
 
-func FmtDiff(d api.Diff, withDirection bool) {
+func FmtDiff(d apigen.Diff, withDirection bool) {
 	action, color := diff.Fmt(d.Type)
 
 	if !withDirection {

--- a/cmd/lakectl/cmd/diff.go
+++ b/cmd/lakectl/cmd/diff.go
@@ -7,8 +7,8 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/treeverse/lakefs/pkg/api"
 	"github.com/treeverse/lakefs/pkg/api/apigen"
+	"github.com/treeverse/lakefs/pkg/api/apiutil"
 	"github.com/treeverse/lakefs/pkg/diff"
 	"github.com/treeverse/lakefs/pkg/uri"
 	"golang.org/x/sync/errgroup"
@@ -89,8 +89,8 @@ func printDiffBranch(ctx context.Context, client apigen.ClientWithResponsesInter
 	pageSize := pageSize(minDiffPageSize)
 	for {
 		resp, err := client.DiffBranchWithResponse(ctx, repository, branch, &apigen.DiffBranchParams{
-			After:  api.PaginationAfterPtr(after),
-			Amount: api.PaginationAmountPtr(int(pageSize)),
+			After:  apiutil.Ptr(apigen.PaginationAfter(after)),
+			Amount: apiutil.Ptr(apigen.PaginationAmount(pageSize)),
 		})
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusOK)
 		if resp.JSON200 == nil {

--- a/cmd/lakectl/cmd/doctor.go
+++ b/cmd/lakectl/cmd/doctor.go
@@ -11,6 +11,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 )
 
 type Detailed interface {
@@ -132,7 +133,7 @@ func ListRepositoriesAndAnalyze(ctx context.Context) error {
 	}
 	client := getClient()
 	WriteIfVerbose(analyzingMessageTemplate, &UserMessage{Message: "Trying to run a sanity command using current configuration."})
-	resp, err := client.ListRepositoriesWithResponse(ctx, &api.ListRepositoriesParams{})
+	resp, err := client.ListRepositoriesWithResponse(ctx, &apigen.ListRepositoriesParams{})
 
 	switch {
 	case err != nil:

--- a/cmd/lakectl/cmd/doctor.go
+++ b/cmd/lakectl/cmd/doctor.go
@@ -10,8 +10,8 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"github.com/treeverse/lakefs/pkg/api"
 	"github.com/treeverse/lakefs/pkg/api/apigen"
+	"github.com/treeverse/lakefs/pkg/api/apiutil"
 )
 
 type Detailed interface {
@@ -110,7 +110,7 @@ var doctorCmd = &cobra.Command{
 
 		WriteIfVerbose(analyzingMessageTemplate, &UserMessage{Message: "Trying to validate endpoint URL format."})
 		serverEndpoint := string(cfg.Server.EndpointURL)
-		if !strings.HasSuffix(serverEndpoint, api.BaseURL) {
+		if !strings.HasSuffix(serverEndpoint, apiutil.BaseURL) {
 			Write(analyzingMessageTemplate, &UserMessage{Message: "Suspicious URI format for server.endpoint_url: " + serverEndpoint})
 		} else {
 			WriteIfVerbose(analyzingMessageTemplate, &UserMessage{Message: "Couldn't find a problem with endpoint URL format."})

--- a/cmd/lakectl/cmd/find_merge_base.go
+++ b/cmd/lakectl/cmd/find_merge_base.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 
 	"github.com/spf13/cobra"
-	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 )
 
 const (
@@ -50,7 +50,7 @@ var findMergeBaseCmd = &cobra.Command{
 
 		Write(findMergeBaseTemplate, struct {
 			Merge  FromToBase
-			Result *api.FindMergeBaseResult
+			Result *apigen.FindMergeBaseResult
 		}{
 			Merge: FromToBase{
 				FromRef: resp.JSON200.SourceCommitId,

--- a/cmd/lakectl/cmd/fs_cat.go
+++ b/cmd/lakectl/cmd/fs_cat.go
@@ -5,9 +5,10 @@ import (
 	"net/http"
 	"os"
 
+	"github.com/treeverse/lakefs/pkg/api/apigen"
+
 	"github.com/go-openapi/swag"
 	"github.com/spf13/cobra"
-	"github.com/treeverse/lakefs/pkg/api"
 	"github.com/treeverse/lakefs/pkg/api/helpers"
 )
 
@@ -31,7 +32,7 @@ var fsCatCmd = &cobra.Command{
 		} else {
 			preSign := swag.Bool(transport == transportMethodPreSign)
 			var resp *http.Response
-			resp, err = client.GetObject(cmd.Context(), pathURI.Repository, pathURI.Ref, &api.GetObjectParams{
+			resp, err = client.GetObject(cmd.Context(), pathURI.Repository, pathURI.Ref, &apigen.GetObjectParams{
 				Path:    *pathURI.Path,
 				Presign: preSign,
 			})

--- a/cmd/lakectl/cmd/fs_cat.go
+++ b/cmd/lakectl/cmd/fs_cat.go
@@ -5,10 +5,9 @@ import (
 	"net/http"
 	"os"
 
-	"github.com/treeverse/lakefs/pkg/api/apigen"
-
 	"github.com/go-openapi/swag"
 	"github.com/spf13/cobra"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 	"github.com/treeverse/lakefs/pkg/api/helpers"
 )
 

--- a/cmd/lakectl/cmd/fs_download.go
+++ b/cmd/lakectl/cmd/fs_download.go
@@ -14,6 +14,7 @@ import (
 	"github.com/go-openapi/swag"
 	"github.com/spf13/cobra"
 	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 	"github.com/treeverse/lakefs/pkg/api/helpers"
 	"github.com/treeverse/lakefs/pkg/uri"
 )
@@ -111,11 +112,11 @@ var fsDownloadCmd = &cobra.Command{
 	},
 }
 
-func listRecursiveHelper(ctx context.Context, client *api.ClientWithResponses, repo, ref, prefix string, ch chan string) {
-	pfx := api.PaginationPrefix(prefix)
+func listRecursiveHelper(ctx context.Context, client *apigen.ClientWithResponses, repo, ref, prefix string, ch chan string) {
+	pfx := apigen.PaginationPrefix(prefix)
 	var from string
 	for {
-		params := &api.ListObjectsParams{
+		params := &apigen.ListObjectsParams{
 			Prefix: &pfx,
 			After:  api.PaginationAfterPtr(from),
 		}
@@ -132,7 +133,7 @@ func listRecursiveHelper(ctx context.Context, client *api.ClientWithResponses, r
 	}
 }
 
-func downloadHelper(ctx context.Context, client *api.ClientWithResponses, method transportMethod, src uri.URI, dst string) error {
+func downloadHelper(ctx context.Context, client *apigen.ClientWithResponses, method transportMethod, src uri.URI, dst string) error {
 	body, err := getObjectHelper(ctx, client, method, src)
 	if err != nil {
 		return err
@@ -153,7 +154,7 @@ func downloadHelper(ctx context.Context, client *api.ClientWithResponses, method
 	return err
 }
 
-func getObjectHelper(ctx context.Context, client *api.ClientWithResponses, method transportMethod, src uri.URI) (io.ReadCloser, error) {
+func getObjectHelper(ctx context.Context, client *apigen.ClientWithResponses, method transportMethod, src uri.URI) (io.ReadCloser, error) {
 	if method == transportMethodDirect {
 		// download directly from storage
 		_, body, err := helpers.ClientDownload(ctx, client, src.Repository, src.Ref, *src.Path)
@@ -165,7 +166,7 @@ func getObjectHelper(ctx context.Context, client *api.ClientWithResponses, metho
 
 	// download from lakefs
 	preSign := swag.Bool(method == transportMethodPreSign)
-	resp, err := client.GetObject(ctx, src.Repository, src.Ref, &api.GetObjectParams{
+	resp, err := client.GetObject(ctx, src.Repository, src.Ref, &apigen.GetObjectParams{
 		Path:    *src.Path,
 		Presign: preSign,
 	})

--- a/cmd/lakectl/cmd/fs_download.go
+++ b/cmd/lakectl/cmd/fs_download.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/go-openapi/swag"
 	"github.com/spf13/cobra"
-	"github.com/treeverse/lakefs/pkg/api"
 	"github.com/treeverse/lakefs/pkg/api/apigen"
+	"github.com/treeverse/lakefs/pkg/api/apiutil"
 	"github.com/treeverse/lakefs/pkg/api/helpers"
 	"github.com/treeverse/lakefs/pkg/uri"
 )
@@ -52,7 +52,7 @@ var fsDownloadCmd = &cobra.Command{
 		// list the files
 		client := getClient()
 		downloadCh := make(chan string)
-		sourcePath := api.StringValue(pathURI.Path)
+		sourcePath := apiutil.Value(pathURI.Path)
 
 		// recursive assume the source is directory
 		if recursive && len(sourcePath) > 0 && !strings.HasSuffix(sourcePath, uri.PathSeparator) {
@@ -71,7 +71,7 @@ var fsDownloadCmd = &cobra.Command{
 			if recursive {
 				listRecursiveHelper(ctx, client, pathURI.Repository, pathURI.Ref, sourcePath, downloadCh)
 			} else {
-				downloadCh <- api.StringValue(pathURI.Path)
+				downloadCh <- apiutil.Value(pathURI.Path)
 			}
 		}()
 
@@ -118,7 +118,7 @@ func listRecursiveHelper(ctx context.Context, client *apigen.ClientWithResponses
 	for {
 		params := &apigen.ListObjectsParams{
 			Prefix: &pfx,
-			After:  api.PaginationAfterPtr(from),
+			After:  apiutil.Ptr(apigen.PaginationAfter(from)),
 		}
 		resp, err := client.ListObjectsWithResponse(ctx, repo, ref, params)
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusOK)

--- a/cmd/lakectl/cmd/fs_ls.go
+++ b/cmd/lakectl/cmd/fs_ls.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 )
 
 var fsLsCmd = &cobra.Command{
@@ -25,14 +26,14 @@ var fsLsCmd = &cobra.Command{
 			trimPrefix = prefix[:idx+1]
 		}
 		// delimiter used for listing
-		var paramsDelimiter api.PaginationDelimiter
+		var paramsDelimiter apigen.PaginationDelimiter
 		if !recursive {
 			paramsDelimiter = PathDelimiter
 		}
 		var from string
 		for {
-			pfx := api.PaginationPrefix(prefix)
-			params := &api.ListObjectsParams{
+			pfx := apigen.PaginationPrefix(prefix)
+			params := &apigen.ListObjectsParams{
 				Prefix:    &pfx,
 				After:     api.PaginationAfterPtr(from),
 				Delimiter: &paramsDelimiter,

--- a/cmd/lakectl/cmd/fs_ls.go
+++ b/cmd/lakectl/cmd/fs_ls.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"github.com/treeverse/lakefs/pkg/api"
 	"github.com/treeverse/lakefs/pkg/api/apigen"
+	"github.com/treeverse/lakefs/pkg/api/apiutil"
 )
 
 var fsLsCmd = &cobra.Command{
@@ -35,7 +35,7 @@ var fsLsCmd = &cobra.Command{
 			pfx := apigen.PaginationPrefix(prefix)
 			params := &apigen.ListObjectsParams{
 				Prefix:    &pfx,
-				After:     api.PaginationAfterPtr(from),
+				After:     apiutil.Ptr(apigen.PaginationAfter(from)),
 				Delimiter: &paramsDelimiter,
 			}
 			resp, err := client.ListObjectsWithResponse(cmd.Context(), pathURI.Repository, pathURI.Ref, params)

--- a/cmd/lakectl/cmd/fs_rm.go
+++ b/cmd/lakectl/cmd/fs_rm.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 	"github.com/treeverse/lakefs/pkg/uri"
 )
 
@@ -51,11 +52,11 @@ var fsRmCmd = &cobra.Command{
 		}
 
 		prefix := *pathURI.Path
-		var paramsDelimiter api.PaginationDelimiter = ""
+		var paramsDelimiter apigen.PaginationDelimiter = ""
 		var from string
-		pfx := api.PaginationPrefix(prefix)
+		pfx := apigen.PaginationPrefix(prefix)
 		for {
-			params := &api.ListObjectsParams{
+			params := &apigen.ListObjectsParams{
 				Prefix:    &pfx,
 				After:     api.PaginationAfterPtr(from),
 				Delimiter: &paramsDelimiter,
@@ -92,7 +93,7 @@ var fsRmCmd = &cobra.Command{
 	},
 }
 
-func deleteObjectWorker(ctx context.Context, client api.ClientWithResponsesInterface, paths <-chan *uri.URI, errors chan<- error, wg *sync.WaitGroup) {
+func deleteObjectWorker(ctx context.Context, client apigen.ClientWithResponsesInterface, paths <-chan *uri.URI, errors chan<- error, wg *sync.WaitGroup) {
 	defer wg.Done()
 	for pathURI := range paths {
 		err := deleteObject(ctx, client, pathURI)
@@ -103,8 +104,8 @@ func deleteObjectWorker(ctx context.Context, client api.ClientWithResponsesInter
 	}
 }
 
-func deleteObject(ctx context.Context, client api.ClientWithResponsesInterface, pathURI *uri.URI) error {
-	resp, err := client.DeleteObjectWithResponse(ctx, pathURI.Repository, pathURI.Ref, &api.DeleteObjectParams{
+func deleteObject(ctx context.Context, client apigen.ClientWithResponsesInterface, pathURI *uri.URI) error {
+	resp, err := client.DeleteObjectWithResponse(ctx, pathURI.Repository, pathURI.Ref, &apigen.DeleteObjectParams{
 		Path: *pathURI.Path,
 	})
 

--- a/cmd/lakectl/cmd/fs_rm.go
+++ b/cmd/lakectl/cmd/fs_rm.go
@@ -8,8 +8,8 @@ import (
 	"sync"
 
 	"github.com/spf13/cobra"
-	"github.com/treeverse/lakefs/pkg/api"
 	"github.com/treeverse/lakefs/pkg/api/apigen"
+	"github.com/treeverse/lakefs/pkg/api/apiutil"
 	"github.com/treeverse/lakefs/pkg/uri"
 )
 
@@ -58,7 +58,7 @@ var fsRmCmd = &cobra.Command{
 		for {
 			params := &apigen.ListObjectsParams{
 				Prefix:    &pfx,
-				After:     api.PaginationAfterPtr(from),
+				After:     apiutil.Ptr(apigen.PaginationAfter(from)),
 				Delimiter: &paramsDelimiter,
 			}
 			resp, err := client.ListObjectsWithResponse(cmd.Context(), pathURI.Repository, pathURI.Ref, params)

--- a/cmd/lakectl/cmd/fs_stage.go
+++ b/cmd/lakectl/cmd/fs_stage.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 
 	"github.com/spf13/cobra"
-	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 )
 
 var fsStageCmd = &cobra.Command{
@@ -29,7 +29,7 @@ var fsStageCmd = &cobra.Command{
 			mtime = &mtimeSeconds
 		}
 
-		obj := api.ObjectStageCreation{
+		obj := apigen.ObjectStageCreation{
 			Checksum:        checksum,
 			Mtime:           mtime,
 			PhysicalAddress: location,
@@ -37,15 +37,15 @@ var fsStageCmd = &cobra.Command{
 			ContentType:     &contentType,
 		}
 		if metaErr == nil {
-			metadata := api.ObjectUserMetadata{
+			metadata := apigen.ObjectUserMetadata{
 				AdditionalProperties: meta,
 			}
 			obj.Metadata = &metadata
 		}
 
-		resp, err := client.StageObjectWithResponse(cmd.Context(), pathURI.Repository, pathURI.Ref, &api.StageObjectParams{
+		resp, err := client.StageObjectWithResponse(cmd.Context(), pathURI.Repository, pathURI.Ref, &apigen.StageObjectParams{
 			Path: *pathURI.Path,
-		}, api.StageObjectJSONRequestBody(obj))
+		}, apigen.StageObjectJSONRequestBody(obj))
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusCreated)
 		if resp.JSON201 == nil {
 			Die("Bad response from server", 1)

--- a/cmd/lakectl/cmd/fs_stat.go
+++ b/cmd/lakectl/cmd/fs_stat.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/go-openapi/swag"
 	"github.com/spf13/cobra"
-	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 )
 
 var fsStatCmd = &cobra.Command{
@@ -17,7 +17,7 @@ var fsStatCmd = &cobra.Command{
 		pathURI := MustParsePathURI("path", args[0])
 		preSign := Must(cmd.Flags().GetBool("pre-sign"))
 		client := getClient()
-		resp, err := client.StatObjectWithResponse(cmd.Context(), pathURI.Repository, pathURI.Ref, &api.StatObjectParams{
+		resp, err := client.StatObjectWithResponse(cmd.Context(), pathURI.Repository, pathURI.Ref, &apigen.StatObjectParams{
 			Path:         *pathURI.Path,
 			Presign:      swag.Bool(preSign),
 			UserMetadata: swag.Bool(true),

--- a/cmd/lakectl/cmd/fs_upload.go
+++ b/cmd/lakectl/cmd/fs_upload.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 	"github.com/treeverse/lakefs/pkg/api/helpers"
 	"github.com/treeverse/lakefs/pkg/uri"
 )
@@ -80,7 +81,7 @@ var fsUploadCmd = &cobra.Command{
 	},
 }
 
-func upload(ctx context.Context, client api.ClientWithResponsesInterface, sourcePathname string, destURI *uri.URI, contentType string, method transportMethod) (*api.ObjectStats, error) {
+func upload(ctx context.Context, client apigen.ClientWithResponsesInterface, sourcePathname string, destURI *uri.URI, contentType string, method transportMethod) (*apigen.ObjectStats, error) {
 	fp := Must(OpenByPath(sourcePathname))
 	defer func() {
 		_ = fp.Close()

--- a/cmd/lakectl/cmd/fs_upload.go
+++ b/cmd/lakectl/cmd/fs_upload.go
@@ -8,8 +8,8 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"github.com/treeverse/lakefs/pkg/api"
 	"github.com/treeverse/lakefs/pkg/api/apigen"
+	"github.com/treeverse/lakefs/pkg/api/apiutil"
 	"github.com/treeverse/lakefs/pkg/api/helpers"
 	"github.com/treeverse/lakefs/pkg/uri"
 )
@@ -86,7 +86,7 @@ func upload(ctx context.Context, client apigen.ClientWithResponsesInterface, sou
 	defer func() {
 		_ = fp.Close()
 	}()
-	objectPath := api.StringValue(destURI.Path)
+	objectPath := apiutil.Value(destURI.Path)
 	switch method {
 	case transportMethodDefault:
 		return helpers.ClientUpload(ctx, client, destURI.Repository, destURI.Ref, objectPath, nil, contentType, fp)

--- a/cmd/lakectl/cmd/gc_set_config.go
+++ b/cmd/lakectl/cmd/gc_set_config.go
@@ -7,7 +7,7 @@ import (
 	"os"
 
 	"github.com/spf13/cobra"
-	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 )
 
 const (
@@ -51,7 +51,7 @@ Example configuration file:
 				_ = reader.Close()
 			}()
 		}
-		var body api.SetGarbageCollectionRulesJSONRequestBody
+		var body apigen.SetGarbageCollectionRulesJSONRequestBody
 		err = json.NewDecoder(reader).Decode(&body)
 		if err != nil {
 			DieErr(err)

--- a/cmd/lakectl/cmd/import.go
+++ b/cmd/lakectl/cmd/import.go
@@ -12,8 +12,8 @@ import (
 
 	"github.com/schollz/progressbar/v3"
 	"github.com/spf13/cobra"
-	"github.com/treeverse/lakefs/pkg/api"
 	"github.com/treeverse/lakefs/pkg/api/apigen"
+	"github.com/treeverse/lakefs/pkg/api/apiutil"
 )
 
 const importSummaryTemplate = `Import of {{ .Objects | yellow }} object(s) into "{{.Branch}}" completed.
@@ -58,7 +58,7 @@ var importCmd = &cobra.Command{
 			},
 			Paths: []apigen.ImportLocation{
 				{
-					Destination: api.StringValue(toURI.Path),
+					Destination: apiutil.Value(toURI.Path),
 					Path:        from,
 					Type:        "common_prefix",
 				},
@@ -129,8 +129,8 @@ var importCmd = &cobra.Command{
 			Branch      string
 			Commit      *apigen.Commit
 		}{
-			Objects:     api.Int64Value(statusResp.JSON200.IngestedObjects),
-			MetaRangeID: api.StringValue(statusResp.JSON200.MetarangeId),
+			Objects:     apiutil.Value(statusResp.JSON200.IngestedObjects),
+			MetaRangeID: apiutil.Value(statusResp.JSON200.MetarangeId),
 			Branch:      toURI.Ref,
 			Commit:      statusResp.JSON200.Commit,
 		})

--- a/cmd/lakectl/cmd/ingest.go
+++ b/cmd/lakectl/cmd/ingest.go
@@ -9,8 +9,8 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/treeverse/lakefs/pkg/api"
 	"github.com/treeverse/lakefs/pkg/api/apigen"
+	"github.com/treeverse/lakefs/pkg/api/apiutil"
 	"github.com/treeverse/lakefs/pkg/block"
 	"github.com/treeverse/lakefs/pkg/ingest/store"
 )
@@ -117,7 +117,7 @@ var ingestCmd = &cobra.Command{
 		elapsed := time.Now()
 		for response := range responses {
 			summary.Objects += 1
-			summary.Bytes += api.Int64Value(response.JSON201.SizeBytes)
+			summary.Bytes += apiutil.Value(response.JSON201.SizeBytes)
 
 			if verbose {
 				Write("Staged "+fsStatTemplate+"\n", response.JSON201)

--- a/cmd/lakectl/cmd/local.go
+++ b/cmd/lakectl/cmd/local.go
@@ -12,7 +12,7 @@ import (
 
 	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
-	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 	"github.com/treeverse/lakefs/pkg/git"
 	"github.com/treeverse/lakefs/pkg/local"
 	"github.com/treeverse/lakefs/pkg/uri"
@@ -82,7 +82,7 @@ type syncFlags struct {
 	presign     bool
 }
 
-func getLocalSyncFlags(cmd *cobra.Command, client *api.ClientWithResponses) syncFlags {
+func getLocalSyncFlags(cmd *cobra.Command, client *apigen.ClientWithResponses) syncFlags {
 	presign := Must(cmd.Flags().GetBool(localPresignFlagName))
 	presignFlag := cmd.Flags().Lookup(localPresignFlagName)
 	if !presignFlag.Changed {
@@ -125,9 +125,9 @@ func getLocalArgs(args []string, requireRemote bool, considerGitRoot bool) (remo
 	return
 }
 
-func localDiff(ctx context.Context, client api.ClientWithResponsesInterface, remote *uri.URI, path string) local.Changes {
+func localDiff(ctx context.Context, client apigen.ClientWithResponsesInterface, remote *uri.URI, path string) local.Changes {
 	fmt.Printf("\ndiff 'local://%s' <--> '%s'...\n", path, remote)
-	currentRemoteState := make(chan api.ObjectStats, maxDiffPageSize)
+	currentRemoteState := make(chan apigen.ObjectStats, maxDiffPageSize)
 	var wg errgroup.Group
 	wg.Go(func() error {
 		return local.ListRemote(ctx, client, remote, currentRemoteState)

--- a/cmd/lakectl/cmd/local_clone.go
+++ b/cmd/lakectl/cmd/local_clone.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/go-openapi/swag"
 	"github.com/spf13/cobra"
-	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 	"github.com/treeverse/lakefs/pkg/fileutil"
 	"github.com/treeverse/lakefs/pkg/local"
 	"github.com/treeverse/lakefs/pkg/uri"
@@ -52,9 +52,9 @@ var localCloneCmd = &cobra.Command{
 			remotePath := remote.GetPath()
 			var after string
 			for {
-				listResp, err := client.ListObjectsWithResponse(ctx, remote.Repository, stableRemote.Ref, &api.ListObjectsParams{
-					After:        (*api.PaginationAfter)(swag.String(after)),
-					Prefix:       (*api.PaginationPrefix)(remote.Path),
+				listResp, err := client.ListObjectsWithResponse(ctx, remote.Repository, stableRemote.Ref, &apigen.ListObjectsParams{
+					After:        (*apigen.PaginationAfter)(swag.String(after)),
+					Prefix:       (*apigen.PaginationPrefix)(remote.Path),
 					UserMetadata: swag.Bool(true),
 				})
 				DieOnErrorOrUnexpectedStatusCode(listResp, err, http.StatusOK)

--- a/cmd/lakectl/cmd/local_commit.go
+++ b/cmd/lakectl/cmd/local_commit.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/go-openapi/swag"
 	"github.com/spf13/cobra"
-	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 	"github.com/treeverse/lakefs/pkg/diff"
 	"github.com/treeverse/lakefs/pkg/git"
 	"github.com/treeverse/lakefs/pkg/local"
@@ -72,7 +72,7 @@ var localCommitCmd = &cobra.Command{
 		if branchCommit != idx.AtHead { // check for changes and conflicts with new head
 			newRemote := remote.WithRef(branchCommit)
 			fmt.Printf("\ndiff '%s' <--> '%s'...\n", newRemote, remote)
-			d := make(chan api.Diff, maxDiffPageSize)
+			d := make(chan apigen.Diff, maxDiffPageSize)
 			var wg errgroup.Group
 			wg.Go(func() error {
 				return diff.StreamRepositoryDiffs(cmd.Context(), client, baseRemote, newRemote, swag.StringValue(remote.Path), d, false)
@@ -151,9 +151,9 @@ var localCommitCmd = &cobra.Command{
 		}
 
 		// commit!
-		response, err := client.CommitWithResponse(cmd.Context(), remote.Repository, remote.Ref, &api.CommitParams{}, api.CommitJSONRequestBody{
+		response, err := client.CommitWithResponse(cmd.Context(), remote.Repository, remote.Ref, &apigen.CommitParams{}, apigen.CommitJSONRequestBody{
 			Message: message,
-			Metadata: &api.CommitCreation_Metadata{
+			Metadata: &apigen.CommitCreation_Metadata{
 				AdditionalProperties: kvPairs,
 			},
 		})
@@ -170,7 +170,7 @@ var localCommitCmd = &cobra.Command{
 
 		Write(commitCreateTemplate, struct {
 			Branch *uri.URI
-			Commit *api.Commit
+			Commit *apigen.Commit
 		}{Branch: branchURI, Commit: commit})
 
 		newHead := response.JSON201.Id

--- a/cmd/lakectl/cmd/local_init.go
+++ b/cmd/lakectl/cmd/local_init.go
@@ -10,7 +10,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 	"github.com/treeverse/lakefs/pkg/git"
 	"github.com/treeverse/lakefs/pkg/local"
 	"github.com/treeverse/lakefs/pkg/uri"
@@ -29,7 +29,7 @@ func localInit(ctx context.Context, dir string, remote *uri.URI, force, updateIg
 
 	remotePath := remote.GetPath()
 	if remotePath != "" && !strings.HasSuffix(remotePath, uri.PathSeparator) { // Verify path is not an existing object
-		stat, err := client.StatObjectWithResponse(ctx, remote.Repository, remote.Ref, &api.StatObjectParams{
+		stat, err := client.StatObjectWithResponse(ctx, remote.Repository, remote.Ref, &apigen.StatObjectParams{
 			Path: *remote.Path,
 		})
 		switch {

--- a/cmd/lakectl/cmd/local_pull.go
+++ b/cmd/lakectl/cmd/local_pull.go
@@ -6,7 +6,7 @@ import (
 
 	"github.com/go-openapi/swag"
 	"github.com/spf13/cobra"
-	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 	"github.com/treeverse/lakefs/pkg/diff"
 	"github.com/treeverse/lakefs/pkg/local"
 	"golang.org/x/sync/errgroup"
@@ -48,7 +48,7 @@ var localPullCmd = &cobra.Command{
 			DieErr(err)
 		}
 		newBase := remote.WithRef(newHead)
-		d := make(chan api.Diff, maxDiffPageSize)
+		d := make(chan apigen.Diff, maxDiffPageSize)
 		var wg errgroup.Group
 		wg.Go(func() error {
 			return diff.StreamRepositoryDiffs(cmd.Context(), client, currentBase, newBase, swag.StringValue(currentBase.Path), d, false)

--- a/cmd/lakectl/cmd/local_status.go
+++ b/cmd/lakectl/cmd/local_status.go
@@ -8,7 +8,7 @@ import (
 	"github.com/go-openapi/swag"
 	"github.com/jedib0t/go-pretty/v6/table"
 	"github.com/spf13/cobra"
-	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 	"github.com/treeverse/lakefs/pkg/diff"
 	"github.com/treeverse/lakefs/pkg/local"
 	"golang.org/x/sync/errgroup"
@@ -46,7 +46,7 @@ var localStatusCmd = &cobra.Command{
 		// compare both
 		if !localOnly {
 			fmt.Printf("diff '%s' <--> '%s'...\n", remoteBase, remote)
-			d := make(chan api.Diff, maxDiffPageSize)
+			d := make(chan apigen.Diff, maxDiffPageSize)
 			var wg errgroup.Group
 			wg.Go(func() error {
 				return diff.StreamRepositoryDiffs(cmd.Context(), client, remoteBase, remote, swag.StringValue(remoteBase.Path), d, false)

--- a/cmd/lakectl/cmd/log.go
+++ b/cmd/lakectl/cmd/log.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"github.com/treeverse/lakefs/pkg/api"
 	"github.com/treeverse/lakefs/pkg/api/apigen"
+	"github.com/treeverse/lakefs/pkg/api/apiutil"
 	"golang.org/x/exp/slices"
 )
 
@@ -98,8 +98,8 @@ var logCmd = &cobra.Command{
 			amountForPagination = internalPageSize
 		}
 		logCommitsParams := &apigen.LogCommitsParams{
-			After:       api.PaginationAfterPtr(after),
-			Amount:      api.PaginationAmountPtr(amountForPagination),
+			After:       apiutil.Ptr(apigen.PaginationAfter(after)),
+			Amount:      apiutil.Ptr(apigen.PaginationAmount(amountForPagination)),
 			Limit:       &limit,
 			FirstParent: &firstParent,
 		}
@@ -125,7 +125,7 @@ var logCmd = &cobra.Command{
 				Die("Bad response from server", 1)
 			}
 			pagination = resp.JSON200.Pagination
-			logCommitsParams.After = api.PaginationAfterPtr(pagination.NextOffset)
+			logCommitsParams.After = apiutil.Ptr(apigen.PaginationAfter(pagination.NextOffset))
 			data := struct {
 				Commits         []apigen.Commit
 				Pagination      *Pagination

--- a/cmd/lakectl/cmd/log.go
+++ b/cmd/lakectl/cmd/log.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 	"golang.org/x/exp/slices"
 )
 
@@ -46,7 +47,7 @@ func (d *dotWriter) End() {
 	_, _ = fmt.Fprint(d.w, "\n}\n")
 }
 
-func (d *dotWriter) Write(commits []api.Commit) {
+func (d *dotWriter) Write(commits []apigen.Commit) {
 	repoID := url.PathEscape(d.repositoryID)
 	for _, commit := range commits {
 		isMerge := len(commit.Parents) > 1
@@ -88,7 +89,7 @@ var logCmd = &cobra.Command{
 			Die("Prefixes list contains empty string!", 1)
 		}
 
-		pagination := api.Pagination{HasMore: true}
+		pagination := apigen.Pagination{HasMore: true}
 		showMetaRangeID := Must(cmd.Flags().GetBool("show-meta-range-id"))
 		client := getClient()
 		branchURI := MustParseRefURI("branch", args[0])
@@ -96,7 +97,7 @@ var logCmd = &cobra.Command{
 		if amountForPagination <= 0 {
 			amountForPagination = internalPageSize
 		}
-		logCommitsParams := &api.LogCommitsParams{
+		logCommitsParams := &apigen.LogCommitsParams{
 			After:       api.PaginationAfterPtr(after),
 			Amount:      api.PaginationAmountPtr(amountForPagination),
 			Limit:       &limit,
@@ -126,7 +127,7 @@ var logCmd = &cobra.Command{
 			pagination = resp.JSON200.Pagination
 			logCommitsParams.After = api.PaginationAfterPtr(pagination.NextOffset)
 			data := struct {
-				Commits         []api.Commit
+				Commits         []apigen.Commit
 				Pagination      *Pagination
 				ShowMetaRangeID bool
 			}{

--- a/cmd/lakectl/cmd/merge.go
+++ b/cmd/lakectl/cmd/merge.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 
 	"github.com/spf13/cobra"
-	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 )
 
 const (
@@ -48,7 +48,7 @@ var mergeCmd = &cobra.Command{
 			Die("Invalid strategy value. Expected \"dest-wins\" or \"source-wins\"", 1)
 		}
 
-		resp, err := client.MergeIntoBranchWithResponse(cmd.Context(), destinationRef.Repository, sourceRef.Ref, destinationRef.Ref, api.MergeIntoBranchJSONRequestBody{Strategy: &strategy})
+		resp, err := client.MergeIntoBranchWithResponse(cmd.Context(), destinationRef.Repository, sourceRef.Ref, destinationRef.Ref, apigen.MergeIntoBranchJSONRequestBody{Strategy: &strategy})
 		if resp != nil && resp.JSON409 != nil {
 			Die("Conflict found.", 1)
 		}
@@ -59,7 +59,7 @@ var mergeCmd = &cobra.Command{
 
 		Write(mergeCreateTemplate, struct {
 			Merge  FromTo
-			Result *api.MergeResult
+			Result *apigen.MergeResult
 		}{
 			Merge: FromTo{
 				FromRef: sourceRef.Ref,

--- a/cmd/lakectl/cmd/metastore_create_symlink.go
+++ b/cmd/lakectl/cmd/metastore_create_symlink.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 	"github.com/treeverse/lakefs/pkg/metastore"
 )
 
@@ -28,7 +28,7 @@ var metastoreCreateSymlinkCmd = &cobra.Command{
 		defer fromClientDeferFunc()
 		defer toClientDeferFunc()
 
-		resp, err := apiClient.CreateSymlinkFileWithResponse(cmd.Context(), repo, branch, &api.CreateSymlinkFileParams{Location: &path})
+		resp, err := apiClient.CreateSymlinkFileWithResponse(cmd.Context(), repo, branch, &apigen.CreateSymlinkFileParams{Location: &path})
 		if err != nil {
 			DieErr(err)
 		}

--- a/cmd/lakectl/cmd/refs_restore.go
+++ b/cmd/lakectl/cmd/refs_restore.go
@@ -7,7 +7,7 @@ import (
 	"net/http"
 
 	"github.com/spf13/cobra"
-	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 )
 
 const refsRestoreSuccess = `
@@ -38,14 +38,14 @@ Since a bare repo is expected, in case of transient failure, delete the reposito
 		if err != nil {
 			DieErr(err)
 		}
-		var manifest api.RefsDump
+		var manifest apigen.RefsDump
 		err = json.Unmarshal(data, &manifest)
 		if err != nil {
 			DieErr(err)
 		}
 		// execute the restore operation
 		client := getClient()
-		resp, err := client.RestoreRefsWithResponse(cmd.Context(), repoURI.Repository, api.RestoreRefsJSONRequestBody(manifest))
+		resp, err := client.RestoreRefsWithResponse(cmd.Context(), repoURI.Repository, apigen.RestoreRefsJSONRequestBody(manifest))
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusOK)
 		Write(refsRestoreSuccess, nil)
 	},

--- a/cmd/lakectl/cmd/repo_create.go
+++ b/cmd/lakectl/cmd/repo_create.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 
 	"github.com/spf13/cobra"
-	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 )
 
 const (
@@ -31,8 +31,8 @@ var repoCreateCmd = &cobra.Command{
 			DieErr(err)
 		}
 		resp, err := clt.CreateRepositoryWithResponse(cmd.Context(),
-			&api.CreateRepositoryParams{},
-			api.CreateRepositoryJSONRequestBody{
+			&apigen.CreateRepositoryParams{},
+			apigen.CreateRepositoryJSONRequestBody{
 				Name:             u.Repository,
 				StorageNamespace: args[1],
 				DefaultBranch:    &defaultBranch,

--- a/cmd/lakectl/cmd/repo_create_bare.go
+++ b/cmd/lakectl/cmd/repo_create_bare.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 
 	"github.com/spf13/cobra"
-	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 )
 
 // repoCreateBareCmd represents the create repo command
@@ -26,9 +26,9 @@ var repoCreateBareCmd = &cobra.Command{
 			DieErr(err)
 		}
 		bareRepo := true
-		resp, err := clt.CreateRepositoryWithResponse(cmd.Context(), &api.CreateRepositoryParams{
+		resp, err := clt.CreateRepositoryWithResponse(cmd.Context(), &apigen.CreateRepositoryParams{
 			Bare: &bareRepo,
-		}, api.CreateRepositoryJSONRequestBody{
+		}, apigen.CreateRepositoryJSONRequestBody{
 			DefaultBranch:    &defaultBranch,
 			Name:             u.Repository,
 			StorageNamespace: args[1],

--- a/cmd/lakectl/cmd/repo_list.go
+++ b/cmd/lakectl/cmd/repo_list.go
@@ -5,8 +5,8 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/treeverse/lakefs/pkg/api"
 	"github.com/treeverse/lakefs/pkg/api/apigen"
+	"github.com/treeverse/lakefs/pkg/api/apiutil"
 )
 
 var repoListCmd = &cobra.Command{
@@ -22,8 +22,8 @@ var repoListCmd = &cobra.Command{
 		clt := getClient()
 
 		resp, err := clt.ListRepositoriesWithResponse(cmd.Context(), &apigen.ListRepositoriesParams{
-			After:  api.PaginationAfterPtr(after),
-			Amount: api.PaginationAmountPtr(amount),
+			After:  apiutil.Ptr(apigen.PaginationAfter(after)),
+			Amount: apiutil.Ptr(apigen.PaginationAmount(amount)),
 		})
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusOK)
 		if resp.JSON200 == nil {

--- a/cmd/lakectl/cmd/repo_list.go
+++ b/cmd/lakectl/cmd/repo_list.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 )
 
 var repoListCmd = &cobra.Command{
@@ -20,7 +21,7 @@ var repoListCmd = &cobra.Command{
 		after := Must(cmd.Flags().GetString("after"))
 		clt := getClient()
 
-		resp, err := clt.ListRepositoriesWithResponse(cmd.Context(), &api.ListRepositoriesParams{
+		resp, err := clt.ListRepositoriesWithResponse(cmd.Context(), &apigen.ListRepositoriesParams{
 			After:  api.PaginationAfterPtr(after),
 			Amount: api.PaginationAmountPtr(amount),
 		})

--- a/cmd/lakectl/cmd/root.go
+++ b/cmd/lakectl/cmd/root.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
-	"net/url"
 	"os"
 	"reflect"
 	"strings"
@@ -15,8 +14,8 @@ import (
 	"github.com/mitchellh/mapstructure"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
-	"github.com/treeverse/lakefs/pkg/api"
 	"github.com/treeverse/lakefs/pkg/api/apigen"
+	"github.com/treeverse/lakefs/pkg/api/apiutil"
 	lakefsconfig "github.com/treeverse/lakefs/pkg/config"
 	"github.com/treeverse/lakefs/pkg/logging"
 	"github.com/treeverse/lakefs/pkg/version"
@@ -261,14 +260,9 @@ func getClient() *apigen.ClientWithResponses {
 		DieErr(err)
 	}
 
-	serverEndpoint := cfg.Server.EndpointURL.String()
-	u, err := url.Parse(serverEndpoint)
+	serverEndpoint, err := apiutil.NormalizeLakeFSEndpoint(cfg.Server.EndpointURL.String())
 	if err != nil {
 		DieErr(err)
-	}
-	// if no uri to api is set in configuration - set the default
-	if u.Path == "" || u.Path == "/" {
-		serverEndpoint = strings.TrimRight(serverEndpoint, "/") + api.BaseURL
 	}
 
 	client, err := apigen.NewClientWithResponses(

--- a/cmd/lakectl/cmd/root.go
+++ b/cmd/lakectl/cmd/root.go
@@ -16,6 +16,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 	lakefsconfig "github.com/treeverse/lakefs/pkg/config"
 	"github.com/treeverse/lakefs/pkg/logging"
 	"github.com/treeverse/lakefs/pkg/version"
@@ -216,13 +217,13 @@ var excludeStatsCmds = []string{
 	"config",
 }
 
-func sendStats(ctx context.Context, client api.ClientWithResponsesInterface, cmd string) {
+func sendStats(ctx context.Context, client apigen.ClientWithResponsesInterface, cmd string) {
 	if version.IsVersionUnreleased() {
 		return
 	}
 
-	resp, err := client.PostStatsEventsWithResponse(ctx, api.PostStatsEventsJSONRequestBody{
-		Events: []api.StatsEvent{
+	resp, err := client.PostStatsEventsWithResponse(ctx, apigen.PostStatsEventsJSONRequestBody{
+		Events: []apigen.StatsEvent{
 			{
 				Class: "lakectl",
 				Name:  cmd,
@@ -242,7 +243,7 @@ func sendStats(ctx context.Context, client api.ClientWithResponsesInterface, cmd
 	}
 }
 
-func getClient() *api.ClientWithResponses {
+func getClient() *apigen.ClientWithResponses {
 	// Override MaxIdleConnsPerHost to allow highly concurrent access to our API client.
 	// This is done to avoid accumulating many sockets in `TIME_WAIT` status that were closed
 	// only to be immediately reopened.
@@ -270,11 +271,11 @@ func getClient() *api.ClientWithResponses {
 		serverEndpoint = strings.TrimRight(serverEndpoint, "/") + api.BaseURL
 	}
 
-	client, err := api.NewClientWithResponses(
+	client, err := apigen.NewClientWithResponses(
 		serverEndpoint,
-		api.WithHTTPClient(httpClient),
-		api.WithRequestEditorFn(basicAuthProvider.Intercept),
-		api.WithRequestEditorFn(func(ctx context.Context, req *http.Request) error {
+		apigen.WithHTTPClient(httpClient),
+		apigen.WithRequestEditorFn(basicAuthProvider.Intercept),
+		apigen.WithRequestEditorFn(func(ctx context.Context, req *http.Request) error {
 			req.Header.Set("User-Agent", "lakectl/"+version.Version)
 			return nil
 		}),

--- a/cmd/lakectl/cmd/show_commit.go
+++ b/cmd/lakectl/cmd/show_commit.go
@@ -4,7 +4,7 @@ import (
 	"net/http"
 
 	"github.com/spf13/cobra"
-	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 )
 
 // showCommitCmd represents the show command
@@ -27,11 +27,11 @@ var showCommitCmd = &cobra.Command{
 
 		commit := resp.JSON200
 		commits := struct {
-			Commits         []*api.Commit
+			Commits         []*apigen.Commit
 			Pagination      *Pagination
 			ShowMetaRangeID bool
 		}{
-			Commits:         []*api.Commit{commit},
+			Commits:         []*apigen.Commit{commit},
 			ShowMetaRangeID: showMetaRangeID,
 		}
 

--- a/cmd/lakectl/cmd/tag_create.go
+++ b/cmd/lakectl/cmd/tag_create.go
@@ -5,7 +5,7 @@ import (
 	"net/http"
 
 	"github.com/spf13/cobra"
-	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 )
 
 const tagCreateRequiredArgs = 2
@@ -48,7 +48,7 @@ var tagCreateCmd = &cobra.Command{
 			}
 		}
 
-		resp, err := client.CreateTagWithResponse(ctx, tagURI.Repository, api.CreateTagJSONRequestBody{
+		resp, err := client.CreateTagWithResponse(ctx, tagURI.Repository, apigen.CreateTagJSONRequestBody{
 			Id:  tagURI.Ref,
 			Ref: commitURI.Ref,
 		})

--- a/cmd/lakectl/cmd/tag_list.go
+++ b/cmd/lakectl/cmd/tag_list.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 )
 
 var tagListCmd = &cobra.Command{
@@ -21,7 +22,7 @@ var tagListCmd = &cobra.Command{
 
 		ctx := cmd.Context()
 		client := getClient()
-		resp, err := client.ListTagsWithResponse(ctx, u.Repository, &api.ListTagsParams{
+		resp, err := client.ListTagsWithResponse(ctx, u.Repository, &apigen.ListTagsParams{
 			After:  api.PaginationAfterPtr(after),
 			Amount: api.PaginationAmountPtr(amount),
 		})

--- a/cmd/lakectl/cmd/tag_list.go
+++ b/cmd/lakectl/cmd/tag_list.go
@@ -4,8 +4,8 @@ import (
 	"net/http"
 
 	"github.com/spf13/cobra"
-	"github.com/treeverse/lakefs/pkg/api"
 	"github.com/treeverse/lakefs/pkg/api/apigen"
+	"github.com/treeverse/lakefs/pkg/api/apiutil"
 )
 
 var tagListCmd = &cobra.Command{
@@ -23,8 +23,8 @@ var tagListCmd = &cobra.Command{
 		ctx := cmd.Context()
 		client := getClient()
 		resp, err := client.ListTagsWithResponse(ctx, u.Repository, &apigen.ListTagsParams{
-			After:  api.PaginationAfterPtr(after),
-			Amount: api.PaginationAmountPtr(amount),
+			After:  apiutil.Ptr(apigen.PaginationAfter(after)),
+			Amount: apiutil.Ptr(apigen.PaginationAmount(amount)),
 		})
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusOK)
 		if resp.JSON200 == nil {

--- a/cmd/lakectl/cmd/validargs.go
+++ b/cmd/lakectl/cmd/validargs.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 	"github.com/treeverse/lakefs/pkg/uri"
 )
 
@@ -24,10 +25,10 @@ func validRepositoryToComplete(ctx context.Context, toComplete string) ([]string
 	}
 
 	// extract repository name written so far
-	var prefix api.PaginationPrefix
+	var prefix apigen.PaginationPrefix
 	if strings.HasPrefix(toComplete, uriPrefix) {
 		if !strings.Contains(toComplete[len(uriPrefix):], uri.PathSeparator) {
-			prefix = api.PaginationPrefix(toComplete[len(uriPrefix):])
+			prefix = apigen.PaginationPrefix(toComplete[len(uriPrefix):])
 		}
 	}
 
@@ -38,7 +39,7 @@ func validRepositoryToComplete(ctx context.Context, toComplete string) ([]string
 		after       string
 	)
 	for {
-		params := &api.ListRepositoriesParams{
+		params := &apigen.ListRepositoriesParams{
 			Prefix: &prefix,
 			After:  api.PaginationAfterPtr(after),
 		}

--- a/cmd/lakectl/cmd/validargs.go
+++ b/cmd/lakectl/cmd/validargs.go
@@ -5,8 +5,8 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"github.com/treeverse/lakefs/pkg/api"
 	"github.com/treeverse/lakefs/pkg/api/apigen"
+	"github.com/treeverse/lakefs/pkg/api/apiutil"
 	"github.com/treeverse/lakefs/pkg/uri"
 )
 
@@ -41,7 +41,7 @@ func validRepositoryToComplete(ctx context.Context, toComplete string) ([]string
 	for {
 		params := &apigen.ListRepositoriesParams{
 			Prefix: &prefix,
-			After:  api.PaginationAfterPtr(after),
+			After:  apiutil.Ptr(apigen.PaginationAfter(after)),
 		}
 		resp, err := clt.ListRepositoriesWithResponse(ctx, params)
 		result := resp.JSON200

--- a/cmd/lakefs/cmd/root.go
+++ b/cmd/lakefs/cmd/root.go
@@ -122,7 +122,7 @@ func initConfig() {
 	// read in environment variables
 	viper.AutomaticEnv()
 
-	// read configuration file
+	// read the configuration file
 	err := viper.ReadInConfig()
 	logger = logger.WithField("file", viper.ConfigFileUsed()) // should be called after SetConfigFile
 	var errFileNotFound viper.ConfigFileNotFoundError
@@ -130,7 +130,7 @@ func initConfig() {
 		logger.WithError(err).Fatal("Failed to find a config file")
 	}
 	// fallback - try to load the previous supported $HOME/.lakefs.yaml
-	//   if err is set it will be file-not-found based on previous check
+	//   if err is set it will be file-not-found based on the previous check
 	if err != nil {
 		fallbackCfgFile := path.Join(getHomeDir(), ".lakefs.yaml")
 		if cfgFile != fallbackCfgFile {

--- a/esti/auth_test.go
+++ b/esti/auth_test.go
@@ -7,7 +7,7 @@ import (
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
-	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 	"github.com/treeverse/lakefs/pkg/logging"
 	"github.com/treeverse/lakefs/pkg/testutil"
 )
@@ -19,14 +19,14 @@ func TestAdminPermissions(t *testing.T) {
 
 	// creating new group should succeed
 	const gid = "TestGroup"
-	resCreateGroup, err := client.CreateGroupWithResponse(ctx, api.CreateGroupJSONRequestBody{
+	resCreateGroup, err := client.CreateGroupWithResponse(ctx, apigen.CreateGroupJSONRequestBody{
 		Id: gid,
 	})
 	require.NoError(t, err, "Admin failed while creating group")
 	require.Equal(t, http.StatusCreated, resCreateGroup.StatusCode(), "Admin unexpectedly failed to create group")
 
 	// setting a group ACL should succeed
-	resSetACL, err := client.SetGroupACLWithResponse(ctx, gid, api.SetGroupACLJSONRequestBody{
+	resSetACL, err := client.SetGroupACLWithResponse(ctx, gid, apigen.SetGroupACLJSONRequestBody{
 		Permission: "Write",
 	})
 	require.NoError(t, err, "Admin failed while setting group ACL")
@@ -34,7 +34,7 @@ func TestAdminPermissions(t *testing.T) {
 
 	// creating a new user should succeed
 	const uid = "test-user"
-	resCreateUser, err := client.CreateUserWithResponse(ctx, api.CreateUserJSONRequestBody{
+	resCreateUser, err := client.CreateUserWithResponse(ctx, apigen.CreateUserJSONRequestBody{
 		Id: uid,
 	})
 	require.NoError(t, err, "Admin failed while creating user")
@@ -59,7 +59,7 @@ func TestSuperPermissions(t *testing.T) {
 	superClient := newClientFromGroup(t, ctx, logger, "super", []string{"Supers", "SuperUsers"})
 
 	// listing the available branches should succeed
-	resListBranches, err := superClient.ListBranchesWithResponse(ctx, repo, &api.ListBranchesParams{})
+	resListBranches, err := superClient.ListBranchesWithResponse(ctx, repo, &apigen.ListBranchesParams{})
 	require.NoError(t, err, "Super unexpectedly failed while listing branches of repository")
 	require.Equal(t, http.StatusOK, resListBranches.StatusCode(), "Super unexpectedly failed to list branches of repository")
 
@@ -72,7 +72,7 @@ func TestSuperPermissions(t *testing.T) {
 
 	// creating a branch should succeed
 	branch1 := "feature-1"
-	resAddBranch, err := superClient.CreateBranchWithResponse(ctx, repo, api.CreateBranchJSONRequestBody{
+	resAddBranch, err := superClient.CreateBranchWithResponse(ctx, repo, apigen.CreateBranchJSONRequestBody{
 		Name:   branch1,
 		Source: mainBranch,
 	})
@@ -90,7 +90,7 @@ func TestSuperPermissions(t *testing.T) {
 	require.Equal(t, http.StatusNoContent, resDeleteRepo.StatusCode(), "Super unexpectedly did not receive \"no content\" response while deleting repo")
 
 	// attempting to list the users should be unauthorized
-	resListUsers, err := superClient.ListUsersWithResponse(ctx, &api.ListUsersParams{})
+	resListUsers, err := superClient.ListUsersWithResponse(ctx, &apigen.ListUsersParams{})
 	require.NoError(t, err, "Super failed while testing list users")
 	require.Equal(t, http.StatusUnauthorized, resListUsers.StatusCode(), "Super unexpectedly did not receive unauthorized response while listing users")
 
@@ -108,7 +108,7 @@ func TestWriterPermissions(t *testing.T) {
 	writerClient := newClientFromGroup(t, ctx, logger, "writer", []string{"Writers", "Developers"})
 
 	// listing the available branches should succeed
-	resListBranches, err := writerClient.ListBranchesWithResponse(ctx, repo, &api.ListBranchesParams{})
+	resListBranches, err := writerClient.ListBranchesWithResponse(ctx, repo, &apigen.ListBranchesParams{})
 	require.NoError(t, err, "Writer failed while listing branches of repository")
 	require.Equal(t, http.StatusOK, resListBranches.StatusCode(), "Writer unexpectedly failed to list branches of repository")
 
@@ -121,7 +121,7 @@ func TestWriterPermissions(t *testing.T) {
 
 	// creating a branch should succeed
 	branch1 := "feature-1"
-	resAddBranch, err := writerClient.CreateBranchWithResponse(ctx, repo, api.CreateBranchJSONRequestBody{
+	resAddBranch, err := writerClient.CreateBranchWithResponse(ctx, repo, apigen.CreateBranchJSONRequestBody{
 		Name:   branch1,
 		Source: mainBranch,
 	})
@@ -139,7 +139,7 @@ func TestWriterPermissions(t *testing.T) {
 	require.Equal(t, http.StatusUnauthorized, resDeleteRepo.StatusCode(), "Writer unexpectedly did not receive unauthorized response while deleting repo")
 
 	// attempting to list the users should be unauthorized
-	resListUsers, err := writerClient.ListUsersWithResponse(ctx, &api.ListUsersParams{})
+	resListUsers, err := writerClient.ListUsersWithResponse(ctx, &apigen.ListUsersParams{})
 	require.NoError(t, err, "Writer failed while testing list users")
 	require.Equal(t, http.StatusUnauthorized, resListUsers.StatusCode(), "Writer unexpectedly did not receive unauthorized response while listing users")
 }
@@ -152,7 +152,7 @@ func TestReaderPermissions(t *testing.T) {
 	readerClient := newClientFromGroup(t, ctx, logger, "reader", []string{"Readers", "Viewers"})
 
 	// listing the available branches should succeed
-	resListBranches, err := readerClient.ListBranchesWithResponse(ctx, repo, &api.ListBranchesParams{})
+	resListBranches, err := readerClient.ListBranchesWithResponse(ctx, repo, &apigen.ListBranchesParams{})
 	require.NoError(t, err, "Reader failed while listing branches of repository")
 	require.Equal(t, http.StatusOK, resListBranches.StatusCode(), "Reader unexpectedly failed to list branches of repository")
 
@@ -165,7 +165,7 @@ func TestReaderPermissions(t *testing.T) {
 
 	// attempting to create a branch should be unauthorized
 	const branch1 = "feature-1"
-	resAddBranch, err := readerClient.CreateBranchWithResponse(ctx, repo, api.CreateBranchJSONRequestBody{
+	resAddBranch, err := readerClient.CreateBranchWithResponse(ctx, repo, apigen.CreateBranchJSONRequestBody{
 		Name:   branch1,
 		Source: mainBranch,
 	})
@@ -179,11 +179,11 @@ func TestReaderPermissions(t *testing.T) {
 }
 
 // Creates a client with a user of the given group
-func newClientFromGroup(t *testing.T, context context.Context, logger logging.Logger, id string, groupIDs []string) *api.ClientWithResponses {
+func newClientFromGroup(t *testing.T, context context.Context, logger logging.Logger, id string, groupIDs []string) *apigen.ClientWithResponses {
 	endpointURL := testutil.ParseEndpointURL(logger, viper.GetString("endpoint_url")) // defined in setup.go
 
 	userID := "test-user-" + id
-	_, err := client.CreateUserWithResponse(context, api.CreateUserJSONRequestBody{
+	_, err := client.CreateUserWithResponse(context, apigen.CreateUserJSONRequestBody{
 		Id: userID,
 	})
 	require.NoErrorf(t, err, "Failed to create user %s", userID)
@@ -209,18 +209,18 @@ func newClientFromGroup(t *testing.T, context context.Context, logger logging.Lo
 }
 
 // Tests merge with different clients
-func mergeAuthTest(t *testing.T, cli *api.ClientWithResponses, ctx context.Context, repo string, branch string) (*api.MergeIntoBranchResponse, error) {
+func mergeAuthTest(t *testing.T, cli *apigen.ClientWithResponses, ctx context.Context, repo string, branch string) (*apigen.MergeIntoBranchResponse, error) {
 	uploadFileRandomData(ctx, t, repo, mainBranch, "README", false)
 
-	resMainCommit, err := cli.CommitWithResponse(ctx, repo, mainBranch, &api.CommitParams{}, api.CommitJSONRequestBody{Message: "Initial content"})
+	resMainCommit, err := cli.CommitWithResponse(ctx, repo, mainBranch, &apigen.CommitParams{}, apigen.CommitJSONRequestBody{Message: "Initial content"})
 	require.NoError(t, err, "failed to commit initial content in merge auth test")
 	require.Equal(t, http.StatusCreated, resMainCommit.StatusCode())
 
 	uploadFileRandomData(ctx, t, repo, branch, "foo.txt", false)
 
-	resBranchCommit, err := cli.CommitWithResponse(ctx, repo, branch, &api.CommitParams{}, api.CommitJSONRequestBody{Message: "Additional content"})
+	resBranchCommit, err := cli.CommitWithResponse(ctx, repo, branch, &apigen.CommitParams{}, apigen.CommitJSONRequestBody{Message: "Additional content"})
 	require.NoError(t, err, "failed to commit additional content in merge auth test")
 	require.Equal(t, http.StatusCreated, resBranchCommit.StatusCode())
 
-	return client.MergeIntoBranchWithResponse(ctx, repo, branch, mainBranch, api.MergeIntoBranchJSONRequestBody{})
+	return client.MergeIntoBranchWithResponse(ctx, repo, branch, mainBranch, apigen.MergeIntoBranchJSONRequestBody{})
 }

--- a/esti/commit_test.go
+++ b/esti/commit_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 )
 
 func TestCommitSingle(t *testing.T) {
@@ -23,14 +23,14 @@ func TestCommitSingle(t *testing.T) {
 			objPath := "1.txt"
 
 			_, objContent := uploadFileRandomData(ctx, t, repo, mainBranch, objPath, direct)
-			commitResp, err := client.CommitWithResponse(ctx, repo, mainBranch, &api.CommitParams{}, api.CommitJSONRequestBody{
+			commitResp, err := client.CommitWithResponse(ctx, repo, mainBranch, &apigen.CommitParams{}, apigen.CommitJSONRequestBody{
 				Message: "singleCommit",
 			})
 			require.NoError(t, err, "failed to commit changes")
 			require.NoErrorf(t, verifyResponse(commitResp.HTTPResponse, commitResp.Body),
 				"failed to commit changes repo %s branch %s", repo, mainBranch)
 
-			getObjResp, err := client.GetObjectWithResponse(ctx, repo, mainBranch, &api.GetObjectParams{Path: objPath})
+			getObjResp, err := client.GetObjectWithResponse(ctx, repo, mainBranch, &apigen.GetObjectParams{Path: objPath})
 			require.NoError(t, err, "failed to get object")
 			require.NoErrorf(t, verifyResponse(getObjResp.HTTPResponse, getObjResp.Body),
 				"failed to get object repo %s branch %s path %s", repo, mainBranch, objPath)
@@ -101,7 +101,7 @@ func TestCommitInMixedOrder(t *testing.T) {
 				t.FailNow()
 			}
 
-			commitResp, err := client.CommitWithResponse(ctx, repo, mainBranch, &api.CommitParams{}, api.CommitJSONRequestBody{
+			commitResp, err := client.CommitWithResponse(ctx, repo, mainBranch, &apigen.CommitParams{}, apigen.CommitJSONRequestBody{
 				Message: "mixedOrderCommit1",
 			})
 			require.NoError(t, err, "failed to commit changes")
@@ -130,7 +130,7 @@ func TestCommitInMixedOrder(t *testing.T) {
 				t.FailNow()
 			}
 
-			commitResp, err = client.CommitWithResponse(ctx, repo, mainBranch, &api.CommitParams{}, api.CommitJSONRequestBody{
+			commitResp, err = client.CommitWithResponse(ctx, repo, mainBranch, &apigen.CommitParams{}, apigen.CommitJSONRequestBody{
 				Message: "mixedOrderCommit2",
 			})
 			require.NoError(t, err, "failed to commit second set of changes")
@@ -154,7 +154,7 @@ func TestCommitWithTombstone(t *testing.T) {
 			origObjPathHigh := "objc.txt"
 			uploadFileRandomData(ctx, t, repo, mainBranch, origObjPathLow, direct)
 			uploadFileRandomData(ctx, t, repo, mainBranch, origObjPathHigh, direct)
-			commitResp, err := client.CommitWithResponse(ctx, repo, mainBranch, &api.CommitParams{}, api.CommitJSONRequestBody{
+			commitResp, err := client.CommitWithResponse(ctx, repo, mainBranch, &apigen.CommitParams{}, apigen.CommitJSONRequestBody{
 				Message: "First commit",
 			})
 			require.NoError(t, err, "failed to commit changes")
@@ -167,11 +167,11 @@ func TestCommitWithTombstone(t *testing.T) {
 			uploadFileRandomData(ctx, t, repo, mainBranch, newObjPath, direct)
 
 			// Turning tombstoneObjPath to tombstone
-			resp, err := client.DeleteObjectWithResponse(ctx, repo, mainBranch, &api.DeleteObjectParams{Path: tombstoneObjPath})
+			resp, err := client.DeleteObjectWithResponse(ctx, repo, mainBranch, &apigen.DeleteObjectParams{Path: tombstoneObjPath})
 			require.NoError(t, err, "failed to delete object")
 			require.Equal(t, http.StatusNoContent, resp.StatusCode())
 
-			commitResp, err = client.CommitWithResponse(ctx, repo, mainBranch, &api.CommitParams{}, api.CommitJSONRequestBody{
+			commitResp, err = client.CommitWithResponse(ctx, repo, mainBranch, &apigen.CommitParams{}, apigen.CommitJSONRequestBody{
 				Message: "Commit with tombstone",
 			})
 			require.NoError(t, err, "failed to commit changes")

--- a/esti/delete_objects_test.go
+++ b/esti/delete_objects_test.go
@@ -11,8 +11,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/treeverse/lakefs/pkg/api"
 	"github.com/treeverse/lakefs/pkg/api/apigen"
+	"github.com/treeverse/lakefs/pkg/api/apiutil"
 )
 
 func TestDeleteObjects(t *testing.T) {
@@ -101,7 +101,7 @@ func TestDeleteObjects_Viewer(t *testing.T) {
 	deleteOut, err := svcViewer.DeleteObjects(&s3.DeleteObjectsInput{
 		Bucket: aws.String(repo),
 		Delete: &s3.Delete{
-			Objects: []*s3.ObjectIdentifier{{Key: api.StringPtr(mainBranch + "/" + filename)}},
+			Objects: []*s3.ObjectIdentifier{{Key: apiutil.Ptr(mainBranch + "/" + filename)}},
 		},
 	})
 	// make sure we got an error we fail to delete the file

--- a/esti/delete_objects_test.go
+++ b/esti/delete_objects_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 )
 
 func TestDeleteObjects(t *testing.T) {
@@ -68,7 +69,7 @@ func TestDeleteObjects_Viewer(t *testing.T) {
 
 	// setup user with only view rights - create user, add to group, generate credentials
 	uid := "del-viewer"
-	resCreateUser, err := client.CreateUserWithResponse(ctx, api.CreateUserJSONRequestBody{
+	resCreateUser, err := client.CreateUserWithResponse(ctx, apigen.CreateUserJSONRequestBody{
 		Id: uid,
 	})
 	require.NoError(t, err, "Admin failed while creating user")

--- a/esti/delete_test.go
+++ b/esti/delete_test.go
@@ -8,11 +8,11 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 )
 
 func found(ctx context.Context, repo, ref, path string) (bool, error) {
-	res, err := client.GetObjectWithResponse(ctx, repo, ref, &api.GetObjectParams{Path: path})
+	res, err := client.GetObjectWithResponse(ctx, repo, ref, &apigen.GetObjectParams{Path: path})
 	if err == nil && res.HTTPResponse.StatusCode == http.StatusOK {
 		return true, nil
 	}
@@ -34,7 +34,7 @@ func TestDeleteStaging(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, f, "uploaded object found")
 
-	resp, err := client.DeleteObjectWithResponse(ctx, repo, mainBranch, &api.DeleteObjectParams{Path: objPath})
+	resp, err := client.DeleteObjectWithResponse(ctx, repo, mainBranch, &apigen.DeleteObjectParams{Path: objPath})
 	require.NoError(t, err, "failed to delete object")
 	require.Equal(t, http.StatusNoContent, resp.StatusCode())
 
@@ -54,11 +54,11 @@ func TestDeleteCommitted(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, f, "uploaded object found")
 
-	commitResp, err := client.CommitWithResponse(ctx, repo, mainBranch, &api.CommitParams{}, api.CommitJSONRequestBody{Message: "singleCommit"})
+	commitResp, err := client.CommitWithResponse(ctx, repo, mainBranch, &apigen.CommitParams{}, apigen.CommitJSONRequestBody{Message: "singleCommit"})
 	require.NoError(t, err, "commit changes")
 	require.Equal(t, http.StatusCreated, commitResp.StatusCode())
 
-	getResp, err := client.DeleteObjectWithResponse(ctx, repo, mainBranch, &api.DeleteObjectParams{Path: objPath})
+	getResp, err := client.DeleteObjectWithResponse(ctx, repo, mainBranch, &apigen.DeleteObjectParams{Path: objPath})
 	require.NoError(t, err, "failed to delete object")
 	require.Equal(t, http.StatusNoContent, getResp.StatusCode())
 
@@ -78,17 +78,17 @@ func TestCommitDeleteCommitted(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, f, "uploaded object found")
 
-	commitResp, err := client.CommitWithResponse(ctx, repo, mainBranch, &api.CommitParams{}, api.CommitJSONRequestBody{
+	commitResp, err := client.CommitWithResponse(ctx, repo, mainBranch, &apigen.CommitParams{}, apigen.CommitJSONRequestBody{
 		Message: "singleCommit",
 	})
 	require.NoError(t, err, "commit new file")
 	require.Equal(t, http.StatusCreated, commitResp.StatusCode())
 
-	deleteResp, err := client.DeleteObjectWithResponse(ctx, repo, mainBranch, &api.DeleteObjectParams{Path: objPath})
+	deleteResp, err := client.DeleteObjectWithResponse(ctx, repo, mainBranch, &apigen.DeleteObjectParams{Path: objPath})
 	require.NoError(t, err, "failed to delete object")
 	require.Equal(t, http.StatusNoContent, deleteResp.StatusCode())
 
-	commitResp, err = client.CommitWithResponse(ctx, repo, mainBranch, &api.CommitParams{}, api.CommitJSONRequestBody{
+	commitResp, err = client.CommitWithResponse(ctx, repo, mainBranch, &apigen.CommitParams{}, apigen.CommitJSONRequestBody{
 		Message: "deleteCommit",
 	})
 	require.NoError(t, err, "commit delete file")

--- a/esti/gc_test.go
+++ b/esti/gc_test.go
@@ -7,7 +7,7 @@ import (
 	"time"
 
 	"github.com/spf13/viper"
-	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 	"github.com/treeverse/lakefs/pkg/block"
 	"github.com/treeverse/lakefs/pkg/config"
 	"github.com/treeverse/lakefs/pkg/testutil"
@@ -32,7 +32,7 @@ var (
 
 type testCase struct {
 	id           string
-	policy       api.GarbageCollectionRules
+	policy       apigen.GarbageCollectionRules
 	branches     []branchProperty
 	fileDeleted  bool
 	description  string
@@ -48,7 +48,7 @@ type branchProperty struct {
 var testCases = []testCase{
 	{
 		id:     "1",
-		policy: api.GarbageCollectionRules{Branches: []api.GarbageCollectionRule{}, DefaultRetentionDays: 1},
+		policy: apigen.GarbageCollectionRules{Branches: []apigen.GarbageCollectionRule{}, DefaultRetentionDays: 1},
 		branches: []branchProperty{
 			{name: "a1", deleteCommitDaysAgo: 2}, {name: "b1", deleteCommitDaysAgo: 2},
 		},
@@ -58,7 +58,7 @@ var testCases = []testCase{
 	},
 	{
 		id:     "2",
-		policy: api.GarbageCollectionRules{Branches: []api.GarbageCollectionRule{{BranchId: "a2", RetentionDays: 1}, {BranchId: "b2", RetentionDays: 3}}, DefaultRetentionDays: 5},
+		policy: apigen.GarbageCollectionRules{Branches: []apigen.GarbageCollectionRule{{BranchId: "a2", RetentionDays: 1}, {BranchId: "b2", RetentionDays: 3}}, DefaultRetentionDays: 5},
 		branches: []branchProperty{
 			{name: "a2", deleteCommitDaysAgo: 4}, {name: "b2", deleteCommitDaysAgo: 4},
 		},
@@ -68,7 +68,7 @@ var testCases = []testCase{
 	},
 	{
 		id:     "3",
-		policy: api.GarbageCollectionRules{Branches: []api.GarbageCollectionRule{{BranchId: "a3", RetentionDays: 1}, {BranchId: "b3", RetentionDays: 3}}, DefaultRetentionDays: 5},
+		policy: apigen.GarbageCollectionRules{Branches: []apigen.GarbageCollectionRule{{BranchId: "a3", RetentionDays: 1}, {BranchId: "b3", RetentionDays: 3}}, DefaultRetentionDays: 5},
 		branches: []branchProperty{
 			{name: "a3", deleteCommitDaysAgo: 4}, {name: "b3", deleteCommitDaysAgo: 2},
 		},
@@ -78,7 +78,7 @@ var testCases = []testCase{
 	},
 	{
 		id:     "4",
-		policy: api.GarbageCollectionRules{Branches: []api.GarbageCollectionRule{}, DefaultRetentionDays: 5},
+		policy: apigen.GarbageCollectionRules{Branches: []apigen.GarbageCollectionRule{}, DefaultRetentionDays: 5},
 		branches: []branchProperty{
 			{name: "a4", deleteCommitDaysAgo: 4}, {name: "b4", deleteCommitDaysAgo: 2},
 		},
@@ -88,7 +88,7 @@ var testCases = []testCase{
 	},
 	{
 		id:     "5",
-		policy: api.GarbageCollectionRules{Branches: []api.GarbageCollectionRule{{BranchId: "a5", RetentionDays: 1}, {BranchId: "b5", RetentionDays: 3}}, DefaultRetentionDays: 5},
+		policy: apigen.GarbageCollectionRules{Branches: []apigen.GarbageCollectionRule{{BranchId: "a5", RetentionDays: 1}, {BranchId: "b5", RetentionDays: 3}}, DefaultRetentionDays: 5},
 		branches: []branchProperty{
 			{name: "a5", deleteCommitDaysAgo: 1},
 		},
@@ -98,7 +98,7 @@ var testCases = []testCase{
 	},
 	{
 		id:     "6",
-		policy: api.GarbageCollectionRules{Branches: []api.GarbageCollectionRule{{BranchId: "a6", RetentionDays: 1}}, DefaultRetentionDays: 5},
+		policy: apigen.GarbageCollectionRules{Branches: []apigen.GarbageCollectionRule{{BranchId: "a6", RetentionDays: 1}}, DefaultRetentionDays: 5},
 		branches: []branchProperty{
 			{name: "a6", deleteCommitDaysAgo: 1}, {name: "b6", deleteCommitDaysAgo: 4},
 		},
@@ -108,7 +108,7 @@ var testCases = []testCase{
 	},
 	{
 		id:     "7",
-		policy: api.GarbageCollectionRules{Branches: []api.GarbageCollectionRule{{BranchId: "a7", RetentionDays: 1}}, DefaultRetentionDays: 5},
+		policy: apigen.GarbageCollectionRules{Branches: []apigen.GarbageCollectionRule{{BranchId: "a7", RetentionDays: 1}}, DefaultRetentionDays: 5},
 		branches: []branchProperty{
 			{name: "a7", deleteCommitDaysAgo: 1}, {name: "b7", deleteCommitDaysAgo: 5},
 		},
@@ -118,7 +118,7 @@ var testCases = []testCase{
 	},
 	{
 		id:     "8",
-		policy: api.GarbageCollectionRules{Branches: []api.GarbageCollectionRule{{BranchId: "a8", RetentionDays: 3}}, DefaultRetentionDays: 1},
+		policy: apigen.GarbageCollectionRules{Branches: []apigen.GarbageCollectionRule{{BranchId: "a8", RetentionDays: 3}}, DefaultRetentionDays: 1},
 		branches: []branchProperty{
 			{name: "a8", deleteCommitDaysAgo: 2}, {name: "b8", deleteCommitDaysAgo: -1},
 		},
@@ -128,7 +128,7 @@ var testCases = []testCase{
 	},
 	{
 		id:     "9",
-		policy: api.GarbageCollectionRules{Branches: []api.GarbageCollectionRule{}, DefaultRetentionDays: 1},
+		policy: apigen.GarbageCollectionRules{Branches: []apigen.GarbageCollectionRule{}, DefaultRetentionDays: 1},
 		branches: []branchProperty{
 			{name: "a9", deleteCommitDaysAgo: -1}, {name: "b9", deleteCommitDaysAgo: -1},
 		},
@@ -138,7 +138,7 @@ var testCases = []testCase{
 	},
 	{
 		id:     "10",
-		policy: api.GarbageCollectionRules{Branches: []api.GarbageCollectionRule{}, DefaultRetentionDays: 1},
+		policy: apigen.GarbageCollectionRules{Branches: []apigen.GarbageCollectionRule{}, DefaultRetentionDays: 1},
 		branches: []branchProperty{
 			{name: "a10", deleteCommitDaysAgo: -1}, {name: "b10", deleteCommitDaysAgo: -1},
 		},
@@ -149,7 +149,7 @@ var testCases = []testCase{
 	},
 	{
 		id:     "11",
-		policy: api.GarbageCollectionRules{Branches: []api.GarbageCollectionRule{}, DefaultRetentionDays: 1},
+		policy: apigen.GarbageCollectionRules{Branches: []apigen.GarbageCollectionRule{}, DefaultRetentionDays: 1},
 		branches: []branchProperty{
 			{name: "a11", deleteCommitDaysAgo: -1}, {name: "b11", deleteCommitDaysAgo: -1},
 		},
@@ -232,13 +232,13 @@ func prepareForGC(t *testing.T, ctx context.Context, testCase *testCase, blockst
 	_, _ = uploadFileRandomData(ctx, t, repo, mainBranch, "not_deleted_file3", direct)
 
 	commitTime := int64(0)
-	_, err := client.CommitWithResponse(ctx, repo, mainBranch, &api.CommitParams{}, api.CommitJSONRequestBody{Message: "add three files not to be deleted", Date: &commitTime})
+	_, err := client.CommitWithResponse(ctx, repo, mainBranch, &apigen.CommitParams{}, apigen.CommitJSONRequestBody{Message: "add three files not to be deleted", Date: &commitTime})
 	if err != nil {
 		t.Fatalf("Commit some data %s", err)
 	}
 
 	newBranch := "a" + testCase.id
-	_, err = client.CreateBranchWithResponse(ctx, repo, api.CreateBranchJSONRequestBody{Name: newBranch, Source: mainBranch})
+	_, err = client.CreateBranchWithResponse(ctx, repo, apigen.CreateBranchJSONRequestBody{Name: newBranch, Source: mainBranch})
 	if err != nil {
 		t.Fatalf("Create new branch %s", err)
 	}
@@ -248,37 +248,37 @@ func prepareForGC(t *testing.T, ctx context.Context, testCase *testCase, blockst
 	commitTime = int64(10)
 
 	// get commit id after commit for validation step in the tests
-	commitRes, err := client.CommitWithResponse(ctx, repo, newBranch, &api.CommitParams{}, api.CommitJSONRequestBody{Message: "Uploaded file" + testCase.id, Date: &commitTime})
+	commitRes, err := client.CommitWithResponse(ctx, repo, newBranch, &apigen.CommitParams{}, apigen.CommitJSONRequestBody{Message: "Uploaded file" + testCase.id, Date: &commitTime})
 	if err != nil || commitRes.StatusCode() != 201 {
 		t.Fatalf("Commit some data %s", err)
 	}
 	commit := commitRes.JSON201
 	commitId := commit.Id
 
-	_, err = client.CreateBranchWithResponse(ctx, repo, api.CreateBranchJSONRequestBody{Name: "b" + testCase.id, Source: newBranch})
+	_, err = client.CreateBranchWithResponse(ctx, repo, apigen.CreateBranchJSONRequestBody{Name: "b" + testCase.id, Source: newBranch})
 	if err != nil {
 		t.Fatalf("Create new branch %s", err)
 	}
 
-	_, err = client.SetGarbageCollectionRulesWithResponse(ctx, repo, api.SetGarbageCollectionRulesJSONRequestBody{Branches: testCase.policy.Branches, DefaultRetentionDays: testCase.policy.DefaultRetentionDays})
+	_, err = client.SetGarbageCollectionRulesWithResponse(ctx, repo, apigen.SetGarbageCollectionRulesJSONRequestBody{Branches: testCase.policy.Branches, DefaultRetentionDays: testCase.policy.DefaultRetentionDays})
 	if err != nil {
 		t.Fatalf("Set GC rules %s", err)
 	}
 
 	for _, branch := range testCase.branches {
 		if branch.deleteCommitDaysAgo > -1 {
-			_, err = client.DeleteObjectWithResponse(ctx, repo, branch.name, &api.DeleteObjectParams{Path: "file" + testCase.id})
+			_, err = client.DeleteObjectWithResponse(ctx, repo, branch.name, &apigen.DeleteObjectParams{Path: "file" + testCase.id})
 			if err != nil {
 				t.Fatalf("DeleteObject %s", err)
 			}
 			epochCommitDateInSeconds := currentEpochInSeconds - (dayInSeconds * branch.deleteCommitDaysAgo)
-			_, err = client.CommitWithResponse(ctx, repo, branch.name, &api.CommitParams{}, api.CommitJSONRequestBody{Message: "Deleted file" + testCase.id, Date: &epochCommitDateInSeconds})
+			_, err = client.CommitWithResponse(ctx, repo, branch.name, &apigen.CommitParams{}, apigen.CommitJSONRequestBody{Message: "Deleted file" + testCase.id, Date: &epochCommitDateInSeconds})
 			if err != nil {
 				t.Fatalf("Commit some data %s", err)
 			}
 			_, _ = uploadFileRandomData(ctx, t, repo, branch.name, "file"+testCase.id+"not_deleted", false)
 			// This is for the previous commit to be the HEAD of the branch outside the retention time (according to GC https://github.com/treeverse/lakeFS/issues/1932)
-			_, err = client.CommitWithResponse(ctx, repo, branch.name, &api.CommitParams{}, api.CommitJSONRequestBody{Message: "not deleted file commit: " + testCase.id, Date: &epochCommitDateInSeconds})
+			_, err = client.CommitWithResponse(ctx, repo, branch.name, &apigen.CommitParams{}, apigen.CommitJSONRequestBody{Message: "not deleted file commit: " + testCase.id, Date: &epochCommitDateInSeconds})
 			if err != nil {
 				t.Fatalf("Commit some data %s", err)
 			}
@@ -295,7 +295,7 @@ func prepareForGC(t *testing.T, ctx context.Context, testCase *testCase, blockst
 func validateGCJob(t *testing.T, ctx context.Context, testCase *testCase, existingRef string) {
 	repo := committedGCRepoName + testCase.id
 
-	res, _ := client.GetObjectWithResponse(ctx, repo, existingRef, &api.GetObjectParams{Path: "file" + testCase.id})
+	res, _ := client.GetObjectWithResponse(ctx, repo, existingRef, &apigen.GetObjectParams{Path: "file" + testCase.id})
 	fileExists := res.StatusCode() == 200
 
 	if fileExists && testCase.fileDeleted {
@@ -305,7 +305,7 @@ func validateGCJob(t *testing.T, ctx context.Context, testCase *testCase, existi
 	}
 	locations := []string{"not_deleted_file1", "not_deleted_file2", "not_deleted_file3"}
 	for _, location := range locations {
-		res, _ = client.GetObjectWithResponse(ctx, repo, "main", &api.GetObjectParams{Path: location})
+		res, _ = client.GetObjectWithResponse(ctx, repo, "main", &apigen.GetObjectParams{Path: location})
 		if res.StatusCode() != 200 {
 			t.Errorf("expected '%s' to exist. Test case '%s', Test description '%s'", location, testCase.id, testCase.description)
 		}

--- a/esti/hooks_failure_test.go
+++ b/esti/hooks_failure_test.go
@@ -8,7 +8,7 @@ import (
 	"time"
 
 	"github.com/stretchr/testify/require"
-	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 )
 
 var actionPreCommitTmpl = template.Must(template.New("action-pre-commit").Parse(
@@ -43,7 +43,7 @@ func hookFailToCommit(t *testing.T, path string) {
 	const branch = "feature-1"
 
 	logger.WithField("branch", branch).Info("Create branch")
-	resp, err := client.CreateBranchWithResponse(ctx, repo, api.CreateBranchJSONRequestBody{
+	resp, err := client.CreateBranchWithResponse(ctx, repo, apigen.CreateBranchJSONRequestBody{
 		Name:   branch,
 		Source: mainBranch,
 	})
@@ -75,7 +75,7 @@ func hookFailToCommit(t *testing.T, path string) {
 	require.Equal(t, http.StatusCreated, uploadResp.StatusCode())
 	logger.WithField("branch", branch).Info("Commit initial content")
 
-	commitResp, err := client.CommitWithResponse(ctx, repo, branch, &api.CommitParams{}, api.CommitJSONRequestBody{
+	commitResp, err := client.CommitWithResponse(ctx, repo, branch, &apigen.CommitParams{}, apigen.CommitJSONRequestBody{
 		Message: "Initial content",
 	})
 	require.NoError(t, err)

--- a/esti/hooks_test.go
+++ b/esti/hooks_test.go
@@ -15,8 +15,8 @@ import (
 
 	"github.com/cenkalti/backoff/v4"
 	"github.com/stretchr/testify/require"
-	"github.com/treeverse/lakefs/pkg/api"
 	"github.com/treeverse/lakefs/pkg/api/apigen"
+	"github.com/treeverse/lakefs/pkg/api/apiutil"
 )
 
 //go:embed action_files/*.yaml
@@ -83,7 +83,7 @@ func waitForListRepositoryRunsLen(ctx context.Context, t *testing.T, repo, ref s
 	bo.MaxElapsedTime = 30 * time.Second
 	listFunc := func() error {
 		runsResp, err := client.ListRepositoryRunsWithResponse(ctx, repo, &apigen.ListRepositoryRunsParams{
-			Commit: api.StringPtr(ref),
+			Commit: apiutil.Ptr(ref),
 		})
 		require.NoError(t, err)
 		runs = runsResp.JSON200

--- a/esti/hooks_test.go
+++ b/esti/hooks_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cenkalti/backoff/v4"
 	"github.com/stretchr/testify/require"
 	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 )
 
 //go:embed action_files/*.yaml
@@ -41,7 +42,7 @@ func TestHooksSuccess(t *testing.T) {
 	ctx, _, repo := setupTest(t)
 	defer tearDownTest(repo)
 	parseAndUploadActions(t, ctx, repo, mainBranch)
-	commitResp, err := client.CommitWithResponse(ctx, repo, mainBranch, &api.CommitParams{}, api.CommitJSONRequestBody{
+	commitResp, err := client.CommitWithResponse(ctx, repo, mainBranch, &apigen.CommitParams{}, apigen.CommitJSONRequestBody{
 		Message: "Initial content",
 	})
 	require.NoError(t, err, "failed to commit initial content")
@@ -75,13 +76,13 @@ func TestHooksSuccess(t *testing.T) {
 	}
 }
 
-func waitForListRepositoryRunsLen(ctx context.Context, t *testing.T, repo, ref string, l int) *api.ActionRunList {
-	var runs *api.ActionRunList
+func waitForListRepositoryRunsLen(ctx context.Context, t *testing.T, repo, ref string, l int) *apigen.ActionRunList {
+	var runs *apigen.ActionRunList
 	bo := backoff.NewExponentialBackOff()
 	bo.MaxInterval = 5 * time.Second
 	bo.MaxElapsedTime = 30 * time.Second
 	listFunc := func() error {
-		runsResp, err := client.ListRepositoryRunsWithResponse(ctx, repo, &api.ListRepositoryRunsParams{
+		runsResp, err := client.ListRepositoryRunsWithResponse(ctx, repo, &apigen.ListRepositoryRunsParams{
 			Commit: api.StringPtr(ref),
 		})
 		require.NoError(t, err)
@@ -101,7 +102,7 @@ func testCommitMerge(t *testing.T, ctx context.Context, repo string) {
 	const branch = "feature-1"
 
 	t.Log("Create branch", branch)
-	createBranchResp, err := client.CreateBranchWithResponse(ctx, repo, api.CreateBranchJSONRequestBody{
+	createBranchResp, err := client.CreateBranchWithResponse(ctx, repo, apigen.CreateBranchJSONRequestBody{
 		Name:   branch,
 		Source: mainBranch,
 	})
@@ -115,7 +116,7 @@ func testCommitMerge(t *testing.T, ctx context.Context, repo string) {
 	require.Equal(t, http.StatusCreated, resp.StatusCode())
 
 	t.Log("Commit content", branch)
-	commitResp, err := client.CommitWithResponse(ctx, repo, branch, &api.CommitParams{}, api.CommitJSONRequestBody{
+	commitResp, err := client.CommitWithResponse(ctx, repo, branch, &apigen.CommitParams{}, apigen.CommitJSONRequestBody{
 		Message: "Initial content",
 	})
 	require.NoError(t, err, "failed to commit initial content")
@@ -168,7 +169,7 @@ func testCommitMerge(t *testing.T, ctx context.Context, repo string) {
 		Metadata:      commitRecord.Metadata.AdditionalProperties,
 	}, postCommitEvent)
 
-	mergeResp, err := client.MergeIntoBranchWithResponse(ctx, repo, branch, mainBranch, api.MergeIntoBranchJSONRequestBody{})
+	mergeResp, err := client.MergeIntoBranchWithResponse(ctx, repo, branch, mainBranch, apigen.MergeIntoBranchJSONRequestBody{})
 	require.NoError(t, err)
 
 	webhookData, err = responseWithTimeout(server, 1*time.Minute)
@@ -233,7 +234,7 @@ func testCommitMerge(t *testing.T, ctx context.Context, repo string) {
 
 func testCreateDeleteBranch(t *testing.T, ctx context.Context, repo string) {
 	const testBranch = "test_branch_delete"
-	createBranchResp, err := client.CreateBranchWithResponse(ctx, repo, api.CreateBranchJSONRequestBody{
+	createBranchResp, err := client.CreateBranchWithResponse(ctx, repo, apigen.CreateBranchJSONRequestBody{
 		Name:   testBranch,
 		Source: mainBranch,
 	})
@@ -338,7 +339,7 @@ func testCreateDeleteTag(t *testing.T, ctx context.Context, repo string) {
 	require.Equal(t, http.StatusOK, resp.StatusCode())
 	commitID := resp.JSON200.CommitId
 
-	createTagResp, err := client.CreateTagWithResponse(ctx, repo, api.CreateTagJSONRequestBody{
+	createTagResp, err := client.CreateTagWithResponse(ctx, repo, apigen.CreateTagJSONRequestBody{
 		Id:  tagID,
 		Ref: commitID,
 	})

--- a/esti/identity_test.go
+++ b/esti/identity_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 )
 
 func TestIdentity(t *testing.T) {
@@ -20,7 +20,7 @@ func TestIdentity(t *testing.T) {
 			branch1 := "feature-1"
 			branch2 := "feature-2"
 
-			_, err := client.CreateBranchWithResponse(ctx, repo, api.CreateBranchJSONRequestBody{
+			_, err := client.CreateBranchWithResponse(ctx, repo, apigen.CreateBranchJSONRequestBody{
 				Name:   branch1,
 				Source: mainBranch,
 			})
@@ -28,7 +28,7 @@ func TestIdentity(t *testing.T) {
 
 			checksum, objContent, err := uploadFileRandomDataAndReport(ctx, repo, branch1, objPath, direct)
 			require.NoError(t, err, "failed uploading file")
-			commitResp, err := client.CommitWithResponse(ctx, repo, branch1, &api.CommitParams{}, api.CommitJSONRequestBody{
+			commitResp, err := client.CommitWithResponse(ctx, repo, branch1, &apigen.CommitParams{}, apigen.CommitJSONRequestBody{
 				Message: "commit on branch1",
 			})
 			require.NoError(t, err, "failed to commit changes")
@@ -36,7 +36,7 @@ func TestIdentity(t *testing.T) {
 				"failed to commit changes repo %s branch %s", repo, mainBranch)
 
 			// upload the same content again to a different branch
-			_, err = client.CreateBranchWithResponse(ctx, repo, api.CreateBranchJSONRequestBody{
+			_, err = client.CreateBranchWithResponse(ctx, repo, apigen.CreateBranchJSONRequestBody{
 				Name:   branch2,
 				Source: mainBranch,
 			})
@@ -46,16 +46,16 @@ func TestIdentity(t *testing.T) {
 			require.NoError(t, err)
 			require.Equal(t, checksum, checksumNew, "Same file uploaded to committed branch, expected no checksum difference")
 
-			_, err = client.CommitWithResponse(ctx, repo, branch2, &api.CommitParams{}, api.CommitJSONRequestBody{
+			_, err = client.CommitWithResponse(ctx, repo, branch2, &apigen.CommitParams{}, apigen.CommitJSONRequestBody{
 				Message: "commit on branch2",
 			})
 			require.NoError(t, err, "failed to commit changes")
 
-			diff, err := client.DiffRefsWithResponse(ctx, repo, branch1, branch2, &api.DiffRefsParams{})
+			diff, err := client.DiffRefsWithResponse(ctx, repo, branch1, branch2, &apigen.DiffRefsParams{})
 			require.NoError(t, err, "Diff refs failed")
 			require.Empty(t, diff.JSON200.Results, "Expected no diff files")
 
-			resp, err := client.MergeIntoBranchWithResponse(ctx, repo, branch1, branch2, api.MergeIntoBranchJSONRequestBody{})
+			resp, err := client.MergeIntoBranchWithResponse(ctx, repo, branch1, branch2, apigen.MergeIntoBranchJSONRequestBody{})
 			require.NoError(t, err, "error during merge")
 			require.NotEmpty(t, resp.JSON200, "allow merge with no changes between the branches")
 		})

--- a/esti/import_test.go
+++ b/esti/import_test.go
@@ -15,8 +15,8 @@ import (
 	"github.com/rs/xid"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
-	"github.com/treeverse/lakefs/pkg/api"
 	"github.com/treeverse/lakefs/pkg/api/apigen"
+	"github.com/treeverse/lakefs/pkg/api/apiutil"
 	"github.com/treeverse/lakefs/pkg/block"
 	"github.com/treeverse/lakefs/pkg/catalog"
 	"github.com/treeverse/lakefs/pkg/config"
@@ -181,7 +181,7 @@ func ingestRange(t testing.TB, ctx context.Context, repoName, importPath string)
 		require.Equal(t, http.StatusCreated, resp.StatusCode())
 		require.NotNil(t, resp.JSON201)
 		ranges = append(ranges, *resp.JSON201.Range)
-		stagingToken = api.StringValue(resp.JSON201.Pagination.StagingToken)
+		stagingToken = apiutil.Value(resp.JSON201.Pagination.StagingToken)
 		if !resp.JSON201.Pagination.HasMore {
 			break
 		}

--- a/esti/import_test.go
+++ b/esti/import_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 	"github.com/treeverse/lakefs/pkg/block"
 	"github.com/treeverse/lakefs/pkg/catalog"
 	"github.com/treeverse/lakefs/pkg/config"
@@ -132,7 +133,7 @@ func verifyImportObjects(t testing.TB, ctx context.Context, repoName, prefix, im
 	for _, k := range importFilesToCheck {
 		// try to read some values from that ingested branch
 		objPath := prefix + k
-		objResp, err := client.GetObjectWithResponse(ctx, repoName, importBranch, &api.GetObjectParams{
+		objResp, err := client.GetObjectWithResponse(ctx, repoName, importBranch, &apigen.GetObjectParams{
 			Path: objPath,
 		})
 		require.NoError(t, err, "get object failed: %s", objPath)
@@ -142,16 +143,16 @@ func verifyImportObjects(t testing.TB, ctx context.Context, repoName, prefix, im
 		}
 	}
 	hasMore := true
-	after := api.PaginationAfter("")
+	after := apigen.PaginationAfter("")
 	count := 0
 	for hasMore {
-		listResp, err := client.ListObjectsWithResponse(ctx, repoName, importBranch, &api.ListObjectsParams{After: &after})
+		listResp, err := client.ListObjectsWithResponse(ctx, repoName, importBranch, &apigen.ListObjectsParams{After: &after})
 		require.NoError(t, err, "list objects failed")
 		require.NotNil(t, listResp.JSON200)
 
 		hasMore = listResp.JSON200.Pagination.HasMore
-		after = api.PaginationAfter(listResp.JSON200.Pagination.NextOffset)
-		prev := api.ObjectStats{}
+		after = apigen.PaginationAfter(listResp.JSON200.Pagination.NextOffset)
+		prev := apigen.ObjectStats{}
 		for _, obj := range listResp.JSON200.Results {
 			count++
 			require.True(t, strings.HasPrefix(obj.Path, prefix), "obj with wrong prefix imported", obj.Path, prefix)
@@ -162,15 +163,15 @@ func verifyImportObjects(t testing.TB, ctx context.Context, repoName, prefix, im
 	t.Log("Total objects imported:", count)
 }
 
-func ingestRange(t testing.TB, ctx context.Context, repoName, importPath string) ([]api.RangeMetadata, string) {
+func ingestRange(t testing.TB, ctx context.Context, repoName, importPath string) ([]apigen.RangeMetadata, string) {
 	var (
 		after        string
 		token        *string
-		ranges       []api.RangeMetadata
+		ranges       []apigen.RangeMetadata
 		stagingToken string
 	)
 	for {
-		resp, err := client.IngestRangeWithResponse(ctx, repoName, api.IngestRangeJSONRequestBody{
+		resp, err := client.IngestRangeWithResponse(ctx, repoName, apigen.IngestRangeJSONRequestBody{
 			After:             after,
 			ContinuationToken: token,
 			FromSourceURI:     importPath,
@@ -193,7 +194,7 @@ func ingestRange(t testing.TB, ctx context.Context, repoName, importPath string)
 func testImport(t testing.TB, ctx context.Context, repoName, importPath, importBranch string) {
 	ranges, stagingToken := ingestRange(t, ctx, repoName, importPath)
 
-	metarangeResp, err := client.CreateMetaRangeWithResponse(ctx, repoName, api.CreateMetaRangeJSONRequestBody{
+	metarangeResp, err := client.CreateMetaRangeWithResponse(ctx, repoName, apigen.CreateMetaRangeJSONRequestBody{
 		Ranges: ranges,
 	})
 
@@ -201,18 +202,18 @@ func testImport(t testing.TB, ctx context.Context, repoName, importPath, importB
 	require.Equal(t, http.StatusCreated, metarangeResp.StatusCode())
 	require.NotNil(t, metarangeResp.JSON201.Id, "failed to create metarange")
 
-	createResp, err := client.CreateBranchWithResponse(ctx, repoName, api.CreateBranchJSONRequestBody{
+	createResp, err := client.CreateBranchWithResponse(ctx, repoName, apigen.CreateBranchJSONRequestBody{
 		Name:   importBranch,
 		Source: "main",
 	})
 	require.NoError(t, err, "failed to create branch", importBranch)
 	require.Equal(t, http.StatusCreated, createResp.StatusCode(), "failed to create branch", importBranch)
 
-	commitResp, err := client.CommitWithResponse(ctx, repoName, importBranch, &api.CommitParams{
+	commitResp, err := client.CommitWithResponse(ctx, repoName, importBranch, &apigen.CommitParams{
 		SourceMetarange: metarangeResp.JSON201.Id,
-	}, api.CommitJSONRequestBody{
+	}, apigen.CommitJSONRequestBody{
 		Message: "created by import",
-		Metadata: &api.CommitCreation_Metadata{
+		Metadata: &apigen.CommitCreation_Metadata{
 			AdditionalProperties: map[string]string{"created_by": "import"},
 		},
 	})
@@ -220,13 +221,13 @@ func testImport(t testing.TB, ctx context.Context, repoName, importPath, importB
 	require.Equal(t, http.StatusCreated, commitResp.StatusCode(), "failed to commit")
 
 	if stagingToken != "" {
-		stageResp, err := client.UpdateBranchTokenWithResponse(ctx, repoName, importBranch, api.UpdateBranchTokenJSONRequestBody{StagingToken: stagingToken})
+		stageResp, err := client.UpdateBranchTokenWithResponse(ctx, repoName, importBranch, apigen.UpdateBranchTokenJSONRequestBody{StagingToken: stagingToken})
 		require.NoError(t, err, "failed to change branch token")
 		require.Equal(t, http.StatusNoContent, stageResp.StatusCode(), "failed to change branch token")
 
-		commitResp, err = client.CommitWithResponse(ctx, repoName, importBranch, &api.CommitParams{}, api.CommitJSONRequestBody{
+		commitResp, err = client.CommitWithResponse(ctx, repoName, importBranch, &apigen.CommitParams{}, apigen.CommitJSONRequestBody{
 			Message: "created by import on skipped objects",
-			Metadata: &api.CommitCreation_Metadata{
+			Metadata: &apigen.CommitCreation_Metadata{
 				AdditionalProperties: map[string]string{"created_by": "import"},
 			},
 		})
@@ -286,7 +287,7 @@ func TestAzureDataLakeV2(t *testing.T) {
 			}
 			testImport(t, ctx, repoName, importPath, importBranch)
 			if len(tt.filesToCheck) == 0 {
-				resp, err := client.ListObjectsWithResponse(ctx, repoName, importBranch, &api.ListObjectsParams{})
+				resp, err := client.ListObjectsWithResponse(ctx, repoName, importBranch, &apigen.ListObjectsParams{})
 				require.NoError(t, err)
 				require.NotNil(t, resp.JSON200)
 				require.Empty(t, resp.JSON200.Results)
@@ -305,7 +306,7 @@ func TestImportNew(t *testing.T) {
 		ctx, _, repoName := setupTest(t)
 		defer tearDownTest(repoName)
 		branch := fmt.Sprintf("%s-%s", importBranchBase, "default")
-		paths := []api.ImportLocation{{
+		paths := []apigen.ImportLocation{{
 			Destination: importTargetPrefix,
 			Path:        importPath,
 			Type:        catalog.ImportPathTypePrefix,
@@ -314,13 +315,13 @@ func TestImportNew(t *testing.T) {
 		verifyImportObjects(t, ctx, repoName, importTargetPrefix, branch, importFilesToCheck, expectedContentLength)
 
 		// Verify we cannot cancel a completed import
-		cancelResp, err := client.ImportCancelWithResponse(ctx, repoName, branch, &api.ImportCancelParams{
+		cancelResp, err := client.ImportCancelWithResponse(ctx, repoName, branch, &apigen.ImportCancelParams{
 			Id: importID,
 		})
 		require.NoError(t, err)
 		require.Equal(t, http.StatusConflict, cancelResp.StatusCode())
 
-		statusResp, err := client.ImportStatusWithResponse(ctx, repoName, branch, &api.ImportStatusParams{
+		statusResp, err := client.ImportStatusWithResponse(ctx, repoName, branch, &apigen.ImportStatusParams{
 			Id: importID,
 		})
 		require.NoError(t, err)
@@ -337,7 +338,6 @@ func TestImportNew(t *testing.T) {
 		importMetadata, ok := repoMetadata[graveler.MetadataKeyLastImportTimeStamp]
 		require.True(t, ok)
 		require.Equal(t, strconv.FormatInt(statusResp.JSON200.Commit.CreationDate, 10), importMetadata)
-
 	})
 
 	t.Run("parent", func(t *testing.T) {
@@ -349,7 +349,7 @@ func TestImportNew(t *testing.T) {
 		}
 		// import without the directory separator as suffix to include the parent directory
 		importPathParent := strings.TrimSuffix(importPath, "/")
-		paths := []api.ImportLocation{{
+		paths := []apigen.ImportLocation{{
 			Destination: importTargetPrefix,
 			Path:        importPathParent,
 			Type:        catalog.ImportPathTypePrefix,
@@ -362,16 +362,16 @@ func TestImportNew(t *testing.T) {
 		ctx, _, repoName := setupTest(t)
 		defer tearDownTest(repoName)
 		branch := fmt.Sprintf("%s-%s", importBranchBase, "several-paths")
-		var paths []api.ImportLocation
+		var paths []apigen.ImportLocation
 		for i := 1; i < 8; i++ {
 			prefix := fmt.Sprintf("prefix-%d/", i)
-			paths = append(paths, api.ImportLocation{
+			paths = append(paths, apigen.ImportLocation{
 				Destination: importTargetPrefix + prefix,
 				Path:        importPath + prefix,
 				Type:        catalog.ImportPathTypePrefix,
 			})
 		}
-		paths = append(paths, api.ImportLocation{
+		paths = append(paths, apigen.ImportLocation{
 			Destination: importTargetPrefix + "nested",
 			Path:        importPath + "nested/",
 			Type:        catalog.ImportPathTypePrefix,
@@ -385,10 +385,10 @@ func TestImportNew(t *testing.T) {
 		ctx, _, repoName := setupTest(t)
 		defer tearDownTest(repoName)
 		branch := fmt.Sprintf("%s-%s", importBranchBase, "prefixes-and-objects")
-		var paths []api.ImportLocation
+		var paths []apigen.ImportLocation
 		for i := 1; i < 8; i++ {
 			prefix := fmt.Sprintf("prefix-%d/", i)
-			paths = append(paths, api.ImportLocation{
+			paths = append(paths, apigen.ImportLocation{
 				Destination: importTargetPrefix + prefix,
 				Path:        importPath + prefix,
 				Type:        catalog.ImportPathTypePrefix,
@@ -396,7 +396,7 @@ func TestImportNew(t *testing.T) {
 		}
 		for _, p := range importFilesToCheck {
 			if strings.HasPrefix(p, "nested") {
-				paths = append(paths, api.ImportLocation{
+				paths = append(paths, apigen.ImportLocation{
 					Destination: importTargetPrefix + p,
 					Path:        importPath + p,
 					Type:        catalog.ImportPathTypeObject,
@@ -408,22 +408,22 @@ func TestImportNew(t *testing.T) {
 	})
 }
 
-func testImportNew(t testing.TB, ctx context.Context, repoName, importBranch string, paths []api.ImportLocation, metadata *map[string]string) string {
-	createResp, err := client.CreateBranchWithResponse(ctx, repoName, api.CreateBranchJSONRequestBody{
+func testImportNew(t testing.TB, ctx context.Context, repoName, importBranch string, paths []apigen.ImportLocation, metadata *map[string]string) string {
+	createResp, err := client.CreateBranchWithResponse(ctx, repoName, apigen.CreateBranchJSONRequestBody{
 		Name:   importBranch,
 		Source: "main",
 	})
 	require.NoError(t, err, "failed to create branch", importBranch)
 	require.Equal(t, http.StatusCreated, createResp.StatusCode(), "failed to create branch", importBranch)
 
-	body := api.ImportStartJSONRequestBody{
-		Commit: api.CommitCreation{
+	body := apigen.ImportStartJSONRequestBody{
+		Commit: apigen.CommitCreation{
 			Message: "created by import",
 		},
 		Paths: paths,
 	}
 	if metadata != nil {
-		body.Commit.Metadata = &api.CommitCreation_Metadata{AdditionalProperties: *metadata}
+		body.Commit.Metadata = &apigen.CommitCreation_Metadata{AdditionalProperties: *metadata}
 	}
 
 	importResp, err := client.ImportStartWithResponse(ctx, repoName, importBranch, body)
@@ -431,7 +431,7 @@ func testImportNew(t testing.TB, ctx context.Context, repoName, importBranch str
 	require.NotNil(t, importResp.JSON202.Id, "missing import ID")
 
 	var (
-		statusResp *api.ImportStatusResponse
+		statusResp *apigen.ImportStatusResponse
 		updateTime time.Time
 	)
 	importID := importResp.JSON202.Id
@@ -442,7 +442,7 @@ func testImportNew(t testing.TB, ctx context.Context, repoName, importBranch str
 		case <-ctx.Done():
 			t.Fatalf("context canceled")
 		case <-ticker.C:
-			statusResp, err = client.ImportStatusWithResponse(ctx, repoName, importBranch, &api.ImportStatusParams{
+			statusResp, err = client.ImportStatusWithResponse(ctx, repoName, importBranch, &apigen.ImportStatusParams{
 				Id: importID,
 			})
 			require.NoError(t, err)
@@ -465,19 +465,19 @@ func TestImportCancel(t *testing.T) {
 	ctx, _, repoName := setupTest(t)
 	defer tearDownTest(repoName)
 	branch := fmt.Sprintf("%s-%s", importBranchBase, "canceled")
-	createResp, err := client.CreateBranchWithResponse(ctx, repoName, api.CreateBranchJSONRequestBody{
+	createResp, err := client.CreateBranchWithResponse(ctx, repoName, apigen.CreateBranchJSONRequestBody{
 		Name:   branch,
 		Source: "main",
 	})
 	require.NoError(t, err, "failed to create branch", branch)
 	require.Equal(t, http.StatusCreated, createResp.StatusCode(), "failed to create branch", branch)
 
-	importResp, err := client.ImportStartWithResponse(ctx, repoName, branch, api.ImportStartJSONRequestBody{
-		Commit: api.CommitCreation{
+	importResp, err := client.ImportStartWithResponse(ctx, repoName, branch, apigen.ImportStartJSONRequestBody{
+		Commit: apigen.CommitCreation{
 			Message:  "created by import",
-			Metadata: &api.CommitCreation_Metadata{AdditionalProperties: map[string]string{"created_by": "import"}},
+			Metadata: &apigen.CommitCreation_Metadata{AdditionalProperties: map[string]string{"created_by": "import"}},
 		},
-		Paths: []api.ImportLocation{{
+		Paths: []apigen.ImportLocation{{
 			Destination: importTargetPrefix,
 			Path:        importPath,
 			Type:        catalog.ImportPathTypePrefix,
@@ -488,7 +488,7 @@ func TestImportCancel(t *testing.T) {
 
 	// Wait 1 second and cancel request
 	time.Sleep(1 * time.Second)
-	cancelResp, err := client.ImportCancelWithResponse(ctx, repoName, branch, &api.ImportCancelParams{
+	cancelResp, err := client.ImportCancelWithResponse(ctx, repoName, branch, &apigen.ImportCancelParams{
 		Id: importResp.JSON202.Id,
 	})
 	require.NoError(t, err)
@@ -498,7 +498,7 @@ func TestImportCancel(t *testing.T) {
 	var updateTime time.Time
 	timer := time.NewTimer(0)
 	for range timer.C {
-		statusResp, err := client.ImportStatusWithResponse(ctx, repoName, branch, &api.ImportStatusParams{
+		statusResp, err := client.ImportStatusWithResponse(ctx, repoName, branch, &apigen.ImportStatusParams{
 			Id: importResp.JSON202.Id,
 		})
 		require.NoError(t, err)

--- a/esti/main_test.go
+++ b/esti/main_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/hashicorp/go-multierror"
 	"github.com/spf13/viper"
 	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 	"github.com/treeverse/lakefs/pkg/logging"
 	"github.com/treeverse/lakefs/pkg/testutil"
 	"golang.org/x/exp/slices"
@@ -32,7 +33,7 @@ type (
 
 var (
 	logger      logging.Logger
-	client      api.ClientWithResponsesInterface
+	client      apigen.ClientWithResponsesInterface
 	endpointURL string
 	svc         *s3.S3
 	server      *webhookServer
@@ -88,7 +89,7 @@ func (i *arrayFlags) Set(value string) error {
 	return nil
 }
 
-func envCleanup(client api.ClientWithResponsesInterface, repositoriesToKeep, groupsToKeep, usersToKeep, policiesToKeep arrayFlags) error {
+func envCleanup(client apigen.ClientWithResponsesInterface, repositoriesToKeep, groupsToKeep, usersToKeep, policiesToKeep arrayFlags) error {
 	ctx := context.Background()
 	errRepos := deleteAllRepositories(ctx, client, repositoriesToKeep)
 	errGroups := deleteAllGroups(ctx, client, groupsToKeep)
@@ -97,7 +98,7 @@ func envCleanup(client api.ClientWithResponsesInterface, repositoriesToKeep, gro
 	return multierror.Append(errRepos, errGroups, errPolicies, errUsers).ErrorOrNil()
 }
 
-func deleteAllRepositories(ctx context.Context, client api.ClientWithResponsesInterface, repositoriesToKeep arrayFlags) error {
+func deleteAllRepositories(ctx context.Context, client apigen.ClientWithResponsesInterface, repositoriesToKeep arrayFlags) error {
 	// collect repositories to delete
 	var (
 		repositoriesToDelete []string
@@ -105,7 +106,7 @@ func deleteAllRepositories(ctx context.Context, client api.ClientWithResponsesIn
 	)
 
 	for {
-		resp, err := client.ListRepositoriesWithResponse(ctx, &api.ListRepositoriesParams{After: api.PaginationAfterPtr(nextOffset)})
+		resp, err := client.ListRepositoriesWithResponse(ctx, &apigen.ListRepositoriesParams{After: api.PaginationAfterPtr(nextOffset)})
 		if err != nil {
 			return fmt.Errorf("list repositories: %w", err)
 		}
@@ -136,14 +137,14 @@ func deleteAllRepositories(ctx context.Context, client api.ClientWithResponsesIn
 	return errs.ErrorOrNil()
 }
 
-func deleteAllGroups(ctx context.Context, client api.ClientWithResponsesInterface, groupsToKeep arrayFlags) error {
+func deleteAllGroups(ctx context.Context, client apigen.ClientWithResponsesInterface, groupsToKeep arrayFlags) error {
 	// list groups to delete
 	var (
 		groupsToDelete []string
 		nextOffset     string
 	)
 	for {
-		resp, err := client.ListGroupsWithResponse(ctx, &api.ListGroupsParams{After: api.PaginationAfterPtr(nextOffset)})
+		resp, err := client.ListGroupsWithResponse(ctx, &apigen.ListGroupsParams{After: api.PaginationAfterPtr(nextOffset)})
 		if err != nil {
 			return fmt.Errorf("list groups: %w", err)
 		}
@@ -174,14 +175,14 @@ func deleteAllGroups(ctx context.Context, client api.ClientWithResponsesInterfac
 	return errs.ErrorOrNil()
 }
 
-func deleteAllUsers(ctx context.Context, client api.ClientWithResponsesInterface, usersToKeep arrayFlags) error {
+func deleteAllUsers(ctx context.Context, client apigen.ClientWithResponsesInterface, usersToKeep arrayFlags) error {
 	// collect users to delete
 	var (
 		usersToDelete []string
 		nextOffset    string
 	)
 	for {
-		resp, err := client.ListUsersWithResponse(ctx, &api.ListUsersParams{After: api.PaginationAfterPtr(nextOffset)})
+		resp, err := client.ListUsersWithResponse(ctx, &apigen.ListUsersParams{After: api.PaginationAfterPtr(nextOffset)})
 		if err != nil {
 			return fmt.Errorf("list users: %s", err)
 		}
@@ -212,14 +213,14 @@ func deleteAllUsers(ctx context.Context, client api.ClientWithResponsesInterface
 	return errs.ErrorOrNil()
 }
 
-func deleteAllPolicies(ctx context.Context, client api.ClientWithResponsesInterface, policiesToKeep arrayFlags) error {
+func deleteAllPolicies(ctx context.Context, client apigen.ClientWithResponsesInterface, policiesToKeep arrayFlags) error {
 	// list policies to delete
 	var (
 		policiesToDelete []string
 		nextOffset       string
 	)
 	for {
-		resp, err := client.ListPoliciesWithResponse(ctx, &api.ListPoliciesParams{After: api.PaginationAfterPtr(nextOffset)})
+		resp, err := client.ListPoliciesWithResponse(ctx, &apigen.ListPoliciesParams{After: api.PaginationAfterPtr(nextOffset)})
 		if err != nil {
 			return fmt.Errorf("list policies: %w", err)
 		}

--- a/esti/main_test.go
+++ b/esti/main_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/hashicorp/go-multierror"
 	"github.com/spf13/viper"
-	"github.com/treeverse/lakefs/pkg/api"
 	"github.com/treeverse/lakefs/pkg/api/apigen"
+	"github.com/treeverse/lakefs/pkg/api/apiutil"
 	"github.com/treeverse/lakefs/pkg/logging"
 	"github.com/treeverse/lakefs/pkg/testutil"
 	"golang.org/x/exp/slices"
@@ -106,7 +106,7 @@ func deleteAllRepositories(ctx context.Context, client apigen.ClientWithResponse
 	)
 
 	for {
-		resp, err := client.ListRepositoriesWithResponse(ctx, &apigen.ListRepositoriesParams{After: api.PaginationAfterPtr(nextOffset)})
+		resp, err := client.ListRepositoriesWithResponse(ctx, &apigen.ListRepositoriesParams{After: apiutil.Ptr(apigen.PaginationAfter(nextOffset))})
 		if err != nil {
 			return fmt.Errorf("list repositories: %w", err)
 		}
@@ -144,7 +144,7 @@ func deleteAllGroups(ctx context.Context, client apigen.ClientWithResponsesInter
 		nextOffset     string
 	)
 	for {
-		resp, err := client.ListGroupsWithResponse(ctx, &apigen.ListGroupsParams{After: api.PaginationAfterPtr(nextOffset)})
+		resp, err := client.ListGroupsWithResponse(ctx, &apigen.ListGroupsParams{After: apiutil.Ptr(apigen.PaginationAfter(nextOffset))})
 		if err != nil {
 			return fmt.Errorf("list groups: %w", err)
 		}
@@ -182,7 +182,7 @@ func deleteAllUsers(ctx context.Context, client apigen.ClientWithResponsesInterf
 		nextOffset    string
 	)
 	for {
-		resp, err := client.ListUsersWithResponse(ctx, &apigen.ListUsersParams{After: api.PaginationAfterPtr(nextOffset)})
+		resp, err := client.ListUsersWithResponse(ctx, &apigen.ListUsersParams{After: apiutil.Ptr(apigen.PaginationAfter(nextOffset))})
 		if err != nil {
 			return fmt.Errorf("list users: %s", err)
 		}
@@ -220,7 +220,7 @@ func deleteAllPolicies(ctx context.Context, client apigen.ClientWithResponsesInt
 		nextOffset       string
 	)
 	for {
-		resp, err := client.ListPoliciesWithResponse(ctx, &apigen.ListPoliciesParams{After: api.PaginationAfterPtr(nextOffset)})
+		resp, err := client.ListPoliciesWithResponse(ctx, &apigen.ListPoliciesParams{After: apiutil.Ptr(apigen.PaginationAfter(nextOffset))})
 		if err != nil {
 			return fmt.Errorf("list policies: %w", err)
 		}

--- a/esti/merge_test.go
+++ b/esti/merge_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/treeverse/lakefs/pkg/api"
 	"github.com/treeverse/lakefs/pkg/api/apigen"
+	"github.com/treeverse/lakefs/pkg/api/apiutil"
 	"github.com/treeverse/lakefs/pkg/graveler"
 	"github.com/treeverse/lakefs/pkg/logging"
 )
@@ -81,7 +81,7 @@ func doMergeAndListIteration(t *testing.T, logger logging.Logger, ctx context.Co
 	require.True(t, ok)
 	require.Equal(t, strategy, val)
 
-	resp, err := client.ListObjectsWithResponse(ctx, repo, mainBranch, &apigen.ListObjectsParams{Amount: api.PaginationAmountPtr(100)})
+	resp, err := client.ListObjectsWithResponse(ctx, repo, mainBranch, &apigen.ListObjectsParams{Amount: apiutil.Ptr(apigen.PaginationAmount(100))})
 	require.NoError(t, err, "failed to list objects")
 	require.Equal(t, http.StatusOK, resp.StatusCode())
 	payload := resp.JSON200

--- a/esti/merge_test.go
+++ b/esti/merge_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 	"github.com/treeverse/lakefs/pkg/graveler"
 	"github.com/treeverse/lakefs/pkg/logging"
 )
@@ -24,12 +25,12 @@ func TestMergeAndList(t *testing.T) {
 	}
 
 	logger.WithField("branch", mainBranch).Info("Commit initial content")
-	commitResp, err := client.CommitWithResponse(ctx, repo, mainBranch, &api.CommitParams{}, api.CommitJSONRequestBody{Message: "Initial content"})
+	commitResp, err := client.CommitWithResponse(ctx, repo, mainBranch, &apigen.CommitParams{}, apigen.CommitJSONRequestBody{Message: "Initial content"})
 	require.NoError(t, err, "failed to commit initial content")
 	require.Equal(t, http.StatusCreated, commitResp.StatusCode())
 
 	logger.WithField("branch", branch).Info("Create branch")
-	createBranchResp, err := client.CreateBranchWithResponse(ctx, repo, api.CreateBranchJSONRequestBody{
+	createBranchResp, err := client.CreateBranchWithResponse(ctx, repo, apigen.CreateBranchJSONRequestBody{
 		Name:   branch,
 		Source: mainBranch,
 	})
@@ -50,7 +51,7 @@ func TestMergeAndList(t *testing.T) {
 	}
 }
 
-func doMergeAndListIteration(t *testing.T, logger logging.Logger, ctx context.Context, repo, branch, strategy string, checksums map[string]string, iteration int) []api.ObjectStats {
+func doMergeAndListIteration(t *testing.T, logger logging.Logger, ctx context.Context, repo, branch, strategy string, checksums map[string]string, iteration int) []apigen.ObjectStats {
 	const addedFiles = 10
 	for i := 0; i < addedFiles; i++ {
 		p := fmt.Sprintf("%d.txt", i)
@@ -61,13 +62,13 @@ func doMergeAndListIteration(t *testing.T, logger logging.Logger, ctx context.Co
 	const totalFiles = addedFiles + 1
 
 	logger.WithField("iteration", iteration).Info("Commit uploaded files")
-	commitResp, err := client.CommitWithResponse(ctx, repo, branch, &api.CommitParams{}, api.CommitJSONRequestBody{
+	commitResp, err := client.CommitWithResponse(ctx, repo, branch, &apigen.CommitParams{}, apigen.CommitJSONRequestBody{
 		Message: fmt.Sprintf("Adding %d files", addedFiles),
 	})
 	require.NoError(t, err, "failed to commit changes")
 	require.Equal(t, http.StatusCreated, commitResp.StatusCode())
 
-	mergeRes, err := client.MergeIntoBranchWithResponse(ctx, repo, branch, mainBranch, api.MergeIntoBranchJSONRequestBody{Strategy: &strategy})
+	mergeRes, err := client.MergeIntoBranchWithResponse(ctx, repo, branch, mainBranch, apigen.MergeIntoBranchJSONRequestBody{Strategy: &strategy})
 	require.NoError(t, err, "failed to merge branches")
 	require.Equal(t, http.StatusOK, mergeRes.StatusCode())
 	logger.WithFields(logging.Fields{"iteration": iteration, "mergeResult": mergeRes}).Info("Merged successfully")
@@ -80,7 +81,7 @@ func doMergeAndListIteration(t *testing.T, logger logging.Logger, ctx context.Co
 	require.True(t, ok)
 	require.Equal(t, strategy, val)
 
-	resp, err := client.ListObjectsWithResponse(ctx, repo, mainBranch, &api.ListObjectsParams{Amount: api.PaginationAmountPtr(100)})
+	resp, err := client.ListObjectsWithResponse(ctx, repo, mainBranch, &apigen.ListObjectsParams{Amount: api.PaginationAmountPtr(100)})
 	require.NoError(t, err, "failed to list objects")
 	require.Equal(t, http.StatusOK, resp.StatusCode())
 	payload := resp.JSON200

--- a/esti/multipart_test.go
+++ b/esti/multipart_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/thanhpk/randstr"
-	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 	"github.com/treeverse/lakefs/pkg/logging"
 )
 
@@ -48,7 +48,7 @@ func TestMultipartUpload(t *testing.T) {
 
 	logger.WithField("key", aws.StringValue(completeResponse.Key)).Info("Completed multipart request successfully")
 
-	getResp, err := client.GetObjectWithResponse(ctx, repo, mainBranch, &api.GetObjectParams{Path: file})
+	getResp, err := client.GetObjectWithResponse(ctx, repo, mainBranch, &apigen.GetObjectParams{Path: file})
 	require.NoError(t, err, "failed to get object")
 	require.Equal(t, http.StatusOK, getResp.StatusCode())
 	if !bytes.Equal(partsConcat, getResp.Body) {

--- a/esti/presign_test.go
+++ b/esti/presign_test.go
@@ -11,7 +11,7 @@ import (
 	"github.com/go-openapi/swag"
 	"github.com/stretchr/testify/require"
 	"github.com/thanhpk/randstr"
-	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 	"github.com/treeverse/lakefs/pkg/block"
 )
 
@@ -57,7 +57,7 @@ func TestPreSign(t *testing.T) {
 	}
 
 	t.Run("preSignStat", func(t *testing.T) {
-		response, err := client.StatObjectWithResponse(ctx, repo, mainBranch, &api.StatObjectParams{
+		response, err := client.StatObjectWithResponse(ctx, repo, mainBranch, &apigen.StatObjectParams{
 			Path:    "foo/bar",
 			Presign: swag.Bool(true),
 		})
@@ -72,9 +72,9 @@ func TestPreSign(t *testing.T) {
 	})
 
 	t.Run("preSignList", func(t *testing.T) {
-		paginationDelimiter := api.PaginationDelimiter("/")
-		paginationPrefix := api.PaginationPrefix("foo/")
-		response, err := client.ListObjectsWithResponse(ctx, repo, mainBranch, &api.ListObjectsParams{
+		paginationDelimiter := apigen.PaginationDelimiter("/")
+		paginationPrefix := apigen.PaginationPrefix("foo/")
+		response, err := client.ListObjectsWithResponse(ctx, repo, mainBranch, &apigen.ListObjectsParams{
 			Prefix:    &paginationPrefix,
 			Presign:   swag.Bool(true),
 			Delimiter: &paginationDelimiter,
@@ -91,7 +91,7 @@ func TestPreSign(t *testing.T) {
 	})
 
 	t.Run("preSignGet", func(t *testing.T) {
-		response, err := client.GetObjectWithResponse(ctx, repo, mainBranch, &api.GetObjectParams{
+		response, err := client.GetObjectWithResponse(ctx, repo, mainBranch, &apigen.GetObjectParams{
 			Path:    "foo/bar",
 			Presign: swag.Bool(true),
 		})
@@ -105,7 +105,7 @@ func TestPreSign(t *testing.T) {
 
 	t.Run("preSignGetPhysicalAddress", func(t *testing.T) {
 		// request a pre-signed URL for us to upload to
-		response, err := client.GetPhysicalAddressWithResponse(ctx, repo, mainBranch, &api.GetPhysicalAddressParams{
+		response, err := client.GetPhysicalAddressWithResponse(ctx, repo, mainBranch, &apigen.GetPhysicalAddressParams{
 			Path:    "foo/uploaded",
 			Presign: swag.Bool(true),
 		})
@@ -126,13 +126,13 @@ func TestPreSign(t *testing.T) {
 		require.Truef(t, httpResp.StatusCode < 400, "got a bad response from pre-signed URL for PUT: %s", httpResp.Status)
 
 		// Let's link this physical address
-		linkResponse, err := client.LinkPhysicalAddressWithResponse(ctx, repo, mainBranch, &api.LinkPhysicalAddressParams{
+		linkResponse, err := client.LinkPhysicalAddressWithResponse(ctx, repo, mainBranch, &apigen.LinkPhysicalAddressParams{
 			Path: "foo/uploaded",
-		}, api.LinkPhysicalAddressJSONRequestBody{
+		}, apigen.LinkPhysicalAddressJSONRequestBody{
 			Checksum:    httpResp.Header.Get("Etag"),
 			ContentType: swag.String("application/octet-stream"),
 			SizeBytes:   int64(uploadContentLength),
-			Staging: api.StagingLocation{
+			Staging: apigen.StagingLocation{
 				PhysicalAddress: response.JSON200.PhysicalAddress,
 				PresignedUrl:    response.JSON200.PresignedUrl,
 				Token:           response.JSON200.Token,
@@ -142,7 +142,7 @@ func TestPreSign(t *testing.T) {
 		require.Equalf(t, linkResponse.StatusCode(), http.StatusOK, "unexpected HTTP code for link_physical_address: %s", linkResponse.Status())
 
 		// Finally, let's read it back and see that we get back what we uploaded!
-		readBackResponse, err := client.GetObjectWithResponse(ctx, repo, mainBranch, &api.GetObjectParams{
+		readBackResponse, err := client.GetObjectWithResponse(ctx, repo, mainBranch, &apigen.GetObjectParams{
 			Path: "foo/uploaded",
 		})
 		require.NoError(t, err, "failed to read back linked object")

--- a/esti/rollback_test.go
+++ b/esti/rollback_test.go
@@ -5,7 +5,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 )
 
 func TestResetAll(t *testing.T) {
@@ -20,7 +20,7 @@ func TestResetAll(t *testing.T) {
 	require.True(t, f, "uploaded object found")
 
 	// commit file
-	commitResp, err := client.CommitWithResponse(ctx, repo, mainBranch, &api.CommitParams{}, api.CommitJSONRequestBody{
+	commitResp, err := client.CommitWithResponse(ctx, repo, mainBranch, &apigen.CommitParams{}, apigen.CommitJSONRequestBody{
 		Message: "resetAll",
 	})
 	require.NoError(t, err, "failed to commit changes")
@@ -28,7 +28,7 @@ func TestResetAll(t *testing.T) {
 		"failed to commit changes repo %s branch %s", repo, mainBranch)
 
 	// delete file
-	deleteResp, err := client.DeleteObjectWithResponse(ctx, repo, mainBranch, &api.DeleteObjectParams{
+	deleteResp, err := client.DeleteObjectWithResponse(ctx, repo, mainBranch, &apigen.DeleteObjectParams{
 		Path: objPath,
 	})
 	require.NoError(t, err, "failed to delete file")
@@ -36,16 +36,16 @@ func TestResetAll(t *testing.T) {
 		"failed to delete file %s repo %s branch %s", objPath, repo, mainBranch)
 
 	// reset
-	reset := api.ResetCreation{
+	reset := apigen.ResetCreation{
 		Type: "reset",
 	}
-	resetResp, err := client.ResetBranchWithResponse(ctx, repo, mainBranch, api.ResetBranchJSONRequestBody(reset))
+	resetResp, err := client.ResetBranchWithResponse(ctx, repo, mainBranch, apigen.ResetBranchJSONRequestBody(reset))
 	require.NoError(t, err, "failed to reset")
 	require.NoErrorf(t, verifyResponse(resetResp.HTTPResponse, resetResp.Body),
 		"failed to reset commit %s repo %s branch %s", repo, mainBranch)
 
 	// read file
-	getObjResp, err := client.GetObjectWithResponse(ctx, repo, mainBranch, &api.GetObjectParams{Path: objPath})
+	getObjResp, err := client.GetObjectWithResponse(ctx, repo, mainBranch, &apigen.GetObjectParams{Path: objPath})
 	require.NoError(t, err, "failed to get object")
 	require.NoErrorf(t, verifyResponse(getObjResp.HTTPResponse, getObjResp.Body),
 		"failed to get object repo %s branch %s path %s", repo, mainBranch, objPath)
@@ -73,7 +73,7 @@ func TestResetPath(t *testing.T) {
 	require.True(t, f, "uploaded object found")
 
 	// commit files
-	commitResp, err := client.CommitWithResponse(ctx, repo, mainBranch, &api.CommitParams{}, api.CommitJSONRequestBody{
+	commitResp, err := client.CommitWithResponse(ctx, repo, mainBranch, &apigen.CommitParams{}, apigen.CommitJSONRequestBody{
 		Message: "resetPath",
 	})
 	require.NoError(t, err, "failed to commit changes")
@@ -81,14 +81,14 @@ func TestResetPath(t *testing.T) {
 		"failed to commit changes repo %s branch %s", repo, mainBranch)
 
 	// delete files
-	deleteResp, err := client.DeleteObjectWithResponse(ctx, repo, mainBranch, &api.DeleteObjectParams{
+	deleteResp, err := client.DeleteObjectWithResponse(ctx, repo, mainBranch, &apigen.DeleteObjectParams{
 		Path: objPath1,
 	})
 	require.NoError(t, err, "failed to delete file")
 	require.NoErrorf(t, verifyResponse(deleteResp.HTTPResponse, deleteResp.Body),
 		"failed to delete file %s repo %s branch %s", objPath1, repo, mainBranch)
 
-	deleteResp, err = client.DeleteObjectWithResponse(ctx, repo, mainBranch, &api.DeleteObjectParams{
+	deleteResp, err = client.DeleteObjectWithResponse(ctx, repo, mainBranch, &apigen.DeleteObjectParams{
 		Path: objPath2,
 	})
 	require.NoError(t, err, "failed to delete file")
@@ -97,17 +97,17 @@ func TestResetPath(t *testing.T) {
 
 	// reset only file1 under the prefix
 	prefix := "prefix"
-	reset := api.ResetCreation{
+	reset := apigen.ResetCreation{
 		Path: &prefix,
 		Type: "common_prefix",
 	}
-	resetResp, err := client.ResetBranchWithResponse(ctx, repo, mainBranch, api.ResetBranchJSONRequestBody(reset))
+	resetResp, err := client.ResetBranchWithResponse(ctx, repo, mainBranch, apigen.ResetBranchJSONRequestBody(reset))
 	require.NoError(t, err, "failed to reset")
 	require.NoErrorf(t, verifyResponse(resetResp.HTTPResponse, resetResp.Body),
 		"failed to reset prefix %s repo %s branch %s", prefix, repo, mainBranch)
 
 	// read file1
-	getObjResp, err := client.GetObjectWithResponse(ctx, repo, mainBranch, &api.GetObjectParams{Path: objPath1})
+	getObjResp, err := client.GetObjectWithResponse(ctx, repo, mainBranch, &apigen.GetObjectParams{Path: objPath1})
 	require.NoError(t, err, "failed to get object")
 	require.NoErrorf(t, verifyResponse(getObjResp.HTTPResponse, getObjResp.Body),
 		"failed to get object repo %s branch %s path %s", repo, mainBranch, objPath1)
@@ -140,7 +140,7 @@ func TestResetObject(t *testing.T) {
 	require.True(t, f, "uploaded object found")
 
 	// commit files
-	commitResp, err := client.CommitWithResponse(ctx, repo, mainBranch, &api.CommitParams{}, api.CommitJSONRequestBody{
+	commitResp, err := client.CommitWithResponse(ctx, repo, mainBranch, &apigen.CommitParams{}, apigen.CommitJSONRequestBody{
 		Message: "resetObject",
 	})
 	require.NoError(t, err, "failed to commit changes")
@@ -148,14 +148,14 @@ func TestResetObject(t *testing.T) {
 		"failed to commit changes repo %s branch %s", repo, mainBranch)
 
 	// delete files
-	deleteResp, err := client.DeleteObjectWithResponse(ctx, repo, mainBranch, &api.DeleteObjectParams{
+	deleteResp, err := client.DeleteObjectWithResponse(ctx, repo, mainBranch, &apigen.DeleteObjectParams{
 		Path: objPath1,
 	})
 	require.NoError(t, err, "failed to delete file")
 	require.NoErrorf(t, verifyResponse(deleteResp.HTTPResponse, deleteResp.Body),
 		"failed to delete file %s repo %s branch %s", objPath1, repo, mainBranch)
 
-	deleteResp, err = client.DeleteObjectWithResponse(ctx, repo, mainBranch, &api.DeleteObjectParams{
+	deleteResp, err = client.DeleteObjectWithResponse(ctx, repo, mainBranch, &apigen.DeleteObjectParams{
 		Path: objPath2,
 	})
 	require.NoError(t, err, "failed to delete file")
@@ -163,17 +163,17 @@ func TestResetObject(t *testing.T) {
 		"failed to delete file %s repo %s branch %s", objPath2, repo, mainBranch)
 
 	// reset only file1
-	reset := api.ResetCreation{
+	reset := apigen.ResetCreation{
 		Path: &objPath1,
 		Type: "object",
 	}
-	resetResp, err := client.ResetBranchWithResponse(ctx, repo, mainBranch, api.ResetBranchJSONRequestBody(reset))
+	resetResp, err := client.ResetBranchWithResponse(ctx, repo, mainBranch, apigen.ResetBranchJSONRequestBody(reset))
 	require.NoError(t, err, "failed to reset")
 	require.NoErrorf(t, verifyResponse(resetResp.HTTPResponse, resetResp.Body),
 		"failed to reset object %s repo %s branch %s", objPath1, repo, mainBranch)
 
 	// assert file1 exists
-	getObjResp, err := client.GetObjectWithResponse(ctx, repo, mainBranch, &api.GetObjectParams{Path: objPath1})
+	getObjResp, err := client.GetObjectWithResponse(ctx, repo, mainBranch, &apigen.GetObjectParams{Path: objPath1})
 	require.NoError(t, err, "failed to get object")
 	require.NoErrorf(t, verifyResponse(getObjResp.HTTPResponse, getObjResp.Body),
 		"failed to get object repo %s branch %s path %s", repo, mainBranch, objPath1)
@@ -201,7 +201,7 @@ func TestRevert(t *testing.T) {
 	require.True(t, f, "uploaded object found")
 
 	// commit file1
-	commitResp, err := client.CommitWithResponse(ctx, repo, mainBranch, &api.CommitParams{}, api.CommitJSONRequestBody{
+	commitResp, err := client.CommitWithResponse(ctx, repo, mainBranch, &apigen.CommitParams{}, apigen.CommitJSONRequestBody{
 		Message: "singleCommit",
 	})
 
@@ -218,7 +218,7 @@ func TestRevert(t *testing.T) {
 	require.True(t, f, "uploaded object found")
 
 	// commit file2
-	commitResp, err = client.CommitWithResponse(ctx, repo, mainBranch, &api.CommitParams{}, api.CommitJSONRequestBody{
+	commitResp, err = client.CommitWithResponse(ctx, repo, mainBranch, &apigen.CommitParams{}, apigen.CommitJSONRequestBody{
 		Message: "revert",
 	})
 	require.NoError(t, err, "failed to commit changes")
@@ -226,7 +226,7 @@ func TestRevert(t *testing.T) {
 		"failed to commit changes repo %s branch %s", repo, mainBranch)
 
 	// revert to commit file1
-	revertResp, err := client.RevertBranchWithResponse(ctx, repo, mainBranch, api.RevertBranchJSONRequestBody{
+	revertResp, err := client.RevertBranchWithResponse(ctx, repo, mainBranch, apigen.RevertBranchJSONRequestBody{
 		Ref: commitId,
 	})
 	require.NoError(t, err, "failed to revert")
@@ -239,7 +239,7 @@ func TestRevert(t *testing.T) {
 	require.False(t, f, "object not found")
 
 	// assert file2 exists
-	getObjResp, err := client.GetObjectWithResponse(ctx, repo, mainBranch, &api.GetObjectParams{Path: objPath2})
+	getObjResp, err := client.GetObjectWithResponse(ctx, repo, mainBranch, &apigen.GetObjectParams{Path: objPath2})
 	require.NoError(t, err, "failed to get object")
 	require.NoErrorf(t, verifyResponse(getObjResp.HTTPResponse, getObjResp.Body),
 		"failed to get object repo %s branch %s path %s", repo, mainBranch, objPath2)

--- a/esti/s3_gateway_test.go
+++ b/esti/s3_gateway_test.go
@@ -12,7 +12,7 @@ import (
 	"github.com/minio/minio-go/v7/pkg/credentials"
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
-	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 	"github.com/treeverse/lakefs/pkg/testutil"
 )
 
@@ -289,11 +289,11 @@ func TestS3CopyObject(t *testing.T) {
 		}
 		require.Equal(t, objContent, content.String())
 
-		resp, err := client.StatObjectWithResponse(ctx, repo, mainBranch, &api.StatObjectParams{Path: "data/source-file"})
+		resp, err := client.StatObjectWithResponse(ctx, repo, mainBranch, &apigen.StatObjectParams{Path: "data/source-file"})
 		require.NoError(t, err)
 		require.NotNil(t, resp.JSON200)
 
-		resp, err = client.StatObjectWithResponse(ctx, repo, mainBranch, &api.StatObjectParams{Path: "data/dest-file"})
+		resp, err = client.StatObjectWithResponse(ctx, repo, mainBranch, &apigen.StatObjectParams{Path: "data/dest-file"})
 		require.NoError(t, err)
 		require.NotNil(t, resp.JSON200)
 
@@ -330,12 +330,12 @@ func TestS3CopyObject(t *testing.T) {
 		// compere files content
 		require.Equal(t, contents.String(), objContent)
 
-		resp, err := client.StatObjectWithResponse(ctx, repo, mainBranch, &api.StatObjectParams{Path: "data/source-file"})
+		resp, err := client.StatObjectWithResponse(ctx, repo, mainBranch, &apigen.StatObjectParams{Path: "data/source-file"})
 		require.NoError(t, err)
 		require.NotNil(t, resp.JSON200)
 		sourceObjectStats := resp.JSON200
 
-		resp, err = client.StatObjectWithResponse(ctx, destRepo, mainBranch, &api.StatObjectParams{Path: "data/dest-file"})
+		resp, err = client.StatObjectWithResponse(ctx, destRepo, mainBranch, &apigen.StatObjectParams{Path: "data/dest-file"})
 		if err != nil {
 			t.Fatalf("client.StatObject(%s): %s", destPath, err)
 		}

--- a/esti/sanity_api_test.go
+++ b/esti/sanity_api_test.go
@@ -6,8 +6,8 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
-	"github.com/treeverse/lakefs/pkg/api"
 	"github.com/treeverse/lakefs/pkg/api/apigen"
+	"github.com/treeverse/lakefs/pkg/api/apiutil"
 )
 
 func TestSanityAPI(t *testing.T) {
@@ -122,7 +122,7 @@ func TestSanityAPI(t *testing.T) {
 
 	log.Debug("branch1 - diff changes with main")
 	diffResp, err = client.DiffRefsWithResponse(ctx, repo, mainBranch, "branch1", &apigen.DiffRefsParams{
-		Amount: api.PaginationAmountPtr(-1),
+		Amount: apiutil.Ptr(apigen.PaginationAmount(-1)),
 	})
 	require.NoError(t, err, "diff between branch1 and main")
 	require.Equal(t, http.StatusOK, diffResp.StatusCode())

--- a/esti/system_test.go
+++ b/esti/system_test.go
@@ -17,8 +17,8 @@ import (
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
 	"github.com/thanhpk/randstr"
-	"github.com/treeverse/lakefs/pkg/api"
 	"github.com/treeverse/lakefs/pkg/api/apigen"
+	"github.com/treeverse/lakefs/pkg/api/apiutil"
 	"github.com/treeverse/lakefs/pkg/api/helpers"
 	"github.com/treeverse/lakefs/pkg/config"
 	"github.com/treeverse/lakefs/pkg/logging"
@@ -116,7 +116,7 @@ func createRepository(ctx context.Context, t testing.TB, name string, repoStorag
 		"name":              name,
 	}).Debug("Create repository for test")
 	resp, err := client.CreateRepositoryWithResponse(ctx, &apigen.CreateRepositoryParams{}, apigen.CreateRepositoryJSONRequestBody{
-		DefaultBranch:    api.StringPtr(mainBranch),
+		DefaultBranch:    apiutil.Ptr(mainBranch),
 		Name:             name,
 		StorageNamespace: repoStorage,
 	})
@@ -202,8 +202,8 @@ func listRepositoryObjects(ctx context.Context, t *testing.T, repository string,
 	var after string
 	for {
 		resp, err := client.ListObjectsWithResponse(ctx, repository, ref, &apigen.ListObjectsParams{
-			After:  api.PaginationAfterPtr(after),
-			Amount: api.PaginationAmountPtr(amount),
+			After:  apiutil.Ptr(apigen.PaginationAfter(after)),
+			Amount: apiutil.Ptr(apigen.PaginationAmount(amount)),
 		})
 		require.NoError(t, err, "listing objects")
 		require.NoErrorf(t, verifyResponse(resp.HTTPResponse, resp.Body),
@@ -233,8 +233,8 @@ func listRepositories(t *testing.T, ctx context.Context) []apigen.Repository {
 	var listedRepos []apigen.Repository
 	for {
 		resp, err := client.ListRepositoriesWithResponse(ctx, &apigen.ListRepositoriesParams{
-			After:  api.PaginationAfterPtr(after),
-			Amount: api.PaginationAmountPtr(repoPerPage),
+			After:  apiutil.Ptr(apigen.PaginationAfter(after)),
+			Amount: apiutil.Ptr(apigen.PaginationAmount(repoPerPage)),
 		})
 		require.NoError(t, err, "list repositories")
 		require.NoErrorf(t, verifyResponse(resp.HTTPResponse, resp.Body),
@@ -250,7 +250,7 @@ func listRepositories(t *testing.T, ctx context.Context) []apigen.Repository {
 	return listedRepos
 }
 
-// requireBlockstoreType Skips test if blockstore type doesn't match required type
+// requireBlockstoreType Skips test if blockstore type doesn't match the required type
 func requireBlockstoreType(t testing.TB, requiredTypes ...string) {
 	blockstoreType := viper.GetString(config.BlockstoreTypeKey)
 	if !slices.Contains(requiredTypes, blockstoreType) {

--- a/esti/system_test.go
+++ b/esti/system_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/thanhpk/randstr"
 	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 	"github.com/treeverse/lakefs/pkg/api/helpers"
 	"github.com/treeverse/lakefs/pkg/config"
 	"github.com/treeverse/lakefs/pkg/logging"
@@ -114,7 +115,7 @@ func createRepository(ctx context.Context, t testing.TB, name string, repoStorag
 		"storage_namespace": repoStorage,
 		"name":              name,
 	}).Debug("Create repository for test")
-	resp, err := client.CreateRepositoryWithResponse(ctx, &api.CreateRepositoryParams{}, api.CreateRepositoryJSONRequestBody{
+	resp, err := client.CreateRepositoryWithResponse(ctx, &apigen.CreateRepositoryParams{}, apigen.CreateRepositoryJSONRequestBody{
 		DefaultBranch:    api.StringPtr(mainBranch),
 		Name:             name,
 		StorageNamespace: repoStorage,
@@ -168,7 +169,7 @@ func uploadFileAndReport(ctx context.Context, repo, branch, objPath, objContent 
 	}
 }
 
-func uploadContent(ctx context.Context, repo string, branch string, objPath string, objContent string) (*api.UploadObjectResponse, error) {
+func uploadContent(ctx context.Context, repo string, branch string, objPath string, objContent string) (*apigen.UploadObjectResponse, error) {
 	var b bytes.Buffer
 	w := multipart.NewWriter(&b)
 	contentWriter, err := w.CreateFormFile("content", filepath.Base(objPath))
@@ -183,7 +184,7 @@ func uploadContent(ctx context.Context, repo string, branch string, objPath stri
 	if err != nil {
 		return nil, fmt.Errorf("close form file: %w", err)
 	}
-	return client.UploadObjectWithBodyWithResponse(ctx, repo, branch, &api.UploadObjectParams{
+	return client.UploadObjectWithBodyWithResponse(ctx, repo, branch, &apigen.UploadObjectParams{
 		Path: objPath,
 	}, w.FormDataContentType(), &b)
 }
@@ -194,13 +195,13 @@ func uploadFileRandomData(ctx context.Context, t *testing.T, repo, branch, objPa
 	return checksum, content
 }
 
-func listRepositoryObjects(ctx context.Context, t *testing.T, repository string, ref string) []api.ObjectStats {
+func listRepositoryObjects(ctx context.Context, t *testing.T, repository string, ref string) []apigen.ObjectStats {
 	t.Helper()
 	const amount = 5
-	var entries []api.ObjectStats
+	var entries []apigen.ObjectStats
 	var after string
 	for {
-		resp, err := client.ListObjectsWithResponse(ctx, repository, ref, &api.ListObjectsParams{
+		resp, err := client.ListObjectsWithResponse(ctx, repository, ref, &apigen.ListObjectsParams{
 			After:  api.PaginationAfterPtr(after),
 			Amount: api.PaginationAmountPtr(amount),
 		})
@@ -226,12 +227,12 @@ func listRepositoriesIDs(t *testing.T, ctx context.Context) []string {
 	return ids
 }
 
-func listRepositories(t *testing.T, ctx context.Context) []api.Repository {
+func listRepositories(t *testing.T, ctx context.Context) []apigen.Repository {
 	var after string
 	const repoPerPage = 2
-	var listedRepos []api.Repository
+	var listedRepos []apigen.Repository
 	for {
-		resp, err := client.ListRepositoriesWithResponse(ctx, &api.ListRepositoriesParams{
+		resp, err := client.ListRepositoriesWithResponse(ctx, &apigen.ListRepositoriesParams{
 			After:  api.PaginationAfterPtr(after),
 			Amount: api.PaginationAmountPtr(repoPerPage),
 		})

--- a/esti/unified_gc_test.go
+++ b/esti/unified_gc_test.go
@@ -9,7 +9,7 @@ import (
 
 	"github.com/go-openapi/swag"
 	"github.com/stretchr/testify/require"
-	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 	"github.com/treeverse/lakefs/pkg/testutil"
 )
 
@@ -24,7 +24,7 @@ type objectEvent struct {
 func gcTestCreateObject(t *testing.T, ctx context.Context, branch string, key string) string {
 	t.Helper()
 	_, _ = uploadFileRandomData(ctx, t, RepoName, branch, key, false)
-	res, err := client.StatObjectWithResponse(ctx, RepoName, branch, &api.StatObjectParams{
+	res, err := client.StatObjectWithResponse(ctx, RepoName, branch, &apigen.StatObjectParams{
 		Path:    key,
 		Presign: swag.Bool(true),
 	})
@@ -32,9 +32,10 @@ func gcTestCreateObject(t *testing.T, ctx context.Context, branch string, key st
 	require.Falsef(t, res.StatusCode() != 200, "Unexpected status code %d in stats object after upload", res.StatusCode())
 	return res.JSON200.PhysicalAddress
 }
+
 func gcTestDeleteObject(t *testing.T, ctx context.Context, branch string, key string) {
 	t.Helper()
-	res, err := client.DeleteObjectWithResponse(ctx, RepoName, branch, &api.DeleteObjectParams{Path: key})
+	res, err := client.DeleteObjectWithResponse(ctx, RepoName, branch, &apigen.DeleteObjectParams{Path: key})
 	testutil.MustDo(t, fmt.Sprintf("Delete %s", key), err)
 	require.Falsef(t, res.StatusCode() > 299, "Unexpected status code %d in delete object", res.StatusCode())
 }
@@ -42,7 +43,7 @@ func gcTestDeleteObject(t *testing.T, ctx context.Context, branch string, key st
 func gcTestCommit(t *testing.T, ctx context.Context, branch string, daysAgo int) {
 	t.Helper()
 	commitTimeSeconds := time.Now().AddDate(0, 0, -daysAgo).Unix()
-	res, err := client.CommitWithResponse(ctx, RepoName, branch, &api.CommitParams{}, api.CommitJSONRequestBody{Message: "commit event", Date: &commitTimeSeconds})
+	res, err := client.CommitWithResponse(ctx, RepoName, branch, &apigen.CommitParams{}, apigen.CommitJSONRequestBody{Message: "commit event", Date: &commitTimeSeconds})
 	testutil.MustDo(t, fmt.Sprintf("Commit branch %s", branch), err)
 	require.Falsef(t, res.StatusCode() > 299, "Unexpected status code %d in commit", res.StatusCode())
 }
@@ -152,7 +153,7 @@ func TestUnifiedGC(t *testing.T) {
 	deleteRes, err := client.DeleteBranchWithResponse(ctx, RepoName, "dev2")
 	testutil.MustDo(t, "Delete dev2 branch", err)
 	require.Falsef(t, deleteRes.StatusCode() > 299, "Unexpected status code %d in delete branch dev2", deleteRes.StatusCode())
-	revertRes, err := client.ResetBranchWithResponse(ctx, RepoName, "dev", api.ResetBranchJSONRequestBody{Type: "reset"})
+	revertRes, err := client.ResetBranchWithResponse(ctx, RepoName, "dev", apigen.ResetBranchJSONRequestBody{Type: "reset"})
 	require.Falsef(t, revertRes.StatusCode() > 299, "Unexpected status code %d in revert branch dev", revertRes.StatusCode())
 	testutil.MustDo(t, "Revert changes in dev branch", err)
 	err = runSparkSubmit(&sparkSubmitConfig{
@@ -194,13 +195,13 @@ func TestUnifiedGC(t *testing.T) {
 
 func prepareForUnifiedGC(t *testing.T, ctx context.Context) {
 	repo := createRepositoryByName(ctx, t, RepoName)
-	createBranchRes, err := client.CreateBranchWithResponse(ctx, repo, api.CreateBranchJSONRequestBody{Name: "dev", Source: mainBranch})
+	createBranchRes, err := client.CreateBranchWithResponse(ctx, repo, apigen.CreateBranchJSONRequestBody{Name: "dev", Source: mainBranch})
 	testutil.MustDo(t, "Create branch dev", err)
 	require.False(t, createBranchRes.StatusCode() > 299, "Create branch dev")
-	createBranchRes, err = client.CreateBranchWithResponse(ctx, repo, api.CreateBranchJSONRequestBody{Name: "dev2", Source: mainBranch})
+	createBranchRes, err = client.CreateBranchWithResponse(ctx, repo, apigen.CreateBranchJSONRequestBody{Name: "dev2", Source: mainBranch})
 	testutil.MustDo(t, "Create branch dev2", err)
 	require.False(t, createBranchRes.StatusCode() > 299, "Create branch dev2")
-	setGCRulesRes, err := client.SetGarbageCollectionRulesWithResponse(ctx, repo, api.SetGarbageCollectionRulesJSONRequestBody{Branches: []api.GarbageCollectionRule{
+	setGCRulesRes, err := client.SetGarbageCollectionRulesWithResponse(ctx, repo, apigen.SetGarbageCollectionRulesJSONRequestBody{Branches: []apigen.GarbageCollectionRule{
 		{BranchId: "main", RetentionDays: 10}, {BranchId: "dev", RetentionDays: 7}, {BranchId: "dev", RetentionDays: 7},
 	}, DefaultRetentionDays: 7})
 	testutil.MustDo(t, "Set gc rules", err)

--- a/pkg/api/apigen/doc.go
+++ b/pkg/api/apigen/doc.go
@@ -1,0 +1,4 @@
+// Package apigen provides generated code for our OpenAPI
+package apigen
+
+//go:generate go run github.com/deepmap/oapi-codegen/cmd/oapi-codegen@v1.5.6 -package apigen -generate "types,client,chi-server,spec" -templates tmpl -o lakefs.gen.go ../../../api/swagger.yml

--- a/pkg/api/apigen/doc.go
+++ b/pkg/api/apigen/doc.go
@@ -1,4 +1,4 @@
 // Package apigen provides generated code for our OpenAPI
 package apigen
 
-//go:generate go run github.com/deepmap/oapi-codegen/cmd/oapi-codegen@v1.5.6 -package apigen -generate "types,client,chi-server,spec" -templates tmpl -o lakefs.gen.go ../../../api/swagger.yml
+//go:generate go run github.com/deepmap/oapi-codegen/cmd/oapi-codegen@v1.5.6 -package apigen -generate "types,client,chi-server,spec" -templates ../tmpl -o lakefs.gen.go ../../../api/swagger.yml

--- a/pkg/api/apiutil/constant.go
+++ b/pkg/api/apiutil/constant.go
@@ -1,0 +1,10 @@
+package apiutil
+
+const BaseURL = "/api/v1"
+
+const LakeFSMetadataPrefix = "::lakefs::"
+
+const (
+	LakeFSHeaderInternalPrefix = "x-lakefs-internal-"
+	LakeFSHeaderMetadataPrefix = "x-lakefs-meta-"
+)

--- a/pkg/api/apiutil/endpoint.go
+++ b/pkg/api/apiutil/endpoint.go
@@ -1,0 +1,19 @@
+package apiutil
+
+import (
+	"net/url"
+	"strings"
+)
+
+// NormalizeLakeFSEndpoint verify and return the endpoint for the lakeFS server
+func NormalizeLakeFSEndpoint(endpoint string) (string, error) {
+	u, err := url.Parse(endpoint)
+	if err != nil {
+		return "", err
+	}
+	// if no uri to api is set in configuration - set the default
+	if u.Path == "" || u.Path == "/" {
+		endpoint = strings.TrimRight(endpoint, "/") + BaseURL
+	}
+	return endpoint, nil
+}

--- a/pkg/api/apiutil/util.go
+++ b/pkg/api/apiutil/util.go
@@ -1,0 +1,16 @@
+package apiutil
+
+func IsStatusCodeOK(statusCode int) bool {
+	return statusCode >= 200 && statusCode <= 299
+}
+
+func Value[T any](ptr *T) T {
+	if ptr == nil {
+		return *new(T)
+	}
+	return *ptr
+}
+
+func Ptr[T any](val T) *T {
+	return &val
+}

--- a/pkg/api/auth_middleware.go
+++ b/pkg/api/auth_middleware.go
@@ -13,6 +13,7 @@ import (
 	"github.com/getkin/kin-openapi/routers/legacy"
 	"github.com/golang-jwt/jwt"
 	"github.com/gorilla/sessions"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 	"github.com/treeverse/lakefs/pkg/auth"
 	"github.com/treeverse/lakefs/pkg/auth/model"
 	oidc_encoding "github.com/treeverse/lakefs/pkg/auth/oidc/encoding"
@@ -58,7 +59,7 @@ type CookieAuthConfig struct {
 }
 
 func GenericAuthMiddleware(logger logging.Logger, authenticator auth.Authenticator, authService auth.Service, oidcConfig *OIDCConfig, cookieAuthConfig *CookieAuthConfig) (func(next http.Handler) http.Handler, error) {
-	swagger, err := GetSwagger()
+	swagger, err := apigen.GetSwagger()
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/api/auth_middleware_test.go
+++ b/pkg/api/auth_middleware_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/gorilla/securecookie"
 	"github.com/gorilla/sessions"
 	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 	"github.com/treeverse/lakefs/pkg/auth"
 	"github.com/treeverse/lakefs/pkg/auth/model"
 )
@@ -24,7 +25,7 @@ func TestAuthMiddleware(t *testing.T) {
 	t.Run("valid basic auth", func(t *testing.T) {
 		ctx := context.Background()
 		authClient := setupClientByEndpoint(t, server.URL, cred.AccessKeyID, cred.SecretAccessKey)
-		resp, err := authClient.ListRepositoriesWithResponse(ctx, &api.ListRepositoriesParams{})
+		resp, err := authClient.ListRepositoriesWithResponse(ctx, &apigen.ListRepositoriesParams{})
 		if err != nil {
 			t.Fatal("ListRepositories() should return without error:", err)
 		}
@@ -36,7 +37,7 @@ func TestAuthMiddleware(t *testing.T) {
 	t.Run("invalid basic auth", func(t *testing.T) {
 		ctx := context.Background()
 		authClient := setupClientByEndpoint(t, server.URL, "foo", "bar")
-		resp, err := authClient.ListRepositoriesWithResponse(ctx, &api.ListRepositoriesParams{})
+		resp, err := authClient.ListRepositoriesWithResponse(ctx, &apigen.ListRepositoriesParams{})
 		if err != nil {
 			t.Fatal("ListRepositories() should return without error:", err)
 		}
@@ -55,11 +56,11 @@ func TestAuthMiddleware(t *testing.T) {
 		if err != nil {
 			t.Fatal("basic auth security provider", err)
 		}
-		authClient, err := api.NewClientWithResponses(apiEndpoint, api.WithRequestEditorFn(authProvider.Intercept))
+		authClient, err := apigen.NewClientWithResponses(apiEndpoint, apigen.WithRequestEditorFn(authProvider.Intercept))
 		if err != nil {
 			t.Fatal("failed to create lakefs api client:", err)
 		}
-		resp, err := authClient.ListRepositoriesWithResponse(ctx, &api.ListRepositoriesParams{})
+		resp, err := authClient.ListRepositoriesWithResponse(ctx, &apigen.ListRepositoriesParams{})
 		if err != nil {
 			t.Fatal("ListRepositories() should return without error:", err)
 		}
@@ -75,11 +76,11 @@ func TestAuthMiddleware(t *testing.T) {
 		if err != nil {
 			t.Fatal("basic auth security provider", err)
 		}
-		authClient, err := api.NewClientWithResponses(apiEndpoint, api.WithRequestEditorFn(authProvider.Intercept))
+		authClient, err := apigen.NewClientWithResponses(apiEndpoint, apigen.WithRequestEditorFn(authProvider.Intercept))
 		if err != nil {
 			t.Fatal("failed to create lakefs api client:", err)
 		}
-		resp, err := authClient.ListRepositoriesWithResponse(ctx, &api.ListRepositoriesParams{})
+		resp, err := authClient.ListRepositoriesWithResponse(ctx, &apigen.ListRepositoriesParams{})
 		if err != nil {
 			t.Fatal("ListRepositories() should return without error:", err)
 		}
@@ -104,11 +105,11 @@ func TestAuthMiddleware(t *testing.T) {
 		if err != nil {
 			t.Fatal("gorilla session security provider", err)
 		}
-		authClient, err := api.NewClientWithResponses(apiEndpoint, api.WithRequestEditorFn(authProvider.Intercept))
+		authClient, err := apigen.NewClientWithResponses(apiEndpoint, apigen.WithRequestEditorFn(authProvider.Intercept))
 		if err != nil {
 			t.Fatal("failed to create lakefs api client:", err)
 		}
-		resp, err := authClient.ListRepositoriesWithResponse(ctx, &api.ListRepositoriesParams{})
+		resp, err := authClient.ListRepositoriesWithResponse(ctx, &apigen.ListRepositoriesParams{})
 		if err != nil {
 			t.Fatal("ListRepositories() should return without error:", err)
 		}
@@ -130,11 +131,11 @@ func TestAuthMiddleware(t *testing.T) {
 		if err != nil {
 			t.Fatal("gorilla session security provider", err)
 		}
-		authClient, err := api.NewClientWithResponses(apiEndpoint, api.WithRequestEditorFn(authProvider.Intercept))
+		authClient, err := apigen.NewClientWithResponses(apiEndpoint, apigen.WithRequestEditorFn(authProvider.Intercept))
 		if err != nil {
 			t.Fatal("failed to create lakefs api client:", err)
 		}
-		resp, err := authClient.ListRepositoriesWithResponse(ctx, &api.ListRepositoriesParams{})
+		resp, err := authClient.ListRepositoriesWithResponse(ctx, &apigen.ListRepositoriesParams{})
 		if err != nil {
 			t.Fatal("ListRepositories() should return without error:", err)
 		}
@@ -147,9 +148,9 @@ func TestAuthMiddleware(t *testing.T) {
 	})
 }
 
-func testGenerateApiToken(ctx context.Context, t testing.TB, clt api.ClientWithResponsesInterface, cred *model.BaseCredential) string {
+func testGenerateApiToken(ctx context.Context, t testing.TB, clt apigen.ClientWithResponsesInterface, cred *model.BaseCredential) string {
 	t.Helper()
-	loginReq := api.LoginJSONRequestBody{
+	loginReq := apigen.LoginJSONRequestBody{
 		AccessKeyId:     cred.AccessKeyID,
 		SecretAccessKey: cred.SecretAccessKey,
 	}

--- a/pkg/api/auth_middleware_test.go
+++ b/pkg/api/auth_middleware_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gorilla/sessions"
 	"github.com/treeverse/lakefs/pkg/api"
 	"github.com/treeverse/lakefs/pkg/api/apigen"
+	"github.com/treeverse/lakefs/pkg/api/apiutil"
 	"github.com/treeverse/lakefs/pkg/auth"
 	"github.com/treeverse/lakefs/pkg/auth/model"
 )
@@ -18,7 +19,7 @@ import (
 func TestAuthMiddleware(t *testing.T) {
 	handler, deps := setupHandler(t)
 	server := setupServer(t, handler)
-	apiEndpoint := server.URL + api.BaseURL
+	apiEndpoint := server.URL + apiutil.BaseURL
 	clt := setupClientByEndpoint(t, server.URL, "", "")
 	cred := createDefaultAdminUser(t, clt)
 

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -33,6 +33,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/treeverse/lakefs/pkg/api"
 	"github.com/treeverse/lakefs/pkg/api/apigen"
+	"github.com/treeverse/lakefs/pkg/api/apiutil"
 	"github.com/treeverse/lakefs/pkg/auth"
 	"github.com/treeverse/lakefs/pkg/block"
 	"github.com/treeverse/lakefs/pkg/catalog"
@@ -74,7 +75,7 @@ func verifyResponseOK(t testing.TB, resp Statuser, err error) {
 		t.Fatal("request's response is missing")
 	}
 	statusCode := resp.StatusCode()
-	if !api.IsStatusCodeOK(statusCode) {
+	if !apiutil.IsStatusCodeOK(statusCode) {
 		t.Fatal("request response failed with code", statusCode)
 	}
 }
@@ -127,7 +128,7 @@ func TestController_ListRepositoriesHandler(t *testing.T) {
 	t.Run("paginate repos", func(t *testing.T) {
 		// write some repos
 		resp, err := clt.ListRepositoriesWithResponse(ctx, &apigen.ListRepositoriesParams{
-			Amount: api.PaginationAmountPtr(2),
+			Amount: apiutil.Ptr(apigen.PaginationAmount(2)),
 		})
 		if err != nil {
 			t.Fatal(err)
@@ -148,8 +149,8 @@ func TestController_ListRepositoriesHandler(t *testing.T) {
 	t.Run("paginate repos after", func(t *testing.T) {
 		// write some repos
 		resp, err := clt.ListRepositoriesWithResponse(ctx, &apigen.ListRepositoriesParams{
-			After:  api.PaginationAfterPtr("foo2"),
-			Amount: api.PaginationAmountPtr(2),
+			After:  apiutil.Ptr(apigen.PaginationAfter("foo2")),
+			Amount: apiutil.Ptr(apigen.PaginationAmount(2)),
 		})
 		if err != nil {
 			t.Fatal(err)
@@ -319,7 +320,7 @@ func TestController_LogCommitsHandler(t *testing.T) {
 			}
 			if tt.limit {
 				params.Limit = &tt.limit
-				params.Amount = api.PaginationAmountPtr(1)
+				params.Amount = apiutil.Ptr(apigen.PaginationAmount(1))
 			}
 			resp, err := clt.LogCommitsWithResponse(ctx, repo, "main", params)
 			verifyResponseOK(t, resp, err)
@@ -486,10 +487,10 @@ func TestController_LogCommitsPredefinedData(t *testing.T) {
 			}
 			if tt.limit {
 				params.Limit = &tt.limit
-				params.Amount = api.PaginationAmountPtr(1)
+				params.Amount = apiutil.Ptr(apigen.PaginationAmount(1))
 			}
 			if tt.amount > 0 {
-				params.Amount = api.PaginationAmountPtr(tt.amount)
+				params.Amount = apiutil.Ptr(apigen.PaginationAmount(tt.amount))
 			}
 
 			resp, err := clt.LogCommitsWithResponse(ctx, repo, "main", params)
@@ -952,7 +953,7 @@ func TestController_CreateRepositoryHandler(t *testing.T) {
 	t.Run("create repo success", func(t *testing.T) {
 		repoName := testUniqueRepoName()
 		resp, err := clt.CreateRepositoryWithResponse(ctx, &apigen.CreateRepositoryParams{}, apigen.CreateRepositoryJSONRequestBody{
-			DefaultBranch:    api.StringPtr("main"),
+			DefaultBranch:    apiutil.Ptr("main"),
 			Name:             repoName,
 			StorageNamespace: onBlock(deps, "foo-bucket-1"),
 		})
@@ -974,7 +975,7 @@ func TestController_CreateRepositoryHandler(t *testing.T) {
 			&apigen.CreateRepositoryParams{
 				Bare: &bareRepo,
 			}, apigen.CreateRepositoryJSONRequestBody{
-				DefaultBranch:    api.StringPtr("main"),
+				DefaultBranch:    apiutil.Ptr("main"),
 				Name:             repoName,
 				StorageNamespace: onBlock(deps, "foo-bucket-1"),
 			})
@@ -996,7 +997,7 @@ func TestController_CreateRepositoryHandler(t *testing.T) {
 			t.Fatal(err)
 		}
 		resp, err := clt.CreateRepositoryWithResponse(ctx, &apigen.CreateRepositoryParams{}, apigen.CreateRepositoryJSONRequestBody{
-			DefaultBranch:    api.StringPtr("main"),
+			DefaultBranch:    apiutil.Ptr("main"),
 			Name:             repo,
 			StorageNamespace: onBlock(deps, "foo-bucket-2"),
 		})
@@ -1019,7 +1020,7 @@ func TestController_CreateRepositoryHandler(t *testing.T) {
 		// create a client with the user
 		regClt := setupClientByEndpoint(t, deps.server.URL, creds.AccessKeyID, creds.SecretAccessKey)
 		resp, err := regClt.CreateRepositoryWithResponse(ctx, &apigen.CreateRepositoryParams{}, apigen.CreateRepositoryJSONRequestBody{
-			DefaultBranch:    api.StringPtr("main"),
+			DefaultBranch:    apiutil.Ptr("main"),
 			Name:             repo,
 			StorageNamespace: onBlock(deps, "foo-bucket-1"),
 		})
@@ -1040,7 +1041,7 @@ func TestController_CreateRepositoryHandler(t *testing.T) {
 	t.Run("create repo with conflicting storage type", func(t *testing.T) {
 		repo := testUniqueRepoName()
 		resp, _ := clt.CreateRepositoryWithResponse(ctx, &apigen.CreateRepositoryParams{}, apigen.CreateRepositoryJSONRequestBody{
-			DefaultBranch:    api.StringPtr("main"),
+			DefaultBranch:    apiutil.Ptr("main"),
 			Name:             repo,
 			StorageNamespace: "s3://foo-bucket",
 		})
@@ -1111,7 +1112,7 @@ func TestController_GetRepositoryMetadataHandler(t *testing.T) {
 	t.Run("get repo metadata empty", func(t *testing.T) {
 		repoName := testUniqueRepoName()
 		createResp, err := clt.CreateRepositoryWithResponse(ctx, &apigen.CreateRepositoryParams{}, apigen.CreateRepositoryJSONRequestBody{
-			DefaultBranch:    api.StringPtr("main"),
+			DefaultBranch:    apiutil.Ptr("main"),
 			Name:             repoName,
 			StorageNamespace: onBlock(deps, "foo-bucket-1"),
 		})
@@ -1130,7 +1131,7 @@ func TestController_GetRepositoryMetadataHandler(t *testing.T) {
 			&apigen.CreateRepositoryParams{
 				Bare: &bareRepo,
 			}, apigen.CreateRepositoryJSONRequestBody{
-				DefaultBranch:    api.StringPtr("main"),
+				DefaultBranch:    apiutil.Ptr("main"),
 				Name:             repoName,
 				StorageNamespace: onBlock(deps, "foo-bucket-2"),
 			})
@@ -1152,7 +1153,7 @@ func TestController_GetRepositoryMetadataHandler(t *testing.T) {
 	t.Run("get repo metadata user unauthorized", func(t *testing.T) {
 		repoName := testUniqueRepoName()
 		createResp, err := clt.CreateRepositoryWithResponse(ctx, &apigen.CreateRepositoryParams{}, apigen.CreateRepositoryJSONRequestBody{
-			DefaultBranch:    api.StringPtr("main"),
+			DefaultBranch:    apiutil.Ptr("main"),
 			Name:             repoName,
 			StorageNamespace: onBlock(deps, "foo-bucket-3"),
 		})
@@ -1178,7 +1179,7 @@ func TestController_ListBranchesHandler(t *testing.T) {
 		_, err := deps.catalog.CreateRepository(ctx, repo, onBlock(deps, "foo1"), "main")
 		testutil.Must(t, err)
 		resp, err := clt.ListBranchesWithResponse(ctx, repo, &apigen.ListBranchesParams{
-			Amount: api.PaginationAmountPtr(-1),
+			Amount: apiutil.Ptr(apigen.PaginationAmount(-1)),
 		})
 		verifyResponseOK(t, resp, err)
 
@@ -1206,7 +1207,7 @@ func TestController_ListBranchesHandler(t *testing.T) {
 			testutil.MustDo(t, "create branch "+branchName, err)
 		}
 		resp, err := clt.ListBranchesWithResponse(ctx, repo, &apigen.ListBranchesParams{
-			Amount: api.PaginationAmountPtr(2),
+			Amount: apiutil.Ptr(apigen.PaginationAmount(2)),
 		})
 		verifyResponseOK(t, resp, err)
 		if len(resp.JSON200.Results) != 2 {
@@ -1214,8 +1215,8 @@ func TestController_ListBranchesHandler(t *testing.T) {
 		}
 
 		resp, err = clt.ListBranchesWithResponse(ctx, repo, &apigen.ListBranchesParams{
-			After:  api.PaginationAfterPtr("main1"),
-			Amount: api.PaginationAmountPtr(2),
+			After:  apiutil.Ptr(apigen.PaginationAfter("main1")),
+			Amount: apiutil.Ptr(apigen.PaginationAmount(2)),
 		})
 		verifyResponseOK(t, resp, err)
 		results := resp.JSON200.Results
@@ -1231,7 +1232,7 @@ func TestController_ListBranchesHandler(t *testing.T) {
 
 	t.Run("list branches repo doesnt exist", func(t *testing.T) {
 		resp, err := clt.ListBranchesWithResponse(ctx, "repo666", &apigen.ListBranchesParams{
-			Amount: api.PaginationAmountPtr(2),
+			Amount: apiutil.Ptr(apigen.PaginationAmount(2)),
 		})
 		testutil.Must(t, err)
 		if resp == nil {
@@ -1272,7 +1273,7 @@ func TestController_ListTagsHandler(t *testing.T) {
 
 	t.Run("default", func(t *testing.T) {
 		resp, err := clt.ListTagsWithResponse(ctx, repo, &apigen.ListTagsParams{
-			Amount: api.PaginationAmountPtr(-1),
+			Amount: apiutil.Ptr(apigen.PaginationAmount(-1)),
 		})
 		verifyResponseOK(t, resp, err)
 		payload := resp.JSON200
@@ -1293,8 +1294,8 @@ func TestController_ListTagsHandler(t *testing.T) {
 		for {
 			calls++
 			resp, err := clt.ListTagsWithResponse(ctx, repo, &apigen.ListTagsParams{
-				After:  api.PaginationAfterPtr(after),
-				Amount: api.PaginationAmountPtr(pageSize),
+				After:  apiutil.Ptr(apigen.PaginationAfter(after)),
+				Amount: apiutil.Ptr(apigen.PaginationAmount(pageSize)),
 			})
 			testutil.Must(t, err)
 			payload := resp.JSON200
@@ -1741,7 +1742,7 @@ func TestController_UploadObjectHandler(t *testing.T) {
 	})
 
 	t.Run("disable overwrite with if-none-match (no entry)", func(t *testing.T) {
-		ifNoneMatch := api.StringPtr("*")
+		ifNoneMatch := apiutil.Ptr("*")
 		contentType, buf := writeMultipart("content", "baz4", "something else!")
 		resp, err := clt.UploadObjectWithBodyWithResponse(ctx, "my-new-repo", "main", &apigen.UploadObjectParams{
 			Path:        "foo/baz4",
@@ -2037,7 +2038,7 @@ func TestController_ObjectsStatObjectHandler(t *testing.T) {
 		if objectStats.Path != entry.Path {
 			t.Fatalf("expected to get back our path, got %s", objectStats.Path)
 		}
-		if api.Int64Value(objectStats.SizeBytes) != entry.Size {
+		if apiutil.Value(objectStats.SizeBytes) != entry.Size {
 			t.Fatalf("expected correct size, got %d", objectStats.SizeBytes)
 		}
 		if objectStats.PhysicalAddress != onBlock(deps, "some-bucket/")+entry.PhysicalAddress {
@@ -2046,7 +2047,7 @@ func TestController_ObjectsStatObjectHandler(t *testing.T) {
 		if diff := deep.Equal(objectStats.Metadata.AdditionalProperties, map[string]string(entry.Metadata)); diff != nil {
 			t.Fatalf("expected to get back user-defined metadata: %s", diff)
 		}
-		contentType := api.StringValue(objectStats.ContentType)
+		contentType := apiutil.Value(objectStats.ContentType)
 		if contentType != catalog.DefaultContentType {
 			t.Fatalf("expected to get default content type, got: %s", contentType)
 		}
@@ -2077,7 +2078,7 @@ func TestController_ObjectsStatObjectHandler(t *testing.T) {
 		objectStats := resp.JSON200
 
 		// verify stat custom content-type
-		contentType := api.StringValue(objectStats.ContentType)
+		contentType := apiutil.Value(objectStats.ContentType)
 		if contentType != entry.ContentType {
 			t.Fatalf("expected to get entry content type, got: %s, expected: %s", contentType, entry.ContentType)
 		}
@@ -2163,7 +2164,7 @@ func TestController_ObjectsListObjectsHandler(t *testing.T) {
 		prefix := apigen.PaginationPrefix("foo/")
 		resp, err := clt.ListObjectsWithResponse(ctx, repo, "main", &apigen.ListObjectsParams{
 			Prefix: &prefix,
-			Amount: api.PaginationAmountPtr(2),
+			Amount: apiutil.Ptr(apigen.PaginationAmount(2)),
 		})
 		verifyResponseOK(t, resp, err)
 		if len(resp.JSON200.Results) != 2 {
@@ -2396,7 +2397,7 @@ func TestController_ObjectsGetObjectHandler(t *testing.T) {
 			t.Fatalf("expected to get underlying properties, status code %d", resp.StatusCode())
 		}
 
-		if api.StringValue(properties.StorageClass) != expensiveString {
+		if apiutil.Value(properties.StorageClass) != expensiveString {
 			t.Errorf("expected to get \"%s\" storage class, got %#v", expensiveString, properties)
 		}
 	})
@@ -2417,7 +2418,7 @@ func TestController_ObjectsUploadObjectHandler(t *testing.T) {
 		resp, err := uploadObjectHelper(t, ctx, clt, "foo/bar", strings.NewReader(content), repo, "main")
 		verifyResponseOK(t, resp, err)
 
-		sizeBytes := api.Int64Value(resp.JSON201.SizeBytes)
+		sizeBytes := apiutil.Value(resp.JSON201.SizeBytes)
 		const expectedSize = 38
 		if sizeBytes != expectedSize {
 			t.Fatalf("expected %d bytes to be written, got back %d", expectedSize, sizeBytes)
@@ -2475,7 +2476,7 @@ func TestController_ObjectsStageObjectHandler(t *testing.T) {
 		})
 		verifyResponseOK(t, resp, err)
 
-		sizeBytes := api.Int64Value(resp.JSON201.SizeBytes)
+		sizeBytes := apiutil.Value(resp.JSON201.SizeBytes)
 		if sizeBytes != expectedSizeBytes {
 			t.Fatalf("expected %d bytes to be written, got back %d", expectedSizeBytes, sizeBytes)
 		}
@@ -2508,7 +2509,7 @@ func TestController_ObjectsStageObjectHandler(t *testing.T) {
 		})
 		verifyResponseOK(t, resp, err)
 
-		sizeBytes := api.Int64Value(resp.JSON200.SizeBytes)
+		sizeBytes := apiutil.Value(resp.JSON200.SizeBytes)
 		if sizeBytes != expectedSizeBytes {
 			t.Fatalf("expected %d bytes to be written, got back %d", expectedSizeBytes, sizeBytes)
 		}
@@ -2520,7 +2521,7 @@ func TestController_ObjectsStageObjectHandler(t *testing.T) {
 			t.Fatalf("StatObject non 200 - status code %d", statResp.StatusCode())
 		}
 		objectStat := statResp.JSON200
-		if objectStat.PhysicalAddress != api.StringValue(linkResp.JSON200.PhysicalAddress) {
+		if objectStat.PhysicalAddress != apiutil.Value(linkResp.JSON200.PhysicalAddress) {
 			t.Fatalf("unexpected physical address: %s", objectStat.PhysicalAddress)
 		}
 	})
@@ -2637,7 +2638,7 @@ func TestController_ObjectsDeleteObjectHandler(t *testing.T) {
 		resp, err := uploadObjectHelper(t, ctx, clt, "foo/bar", strings.NewReader(content), repo, branch)
 		verifyResponseOK(t, resp, err)
 
-		sizeBytes := api.Int64Value(resp.JSON201.SizeBytes)
+		sizeBytes := apiutil.Value(resp.JSON201.SizeBytes)
 		if sizeBytes != 38 {
 			t.Fatalf("expected 38 bytes to be written, got back %d", sizeBytes)
 		}
@@ -2767,7 +2768,7 @@ func TestController_ObjectsDeleteObjectHandler(t *testing.T) {
 		}
 		var errPaths []string
 		for _, item := range delResp.JSON200.Errors {
-			errPaths = append(errPaths, api.StringValue(item.Path))
+			errPaths = append(errPaths, apiutil.Value(item.Path))
 		}
 		// sort both lists to match
 		sort.Strings(errPaths)
@@ -2783,7 +2784,7 @@ func TestController_CreatePolicyHandler(t *testing.T) {
 	ctx := context.Background()
 	t.Run("valid_policy", func(t *testing.T) {
 		resp, err := clt.CreatePolicyWithResponse(ctx, apigen.CreatePolicyJSONRequestBody{
-			CreationDate: api.Int64Ptr(time.Now().Unix()),
+			CreationDate: apiutil.Ptr(time.Now().Unix()),
 			Id:           "ValidPolicyID",
 			Statement: []apigen.Statement{
 				{
@@ -2798,7 +2799,7 @@ func TestController_CreatePolicyHandler(t *testing.T) {
 
 	t.Run("invalid_policy_action", func(t *testing.T) {
 		resp, err := clt.CreatePolicyWithResponse(ctx, apigen.CreatePolicyJSONRequestBody{
-			CreationDate: api.Int64Ptr(time.Now().Unix()),
+			CreationDate: apiutil.Ptr(time.Now().Unix()),
 			Id:           "ValidPolicyID",
 			Statement: []apigen.Statement{
 				{
@@ -2816,7 +2817,7 @@ func TestController_CreatePolicyHandler(t *testing.T) {
 
 	t.Run("invalid_policy_effect", func(t *testing.T) {
 		resp, err := clt.CreatePolicyWithResponse(ctx, apigen.CreatePolicyJSONRequestBody{
-			CreationDate: api.Int64Ptr(time.Now().Unix()),
+			CreationDate: apiutil.Ptr(time.Now().Unix()),
 			Id:           "ValidPolicyID",
 			Statement: []apigen.Statement{
 				{
@@ -2835,7 +2836,7 @@ func TestController_CreatePolicyHandler(t *testing.T) {
 
 	t.Run("invalid_policy_arn", func(t *testing.T) {
 		resp, err := clt.CreatePolicyWithResponse(ctx, apigen.CreatePolicyJSONRequestBody{
-			CreationDate: api.Int64Ptr(time.Now().Unix()),
+			CreationDate: apiutil.Ptr(time.Now().Unix()),
 			Id:           "ValidPolicyID",
 			Statement: []apigen.Statement{
 				{
@@ -3098,7 +3099,7 @@ func TestController_ListRepositoryRuns(t *testing.T) {
 	// create repository
 	repo := testUniqueRepoName()
 	resp, err := clt.CreateRepositoryWithResponse(ctx, &apigen.CreateRepositoryParams{}, apigen.CreateRepositoryJSONRequestBody{
-		DefaultBranch:    api.StringPtr("main"),
+		DefaultBranch:    apiutil.Ptr("main"),
 		Name:             repo,
 		StorageNamespace: "mem://repo9",
 	})
@@ -3134,7 +3135,7 @@ func TestController_ListRepositoryRuns(t *testing.T) {
 
 	t.Run("total", func(t *testing.T) {
 		respList, err := clt.ListRepositoryRunsWithResponse(ctx, repo, &apigen.ListRepositoryRunsParams{
-			Amount: api.PaginationAmountPtr(100),
+			Amount: apiutil.Ptr(apigen.PaginationAmount(100)),
 		})
 		verifyResponseOK(t, respList, err)
 		runsCount := len(respList.JSON200.Results)
@@ -3145,8 +3146,8 @@ func TestController_ListRepositoryRuns(t *testing.T) {
 
 	t.Run("on branch", func(t *testing.T) {
 		respList, err := clt.ListRepositoryRunsWithResponse(ctx, repo, &apigen.ListRepositoryRunsParams{
-			Branch: api.StringPtr("work"),
-			Amount: api.PaginationAmountPtr(100),
+			Branch: apiutil.Ptr("work"),
+			Amount: apiutil.Ptr(apigen.PaginationAmount(100)),
 		})
 		verifyResponseOK(t, respList, err)
 		runsCount := len(respList.JSON200.Results)
@@ -3157,9 +3158,9 @@ func TestController_ListRepositoryRuns(t *testing.T) {
 
 	t.Run("on branch and commit", func(t *testing.T) {
 		respList, err := clt.ListRepositoryRunsWithResponse(ctx, repo, &apigen.ListRepositoryRunsParams{
-			Branch: api.StringPtr("someBranch"),
-			Commit: api.StringPtr("someCommit"),
-			Amount: api.PaginationAmountPtr(100),
+			Branch: apiutil.Ptr("someBranch"),
+			Commit: apiutil.Ptr("someCommit"),
+			Amount: apiutil.Ptr(apigen.PaginationAmount(100)),
 		})
 		require.NoError(t, err)
 		require.NotNil(t, respList)
@@ -3172,8 +3173,8 @@ func TestController_ListRepositoryRuns(t *testing.T) {
 		verifyResponseOK(t, delResp, err)
 
 		respList, err := clt.ListRepositoryRunsWithResponse(ctx, repo, &apigen.ListRepositoryRunsParams{
-			Branch: api.StringPtr("work"),
-			Amount: api.PaginationAmountPtr(100),
+			Branch: apiutil.Ptr("work"),
+			Amount: apiutil.Ptr(apigen.PaginationAmount(100)),
 		})
 		verifyResponseOK(t, respList, err)
 		runsCount := len(respList.JSON200.Results)
@@ -3189,7 +3190,7 @@ func TestController_MergeInvalidStrategy(t *testing.T) {
 
 	repoName := testUniqueRepoName()
 	repoResp, err := clt.CreateRepositoryWithResponse(ctx, &apigen.CreateRepositoryParams{}, apigen.CreateRepositoryJSONRequestBody{
-		DefaultBranch:    api.StringPtr("main"),
+		DefaultBranch:    apiutil.Ptr("main"),
 		Name:             repoName,
 		StorageNamespace: "mem://",
 	})
@@ -3207,7 +3208,7 @@ func TestController_MergeInvalidStrategy(t *testing.T) {
 
 	strategy := "bad strategy"
 	mergeResp, err := clt.MergeIntoBranchWithResponse(ctx, repoName, "work", "main", apigen.MergeIntoBranchJSONRequestBody{
-		Message:  api.StringPtr("merge work to main"),
+		Message:  apiutil.Ptr("merge work to main"),
 		Strategy: &strategy,
 	})
 	testutil.Must(t, err)
@@ -3220,7 +3221,7 @@ func TestController_MergeDiffWithParent(t *testing.T) {
 
 	repoName := testUniqueRepoName()
 	repoResp, err := clt.CreateRepositoryWithResponse(ctx, &apigen.CreateRepositoryParams{}, apigen.CreateRepositoryJSONRequestBody{
-		DefaultBranch:    api.StringPtr("main"),
+		DefaultBranch:    apiutil.Ptr("main"),
 		Name:             repoName,
 		StorageNamespace: "mem://",
 	})
@@ -3237,7 +3238,7 @@ func TestController_MergeDiffWithParent(t *testing.T) {
 	verifyResponseOK(t, commitResp, err)
 
 	mergeResp, err := clt.MergeIntoBranchWithResponse(ctx, repoName, "work", "main", apigen.MergeIntoBranchJSONRequestBody{
-		Message: api.StringPtr("merge work to main"),
+		Message: apiutil.Ptr("merge work to main"),
 	})
 	verifyResponseOK(t, mergeResp, err)
 
@@ -3771,7 +3772,7 @@ func TestController_UpdatePolicy(t *testing.T) {
 	ctx := context.Background()
 
 	// test policy
-	now := api.Int64Ptr(time.Now().Unix())
+	now := apiutil.Ptr(time.Now().Unix())
 	const existingPolicyID = "TestUpdatePolicy"
 	response, err := clt.CreatePolicyWithResponse(ctx, apigen.CreatePolicyJSONRequestBody{
 		CreationDate: now,
@@ -3885,7 +3886,7 @@ func TestController_GetPhysicalAddress(t *testing.T) {
 				t.Fatalf("GetPhysicalAddressWithResponse %s, non JSON 200 response: %s", params.Path, resp.Status())
 			}
 
-			address := api.StringValue(resp.JSON200.PhysicalAddress)
+			address := apiutil.Value(resp.JSON200.PhysicalAddress)
 			t.Log(address)
 
 			const expectedPrefix = ns + "/" + upload.DefaultDataPrefix + "/"
@@ -4327,7 +4328,7 @@ func TestController_CopyObjectHandler(t *testing.T) {
 		uploadResp, err := uploadObjectHelper(t, ctx, clt, objPath, strings.NewReader(content), repository, branch)
 		verifyResponseOK(t, uploadResp, err)
 		require.NotNil(t, uploadResp.JSON201)
-		require.Equal(t, len(content), int(api.Int64Value(uploadResp.JSON201.SizeBytes)))
+		require.Equal(t, len(content), int(apiutil.Value(uploadResp.JSON201.SizeBytes)))
 		return *uploadResp.JSON201
 	}
 
@@ -4367,7 +4368,7 @@ func TestController_CopyObjectHandler(t *testing.T) {
 			DestPath: destPath,
 		}, apigen.CopyObjectJSONRequestBody{
 			SrcPath: srcPath,
-			SrcRef:  api.StringPtr("alt"),
+			SrcRef:  apiutil.Ptr("alt"),
 		})
 		verifyResponseOK(t, copyResp, err)
 
@@ -4407,7 +4408,7 @@ func TestController_CopyObjectHandler(t *testing.T) {
 			DestPath: destPath,
 		}, apigen.CopyObjectJSONRequestBody{
 			SrcPath: srcPath,
-			SrcRef:  api.StringPtr("main"),
+			SrcRef:  apiutil.Ptr("main"),
 		})
 		verifyResponseOK(t, copyResp, err)
 
@@ -4436,7 +4437,7 @@ func TestController_CopyObjectHandler(t *testing.T) {
 			DestPath: "bar/foo",
 		}, apigen.CopyObjectJSONRequestBody{
 			SrcPath: "not/found",
-			SrcRef:  api.StringPtr("main"),
+			SrcRef:  apiutil.Ptr("main"),
 		})
 		require.NoError(t, err)
 		require.NotNil(t, resp.JSON404)
@@ -4469,8 +4470,8 @@ func TestController_OtfDiff(t *testing.T) {
 	server := deps.server
 	authProvider := generateJWTToken(deps.authService, username)
 	nonExistingUserAuthProvider := generateJWTToken(deps.authService, username+"NE")
-	noCredsClient, _ := apigen.NewClientWithResponses(server.URL+api.BaseURL, apigen.WithRequestEditorFn(authProvider.Intercept))
-	noUserClient, _ := apigen.NewClientWithResponses(server.URL+api.BaseURL, apigen.WithRequestEditorFn(nonExistingUserAuthProvider.Intercept))
+	noCredsClient, _ := apigen.NewClientWithResponses(server.URL+apiutil.BaseURL, apigen.WithRequestEditorFn(authProvider.Intercept))
+	noUserClient, _ := apigen.NewClientWithResponses(server.URL+apiutil.BaseURL, apigen.WithRequestEditorFn(nonExistingUserAuthProvider.Intercept))
 
 	repo := testUniqueRepoName()
 

--- a/pkg/api/helpers/adapters.go
+++ b/pkg/api/helpers/adapters.go
@@ -11,7 +11,7 @@ import (
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
-	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apiutil"
 )
 
 // ObjectStats metadata of an object stored on a backing store.
@@ -77,7 +77,7 @@ func (s *s3Adapter) Upload(ctx context.Context, physicalAddress *url.URL, conten
 	manager := s3manager.NewUploader(s.sess)
 	out, err := manager.UploadWithContext(ctx, &s3manager.UploadInput{
 		Body:   contents,
-		Bucket: api.StringPtr(physicalAddress.Hostname()),
+		Bucket: apiutil.Ptr(physicalAddress.Hostname()),
 		Key:    &physicalAddress.Path,
 	})
 	if err != nil {
@@ -89,7 +89,7 @@ func (s *s3Adapter) Upload(ctx context.Context, physicalAddress *url.URL, conten
 	}
 	return ObjectStats{
 		Size: size,
-		ETag: api.StringValue(out.ETag),
+		ETag: apiutil.Value(out.ETag),
 		// S3Manager Upload does not return creation time.
 	}, nil
 }
@@ -100,7 +100,7 @@ func (s *s3Adapter) Download(ctx context.Context, physicalAddress *url.URL) (io.
 	}
 	// TODO(ariels): Allow customization of request
 	getObjectResponse, err := s.svc.GetObjectWithContext(ctx, &s3.GetObjectInput{
-		Bucket: api.StringPtr(physicalAddress.Hostname()),
+		Bucket: apiutil.Ptr(physicalAddress.Hostname()),
 		Key:    &physicalAddress.Path,
 	})
 	if err != nil {

--- a/pkg/api/helpers/download.go
+++ b/pkg/api/helpers/download.go
@@ -6,14 +6,14 @@ import (
 	"io"
 	"net/url"
 
-	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 )
 
 // ClientDownload downloads a file using client-side ("direct") access to underlying storage.
 // It requires credentials both to lakeFS and to underlying storage, but considerably reduces
 // the load on the lakeFS server.
-func ClientDownload(ctx context.Context, client api.ClientWithResponsesInterface, repoID, ref, filePath string) (*api.ObjectStats, io.ReadCloser, error) {
-	resp, err := client.StatObjectWithResponse(ctx, repoID, ref, &api.StatObjectParams{
+func ClientDownload(ctx context.Context, client apigen.ClientWithResponsesInterface, repoID, ref, filePath string) (*apigen.ObjectStats, io.ReadCloser, error) {
+	resp, err := client.StatObjectWithResponse(ctx, repoID, ref, &apigen.StatObjectParams{
 		Path: filePath,
 	})
 	if err != nil {

--- a/pkg/api/helpers/errors.go
+++ b/pkg/api/helpers/errors.go
@@ -9,7 +9,7 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 )
 
 var (
@@ -134,7 +134,7 @@ func ResponseAsError(response interface{}) error {
 	f = r.FieldByName("Body")
 	if f.IsValid() && f.Type().Kind() == reflect.Slice && f.Type().Elem().Kind() == reflect.Uint8 {
 		body := f.Bytes()
-		var apiError api.Error
+		var apiError apigen.Error
 		if json.Unmarshal(body, &apiError) == nil && apiError.Message != "" {
 			message = apiError.Message
 		}
@@ -162,7 +162,7 @@ func HTTPResponseAsError(httpResponse *http.Response) error {
 	var message string
 	body, err := io.ReadAll(httpResponse.Body)
 	if err == nil {
-		var apiError api.Error
+		var apiError apigen.Error
 		if json.Unmarshal(body, &apiError) == nil && apiError.Message != "" {
 			message = apiError.Message
 		}

--- a/pkg/api/helpers/upload.go
+++ b/pkg/api/helpers/upload.go
@@ -16,10 +16,11 @@ import (
 
 	"github.com/go-openapi/swag"
 	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 )
 
 // ClientUpload uploads contents as a file via lakeFS
-func ClientUpload(ctx context.Context, client api.ClientWithResponsesInterface, repoID, branchID, objPath string, metadata map[string]string, contentType string, contents io.ReadSeeker) (*api.ObjectStats, error) {
+func ClientUpload(ctx context.Context, client apigen.ClientWithResponsesInterface, repoID, branchID, objPath string, metadata map[string]string, contentType string, contents io.ReadSeeker) (*apigen.ObjectStats, error) {
 	pr, pw := io.Pipe()
 	defer func() {
 		_ = pr.Close()
@@ -58,7 +59,7 @@ func ClientUpload(ctx context.Context, client api.ClientWithResponsesInterface, 
 		}
 	}()
 
-	resp, err := client.UploadObjectWithBodyWithResponse(ctx, repoID, branchID, &api.UploadObjectParams{
+	resp, err := client.UploadObjectWithBodyWithResponse(ctx, repoID, branchID, &apigen.UploadObjectParams{
 		Path: objPath,
 	}, mpContentType, pr, func(ctx context.Context, req *http.Request) error {
 		var metaKey string
@@ -85,8 +86,8 @@ func ClientUpload(ctx context.Context, client api.ClientWithResponsesInterface, 
 // ClientUploadDirect uploads contents as a file using client-side ("direct") access to underlying
 // storage.  It requires credentials both to lakeFS and to underlying storage, but
 // considerably reduces the load on the lakeFS server.
-func ClientUploadDirect(ctx context.Context, client api.ClientWithResponsesInterface, repoID, branchID, objPath string, metadata map[string]string, contentType string, contents io.ReadSeeker) (*api.ObjectStats, error) {
-	stagingLocation, err := getPhysicalAddress(ctx, client, repoID, branchID, &api.GetPhysicalAddressParams{
+func ClientUploadDirect(ctx context.Context, client apigen.ClientWithResponsesInterface, repoID, branchID, objPath string, metadata map[string]string, contentType string, contents io.ReadSeeker) (*apigen.ObjectStats, error) {
+	stagingLocation, err := getPhysicalAddress(ctx, client, repoID, branchID, &apigen.GetPhysicalAddressParams{
 		Path: objPath,
 	})
 	if err != nil {
@@ -110,13 +111,13 @@ func ClientUploadDirect(ctx context.Context, client api.ClientWithResponsesInter
 			return nil, fmt.Errorf("upload to backing store: %w", err)
 		}
 
-		resp, err := client.LinkPhysicalAddressWithResponse(ctx, repoID, branchID, &api.LinkPhysicalAddressParams{
+		resp, err := client.LinkPhysicalAddressWithResponse(ctx, repoID, branchID, &apigen.LinkPhysicalAddressParams{
 			Path: objPath,
-		}, api.LinkPhysicalAddressJSONRequestBody{
+		}, apigen.LinkPhysicalAddressJSONRequestBody{
 			Checksum:  stats.ETag,
 			SizeBytes: stats.Size,
 			Staging:   *stagingLocation,
-			UserMetadata: &api.StagingMetadata_UserMetadata{
+			UserMetadata: &apigen.StagingMetadata_UserMetadata{
 				AdditionalProperties: metadata,
 			},
 			ContentType: &contentType,
@@ -137,7 +138,7 @@ func ClientUploadDirect(ctx context.Context, client api.ClientWithResponsesInter
 	}
 }
 
-func ClientUploadPreSign(ctx context.Context, client api.ClientWithResponsesInterface, repoID, branchID, objPath string, metadata map[string]string, contentType string, contents io.ReadSeeker) (*api.ObjectStats, error) {
+func ClientUploadPreSign(ctx context.Context, client apigen.ClientWithResponsesInterface, repoID, branchID, objPath string, metadata map[string]string, contentType string, contents io.ReadSeeker) (*apigen.ObjectStats, error) {
 	// calculate size using seek
 	contentLength, err := contents.Seek(0, io.SeekEnd)
 	if err != nil {
@@ -159,8 +160,8 @@ func ClientUploadPreSign(ctx context.Context, client api.ClientWithResponsesInte
 
 // clientUploadPreSignHelper helper func to get physical address an upload content. Special case if conflict that
 // ErrConflict is returned where a re-try is required.
-func clientUploadPreSignHelper(ctx context.Context, client api.ClientWithResponsesInterface, repoID string, branchID string, objPath string, metadata map[string]string, contentType string, contents io.ReadSeeker, contentLength int64) (*api.ObjectStats, error) {
-	stagingLocation, err := getPhysicalAddress(ctx, client, repoID, branchID, &api.GetPhysicalAddressParams{
+func clientUploadPreSignHelper(ctx context.Context, client apigen.ClientWithResponsesInterface, repoID string, branchID string, objPath string, metadata map[string]string, contentType string, contents io.ReadSeeker, contentLength int64) (*apigen.ObjectStats, error) {
+	stagingLocation, err := getPhysicalAddress(ctx, client, repoID, branchID, &apigen.GetPhysicalAddressParams{
 		Path:    objPath,
 		Presign: swag.Bool(true),
 	})
@@ -202,17 +203,17 @@ func clientUploadPreSignHelper(ctx context.Context, client api.ClientWithRespons
 		return nil, fmt.Errorf("etag is missing: %w", ErrRequestFailed)
 	}
 
-	linkReqBody := api.LinkPhysicalAddressJSONRequestBody{
+	linkReqBody := apigen.LinkPhysicalAddressJSONRequestBody{
 		Checksum:  etag,
 		SizeBytes: contentLength,
 		Staging:   *stagingLocation,
-		UserMetadata: &api.StagingMetadata_UserMetadata{
+		UserMetadata: &apigen.StagingMetadata_UserMetadata{
 			AdditionalProperties: metadata,
 		},
 		ContentType: api.StringPtr(contentType),
 	}
 	linkResp, err := client.LinkPhysicalAddressWithResponse(ctx, repoID, branchID,
-		&api.LinkPhysicalAddressParams{
+		&apigen.LinkPhysicalAddressParams{
 			Path: objPath,
 		}, linkReqBody)
 	if err != nil {
@@ -227,7 +228,7 @@ func clientUploadPreSignHelper(ctx context.Context, client api.ClientWithRespons
 	return nil, fmt.Errorf("link object to backing store: %w (%s)", ErrRequestFailed, linkResp.Status())
 }
 
-func getPhysicalAddress(ctx context.Context, client api.ClientWithResponsesInterface, repoID string, branchID string, params *api.GetPhysicalAddressParams) (*api.StagingLocation, error) {
+func getPhysicalAddress(ctx context.Context, client apigen.ClientWithResponsesInterface, repoID string, branchID string, params *apigen.GetPhysicalAddressParams) (*apigen.StagingLocation, error) {
 	resp, err := client.GetPhysicalAddressWithResponse(ctx, repoID, branchID, params)
 	if err != nil {
 		return nil, fmt.Errorf("get physical address to upload object: %w", err)

--- a/pkg/api/helpers/upload.go
+++ b/pkg/api/helpers/upload.go
@@ -15,8 +15,8 @@ import (
 	"strings"
 
 	"github.com/go-openapi/swag"
-	"github.com/treeverse/lakefs/pkg/api"
 	"github.com/treeverse/lakefs/pkg/api/apigen"
+	"github.com/treeverse/lakefs/pkg/api/apiutil"
 )
 
 // ClientUpload uploads contents as a file via lakeFS
@@ -65,10 +65,10 @@ func ClientUpload(ctx context.Context, client apigen.ClientWithResponsesInterfac
 		var metaKey string
 		for k, v := range metadata {
 			lowerKey := strings.ToLower(k)
-			if strings.HasPrefix(lowerKey, api.LakeFSMetadataPrefix) {
-				metaKey = api.LakeFSHeaderInternalPrefix + lowerKey[len(api.LakeFSMetadataPrefix):]
+			if strings.HasPrefix(lowerKey, apiutil.LakeFSMetadataPrefix) {
+				metaKey = apiutil.LakeFSHeaderInternalPrefix + lowerKey[len(apiutil.LakeFSMetadataPrefix):]
 			} else {
-				metaKey = api.LakeFSHeaderMetadataPrefix + lowerKey
+				metaKey = apiutil.LakeFSHeaderMetadataPrefix + lowerKey
 			}
 			req.Header.Set(metaKey, v)
 		}
@@ -95,7 +95,7 @@ func ClientUploadDirect(ctx context.Context, client apigen.ClientWithResponsesIn
 	}
 
 	for { // Return from inside loop
-		physicalAddress := api.StringValue(stagingLocation.PhysicalAddress)
+		physicalAddress := apiutil.Value(stagingLocation.PhysicalAddress)
 		parsedAddress, err := url.Parse(physicalAddress)
 		if err != nil {
 			return nil, fmt.Errorf("parse physical address URL %s: %w", physicalAddress, err)
@@ -210,7 +210,7 @@ func clientUploadPreSignHelper(ctx context.Context, client apigen.ClientWithResp
 		UserMetadata: &apigen.StagingMetadata_UserMetadata{
 			AdditionalProperties: metadata,
 		},
-		ContentType: api.StringPtr(contentType),
+		ContentType: apiutil.Ptr(contentType),
 	}
 	linkResp, err := client.LinkPhysicalAddressWithResponse(ctx, repoID, branchID,
 		&apigen.LinkPhysicalAddressParams{

--- a/pkg/api/serve.go
+++ b/pkg/api/serve.go
@@ -15,6 +15,7 @@ import (
 	"github.com/gorilla/sessions"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
 	"github.com/treeverse/lakefs/pkg/api/apigen"
+	"github.com/treeverse/lakefs/pkg/api/apiutil"
 	"github.com/treeverse/lakefs/pkg/api/params"
 	"github.com/treeverse/lakefs/pkg/auth"
 	"github.com/treeverse/lakefs/pkg/auth/email"
@@ -33,7 +34,6 @@ import (
 const (
 	RequestIDHeaderName = "X-Request-ID"
 	LoggerServiceName   = "rest_api"
-	BaseURL             = "/api/v1"
 
 	extensionValidationExcludeBody = "x-validation-exclude-body"
 )
@@ -98,13 +98,13 @@ func Serve(
 		pathProvider,
 		otfService,
 	)
-	apigen.HandlerFromMuxWithBaseURL(controller, apiRouter, BaseURL)
+	apigen.HandlerFromMuxWithBaseURL(controller, apiRouter, apiutil.BaseURL)
 
 	r.Mount("/_health", httputil.ServeHealth())
 	r.Mount("/metrics", promhttp.Handler())
 	r.Mount("/_pprof/", httputil.ServePPROF("/_pprof/"))
 	r.Mount("/swagger.json", http.HandlerFunc(swaggerSpecHandler))
-	r.Mount(BaseURL, http.HandlerFunc(InvalidAPIEndpointHandler))
+	r.Mount(apiutil.BaseURL, http.HandlerFunc(InvalidAPIEndpointHandler))
 	r.Mount("/logout", NewLogoutHandler(sessionStore, logger, cfg.Auth.LogoutRedirectURL))
 
 	// Configuration flag to control if the embedded UI is served

--- a/pkg/api/serve.go
+++ b/pkg/api/serve.go
@@ -1,6 +1,6 @@
 package api
 
-//go:generate go run github.com/deepmap/oapi-codegen/cmd/oapi-codegen@v1.5.6 -package api -generate "types,client,chi-server,spec" -templates tmpl -o lakefs.gen.go ../../api/swagger.yml
+//go:generate go run github.com/deepmap/oapi-codegen/cmd/oapi-codegen@v1.5.6 -package apigen -generate "types,client,chi-server,spec" -templates tmpl -o apigen/lakefs.gen.go ../../api/swagger.yml
 
 import (
 	"errors"
@@ -14,6 +14,7 @@ import (
 	"github.com/go-chi/chi/v5"
 	"github.com/gorilla/sessions"
 	"github.com/prometheus/client_golang/prometheus/promhttp"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 	"github.com/treeverse/lakefs/pkg/api/params"
 	"github.com/treeverse/lakefs/pkg/auth"
 	"github.com/treeverse/lakefs/pkg/auth/email"
@@ -58,7 +59,7 @@ func Serve(
 	otfService *tablediff.Service,
 ) http.Handler {
 	logger.Info("initialize OpenAPI server")
-	swagger, err := GetSwagger()
+	swagger, err := apigen.GetSwagger()
 	if err != nil {
 		panic(err)
 	}
@@ -97,7 +98,7 @@ func Serve(
 		pathProvider,
 		otfService,
 	)
-	HandlerFromMuxWithBaseURL(controller, apiRouter, BaseURL)
+	apigen.HandlerFromMuxWithBaseURL(controller, apiRouter, BaseURL)
 
 	r.Mount("/_health", httputil.ServeHealth())
 	r.Mount("/metrics", promhttp.Handler())
@@ -125,7 +126,7 @@ func Serve(
 }
 
 func swaggerSpecHandler(w http.ResponseWriter, _ *http.Request) {
-	reader, err := GetSwaggerSpecReader()
+	reader, err := apigen.GetSwaggerSpecReader()
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return

--- a/pkg/api/serve.go
+++ b/pkg/api/serve.go
@@ -1,7 +1,5 @@
 package api
 
-//go:generate go run github.com/deepmap/oapi-codegen/cmd/oapi-codegen@v1.5.6 -package apigen -generate "types,client,chi-server,spec" -templates tmpl -o apigen/lakefs.gen.go ../../api/swagger.yml
-
 import (
 	"errors"
 	"io"

--- a/pkg/api/serve_test.go
+++ b/pkg/api/serve_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/treeverse/lakefs/pkg/actions"
 	"github.com/treeverse/lakefs/pkg/api"
 	"github.com/treeverse/lakefs/pkg/api/apigen"
+	"github.com/treeverse/lakefs/pkg/api/apiutil"
 	"github.com/treeverse/lakefs/pkg/auth"
 	"github.com/treeverse/lakefs/pkg/auth/crypt"
 	"github.com/treeverse/lakefs/pkg/auth/email"
@@ -237,7 +238,7 @@ func setupClientByEndpoint(t testing.TB, endpointURL string, accessKeyID, secret
 		}
 		opts = append(opts, apigen.WithRequestEditorFn(basicAuthProvider.Intercept))
 	}
-	clt, err := apigen.NewClientWithResponses(endpointURL+api.BaseURL, opts...)
+	clt, err := apigen.NewClientWithResponses(endpointURL+apiutil.BaseURL, opts...)
 	if err != nil {
 		t.Fatal("failed to create lakefs api client:", err)
 	}
@@ -293,7 +294,7 @@ func TestInvalidRoute(t *testing.T) {
 	if err != nil {
 		t.Fatal("basic auth security provider", err)
 	}
-	clt, err = apigen.NewClientWithResponses(server.URL+api.BaseURL+"//", apigen.WithRequestEditorFn(basicAuthProvider.Intercept))
+	clt, err = apigen.NewClientWithResponses(server.URL+apiutil.BaseURL+"//", apigen.WithRequestEditorFn(basicAuthProvider.Intercept))
 	if err != nil {
 		t.Fatal("failed to create api client:", err)
 	}

--- a/pkg/api/serve_test.go
+++ b/pkg/api/serve_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/spf13/viper"
 	"github.com/treeverse/lakefs/pkg/actions"
 	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 	"github.com/treeverse/lakefs/pkg/auth"
 	"github.com/treeverse/lakefs/pkg/auth/crypt"
 	"github.com/treeverse/lakefs/pkg/auth/email"
@@ -86,9 +87,9 @@ func (m *memCollector) CollectCommPrefs(email, installationID string, featureUpd
 
 func (m *memCollector) Close() {}
 
-func createDefaultAdminUser(t testing.TB, clt api.ClientWithResponsesInterface) *authmodel.BaseCredential {
+func createDefaultAdminUser(t testing.TB, clt apigen.ClientWithResponsesInterface) *authmodel.BaseCredential {
 	t.Helper()
-	res, err := clt.SetupWithResponse(context.Background(), api.SetupJSONRequestBody{
+	res, err := clt.SetupWithResponse(context.Background(), apigen.SetupJSONRequestBody{
 		Username: "admin",
 	})
 	testutil.Must(t, err)
@@ -102,10 +103,10 @@ func createDefaultAdminUser(t testing.TB, clt api.ClientWithResponsesInterface) 
 	}
 }
 
-func createUserWithDefaultGroup(t testing.TB, clt api.ClientWithResponsesInterface) *authmodel.BaseCredential {
+func createUserWithDefaultGroup(t testing.TB, clt apigen.ClientWithResponsesInterface) *authmodel.BaseCredential {
 	t.Helper()
 	// create the user
-	createUsrRes, err := clt.CreateUserWithResponse(context.Background(), api.CreateUserJSONRequestBody{
+	createUsrRes, err := clt.CreateUserWithResponse(context.Background(), apigen.CreateUserJSONRequestBody{
 		Id:         "test@example.com",
 		InviteUser: swag.Bool(false),
 	})
@@ -226,7 +227,7 @@ func setupHandler(t testing.TB) (http.Handler, *dependencies) {
 	return setupHandlerWithWalkerFactory(t, store.NewFactory(nil))
 }
 
-func setupClientByEndpoint(t testing.TB, endpointURL string, accessKeyID, secretAccessKey string, opts ...api.ClientOption) api.ClientWithResponsesInterface {
+func setupClientByEndpoint(t testing.TB, endpointURL string, accessKeyID, secretAccessKey string, opts ...apigen.ClientOption) apigen.ClientWithResponsesInterface {
 	t.Helper()
 
 	if accessKeyID != "" {
@@ -234,9 +235,9 @@ func setupClientByEndpoint(t testing.TB, endpointURL string, accessKeyID, secret
 		if err != nil {
 			t.Fatal("basic auth security provider", err)
 		}
-		opts = append(opts, api.WithRequestEditorFn(basicAuthProvider.Intercept))
+		opts = append(opts, apigen.WithRequestEditorFn(basicAuthProvider.Intercept))
 	}
-	clt, err := api.NewClientWithResponses(endpointURL+api.BaseURL, opts...)
+	clt, err := apigen.NewClientWithResponses(endpointURL+api.BaseURL, opts...)
 	if err != nil {
 		t.Fatal("failed to create lakefs api client:", err)
 	}
@@ -265,12 +266,12 @@ func shouldUseServerTimeout() bool {
 	return withServerTimeout
 }
 
-func setupClientWithAdmin(t testing.TB) (api.ClientWithResponsesInterface, *dependencies) {
+func setupClientWithAdmin(t testing.TB) (apigen.ClientWithResponsesInterface, *dependencies) {
 	t.Helper()
 	return setupClientWithAdminAndWalkerFactory(t, store.NewFactory(nil))
 }
 
-func setupClientWithAdminAndWalkerFactory(t testing.TB, factory catalog.WalkerFactory) (api.ClientWithResponsesInterface, *dependencies) {
+func setupClientWithAdminAndWalkerFactory(t testing.TB, factory catalog.WalkerFactory) (apigen.ClientWithResponsesInterface, *dependencies) {
 	t.Helper()
 	handler, deps := setupHandlerWithWalkerFactory(t, factory)
 	server := setupServer(t, handler)
@@ -292,13 +293,13 @@ func TestInvalidRoute(t *testing.T) {
 	if err != nil {
 		t.Fatal("basic auth security provider", err)
 	}
-	clt, err = api.NewClientWithResponses(server.URL+api.BaseURL+"//", api.WithRequestEditorFn(basicAuthProvider.Intercept))
+	clt, err = apigen.NewClientWithResponses(server.URL+api.BaseURL+"//", apigen.WithRequestEditorFn(basicAuthProvider.Intercept))
 	if err != nil {
 		t.Fatal("failed to create api client:", err)
 	}
 
 	ctx := context.Background()
-	resp, err := clt.ListRepositoriesWithResponse(ctx, &api.ListRepositoriesParams{})
+	resp, err := clt.ListRepositoriesWithResponse(ctx, &apigen.ListRepositoriesParams{})
 	if err != nil {
 		t.Fatalf("failed to get lakefs server version")
 	}

--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -7,8 +7,8 @@ import (
 
 	"github.com/go-openapi/swag"
 	"github.com/jedib0t/go-pretty/v6/text"
-	"github.com/treeverse/lakefs/pkg/api"
 	"github.com/treeverse/lakefs/pkg/api/apigen"
+	"github.com/treeverse/lakefs/pkg/api/apiutil"
 	"github.com/treeverse/lakefs/pkg/local"
 	"github.com/treeverse/lakefs/pkg/uri"
 )
@@ -22,7 +22,7 @@ func StreamRepositoryDiffs(ctx context.Context, client apigen.ClientWithResponse
 	}()
 	var diffType *string
 	if twoDot {
-		diffType = api.StringPtr(diffTypeTwoDot)
+		diffType = apiutil.Ptr(diffTypeTwoDot)
 	}
 
 	hasMore := true

--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -8,6 +8,7 @@ import (
 	"github.com/go-openapi/swag"
 	"github.com/jedib0t/go-pretty/v6/text"
 	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 	"github.com/treeverse/lakefs/pkg/local"
 	"github.com/treeverse/lakefs/pkg/uri"
 )
@@ -15,7 +16,7 @@ import (
 const diffTypeTwoDot = "two_dot"
 
 // StreamRepositoryDiffs asynchronously fetches differences between 'left' and 'right' references, assumes both are in the same repository
-func StreamRepositoryDiffs(ctx context.Context, client api.ClientWithResponsesInterface, left, right *uri.URI, prefix string, diffs chan<- api.Diff, twoDot bool) error {
+func StreamRepositoryDiffs(ctx context.Context, client apigen.ClientWithResponsesInterface, left, right *uri.URI, prefix string, diffs chan<- apigen.Diff, twoDot bool) error {
 	defer func() {
 		close(diffs)
 	}()
@@ -27,9 +28,9 @@ func StreamRepositoryDiffs(ctx context.Context, client api.ClientWithResponsesIn
 	hasMore := true
 	var after string
 	for hasMore {
-		diffResp, err := client.DiffRefsWithResponse(ctx, left.Repository, left.Ref, right.Ref, &api.DiffRefsParams{
-			After:  (*api.PaginationAfter)(swag.String(after)),
-			Prefix: (*api.PaginationPrefix)(&prefix),
+		diffResp, err := client.DiffRefsWithResponse(ctx, left.Repository, left.Ref, right.Ref, &apigen.DiffRefsParams{
+			After:  (*apigen.PaginationAfter)(swag.String(after)),
+			Prefix: (*apigen.PaginationPrefix)(&prefix),
 			Type:   diffType,
 		})
 		if err != nil {

--- a/pkg/gateway/operations/putobject_test.go
+++ b/pkg/gateway/operations/putobject_test.go
@@ -8,7 +8,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apiutil"
 	"github.com/treeverse/lakefs/pkg/block"
 	"github.com/treeverse/lakefs/pkg/upload"
 )
@@ -29,8 +29,8 @@ func TestReadBlob(t *testing.T) {
 	}{
 		{"no data", 0, nil},
 		{"100 bytes", 100, nil},
-		{"1 block", ObjectBlockSize, api.StringPtr(expensiveString)},
-		{"1 block and 100 bytes", ObjectBlockSize + 100, api.StringPtr(cheapString)},
+		{"1 block", ObjectBlockSize, apiutil.Ptr(expensiveString)},
+		{"1 block and 100 bytes", ObjectBlockSize + 100, apiutil.Ptr(cheapString)},
 		{"2 blocks and 1 bytes", ObjectBlockSize*2 + 1, nil},
 		{"1000 blocks", ObjectBlockSize * 1000, nil},
 	}

--- a/pkg/loadtest/loader.go
+++ b/pkg/loadtest/loader.go
@@ -14,6 +14,7 @@ import (
 	"github.com/google/uuid"
 	"github.com/jedib0t/go-pretty/v6/text"
 	"github.com/schollz/progressbar/v3"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 	vegeta "github.com/tsenart/vegeta/v12/lib"
 
 	"github.com/treeverse/lakefs/pkg/api"
@@ -106,14 +107,14 @@ func (t *Loader) Run() error {
 	return nil
 }
 
-func (t *Loader) createRepo(apiClient api.ClientWithResponsesInterface) (string, error) {
+func (t *Loader) createRepo(apiClient apigen.ClientWithResponsesInterface) (string, error) {
 	if t.Config.RepoName != "" {
 		// using an existing repo, no need to create one
 		return t.Config.RepoName, nil
 	}
 	t.NewRepoName = uuid.New().String()
 	ctx := context.Background()
-	resp, err := apiClient.CreateRepositoryWithResponse(ctx, &api.CreateRepositoryParams{}, api.CreateRepositoryJSONRequestBody{
+	resp, err := apiClient.CreateRepositoryWithResponse(ctx, &apigen.CreateRepositoryParams{}, apigen.CreateRepositoryJSONRequestBody{
 		DefaultBranch:    api.StringPtr("main"),
 		Name:             t.NewRepoName,
 		StorageNamespace: t.Config.StorageNamespace,
@@ -127,7 +128,7 @@ func (t *Loader) createRepo(apiClient api.ClientWithResponsesInterface) (string,
 	return t.NewRepoName, nil
 }
 
-func (t *Loader) getClient() (api.ClientWithResponsesInterface, error) {
+func (t *Loader) getClient() (apigen.ClientWithResponsesInterface, error) {
 	if t.Config.RepoName != "" {
 		// using an existing repo, no need to create a client
 		return nil, nil
@@ -138,10 +139,10 @@ func (t *Loader) getClient() (api.ClientWithResponsesInterface, error) {
 	}
 
 	serverEndpoint := t.Config.ServerAddress + api.BaseURL
-	apiClient, err := api.NewClientWithResponses(
+	apiClient, err := apigen.NewClientWithResponses(
 		serverEndpoint,
-		api.WithRequestEditorFn(basicAuthProvider.Intercept),
-		api.WithRequestEditorFn(func(ctx context.Context, req *http.Request) error {
+		apigen.WithRequestEditorFn(basicAuthProvider.Intercept),
+		apigen.WithRequestEditorFn(func(ctx context.Context, req *http.Request) error {
 			req.Header.Set("User-Agent", "lakefs-loadtest/"+version.Version)
 			return nil
 		}),

--- a/pkg/loadtest/loader.go
+++ b/pkg/loadtest/loader.go
@@ -15,12 +15,11 @@ import (
 	"github.com/jedib0t/go-pretty/v6/text"
 	"github.com/schollz/progressbar/v3"
 	"github.com/treeverse/lakefs/pkg/api/apigen"
-	vegeta "github.com/tsenart/vegeta/v12/lib"
-
-	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apiutil"
 	"github.com/treeverse/lakefs/pkg/auth/model"
 	"github.com/treeverse/lakefs/pkg/logging"
 	"github.com/treeverse/lakefs/pkg/version"
+	vegeta "github.com/tsenart/vegeta/v12/lib"
 )
 
 type Loader struct {
@@ -115,7 +114,7 @@ func (t *Loader) createRepo(apiClient apigen.ClientWithResponsesInterface) (stri
 	t.NewRepoName = uuid.New().String()
 	ctx := context.Background()
 	resp, err := apiClient.CreateRepositoryWithResponse(ctx, &apigen.CreateRepositoryParams{}, apigen.CreateRepositoryJSONRequestBody{
-		DefaultBranch:    api.StringPtr("main"),
+		DefaultBranch:    apiutil.Ptr("main"),
 		Name:             t.NewRepoName,
 		StorageNamespace: t.Config.StorageNamespace,
 	})
@@ -138,7 +137,7 @@ func (t *Loader) getClient() (apigen.ClientWithResponsesInterface, error) {
 		return nil, err
 	}
 
-	serverEndpoint := t.Config.ServerAddress + api.BaseURL
+	serverEndpoint := t.Config.ServerAddress + apiutil.BaseURL
 	apiClient, err := apigen.NewClientWithResponses(
 		serverEndpoint,
 		apigen.WithRequestEditorFn(basicAuthProvider.Intercept),

--- a/pkg/local/diff.go
+++ b/pkg/local/diff.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 
 	"github.com/go-openapi/swag"
-	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 	"github.com/treeverse/lakefs/pkg/uri"
 )
 
@@ -187,11 +187,11 @@ func Undo(c Changes) Changes {
 // DiffLocalWithHead Checks changes between a local directory and the head it is pointing to. The diff check assumes the remote
 // is an immutable set so any changes found resulted from changes in the local directory
 // left is an object channel which contains results from a remote source. rightPath is the local directory to diff with
-func DiffLocalWithHead(left <-chan api.ObjectStats, rightPath string) (Changes, error) {
+func DiffLocalWithHead(left <-chan apigen.ObjectStats, rightPath string) (Changes, error) {
 	// left should be the base commit
 	changes := make([]*Change, 0)
 	var (
-		currentRemoteFile api.ObjectStats
+		currentRemoteFile apigen.ObjectStats
 		hasMore           bool
 	)
 	err := filepath.Walk(rightPath, func(path string, info fs.FileInfo, err error) error {
@@ -249,7 +249,7 @@ func DiffLocalWithHead(left <-chan api.ObjectStats, rightPath string) (Changes, 
 }
 
 // ListRemote - Lists objects from a remote uri and inserts them into the objects channel
-func ListRemote(ctx context.Context, client api.ClientWithResponsesInterface, loc *uri.URI, objects chan<- api.ObjectStats) error {
+func ListRemote(ctx context.Context, client apigen.ClientWithResponsesInterface, loc *uri.URI, objects chan<- apigen.ObjectStats) error {
 	hasMore := true
 	var after string
 	defer func() {
@@ -257,9 +257,9 @@ func ListRemote(ctx context.Context, client api.ClientWithResponsesInterface, lo
 	}()
 
 	for hasMore {
-		listResp, err := client.ListObjectsWithResponse(ctx, loc.Repository, loc.Ref, &api.ListObjectsParams{
-			After:        (*api.PaginationAfter)(swag.String(after)),
-			Prefix:       (*api.PaginationPrefix)(loc.Path),
+		listResp, err := client.ListObjectsWithResponse(ctx, loc.Repository, loc.Ref, &apigen.ListObjectsParams{
+			After:        (*apigen.PaginationAfter)(swag.String(after)),
+			Prefix:       (*apigen.PaginationPrefix)(loc.Path),
 			UserMetadata: swag.Bool(true),
 		})
 		if err != nil {
@@ -276,7 +276,7 @@ func ListRemote(ctx context.Context, client api.ClientWithResponsesInterface, lo
 				continue
 			}
 			path = strings.TrimPrefix(path, uri.PathSeparator)
-			objects <- api.ObjectStats{
+			objects <- apigen.ObjectStats{
 				Checksum:        o.Checksum,
 				ContentType:     o.ContentType,
 				Metadata:        o.Metadata,

--- a/pkg/local/diff_test.go
+++ b/pkg/local/diff_test.go
@@ -10,7 +10,7 @@ import (
 
 	"github.com/go-openapi/swag"
 	"github.com/stretchr/testify/require"
-	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 	"github.com/treeverse/lakefs/pkg/local"
 )
 
@@ -22,13 +22,13 @@ func TestDiffLocal(t *testing.T) {
 	cases := []struct {
 		Name       string
 		LocalPath  string
-		RemoteList []api.ObjectStats
+		RemoteList []apigen.ObjectStats
 		Expected   []*local.Change
 	}{
 		{
 			Name:      "t1_no_diff",
 			LocalPath: "testdata/localdiff/t1",
-			RemoteList: []api.ObjectStats{
+			RemoteList: []apigen.ObjectStats{
 				{
 					Path:      "sub/f.txt",
 					SizeBytes: swag.Int64(3),
@@ -45,7 +45,7 @@ func TestDiffLocal(t *testing.T) {
 		{
 			Name:      "t1_modified",
 			LocalPath: "testdata/localdiff/t1",
-			RemoteList: []api.ObjectStats{
+			RemoteList: []apigen.ObjectStats{
 				{
 					Path:      "sub/f.txt",
 					SizeBytes: swag.Int64(3),
@@ -71,7 +71,7 @@ func TestDiffLocal(t *testing.T) {
 		{
 			Name:      "t1_local_before",
 			LocalPath: "testdata/localdiff/t1",
-			RemoteList: []api.ObjectStats{
+			RemoteList: []apigen.ObjectStats{
 				{
 					Path:      "sub/folder/f.txt",
 					SizeBytes: swag.Int64(6),
@@ -88,7 +88,7 @@ func TestDiffLocal(t *testing.T) {
 		{
 			Name:      "t1_local_after",
 			LocalPath: "testdata/localdiff/t1",
-			RemoteList: []api.ObjectStats{
+			RemoteList: []apigen.ObjectStats{
 				{
 					Path:      "tub/r.txt",
 					SizeBytes: swag.Int64(6),
@@ -119,7 +119,7 @@ func TestDiffLocal(t *testing.T) {
 			sort.SliceStable(left, func(i, j int) bool {
 				return left[i].Path < left[j].Path
 			})
-			lc := make(chan api.ObjectStats, len(left))
+			lc := make(chan apigen.ObjectStats, len(left))
 			makeChan(lc, left)
 			changes, err := local.DiffLocalWithHead(lc, tt.LocalPath)
 			if err != nil {

--- a/pkg/local/sync.go
+++ b/pkg/local/sync.go
@@ -16,8 +16,8 @@ import (
 	"time"
 
 	"github.com/go-openapi/swag"
-	"github.com/treeverse/lakefs/pkg/api"
 	"github.com/treeverse/lakefs/pkg/api/apigen"
+	"github.com/treeverse/lakefs/pkg/api/apiutil"
 	"github.com/treeverse/lakefs/pkg/api/helpers"
 	"github.com/treeverse/lakefs/pkg/fileutil"
 	"github.com/treeverse/lakefs/pkg/uri"
@@ -26,7 +26,7 @@ import (
 
 const (
 	DefaultDirectoryMask   = 0o755
-	ClientMtimeMetadataKey = api.LakeFSMetadataPrefix + "client-mtime"
+	ClientMtimeMetadataKey = apiutil.LakeFSMetadataPrefix + "client-mtime"
 )
 
 func getMtimeFromStats(stats apigen.ObjectStats) (int64, error) {

--- a/pkg/testutil/setup.go
+++ b/pkg/testutil/setup.go
@@ -15,8 +15,8 @@ import (
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/deepmap/oapi-codegen/pkg/securityprovider"
 	"github.com/spf13/viper"
-	"github.com/treeverse/lakefs/pkg/api"
 	"github.com/treeverse/lakefs/pkg/api/apigen"
+	"github.com/treeverse/lakefs/pkg/api/apiutil"
 	"github.com/treeverse/lakefs/pkg/block"
 	"github.com/treeverse/lakefs/pkg/config"
 	"github.com/treeverse/lakefs/pkg/logging"
@@ -150,7 +150,7 @@ func ParseEndpointURL(logger logging.Logger, endpointURL string) string {
 		logger.WithError(err).Fatal("could not initialize API client with security provider")
 	}
 	if u.Path == "" || u.Path == "/" {
-		endpointURL = strings.TrimRight(endpointURL, "/") + api.BaseURL
+		endpointURL = strings.TrimRight(endpointURL, "/") + apiutil.BaseURL
 	}
 
 	return endpointURL

--- a/pkg/version/audit_test.go
+++ b/pkg/version/audit_test.go
@@ -19,6 +19,7 @@ type LogLine struct {
 	Level  string
 	Msg    string
 }
+
 type MemLogger struct {
 	log    []*LogLine
 	fields logging.Fields


### PR DESCRIPTION
Split the generated API code from the `api` package that implements the server side.
lakectl and other packages can use the generated package without compile and import code they do not use.

Close https://github.com/treeverse/lakeFS/issues/6560