### PR TITLE
UI: Allow commit message and metadata in merge action

### DIFF
--- a/webui/src/lib/api/index.js
+++ b/webui/src/lib/api/index.js
@@ -790,10 +790,10 @@ class Refs {
         return response.json();
     }
 
-    async merge(repoId, sourceBranch, destinationBranch, strategy = "") {
+    async merge(repoId, sourceBranch, destinationBranch, strategy = "", message = "", metadata = {}) {
         const response = await apiRequest(`/repositories/${encodeURIComponent(repoId)}/refs/${encodeURIComponent(sourceBranch)}/merge/${encodeURIComponent(destinationBranch)}`, {
             method: 'POST',
-            body: JSON.stringify({strategy})
+            body: JSON.stringify({strategy, message, metadata})
         });
 
         let resp;


### PR DESCRIPTION
Closes #6895
## Change Description

### Background

Allow adding commit message and metadata when merging from UI

Enhance functionality in UI

### Testing Details

Tested manually, verified:
1. Merge works with empty commit message and metadata
2. Commit message and metadata exists when explicitly adding them in merge

How it looks:

![image](https://github.com/treeverse/lakeFS/assets/3787958/3d00f87e-263b-4984-b25c-9d53523285ce)

