### PR TITLE
CosmosDB: Add throughput configuration

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -65,8 +65,8 @@ This reference uses `.` to denote the nesting of values.
     + `database.cosmosdb.endpoint` `(string : "")` - CosmosDB account endpoint, e.g. `https://<account>.documents.azure.com/`.
     + `database.cosmosdb.database` `(string : "")` - CosmosDB database name.
     + `database.cosmosdb.container` `(string : "")` - CosmosDB container name.
-    + `database.cosmosdb.throughput` `(uint : 400)` - The container's RU/s.
-    + `database.cosmosdb.autoscale` `(bool : false)` - If set, container throughput is autoscaled (requires a minimum of 1000 RU/s). Otherwise, uses "Manual" mode ([Docs](https://learn.microsoft.com/en-us/azure/cosmos-db/provision-throughput-autoscale)).
+    + `database.cosmosdb.throughput` `(int32 : )` - CosmosDB container's RU/s. If not set - the default CosmosDB container throughput is used. 
+    + `database.cosmosdb.autoscale` `(bool : false)` - If set, CosmosDB container throughput is autoscaled (See CosmosDB docs for minimum throughput requirement). Otherwise, uses "Manual" mode ([Docs](https://learn.microsoft.com/en-us/azure/cosmos-db/provision-throughput-autoscale)).
   + `database.local` - Configuration section when using `database.type="local"`
     + `database.local.path` `(string : "~/lakefs/metadata")` - Local path on the filesystem to store embedded KV metadata, like branches and uncommitted entries
     + `database.local.sync_writes` `(bool: true)` - Ensure each write is written to the disk. Disable to increase performance

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -65,6 +65,8 @@ This reference uses `.` to denote the nesting of values.
     + `database.cosmosdb.endpoint` `(string : "")` - CosmosDB account endpoint, e.g. `https://<account>.documents.azure.com/`.
     + `database.cosmosdb.database` `(string : "")` - CosmosDB database name.
     + `database.cosmosdb.container` `(string : "")` - CosmosDB container name.
+    + `database.cosmosdb.throughput` `(uint : 400)` - The container's RU/s.
+    + `database.cosmosdb.autoscale` `(bool : false)` - If set, container throughput is autoscaled (requires a minimum of 1000 RU/s). Otherwise, uses "Manual" mode ([Docs](https://learn.microsoft.com/en-us/azure/cosmos-db/provision-throughput-autoscale)).
   + `database.local` - Configuration section when using `database.type="local"`
     + `database.local.path` `(string : "~/lakefs/metadata")` - Local path on the filesystem to store embedded KV metadata, like branches and uncommitted entries
     + `database.local.sync_writes` `(bool: true)` - Ensure each write is written to the disk. Disable to increase performance

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -172,10 +172,12 @@ type Config struct {
 		} `mapstructure:"dynamodb"`
 
 		CosmosDB *struct {
-			Key       SecureString `mapstructure:"key"`
-			Endpoint  string       `mapstructure:"endpoint"`
-			Database  string       `mapstructure:"database"`
-			Container string       `mapstructure:"container"`
+			Key        SecureString `mapstructure:"key"`
+			Endpoint   string       `mapstructure:"endpoint"`
+			Database   string       `mapstructure:"database"`
+			Container  string       `mapstructure:"container"`
+			Throughput uint         `mapstructure:"throughput"`
+			Autoscale  bool         `mapstructure:"autoscale"`
 		} `mapstructure:"cosmosdb"`
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -176,7 +176,7 @@ type Config struct {
 			Endpoint   string       `mapstructure:"endpoint"`
 			Database   string       `mapstructure:"database"`
 			Container  string       `mapstructure:"container"`
-			Throughput *int32       `mapstructure:"throughput"`
+			Throughput int32        `mapstructure:"throughput"`
 			Autoscale  bool         `mapstructure:"autoscale"`
 		} `mapstructure:"cosmosdb"`
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -176,7 +176,7 @@ type Config struct {
 			Endpoint   string       `mapstructure:"endpoint"`
 			Database   string       `mapstructure:"database"`
 			Container  string       `mapstructure:"container"`
-			Throughput uint         `mapstructure:"throughput"`
+			Throughput *int32       `mapstructure:"throughput"`
 			Autoscale  bool         `mapstructure:"autoscale"`
 		} `mapstructure:"cosmosdb"`
 	}

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -14,6 +14,7 @@ const (
 	DefaultQuickstartUsername   = "quickstart"
 	DefaultQuickstartKeyID      = "AKIAIOSFOLQUICKSTART"
 	DefaultQuickstartSecretKey  = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" // nolint:gosec
+	DefaultCosmosDBThroughput   = 400
 )
 
 //nolint:gomnd
@@ -111,6 +112,8 @@ func setDefaults(cfgType string) {
 
 	viper.SetDefault("database.dynamodb.table_name", "kvstore")
 	viper.SetDefault("database.dynamodb.scan_limit", 1024)
+
+	viper.SetDefault("database.cosmosdb.throughput", DefaultCosmosDBThroughput)
 
 	viper.SetDefault("database.postgres.max_open_connections", 25)
 	viper.SetDefault("database.postgres.max_idle_connections", 25)

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -14,7 +14,6 @@ const (
 	DefaultQuickstartUsername   = "quickstart"
 	DefaultQuickstartKeyID      = "AKIAIOSFOLQUICKSTART"
 	DefaultQuickstartSecretKey  = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY" // nolint:gosec
-	DefaultCosmosDBThroughput   = 400
 )
 
 //nolint:gomnd
@@ -112,8 +111,6 @@ func setDefaults(cfgType string) {
 
 	viper.SetDefault("database.dynamodb.table_name", "kvstore")
 	viper.SetDefault("database.dynamodb.scan_limit", 1024)
-
-	viper.SetDefault("database.cosmosdb.throughput", DefaultCosmosDBThroughput)
 
 	viper.SetDefault("database.postgres.max_open_connections", 25)
 	viper.SetDefault("database.postgres.max_idle_connections", 25)

--- a/pkg/kv/cosmosdb/store.go
+++ b/pkg/kv/cosmosdb/store.go
@@ -130,9 +130,9 @@ func getOrCreateDatabase(ctx context.Context, client *azcosmos.Client, params *k
 
 func getOrCreateContainer(ctx context.Context, dbClient *azcosmos.DatabaseClient, params *kvparams.CosmosDB) (*azcosmos.ContainerClient, error) {
 	var opts *azcosmos.CreateContainerOptions
-	if params.Throughput != nil {
+	if params.Throughput > 0 {
 		var throughputProperties azcosmos.ThroughputProperties
-		tp := *params.Throughput
+		tp := params.Throughput
 		if params.Autoscale {
 			throughputProperties = azcosmos.NewAutoscaleThroughputProperties(tp)
 		} else {

--- a/pkg/kv/cosmosdb/store.go
+++ b/pkg/kv/cosmosdb/store.go
@@ -132,11 +132,10 @@ func getOrCreateContainer(ctx context.Context, dbClient *azcosmos.DatabaseClient
 	var opts *azcosmos.CreateContainerOptions
 	if params.Throughput > 0 {
 		var throughputProperties azcosmos.ThroughputProperties
-		tp := params.Throughput
 		if params.Autoscale {
-			throughputProperties = azcosmos.NewAutoscaleThroughputProperties(tp)
+			throughputProperties = azcosmos.NewAutoscaleThroughputProperties(params.Throughput)
 		} else {
-			throughputProperties = azcosmos.NewManualThroughputProperties(tp)
+			throughputProperties = azcosmos.NewManualThroughputProperties(params.Throughput)
 		}
 		opts = &azcosmos.CreateContainerOptions{ThroughputProperties: &throughputProperties}
 	}

--- a/pkg/kv/kvparams/database.go
+++ b/pkg/kv/kvparams/database.go
@@ -63,11 +63,12 @@ type DynamoDB struct {
 }
 
 type CosmosDB struct {
-	Key       string
-	Endpoint  string
-	Database  string
-	Container string
-
+	Key        string
+	Endpoint   string
+	Database   string
+	Container  string
+	Throughput uint
+	Autoscale  bool
 	// These values should only be set to false for testing purposes using the CosmosDB emulator
 	Client            *http.Client
 	StrongConsistency bool
@@ -116,6 +117,8 @@ func NewConfig(cfg *config.Config) (Config, error) {
 			Endpoint:          cfg.Database.CosmosDB.Endpoint,
 			Database:          cfg.Database.CosmosDB.Database,
 			Container:         cfg.Database.CosmosDB.Container,
+			Throughput:        cfg.Database.CosmosDB.Throughput,
+			Autoscale:         cfg.Database.CosmosDB.Autoscale,
 			StrongConsistency: true,
 		}
 	}

--- a/pkg/kv/kvparams/database.go
+++ b/pkg/kv/kvparams/database.go
@@ -67,7 +67,7 @@ type CosmosDB struct {
 	Endpoint   string
 	Database   string
 	Container  string
-	Throughput uint
+	Throughput *int32
 	Autoscale  bool
 	// These values should only be set to false for testing purposes using the CosmosDB emulator
 	Client            *http.Client
@@ -112,6 +112,9 @@ func NewConfig(cfg *config.Config) (Config, error) {
 	}
 
 	if cfg.Database.CosmosDB != nil {
+		if cfg.Database.CosmosDB.Autoscale && cfg.Database.CosmosDB.Throughput == nil {
+			return Config{}, fmt.Errorf("enabling autoscale requires setting the throughput param: %w", config.ErrBadConfiguration)
+		}
 		p.CosmosDB = &CosmosDB{
 			Key:               cfg.Database.CosmosDB.Key.SecureValue(),
 			Endpoint:          cfg.Database.CosmosDB.Endpoint,

--- a/pkg/kv/kvparams/database.go
+++ b/pkg/kv/kvparams/database.go
@@ -67,7 +67,7 @@ type CosmosDB struct {
 	Endpoint   string
 	Database   string
 	Container  string
-	Throughput *int32
+	Throughput int32
 	Autoscale  bool
 	// These values should only be set to false for testing purposes using the CosmosDB emulator
 	Client            *http.Client
@@ -112,7 +112,7 @@ func NewConfig(cfg *config.Config) (Config, error) {
 	}
 
 	if cfg.Database.CosmosDB != nil {
-		if cfg.Database.CosmosDB.Autoscale && cfg.Database.CosmosDB.Throughput == nil {
+		if cfg.Database.CosmosDB.Autoscale && cfg.Database.CosmosDB.Throughput == 0 {
 			return Config{}, fmt.Errorf("enabling autoscale requires setting the throughput param: %w", config.ErrBadConfiguration)
 		}
 		p.CosmosDB = &CosmosDB{


### PR DESCRIPTION
Closes #6692

## Change Description

### Background

Add configuration to control CosmosDB container throughput RU/s and autoscaling mode
      
### Testing Details

Tested manually

### Breaking Change?

No
