### PR TITLE
LinkPhysicalAddress trim quotes and spaces from checksum

### DIFF
--- a/esti/lakectl_test.go
+++ b/esti/lakectl_test.go
@@ -112,7 +112,6 @@ func TestLakectlPreSignUpload(t *testing.T) {
 	filePath := "ro_1k.1"
 	vars["FILE_PATH"] = filePath
 	RunCmdAndVerifySuccessWithFile(t, Lakectl()+" fs upload -s files/ro_1k lakefs://"+repoName+"/"+mainBranch+"/"+filePath+" --pre-sign", false, "lakectl_fs_upload_pre_signed", vars)
-
 }
 
 func TestLakectlCommit(t *testing.T) {

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -359,7 +359,6 @@ func (c *Controller) LinkPhysicalAddress(w http.ResponseWriter, r *http.Request,
 
 	writeTime := time.Now()
 	physicalAddress, addressType := normalizePhysicalAddress(repo.StorageNamespace, swag.StringValue(body.Staging.PhysicalAddress))
-
 	if addressType == catalog.AddressTypeRelative {
 		// if the address is in the storage namespace, verify it has been saved for linking
 		err = c.Catalog.VerifyLinkAddress(ctx, repository, physicalAddress)
@@ -367,7 +366,13 @@ func (c *Controller) LinkPhysicalAddress(w http.ResponseWriter, r *http.Request,
 			return
 		}
 	}
+
 	checksum := strings.Trim(strings.TrimSpace(body.Checksum), `"`) // trim etag spaces and quotes
+	if checksum == "" {
+		writeError(w, r, http.StatusBadRequest, "checksum is required")
+		return
+	}
+
 	entryBuilder := catalog.NewDBEntryBuilder().
 		CommonLevel(false).
 		Path(params.Path).

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -367,6 +367,7 @@ func (c *Controller) LinkPhysicalAddress(w http.ResponseWriter, r *http.Request,
 			return
 		}
 	}
+	checksum := strings.Trim(strings.TrimSpace(body.Checksum), `"`) // trim etag spaces and quotes
 	entryBuilder := catalog.NewDBEntryBuilder().
 		CommonLevel(false).
 		Path(params.Path).
@@ -374,7 +375,7 @@ func (c *Controller) LinkPhysicalAddress(w http.ResponseWriter, r *http.Request,
 		AddressType(addressType).
 		CreationDate(writeTime).
 		Size(body.SizeBytes).
-		Checksum(body.Checksum).
+		Checksum(checksum).
 		ContentType(swag.StringValue(body.ContentType))
 	if body.UserMetadata != nil {
 		entryBuilder.Metadata(body.UserMetadata.AdditionalProperties)

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -367,7 +367,10 @@ func (c *Controller) LinkPhysicalAddress(w http.ResponseWriter, r *http.Request,
 		}
 	}
 
-	checksum := strings.Trim(strings.TrimSpace(body.Checksum), `"`) // trim etag spaces and quotes
+	// trim spaces and quotes from etag
+	checksum := strings.TrimFunc(body.Checksum, func(r rune) bool {
+		return r == '"' || r == ' '
+	})
 	if checksum == "" {
 		writeError(w, r, http.StatusBadRequest, "checksum is required")
 		return

--- a/pkg/api/helpers/upload.go
+++ b/pkg/api/helpers/upload.go
@@ -156,7 +156,6 @@ func clientUploadPreSignHelper(ctx context.Context, client apigen.ClientWithResp
 
 	etag := putResp.Header.Get("Etag")
 	etag = strings.TrimSpace(etag)
-	etag = strings.Trim(etag, "\"")
 	if etag == "" {
 		return nil, fmt.Errorf("etag is missing: %w", ErrRequestFailed)
 	}


### PR DESCRIPTION
Close #6743

This should handle the case where a API provides checksum with `"` as part of Etag value as checksum.
As lakeFS holds this value without `"`, we strip them before we write the entry.