### PR TITLE
lakectl: block `fs stage` command for objects in the storage namespace

### DIFF
--- a/clients/hadoopfs/src/test/java/io/lakefs/LakeFSFileSystemServerTest.java
+++ b/clients/hadoopfs/src/test/java/io/lakefs/LakeFSFileSystemServerTest.java
@@ -701,6 +701,34 @@ public class LakeFSFileSystemServerTest extends FSTestBase {
         Assert.assertFalse(renamed);
     }
 
+    // /**
+    //  * Check that a file is renamed when working against a lakeFS version
+    //  * where CopyObject API doesn't exist
+    //  */
+    // TODO(johnnyaug): Do we still need this test?
+    //
+    // @Test
+    // public void testRename_fallbackStageAPI() throws ApiException, IOException {
+    //     Path src = new Path("lakefs://repo/main/existing-dir1/existing.src");
+    //     ObjectLocation srcObjLoc = fs.pathToObjectLocation(src);
+    //     mockExistingFilePath(srcObjLoc);
+
+    //     Path fileInDstDir = new Path("lakefs://repo/main/existing-dir2/existing.src");
+    //     ObjectLocation fileObjLoc = fs.pathToObjectLocation(fileInDstDir);
+    //     Path dst = new Path("lakefs://repo/main/existing-dir2");
+    //     ObjectLocation dstObjLoc = fs.pathToObjectLocation(dst);
+
+    //     mockExistingDirPath(dstObjLoc, ImmutableList.of(fileObjLoc));
+    //     mockDirectoryMarker(fs.pathToObjectLocation(src.getParent()));
+    //     mockMissingCopyAPI();
+
+    //     boolean renamed = fs.rename(src, dst);
+    //     Assert.assertTrue(renamed);
+    //     Path expectedDstPath = new Path("lakefs://repo/main/existing-dir2/existing.src");
+    //     Assert.assertTrue(dstPathLinkedToSrcPhysicalAddress(srcObjLoc, fs.pathToObjectLocation(expectedDstPath)));
+    //     verifyObjDeletion(srcObjLoc);
+    // }
+
     @Test
     public void testRename_srcAndDstOnDifferentBranch() throws IOException {
         Path src = new Path("lakefs://repo/branch/existing.src");

--- a/clients/hadoopfs/src/test/java/io/lakefs/LakeFSFileSystemServerTest.java
+++ b/clients/hadoopfs/src/test/java/io/lakefs/LakeFSFileSystemServerTest.java
@@ -701,34 +701,6 @@ public class LakeFSFileSystemServerTest extends FSTestBase {
         Assert.assertFalse(renamed);
     }
 
-    // /**
-    //  * Check that a file is renamed when working against a lakeFS version
-    //  * where CopyObject API doesn't exist
-    //  */
-    // TODO(johnnyaug): Do we still need this test?
-    //
-    // @Test
-    // public void testRename_fallbackStageAPI() throws ApiException, IOException {
-    //     Path src = new Path("lakefs://repo/main/existing-dir1/existing.src");
-    //     ObjectLocation srcObjLoc = fs.pathToObjectLocation(src);
-    //     mockExistingFilePath(srcObjLoc);
-
-    //     Path fileInDstDir = new Path("lakefs://repo/main/existing-dir2/existing.src");
-    //     ObjectLocation fileObjLoc = fs.pathToObjectLocation(fileInDstDir);
-    //     Path dst = new Path("lakefs://repo/main/existing-dir2");
-    //     ObjectLocation dstObjLoc = fs.pathToObjectLocation(dst);
-
-    //     mockExistingDirPath(dstObjLoc, ImmutableList.of(fileObjLoc));
-    //     mockDirectoryMarker(fs.pathToObjectLocation(src.getParent()));
-    //     mockMissingCopyAPI();
-
-    //     boolean renamed = fs.rename(src, dst);
-    //     Assert.assertTrue(renamed);
-    //     Path expectedDstPath = new Path("lakefs://repo/main/existing-dir2/existing.src");
-    //     Assert.assertTrue(dstPathLinkedToSrcPhysicalAddress(srcObjLoc, fs.pathToObjectLocation(expectedDstPath)));
-    //     verifyObjDeletion(srcObjLoc);
-    // }
-
     @Test
     public void testRename_srcAndDstOnDifferentBranch() throws IOException {
         Path src = new Path("lakefs://repo/branch/existing.src");

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2202,7 +2202,13 @@ lakectl fs rm <path uri> [flags]
 **note:** This command is a lakeFS plumbing command. Don't use it unless you're really sure you know what you're doing.
 {: .note .note-warning }
 
-Stage a reference to an existing object, to be managed in lakeFS
+Link an external object with a path in a repository
+
+#### Synopsis
+{:.no_toc}
+
+Link an external object with a path in a repository, creating an uncommitted change.
+The object location must be outside the repository's storage namespace
 
 ```
 lakectl fs stage <path uri> [flags]


### PR DESCRIPTION
Resolves #6537.