### PR TITLE
Update github workflows to use amazon-ecr-login v2

### DIFF
--- a/.github/actions/bootstrap-test-lakefs/action.yaml
+++ b/.github/actions/bootstrap-test-lakefs/action.yaml
@@ -31,7 +31,7 @@ runs:
         aws-region: us-east-1
     - name: Login to Amazon ECR
       id: login-ecr
-      uses: aws-actions/amazon-ecr-login@v1
+      uses: aws-actions/amazon-ecr-login@v2
     - name: Start docker-compose
       env:
         LAKEFS_STATS_ENABLED: "false"

--- a/.github/workflows/docker-publish-lakefs-rclone-export.yaml
+++ b/.github/workflows/docker-publish-lakefs-rclone-export.yaml
@@ -42,7 +42,7 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@v2
 
       - name: Login to DockerHub
         uses: docker/login-action@v2

--- a/.github/workflows/docker-publish.yaml
+++ b/.github/workflows/docker-publish.yaml
@@ -67,7 +67,7 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@v2
 
       - name: Login to DockerHub
         uses: docker/login-action@v2

--- a/.github/workflows/esti.yaml
+++ b/.github/workflows/esti.yaml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@v2
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
@@ -123,7 +123,7 @@ jobs:
           mask-aws-account-id: 'false'
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@v2
     outputs:
       registry: ${{ steps.login-ecr.outputs.registry }}
       docker_username: ${{ steps.login-ecr.outputs.docker_username_977611293394_dkr_ecr_us_east_1_amazonaws_com }}
@@ -249,7 +249,7 @@ jobs:
 
       - name: Login to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v1
+        uses: aws-actions/amazon-ecr-login@v2
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2

--- a/.github/workflows/esti.yaml
+++ b/.github/workflows/esti.yaml
@@ -110,6 +110,7 @@ jobs:
             type=s3,region=us-east-1,bucket=lakefs-docker-cache,name=lakefs
           cache-to: |
             type=s3,region=us-east-1,bucket=lakefs-docker-cache,name=lakefs,mode=max
+
   login-to-amazon-ecr:
     runs-on: ubuntu-latest
     needs: [check-secrets]
@@ -124,6 +125,8 @@ jobs:
       - name: Login to Amazon ECR
         id: login-ecr
         uses: aws-actions/amazon-ecr-login@v2
+        with:
+          mask-password: 'false'
     outputs:
       registry: ${{ steps.login-ecr.outputs.registry }}
       docker_username: ${{ steps.login-ecr.outputs.docker_username_977611293394_dkr_ecr_us_east_1_amazonaws_com }}


### PR DESCRIPTION
Fix mask password warning.

_Example:_
```
Test lakeFS Hadoop FileSystem compatibility (0.92.0)Your docker password is not masked. See https://github.com/aws-actions/amazon-ecr-login#docker-credentials for more information.
```

