### PR TITLE
[Bug] Write headers just before writing contents

### DIFF
--- a/esti/s3_gateway_test.go
+++ b/esti/s3_gateway_test.go
@@ -174,18 +174,15 @@ func TestS3ReadObject(t *testing.T) {
 		t.Run("ExistsPreSigned", func(t *testing.T) {
 			// using presigned URL so we can check the headers
 			// We expect the Content-Length header to be set
-			preSignedUrl, err := client.Presign(ctx, "GET", repo, goodPath, time.Second*60, url.Values{})
+			preSignedUrl, err := client.Presign(ctx, http.MethodGet, repo, goodPath, time.Second*60, url.Values{})
 			if err != nil {
-				t.Errorf("client.Presign(%s, %s): %s", repo, goodPath, err)
+				t.Fatalf("client.Presign(%s, %s): %s", repo, goodPath, err)
 			}
 
-			req, err := http.NewRequest("GET", preSignedUrl.String(), nil)
+			resp, err := http.Get(preSignedUrl.String())
+			defer func() { _ = resp.Body.Close() }()
 			if err != nil {
-				t.Errorf("http.NewRequest: %s", err)
-			}
-			resp, err := http.DefaultClient.Do(req)
-			if err != nil {
-				t.Errorf("http.DefaultClient.Do: %s", err)
+				t.Fatalf("http.DefaultClient.Do: %s", err)
 			}
 			contentLength := resp.Header.Get("Content-Length")
 			if contentLength == "" {

--- a/esti/s3_gateway_test.go
+++ b/esti/s3_gateway_test.go
@@ -171,8 +171,9 @@ func TestS3ReadObject(t *testing.T) {
 				t.Errorf("Got contents \"%s\" but expected \"%s\"", string(got), contents)
 			}
 		})
-		t.Run("Exists - should have Content-Length header", func(t *testing.T) {
+		t.Run("ExistsPreSigned", func(t *testing.T) {
 			// using presigned URL so we can check the headers
+			// We expect the Content-Length header to be set
 			preSignedUrl, err := client.Presign(ctx, "GET", repo, goodPath, time.Second*60, url.Values{})
 			if err != nil {
 				t.Errorf("client.Presign(%s, %s): %s", repo, goodPath, err)
@@ -206,27 +207,6 @@ func TestS3ReadObject(t *testing.T) {
 			if s3ErrorResponse.StatusCode != 404 {
 				t.Errorf("Got %+v [%d] on reading when expecting Not Found [404]",
 					s3ErrorResponse, s3ErrorResponse.StatusCode)
-			}
-		})
-
-		t.Run("Dosn't exist - should not have Content-Length header", func(t *testing.T) {
-			// using presigned URL so we can check the headers
-			preSignedUrl, err := client.Presign(ctx, "GET", repo, badPath, time.Second*60, url.Values{})
-			if err != nil {
-				t.Errorf("client.Presign(%s, %s): %s", repo, badPath, err)
-			}
-
-			req, err := http.NewRequest("GET", preSignedUrl.String(), nil)
-			if err != nil {
-				t.Errorf("http.NewRequest: %s", err)
-			}
-			resp, err := http.DefaultClient.Do(req)
-			if err != nil {
-				t.Errorf("http.DefaultClient.Do: %s", err)
-			}
-			contentLength := resp.Header.Get("Content-Length")
-			if contentLength != "" {
-				t.Errorf("Expected Content-Length header not to be set")
 			}
 		})
 	})

--- a/esti/s3_gateway_test.go
+++ b/esti/s3_gateway_test.go
@@ -174,16 +174,16 @@ func TestS3ReadObject(t *testing.T) {
 		t.Run("ExistsPreSigned", func(t *testing.T) {
 			// using presigned URL so we can check the headers
 			// We expect the Content-Length header to be set
-			preSignedUrl, err := client.Presign(ctx, http.MethodGet, repo, goodPath, time.Second*60, url.Values{})
+			preSignedURL, err := client.Presign(ctx, http.MethodGet, repo, goodPath, time.Second*60, url.Values{})
 			if err != nil {
 				t.Fatalf("client.Presign(%s, %s): %s", repo, goodPath, err)
 			}
 
-			resp, err := http.Get(preSignedUrl.String())
-			defer func() { _ = resp.Body.Close() }()
+			resp, err := http.Get(preSignedURL.String())
 			if err != nil {
-				t.Fatalf("http.DefaultClient.Do: %s", err)
+				t.Fatalf("http.Get %s: %s", preSignedURL.String(), err)
 			}
+			defer func() { _ = resp.Body.Close() }()
 			contentLength := resp.Header.Get("Content-Length")
 			if contentLength == "" {
 				t.Errorf("Expected Content-Length header to be set")

--- a/esti/s3_gateway_test.go
+++ b/esti/s3_gateway_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"sync"
 	"testing"
+	"time"
 
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
@@ -172,7 +173,7 @@ func TestS3ReadObject(t *testing.T) {
 		})
 		t.Run("Exists - should have Content-Length header", func(t *testing.T) {
 			// using presigned URL so we can check the headers
-			preSignedUrl, err := client.Presign(ctx, "GET", repo, goodPath, 60, url.Values{})
+			preSignedUrl, err := client.Presign(ctx, "GET", repo, goodPath, time.Second*60, url.Values{})
 			if err != nil {
 				t.Errorf("client.Presign(%s, %s): %s", repo, goodPath, err)
 			}
@@ -210,7 +211,7 @@ func TestS3ReadObject(t *testing.T) {
 
 		t.Run("Dosn't exist - should not have Content-Length header", func(t *testing.T) {
 			// using presigned URL so we can check the headers
-			preSignedUrl, err := client.Presign(ctx, "GET", repo, badPath, 60, url.Values{})
+			preSignedUrl, err := client.Presign(ctx, "GET", repo, badPath, time.Second*60, url.Values{})
 			if err != nil {
 				t.Errorf("client.Presign(%s, %s): %s", repo, badPath, err)
 			}

--- a/esti/s3_gateway_test.go
+++ b/esti/s3_gateway_test.go
@@ -172,7 +172,7 @@ func TestS3ReadObject(t *testing.T) {
 		})
 		t.Run("Exists - should have Content-Length header", func(t *testing.T) {
 			// using presigned URL so we can check the headers
-			preSignedUrl, err := client.Presign(ctx, "GET", repo, goodPath, 0, url.Values{})
+			preSignedUrl, err := client.Presign(ctx, "GET", repo, goodPath, 60, url.Values{})
 			if err != nil {
 				t.Errorf("client.Presign(%s, %s): %s", repo, goodPath, err)
 			}
@@ -210,7 +210,7 @@ func TestS3ReadObject(t *testing.T) {
 
 		t.Run("Dosn't exist - should not have Content-Length header", func(t *testing.T) {
 			// using presigned URL so we can check the headers
-			preSignedUrl, err := client.Presign(ctx, "GET", repo, badPath, 0, url.Values{})
+			preSignedUrl, err := client.Presign(ctx, "GET", repo, badPath, 60, url.Values{})
 			if err != nil {
 				t.Errorf("client.Presign(%s, %s): %s", repo, badPath, err)
 			}

--- a/pkg/gateway/operations/getobject.go
+++ b/pkg/gateway/operations/getobject.go
@@ -84,6 +84,7 @@ func (controller *GetObject) Handle(w http.ResponseWriter, req *http.Request, o 
 		// by here, we have a range we can use.
 	}
 
+	var contentLength int64
 	if rangeSpec == "" || err != nil {
 		// assemble a response body (range-less query)
 		data, err = o.BlockStore.Get(req.Context(), block.ObjectPointer{
@@ -95,7 +96,7 @@ func (controller *GetObject) Handle(w http.ResponseWriter, req *http.Request, o 
 			_ = o.EncodeError(w, req, err, gatewayerrors.Codes.ToAPIErr(gatewayerrors.ErrInternalError))
 			return
 		}
-		o.SetHeader(w, "Content-Length", fmt.Sprintf("%d", entry.Size))
+		contentLength = entry.Size
 	} else {
 		data, err = o.BlockStore.GetRange(req.Context(), block.ObjectPointer{
 			StorageNamespace: o.Repository.StorageNamespace,
@@ -108,10 +109,11 @@ func (controller *GetObject) Handle(w http.ResponseWriter, req *http.Request, o 
 		}
 		contentRange := fmt.Sprintf("bytes %d-%d/%d", rng.StartOffset, rng.EndOffset, entry.Size)
 		o.SetHeader(w, "Content-Range", contentRange)
-		o.SetHeader(w, "Content-Length", fmt.Sprintf("%d", rng.Size()))
+		contentLength = rng.Size()
 		w.WriteHeader(http.StatusPartialContent)
 	}
 
+	o.SetHeader(w, "Content-Length", fmt.Sprintf("%d", contentLength))
 	o.SetHeader(w, "X-Content-Type-Options", "nosniff")
 	o.SetHeader(w, "X-Frame-Options", "SAMEORIGIN")
 	o.SetHeader(w, "Content-Security-Policy", "default-src 'none'")

--- a/pkg/gateway/operations/getobject.go
+++ b/pkg/gateway/operations/getobject.go
@@ -61,7 +61,11 @@ func (controller *GetObject) Handle(w http.ResponseWriter, req *http.Request, o 
 		_ = o.EncodeError(w, req, err, gatewayerrors.Codes.ToAPIErr(gatewayerrors.ErrInternalError))
 		return
 	}
-
+	o.SetHeader(w, "Last-Modified", httputil.HeaderTimestamp(entry.CreationDate))
+	o.SetHeader(w, "ETag", httputil.ETag(entry.Checksum))
+	o.SetHeader(w, "Content-Type", entry.ContentType)
+	o.SetHeader(w, "Accept-Ranges", "bytes")
+	amzMetaWriteHeaders(w, entry.Metadata)
 	// TODO: the rest of https://docs.aws.amazon.com/en_pv/AmazonS3/latest/API/API_GetObject.html
 	// range query
 	var data io.ReadCloser
@@ -79,7 +83,7 @@ func (controller *GetObject) Handle(w http.ResponseWriter, req *http.Request, o 
 		}
 		// by here, we have a range we can use.
 	}
-	var contentLength int64
+
 	if rangeSpec == "" || err != nil {
 		// assemble a response body (range-less query)
 		data, err = o.BlockStore.Get(req.Context(), block.ObjectPointer{
@@ -91,7 +95,7 @@ func (controller *GetObject) Handle(w http.ResponseWriter, req *http.Request, o 
 			_ = o.EncodeError(w, req, err, gatewayerrors.Codes.ToAPIErr(gatewayerrors.ErrInternalError))
 			return
 		}
-		contentLength = entry.Size
+		o.SetHeader(w, "Content-Length", fmt.Sprintf("%d", entry.Size))
 	} else {
 		data, err = o.BlockStore.GetRange(req.Context(), block.ObjectPointer{
 			StorageNamespace: o.Repository.StorageNamespace,
@@ -104,16 +108,10 @@ func (controller *GetObject) Handle(w http.ResponseWriter, req *http.Request, o 
 		}
 		contentRange := fmt.Sprintf("bytes %d-%d/%d", rng.StartOffset, rng.EndOffset, entry.Size)
 		o.SetHeader(w, "Content-Range", contentRange)
-		contentLength = rng.Size()
+		o.SetHeader(w, "Content-Length", fmt.Sprintf("%d", rng.Size()))
 		w.WriteHeader(http.StatusPartialContent)
 	}
 
-	o.SetHeader(w, "Last-Modified", httputil.HeaderTimestamp(entry.CreationDate))
-	o.SetHeader(w, "ETag", httputil.ETag(entry.Checksum))
-	o.SetHeader(w, "Content-Type", entry.ContentType)
-	o.SetHeader(w, "Accept-Ranges", "bytes")
-	amzMetaWriteHeaders(w, entry.Metadata)
-	o.SetHeader(w, "Content-Length", fmt.Sprintf("%d", contentLength))
 	o.SetHeader(w, "X-Content-Type-Options", "nosniff")
 	o.SetHeader(w, "X-Frame-Options", "SAMEORIGIN")
 	o.SetHeader(w, "Content-Security-Policy", "default-src 'none'")

--- a/pkg/gateway/operations/getobject.go
+++ b/pkg/gateway/operations/getobject.go
@@ -61,11 +61,7 @@ func (controller *GetObject) Handle(w http.ResponseWriter, req *http.Request, o 
 		_ = o.EncodeError(w, req, err, gatewayerrors.Codes.ToAPIErr(gatewayerrors.ErrInternalError))
 		return
 	}
-	o.SetHeader(w, "Last-Modified", httputil.HeaderTimestamp(entry.CreationDate))
-	o.SetHeader(w, "ETag", httputil.ETag(entry.Checksum))
-	o.SetHeader(w, "Content-Type", entry.ContentType)
-	o.SetHeader(w, "Accept-Ranges", "bytes")
-	amzMetaWriteHeaders(w, entry.Metadata)
+
 	// TODO: the rest of https://docs.aws.amazon.com/en_pv/AmazonS3/latest/API/API_GetObject.html
 	// range query
 	var data io.ReadCloser
@@ -83,7 +79,8 @@ func (controller *GetObject) Handle(w http.ResponseWriter, req *http.Request, o 
 		}
 		// by here, we have a range we can use.
 	}
-
+	var returnHTTPStatus int
+	var contentLength int64
 	if rangeSpec == "" || err != nil {
 		// assemble a response body (range-less query)
 		data, err = o.BlockStore.Get(req.Context(), block.ObjectPointer{
@@ -95,7 +92,8 @@ func (controller *GetObject) Handle(w http.ResponseWriter, req *http.Request, o 
 			_ = o.EncodeError(w, req, err, gatewayerrors.Codes.ToAPIErr(gatewayerrors.ErrInternalError))
 			return
 		}
-		o.SetHeader(w, "Content-Length", fmt.Sprintf("%d", entry.Size))
+		contentLength = entry.Size
+		returnHTTPStatus = http.StatusOK
 	} else {
 		data, err = o.BlockStore.GetRange(req.Context(), block.ObjectPointer{
 			StorageNamespace: o.Repository.StorageNamespace,
@@ -108,13 +106,20 @@ func (controller *GetObject) Handle(w http.ResponseWriter, req *http.Request, o 
 		}
 		contentRange := fmt.Sprintf("bytes %d-%d/%d", rng.StartOffset, rng.EndOffset, entry.Size)
 		o.SetHeader(w, "Content-Range", contentRange)
-		o.SetHeader(w, "Content-Length", fmt.Sprintf("%d", rng.Size()))
-		w.WriteHeader(http.StatusPartialContent)
+		contentLength = rng.Size()
+		returnHTTPStatus = http.StatusPartialContent
 	}
 
+	o.SetHeader(w, "Last-Modified", httputil.HeaderTimestamp(entry.CreationDate))
+	o.SetHeader(w, "ETag", httputil.ETag(entry.Checksum))
+	o.SetHeader(w, "Content-Type", entry.ContentType)
+	o.SetHeader(w, "Accept-Ranges", "bytes")
+	amzMetaWriteHeaders(w, entry.Metadata)
+	o.SetHeader(w, "Content-Length", fmt.Sprintf("%d", contentLength))
 	o.SetHeader(w, "X-Content-Type-Options", "nosniff")
 	o.SetHeader(w, "X-Frame-Options", "SAMEORIGIN")
 	o.SetHeader(w, "Content-Security-Policy", "default-src 'none'")
+	w.WriteHeader(returnHTTPStatus)
 
 	defer func() {
 		_ = data.Close()

--- a/pkg/gateway/operations/getobject.go
+++ b/pkg/gateway/operations/getobject.go
@@ -29,6 +29,7 @@ func (controller *GetObject) RequiredPermissions(_ *http.Request, repoID, _, pat
 
 func (controller *GetObject) Handle(w http.ResponseWriter, req *http.Request, o *PathOperation) {
 	o.Incr("get_object", o.Principal, o.Repository.Name, o.Reference)
+	ctx := req.Context()
 	query := req.URL.Query()
 	if _, exists := query["versioning"]; exists {
 		o.EncodeResponse(w, req, serde.VersioningConfiguration{}, http.StatusOK)
@@ -41,7 +42,7 @@ func (controller *GetObject) Handle(w http.ResponseWriter, req *http.Request, o 
 	}
 
 	beforeMeta := time.Now()
-	entry, err := o.Catalog.GetEntry(req.Context(), o.Repository.Name, o.Reference, o.Path, catalog.GetEntryParams{})
+	entry, err := o.Catalog.GetEntry(ctx, o.Repository.Name, o.Reference, o.Path, catalog.GetEntryParams{})
 	metaTook := time.Since(beforeMeta)
 	o.Log(req).
 		WithField("took", metaTook).
@@ -79,47 +80,43 @@ func (controller *GetObject) Handle(w http.ResponseWriter, req *http.Request, o 
 		}
 		// by here, we have a range we can use.
 	}
-	var returnHTTPStatus int
-	var contentLength int64
+
+	statusCode := http.StatusOK
+	contentLength := entry.Size
+	contentRange := ""
+	objectPointer := block.ObjectPointer{
+		StorageNamespace: o.Repository.StorageNamespace,
+		IdentifierType:   entry.AddressType.ToIdentifierType(),
+		Identifier:       entry.PhysicalAddress,
+	}
+
 	if rangeSpec == "" || err != nil {
 		// assemble a response body (range-less query)
-		data, err = o.BlockStore.Get(req.Context(), block.ObjectPointer{
-			StorageNamespace: o.Repository.StorageNamespace,
-			IdentifierType:   entry.AddressType.ToIdentifierType(),
-			Identifier:       entry.PhysicalAddress,
-		}, entry.Size)
-		if err != nil {
-			_ = o.EncodeError(w, req, err, gatewayerrors.Codes.ToAPIErr(gatewayerrors.ErrInternalError))
-			return
-		}
-		contentLength = entry.Size
-		returnHTTPStatus = http.StatusOK
+		data, err = o.BlockStore.Get(ctx, objectPointer, entry.Size)
 	} else {
-		data, err = o.BlockStore.GetRange(req.Context(), block.ObjectPointer{
-			StorageNamespace: o.Repository.StorageNamespace,
-			IdentifierType:   entry.AddressType.ToIdentifierType(),
-			Identifier:       entry.PhysicalAddress,
-		}, rng.StartOffset, rng.EndOffset)
-		if err != nil {
-			_ = o.EncodeError(w, req, err, gatewayerrors.Codes.ToAPIErr(gatewayerrors.ErrInternalError))
-			return
-		}
-		contentRange := fmt.Sprintf("bytes %d-%d/%d", rng.StartOffset, rng.EndOffset, entry.Size)
-		o.SetHeader(w, "Content-Range", contentRange)
 		contentLength = rng.Size()
-		returnHTTPStatus = http.StatusPartialContent
+		contentRange = fmt.Sprintf("bytes %d-%d/%d", rng.StartOffset, rng.EndOffset, entry.Size)
+		statusCode = http.StatusPartialContent
+		data, err = o.BlockStore.GetRange(ctx, objectPointer, rng.StartOffset, rng.EndOffset)
+	}
+	if err != nil {
+		_ = o.EncodeError(w, req, err, gatewayerrors.Codes.ToAPIErr(gatewayerrors.ErrInternalError))
+		return
 	}
 
 	o.SetHeader(w, "Last-Modified", httputil.HeaderTimestamp(entry.CreationDate))
 	o.SetHeader(w, "ETag", httputil.ETag(entry.Checksum))
 	o.SetHeader(w, "Content-Type", entry.ContentType)
 	o.SetHeader(w, "Accept-Ranges", "bytes")
-	amzMetaWriteHeaders(w, entry.Metadata)
+	if contentRange != "" {
+		o.SetHeader(w, "Content-Range", contentRange)
+	}
 	o.SetHeader(w, "Content-Length", fmt.Sprintf("%d", contentLength))
 	o.SetHeader(w, "X-Content-Type-Options", "nosniff")
 	o.SetHeader(w, "X-Frame-Options", "SAMEORIGIN")
 	o.SetHeader(w, "Content-Security-Policy", "default-src 'none'")
-	w.WriteHeader(returnHTTPStatus)
+	amzMetaWriteHeaders(w, entry.Metadata)
+	w.WriteHeader(statusCode)
 
 	defer func() {
 		_ = data.Close()


### PR DESCRIPTION
Closes #6718 

## Change Description

### Bug Fix

In S3 GW `get_object` operation, the headers (incl. `Content-Length`) are written too early. If we end up returning an error, there will be a mismatch between the returned content and the headers. 

For example, if an object is deleted from the underlying storage, we'd expect to get a response with HTTP status 410 (Gone). In practice, the response depends on the size of the object. If the object was smaller than the byte length of the error message, we'd get a server-side encoding error. If the object was larger than the byte length of the error message, we get a client-side error (depending on the client) since it reaches EOF before reading the expected content length.

Writing the headers after all the error checks and just before we write the object/range to the writer ensures this mismatch doesn't happen.

### Testing Details

The minio client used for S3 GW testing is too high-level to allow us to test the returned headers. It returns the object requested and abstracts away the underlying object store request. If also doesn't check the `Content-Length` header and reads the response buffer to completion. 

As validation, we'd like to see this PR pass existing tests (i.e., rule out regression). I'll open another issue to consider replacing the minio client used for our tests with one that allows lower-level testing of the response, incl. the returned headers.