### PR TITLE
docs: render links to sdk as text until packages are published

### DIFF
--- a/docs/understand/towards-1.0-sdk.md
+++ b/docs/understand/towards-1.0-sdk.md
@@ -56,8 +56,8 @@ following interfaces:
 * Any call to such an interface through the published, generated SDKs.
   These include:
 
-  * [Python `lakefs-sdk`](https://pypi.org/project/lakefs-sdk/)
-  * [Java Maven `io.lakefs:lakefs-sdk`](https://mvnrepository.com/artifact/io.lakefs/lakefs-sdk)
+  * Python `lakefs-sdk` - `https://pypi.org/project/lakefs-sdk/`
+  * Java Maven `io.lakefs:lakefs-sdk` - `https://mvnrepository.com/artifact/io.lakefs/lakefs-sdk`
 
   If your program only uses such calls on the SDK, it will continue to
   compile and function across a minor version upgrade of the SDK.


### PR DESCRIPTION
currently the links are dead and the checks fails on all PRs
