### PR TITLE
Use io.lakefs:sdk coordinates

### DIFF
--- a/.github/workflows/esti.yaml
+++ b/.github/workflows/esti.yaml
@@ -296,11 +296,6 @@ jobs:
           STORAGE_NAMESPACE: s3://test-bucket/data
           REPOSITORY: lakefsfs-contract-test
 
-      - name: Build current lakeFS SDK
-        # TODO(ariels): Remove this in favour of a single lakeFS client version
-        working-directory: clients/java
-        run: mvn -P'!treeverse-signing' install
-
       - name: Build and test hadoopfs (hadoop2)
         working-directory: clients/hadoopfs
         run: mvn clean --quiet --batch-mode --update-snapshots -P'!treeverse-signing',contract-tests-hadoop2 verify
@@ -387,10 +382,7 @@ jobs:
           distribution: "adopt-hotspot"
           java-version: "8"
           cache: "sbt"
-      - name: Build current lakeFS SDK
-        # TODO(ariels): Remove this in favour of a single lakeFS client version
-        working-directory: clients/java
-        run: mvn -P'!treeverse-signing' install
+
       - name: Build lakeFS HadoopFS
         working-directory: clients/hadoopfs
         run: mvn -Passembly -DfinalName=client --batch-mode --update-snapshots package -DskipTests

--- a/clients/hadoopfs/pom.xml
+++ b/clients/hadoopfs/pom.xml
@@ -277,8 +277,8 @@ To export to S3:
         <dependency>
             <groupId>io.lakefs</groupId>
             <!-- TODO(ariels): Publish an actual sdk-client version and use *that*! -->
-            <artifactId>sdk-client</artifactId>
-            <version>0.111.2-RC.0</version>
+            <artifactId>sdk</artifactId>
+            <version>0.112.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Also revert *Esti* to use a published SDK from Maven central.  Previously it
was temporarily building its own SDK copy.

Fixes #6730.