### PR TITLE
Bug: Lua runtime - marshaling arrays

### DIFF
--- a/docs/howto/hooks/lua.md
+++ b/docs/howto/hooks/lua.md
@@ -93,6 +93,10 @@ For more examples and configuration samples, check out the [examples/hooks/](htt
 
 The Lua runtime embedded in lakeFS is limited for security reasons. The provided APIs are shown below.
 
+### `array(table)`
+
+Helper function to mark a table object as an array for the runtime by setting `_is_array: true` metatable field.
+
 ### `aws/s3.get_object(bucket, key)`
 
 Returns the body (as a Lua string) of the requested object and a boolean value that is true if the requested object exists

--- a/pkg/actions/lua/open.go
+++ b/pkg/actions/lua/open.go
@@ -20,6 +20,7 @@ import (
 	"github.com/treeverse/lakefs/pkg/actions/lua/storage/gcloud"
 	"github.com/treeverse/lakefs/pkg/actions/lua/strings"
 	"github.com/treeverse/lakefs/pkg/actions/lua/time"
+	"github.com/treeverse/lakefs/pkg/actions/lua/util"
 	"github.com/treeverse/lakefs/pkg/actions/lua/uuid"
 )
 
@@ -29,6 +30,7 @@ import (
 func Open(l *lua.State, ctx context.Context, cfg OpenSafeConfig) {
 	regexp.Open(l)
 	strings.Open(l)
+	util.Open(l)
 	json.Open(l)
 	yaml.Open(l)
 	time.Open(l)


### PR DESCRIPTION
Closes #6654 

What's changed: new helper function `array` when working with go-lua marshall.  

This is a blocker for #6653 and to anyone that needs to marshal array types in a lua table. 

This enables using `array(...)` function to mark a table as an array, same way we use it in [deep_push.go](https://github.com/treeverse/lakeFS/blob/master/pkg/actions/lua/util/deep_push.go#L108). 

Usage: 

```lua
local arr = array({Value=1}) -- initialize array
json.marshal(arr) -- now works! 
```