### PR TITLE
test: compatibility test storage more unique identifier

### DIFF
--- a/.github/workflows/compatibility-tests.yaml
+++ b/.github/workflows/compatibility-tests.yaml
@@ -150,7 +150,8 @@ jobs:
 
       - name: Generate uniquifying value
         id: unique
-        run: echo "value=$RANDOM" >> $GITHUB_OUTPUT
+        shell: bash
+        run: echo "value=$(cat /proc/sys/kernel/random/uuid)" >> $GITHUB_OUTPUT
 
       - name: Start lakeFS for Spark tests
         uses: ./.github/actions/bootstrap-test-lakefs
@@ -237,10 +238,10 @@ jobs:
           cache: 'pip'
       - run: pip install -r ./test/spark/requirements.txt
 
-
       - name: Generate uniquifying value
         id: unique
-        run: echo "value=${RANDOM}${RANDOM}${RANDOM}${RANDOM}" >> $GITHUB_OUTPUT
+        shell: bash
+        run: echo "value=$(cat /proc/sys/kernel/random/uuid)" >> $GITHUB_OUTPUT
 
       - name: Start lakeFS for Spark tests
         uses: ./.github/actions/bootstrap-test-lakefs

--- a/.github/workflows/compatibility-tests.yaml
+++ b/.github/workflows/compatibility-tests.yaml
@@ -240,7 +240,7 @@ jobs:
 
       - name: Generate uniquifying value
         id: unique
-        run: echo "value=$RANDOM" >> $GITHUB_OUTPUT
+        run: echo "value=${RANDOM}${RANDOM}${RANDOM}${RANDOM}" >> $GITHUB_OUTPUT
 
       - name: Start lakeFS for Spark tests
         uses: ./.github/actions/bootstrap-test-lakefs


### PR DESCRIPTION
Compatibility test fails with storage namespace already in-use.

```
lakefs_client.exceptions.ApiException: (400)
Reason: Bad Request
HTTP response headers: HTTPHeaderDict({'Content-Type': 'application/json', 'X-Content-Type-Options': 'nosniff', 'X-Request-Id': '88c58920-9[55](https://github.com/treeverse/lakeFS/actions/runs/6369142100/job/17289144036#step:10:56)7-4c5a-bbed-68211e85d0c5', 'Date': 'Sun, 01 Oct 2023 08:11:27 GMT', 'Content-Length': '186'})
HTTP response body: {"message":"failed to create repository: found lakeFS objects in the storage namespace(s3://esti-system-testing/compatibility/304-spark3-client/4792): storage namespace already in use"}
```

In this PR we use UUID as the unique ID that will be used as part of the storage namespace.
