### PR TITLE
Fix quickstart bug: branch protection

### DIFF
--- a/esti/repository_test.go
+++ b/esti/repository_test.go
@@ -41,7 +41,6 @@ func TestRepositoryCreateSampleRepo(t *testing.T) {
 	name := generateUniqueRepositoryName()
 	storageNamespace := generateUniqueStorageNamespace(name)
 	name = makeRepositoryName(name)
-	createRepository(ctx, t, name, storageNamespace)
 	logger.WithFields(logging.Fields{
 		"repository":        name,
 		"storage_namespace": storageNamespace,

--- a/esti/repository_test.go
+++ b/esti/repository_test.go
@@ -5,7 +5,11 @@ import (
 	"net/http"
 	"testing"
 
+	"github.com/go-openapi/swag"
 	"github.com/stretchr/testify/require"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
+	"github.com/treeverse/lakefs/pkg/api/apiutil"
+	"github.com/treeverse/lakefs/pkg/logging"
 )
 
 func TestRepositoryBasicOps(t *testing.T) {
@@ -30,4 +34,31 @@ func TestRepositoryBasicOps(t *testing.T) {
 		require.NoErrorf(t, err, "failed to delete repository %s, storage %s", repo)
 		require.Equal(t, http.StatusNoContent, resp.StatusCode())
 	}
+}
+
+func TestRepositoryCreateSampleRepo(t *testing.T) {
+	ctx := context.Background()
+	name := generateUniqueRepositoryName()
+	storageNamespace := generateUniqueStorageNamespace(name)
+	name = makeRepositoryName(name)
+	createRepository(ctx, t, name, storageNamespace)
+	logger.WithFields(logging.Fields{
+		"repository":        name,
+		"storage_namespace": storageNamespace,
+		"name":              name,
+	}).Debug("Create repository for test")
+	resp, err := client.CreateRepositoryWithResponse(ctx, &apigen.CreateRepositoryParams{}, apigen.CreateRepositoryJSONRequestBody{
+		DefaultBranch:    apiutil.Ptr(mainBranch),
+		Name:             name,
+		StorageNamespace: storageNamespace,
+		SampleData:       swag.Bool(true),
+	})
+	require.NoErrorf(t, err, "failed to create repository '%s', storage '%s'", name, storageNamespace)
+	require.NoErrorf(t, verifyResponse(resp.HTTPResponse, resp.Body),
+		"create repository '%s', storage '%s'", name, storageNamespace)
+	_, err = client.GetRepositoryWithResponse(ctx, name)
+	require.NoErrorf(t, err, "failed to get repository '%s'", name)
+	listResp, err := client.ListObjectsWithResponse(ctx, name, mainBranch, &apigen.ListObjectsParams{})
+	require.NoErrorf(t, err, "failed to list objects in repository '%s'", name)
+	require.NotEmptyf(t, listResp.JSON200.Results, "repository '%s' has no objects in main branch", name)
 }

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -1788,7 +1788,7 @@ func (c *Controller) GetBranchProtectionRules(w http.ResponseWriter, r *http.Req
 			Pattern: pattern,
 		})
 	}
-	w.Header().Set("ETag", eTag)
+	w.Header().Set("ETag", swag.StringValue(eTag))
 	writeResponse(w, r, http.StatusOK, resp)
 }
 
@@ -1816,6 +1816,9 @@ func (c *Controller) SetBranchProtectionRules(w http.ResponseWriter, r *http.Req
 		}
 	}
 	eTag := params.IfMatch
