### PR TITLE
misc: code cleanup

### DIFF
--- a/esti/webhook_server_test.go
+++ b/esti/webhook_server_test.go
@@ -63,7 +63,7 @@ func startWebhookServer() (*webhookServer, error) {
 	}
 	go func() {
 		if err = s.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
-			log.Fatalf("listen:%s\n", err)
+			log.Fatalf("listen: %s\n", err)
 		}
 	}()
 

--- a/pkg/api/auth_middleware.go
+++ b/pkg/api/auth_middleware.go
@@ -15,7 +15,7 @@ import (
 	"github.com/treeverse/lakefs/pkg/api/apigen"
 	"github.com/treeverse/lakefs/pkg/auth"
 	"github.com/treeverse/lakefs/pkg/auth/model"
-	oidc_encoding "github.com/treeverse/lakefs/pkg/auth/oidc/encoding"
+	oidcencoding "github.com/treeverse/lakefs/pkg/auth/oidc/encoding"
 	"github.com/treeverse/lakefs/pkg/logging"
 )
 
@@ -202,7 +202,7 @@ func enhanceWithFriendlyName(user *model.User, friendlyName string) *model.User 
 // If the user doesn't exist on the lakeFS side, it is created.
 // This function does not make any calls to an external provider.
 func userFromSAML(ctx context.Context, logger logging.Logger, authService auth.Service, authSession *sessions.Session, cookieAuthConfig *CookieAuthConfig) (*model.User, error) {
-	idTokenClaims, ok := authSession.Values[SAMLTokenClaimsSessionKey].(oidc_encoding.Claims)
+	idTokenClaims, ok := authSession.Values[SAMLTokenClaimsSessionKey].(oidcencoding.Claims)
 	if idTokenClaims == nil {
 		return nil, nil
 	}
@@ -291,7 +291,7 @@ func userFromSAML(ctx context.Context, logger logging.Logger, authService auth.S
 // If the user doesn't exist on the lakeFS side, it is created.
 // This function does not make any calls to an external provider.
 func userFromOIDC(ctx context.Context, logger logging.Logger, authService auth.Service, authSession *sessions.Session, oidcConfig *OIDCConfig) (*model.User, error) {
-	idTokenClaims, ok := authSession.Values[IDTokenClaimsSessionKey].(oidc_encoding.Claims)
+	idTokenClaims, ok := authSession.Values[IDTokenClaimsSessionKey].(oidcencoding.Claims)
 	if idTokenClaims == nil {
 		return nil, nil
 	}

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -557,7 +557,7 @@ func (c *Controller) GetGroup(w http.ResponseWriter, r *http.Request, groupID st
 }
 
 func (c *Controller) GetGroupACL(w http.ResponseWriter, r *http.Request, groupID string) {
-	aclPolicyName := acl.ACLPolicyName(groupID)
+	aclPolicyName := acl.PolicyName(groupID)
 	if !c.authorize(w, r, permissions.Node{
 		Type: permissions.NodeTypeAnd,
 		Nodes: []permissions.Node{
@@ -629,7 +629,7 @@ func (c *Controller) GetGroupACL(w http.ResponseWriter, r *http.Request, groupID
 }
 
 func (c *Controller) SetGroupACL(w http.ResponseWriter, r *http.Request, body apigen.SetGroupACLJSONRequestBody, groupID string) {
-	aclPolicyName := acl.ACLPolicyName(groupID)
+	aclPolicyName := acl.PolicyName(groupID)
 	if !c.authorize(w, r, permissions.Node{
 		Type: permissions.NodeTypeAnd,
 		Nodes: []permissions.Node{
@@ -1583,7 +1583,7 @@ func (c *Controller) CreateRepository(w http.ResponseWriter, r *http.Request, bo
 			return
 		}
 
-		err = samplerepo.SampleRepoAddBranchProtection(ctx, newRepo, c.Catalog)
+		err = samplerepo.AddBranchProtection(ctx, newRepo, c.Catalog)
 		if err != nil {
 			c.handleAPIError(ctx, w, r, fmt.Errorf("error adding branch protection to sample repository: %w", err))
 			return

--- a/pkg/auth/acl/name.go
+++ b/pkg/auth/acl/name.go
@@ -2,13 +2,13 @@ package acl
 
 import "strings"
 
-const ACLPolicyPrefix = "ACL(_-_)"
+const PolicyPrefix = "ACL(_-_)"
 
-// ACLPolicyName returns the policy identifier for the ACL for groupID.
-func ACLPolicyName(groupID string) string {
-	return ACLPolicyPrefix + groupID
+// PolicyName returns the policy identifier for the ACL for groupID.
+func PolicyName(groupID string) string {
+	return PolicyPrefix + groupID
 }
 
-func IsACLPolicyName(policyName string) bool {
-	return strings.HasPrefix(policyName, ACLPolicyPrefix)
+func IsPolicyName(policyName string) bool {
+	return strings.HasPrefix(policyName, PolicyPrefix)
 }

--- a/pkg/auth/acl/permission.go
+++ b/pkg/auth/acl/permission.go
@@ -9,19 +9,19 @@ import (
 )
 
 const (
-	// ACLRead allows reading the specified repositories, as well as
+	// ReadPermission allows reading the specified repositories, as well as
 	// managing own credentials.
-	ACLRead model.ACLPermission = "Read"
-	// ACLWrite allows reading and writing the specified repositories,
+	ReadPermission model.ACLPermission = "Read"
+	// WritePermission allows reading and writing the specified repositories,
 	// as well as managing own credentials.
-	ACLWrite model.ACLPermission = "Write"
-	// ACLSuper allows reading, writing, and all other actions on the
+	WritePermission model.ACLPermission = "Write"
+	// SuperPermission allows reading, writing, and all other actions on the
 	// specified repositories, as well as managing own credentials.
-	ACLSuper model.ACLPermission = "Super"
-	// ACLAdmin allows all operations, including all reading, writing,
+	SuperPermission model.ACLPermission = "Super"
+	// AdminPermission allows all operations, including all reading, writing,
 	// and all other actions on all repositories, and managing
 	// authorization and credentials of all users.
-	ACLAdmin model.ACLPermission = "Admin"
+	AdminPermission model.ACLPermission = "Admin"
 )
 
 var (
@@ -38,7 +38,7 @@ func ACLToStatement(acl model.ACL) (model.Statements, error) {
 	)
 
 	switch acl.Permission {
-	case ACLRead:
+	case ReadPermission:
 		statements, err = auth.MakeStatementForPolicyType("FSRead", all)
 		if err != nil {
 			return nil, fmt.Errorf("%s: %w", acl.Permission, ErrBadACLPermission)
@@ -53,7 +53,7 @@ func ACLToStatement(acl model.ACL) (model.Statements, error) {
 			return nil, err
 		}
 		statements = append(append(statements, readConfigStatement...), ownCredentialsStatement...)
-	case ACLWrite:
+	case WritePermission:
 		statements, err = auth.MakeStatementForPolicyType("FSReadWrite", all)
 		if err != nil {
 			return nil, fmt.Errorf("%s: %w", acl.Permission, ErrBadACLPermission)
@@ -70,7 +70,7 @@ func ACLToStatement(acl model.ACL) (model.Statements, error) {
 		}
 
 		statements = append(statements, append(ownCredentialsStatement, ciStatement...)...)
-	case ACLSuper:
+	case SuperPermission:
 		statements, err = auth.MakeStatementForPolicyType("FSFullAccess", all)
 		if err != nil {
 			return nil, fmt.Errorf("%s: get FSFullAccess: %w", acl.Permission, ErrBadACLPermission)
@@ -87,7 +87,7 @@ func ACLToStatement(acl model.ACL) (model.Statements, error) {
 		}
 
 		statements = append(statements, append(ownCredentialsStatement, ciStatement...)...)
-	case ACLAdmin:
+	case AdminPermission:
 		statements, err = auth.MakeStatementForPolicyType("AllAccess", []string{permissions.All})
 		if err != nil {
 			return nil, fmt.Errorf("%s: %w", acl.Permission, ErrBadACLPermission)

--- a/pkg/auth/acl/write.go
+++ b/pkg/auth/acl/write.go
@@ -7,18 +7,17 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/hashicorp/go-multierror"
 	"github.com/treeverse/lakefs/pkg/auth"
 	"github.com/treeverse/lakefs/pkg/auth/model"
 	"github.com/treeverse/lakefs/pkg/logging"
-
-	"github.com/hashicorp/go-multierror"
 )
 
 const (
-	ACLAdminsGroup  = "Admins"
-	ACLSupersGroup  = "Supers"
-	ACLWritersGroup = "Writers"
-	ACLReadersGroup = "Readers"
+	AdminsGroup  = "Admins"
+	SupersGroup  = "Supers"
+	WritersGroup = "Writers"
+	ReadersGroup = "Readers"
 )
 
 func WriteGroupACL(ctx context.Context, svc auth.Service, groupName string, acl model.ACL, creationTime time.Time, warnIfCreate bool) error {
@@ -29,7 +28,7 @@ func WriteGroupACL(ctx context.Context, svc auth.Service, groupName string, acl 
 		return fmt.Errorf("%s: translate ACL %+v to statements: %w", groupName, acl, err)
 	}
 
-	aclPolicyName := ACLPolicyName(groupName)
+	aclPolicyName := PolicyName(groupName)
 
 	policy := &model.Policy{
 		CreatedAt:   creationTime,

--- a/pkg/auth/service_test.go
+++ b/pkg/auth/service_test.go
@@ -22,7 +22,7 @@ import (
 	"github.com/treeverse/lakefs/pkg/auth/mock"
 	"github.com/treeverse/lakefs/pkg/auth/model"
 	authparams "github.com/treeverse/lakefs/pkg/auth/params"
-	auth_testutil "github.com/treeverse/lakefs/pkg/auth/testutil"
+	authtestutil "github.com/treeverse/lakefs/pkg/auth/testutil"
 	"github.com/treeverse/lakefs/pkg/kv/kvtest"
 	"github.com/treeverse/lakefs/pkg/logging"
 	"github.com/treeverse/lakefs/pkg/permissions"
@@ -212,7 +212,7 @@ func TestAuthService_DeleteUserWithRelations(t *testing.T) {
 	policyNames := []string{"policy01", "policy02", "policy03", "policy04"}
 
 	ctx := context.Background()
-	authService, _ := auth_testutil.SetupService(t, ctx, someSecret)
+	authService, _ := authtestutil.SetupService(t, ctx, someSecret)
 
 	// create initial data set and verify users groups and policies are create and related as expected
 	createInitialDataSet(t, ctx, authService, userNames, groupNames, policyNames)
@@ -280,7 +280,7 @@ func TestAuthService_DeleteGroupWithRelations(t *testing.T) {
 	policyNames := []string{"policy01", "policy02", "policy03", "policy04"}
 
 	ctx := context.Background()
-	authService, _ := auth_testutil.SetupService(t, ctx, someSecret)
+	authService, _ := authtestutil.SetupService(t, ctx, someSecret)
 
 	// create initial data set and verify users groups and policies are created and related as expected
 	createInitialDataSet(t, ctx, authService, userNames, groupNames, policyNames)
@@ -364,7 +364,7 @@ func TestAuthService_DeletePoliciesWithRelations(t *testing.T) {
 	policyNames := []string{"policy01", "policy02", "policy03", "policy04"}
 
 	ctx := context.Background()
-	authService, _ := auth_testutil.SetupService(t, ctx, someSecret)
+	authService, _ := authtestutil.SetupService(t, ctx, someSecret)
 
 	// create initial data set and verify users groups and policies are create and related as expected
 	createInitialDataSet(t, ctx, authService, userNames, groupNames, policyNames)
@@ -585,7 +585,7 @@ func describeAllowed(allowed bool) string {
 }
 
 func TestACL(t *testing.T) {
-	hierarchy := []model.ACLPermission{acl.ACLRead, acl.ACLWrite, acl.ACLSuper, acl.ACLAdmin}
+	hierarchy := []model.ACLPermission{acl.ReadPermission, acl.WritePermission, acl.SuperPermission, acl.AdminPermission}
 
 	type PermissionFrom map[model.ACLPermission][]permissions.Permission
 	type TestCase struct {
@@ -604,25 +604,25 @@ func TestACL(t *testing.T) {
 			Name: "all repos",
 			ACL:  model.ACL{},
 			PermissionFrom: PermissionFrom{
-				acl.ACLRead: []permissions.Permission{
+				acl.ReadPermission: []permissions.Permission{
 					{Action: permissions.ReadObjectAction, Resource: permissions.ObjectArn("foo", "some/path")},
 					{Action: permissions.ListObjectsAction, Resource: permissions.ObjectArn("foo", "some/path")},
 					{Action: permissions.ListObjectsAction, Resource: permissions.ObjectArn("quux", "")},
 					{Action: permissions.CreateCredentialsAction, Resource: permissions.UserArn("${user}")},
 				},
-				acl.ACLWrite: []permissions.Permission{
+				acl.WritePermission: []permissions.Permission{
 					{Action: permissions.WriteObjectAction, Resource: permissions.ObjectArn("foo", "some/path")},
 					{Action: permissions.DeleteObjectAction, Resource: permissions.ObjectArn("foo", "some/path")},
 					{Action: permissions.CreateBranchAction, Resource: permissions.BranchArn("foo", "twig")},
 					{Action: permissions.CreateCommitAction, Resource: permissions.BranchArn("foo", "twig")},
 					{Action: permissions.CreateMetaRangeAction, Resource: permissions.RepoArn("foo")},
 				},
-				acl.ACLSuper: []permissions.Permission{
+				acl.SuperPermission: []permissions.Permission{
 					{Action: permissions.AttachStorageNamespaceAction, Resource: permissions.StorageNamespace("storage://bucket/path")},
 					{Action: permissions.ImportFromStorageAction, Resource: permissions.StorageNamespace("storage://bucket/path")},
 					{Action: permissions.ImportCancelAction, Resource: permissions.BranchArn("foo", "twig")},
 				},
-				acl.ACLAdmin: []permissions.Permission{
+				acl.AdminPermission: []permissions.Permission{
 					{Action: permissions.CreateUserAction, Resource: permissions.UserArn("you")},
 				},
 			},
@@ -633,7 +633,7 @@ func TestACL(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.Name, func(t *testing.T) {
-			s, _ := auth_testutil.SetupService(t, ctx, someSecret)
+			s, _ := authtestutil.SetupService(t, ctx, someSecret)
 			userID := make(map[model.ACLPermission]string, len(hierarchy))
 			for _, aclPermission := range hierarchy {
 				tt.ACL.Permission = aclPermission

--- a/pkg/auth/setup/setup.go
+++ b/pkg/auth/setup/setup.go
@@ -114,7 +114,7 @@ func attachPolicies(ctx context.Context, authService auth.Service, groupID strin
 	return nil
 }
 
-func SetupRBACBaseGroups(ctx context.Context, authService auth.Service, ts time.Time) error {
+func CreateRBACBaseGroups(ctx context.Context, authService auth.Service, ts time.Time) error {
 	err := createGroups(ctx, authService, []*model.Group{
 		{CreatedAt: ts, DisplayName: AdminsGroup},
 		{CreatedAt: ts, DisplayName: SuperUsersGroup},
@@ -150,43 +150,43 @@ func SetupRBACBaseGroups(ctx context.Context, authService auth.Service, ts time.
 	return nil
 }
 
-func SetupACLBaseGroups(ctx context.Context, authService auth.Service, ts time.Time) error {
-	if err := authService.CreateGroup(ctx, &model.Group{CreatedAt: ts, DisplayName: acl.ACLAdminsGroup}); err != nil {
-		return fmt.Errorf("setup: create base ACL group %s: %w", acl.ACLAdminsGroup, err)
+func CreateACLBaseGroups(ctx context.Context, authService auth.Service, ts time.Time) error {
+	if err := authService.CreateGroup(ctx, &model.Group{CreatedAt: ts, DisplayName: acl.AdminsGroup}); err != nil {
+		return fmt.Errorf("setup: create base ACL group %s: %w", acl.AdminsGroup, err)
 	}
-	if err := acl.WriteGroupACL(ctx, authService, acl.ACLAdminsGroup, model.ACL{Permission: acl.ACLAdmin}, ts, false); err != nil {
+	if err := acl.WriteGroupACL(ctx, authService, acl.AdminsGroup, model.ACL{Permission: acl.AdminPermission}, ts, false); err != nil {
 		return fmt.Errorf("setup: %w", err)
 	}
 
-	if err := authService.CreateGroup(ctx, &model.Group{CreatedAt: ts, DisplayName: acl.ACLSupersGroup}); err != nil {
-		return fmt.Errorf("setup: create base ACL group %s: %w", acl.ACLSupersGroup, err)
+	if err := authService.CreateGroup(ctx, &model.Group{CreatedAt: ts, DisplayName: acl.SupersGroup}); err != nil {
+		return fmt.Errorf("setup: create base ACL group %s: %w", acl.SupersGroup, err)
 	}
-	if err := acl.WriteGroupACL(ctx, authService, acl.ACLSupersGroup, model.ACL{Permission: acl.ACLSuper}, ts, false); err != nil {
+	if err := acl.WriteGroupACL(ctx, authService, acl.SupersGroup, model.ACL{Permission: acl.SuperPermission}, ts, false); err != nil {
 		return fmt.Errorf("setup: %w", err)
 	}
 
-	if err := authService.CreateGroup(ctx, &model.Group{CreatedAt: ts, DisplayName: acl.ACLWritersGroup}); err != nil {
-		return fmt.Errorf("setup: create base ACL group %s: %w", acl.ACLWritersGroup, err)
+	if err := authService.CreateGroup(ctx, &model.Group{CreatedAt: ts, DisplayName: acl.WritersGroup}); err != nil {
+		return fmt.Errorf("setup: create base ACL group %s: %w", acl.WritersGroup, err)
 	}
-	if err := acl.WriteGroupACL(ctx, authService, acl.ACLWritersGroup, model.ACL{Permission: acl.ACLWrite}, ts, false); err != nil {
+	if err := acl.WriteGroupACL(ctx, authService, acl.WritersGroup, model.ACL{Permission: acl.WritePermission}, ts, false); err != nil {
 		return fmt.Errorf("setup: %w", err)
 	}
 
-	if err := authService.CreateGroup(ctx, &model.Group{CreatedAt: ts, DisplayName: acl.ACLReadersGroup}); err != nil {
-		return fmt.Errorf("create base ACL group %s: %w", acl.ACLReadersGroup, err)
+	if err := authService.CreateGroup(ctx, &model.Group{CreatedAt: ts, DisplayName: acl.ReadersGroup}); err != nil {
+		return fmt.Errorf("create base ACL group %s: %w", acl.ReadersGroup, err)
 	}
-	if err := acl.WriteGroupACL(ctx, authService, acl.ACLReadersGroup, model.ACL{Permission: acl.ACLRead}, ts, false); err != nil {
+	if err := acl.WriteGroupACL(ctx, authService, acl.ReadersGroup, model.ACL{Permission: acl.ReadPermission}, ts, false); err != nil {
 		return fmt.Errorf("setup: %w", err)
 	}
 
 	return nil
 }
 
-// SetupAdminUser setup base groups, policies and create admin user
-func SetupAdminUser(ctx context.Context, authService auth.Service, cfg *config.Config, superuser *model.SuperuserConfiguration) (*model.Credential, error) {
+// CreateAdminUser setup base groups, policies and create admin user
+func CreateAdminUser(ctx context.Context, authService auth.Service, cfg *config.Config, superuser *model.SuperuserConfiguration) (*model.Credential, error) {
 	// Set up the basic groups and policies
 	now := time.Now()
-	err := SetupBaseGroups(ctx, authService, cfg, now)
+	err := CreateBaseGroups(ctx, authService, cfg, now)
 	if err != nil {
 		return nil, err
 	}
@@ -245,7 +245,7 @@ func CreateInitialAdminUserWithKeys(ctx context.Context, authService auth.Servic
 	}
 
 	// create first admin user
-	cred, err := SetupAdminUser(ctx, authService, cfg, adminUser)
+	cred, err := CreateAdminUser(ctx, authService, cfg, adminUser)
 	if err != nil {
 		return nil, err
 	}
@@ -257,9 +257,9 @@ func CreateInitialAdminUserWithKeys(ctx context.Context, authService auth.Servic
 	return cred, err
 }
 
-func SetupBaseGroups(ctx context.Context, authService auth.Service, cfg *config.Config, ts time.Time) error {
+func CreateBaseGroups(ctx context.Context, authService auth.Service, cfg *config.Config, ts time.Time) error {
 	if cfg.IsAuthUISimplified() {
-		return SetupACLBaseGroups(ctx, authService, ts)
+		return CreateACLBaseGroups(ctx, authService, ts)
 	}
-	return SetupRBACBaseGroups(ctx, authService, ts)
+	return CreateRBACBaseGroups(ctx, authService, ts)
 }

--- a/pkg/block/blocktest/adapter.go
+++ b/pkg/block/blocktest/adapter.go
@@ -58,7 +58,9 @@ func testAdapterPutGet(t *testing.T, adapter block.Adapter, storageNamespace, ex
 
 			reader, err := adapter.Get(ctx, obj, size)
 			require.NoError(t, err)
-			defer func() { _ = reader.Close() }()
+			defer func() {
+				require.NoError(t, reader.Close())
+			}()
 			got, err := io.ReadAll(reader)
 			require.NoError(t, err)
 			require.Equal(t, contents, string(got))

--- a/pkg/block/gs/adapter_test.go
+++ b/pkg/block/gs/adapter_test.go
@@ -23,14 +23,18 @@ func TestAdapter(t *testing.T) {
 	require.NoError(t, err)
 
 	adapter := newAdapter()
-	defer require.NoError(t, adapter.Close())
+	defer func() {
+		require.NoError(t, adapter.Close())
+	}()
 
 	blocktest.AdapterTest(t, adapter, localPath, externalPath)
 }
 
 func TestAdapterNamespace(t *testing.T) {
 	adapter := newAdapter()
-	defer require.NoError(t, adapter.Close())
+	defer func() {
+		require.NoError(t, adapter.Close())
+	}()
 
 	expr, err := regexp.Compile(adapter.GetStorageNamespaceInfo().ValidityRegex)
 	require.NoError(t, err)

--- a/pkg/block/gs/adapter_test.go
+++ b/pkg/block/gs/adapter_test.go
@@ -10,12 +10,11 @@ import (
 	"github.com/treeverse/lakefs/pkg/block/gs"
 )
 
-func getAdapter() *gs.Adapter {
-	adapter := gs.NewAdapter(client)
-	return adapter
+func newAdapter() *gs.Adapter {
+	return gs.NewAdapter(client)
 }
 
-func TestS3Adapter(t *testing.T) {
+func TestAdapter(t *testing.T) {
 	basePath, err := url.JoinPath("gs://", bucketName)
 	require.NoError(t, err)
 	localPath, err := url.JoinPath(basePath, "lakefs")
@@ -23,12 +22,16 @@ func TestS3Adapter(t *testing.T) {
 	externalPath, err := url.JoinPath(basePath, "external")
 	require.NoError(t, err)
 
-	adapter := getAdapter()
+	adapter := newAdapter()
+	defer require.NoError(t, adapter.Close())
+
 	blocktest.AdapterTest(t, adapter, localPath, externalPath)
 }
 
 func TestAdapterNamespace(t *testing.T) {
-	adapter := getAdapter()
+	adapter := newAdapter()
+	defer require.NoError(t, adapter.Close())
+
 	expr, err := regexp.Compile(adapter.GetStorageNamespaceInfo().ValidityRegex)
 	require.NoError(t, err)
 

--- a/pkg/block/gs/main_test.go
+++ b/pkg/block/gs/main_test.go
@@ -13,32 +13,28 @@ import (
 	"google.golang.org/api/option"
 )
 
-const (
-	emulatorContainerTimeoutSeconds = 10 * 60 // 10 min
-	bucketName                      = "bucket1"
-	emulatorTestEndpoint            = "127.0.0.1"
-	emulatorTestPort                = "4443"
-	gcsProjectID                    = "testProject"
-)
+const bucketName = "bucket1"
 
-var (
-	blockURL string
-	pool     *dockertest.Pool
-	client   *storage.Client
-)
+var client *storage.Client
 
 func TestMain(m *testing.M) {
-	var err error
+	const (
+		emulatorContainerTimeoutSeconds = 10 * 60 // 10 min
+		emulatorTestEndpoint            = "127.0.0.1"
+		emulatorTestPort                = "4443"
+		gcsProjectID                    = "testProject"
+	)
+
 	ctx := context.Background()
-	// External port required for -public-host configuration in docker cmd
+	// External port required for '-public-host' configuration in docker cmd
 	endpoint := fmt.Sprintf("%s:%s", emulatorTestEndpoint, emulatorTestPort)
-	pool, err = dockertest.NewPool("")
+	pool, err := dockertest.NewPool("")
 	if err != nil {
 		log.Fatalf("Could not connect to Docker: %s", err)
 	}
 	resource, err := pool.RunWithOptions(&dockertest.RunOptions{
 		Repository: "fsouza/fake-gcs-server",
-		Tag:        "1.45.2",
+		Tag:        "1.47.4",
 		Cmd: []string{
 			"-scheme",
 			"http",
@@ -55,32 +51,32 @@ func TestMain(m *testing.M) {
 		},
 	})
 	if err != nil {
-		panic(err)
+		log.Fatalf("Could not start fake-gcs-server: %s", err)
 	}
 
 	// set cleanup
 	closer := func() {
 		err = pool.Purge(resource)
 		if err != nil {
-			panic("could not purge emulator container: " + err.Error())
+			log.Fatalf("Could not purge fake-gcs-server: %s", err)
 		}
 	}
 
 	// expire, just to make sure
 	err = resource.Expire(emulatorContainerTimeoutSeconds)
 	if err != nil {
-		panic("could not expire emulator container: " + err.Error())
+		log.Fatalf("Could not expire fake-gcs-server: %s", err)
 	}
 
-	// Create test client and bucket
-	blockURL = fmt.Sprintf("http://%s/storage/v1/", endpoint)
+	// Create the test client and bucket
+	blockURL := fmt.Sprintf("http://%s/storage/v1/", endpoint)
 	client, err = storage.NewClient(ctx, option.WithEndpoint(blockURL), option.WithoutAuthentication())
 	if err != nil {
-		log.Fatalf("create client: %s", err)
+		log.Fatalf("Could not create gs client: %s", err)
 	}
 
-	if err = client.Bucket(bucketName).Create(ctx, gcsProjectID, nil); err != nil {
-		log.Fatalf("create bucket: %s", err)
+	if err := client.Bucket(bucketName).Create(ctx, gcsProjectID, nil); err != nil {
+		log.Fatalf("Could not create bucket '%s': %s", bucketName, err)
 	}
 
 	code := m.Run()

--- a/pkg/gateway/operations/listbuckets.go
+++ b/pkg/gateway/operations/listbuckets.go
@@ -23,7 +23,7 @@ func (controller *ListBuckets) RequiredPermissions(_ *http.Request) (permissions
 func (controller *ListBuckets) Handle(w http.ResponseWriter, req *http.Request, o *AuthorizedOperation) {
 	o.Incr("list_repos", o.Principal, "", "")
 
-	buckets := []serde.Bucket{}
+	buckets := make([]serde.Bucket, 0)
 	var after string
 	for {
 		// list repositories

--- a/pkg/graveler/committed/diff_test.go
+++ b/pkg/graveler/committed/diff_test.go
@@ -350,7 +350,7 @@ func TestNextRange(t *testing.T) {
 		if it.NextRange() {
 			t.Fatal("expected false from iterator after close")
 		}
-		if err := it.Err(); err != committed.ErrNoRange {
+		if err := it.Err(); !errors.Is(err, committed.ErrNoRange) {
 			t.Fatalf("expected to get err=%s, got: %s", committed.ErrNoRange, err)
 		}
 	})
@@ -388,7 +388,7 @@ func TestNextErr(t *testing.T) {
 		val, rng := it.Value()
 		t.Fatalf("unexptected result from it.NextRange(), expected false, got true with value=%v , rng=%v", val, rng)
 	}
-	if err := it.Err(); err != committed.ErrNoRange {
+	if err := it.Err(); !errors.Is(err, committed.ErrNoRange) {
 		t.Fatalf("expected to get err=%s, got: %s", committed.ErrNoRange, err)
 	}
 }

--- a/pkg/graveler/committed/import_test.go
+++ b/pkg/graveler/committed/import_test.go
@@ -2,11 +2,13 @@ package committed_test
 
 import (
 	"context"
+	"errors"
+	"testing"
+
 	"github.com/golang/mock/gomock"
 	"github.com/treeverse/lakefs/pkg/graveler"
 	"github.com/treeverse/lakefs/pkg/graveler/committed"
 	"github.com/treeverse/lakefs/pkg/graveler/committed/mock"
-	"testing"
 )
 
 func Test_import(t *testing.T) {
@@ -371,8 +373,8 @@ func Test_import(t *testing.T) {
 				writer.EXPECT().Close(gomock.Any()).Return(&metaRangeId, nil).AnyTimes()
 				committedManager := committed.NewCommittedManager(metaRangeManager, rangeManager, params)
 				_, err := committedManager.Import(ctx, "ns", destMetaRangeID, sourceMetaRangeID, tst.prefixes)
-				if err != expectedResult.expectedErr {
-					t.Fatal(err)
+				if !errors.Is(err, expectedResult.expectedErr) {
+					t.Fatalf("Import error = '%v', expected '%v'", err, expectedResult.expectedErr)
 				}
 			})
 		}

--- a/pkg/graveler/committed/merge_test.go
+++ b/pkg/graveler/committed/merge_test.go
@@ -1730,8 +1730,8 @@ func runMergeTests(tests testCases, t *testing.T) {
 					writer.EXPECT().Close(gomock.Any()).Return(&metaRangeId, nil).AnyTimes()
 					committedManager := committed.NewCommittedManager(metaRangeManager, rangeManager, params)
 					_, err := committedManager.Merge(ctx, "ns", destMetaRangeID, sourceMetaRangeID, baseMetaRangeID, mergeStrategy)
-					if err != expectedResult.expectedErr {
-						t.Fatal(err)
+					if !errors.Is(err, expectedResult.expectedErr) {
+						t.Fatalf("Merge error='%v', expected='%v'", err, expectedResult.expectedErr)
 					}
 				})
 			}

--- a/pkg/graveler/graveler_test.go
+++ b/pkg/graveler/graveler_test.go
@@ -270,7 +270,7 @@ func TestGraveler_Get(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			Value, err := tt.r.Get(context.Background(), repository, "", []byte("key"))
-			if err != tt.expectedErr {
+			if !errors.Is(err, tt.expectedErr) {
 				t.Fatalf("wrong error, expected:%v got:%v", tt.expectedErr, err)
 			}
 			if err != nil {
@@ -347,7 +347,7 @@ func TestGraveler_Set(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			store := newGraveler(t, tt.committedMgr, tt.stagingMgr, tt.refMgr, nil, testutil.NewProtectedBranchesManagerFake())
 			err := store.Set(ctx, repository, "branch-1", newSetVal.Key, *newSetVal.Value, graveler.WithIfAbsent(tt.ifAbsent))
-			if err != tt.expectedErr {
+			if !errors.Is(err, tt.expectedErr) {
 				t.Fatalf("Set() - error: %v, expected: %v", err, tt.expectedErr)
 			}
 			lastVal := tt.stagingMgr.LastSetValueRecord
@@ -573,7 +573,7 @@ func TestGravelerGet_Advanced(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			Value, err := tt.r.Get(context.Background(), repository, "", []byte("staged"))
-			if err != tt.expectedErr {
+			if !errors.Is(err, tt.expectedErr) {
 				t.Fatalf("wrong error, expected:%v got:%v", tt.expectedErr, err)
 			}
 			if err != nil {
@@ -811,7 +811,7 @@ func TestGraveler_Diff(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
 			diff, err := tt.r.Diff(ctx, repository, "ref1", "b1")
-			if err != tt.expectedErr {
+			if !errors.Is(err, tt.expectedErr) {
 				t.Fatalf("wrong error, expected:%s got:%s", tt.expectedErr, err)
 			}
 			if err != nil {
@@ -924,7 +924,7 @@ func TestGraveler_DiffUncommitted(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			ctx := context.Background()
 			diff, err := tt.r.DiffUncommitted(ctx, repository, "branch")
-			if err != tt.expectedErr {
+			if !errors.Is(err, tt.expectedErr) {
 				t.Fatalf("wrong error, expected:%s got:%s", tt.expectedErr, err)
 			}
 			if err != nil {

--- a/pkg/graveler/ref/manager_test.go
+++ b/pkg/graveler/ref/manager_test.go
@@ -852,7 +852,7 @@ func TestManager_LogGraph(t *testing.T) {
 				nextCommitTS = nextCommitTS.Add(time.Minute)
 				parentIDs := make([]graveler.CommitID, 0, len(parentNames))
 				for _, parentName := range parentNames {
-					parentIDs = append(parentIDs, graveler.CommitID(commitNameToID[parentName]))
+					parentIDs = append(parentIDs, commitNameToID[parentName])
 				}
 				c := graveler.Commit{
 					Committer:    "user1",

--- a/pkg/graveler/settings/manager_test.go
+++ b/pkg/graveler/settings/manager_test.go
@@ -208,7 +208,7 @@ func TestEmpty(t *testing.T) {
 	emptySettings := &settings.ExampleSettings{}
 	_, err := m.Get(ctx, repository, "settingKey", emptySettings)
 	// the key was not set, an error should be returned
-	if err != graveler.ErrNotFound {
+	if !errors.Is(err, graveler.ErrNotFound) {
 		t.Fatalf("expected error %v, got %v", graveler.ErrNotFound, err)
 	}
 	// when using Update on an unset key, the update function gets an empty setting object to operate on

--- a/pkg/kv/kvtest/store.go
+++ b/pkg/kv/kvtest/store.go
@@ -297,7 +297,7 @@ func testStoreSetIf(t *testing.T, ms MakeStore) {
 
 	t.Run("predicate_empty_slice", func(t *testing.T) {
 		key := uniqueKey("predicate-empty-slice")
-		val1 := []byte{}
+		val1 := make([]byte, 0)
 		err := store.Set(ctx, []byte(testPartitionKey), key, val1)
 		if err != nil {
 			t.Fatalf("Set while testing predicate empty slice - key=%s value=%s: %s", key, val1, err)
@@ -561,7 +561,7 @@ func testStoreContextCancelled(t *testing.T, ms MakeStore) {
 	// cancel the context for all requests
 	cancel()
 	t.Run("Set", func(t *testing.T) {
-		// set test key with value1
+		// set the test key with value1
 		err := store.Set(ctx, []byte(testPartitionKey), testKey, testValue1)
 		if err != nil && !errors.Is(err, context.Canceled) {
 			t.Fatalf("expected context cancellation error, got: %s", err)

--- a/pkg/kv/migrations/rbac_to_acl.go
+++ b/pkg/kv/migrations/rbac_to_acl.go
@@ -29,7 +29,7 @@ const (
 var (
 	// ErrTooMany is returned when this migration does not support a
 	// particular number of resources.  It should not occur on any
-	// reasonably-sized installation.
+	// reasonably sized installation.
 	ErrTooMany         = errors.New("too many")
 	ErrTooManyPolicies = fmt.Errorf("%w policies", ErrTooMany)
 	ErrTooManyGroups   = fmt.Errorf("%w groups", ErrTooMany)
@@ -42,7 +42,7 @@ var (
 
 	// allPermissions lists all permissions, from most restrictive to
 	// most permissive.  It includes "" for some edge cases.
-	allPermissions = []model.ACLPermission{"", acl.ACLRead, acl.ACLWrite, acl.ACLSuper, acl.ACLAdmin}
+	allPermissions = []model.ACLPermission{"", acl.ReadPermission, acl.WritePermission, acl.SuperPermission, acl.AdminPermission}
 )
 
 func MigrateToACL(ctx context.Context, kvStore kv.Store, cfg *config.Config, logger logging.Logger, version int, force bool) error {
@@ -132,9 +132,9 @@ func reportACL(acl model.ACL) string {
 }
 
 // checkPolicyACLName fails if policy name is named as an ACL policy (start
-// with ACLPolicyPrefix) but is not an ACL policy.
+// with PolicyPrefix) but is not an ACL policy.
 func checkPolicyACLName(ctx context.Context, svc auth.Service, name string) error {
-	if !acl.IsACLPolicyName(name) {
+	if !acl.IsPolicyName(name) {
 		return nil
 	}
 
@@ -187,7 +187,7 @@ func rbacToACL(ctx context.Context, svc auth.Service, doUpdate bool, creationTim
 			"acl":   fmt.Sprintf("%+v", newACL),
 		}).Info("Computed ACL")
 
-		aclPolicyName := acl.ACLPolicyName(group.DisplayName)
+		aclPolicyName := acl.PolicyName(group.DisplayName)
 		err = checkPolicyACLName(ctx, svc, aclPolicyName)
 		if err != nil {
 			warnings = multierror.Append(warnings, warn)
@@ -259,7 +259,7 @@ type ACLsMigrator struct {
 }
 
 func makeSet(allEls ...[]string) map[string]struct{} {
-	ret := make(map[string]struct{}, 0)
+	ret := make(map[string]struct{})
 	for _, els := range allEls {
 		for _, el := range els {
 			ret[el] = struct{}{}
@@ -277,10 +277,10 @@ func NewACLsMigrator(svc auth.Service, doUpdate bool) *ACLsMigrator {
 		svc:      svc,
 		doUpdate: doUpdate,
 		Actions: map[model.ACLPermission]map[string]struct{}{
-			acl.ACLAdmin: makeSet(auth.GetActionsForPolicyTypeOrDie("AllAccess")),
-			acl.ACLSuper: makeSet(auth.GetActionsForPolicyTypeOrDie("FSFullAccess"), manageOwnCredentials, ciRead),
-			acl.ACLWrite: makeSet(auth.GetActionsForPolicyTypeOrDie("FSReadWrite"), manageOwnCredentials, ciRead),
-			acl.ACLRead:  makeSet(auth.GetActionsForPolicyTypeOrDie("FSRead"), manageOwnCredentials),
+			acl.AdminPermission: makeSet(auth.GetActionsForPolicyTypeOrDie("AllAccess")),
+			acl.SuperPermission: makeSet(auth.GetActionsForPolicyTypeOrDie("FSFullAccess"), manageOwnCredentials, ciRead),
+			acl.WritePermission: makeSet(auth.GetActionsForPolicyTypeOrDie("FSReadWrite"), manageOwnCredentials, ciRead),
+			acl.ReadPermission:  makeSet(auth.GetActionsForPolicyTypeOrDie("FSRead"), manageOwnCredentials),
 		},
 	}
 }
@@ -354,7 +354,7 @@ func (mig *ACLsMigrator) GetMinPermission(action string) model.ACLPermission {
 	}
 
 	// Try a wildcard match against all known actions: find the least
-	// permissions that allows all actions that the action pattern
+	// permission that allows all actions that the action pattern
 	// matches.
 	for _, permission := range allPermissions {
 		// This loop is reasonably efficient only for small numbers
@@ -363,11 +363,11 @@ func (mig *ACLsMigrator) GetMinPermission(action string) model.ACLPermission {
 		permissionOK := true
 		for _, a := range permissions.Actions {
 			if !wildcard.Match(action, a) {
-				// a does not include action.
+				// 'a' does not include action.
 				continue
 			}
 			if someActionMatches(a, actionsForPermission) {
-				// a is allowed at permission.
+				// 'a' is allowed at permission.
 				continue
 			}
 			permissionOK = false
@@ -402,7 +402,7 @@ func (mig *ACLsMigrator) ComputePermission(ctx context.Context, actions []string
 		}
 	}
 	if permission == "" {
-		return permission, fmt.Errorf("%w actions", ErrEmpty)
+		return "", fmt.Errorf("%w actions", ErrEmpty)
 	}
 
 	return permission, nil
@@ -413,15 +413,15 @@ func (mig *ACLsMigrator) ComputePermission(ctx context.Context, actions []string
 func (mig *ACLsMigrator) ComputeAddedActions(permission model.ACLPermission, alreadyAllowedActions map[string]struct{}) []string {
 	var allAllowedActions map[string]struct{}
 	switch permission {
-	case acl.ACLRead:
-		allAllowedActions = mig.Actions[acl.ACLRead]
-	case acl.ACLWrite:
-		allAllowedActions = mig.Actions[acl.ACLWrite]
-	case acl.ACLSuper:
-		allAllowedActions = mig.Actions[acl.ACLSuper]
-	case acl.ACLAdmin:
+	case acl.ReadPermission:
+		allAllowedActions = mig.Actions[acl.ReadPermission]
+	case acl.WritePermission:
+		allAllowedActions = mig.Actions[acl.WritePermission]
+	case acl.SuperPermission:
+		allAllowedActions = mig.Actions[acl.SuperPermission]
+	case acl.AdminPermission:
 	default:
-		allAllowedActions = mig.Actions[acl.ACLAdmin]
+		allAllowedActions = mig.Actions[acl.AdminPermission]
 	}
 	addedActions := make(map[string]struct{}, len(allAllowedActions))
 	for _, action := range permissions.Actions {
@@ -441,14 +441,14 @@ func BroaderPermission(a, b model.ACLPermission) bool {
 	switch a {
 	case "":
 		return false
-	case acl.ACLRead:
+	case acl.ReadPermission:
 		return b == ""
-	case acl.ACLWrite:
-		return b == "" || b == acl.ACLRead
-	case acl.ACLSuper:
-		return b == "" || b == acl.ACLRead || b == acl.ACLWrite
-	case acl.ACLAdmin:
-		return b == "" || b == acl.ACLRead || b == acl.ACLWrite || b == acl.ACLSuper
+	case acl.WritePermission:
+		return b == "" || b == acl.ReadPermission
+	case acl.SuperPermission:
+		return b == "" || b == acl.ReadPermission || b == acl.WritePermission
+	case acl.AdminPermission:
+		return b == "" || b == acl.ReadPermission || b == acl.WritePermission || b == acl.SuperPermission
 	}
 	panic(fmt.Sprintf("impossible comparison %s and %s", a, b))
 }

--- a/pkg/loadtest/local_load_test.go
+++ b/pkg/loadtest/local_load_test.go
@@ -73,7 +73,7 @@ func TestLocalLoad(t *testing.T) {
 	actionsService := actions.NewService(ctx, actions.NewActionsKVStore(kvStore), source, outputWriter, &actions.DecreasingIDGenerator{}, &stats.NullCollector{}, actions.Config{Enabled: true})
 	c.SetHooksHandler(actionsService)
 
-	credentials, err := setup.SetupAdminUser(ctx, authService, conf, superuser)
+	credentials, err := setup.CreateAdminUser(ctx, authService, conf, superuser)
 	testutil.Must(t, err)
 
 	authenticator := auth.NewBuiltinAuthenticator(authService)

--- a/pkg/samplerepo/samplecontent.go
+++ b/pkg/samplerepo/samplecontent.go
@@ -105,7 +105,6 @@ func PopulateSampleRepo(ctx context.Context, repo *catalog.Repository, cat catal
 
 		return nil
 	})
-
 	if err != nil {
 		return err
 	}
@@ -118,10 +117,7 @@ func PopulateSampleRepo(ctx context.Context, repo *catalog.Repository, cat catal
 	return err
 }
 
-func SampleRepoAddBranchProtection(ctx context.Context, repo *catalog.Repository, cat catalog.Interface) error {
-	// Set branch protection on main branch
-
-	err := cat.CreateBranchProtectionRule(ctx, repo.Name, repo.DefaultBranch, []graveler.BranchProtectionBlockedAction{graveler.BranchProtectionBlockedAction_COMMIT})
-
-	return err
+func AddBranchProtection(ctx context.Context, repo *catalog.Repository, cat catalog.Interface) error {
+	// Set branch protection on the main branch
+	return cat.CreateBranchProtectionRule(ctx, repo.Name, repo.DefaultBranch, []graveler.BranchProtectionBlockedAction{graveler.BranchProtectionBlockedAction_COMMIT})
 }


### PR DESCRIPTION
- Use `errors.Is` and `errors.As` when needed
- No snake-case package names: `oidc_encoding` `auth_testutil`
- No types name with prefix as package name: `ACL` `Setup` `SampleRepo`
- Names Id -> ID
- Code style - empty slice using make