### PR TITLE
added support to detect content-type in lakectl

### DIFF
--- a/cmd/lakectl/cmd/common_helpers.go
+++ b/cmd/lakectl/cmd/common_helpers.go
@@ -6,8 +6,10 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"mime"
 	"net/http"
 	"os"
+	"path/filepath"
 	"reflect"
 	"strconv"
 	"strings"
@@ -313,6 +315,17 @@ func MustParsePathURI(name, s string) *uri.URI {
 		DieFmt("Invalid '%s': %s", name, uri.ErrInvalidPathURI)
 	}
 	return u
+}
+
+func MustGetContentType(flagSet *pflag.FlagSet, sourcePathname string) string {
+	contentType, err := flagSet.GetString("content-type")
+	if err != nil {
+		DieErr(err)
+	}
+	if len(contentType) != 0 {
+		return contentType
+	}
+	return mime.TypeByExtension(filepath.Ext(sourcePathname))
 }
 
 const (

--- a/cmd/lakectl/cmd/fs_upload.go
+++ b/cmd/lakectl/cmd/fs_upload.go
@@ -32,7 +32,7 @@ var fsUploadCmd = &cobra.Command{
 		recursive := Must(flagSet.GetBool("recursive"))
 		direct := Must(flagSet.GetBool("direct"))
 		preSignMode := Must(flagSet.GetBool("pre-sign"))
-		contentType := Must(flagSet.GetString("content-type"))
+		contentType := MustGetContentType(flagSet, source)
 
 		ctx := cmd.Context()
 		transport := transportMethodFromFlags(direct, preSignMode)

--- a/webui/src/lib/api/index.js
+++ b/webui/src/lib/api/index.js
@@ -1059,6 +1059,22 @@ class MetaRanges {
     }
 }
 
+class Templates {
+    async expandTemplate(templateLocation, params) {
+        const urlParams = new URLSearchParams();
+        for (const [k, v] of Object.entries(params)) {
+            urlParams.set(k, v);
+        }
+        const response = await apiRequest(
+            `/templates/${encodeURI(templateLocation)}?${urlParams.toString()}`,
+            {method: 'GET'});
+        if (!response.ok) {
+            throw new Error(await extractError(response));
+        }
+        return response.text();
+    }
+}
+
 class Statistics {
     async postStatsEvents(statsEvents) {
         const request = {
@@ -1175,6 +1191,7 @@ export const config = new Config();
 export const branchProtectionRules = new BranchProtectionRules();
 export const ranges = new Ranges();
 export const metaRanges = new MetaRanges();
+export const templates = new Templates();
 export const statistics = new Statistics();
 export const staging = new Staging();
 export const otfDiffs = new OTFDiffs();


### PR DESCRIPTION
Closes #6584

## Change Description

### Background

Used mime pkg from golang sdk.

### Bug Fix

If this PR is a bug fix, please let us know about:

1. Problem - lakectl fs upload pdf file can not be previewed
2. Root cause - lakectl local doesn't support upload with content type
3. Solution - bug was fixed by using mime pkg to detect content type based on filepath

### Testing Details

How were the changes tested?
Using cmd line.

### Contact Details

chaitubhojane@gmail.com
