### PR TITLE
Following API changes lakeFSFS only compatible with lakeFS >= 0.108.0

### DIFF
--- a/.github/workflows/compatibility-tests.yaml
+++ b/.github/workflows/compatibility-tests.yaml
@@ -121,7 +121,7 @@ jobs:
       matrix:
         # Removing a version from this list means the published client is no longer compatible with
         # that lakeFS version.
-        lakefs_version: [ 0.90.0, 0.91.0, 0.92.0, 0.93.0, 0.94.1, 0.95.0, 0.96.0, 0.96.1, 0.97.4, 0.97.5, 0.98.0, 0.99.0, 0.100.0, 0.101.0, 0.102.0, 0.102.1, 0.102.2, 0.103.0, 0.104.0, 0.105.0, 0.106.2, 0.107.0, 0.107.1, 0.108.0, 0.109.0, 0.110.0, 0.111.0, 0.111.1 ]
+        lakefs_version: [ 0.108.0, 0.109.0, 0.110.0, 0.111.0, 0.111.1 ]
     runs-on: ubuntu-20.04
     env:
       TAG: ${{ matrix.lakefs_version }}


### PR DESCRIPTION
No need to test lakeFSFS with previous server versions - [it
fails][lakefsfs-fails-pre-0.108.0], and this is fine.


[lakefsfs-fails-pre-0.108.0]:  https://github.com/treeverse/lakeFS/actions/runs/6445679752/job/17500027493