### PR TITLE
lakectl: deprecate dbt and metastore commands

### DIFF
--- a/.github/workflows/check-ui-links.yaml
+++ b/.github/workflows/check-ui-links.yaml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Check links
         id: lychee
-        uses: lycheeverse/lychee-action@v1.7.0
+        uses: lycheeverse/lychee-action@v1.8.0
         with:
           args: /tmp/links_to_check.txt
           fail: false

--- a/.github/workflows/docs-pr.yaml
+++ b/.github/workflows/docs-pr.yaml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Check links
         id: lychee
-        uses: lycheeverse/lychee-action@v1.7.0
+        uses: lycheeverse/lychee-action@v1.8.0
         with:
           args: docs/_site --no-progress --exclude-file=docs/.lycheeignore
           fail: true

--- a/cmd/lakectl/cmd/dbt.go
+++ b/cmd/lakectl/cmd/dbt.go
@@ -26,8 +26,9 @@ func ExecuteCommand(cmd *exec.Cmd) ([]byte, error) {
 }
 
 var dbtCmd = &cobra.Command{
-	Use:   "dbt",
-	Short: "Integration with dbt commands",
+	Use:        "dbt",
+	Short:      "Integration with dbt commands",
+	Deprecated: "Upcoming releases of lakectl will no longer support this command.",
 }
 
 //nolint:gochecknoinits

