### PR TITLE
Reintroduce recursive flag for fs download/upload

### DIFF
--- a/cmd/lakectl/cmd/annotate.go
+++ b/cmd/lakectl/cmd/annotate.go
@@ -30,7 +30,7 @@ var annotateCmd = &cobra.Command{
 	ValidArgsFunction: ValidArgsRepository,
 	Run: func(cmd *cobra.Command, args []string) {
 		pathURI := MustParsePathURI("path", args[0])
-		recursive := Must(cmd.Flags().GetBool("recursive"))
+		recursive := Must(cmd.Flags().GetBool(recursiveFlagName))
 		firstParent := Must(cmd.Flags().GetBool("first-parent"))
 		client := getClient()
 		pfx := apigen.PaginationPrefix(*pathURI.Path)
@@ -105,7 +105,6 @@ func splitOnNewLine(str string) string {
 //nolint:gochecknoinits
 func init() {
 	rootCmd.AddCommand(annotateCmd)
-
-	annotateCmd.Flags().BoolP("recursive", "r", false, "recursively annotate all entries under a given path or prefix")
+	withRecursiveFlag(annotateCmd, "recursively annotate all entries under a given path or prefix")
 	annotateCmd.Flags().Bool("first-parent", false, "follow only the first parent commit upon seeing a merge commit")
 }

--- a/cmd/lakectl/cmd/fs_cat.go
+++ b/cmd/lakectl/cmd/fs_cat.go
@@ -17,16 +17,15 @@ var fsCatCmd = &cobra.Command{
 	ValidArgsFunction: ValidArgsRepository,
 	Run: func(cmd *cobra.Command, args []string) {
 		pathURI := MustParsePathURI("path", args[0])
-		flagSet := cmd.Flags()
-		preSignMode := Must(flagSet.GetBool("pre-sign"))
+		client := getClient()
+		preSign := getPresignMode(cmd, client)
 
 		var err error
 		var body io.ReadCloser
-		client := getClient()
 		var resp *http.Response
 		resp, err = client.GetObject(cmd.Context(), pathURI.Repository, pathURI.Ref, &apigen.GetObjectParams{
 			Path:    *pathURI.Path,
-			Presign: swag.Bool(preSignMode),
+			Presign: swag.Bool(preSign),
 		})
 		DieOnHTTPError(resp)
 		body = resp.Body
@@ -48,7 +47,6 @@ var fsCatCmd = &cobra.Command{
 
 //nolint:gochecknoinits
 func init() {
-	fsCatCmd.Flags().Bool("pre-sign", false, "Use pre-sign link to access the data")
-
+	withPresignFlag(fsCatCmd)
 	fsCmd.AddCommand(fsCatCmd)
 }

--- a/cmd/lakectl/cmd/fs_download.go
+++ b/cmd/lakectl/cmd/fs_download.go
@@ -43,11 +43,13 @@ var fsDownloadCmd = &cobra.Command{
 				Path:   remotePath,
 				Type:   local.ChangeTypeAdded,
 			}
+			close(ch)
 		} else {
 			if remotePath != "" && !strings.HasSuffix(remotePath, uri.PathSeparator) {
 				*remote.Path += uri.PathSeparator
 			}
 			go func() {
+				defer close(ch)
 				var after string
 				for {
 					listResp, err := client.ListObjectsWithResponse(ctx, remote.Repository, remote.Ref, &apigen.ListObjectsParams{
@@ -84,7 +86,6 @@ var fsDownloadCmd = &cobra.Command{
 				}
 			}()
 		}
-		close(ch)
 
 		s := local.NewSyncManager(ctx, client, syncFlags)
 		err := s.Sync(dest, remote, ch)

--- a/cmd/lakectl/cmd/fs_ls.go
+++ b/cmd/lakectl/cmd/fs_ls.go
@@ -17,7 +17,7 @@ var fsLsCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getClient()
 		pathURI := MustParsePathURI("path", args[0])
-		recursive := Must(cmd.Flags().GetBool("recursive"))
+		recursive := Must(cmd.Flags().GetBool(recursiveFlagName))
 		prefix := *pathURI.Path
 
 		// prefix we need to trim in ls output (non-recursive)
@@ -65,8 +65,7 @@ var fsLsCmd = &cobra.Command{
 
 //nolint:gochecknoinits
 func init() {
-	fsLsCmd.Flags().Bool("recursive", false, "list all objects under the specified prefix")
-
+	withRecursiveFlag(fsLsCmd, "list all objects under the specified path")
 	fsCmd.AddCommand(fsLsCmd)
 }
 

--- a/cmd/lakectl/cmd/fs_rm.go
+++ b/cmd/lakectl/cmd/fs_rm.go
@@ -19,7 +19,7 @@ var fsRmCmd = &cobra.Command{
 	Args:              cobra.ExactArgs(1),
 	ValidArgsFunction: ValidArgsRepository,
 	Run: func(cmd *cobra.Command, args []string) {
-		recursive := Must(cmd.Flags().GetBool("recursive"))
+		recursive := Must(cmd.Flags().GetBool(recursiveFlagName))
 		concurrency := Must(cmd.Flags().GetInt("concurrency"))
 		pathURI := MustParsePathURI("path", args[0])
 		client := getClient()
@@ -115,7 +115,7 @@ func deleteObject(ctx context.Context, client apigen.ClientWithResponsesInterfac
 //nolint:gochecknoinits
 func init() {
 	const defaultConcurrency = 50
-	fsRmCmd.Flags().BoolP("recursive", "r", false, "recursively delete all objects under the specified path")
+	withRecursiveFlag(fsRmCmd, "recursively delete all objects under the specified path")
 	fsRmCmd.Flags().IntP("concurrency", "C", defaultConcurrency, "max concurrent single delete operations to send to the lakeFS server")
 
 	fsCmd.AddCommand(fsRmCmd)

--- a/cmd/lakectl/cmd/fs_stat.go
+++ b/cmd/lakectl/cmd/fs_stat.go
@@ -15,8 +15,9 @@ var fsStatCmd = &cobra.Command{
 	ValidArgsFunction: ValidArgsRepository,
 	Run: func(cmd *cobra.Command, args []string) {
 		pathURI := MustParsePathURI("path", args[0])
-		preSign := Must(cmd.Flags().GetBool("pre-sign"))
 		client := getClient()
+		preSign := getPresignMode(cmd, client)
+
 		resp, err := client.StatObjectWithResponse(cmd.Context(), pathURI.Repository, pathURI.Ref, &apigen.StatObjectParams{
 			Path:         *pathURI.Path,
 			Presign:      swag.Bool(preSign),
@@ -49,7 +50,6 @@ Metadata:
 
 //nolint:gochecknoinits
 func init() {
-	fsStatCmd.Flags().Bool("pre-sign", false, "Request pre-sign for physical address")
-
+	withPresignFlag(fsStatCmd)
 	fsCmd.AddCommand(fsStatCmd)
 }

--- a/cmd/lakectl/cmd/fs_upload.go
+++ b/cmd/lakectl/cmd/fs_upload.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"context"
-	"path"
 	"path/filepath"
 	"strings"
 
@@ -26,10 +25,11 @@ var fsUploadCmd = &cobra.Command{
 		source := Must(cmd.Flags().GetString("source"))
 		contentType := Must(cmd.Flags().GetString("content-type"))
 		recursive := Must(cmd.Flags().GetBool(recursiveFlagName))
+		remotePath := pathURI.GetPath()
 		ctx := cmd.Context()
 
 		if !recursive { // Assume source is a single file
-			if pathURI.GetPath() == "" || path.Clean(pathURI.GetPath()) != pathURI.GetPath() {
+			if strings.HasSuffix(remotePath, uri.PathSeparator) {
 				Die("target path is not a valid URI", 1)
 			}
 			stat, err := upload(ctx, client, source, pathURI, contentType, syncFlags.Presign)
@@ -44,7 +44,7 @@ var fsUploadCmd = &cobra.Command{
 		if !strings.HasSuffix(source, string(filepath.Separator)) {
 			source += string(filepath.Separator)
 		}
-		changes := localDiff(cmd.Context(), client, pathURI, source)
+		changes := localDiff(ctx, client, pathURI, source)
 		// sync changes
 		c := make(chan *local.Change, filesChanSize)
 		go func() {

--- a/cmd/lakectl/cmd/fs_upload.go
+++ b/cmd/lakectl/cmd/fs_upload.go
@@ -2,8 +2,9 @@ package cmd
 
 import (
 	"context"
-	"os"
+	"path"
 	"path/filepath"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/treeverse/lakefs/pkg/api/apigen"
@@ -20,30 +21,18 @@ var fsUploadCmd = &cobra.Command{
 	ValidArgsFunction: ValidArgsRepository,
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getClient()
-		pathURI := MustParsePathURI("path", args[0])
-		flagSet := cmd.Flags()
-		source := Must(flagSet.GetString("source"))
-		preSignMode := Must(flagSet.GetBool("pre-sign"))
-		parallelism := Must(flagSet.GetInt("parallelism"))
-		contentType := Must(flagSet.GetString("content-type"))
-
-		if parallelism < 1 {
-			DieFmt("Invalid value for parallelism (%d), minimum is 1.\n", parallelism)
-		}
-
+		pathURI, _ := getSyncArgs(args, true, false)
+		syncFlags := getSyncFlags(cmd, client)
+		source := Must(cmd.Flags().GetString("source"))
+		contentType := Must(cmd.Flags().GetString("content-type"))
+		recursive := Must(cmd.Flags().GetBool(recursiveFlagName))
 		ctx := cmd.Context()
 
-		info, err := os.Stat(source)
-		if err != nil {
-			DieErr(err)
-			return
-		}
-
-		if !info.IsDir() {
-			if pathURI.GetPath() == "" {
+		if !recursive { // Assume source is a single file
+			if pathURI.GetPath() == "" || path.Clean(pathURI.GetPath()) != pathURI.GetPath() {
 				Die("target path is not a valid URI", 1)
 			}
-			stat, err := upload(ctx, client, source, pathURI, contentType, preSignMode)
+			stat, err := upload(ctx, client, source, pathURI, contentType, syncFlags.Presign)
 			if err != nil {
 				DieErr(err)
 			}
@@ -51,6 +40,10 @@ var fsUploadCmd = &cobra.Command{
 			return
 		}
 
+		// Try recursive upload
+		if !strings.HasSuffix(source, string(filepath.Separator)) {
+			source += string(filepath.Separator)
+		}
 		changes := localDiff(cmd.Context(), client, pathURI, source)
 		// sync changes
 		c := make(chan *local.Change, filesChanSize)
@@ -63,7 +56,7 @@ var fsUploadCmd = &cobra.Command{
 				c <- change
 			}
 		}()
-		s := local.NewSyncManager(ctx, client, parallelism, preSignMode)
+		s := local.NewSyncManager(ctx, client, syncFlags)
 		fullPath, err := filepath.Abs(source)
 		if err != nil {
 			DieErr(err)
@@ -99,8 +92,8 @@ func init() {
 	fsUploadCmd.Flags().StringP("source", "s", "", "local file to upload, or \"-\" for stdin")
 	_ = fsUploadCmd.MarkFlagRequired("source")
 	fsUploadCmd.Flags().StringP("content-type", "", "", "MIME type of contents")
-	fsUploadCmd.Flags().Bool("pre-sign", false, "Use pre-sign link to access the data")
-	withParallelismFlag(fsUploadCmd)
+	withRecursiveFlag(fsUploadCmd, "recursively copy all files under local source")
+	withSyncFlags(fsUploadCmd)
 
 	fsCmd.AddCommand(fsUploadCmd)
 }

--- a/cmd/lakectl/cmd/local.go
+++ b/cmd/lakectl/cmd/local.go
@@ -4,16 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"net/http"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"syscall"
 
-	"github.com/mitchellh/go-homedir"
 	"github.com/spf13/cobra"
 	"github.com/treeverse/lakefs/pkg/api/apigen"
-	"github.com/treeverse/lakefs/pkg/git"
 	"github.com/treeverse/lakefs/pkg/local"
 	"github.com/treeverse/lakefs/pkg/uri"
 	"golang.org/x/sync/errgroup"
@@ -22,15 +18,11 @@ import (
 type LocalOperation string
 
 const (
-	localDefaultSyncParallelism = 25
-	localDefaultSyncPresign     = true
-	localDefaultMinArgs         = 0
-	localDefaultMaxArgs         = 1
+	localDefaultMinArgs = 0
+	localDefaultMaxArgs = 1
 
-	localPresignFlagName     = "pre-sign"
-	localParallelismFlagName = "parallelism"
-	localGitIgnoreFlagName   = "gitignore"
-	localForceFlagName       = "force"
+	localGitIgnoreFlagName = "gitignore"
+	localForceFlagName     = "force"
 
 	commitOperation   LocalOperation = "commit"
 	pullOperation     LocalOperation = "pull"
@@ -54,18 +46,13 @@ var (
 )
 
 func withParallelismFlag(cmd *cobra.Command) {
-	cmd.Flags().IntP(localParallelismFlagName, "p", localDefaultSyncParallelism,
+	cmd.Flags().IntP(parallelismFlagName, "p", defaultSyncParallelism,
 		"Max concurrent operations to perform")
 }
 
 func withPresignFlag(cmd *cobra.Command) {
-	cmd.Flags().Bool(localPresignFlagName, localDefaultSyncPresign,
+	cmd.Flags().Bool(presignFlagName, defaultSyncPresign,
 		"Use pre-signed URLs when downloading/uploading data (recommended)")
-}
-
-func withLocalSyncFlags(cmd *cobra.Command) {
-	withParallelismFlag(cmd)
-	withPresignFlag(cmd)
 }
 
 func withGitIgnoreFlag(cmd *cobra.Command) {
@@ -75,57 +62,6 @@ func withGitIgnoreFlag(cmd *cobra.Command) {
 
 func withForceFlag(cmd *cobra.Command, usage string) {
 	cmd.Flags().Bool(localForceFlagName, false, usage)
-}
-
-type syncFlags struct {
-	parallelism int
-	presign     bool
-}
-
-func getLocalSyncFlags(cmd *cobra.Command, client *apigen.ClientWithResponses) syncFlags {
-	presign := Must(cmd.Flags().GetBool(localPresignFlagName))
-	presignFlag := cmd.Flags().Lookup(localPresignFlagName)
-	if !presignFlag.Changed {
-		resp, err := client.GetConfigWithResponse(cmd.Context())
-		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusOK)
-		if resp.JSON200 == nil {
-			Die("Bad response from server", 1)
-		}
-		presign = resp.JSON200.StorageConfig.PreSignSupport
-	}
-
-	parallelism := Must(cmd.Flags().GetInt(localParallelismFlagName))
-	if parallelism < 1 {
-		DieFmt("Invalid value for parallelism (%d), minimum is 1.\n", parallelism)
-	}
-	return syncFlags{parallelism: parallelism, presign: presign}
-}
-
-// getSyncArgs parses arguments to extract a remote URI and deduces the local path.
-// If the local path isn't provided and considerGitRoot is true, it uses the git repository root.
-func getSyncArgs(args []string, requireRemote bool, considerGitRoot bool) (remote *uri.URI, localPath string) {
-	idx := 0
-	if requireRemote {
-		remote = MustParsePathURI("path", args[0])
-		idx += 1
-	}
-
-	if len(args) > idx {
-		expanded := Must(homedir.Expand(args[idx]))
-		localPath = Must(filepath.Abs(expanded))
-		return
-	}
-	localPath = Must(filepath.Abs("."))
-
-	if considerGitRoot {
-		gitRoot, err := git.GetRepositoryPath(localPath)
-		if err == nil {
-			localPath = gitRoot
-		} else if !(errors.Is(err, git.ErrNotARepository) || errors.Is(err, git.ErrNoGit)) { // allow support in environments with no git
-			DieErr(err)
-		}
-	}
-	return
 }
 
 func localDiff(ctx context.Context, client apigen.ClientWithResponsesInterface, remote *uri.URI, path string) local.Changes {

--- a/cmd/lakectl/cmd/local.go
+++ b/cmd/lakectl/cmd/local.go
@@ -45,16 +45,6 @@ var (
 	ErrUnknownOperation   = errors.New("unknown operation")
 )
 
-func withParallelismFlag(cmd *cobra.Command) {
-	cmd.Flags().IntP(parallelismFlagName, "p", defaultSyncParallelism,
-		"Max concurrent operations to perform")
-}
-
-func withPresignFlag(cmd *cobra.Command) {
-	cmd.Flags().Bool(presignFlagName, defaultSyncPresign,
-		"Use pre-signed URLs when downloading/uploading data (recommended)")
-}
-
 func withGitIgnoreFlag(cmd *cobra.Command) {
 	cmd.Flags().Bool(localGitIgnoreFlagName, true,
 		"Update .gitignore file when working in a git repository context")

--- a/cmd/lakectl/cmd/local_checkout.go
+++ b/cmd/lakectl/cmd/local_checkout.go
@@ -40,7 +40,7 @@ var localCheckoutCmd = &cobra.Command{
 
 func localCheckout(cmd *cobra.Command, localPath string, specifiedRef string, confirmByFlag bool) {
 	client := getClient()
-	locaSyncFlags := getLocalSyncFlags(cmd, client)
+	syncFlags := getSyncFlags(cmd, client)
 	idx, err := local.ReadIndex(localPath)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
@@ -57,7 +57,7 @@ func localCheckout(cmd *cobra.Command, localPath string, specifiedRef string, co
 	currentBase := remote.WithRef(idx.AtHead)
 	diffs := local.Undo(localDiff(cmd.Context(), client, currentBase, idx.LocalPath()))
 	sigCtx := localHandleSyncInterrupt(cmd.Context(), idx, string(checkoutOperation))
-	syncMgr := local.NewSyncManager(sigCtx, client, locaSyncFlags.parallelism, locaSyncFlags.presign)
+	syncMgr := local.NewSyncManager(sigCtx, client, syncFlags)
 	// confirm on local changes
 	if confirmByFlag && len(diffs) > 0 {
 		fmt.Println("Uncommitted changes exist, the operation will revert all changes on local directory.")
@@ -120,6 +120,6 @@ func init() {
 	localCheckoutCmd.Flags().Bool("all", false, "Checkout given source branch or reference for all linked directories")
 	localCheckoutCmd.MarkFlagsMutuallyExclusive("ref", "all")
 	AssignAutoConfirmFlag(localCheckoutCmd.Flags())
-	withLocalSyncFlags(localCheckoutCmd)
+	withSyncFlags(localCheckoutCmd)
 	localCmd.AddCommand(localCheckoutCmd)
 }

--- a/cmd/lakectl/cmd/local_clone.go
+++ b/cmd/lakectl/cmd/local_clone.go
@@ -28,7 +28,7 @@ var localCloneCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getClient()
 		remote, localPath := getSyncArgs(args, true, false)
-		syncFlags := getLocalSyncFlags(cmd, client)
+		syncFlags := getSyncFlags(cmd, client)
 		updateIgnore := Must(cmd.Flags().GetBool(localGitIgnoreFlagName))
 		empty, err := fileutil.IsDirEmpty(localPath)
 		if err != nil {
@@ -87,7 +87,7 @@ var localCloneCmd = &cobra.Command{
 			DieErr(err)
 		}
 		sigCtx := localHandleSyncInterrupt(ctx, idx, string(cloneOperation))
-		s := local.NewSyncManager(sigCtx, client, syncFlags.parallelism, syncFlags.presign)
+		s := local.NewSyncManager(sigCtx, client, syncFlags)
 		err = s.Sync(localPath, stableRemote, ch)
 		if err != nil {
 			DieErr(err)
@@ -106,6 +106,6 @@ var localCloneCmd = &cobra.Command{
 //nolint:gochecknoinits
 func init() {
 	withGitIgnoreFlag(localCloneCmd)
-	withLocalSyncFlags(localCloneCmd)
+	withSyncFlags(localCloneCmd)
 	localCmd.AddCommand(localCloneCmd)
 }

--- a/cmd/lakectl/cmd/local_commit.go
+++ b/cmd/lakectl/cmd/local_commit.go
@@ -36,7 +36,7 @@ var localCommitCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getClient()
 		_, localPath := getSyncArgs(args, false, false)
-		syncFlags := getLocalSyncFlags(cmd, client)
+		syncFlags := getSyncFlags(cmd, client)
 		message := Must(cmd.Flags().GetString(localCommitMessageFlagName))
 		allowEmptyMessage := Must(cmd.Flags().GetBool(localCommitAllowEmptyMessage))
 		if message == "" && !allowEmptyMessage {
@@ -119,7 +119,7 @@ var localCommitCmd = &cobra.Command{
 			}
 		}()
 		sigCtx := localHandleSyncInterrupt(cmd.Context(), idx, string(commitOperation))
-		s := local.NewSyncManager(sigCtx, client, syncFlags.parallelism, syncFlags.presign)
+		s := local.NewSyncManager(sigCtx, client, syncFlags)
 		err = s.Sync(idx.LocalPath(), remote, c)
 		if err != nil {
 			DieErr(err)
@@ -187,6 +187,6 @@ func init() {
 	localCommitCmd.Flags().Bool(localCommitAllowEmptyMessage, false, "Allow commit with empty message")
 	localCommitCmd.MarkFlagsMutuallyExclusive(localCommitMessageFlagName, localCommitAllowEmptyMessage)
 	localCommitCmd.Flags().StringSlice(metaFlagName, []string{}, "key value pair in the form of key=value")
-	withLocalSyncFlags(localCommitCmd)
+	withSyncFlags(localCommitCmd)
 	localCmd.AddCommand(localCommitCmd)
 }

--- a/cmd/lakectl/cmd/local_pull.go
+++ b/cmd/lakectl/cmd/local_pull.go
@@ -20,7 +20,7 @@ var localPullCmd = &cobra.Command{
 		client := getClient()
 		_, localPath := getSyncArgs(args, false, false)
 		force := Must(cmd.Flags().GetBool(localForceFlagName))
-		syncFlags := getLocalSyncFlags(cmd, client)
+		syncFlags := getSyncFlags(cmd, client)
 		idx, err := local.ReadIndex(localPath)
 		if err != nil {
 			DieErr(err)
@@ -66,7 +66,7 @@ var localPullCmd = &cobra.Command{
 			return nil
 		})
 		sigCtx := localHandleSyncInterrupt(cmd.Context(), idx, string(pullOperation))
-		s := local.NewSyncManager(sigCtx, client, syncFlags.parallelism, syncFlags.presign)
+		s := local.NewSyncManager(sigCtx, client, syncFlags)
 		err = s.Sync(idx.LocalPath(), newBase, c)
 		if err != nil {
 			DieErr(err)
@@ -89,6 +89,6 @@ var localPullCmd = &cobra.Command{
 //nolint:gochecknoinits
 func init() {
 	withForceFlag(localPullCmd, "Reset any uncommitted local change")
-	withLocalSyncFlags(localPullCmd)
+	withSyncFlags(localPullCmd)
 	localCmd.AddCommand(localPullCmd)
 }

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2113,7 +2113,7 @@ lakectl fs cat <path uri> [flags]
 
 ```
   -h, --help       help for cat
-      --pre-sign   Use pre-sign link to access the data
+      --pre-sign   Use pre-signed URLs when downloading/uploading data (recommended) (default true)
 ```
 
 
@@ -2132,7 +2132,8 @@ lakectl fs download <path uri> [<destination path>] [flags]
 ```
   -h, --help              help for download
   -p, --parallelism int   Max concurrent operations to perform (default 25)
-      --pre-sign          Use pre-sign link to access the data
+      --pre-sign          Use pre-signed URLs when downloading/uploading data (recommended) (default true)
+  -r, --recursive         recursively download all objects under path
 ```
 
 
@@ -2173,7 +2174,7 @@ lakectl fs ls <path uri> [flags]
 
 ```
   -h, --help        help for ls
-      --recursive   list all objects under the specified prefix
+  -r, --recursive   list all objects under the specified path
 ```
 
 
@@ -2242,7 +2243,7 @@ lakectl fs stat <path uri> [flags]
 
 ```
   -h, --help       help for stat
-      --pre-sign   Request pre-sign for physical address
+      --pre-sign   Use pre-signed URLs when downloading/uploading data (recommended) (default true)
 ```
 
 
@@ -2262,7 +2263,8 @@ lakectl fs upload <path uri> [flags]
       --content-type string   MIME type of contents
   -h, --help                  help for upload
   -p, --parallelism int       Max concurrent operations to perform (default 25)
-      --pre-sign              Use pre-sign link to access the data
+      --pre-sign              Use pre-signed URLs when downloading/uploading data (recommended) (default true)
+  -r, --recursive             recursively copy all files under local source
   -s, --source string         local file to upload, or "-" for stdin
 ```
 

--- a/esti/lakectl_local_test.go
+++ b/esti/lakectl_local_test.go
@@ -1,6 +1,7 @@
 package esti
 
 import (
+	"context"
 	"fmt"
 	"io/fs"
 	"os"
@@ -200,8 +201,9 @@ func TestLakectlLocal_clone(t *testing.T) {
 		require.NoError(t, err)
 		vars["PREFIX"] = "dir_marker/"
 		vars["LOCAL_DIR"] = dataDir
-		localCreateTestData(t, vars, []string{vars["PREFIX"]})
+		_, err = uploadContent(context.Background(), vars["REPO"], vars["BRANCH"], vars["PREFIX"], "")
 		require.NoError(t, err)
+		runCmd(t, Lakectl()+" commit lakefs://"+vars["REPO"]+"/"+vars["BRANCH"]+" --allow-empty-message -m \" \"", false, false, vars)
 		RunCmdAndVerifyContainsText(t, Lakectl()+" local clone lakefs://"+repoName+"/"+mainBranch+"/"+vars["PREFIX"]+" "+dataDir, false, "Successfully cloned lakefs://${REPO}/${REF}/${PREFIX} to ${LOCAL_DIR}.", vars)
 
 		relPath, err := filepath.Rel(tmpDir, dataDir)

--- a/pkg/diff/diff.go
+++ b/pkg/diff/diff.go
@@ -37,7 +37,7 @@ func StreamRepositoryDiffs(ctx context.Context, client apigen.ClientWithResponse
 			return err
 		}
 		if diffResp.HTTPResponse.StatusCode != http.StatusOK {
-			return fmt.Errorf("HTTP %d: %w", diffResp.StatusCode(), local.ErrRemoteDiffFailed)
+			return fmt.Errorf("diff remote failed. HTTP %d: %w", diffResp.StatusCode(), local.ErrRemoteFailure)
 		}
 
 		for _, d := range diffResp.JSON200.Results {

--- a/pkg/local/diff.go
+++ b/pkg/local/diff.go
@@ -195,6 +195,9 @@ func DiffLocalWithHead(left <-chan apigen.ObjectStats, rightPath string) (Change
 		hasMore           bool
 	)
 	err := filepath.Walk(rightPath, func(path string, info fs.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
 		if info.IsDir() || diffShouldIgnore(info.Name()) {
 			return nil
 		}
@@ -267,7 +270,7 @@ func ListRemote(ctx context.Context, client apigen.ClientWithResponsesInterface,
 		}
 
 		if listResp.HTTPResponse.StatusCode != http.StatusOK {
-			return fmt.Errorf("HTTP %d: %w", listResp.StatusCode(), ErrRemoteDiffFailed)
+			return fmt.Errorf("list remote failed. HTTP %d: %w", listResp.StatusCode(), ErrRemoteFailure)
 		}
 		for _, o := range listResp.JSON200.Results {
 			path := strings.TrimPrefix(o.Path, loc.GetPath())

--- a/pkg/local/errors.go
+++ b/pkg/local/errors.go
@@ -3,7 +3,7 @@ package local
 import "errors"
 
 var (
-	ErrConflict         = errors.New("conflict")
-	ErrDownloadingFile  = errors.New("error downloading file")
-	ErrRemoteDiffFailed = errors.New("remote diff failed")
+	ErrConflict        = errors.New("conflict")
+	ErrDownloadingFile = errors.New("error downloading file")
+	ErrRemoteFailure   = errors.New("remote failure")
 )


### PR DESCRIPTION
Closes #6762
## Change Description

### Background

Reintroduce recursive flag for fs upload/download to align with aws cli conventions and rest of fs commands
      
### New Feature

Changes in addition:

- Refactor sync flags for lakectl
- Align pre-sign default value to true on fs commands (when flag is not set - it checks capability with the server)


### Testing Details

Added and modified esti tests

### Breaking Change?

Change will require setting recursive flag for recursive operations (multiple files).
pre-sign mode is now enabled by default if server provides functionality
