### PR TITLE
Add HealthCheckRequired config param to Auth API

### DIFF
--- a/cmd/lakefs/cmd/run.go
+++ b/cmd/lakefs/cmd/run.go
@@ -129,11 +129,10 @@ var runCmd = &cobra.Command{
 				logger.WithError(err).Fatal("failed to create authentication service")
 			}
 			authService = apiService
-			if err := apiService.CheckHealth(ctx, logger, cfg.Auth.API.HealthCheckTimeout); err != nil {
-				if cfg.Auth.API.HealthCheckRequired {
+			if !cfg.Auth.API.SkipHealthCheck {
+				if err := apiService.CheckHealth(ctx, logger, cfg.Auth.API.HealthCheckTimeout); err != nil {
 					logger.WithError(err).Fatal("Auth API health check failed")
 				}
-				logger.WithError(err).Errorf("Auth API health check failed")
 			}
 		} else {
 			authService = auth.NewAuthService(

--- a/cmd/lakefs/cmd/run.go
+++ b/cmd/lakefs/cmd/run.go
@@ -130,7 +130,10 @@ var runCmd = &cobra.Command{
 			}
 			authService = apiService
 			if err := apiService.CheckHealth(ctx, logger, cfg.Auth.API.HealthCheckTimeout); err != nil {
-				logger.WithError(err).Fatal("Auth API health check failed")
+				if cfg.Auth.API.HealthCheckRequired {
+					logger.WithError(err).Fatal("Auth API health check failed")
+				}
+				logger.WithError(err).Errorf("Auth API health check failed")
 			}
 		} else {
 			authService = auth.NewAuthService(

--- a/pkg/auth/service.go
+++ b/pkg/auth/service.go
@@ -1877,7 +1877,7 @@ func (a *APIAuthService) ClaimTokenIDOnce(ctx context.Context, tokenID string, e
 }
 
 func (a *APIAuthService) CheckHealth(ctx context.Context, logger logging.Logger, timeout time.Duration) error {
-	// Perform health check for API auth service
+	logger.Info("perform health check, this can take up to ", timeout)
 	bo := backoff.NewExponentialBackOff()
 	bo.MaxInterval = healthCheckMaxInterval
 	bo.InitialInterval = healthCheckInitialInterval

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -195,10 +195,11 @@ type Config struct {
 			SecretKey SecureString `mapstructure:"secret_key" validate:"required"`
 		} `mapstructure:"encrypt"`
 		API struct {
-			Endpoint           string        `mapstructure:"endpoint"`
-			Token              SecureString  `mapstructure:"token"`
-			SupportsInvites    bool          `mapstructure:"supports_invites"`
-			HealthCheckTimeout time.Duration `mapstructure:"health_check_timeout"`
+			Endpoint            string        `mapstructure:"endpoint"`
+			Token               SecureString  `mapstructure:"token"`
+			SupportsInvites     bool          `mapstructure:"supports_invites"`
+			HealthCheckTimeout  time.Duration `mapstructure:"health_check_timeout"`
+			HealthCheckRequired bool          `mapstructure:"health_check_required"`
 		} `mapstructure:"api"`
 		RemoteAuthenticator struct {
 			// Enabled if set true will enable remote authentication

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -195,11 +195,11 @@ type Config struct {
 			SecretKey SecureString `mapstructure:"secret_key" validate:"required"`
 		} `mapstructure:"encrypt"`
 		API struct {
-			Endpoint            string        `mapstructure:"endpoint"`
-			Token               SecureString  `mapstructure:"token"`
-			SupportsInvites     bool          `mapstructure:"supports_invites"`
-			HealthCheckTimeout  time.Duration `mapstructure:"health_check_timeout"`
-			HealthCheckRequired bool          `mapstructure:"health_check_required"`
+			Endpoint           string        `mapstructure:"endpoint"`
+			Token              SecureString  `mapstructure:"token"`
+			SupportsInvites    bool          `mapstructure:"supports_invites"`
+			HealthCheckTimeout time.Duration `mapstructure:"health_check_timeout"`
+			SkipHealthCheck    bool          `mapstructure:"skip_health_check"`
 		} `mapstructure:"api"`
 		RemoteAuthenticator struct {
 			// Enabled if set true will enable remote authentication

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -62,7 +62,6 @@ func setDefaults(cfgType string) {
 	viper.SetDefault("auth.remote_authenticator.request_timeout", 10*time.Second)
 
 	viper.SetDefault("auth.api.health_check_timeout", DefaultAuthAPIHealthCheckTimeout)
-	viper.SetDefault("auth.api.health_check_required", true)
 
 	viper.SetDefault("blockstore.local.path", "~/lakefs/data/block")
 	viper.SetDefault("blockstore.s3.region", "us-east-1")

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -62,6 +62,7 @@ func setDefaults(cfgType string) {
 	viper.SetDefault("auth.remote_authenticator.request_timeout", 10*time.Second)
 
 	viper.SetDefault("auth.api.health_check_timeout", DefaultAuthAPIHealthCheckTimeout)
+	viper.SetDefault("auth.api.health_check_required", true)
 
 	viper.SetDefault("blockstore.local.path", "~/lakefs/data/block")
 	viper.SetDefault("blockstore.s3.region", "us-east-1")


### PR DESCRIPTION
Closes #6866

## Change Description

### Background

Add option to not fail during lakeFS init if Auth API health check fails

