### PR TITLE
Fix new Python SDK upload_object non file content

### DIFF
--- a/clients/python/lakefs_sdk/client.py
+++ b/clients/python/lakefs_sdk/client.py
@@ -46,7 +46,7 @@ class _WrappedApiClient(ApiClient):
                 if type(file_name) is str:
                     files_to_read[key] = file_name
                 else:
-                    name = f'{key}{idx}'
+                    name = f'{key}_{idx}'
                     mimetype = 'application/octet-stream'
                     params.append(tuple([key, tuple([name, value, mimetype])]))
 

--- a/clients/python/lakefs_sdk/client.py
+++ b/clients/python/lakefs_sdk/client.py
@@ -22,20 +22,37 @@ from lakefs_sdk.api import tags_api
 class _WrappedApiClient(ApiClient):
     """ApiClient that fixes some weirdness"""
 
-    # Wrap files_parameters to work with unnamed "files" (e.g. MemIOs).
     def files_parameters(self, files=None):
-        if files is not None:
-            for (param_name, file_instances) in files.items():
-                i = 0
-                if file_instances is None:
-                    continue
-                for file_instance in file_instances:
-                    if file_instance is not None and not hasattr(file_instance, 'name'):
-                        # Generate a fake name.
-                        i += 1
-                        file_instance.name = f'{param_name}{i}'
-        return super().files_parameters(files)
+        """
+        Transforms input file data into a formatted list and combines it with superclass file parameters.
+        In case file_name is a string we assume that it is a path to the file that needs to be read.
+        In case file_name is bytes we assume that it is a file-like object that we append the information.
+        The parent class will handle the files to read.
+        """
+        if not files:
+            return []
 
+        params = []
+        files_to_read = {}
+        item_index = 0
+
+        for key, value in files.items():
+            if not value:
+                continue
+
+            # Ensure the value is always a list.
+            file_names = value if isinstance(value, list) else [value]
+
+            for file_name in file_names:
+                if type(file_name) is str:
+                    files_to_read[k] = file_name
+                else:
+                    item_index += 1
+                    name = f'{k}{item_index}'
+                    mimetype = 'application/octet-stream'
+                    params.append(tuple([k, tuple([name, value, mimetype])]))
+
+        return super().files_parameters(files_to_read) + params
 
 class LakeFSClient:
     def __init__(self, configuration=None, header_name=None, header_value=None, cookie=None, pool_threads=1):

--- a/clients/python/lakefs_sdk/client.py
+++ b/clients/python/lakefs_sdk/client.py
@@ -24,9 +24,9 @@ class _WrappedApiClient(ApiClient):
 
     def files_parameters(self, files=None):
         """
-        Transforms input file data into a formatted list and combines it with superclass file parameters.
-        In case file_name is a string we assume that it is a path to the file that needs to be read.
-        In case file_name is bytes we assume that it is a file-like object that we append the information.
+        Transforms input file data into a formatted list to return file_parameters.
+        Assume a string file_name is a path to the file to read.
+        Assume a bytes file_name is a file-like object that we append the information.
         The parent class will handle the files to read.
         """
         if not files:
@@ -34,9 +34,8 @@ class _WrappedApiClient(ApiClient):
 
         params = []
         files_to_read = {}
-        item_index = 0
 
-        for key, value in files.items():
+        for idx, (key, value) in enumerate(files.items()):
             if not value:
                 continue
 
@@ -47,8 +46,7 @@ class _WrappedApiClient(ApiClient):
                 if type(file_name) is str:
                     files_to_read[key] = file_name
                 else:
-                    item_index += 1
-                    name = f'{key}{item_index}'
+                    name = f'{key}{idx}'
                     mimetype = 'application/octet-stream'
                     params.append(tuple([key, tuple([name, value, mimetype])]))
 

--- a/clients/python/lakefs_sdk/client.py
+++ b/clients/python/lakefs_sdk/client.py
@@ -45,12 +45,12 @@ class _WrappedApiClient(ApiClient):
 
             for file_name in file_names:
                 if type(file_name) is str:
-                    files_to_read[k] = file_name
+                    files_to_read[key] = file_name
                 else:
                     item_index += 1
-                    name = f'{k}{item_index}'
+                    name = f'{key}{item_index}'
                     mimetype = 'application/octet-stream'
-                    params.append(tuple([k, tuple([name, value, mimetype])]))
+                    params.append(tuple([key, tuple([name, value, mimetype])]))
 
         return super().files_parameters(files_to_read) + params
 

