### PR TITLE
logging and lakectl NO_COLOR support

### DIFF
--- a/cmd/lakectl/cmd/root.go
+++ b/cmd/lakectl/cmd/root.go
@@ -296,13 +296,18 @@ func init() {
 	// will be global for your application.
 	cobra.OnInitialize(initConfig)
 	rootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", "config file (default is $HOME/.lakectl.yaml)")
-	rootCmd.PersistentFlags().BoolVar(&noColorRequested, "no-color", false, "don't use fancy output colors (default when not attached to an interactive terminal)")
+	rootCmd.PersistentFlags().BoolVar(&noColorRequested, "no-color", getEnvNoColor(), "don't use fancy output colors (default when not attached to an interactive terminal)")
 	rootCmd.PersistentFlags().StringVarP(&baseURI, "base-uri", "", os.Getenv("LAKECTL_BASE_URI"), "base URI used for lakeFS address parse")
 	rootCmd.PersistentFlags().StringVarP(&logLevel, "log-level", "", "none", "set logging level")
 	rootCmd.PersistentFlags().StringVarP(&logFormat, "log-format", "", "", "set logging output format")
 	rootCmd.PersistentFlags().StringSliceVarP(&logOutputs, "log-output", "", []string{}, "set logging output(s)")
 	rootCmd.PersistentFlags().BoolVar(&verboseMode, "verbose", false, "run in verbose mode")
 	rootCmd.Flags().BoolP("version", "v", false, "version for lakectl")
+}
+
+func getEnvNoColor() bool {
+	v := os.Getenv("NO_COLOR")
+	return v != "" && v != "0"
 }
 
 // initConfig reads in config file and ENV variables if set.

--- a/cmd/lakectl/cmd/root.go
+++ b/cmd/lakectl/cmd/root.go
@@ -296,7 +296,7 @@ func init() {
 	// will be global for your application.
 	cobra.OnInitialize(initConfig)
 	rootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", "config file (default is $HOME/.lakectl.yaml)")
-	rootCmd.PersistentFlags().BoolVar(&noColorRequested, "no-color", getEnvNoColor(), "don't use fancy output colors (default when not attached to an interactive terminal)")
+	rootCmd.PersistentFlags().BoolVar(&noColorRequested, "no-color", getEnvNoColor(), "don't use fancy output colors (default value can be set by NO_COLOR environment variable)")
 	rootCmd.PersistentFlags().StringVarP(&baseURI, "base-uri", "", os.Getenv("LAKECTL_BASE_URI"), "base URI used for lakeFS address parse")
 	rootCmd.PersistentFlags().StringVarP(&logLevel, "log-level", "", "none", "set logging level")
 	rootCmd.PersistentFlags().StringVarP(&logFormat, "log-format", "", "", "set logging output format")

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -92,7 +92,7 @@ lakectl [flags]
       --log-format string    set logging output format
       --log-level string     set logging level (default "none")
       --log-output strings   set logging output(s)
-      --no-color             don't use fancy output colors (default when not attached to an interactive terminal)
+      --no-color             don't use fancy output colors (default value can be set by NO_COLOR environment variable)
       --verbose              run in verbose mode
   -v, --version              version for lakectl
 ```

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -152,12 +152,18 @@ func SetOutputFormat(format string, opts ...OutputFormatOptionFunc) {
 	var formatter logrus.Formatter
 	switch strings.ToLower(format) {
 	case "text":
+		disableColors := false
+		noColor := os.Getenv("NO_COLOR")
+		if noColor != "" && noColor != "0" {
+			disableColors = true
+		}
 		formatter = &logrus.TextFormatter{
 			FullTimestamp:          true,
 			DisableLevelTruncation: true,
 			PadLevelText:           true,
 			QuoteEmptyFields:       true,
 			CallerPrettyfier:       options.CallerPrettyfier,
+			DisableColors:          disableColors,
 		}
 	case "json":
 		formatter = &logrus.JSONFormatter{


### PR DESCRIPTION
Default for no-color support is based on NO_COLOR environment variable.

Suppot a standard way to disable color output - https://no-color.org

Close https://github.com/treeverse/lakeFS/issues/6570