### PR TITLE
Added a comment that destination of import should not start with '/'

### DIFF
--- a/webui/src/pages/repositories/services/import_data.jsx
+++ b/webui/src/pages/repositories/services/import_data.jsx
@@ -138,7 +138,7 @@ const ImportForm = ({
                     <Form.Label><strong>Destination:</strong></Form.Label>
                         <Form.Control type="text" autoFocus name="destination" ref={destRef} defaultValue={path}/>
                     <Form.Text style={{color: 'grey'}} md={{offset: 2, span: 10000}}>
-                        Leave empty to import to the repository&apos;s root.
+                        Leave empty to import to the repository&apos;s root. Destination should not start with &lsquo;&sol;&rsquo;
                     </Form.Text>
                 </Form.Group>
             }


### PR DESCRIPTION
Addresses #6600 

## Change Description
As a quick workaround, adding a comment to not accept an import that start with '/'. A better solution would be to not allow the code to accept it and present a suitable message.