--- a/clients/python/templates/client.mustache
+++ b/clients/python/templates/client.mustache
@@ -14,9 +14,9 @@ class _WrappedApiClient(ApiClient):
 
     def files_parameters(self, files=None):
         """
-        Transforms input file data into a formatted list and combines it with superclass file parameters.
-        In case file_name is a string we assume that it is a path to the file that needs to be read.
-        In case file_name is bytes we assume that it is a file-like object that we append the information.
+        Transforms input file data into a formatted list to return file_parameters.
+        Assume a string file_name is a path to the file to read.
+        Assume a bytes file_name is a file-like object that we append the information.
         The parent class will handle the files to read.
         """
         if not files:

--- a/clients/python/templates/client.mustache
+++ b/clients/python/templates/client.mustache
@@ -35,12 +35,12 @@ class _WrappedApiClient(ApiClient):
 
             for file_name in file_names:
                 if type(file_name) is str:
-                    files_to_read[k] = file_name
+                    files_to_read[key] = file_name
                 else:
                     item_index += 1
-                    name = f'{k}{item_index}'
+                    name = f'{key}{item_index}'
                     mimetype = 'application/octet-stream'
-                    params.append(tuple([k, tuple([name, value, mimetype])]))
+                    params.append(tuple([key, tuple([name, value, mimetype])]))
 
         return super().files_parameters(files_to_read) + params
 

--- a/clients/python/templates/client.mustache
+++ b/clients/python/templates/client.mustache
@@ -12,20 +12,37 @@ from {{apiPackage}} import {{classFilename}}
 class _WrappedApiClient(ApiClient):
     """ApiClient that fixes some weirdness"""
 
-    # Wrap files_parameters to work with unnamed "files" (e.g. MemIOs).
     def files_parameters(self, files=None):
-        if files is not None:
-            for (param_name, file_instances) in files.items():
-                i = 0
-                if file_instances is None:
-                    continue
-                for file_instance in file_instances:
-                    if file_instance is not None and not hasattr(file_instance, 'name'):
-                        # Generate a fake name.
-                        i += 1
-                        file_instance.name = f'{param_name}{i}'
-        return super().files_parameters(files)
+        """
+        Transforms input file data into a formatted list and combines it with superclass file parameters.
+        In case file_name is a string we assume that it is a path to the file that needs to be read.
+        In case file_name is bytes we assume that it is a file-like object that we append the information.
+        The parent class will handle the files to read.
+        """
+        if not files:
+            return []
 
+        params = []
+        files_to_read = {}
+        item_index = 0
+
+        for key, value in files.items():
+            if not value:
+                continue
+
+            # Ensure the value is always a list.
+            file_names = value if isinstance(value, list) else [value]
+
+            for file_name in file_names:
+                if type(file_name) is str:
+                    files_to_read[k] = file_name
+                else:
+                    item_index += 1
+                    name = f'{k}{item_index}'
+                    mimetype = 'application/octet-stream'
+                    params.append(tuple([k, tuple([name, value, mimetype])]))
+
+        return super().files_parameters(files_to_read) + params
 
 class LakeFSClient:
     def __init__(self, configuration=None, header_name=None, header_value=None, cookie=None, pool_threads=1):

--- a/clients/python/templates/client.mustache
+++ b/clients/python/templates/client.mustache
@@ -24,9 +24,8 @@ class _WrappedApiClient(ApiClient):
 
         params = []
         files_to_read = {}
-        item_index = 0
 
-        for key, value in files.items():
+        for idx, (key, value) in enumerate(files.items()):
             if not value:
                 continue
 
@@ -37,8 +36,7 @@ class _WrappedApiClient(ApiClient):
                 if type(file_name) is str:
                     files_to_read[key] = file_name
                 else:
-                    item_index += 1
-                    name = f'{key}{item_index}'
+                    name = f'{key}{idx}'
                     mimetype = 'application/octet-stream'
                     params.append(tuple([key, tuple([name, value, mimetype])]))
 

--- a/clients/python/templates/client.mustache
+++ b/clients/python/templates/client.mustache
@@ -36,7 +36,7 @@ class _WrappedApiClient(ApiClient):
                 if type(file_name) is str:
                     files_to_read[key] = file_name
                 else:
-                    name = f'{key}{idx}'
+                    name = f'{key}_{idx}'
                     mimetype = 'application/octet-stream'
                     params.append(tuple([key, tuple([name, value, mimetype])]))
 


### PR DESCRIPTION
This pull request re-implements the previous SDK solution for bytes content, as the new API only handles files (passing filenames).

This change adjust the previous solution we had in the previous SDK by override the `files_parameters` generated method and handle files as content and not as file names that needs to be read.

This solution doesn't not support any readable content as the generated signature limits `content` parameter to be a string or bytes.

Close https://github.com/treeverse/lakeFS/issues/6795