+	if swag.StringValue(eTag) == "" {
+		eTag = swag.String("")
+	}
 	err := c.Catalog.SetBranchProtectionRules(ctx, repository, rules, eTag)
 	if c.handleAPIError(ctx, w, r, err) {
 		return

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -1817,7 +1817,7 @@ func (c *Controller) SetBranchProtectionRules(w http.ResponseWriter, r *http.Req
 	}
 	eTag := params.IfMatch
 	if swag.StringValue(eTag) == "" {
-		eTag = swag.String("")
+		eTag = nil
 	}
 	err := c.Catalog.SetBranchProtectionRules(ctx, repository, rules, eTag)
 	if c.handleAPIError(ctx, w, r, err) {
@@ -3086,7 +3086,7 @@ func (c *Controller) InternalDeleteBranchProtectionRule(w http.ResponseWriter, r
 	for p := range rules.BranchPatternToBlockedActions {
 		if p == body.Pattern {
 			delete(rules.BranchPatternToBlockedActions, p)
-			err = c.Catalog.SetBranchProtectionRules(ctx, repository, rules, nil)
+			err = c.Catalog.SetBranchProtectionRules(ctx, repository, rules, swag.String(graveler.BranchProtectionSkipValidationChecksum))
 			if c.handleAPIError(ctx, w, r, err) {
 				return
 			}
@@ -3140,7 +3140,7 @@ func (c *Controller) InternalCreateBranchProtectionRule(w http.ResponseWriter, r
 		Value: []graveler.BranchProtectionBlockedAction{graveler.BranchProtectionBlockedAction_STAGING_WRITE, graveler.BranchProtectionBlockedAction_COMMIT},
 	}
 	rules.BranchPatternToBlockedActions[body.Pattern] = blockedActions
-	err = c.Catalog.SetBranchProtectionRules(ctx, repository, rules, nil)
+	err = c.Catalog.SetBranchProtectionRules(ctx, repository, rules, swag.String(graveler.BranchProtectionSkipValidationChecksum))
 	if c.handleAPIError(ctx, w, r, err) {
 		return
 	}

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -2079,10 +2079,10 @@ func (c *Catalog) SetGarbageCollectionRules(ctx context.Context, repositoryID st
 	return c.Store.SetGarbageCollectionRules(ctx, repository, rules)
 }
 
-func (c *Catalog) GetBranchProtectionRules(ctx context.Context, repositoryID string) (*graveler.BranchProtectionRules, string, error) {
+func (c *Catalog) GetBranchProtectionRules(ctx context.Context, repositoryID string) (*graveler.BranchProtectionRules, *string, error) {
 	repository, err := c.getRepository(ctx, repositoryID)
 	if err != nil {
-		return nil, "", err
+		return nil, nil, err
 	}
 
 	return c.Store.GetBranchProtectionRules(ctx, repository)

--- a/pkg/catalog/interface.go
+++ b/pkg/catalog/interface.go
@@ -168,8 +168,8 @@ type Interface interface {
 	GetBranchProtectionRules(ctx context.Context, repositoryID string) (*graveler.BranchProtectionRules, *string, error)
 	// SetBranchProtectionRules sets the branch protection rules for the given repository.
 	// If lastKnownChecksum doesn't match the current state, the update will fail with ErrPreconditionFailed.
-	// If lastKnownChecksum is the empty string, the update is performed only if no rules exist.
-	// If lastKnownChecksum is nil, the update is always performed.
+	// If lastKnownChecksum is nil, the update is performed only if no rules exist.
+	// If lastKnownChecksum is equal to BranchProtectionSkipValidationChecksum, the update is always performed.
 	SetBranchProtectionRules(ctx context.Context, repositoryID string, rules *graveler.BranchProtectionRules, lastKnownChecksum *string) error
 
 	// SetLinkAddress to validate single use limited in time of a given physical address

--- a/pkg/catalog/interface.go
+++ b/pkg/catalog/interface.go
@@ -165,10 +165,11 @@ type Interface interface {
 
 	// GetBranchProtectionRules returns the branch protection rules for the given repository.
 	// The returned checksum represents the current state of the rules, and can be passed to SetBranchProtectionRules for conditional updates.
-	GetBranchProtectionRules(ctx context.Context, repositoryID string) (*graveler.BranchProtectionRules, string, error)
+	GetBranchProtectionRules(ctx context.Context, repositoryID string) (*graveler.BranchProtectionRules, *string, error)
 	// SetBranchProtectionRules sets the branch protection rules for the given repository.
 	// If lastKnownChecksum doesn't match the current state, the update will fail with ErrPreconditionFailed.
-	// If lastKnownChecksum is nil, the update will be performed regardless of the current state of the rules.
+	// If lastKnownChecksum is the empty string, the update is performed only if no rules exist.
+	// If lastKnownChecksum is nil, the update is always performed.
 	SetBranchProtectionRules(ctx context.Context, repositoryID string, rules *graveler.BranchProtectionRules, lastKnownChecksum *string) error
 
 	// SetLinkAddress to validate single use limited in time of a given physical address

--- a/pkg/graveler/mock/graveler.go
+++ b/pkg/graveler/mock/graveler.go
@@ -2870,20 +2870,6 @@ func (m *MockProtectedBranchesManager) EXPECT() *MockProtectedBranchesManagerMoc
 	return m.recorder
 }
 
-// Delete mocks base method.
-func (m *MockProtectedBranchesManager) Delete(ctx context.Context, repository *graveler.RepositoryRecord, branchNamePattern string) error {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Delete", ctx, repository, branchNamePattern)
-	ret0, _ := ret[0].(error)
-	return ret0
-}
-
-// Delete indicates an expected call of Delete.
-func (mr *MockProtectedBranchesManagerMockRecorder) Delete(ctx, repository, branchNamePattern interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockProtectedBranchesManager)(nil).Delete), ctx, repository, branchNamePattern)
-}
-
 // GetRules mocks base method.
 func (m *MockProtectedBranchesManager) GetRules(ctx context.Context, repository *graveler.RepositoryRecord) (*graveler.BranchProtectionRules, *string, error) {
 	m.ctrl.T.Helper()

--- a/pkg/graveler/mock/graveler.go
+++ b/pkg/graveler/mock/graveler.go
@@ -481,11 +481,11 @@ func (mr *MockVersionControllerMockRecorder) GetBranch(ctx, repository, branchID
 }
 
 // GetBranchProtectionRules mocks base method.
-func (m *MockVersionController) GetBranchProtectionRules(ctx context.Context, repository *graveler.RepositoryRecord) (*graveler.BranchProtectionRules, string, error) {
+func (m *MockVersionController) GetBranchProtectionRules(ctx context.Context, repository *graveler.RepositoryRecord) (*graveler.BranchProtectionRules, *string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetBranchProtectionRules", ctx, repository)
 	ret0, _ := ret[0].(*graveler.BranchProtectionRules)
-	ret1, _ := ret[1].(string)
+	ret1, _ := ret[1].(*string)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
@@ -2885,11 +2885,11 @@ func (mr *MockProtectedBranchesManagerMockRecorder) Delete(ctx, repository, bran
 }
 
 // GetRules mocks base method.
-func (m *MockProtectedBranchesManager) GetRules(ctx context.Context, repository *graveler.RepositoryRecord) (*graveler.BranchProtectionRules, string, error) {
+func (m *MockProtectedBranchesManager) GetRules(ctx context.Context, repository *graveler.RepositoryRecord) (*graveler.BranchProtectionRules, *string, error) {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "GetRules", ctx, repository)
 	ret0, _ := ret[0].(*graveler.BranchProtectionRules)
-	ret1, _ := ret[1].(string)
+	ret1, _ := ret[1].(*string)
 	ret2, _ := ret[2].(error)
 	return ret0, ret1, ret2
 }
@@ -2930,7 +2930,7 @@ func (mr *MockProtectedBranchesManagerMockRecorder) SetRules(ctx, repository, ru
 }
 
 // SetRulesIf mocks base method.
-func (m *MockProtectedBranchesManager) SetRulesIf(ctx context.Context, repository *graveler.RepositoryRecord, rules *graveler.BranchProtectionRules, lastKnownChecksum string) error {
+func (m *MockProtectedBranchesManager) SetRulesIf(ctx context.Context, repository *graveler.RepositoryRecord, rules *graveler.BranchProtectionRules, lastKnownChecksum *string) error {
 	m.ctrl.T.Helper()
 	ret := m.ctrl.Call(m, "SetRulesIf", ctx, repository, rules, lastKnownChecksum)
 	ret0, _ := ret[0].(error)

--- a/pkg/graveler/settings/manager.go
+++ b/pkg/graveler/settings/manager.go
@@ -77,8 +77,10 @@ func (m *Manager) SaveIf(ctx context.Context, repository *graveler.RepositoryRec
 	}
 	var currentChecksum *string
 	var currentPredicate kv.Predicate
-	if valueWithPredicate != nil && valueWithPredicate.Value != nil {
-		currentChecksum, err = computeChecksum(valueWithPredicate.Value)
+	if valueWithPredicate != nil {
+		if valueWithPredicate.Value != nil {
+			currentChecksum, err = computeChecksum(valueWithPredicate.Value)
+		}
 		if err != nil {
 			return err
 		}

--- a/pkg/graveler/settings/manager.go
+++ b/pkg/graveler/settings/manager.go
@@ -2,12 +2,12 @@ package settings
 
 import (
 	"context"
-	"encoding/base64"
+	"crypto/sha256"
+	"encoding/hex"
 	"errors"
-	"fmt"
 	"time"
 
-	"github.com/cenkalti/backoff/v4"
+	"github.com/go-openapi/swag"
 	"github.com/treeverse/lakefs/pkg/cache"
 	"github.com/treeverse/lakefs/pkg/graveler"
 	"github.com/treeverse/lakefs/pkg/kv"
@@ -25,8 +25,6 @@ type cacheKey struct {
 	RepositoryID graveler.RepositoryID
 	Key          string
 }
-
-type updateFunc func(proto.Message) (proto.Message, error)
 
 // Manager is a key-value store for Graveler repository-level settings.
 // Each setting is stored under a key, and can be any proto.Message.
@@ -70,39 +68,62 @@ func (m *Manager) Save(ctx context.Context, repository *graveler.RepositoryRecor
 
 // SaveIf persists the given setting under the given repository and key. Overrides settings key in KV Store.
 // The setting is persisted only if the current version of the setting matches the given checksum.
-func (m *Manager) SaveIf(ctx context.Context, repository *graveler.RepositoryRecord, key string, setting proto.Message, lastKnownChecksum string) error {
+// If lastKnownChecksum is nil, the setting is persisted only if it does not exist.
+func (m *Manager) SaveIf(ctx context.Context, repository *graveler.RepositoryRecord, key string, setting proto.Message, lastKnownChecksum *string) error {
 	logSetting(logging.FromContext(ctx), repository.RepositoryID, key, setting, "saving repository-level setting")
-	decodedChecksum, err := base64.StdEncoding.DecodeString(lastKnownChecksum)
-	if err != nil {
-		return fmt.Errorf("decode checksum: %w", err)
+	valueWithPredicate, err := m.store.Get(ctx, []byte(graveler.RepoPartition(repository)), []byte(graveler.SettingsPath(key)))
+	if err != nil && !errors.Is(err, kv.ErrNotFound) {
+		return err
 	}
-	return kv.SetMsgIf(ctx, m.store, graveler.RepoPartition(repository), []byte(graveler.SettingsPath(key)), setting, decodedChecksum)
+	var currentChecksum *string
+	var currentPredicate kv.Predicate
+	if valueWithPredicate != nil && valueWithPredicate.Value != nil {
+		currentChecksum, err = computeChecksum(valueWithPredicate.Value)
+		if err != nil {
+			return err
+		}
+		currentPredicate = valueWithPredicate.Predicate
+	}
+	if swag.StringValue(currentChecksum) != swag.StringValue(lastKnownChecksum) {
+		return graveler.ErrPreconditionFailed
+	}
+	err = kv.SetMsgIf(ctx, m.store, graveler.RepoPartition(repository), []byte(graveler.SettingsPath(key)), setting, currentPredicate)
+	if err != nil && errors.Is(err, kv.ErrPredicateFailed) {
+		return graveler.ErrPreconditionFailed
+	}
+	return err
 }
 
-func (m *Manager) getWithPredicate(ctx context.Context, repo *graveler.RepositoryRecord, key string, data proto.Message) (kv.Predicate, error) {
-	pred, err := kv.GetMsg(ctx, m.store, graveler.RepoPartition(repo), []byte(graveler.SettingsPath(key)), data)
+func computeChecksum(value []byte) (*string, error) {
+	h := sha256.New()
+	_, err := h.Write(value)
 	if err != nil {
-		if errors.Is(err, kv.ErrNotFound) {
-			err = graveler.ErrNotFound
-		}
 		return nil, err
 	}
-	return pred, nil
+	return swag.String(hex.EncodeToString(h.Sum(nil))), nil
 }
 
 // GetLatest returns the latest setting under the given repository and key, without using the cache.
 // The returned checksum represents the version of the setting, and can be passed to SaveIf for conditional updates.
-func (m *Manager) GetLatest(ctx context.Context, repository *graveler.RepositoryRecord, key string, settingTemplate proto.Message) (proto.Message, string, error) {
-	data := settingTemplate.ProtoReflect().Interface()
-	pred, err := m.getWithPredicate(ctx, repository, key, data)
+func (m *Manager) GetLatest(ctx context.Context, repository *graveler.RepositoryRecord, key string, settingTemplate proto.Message) (proto.Message, *string, error) {
+	settings, err := m.store.Get(ctx, []byte(graveler.RepoPartition(repository)), []byte(graveler.SettingsPath(key)))
 	if err != nil {
 		if errors.Is(err, kv.ErrNotFound) {
 			err = graveler.ErrNotFound
 		}
-		return nil, "", err
+		return nil, nil, err
+	}
+	checksum, err := computeChecksum(settings.Value)
+	if err != nil {
+		return nil, nil, err
+	}
+	data := settingTemplate.ProtoReflect().Interface()
+	err = proto.Unmarshal(settings.Value, data)
+	if err != nil {
+		return nil, nil, err
 	}
 	logSetting(logging.FromContext(ctx), repository.RepositoryID, key, data, "got repository-level setting")
-	return data, base64.StdEncoding.EncodeToString(pred.([]byte)), nil
+	return data, checksum, nil
 }
 
 // Get fetches the setting under the given repository and key, and returns the result.
@@ -128,46 +149,6 @@ func (m *Manager) Get(ctx context.Context, repository *graveler.RepositoryRecord
 		return nil, graveler.ErrNotFound
 	}
 	return setting.(proto.Message), nil
-}
-
-// Update atomically gets a setting, performs the update function, and persists the setting to the store.
-// The settingTemplate parameter is used to determine the type passed to the update function.
-func (m *Manager) Update(ctx context.Context, repository *graveler.RepositoryRecord, key string, settingTemplate proto.Message, update updateFunc) error {
-	const (
-		maxIntervalSec = 2
-		maxElapsedSec  = 5
-	)
-	bo := backoff.NewExponentialBackOff()
-	bo.MaxInterval = maxIntervalSec * time.Second
-	bo.MaxElapsedTime = maxElapsedSec * time.Second
-
-	err := backoff.Retry(func() error {
-		data := settingTemplate.ProtoReflect().Interface()
-		pred, err := m.getWithPredicate(ctx, repository, key, data)
-		if errors.Is(err, graveler.ErrNotFound) {
-			data = proto.Clone(settingTemplate)
-		} else if err != nil {
-			return backoff.Permanent(err)
-		}
-
-		logSetting(logging.FromContext(ctx), repository.RepositoryID, key, data, "update repository-level setting")
-		newData, err := update(data)
-		if err != nil {
-			return backoff.Permanent(err)
-		}
-		err = kv.SetMsgIf(ctx, m.store, graveler.RepoPartition(repository), []byte(graveler.SettingsPath(key)), newData, pred)
-		if errors.Is(err, kv.ErrPredicateFailed) {
-			logging.FromContext(ctx).WithError(err).Warn("Predicate failed on settings update. Retrying")
-			return graveler.ErrPreconditionFailed
-		} else if err != nil {
-			return backoff.Permanent(err)
-		}
-		return nil
-	}, bo)
-	if errors.Is(err, graveler.ErrPreconditionFailed) {
-		return fmt.Errorf("update settings: %w", graveler.ErrTooManyTries)
-	}
-	return err
 }
 
 func logSetting(logger logging.Logger, repositoryID graveler.RepositoryID, key string, setting proto.Message, logMsg string) {

--- a/pkg/kv/local/store.go
+++ b/pkg/kv/local/store.go
@@ -69,7 +69,6 @@ func (s *Store) Get(ctx context.Context, partitionKey, key []byte) (*kv.ValueWit
 	if err != nil {
 		return nil, err
 	}
-
 	return &kv.ValueWithPredicate{
 		Value:     value,
 		Predicate: kv.Predicate(value),
@@ -145,8 +144,8 @@ func (s *Store) SetIf(ctx context.Context, partitionKey, key, value []byte, valu
 					return kv.ErrPredicateFailed
 				}
 			}
-		} else if !errors.Is(err, badger.ErrKeyNotFound) && value != nil && item.ValueSize() != 0 {
-			log.WithField("predicate", valuePredicate).Trace("predicate condition failed (expected value not to exist)")
+		} else if !errors.Is(err, badger.ErrKeyNotFound) {
+			log.WithField("predicate", valuePredicate).Trace("predicate condition failed (key not found)")
 			return kv.ErrPredicateFailed
 		}
 

--- a/pkg/kv/local/store.go
+++ b/pkg/kv/local/store.go
@@ -145,8 +145,8 @@ func (s *Store) SetIf(ctx context.Context, partitionKey, key, value []byte, valu
 					return kv.ErrPredicateFailed
 				}
 			}
-		} else if !errors.Is(err, badger.ErrKeyNotFound) {
-			log.WithField("predicate", valuePredicate).Trace("predicate condition failed (key not found)")
+		} else if !errors.Is(err, badger.ErrKeyNotFound) && value != nil && item.ValueSize() != 0 {
+			log.WithField("predicate", valuePredicate).Trace("predicate condition failed (expected value not to exist)")
 			return kv.ErrPredicateFailed
 		}
 

--- a/pkg/samplerepo/samplecontent.go
+++ b/pkg/samplerepo/samplecontent.go
@@ -119,12 +119,18 @@ func PopulateSampleRepo(ctx context.Context, repo *catalog.Repository, cat catal
 
 func AddBranchProtection(ctx context.Context, repo *catalog.Repository, cat catalog.Interface) error {
 	// Set branch protection on the main branch
-	rules, eTag, err := cat.GetBranchProtectionRules(ctx, repo.Name)
+	rules, checksum, err := cat.GetBranchProtectionRules(ctx, repo.Name)
 	if err != nil {
 		return err
+	}
+	if rules == nil {
+		rules = &graveler.BranchProtectionRules{}
+	}
+	if rules.BranchPatternToBlockedActions == nil {
+		rules.BranchPatternToBlockedActions = make(map[string]*graveler.BranchProtectionBlockedActions)
 	}
 	rules.BranchPatternToBlockedActions[repo.DefaultBranch] = &graveler.BranchProtectionBlockedActions{
 		Value: []graveler.BranchProtectionBlockedAction{graveler.BranchProtectionBlockedAction_COMMIT},
 	}
-	return cat.SetBranchProtectionRules(ctx, repo.Name, rules, swag.String(eTag))
+	return cat.SetBranchProtectionRules(ctx, repo.Name, rules, checksum)
 }

--- a/webui/src/lib/api/index.js
+++ b/webui/src/lib/api/index.js
@@ -1003,28 +1003,19 @@ class BranchProtectionRules {
     }
 
     async setRules(repoID, rules, lastKnownChecksum) {
+        let additionalHeaders = {}
+        if (lastKnownChecksum) {
+            console.log(`setting branch protection rules with checksum ${lastKnownChecksum}`)
+            additionalHeaders['If-Match'] = lastKnownChecksum
+        }
         const response = await apiRequest(`/repositories/${encodeURIComponent(repoID)}/settings/branch_protection`, {
             method: 'PUT',
             body: JSON.stringify(rules),
-        }, {'If-Match': lastKnownChecksum});
+        }, additionalHeaders);
         if (response.status !== 204) {
             throw new Error(`could not create protection rule: ${await extractError(response)}`);
         }
     }
-
-    async deleteRule(repoID, pattern) {
-        const response = await apiRequest(`/repositories/${encodeURIComponent(repoID)}/branch_protection`, {
-            method: 'DELETE',
-            body: JSON.stringify({pattern: pattern})
-        });
-        if (response.status === 404) {
-            throw new NotFoundError('branch protection rule not found')
-        }
-        if (response.status !== 204) {
-            throw new Error(`could not delete protection rule: ${await extractError(response)}`);
-        }
-    }
-
 }
 
 class Statistics {

--- a/webui/src/pages/repositories/repository/settings/branches.jsx
+++ b/webui/src/pages/repositories/repository/settings/branches.jsx
@@ -22,6 +22,18 @@ const SettingsContainer = () => {
     const {response: rulesResponse, error: rulesError, loading: rulesLoading} = useAPI(async () => {
         return branchProtectionRules.getRules(repo.id)
     }, [repo, refresh])
+    const deleteRule = (pattern) => {
+        let updatedRules = [...rulesResponse['rules']]
+        let lastKnownChecksum = rulesResponse['checksum']
+        updatedRules = updatedRules.filter(r => r.pattern !== pattern)
+        branchProtectionRules.setRules(repo.id, updatedRules, lastKnownChecksum).then(() => {
+            setRefresh(!refresh)
+            setDeleteButtonDisabled(false)
+        }).catch(err => {
+            setDeleteButtonDisabled(false)
+            setActionError(err)
+        })
+    }
     if (error) return <AlertError error={error}/>;
     if (rulesError) return <AlertError error={rulesError}/>;
     if (actionError) return <AlertError error={actionError}/>;
@@ -51,16 +63,7 @@ const SettingsContainer = () => {
                                     return <ListGroup.Item key={r.pattern}>
                                         <div className="d-flex">
                                             <code>{r.pattern}</code>
-                                            <Button disabled={deleteButtonDisabled} className="ms-auto" size="sm" variant="secondary" onClick={() => {
-                                                setDeleteButtonDisabled(true)
-                                                branchProtectionRules.deleteRule(repo.id, r.pattern).then(() => {
-                                                    setRefresh(!refresh)
-                                                    setDeleteButtonDisabled(false)
-                                                }).catch(err => {
-                                                    setDeleteButtonDisabled(false)
-                                                    setActionError(err)
-                                                })
-                                            }}>Delete</Button>
+                                            <Button disabled={deleteButtonDisabled} className="ms-auto" size="sm" variant="secondary" onClick={() => deleteRule(r.pattern)}>Delete</Button>
                                         </div>
                                     </ListGroup.Item>
                                 }) : <Alert variant="info">There aren&apos;t any rules yet.</Alert>}


### PR DESCRIPTION
Resolves #6674.

1. Fix nil check in quickstart.
2. Fix delete branch protection rule in UI.
3. Do not use checksum from the KV store as the ETag.
