### PR TITLE
Lakefs was crashing when using database.type=”dynamodb”  and using

### DIFF
--- a/pkg/kv/dynamodb/store.go
+++ b/pkg/kv/dynamodb/store.go
@@ -474,13 +474,9 @@ func (e *EntriesIterator) runQuery() {
 		e.err = fmt.Errorf("query: %w", err)
 		return
 	}
-
-	var ConsumedCapacity float64 = 0
-	if nil != queryResult.ConsumedCapacity {
-		ConsumedCapacity = *queryResult.ConsumedCapacity.CapacityUnits
+	if queryResult.ConsumedCapacity != nil {
+		dynamoConsumedCapacity.WithLabelValues(operation).Add(*queryResult.ConsumedCapacity.CapacityUnits)
 	}
-
-	dynamoConsumedCapacity.WithLabelValues(operation).Add(ConsumedCapacity)
 	e.queryResult = queryResult
 	e.currEntryIdx = 0
 }

--- a/pkg/kv/dynamodb/store.go
+++ b/pkg/kv/dynamodb/store.go
@@ -474,7 +474,13 @@ func (e *EntriesIterator) runQuery() {
 		e.err = fmt.Errorf("query: %w", err)
 		return
 	}
-	dynamoConsumedCapacity.WithLabelValues(operation).Add(*queryResult.ConsumedCapacity.CapacityUnits)
+
+	var ConsumedCapacity float64 = 0
+	if nil != queryResult.ConsumedCapacity {
+		ConsumedCapacity = *queryResult.ConsumedCapacity.CapacityUnits
+	}
+
+	dynamoConsumedCapacity.WithLabelValues(operation).Add(ConsumedCapacity)
 	e.queryResult = queryResult
 	e.currEntryIdx = 0
 }


### PR DESCRIPTION
using scylladb as a  database (scylladb provides dynamodb API  which can be enabled via alternator feature -
https://opensource.docs.scylladb.com/stable/alternator/alternator.html)

Apparently scylladb does not fully follow the spec and does not return ConsumedCapacity. Adding check for nil pointer to avoid crashes in lakefs.

Closes #(6923)
https://github.com/treeverse/lakeFS/issues/6923

## Change Description
simply checking for nil pointer to avoid crash 

### Background
Running scylladb locally with dynamodb api enabled via alternator feature (https://www.scylladb.com/alternator/)
Lakefs crashes in pkg/kv/dynamodb/store.go: 477 since it is getting nil pointer in queryResult.ConsumedCapacity

// dynamoConsumedCapacity.WithLabelValues(operation).Add(*queryResult.ConsumedCapacity.CapacityUnits)

database:
type: "dynamodb"
dynamodb:
table_name: "kvstore"
endpoint: "http://127.0.0.1:8777/"

Apparently scylladb did not fully follow the spec and returns nil in ConsumedCapacity but crashing is not a good option
Share context and relevant information for the PR: offline discussions, considerations, design decisions etc.

### Bug Fix

If this PR is a bug fix, please let us know about:

1. Problem - The reason for opening the bug
2. Root cause - Discovered root cause after investigation
3. Solution - How the bug was fixed
      
### New Feature

If this PR introduces a new feature, describe it here.

### Testing Details

How were the changes tested?
compiled lakefs from changed srcs and tested against scylldb with dynamodb API enabled  (local scylladb cluster).
Did sanity test -  all works as expected   

### Breaking Change?
Nope 
Does this change break any existing functionality? (API, CLI, Clients)

## Additional info

Logs, outputs, screenshots of changes if applicable (CLI / GUI changes)

### Contact Details

alexey@shvechkov.com

How can we get in touch with you if we need more info? (ex. email@example.com)
