### PR TITLE
Log time.Duration _twice_ in all modes, as string and as nanoseconds

### DIFF
--- a/cmd/lakectl/cmd/root.go
+++ b/cmd/lakectl/cmd/root.go
@@ -267,7 +267,10 @@ var rootCmd = &cobra.Command{
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		logging.SetLevel(logLevel)
 		logging.SetOutputFormat(logFormat)
-		logging.SetOutputs(logOutputs, 0, 0)
+		err := logging.SetOutputs(logOutputs, 0, 0)
+		if err != nil {
+			DieFmt("Failed to setup logging: %s", err)
+		}
 		if noColorRequested {
 			DisableColors()
 		}

--- a/cmd/lakectl/cmd/root.go
+++ b/cmd/lakectl/cmd/root.go
@@ -293,7 +293,7 @@ var rootCmd = &cobra.Command{
 			DieFmt("error reading configuration file: %v", cfgErr)
 		}
 
-		err := viper.UnmarshalExact(&cfg, viper.DecodeHook(
+		err = viper.UnmarshalExact(&cfg, viper.DecodeHook(
 			mapstructure.ComposeDecodeHookFunc(
 				lakefsconfig.DecodeOnlyString,
 				mapstructure.StringToTimeDurationHookFunc())))

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -386,7 +386,10 @@ func newConfig(cfgType string) (*Config, error) {
 
 	// setup logging package
 	logging.SetOutputFormat(c.Logging.Format)
-	logging.SetOutputs(c.Logging.Output, c.Logging.FileMaxSizeMB, c.Logging.FilesKeep)
+	err = logging.SetOutputs(c.Logging.Output, c.Logging.FileMaxSizeMB, c.Logging.FilesKeep)
+	if err != nil {
+		return nil, err
+	}
 	logging.SetLevel(c.Logging.Level)
 	return c, nil
 }

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -245,7 +245,7 @@ var durationType = reflect.TypeOf(time.Duration(0))
 func (l *logrusEntryWrapper) WithFields(fields Fields) Logger {
 	var durationKeys []string
 	for key, value := range fields {
-		if reflect.TypeOf(value).AssignableTo(durationType) {
+		if value != nil && reflect.TypeOf(value).AssignableTo(durationType) {
 			durationKeys = append(durationKeys, key)
 		}
 	}

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -23,9 +23,6 @@ const (
 	ProjectDirectoryName = "lakefs"
 	ModuleName           = "github.com/treeverse/lakefs"
 
-	// durationNsecs is the suffix for the field holding a Duration as
-	// an int.
-	durationNsecs = "_nsecs"
 	// durationStr is the suffix for the field holding a Duration as a
 	// string.
 	durationStr = "_str"
@@ -252,8 +249,7 @@ func (l *logrusEntryWrapper) WithFields(fields Fields) Logger {
 
 	for _, key := range durationKeys {
 		duration := fields[key].(time.Duration)
-		delete(fields, key)
-		fields[key+durationNsecs] = duration.Nanoseconds()
+		fields[key] = duration.Nanoseconds()
 		fields[key+durationStr] = duration.String()
 	}
 

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -121,9 +121,11 @@ func CloseWriters() error {
 	return nil
 }
 
-func SetOutputs(outputs []string, fileMaxSizeMB, filesKeep int) {
+func SetOutputs(outputs []string, fileMaxSizeMB, filesKeep int) error {
 	var writers []io.Writer
-	CloseWriters()
+	if err := CloseWriters(); err != nil {
+		return fmt.Errorf("close previous log writers: %w", err)
+	}
 	for _, output := range outputs {
 		var w io.Writer
 		switch output {
@@ -149,6 +151,7 @@ func SetOutputs(outputs []string, fileMaxSizeMB, filesKeep int) {
 	} else if len(writers) > 1 {
 		defaultLogger.SetOutput(io.MultiWriter(writers...))
 	}
+	return nil
 }
 
 type OutputFormatOptions struct {

--- a/pkg/logging/logger_test.go
+++ b/pkg/logging/logger_test.go
@@ -13,21 +13,30 @@ import (
 func TestSetOutputs(t *testing.T) {
 	t.Run("default", func(t *testing.T) {
 		currentOut := defaultLogger.Out
-		SetOutputs(nil, 0, 0)
+		err := SetOutputs(nil, 0, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
 		if defaultLogger.Out != currentOut {
 			t.Error("Logger output should not change by default")
 		}
 	})
 
 	t.Run("stdout", func(t *testing.T) {
-		SetOutputs([]string{"-"}, 0, 0)
+		err := SetOutputs([]string{"-"}, 0, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
 		if defaultLogger.Out != os.Stdout {
 			t.Error("Logger output should be stdout")
 		}
 	})
 
 	t.Run("stderr", func(t *testing.T) {
-		SetOutputs([]string{"="}, 0, 0)
+		err := SetOutputs([]string{"="}, 0, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
 		if defaultLogger.Out != os.Stderr {
 			t.Error("Logger output should be stderr")
 		}
@@ -37,9 +46,12 @@ func TestSetOutputs(t *testing.T) {
 		logDir := t.TempDir()
 		log1 := filepath.Join(logDir, "file1.log")
 		log2 := filepath.Join(logDir, "file2.log")
-		SetOutputs([]string{log1, log2}, 0, 0)
+		err := SetOutputs([]string{log1, log2}, 0, 0)
+		if err != nil {
+			t.Fatal(err)
+		}
 		const content = "hello log"
-		_, err := io.WriteString(defaultLogger.Out, content)
+		_, err = io.WriteString(defaultLogger.Out, content)
 		if err != nil {
 			t.Fatal("Failed to write to log output with two outputs", err)
 		}
@@ -93,11 +105,14 @@ func TestDurationFormatting(t *testing.T) {
 		t.Run(tc.OutputFormat, func(t *testing.T) {
 			logDir := t.TempDir()
 			log := filepath.Join(logDir, "file.log")
-			SetOutputs([]string{log}, 0, 0)
+			err := SetOutputs([]string{log}, 0, 0)
+			if err != nil {
+				t.Fatal(err)
+			}
 			SetOutputFormat(tc.OutputFormat)
 
 			ContextUnavailable().WithField("xyzzy", duration).Info("log")
-			err := CloseWriters()
+			err = CloseWriters()
 			if err != nil {
 				t.Fatalf("Close writers: %s", err)
 			}

--- a/pkg/logging/logger_test.go
+++ b/pkg/logging/logger_test.go
@@ -89,7 +89,7 @@ func TestDurationFormatting(t *testing.T) {
 		OutputFormat: "text",
 		FormatDurations: func(label string, duration time.Duration) []string {
 			return []string{fmt.Sprint(label, "_str", "=", duration.String()),
-				fmt.Sprint(label, "_nsecs", "=", int64(duration)),
+				fmt.Sprint(label, "=", int64(duration)),
 			}
 		},
 		FormatInt: func(label string, value int) string {
@@ -101,7 +101,7 @@ func TestDurationFormatting(t *testing.T) {
 			// Useful only inside this test.  Does not protect
 			// special chars in label.
 			return []string{fmt.Sprintf("\"%s_str\":\"%s\"", label, duration.String()),
-				fmt.Sprintf("\"%s_nsecs\":%d", label, duration),
+				fmt.Sprintf("\"%s\":%d", label, duration),
 			}
 		},
 		FormatInt: func(label string, value int) string {


### PR DESCRIPTION
Append "_str" or "_nsecs" to the label to be absolutely clear what is being logged.

Fixes #6931.