### PR TITLE
Add latest hadoopfs (lakefsfs) to compatibility test

### DIFF
--- a/.github/workflows/compatibility-tests.yaml
+++ b/.github/workflows/compatibility-tests.yaml
@@ -197,7 +197,7 @@ jobs:
       matrix:
         # Removing a version from this list means the current lakeFS is no longer compatible with
         # that Hadoop lakeFS client version.
-        client_version: [ 0.1.10, 0.1.11, 0.1.12, 0.1.13, 0.1.14, 0.1.15 ]
+        client_version: [ 0.1.10, 0.1.11, 0.1.12, 0.1.13, 0.1.14, 0.1.15, 0.2.1 ]
     runs-on: ubuntu-20.04
     env:
       CLIENT_VERSION: ${{ matrix.client_version }}


### PR DESCRIPTION
Add v0.2.1 to the hadoop fs compatibility test