### PR TITLE
Add URL parser to lua runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ## UNRELEASED
 
+:new: What's new:
+- Restrict lakectl local to common prefixes only (#6510)
+- Added URL parser to lua runtime (#6597)
+  
 # v0.109.0
 
 :new: What's new:

--- a/docs/howto/hooks/lua.md
+++ b/docs/howto/hooks/lua.md
@@ -422,9 +422,7 @@ Returns a new 128-bit [RFC 4122 UUID](https://www.rfc-editor.org/rfc/rfc4122){: 
 
 ### `net/url`
 
-Provides a `parse` function that parses a raw url into a URL structure.
-The url may be relative (a path, without a host) or absolute (starting with a scheme). Trying to parse a hostname and path without a scheme is invalid but may not necessarily return an error, due to parsing ambiguities.
-
+Provides a `parse` function parse a URL string into parts, returns a table with the URL's host, path, scheme, query and fragment.
 
 ```lua
 > local url = require("net/url")

--- a/docs/howto/hooks/lua.md
+++ b/docs/howto/hooks/lua.md
@@ -420,6 +420,25 @@ The `value` string should be in [ISO8601](https://en.wikipedia.org/wiki/ISO_8601
 
 Returns a new 128-bit [RFC 4122 UUID](https://www.rfc-editor.org/rfc/rfc4122){: target="_blank" } in string representation.
 
+### `net/url`
+
+Provides a `parse` function that parses a raw url into a URL structure.
+The url may be relative (a path, without a host) or absolute (starting with a scheme). Trying to parse a hostname and path without a scheme is invalid but may not necessarily return an error, due to parsing ambiguities.
+
+
+```lua
+> local url = require("net/url")
+> url.parse("https://example.com/path?p1=a#section")
+{
+    ["host"] = "example.com"
+    ["path"] = "/path"
+    ["scheme"] = "https"
+    ["query"] = "p1=a"
+    ["fragment"] = "section"
+}
+```
+
+
 ### `net/http` (optional)
 
 Provides a `request` function that performs an HTTP request.

--- a/pkg/actions/lua/net/url/url.go
+++ b/pkg/actions/lua/net/url/url.go
@@ -1,0 +1,36 @@
+package url
+
+import (
+	neturl "net/url"
+
+	"github.com/Shopify/go-lua"
+	"github.com/treeverse/lakefs/pkg/actions/lua/util"
+)
+
+func Open(l *lua.State) {
+	open := func(l *lua.State) int {
+		lua.NewLibrary(l, library)
+		return 1
+	}
+	lua.Require(l, "net/url", open, false)
+	l.Pop(1)
+}
+
+var library = []lua.RegistryFunction{
+	{Name: "parse", Function: Parse},
+}
+
+func Parse(l *lua.State) int {
+	rawURL := lua.CheckString(l, 1)
+	u, err := neturl.Parse(rawURL)
+	if err != nil {
+		lua.Errorf(l, err.Error())
+		panic("unreachable")
+	}
+	return util.DeepPush(l, map[string]string{
+		"host":   u.Host,
+		"path":   u.Path,
+		"scheme": u.Scheme,
+		"query":  u.RawQuery,
+	})
+}

--- a/pkg/actions/lua/net/url/url.go
+++ b/pkg/actions/lua/net/url/url.go
@@ -17,10 +17,10 @@ func Open(l *lua.State) {
 }
 
 var library = []lua.RegistryFunction{
-	{Name: "parse", Function: Parse},
+	{Name: "parse", Function: parse},
 }
 
-func Parse(l *lua.State) int {
+func parse(l *lua.State) int {
 	rawURL := lua.CheckString(l, 1)
 	u, err := neturl.Parse(rawURL)
 	if err != nil {

--- a/pkg/actions/lua/net/url/url.go
+++ b/pkg/actions/lua/net/url/url.go
@@ -28,9 +28,10 @@ func parse(l *lua.State) int {
 		panic("unreachable")
 	}
 	return util.DeepPush(l, map[string]string{
-		"host":   u.Host,
-		"path":   u.Path,
-		"scheme": u.Scheme,
-		"query":  u.RawQuery,
+		"host":     u.Host,
+		"path":     u.Path,
+		"scheme":   u.Scheme,
+		"query":    u.RawQuery,
+		"fragment": u.Fragment,
 	})
 }

--- a/pkg/actions/lua/open.go
+++ b/pkg/actions/lua/open.go
@@ -13,6 +13,7 @@ import (
 	"github.com/treeverse/lakefs/pkg/actions/lua/encoding/parquet"
 	"github.com/treeverse/lakefs/pkg/actions/lua/encoding/yaml"
 	"github.com/treeverse/lakefs/pkg/actions/lua/net/http"
+	"github.com/treeverse/lakefs/pkg/actions/lua/net/url"
 	"github.com/treeverse/lakefs/pkg/actions/lua/path"
 	"github.com/treeverse/lakefs/pkg/actions/lua/regexp"
 	"github.com/treeverse/lakefs/pkg/actions/lua/storage/aws"
@@ -41,6 +42,7 @@ func Open(l *lua.State, ctx context.Context, cfg OpenSafeConfig) {
 	path.Open(l)
 	aws.Open(l, ctx)
 	gcloud.Open(l, ctx)
+	url.Open(l)
 	if cfg.NetHTTPEnabled {
 		http.Open(l)
 	}


### PR DESCRIPTION
Closes #6598 
usage:


```lua
> local url = require("net/url")
> url.parse("https://example.com/path?p1=a#section")
{
    ["host"] = "example.com"
    ["path"] = "/path"
    ["scheme"] = "https"
    ["query"] = "p1=a"
    ["fragment"] = "section"
}
```