### PR TITLE
External auth remove required id from user model

### DIFF
--- a/.github/workflows/openapi-breaking-changes.yaml
+++ b/.github/workflows/openapi-breaking-changes.yaml
@@ -20,7 +20,6 @@ jobs:
           path: 'changed'
           sparse-checkout: |
             api/swagger.yml
-            api/authorization.yml
           sparse-checkout-cone-mode: false
       - name: Check-out base code
         uses: actions/checkout@v4
@@ -29,7 +28,6 @@ jobs:
           path: 'base'
           sparse-checkout: |
             api/swagger.yml
-            api/authorization.yml
           sparse-checkout-cone-mode: false
       - name: Check lakeFS swagger YAML
         id: test_swagger_breaking_changes
@@ -37,11 +35,4 @@ jobs:
         with:
           base: base/api/swagger.yml
           revision: changed/api/swagger.yml
-          fail-on-diff: true
-      - name: Check authorization YAML
-        id: test_authorization_breaking_changes
-        uses: oasdiff/oasdiff-action/breaking@main
-        with:
-          base: base/api/authorization.yml
-          revision: changed/api/authorization.yml
           fail-on-diff: true

--- a/api/authorization.yml
+++ b/api/authorization.yml
@@ -129,7 +129,7 @@ components:
       properties:
         username:
           type: string
-          description: a unique identifier for the user. In password-based authentication, this is the email.
+          description: a unique identifier for the user
         creation_date:
           type: integer
           format: int64

--- a/api/authorization.yml
+++ b/api/authorization.yml
@@ -122,15 +122,11 @@ components:
     User:
       type: object
       required:
-        - id
         - name
         - username
         - creation_date
         - encryptedPassword
       properties:
-        id:
-          type: integer
-          format: int64
         username:
           type: string
           description: a unique identifier for the user. In password-based authentication, this is the email.

--- a/pkg/auth/service.go
+++ b/pkg/auth/service.go
@@ -1189,7 +1189,7 @@ func (a *APIAuthService) CreateUser(ctx context.Context, user *model.User) (stri
 		return InvalidUserID, err
 	}
 
-	return fmt.Sprint(resp.JSON201.Id), nil
+	return resp.JSON201.Username, nil
 }
 
 func (a *APIAuthService) DeleteUser(ctx context.Context, username string) error {

--- a/pkg/auth/service_test.go
+++ b/pkg/auth/service_test.go
@@ -214,7 +214,7 @@ func TestAuthService_DeleteUserWithRelations(t *testing.T) {
 	ctx := context.Background()
 	authService, _ := authtestutil.SetupService(t, ctx, someSecret)
 
-	// create initial data set and verify users groups and policies are create and related as expected
+	// create initial data set and verify users groups and policies are created and related as expected
 	createInitialDataSet(t, ctx, authService, userNames, groupNames, policyNames)
 	users, _, err := authService.ListUsers(ctx, &model.PaginationParams{Amount: 100})
 	require.NoError(t, err)
@@ -366,7 +366,7 @@ func TestAuthService_DeletePoliciesWithRelations(t *testing.T) {
 	ctx := context.Background()
 	authService, _ := authtestutil.SetupService(t, ctx, someSecret)
 
-	// create initial data set and verify users groups and policies are create and related as expected
+	// create initial data set and verify users groups and policies are created and related as expected
 	createInitialDataSet(t, ctx, authService, userNames, groupNames, policyNames)
 	policies, _, err := authService.ListPolicies(ctx, &model.PaginationParams{Amount: 100})
 	require.NoError(t, err)
@@ -397,7 +397,7 @@ func TestAuthService_DeletePoliciesWithRelations(t *testing.T) {
 		require.Equal(t, len(policyNames), len(policies))
 	}
 
-	// delete a user policy (beginning of the names list)
+	// delete a user policy (beginning of the name list)
 	err = authService.DeletePolicy(ctx, policyNames[0])
 	require.NoError(t, err)
 
@@ -486,8 +486,8 @@ func TestAuthService_DeletePoliciesWithRelations(t *testing.T) {
 
 // createInitialDataSet -
 // Creates K users with 2 credentials each, L groups and M policies
-// Adds all users to all groups
-// Attaches M/2 of the policies to all K users and the other M-M/2 policies to all L groups
+// Add all users to all groups
+// Attach M/2 of the policies to all K users and the other M-M/2 policies to all L groups
 func createInitialDataSet(t *testing.T, ctx context.Context, svc auth.Service, userNames, groupNames, policyNames []string) {
 	for _, userName := range userNames {
 		if _, err := svc.CreateUser(ctx, &model.User{Username: userName}); err != nil {
@@ -592,7 +592,7 @@ func TestACL(t *testing.T) {
 		// Name is an identifier for this test case.
 		Name string
 		// ACL is the ACL to test.  ACL.Permission will be tested
-		// with each of hierarchy.
+		// with each of the hierarchies.
 		ACL model.ACL
 		// PermissionFrom holds permissions that must hold starting
 		// at the ACLPermission key in the hierarchy.
@@ -823,14 +823,12 @@ func TestAuthApiGetUserCache(t *testing.T) {
 	ctx := context.Background()
 	mockClient, s := NewTestApiService(t, true)
 	const userID = "123"
-	const uid = int64(123)
 
 	const username = "foo"
 	userMail := "foo@test.com"
 	externalId := "1234"
 	userResult := auth.User{
 		Username:   username,
-		Id:         uid,
 		Email:      &userMail,
 		ExternalId: &externalId,
 	}
@@ -917,7 +915,6 @@ func TestAPIAuthService_CreateUser(t *testing.T) {
 		friendlyName       string
 		source             string
 		responseStatusCode int
-		responseID         int64
 		expectedResponseID string
 		expectedErr        error
 	}{
@@ -927,9 +924,8 @@ func TestAPIAuthService_CreateUser(t *testing.T) {
 			email:              "foo@gmail.com",
 			friendlyName:       "friendly foo",
 			source:             "internal",
-			responseID:         1,
 			responseStatusCode: http.StatusCreated,
-			expectedResponseID: "1",
+			expectedResponseID: "foo",
 			expectedErr:        nil,
 		},
 		{
@@ -969,7 +965,7 @@ func TestAPIAuthService_CreateUser(t *testing.T) {
 					StatusCode: tt.responseStatusCode,
 				},
 				JSON201: &auth.User{
-					Id: tt.responseID,
+					Username: tt.userName,
 				},
 			}
 			mockClient.EXPECT().CreateUserWithResponse(gomock.Any(), auth.CreateUserJSONRequestBody{


### PR DESCRIPTION
Removing the user ID, internal identifier from the user model.
Until now this ID was returned from extenral auth CreateUser call.
The ID is ignored as all the code assume that the unique identifier for user is the Username field and not internal ID representation.

Close https://github.com/treeverse/lakeFS/issues/6926
