### PR TITLE
test: use private members to make linters happy

### DIFF
--- a/pkg/config/struct_keys_test.go
+++ b/pkg/config/struct_keys_test.go
@@ -62,6 +62,8 @@ func TestStructKeys_SimpleTagged(t *testing.T) {
 		B int `toast:"bee"`
 		c int `test:"ccc" toast:"sea"`
 	}
+	// make sure we use the struct as it holds private members
+	_ = s{A: 1, B: 2, c: 3}
 
 	keys := config.GetStructKeys(reflect.TypeOf(s{}), tagName, squashTagValue)
 	if diffs := deep.Equal(keys, []string{"Aaa", "b", "ccc"}); diffs != nil {
@@ -236,6 +238,8 @@ func TestValidateMissingRequired_SimpleTagged(t *testing.T) {
 		B int `toast:"bee" validate:"required"`
 		c int `test:"ccc" toast:"sea" validate:"required"`
 	}
+	// make sure we use the struct as it holds private members
+	_ = s{A: 1, B: 2, c: 3}
 
 	keys := config.ValidateMissingRequiredKeys(s{}, tagName, squashTagValue)
 	if diffs := deep.Equal(keys, []string{"Aaa", "b", "ccc"}); diffs != nil {


### PR DESCRIPTION
Fixing:
```
pkg/config/struct_keys_test.go:63:3: field c is unused (U1000)
pkg/config/struct_keys_test.go:237:3: field c is unused (U1000)
```
