### PR TITLE
Fix lakectl local verify bad path error on Windows

### DIFF
--- a/cmd/lakectl/cmd/local.go
+++ b/cmd/lakectl/cmd/local.go
@@ -99,7 +99,7 @@ func getLocalSyncFlags(cmd *cobra.Command, client *apigen.ClientWithResponses) s
 }
 
 // getLocalArgs parses arguments to extract a remote URI and deduces the local path.
-// If local path isn't provided and considerGitRoot is true, it uses the git repository root.
+// If the local path isn't provided and considerGitRoot is true, it uses the git repository root.
 func getLocalArgs(args []string, requireRemote bool, considerGitRoot bool) (remote *uri.URI, localPath string) {
 	idx := 0
 	if requireRemote {

--- a/cmd/lakectl/cmd/local_clone.go
+++ b/cmd/lakectl/cmd/local_clone.go
@@ -46,9 +46,9 @@ var localCloneCmd = &cobra.Command{
 		}
 		stableRemote := remote.WithRef(head)
 		// Dynamically construct changes
-		c := make(chan *local.Change, filesChanSize)
+		ch := make(chan *local.Change, filesChanSize)
 		go func() {
-			defer close(c)
+			defer close(ch)
 			remotePath := remote.GetPath()
 			var after string
 			for {
@@ -70,7 +70,7 @@ var localCloneCmd = &cobra.Command{
 					if relPath == "" || strings.HasSuffix(relPath, uri.PathSeparator) {
 						continue
 					}
-					c <- &local.Change{
+					ch <- &local.Change{
 						Source: local.ChangeSourceRemote,
 						Path:   relPath,
 						Type:   local.ChangeTypeAdded,
@@ -88,7 +88,7 @@ var localCloneCmd = &cobra.Command{
 		}
 		sigCtx := localHandleSyncInterrupt(ctx, idx, string(cloneOperation))
 		s := local.NewSyncManager(sigCtx, client, syncFlags.parallelism, syncFlags.presign)
-		err = s.Sync(localPath, stableRemote, c)
+		err = s.Sync(localPath, stableRemote, ch)
 		if err != nil {
 			DieErr(err)
 		}

--- a/pkg/fileutil/io.go
+++ b/pkg/fileutil/io.go
@@ -153,7 +153,7 @@ func VerifyAbsPath(absPath, basePath string) error {
 }
 
 func VerifyRelPath(relPath, basePath string) error {
-	abs := basePath + string(os.PathSeparator) + relPath
+	abs := filepath.Join(basePath, relPath)
 	return VerifyAbsPath(abs, basePath)
 }
 


### PR DESCRIPTION
Fix https://github.com/treeverse/lakeFS/issues/6599

- Fix use `filepath.Join` for target path verification
- Sync start workers (goroutines) based on max parallelism instead of creating one for each file
- Code style - not using named return value in `apply` and avoid format instead of string concatenation