### PR TITLE
Fix gateway error for no underlying object

### DIFF
--- a/esti/main_test.go
+++ b/esti/main_test.go
@@ -45,11 +45,6 @@ var (
 	policiesToKeep     arrayFlags
 )
 
-var (
-	azureStorageAccount   string
-	azureStorageAccessKey string
-)
-
 func (bs *Booleans) String() string {
 	ret := make([]string, len(*bs))
 	for i, b := range *bs {
@@ -275,9 +270,6 @@ func TestMain(m *testing.M) {
 	}
 
 	logger, client, svc, endpointURL = testutil.SetupTestingEnv(&params)
-
-	azureStorageAccount = viper.GetString("azure_storage_account")
-	azureStorageAccessKey = viper.GetString("azure_storage_access_key")
 
 	setupLakeFS := viper.GetBool("setup_lakefs")
 	if !setupLakeFS && *cleanupEnv {

--- a/pkg/gateway/operations/getobject.go
+++ b/pkg/gateway/operations/getobject.go
@@ -100,7 +100,11 @@ func (controller *GetObject) Handle(w http.ResponseWriter, req *http.Request, o 
 		data, err = o.BlockStore.GetRange(ctx, objectPointer, rng.StartOffset, rng.EndOffset)
 	}
 	if err != nil {
-		_ = o.EncodeError(w, req, err, gatewayerrors.Codes.ToAPIErr(gatewayerrors.ErrInternalError))
+		code := gatewayerrors.ErrInternalError
+		if errors.Is(err, block.ErrDataNotFound) {
+			code = gatewayerrors.ErrNoSuchVersion
+		}
+		_ = o.EncodeError(w, req, err, gatewayerrors.Codes.ToAPIErr(code))
 		return
 	}
 


### PR DESCRIPTION
S3 gateway will return NoSuchVersion error instead of internal error when the actual object not found in the underlying object store.

Close https://github.com/treeverse/lakeFS/issues/6718