--- a/cmd/lakectl/cmd/dbt_create_branch_schema.go
+++ b/cmd/lakectl/cmd/dbt_create_branch_schema.go
@@ -13,9 +13,10 @@ import (
 )
 
 var dbtCreateBranchSchema = &cobra.Command{
-	Use:     "create-branch-schema",
-	Short:   "Creates a new schema dedicated for branch and clones all dbt models to new schema",
-	Example: "lakectl dbt create-branch-schema --branch <branch-name>",
+	Use:        "create-branch-schema",
+	Short:      "Creates a new schema dedicated for branch and clones all dbt models to new schema",
+	Example:    "lakectl dbt create-branch-schema --branch <branch-name>",
+	Deprecated: "Upcoming releases of lakectl will no longer support this command.",
 	Run: func(cmd *cobra.Command, args []string) {
 		clientType := Must(cmd.Flags().GetString("from-client-type"))
 		branchName := Must(cmd.Flags().GetString("branch"))

--- a/cmd/lakectl/cmd/dbt_generate_schema_macro.go
+++ b/cmd/lakectl/cmd/dbt_generate_schema_macro.go
@@ -9,9 +9,10 @@ import (
 )
 
 var dbtGenerateSchemaMacro = &cobra.Command{
-	Use:     "generate-schema-macro",
-	Short:   "generates the a macro allowing lakectl to run dbt on dynamic schemas",
-	Example: "lakectl dbt generate-schema-macro",
+	Use:        "generate-schema-macro",
+	Short:      "generates the a macro allowing lakectl to run dbt on dynamic schemas",
+	Example:    "lakectl dbt generate-schema-macro",
+	Deprecated: "Upcoming releases of lakectl will no longer support this command.",
 	Run: func(cmd *cobra.Command, args []string) {
 		projectRoot := Must(cmd.Flags().GetString("project-root"))
 

--- a/cmd/lakectl/cmd/metastore.go
+++ b/cmd/lakectl/cmd/metastore.go
@@ -10,8 +10,9 @@ import (
 )
 
 var metastoreCmd = &cobra.Command{
-	Use:   "metastore",
-	Short: "Manage metastore commands",
+	Use:        "metastore",
+	Short:      "Manage metastore commands",
+	Deprecated: "Upcoming releases of lakectl will no longer support this command.",
 }
 
 func getMetastoreAwsConfig(c *Configuration) *aws.Config {

--- a/cmd/lakectl/cmd/metastore_copy.go
+++ b/cmd/lakectl/cmd/metastore_copy.go
@@ -10,9 +10,10 @@ import (
 )
 
 var metastoreCopyCmd = &cobra.Command{
-	Use:   "copy",
-	Short: "Copy or merge table",
-	Long:  "Copy or merge table. the destination table will point to the selected branch",
+	Use:        "copy",
+	Short:      "Copy or merge table",
+	Long:       "Copy or merge table. the destination table will point to the selected branch",
+	Deprecated: "Upcoming releases of lakectl will no longer support this command.",
 	Run: func(cmd *cobra.Command, args []string) {
 		fromClientType := Must(cmd.Flags().GetString("from-client-type"))
 		fromDB := Must(cmd.Flags().GetString("from-schema"))

--- a/cmd/lakectl/cmd/metastore_copy_all.go
+++ b/cmd/lakectl/cmd/metastore_copy_all.go
@@ -8,9 +8,10 @@ import (
 )
 
 var metastoreCopyAllCmd = &cobra.Command{
-	Use:   "copy-all",
-	Short: "Copy from one metastore to another",
-	Long:  "copy or merge requested tables between hive metastores. the destination tables will point to the selected branch",
+	Use:        "copy-all",
+	Short:      "Copy from one metastore to another",
+	Long:       "copy or merge requested tables between hive metastores. the destination tables will point to the selected branch",
+	Deprecated: "Upcoming releases of lakectl will no longer support this command.",
 	Run: func(cmd *cobra.Command, args []string) {
 		fromClientType := Must(cmd.Flags().GetString("from-client-type"))
 		fromAddress := Must(cmd.Flags().GetString("from-address"))

--- a/cmd/lakectl/cmd/metastore_copy_schema.go
+++ b/cmd/lakectl/cmd/metastore_copy_schema.go
@@ -10,9 +10,10 @@ import (
 )
 
 var metastoreCopySchemaCmd = &cobra.Command{
-	Use:   "copy-schema",
-	Short: "Copy schema",
-	Long:  "Copy schema (without tables). the destination schema will point to the selected branch",
+	Use:        "copy-schema",
+	Short:      "Copy schema",
+	Long:       "Copy schema (without tables). the destination schema will point to the selected branch",
+	Deprecated: "Upcoming releases of lakectl will no longer support this command.",
 	Run: func(cmd *cobra.Command, args []string) {
 		fromClientType := Must(cmd.Flags().GetString("from-client-type"))
 		fromDB := Must(cmd.Flags().GetString("from-schema"))

--- a/cmd/lakectl/cmd/metastore_create_symlink.go
+++ b/cmd/lakectl/cmd/metastore_create_symlink.go
@@ -10,9 +10,10 @@ import (
 )
 
 var metastoreCreateSymlinkCmd = &cobra.Command{
-	Use:   "create-symlink",
-	Short: "Create symlink table and data",
-	Long:  "create table with symlinks, and create the symlinks in s3 in order to access from external services that could only access s3 directly (e.g athena)",
+	Use:        "create-symlink",
+	Short:      "Create symlink table and data",
+	Long:       "create table with symlinks, and create the symlinks in s3 in order to access from external services that could only access s3 directly (e.g athena)",
+	Deprecated: "Upcoming releases of lakectl will no longer support this command.",
 	Run: func(cmd *cobra.Command, args []string) {
 		repo := Must(cmd.Flags().GetString("repo"))
 		branch := Must(cmd.Flags().GetString("branch"))

--- a/cmd/lakectl/cmd/metastore_diff.go
+++ b/cmd/lakectl/cmd/metastore_diff.go
@@ -9,8 +9,9 @@ import (
 )
 
 var metastoreDiffCmd = &cobra.Command{
-	Use:   "diff",
-	Short: "Show column and partition differences between two tables",
+	Use:        "diff",
+	Short:      "Show column and partition differences between two tables",
+	Deprecated: "Upcoming releases of lakectl will no longer support this command.",
 	Run: func(cmd *cobra.Command, args []string) {
 		toAddress := Must(cmd.Flags().GetString("to-address"))
 		fromClientType := Must(cmd.Flags().GetString("from-client-type"))

--- a/cmd/lakectl/cmd/metastore_import_all.go
+++ b/cmd/lakectl/cmd/metastore_import_all.go
@@ -15,6 +15,7 @@ import requested tables between hive metastores. the destination tables will poi
 table with location s3://my-s3-bucket/path/to/table 
 will be transformed to location s3://repo-param/bucket-param/path/to/table
 	`,
+	Deprecated: "Upcoming releases of lakectl will no longer support this command.",
 	Run: func(cmd *cobra.Command, args []string) {
 		fromClientType := Must(cmd.Flags().GetString("from-client-type"))
 		fromAddress := Must(cmd.Flags().GetString("from-address"))

--- a/docs/integrations/athena.md
+++ b/docs/integrations/athena.md
@@ -8,7 +8,8 @@ redirect_from: /using/athena.html
 # Using lakeFS with Amazon Athena
 
 {: .warning }
-**Deprecated Feature:** This feature is being phased out. A superior replacement will be introduced soon.
+**Deprecated Feature:** Having heard the feedback from the community, we are planning to replace the below manual steps with an automated process.
+You can read more about it [here](https://github.com/treeverse/lakeFS/issues/6461).
 
 [Amazon Athena](https://aws.amazon.com/athena/) is an interactive query service that makes it easy to analyze data in Amazon S3 using standard SQL.
 {:.pb-5 }

--- a/docs/integrations/athena.md
+++ b/docs/integrations/athena.md
@@ -6,6 +6,10 @@ redirect_from: /using/athena.html
 ---
 
 # Using lakeFS with Amazon Athena
+
+{: .warning }
+**Deprecated Feature:** This feature is being phased out. A superior replacement will be introduced soon.
+
 [Amazon Athena](https://aws.amazon.com/athena/) is an interactive query service that makes it easy to analyze data in Amazon S3 using standard SQL.
 {:.pb-5 }
 
@@ -47,14 +51,14 @@ To query that table with Athena, you need to use the `create-symlink` command as
 
 ```shell
 lakectl metastore create-symlink \
---repo example \
---branch main \
---path my_table \
---from-client-type hive \
---from-schema default \
---from-table my_table \
---to-schema default \ 
---to-table my_table  
+  --repo example \
+  --branch main \
+  --path my_table \
+  --from-client-type hive \
+  --from-schema default \
+  --from-table my_table \
+  --to-schema default \ 
+  --to-table my_table  
 ```
 
 The command will generate two notable outputs:
@@ -62,13 +66,14 @@ The command will generate two notable outputs:
 1. For each partition, the command will create a symlink file:
 
 ```shell
-➜   aws s3 ls s3://my-bucket/my-repo-prefix/my_table/ --recursive
+aws s3 ls s3://my-bucket/my-repo-prefix/my_table/ --recursive
 2021-11-23 17:46:29          0 my-repo-prefix/my_table/symlinks/example/main/my_table/year=2021/month=11/symlink.txt
 2021-11-23 17:46:29         60 my-repo-prefix/my_table/symlinks/example/main/my_table/year=2021/month=12/symlink.txt
 2021-11-23 17:46:30         60 my-repo-prefix/my_table/symlinks/example/main/my_table/year=2022/month=1/symlink.txt
 ```
 
 An example content of a symlink file, where each line represents a single object of the specific partition:
+
 ```text
 s3://my-bucket/my-repo-prefix/5bdc62da516944b49889770d98274227
 s3://my-bucket/my-repo-prefix/64262fbf3d6347a79ead641d2b2baee6

--- a/docs/integrations/dbt.md
+++ b/docs/integrations/dbt.md
@@ -8,7 +8,7 @@ redirect_from: /using/dbt.html
 # Integrating dbt and lakeFS
 
 {: .warning }
-**Deprecated Feature:** This feature is being phased out. A superior replacement will be introduced soon.
+**Deprecated Feature:** This feature is being phased out.
 
 [dbt](https://www.getdbt.com/) can run on lakeFS with a Spark adapter or Presto/Trino adapter. 
 Both Spark and Presto use Hive metastore or Glue to manage tables and views.

--- a/docs/integrations/dbt.md
+++ b/docs/integrations/dbt.md
@@ -7,6 +7,9 @@ redirect_from: /using/dbt.html
 
 # Integrating dbt and lakeFS
 
+{: .warning }
+**Deprecated Feature:** This feature is being phased out. A superior replacement will be introduced soon.
+
 [dbt](https://www.getdbt.com/) can run on lakeFS with a Spark adapter or Presto/Trino adapter. 
 Both Spark and Presto use Hive metastore or Glue to manage tables and views.
 When creating a branch in lakeFS, you receive a logical copy of the data that can be accessed by `s3://my-repo/branch/...` 

--- a/docs/integrations/glue_hive_metastore.md
+++ b/docs/integrations/glue_hive_metastore.md
@@ -8,7 +8,8 @@ redirect_from: /using/glue_hive_metastore.html
 # Using lakeFS with the Glue/Hive Metastore
 
 {: .warning }
-**Deprecated Feature:** Having heard the feedback from the community, we are planning to replace the below manual steps with an automated process. You can read more about it [here](https://github.com/treeverse/lakeFS/issues/6461).
+**Deprecated Feature:** Having heard the feedback from the community, we are planning to replace the below manual steps with an automated process.
+You can read more about it [here](https://github.com/treeverse/lakeFS/issues/6461).
 
 {% include toc_2-3.html %}
 

--- a/docs/integrations/glue_hive_metastore.md
+++ b/docs/integrations/glue_hive_metastore.md
@@ -7,6 +7,9 @@ redirect_from: /using/glue_hive_metastore.html
 
 # Using lakeFS with the Glue/Hive Metastore
 
+{: .warning }
+**Deprecated Feature:** This feature is being phased out. A superior replacement will be introduced soon.
+
 {% include toc_2-3.html %}
 
 ## About Glue / Hive Metastore

--- a/docs/integrations/glue_hive_metastore.md
+++ b/docs/integrations/glue_hive_metastore.md
@@ -8,7 +8,7 @@ redirect_from: /using/glue_hive_metastore.html
 # Using lakeFS with the Glue/Hive Metastore
 
 {: .warning }
-**Deprecated Feature:** This feature is being phased out. A superior replacement will be introduced soon.
+**Deprecated Feature:** Having heard the feedback from the community, we are planning to replace the below manual steps with an automated process. You can read more about it [here](https://github.com/treeverse/lakeFS/issues/6461).
 
 {% include toc_2-3.html %}
 

--- a/docs/integrations/presto_trino.md
+++ b/docs/integrations/presto_trino.md
@@ -117,7 +117,8 @@ WITH (
 ### Example of copying a table with [metastore tools](glue_hive_metastore.md):
 
 {: .warning }
-**Deprecated Feature:** This feature is being phased out. A superior replacement will be introduced soon.
+**Deprecated Feature:** Having heard the feedback from the community, we are planning to replace the below manual steps with an automated process.
+You can read more about it [here](https://github.com/treeverse/lakeFS/issues/6461).
 
 Copy the created table `page_views` on schema `main` to schema `example_branch` with location `s3a://example/example_branch/page_views/` 
 ```shell

--- a/docs/integrations/presto_trino.md
+++ b/docs/integrations/presto_trino.md
@@ -116,6 +116,9 @@ WITH (
 
 ### Example of copying a table with [metastore tools](glue_hive_metastore.md):
 
+{: .warning }
+**Deprecated Feature:** This feature is being phased out. A superior replacement will be introduced soon.
+
 Copy the created table `page_views` on schema `main` to schema `example_branch` with location `s3a://example/example_branch/page_views/` 
 ```shell
 lakectl metastore copy --from-schema main --from-table page_views --to-branch example_branch 

--- a/esti/golden/lakectl_help.golden
+++ b/esti/golden/lakectl_help.golden
@@ -14,7 +14,6 @@ Available Commands:
   commit          Commit changes on a given branch
   completion      Generate completion script
   config          Create/update local lakeFS configuration
-  dbt             Integration with dbt commands
   diff            Show changes between two commits, or the currently uncommitted changes
   doctor          Run a basic diagnosis of the LakeFS configuration
   fs              View and manipulate objects
@@ -24,7 +23,6 @@ Available Commands:
   local           Sync local directories with lakeFS paths
   log             Show log of commits
   merge           Merge & commit changes from source branch into destination branch
-  metastore       Manage metastore commands
   repo            Manage and explore repos
   show            See detailed information about an entity
   tag             Create and manage tags within a repository


### PR DESCRIPTION
All lakectl `dbt` and `metastore` command will print deprecation warnings.

Close https://github.com/treeverse/lakeFS/issues/6564
