### PR TITLE
test: block parser spec longer timeout for container

### DIFF
--- a/clients/spark/core/src/test/scala/io/treeverse/jpebble/BlockParserSpec.scala
+++ b/clients/spark/core/src/test/scala/io/treeverse/jpebble/BlockParserSpec.scala
@@ -5,7 +5,6 @@ import matchers.should._
 import org.scalatest.matchers.must.Matchers.contain
 import org.scalatest.matchers.should.Matchers.convertToAnyShouldWrapper
 import funspec._
-
 import com.dimafeng.testcontainers.{ForAllTestContainer, GenericContainer}
 import com.dimafeng.testcontainers.GenericContainer.FileSystemBind
 import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy
@@ -15,6 +14,7 @@ import java.io.File
 import java.nio.charset.StandardCharsets
 import org.apache.commons.io.IOUtils
 
+import java.time.Duration
 import scala.io.Source
 
 class BlockReadableSpec extends AnyFunSpec with Matchers {
@@ -306,7 +306,10 @@ class GolangContainerSpec extends AnyFunSpec with ForAllTestContainer {
   override val container: GenericContainer = GenericContainer(
     "golang:1.20.6-alpine",
     classpathResourceMapping = Seq(
-      FileSystemBind("parser-test/sst_files_generator.go", "/local/sst_files_generator.go", BindMode.READ_WRITE),
+      FileSystemBind("parser-test/sst_files_generator.go",
+                     "/local/sst_files_generator.go",
+                     BindMode.READ_WRITE
+                    ),
       FileSystemBind("parser-test/go.mod", "/local/go.mod", BindMode.READ_WRITE),
       FileSystemBind("parser-test/go.sum", "/local/go.sum", BindMode.READ_WRITE)
     ),
@@ -314,9 +317,10 @@ class GolangContainerSpec extends AnyFunSpec with ForAllTestContainer {
                   "-c",
                   "cd /local && CGO_ENABLED=0 go run sst_files_generator.go && echo \"done\""
                  ),
-    waitStrategy = new LogMessageWaitStrategy().withRegEx(
-      "done\\n"
-    ) // TODO(Tals): use startupCheckStrategy instead of waitStrategy (https://github.com/treeverse/lakeFS/issues/2455)
+    // TODO(Tals): use startupCheckStrategy instead of waitStrategy (https://github.com/treeverse/lakeFS/issues/2455)
+    waitStrategy = new LogMessageWaitStrategy()
+      .withRegEx("done\\n")
+      .withStartupTimeout(Duration.ofSeconds(120))
   )
 
   describe("A block parser") {


### PR DESCRIPTION
If your PR failed with metadata client test on timeout waiting for done.
This change will help by waiting more and not fail this test.