### PR TITLE
lakectl endpoint configure and endpoint path reuse

### DIFF
--- a/cmd/lakectl/cmd/config.go
+++ b/cmd/lakectl/cmd/config.go
@@ -36,6 +36,9 @@ var configCmd = &cobra.Command{
 			{Key: "credentials.secret_access_key", Prompt: &promptui.Prompt{Label: "Secret access key", Mask: '*'}},
 			{Key: "server.endpoint_url", Prompt: &promptui.Prompt{Label: "Server endpoint URL", Validate: func(rawURL string) error {
 				_, err := url.ParseRequestURI(rawURL)
+				if err != nil {
+					return fmt.Errorf("invalid URL: %w", err)
+				}
 				return err
 			}}},
 		}

--- a/cmd/lakectl/cmd/config.go
+++ b/cmd/lakectl/cmd/config.go
@@ -35,11 +35,14 @@ var configCmd = &cobra.Command{
 			{Key: "credentials.access_key_id", Prompt: &promptui.Prompt{Label: "Access key ID"}},
 			{Key: "credentials.secret_access_key", Prompt: &promptui.Prompt{Label: "Secret access key", Mask: '*'}},
 			{Key: "server.endpoint_url", Prompt: &promptui.Prompt{Label: "Server endpoint URL", Validate: func(rawURL string) error {
-				_, err := url.ParseRequestURI(rawURL)
+				u, err := url.ParseRequestURI(rawURL)
 				if err != nil {
-					return fmt.Errorf("invalid URL: %w", err)
+					return err
 				}
-				return err
+				if u.Path != "" {
+					fmt.Printf("Warning: It's recommended to configure the endpoint without specifying a path (%s)\n", u.Path)
+				}
+				return nil
 			}}},
 		}
 		for _, question := range questions {

--- a/cmd/lakectl/cmd/config.go
+++ b/cmd/lakectl/cmd/config.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 	"net/url"
 	"path/filepath"
@@ -11,8 +10,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
-
-var ErrInvalidEndpoint = errors.New("invalid endpoint")
 
 // configCmd represents the config command
 var configCmd = &cobra.Command{
@@ -33,21 +30,33 @@ var configCmd = &cobra.Command{
 		// get user input
 		questions := []struct {
 			Key    string
-			Prompt *promptui.Prompt
+			Prompt promptui.Prompt
 		}{
-			{Key: "credentials.access_key_id", Prompt: &promptui.Prompt{Label: "Access key ID"}},
-			{Key: "credentials.secret_access_key", Prompt: &promptui.Prompt{Label: "Secret access key", Mask: '*'}},
-			{Key: "server.endpoint_url", Prompt: &promptui.Prompt{Label: "Server endpoint", Validate: func(rawURL string) error {
-				u, err := url.ParseRequestURI(rawURL)
-				if err != nil {
-					return err
-				}
-				if u.Path != "" {
-					return fmt.Errorf("%w: do not specify endpoint path", ErrInvalidEndpoint)
-				}
-				return nil
-			}}},
+			{
+				Key: "credentials.access_key_id",
+				Prompt: promptui.Prompt{
+					Label: "Access key ID",
+				},
+			},
+			{
+				Key: "credentials.secret_access_key",
+				Prompt: promptui.Prompt{
+					Label: "Secret access key",
+					Mask:  '*',
+				},
+			},
+			{
+				Key: "server.endpoint_url",
+				Prompt: promptui.Prompt{
+					Label: "Server endpoint URL (e.g. http://localhost:8000)",
+					Validate: func(rawURL string) error {
+						_, err := url.ParseRequestURI(rawURL)
+						return err
+					},
+				},
+			},
 		}
+
 		for _, question := range questions {
 			question.Prompt.Default = viper.GetString(question.Key)
 			val, err := question.Prompt.Run()

--- a/cmd/lakectl/cmd/config.go
+++ b/cmd/lakectl/cmd/config.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"net/url"
 	"path/filepath"
@@ -10,6 +11,8 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
+
+var ErrInvalidEndpoint = errors.New("invalid endpoint")
 
 // configCmd represents the config command
 var configCmd = &cobra.Command{
@@ -34,13 +37,13 @@ var configCmd = &cobra.Command{
 		}{
 			{Key: "credentials.access_key_id", Prompt: &promptui.Prompt{Label: "Access key ID"}},
 			{Key: "credentials.secret_access_key", Prompt: &promptui.Prompt{Label: "Secret access key", Mask: '*'}},
-			{Key: "server.endpoint_url", Prompt: &promptui.Prompt{Label: "Server endpoint URL", Validate: func(rawURL string) error {
+			{Key: "server.endpoint_url", Prompt: &promptui.Prompt{Label: "Server endpoint", Validate: func(rawURL string) error {
 				u, err := url.ParseRequestURI(rawURL)
 				if err != nil {
 					return err
 				}
 				if u.Path != "" {
-					fmt.Printf("Warning: It's recommended to configure the endpoint without specifying a path (%s)\n", u.Path)
+					return fmt.Errorf("%w: do not specify endpoint path", ErrInvalidEndpoint)
 				}
 				return nil
 			}}},

--- a/cmd/lakectl/cmd/docs.go
+++ b/cmd/lakectl/cmd/docs.go
@@ -53,7 +53,7 @@ lakectl config
 # Config file /home/janedoe/.lakectl.yaml will be used
 # Access key ID: AKIAIOSFODNN7EXAMPLE
 # Secret access key: ****************************************
-# Server endpoint URL: http://localhost:8000/api/v1
+# Server endpoint URL: http://localhost:8000
 ` + "```" + `
 
 This will setup a ` + "`$HOME/.lakectl.yaml`" + ` file with the credentials and API endpoint you've supplied.

--- a/cmd/lakectl/cmd/log.go
+++ b/cmd/lakectl/cmd/log.go
@@ -56,7 +56,7 @@ func (d *dotWriter) Write(commits []apigen.Commit) {
 			label = fmt.Sprintf("<b>%s</b>", label)
 		}
 		baseURL := strings.TrimSuffix(strings.TrimSuffix(
-			string(cfg.Server.EndpointURL), "/api/v1"), "/")
+			string(cfg.Server.EndpointURL), apiutil.BaseURL), "/")
 		_, _ = fmt.Fprintf(d.w, "\n\t\"%s\" [shape=note target=\"_blank\" href=\"%s/repositories/%s/commits/%s\" label=< %s >]\n",
 			commit.Id, baseURL, repoID, commit.Id, label)
 		for _, parent := range commit.Parents {

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -41,7 +41,7 @@ lakectl config
 # Config file /home/janedoe/.lakectl.yaml will be used
 # Access key ID: AKIAIOSFODNN7EXAMPLE
 # Secret access key: ****************************************
-# Server endpoint URL: http://localhost:8000/api/v1
+# Server endpoint URL: http://localhost:8000
 ```
 
 This will setup a `$HOME/.lakectl.yaml` file with the credentials and API endpoint you've supplied.

--- a/esti/gc_utils_test.go
+++ b/esti/gc_utils_test.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/treeverse/lakefs/pkg/api/apiutil"
 	"github.com/treeverse/lakefs/pkg/logging"
 )
 
@@ -15,7 +16,7 @@ func getSparkSubmitArgs(entryPoint string) []string {
 	return []string{
 		"--master", "spark://localhost:7077",
 		"--conf", "spark.driver.extraJavaOptions=-Divy.cache.dir=/tmp -Divy.home=/tmp",
-		"--conf", "spark.hadoop.lakefs.api.url=http://lakefs:8000/api/v1",
+		"--conf", "spark.hadoop.lakefs.api.url=http://lakefs:8000" + apiutil.BaseURL,
 		"--conf", "spark.hadoop.lakefs.api.access_key=AKIAIOSFDNN7EXAMPLEQ",
 		"--conf", "spark.hadoop.lakefs.api.secret_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
 		"--class", entryPoint,
@@ -23,7 +24,8 @@ func getSparkSubmitArgs(entryPoint string) []string {
 }
 
 func getDockerArgs(workingDirectory string, localJar string) []string {
-	return []string{"run", "--network", "host", "--add-host", "lakefs:127.0.0.1",
+	return []string{
+		"run", "--network", "host", "--add-host", "lakefs:127.0.0.1",
 		"-v", fmt.Sprintf("%s/ivy:/opt/bitnami/spark/.ivy2", workingDirectory),
 		"-v", fmt.Sprintf("%s:/opt/metaclient/client.jar", localJar),
 		"--rm",

--- a/esti/lakectl_doctor_test.go
+++ b/esti/lakectl_doctor_test.go
@@ -6,12 +6,13 @@ import (
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"
+	"github.com/treeverse/lakefs/pkg/api/apiutil"
 )
 
 func TestLakectlDoctor(t *testing.T) {
 	accessKeyID := viper.GetString("access_key_id")
 	secretAccessKey := viper.GetString("secret_access_key")
-	endPointURL := viper.GetString("endpoint_url") + "/api/v1"
+	endPointURL := viper.GetString("endpoint_url") + apiutil.BaseURL
 	u, err := url.Parse(endpointURL)
 	require.NoError(t, err)
 	vars := map[string]string{

--- a/pkg/actions/lua.go
+++ b/pkg/actions/lua.go
@@ -14,6 +14,7 @@ import (
 	lualibs "github.com/treeverse/lakefs/pkg/actions/lua"
 	"github.com/treeverse/lakefs/pkg/actions/lua/lakefs"
 	luautil "github.com/treeverse/lakefs/pkg/actions/lua/util"
+	"github.com/treeverse/lakefs/pkg/api/apiutil"
 	"github.com/treeverse/lakefs/pkg/auth"
 	"github.com/treeverse/lakefs/pkg/auth/model"
 	"github.com/treeverse/lakefs/pkg/graveler"
@@ -95,8 +96,11 @@ func (h *LuaHook) Run(ctx context.Context, record graveler.HookRecord, buf *byte
 		if h.Endpoint == nil {
 			return fmt.Errorf("no endpoint configured, cannot request object: %s: %w", h.ScriptPath, ErrInvalidAction)
 		}
-		reqURL := fmt.Sprintf("/api/v1/repositories/%s/refs/%s/objects",
-			url.PathEscape(string(record.RepositoryID)), url.PathEscape(string(record.SourceRef)))
+		reqURL, err := url.JoinPath(apiutil.BaseURL,
+			"repositories", string(record.RepositoryID), "refs", string(record.SourceRef), "objects")
+		if err != nil {
+			return err
+		}
 		req, err := http.NewRequest(http.MethodGet, reqURL, nil)
 		if err != nil {
 			return err

--- a/pkg/actions/lua/lakefs/client.go
+++ b/pkg/actions/lua/lakefs/client.go
@@ -14,6 +14,7 @@ import (
 	"github.com/Shopify/go-lua"
 	"github.com/go-chi/chi/v5"
 	"github.com/treeverse/lakefs/pkg/actions/lua/util"
+	"github.com/treeverse/lakefs/pkg/api/apiutil"
 	"github.com/treeverse/lakefs/pkg/auth"
 	"github.com/treeverse/lakefs/pkg/auth/model"
 	"github.com/treeverse/lakefs/pkg/version"
@@ -31,12 +32,12 @@ func check(l *lua.State, err error) {
 
 func newLakeFSRequest(ctx context.Context, user *model.User, method, url string, data []byte) (*http.Request, error) {
 	if !strings.HasPrefix(url, "/api/") {
-		if strings.HasPrefix(url, "/") {
-			url = fmt.Sprintf("/api/v1%s", url)
-		} else {
-			url = fmt.Sprintf("/api/v1/%s", url)
+		url, err = url.JoinPath(apiutil.BaseURL, url)
+		if err != nil {
+			return nil, err
 		}
 	}
+
 	var body io.Reader
 	if data == nil {
 		body = bytes.NewReader(data)


### PR DESCRIPTION
Close #6542 

- lakectl configure: error when configured with path
- docs: example of lakectl configuration
- reuse /api/v1 constant