### PR TITLE
Fix lakectl local git regex

### DIFF
--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -22,7 +22,7 @@ const (
 )
 
 var (
-	RemoteRegex     = regexp.MustCompile(`(?P<server>[\w.:]+)[/:](?P<owner>[\w.]+)/(?P<project>[\w.]+)\.git$`)
+	RemoteRegex     = regexp.MustCompile(`(?P<server>[\w.:]+)[/:](?P<owner>[\w.-]+)/(?P<project>[\w.-]+)\.git$`)
 	CommitTemplates = map[string]string{
 		"github.com":    "https://github.com/{{ .Owner }}/{{ .Project }}/commit/{{ .Ref }}",
 		"gitlab.com":    "https://gitlab.com/{{ .Owner }}/{{ .Project }}/-/commit/{{ .Ref }}",

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -215,6 +215,14 @@ func TestParseURL(t *testing.T) {
 			},
 		},
 		{
+			Url: "git://git@github.com:Hyphened-Owner/Hyphened-Project.git",
+			ExpectedUrl: &git.URL{
+				Server:  "github.com",
+				Owner:   "Hyphened-Owner",
+				Project: "Hyphened-Project",
+			},
+		},
+		{
 			Url:         "bad_url",
 			ExpectedUrl: nil,
 		},


### PR DESCRIPTION
Closes #6906

## Change Description

### Bug Fix

regex was missing capturing owner and project names which included hyphens. As result the UI button linking to the repository will not be added to the commit after a local commit command

### Testing Details

Added relevant unit test case
