### PR TITLE
API: CreateRepository check if repository exists before trying to validate storage namespace

### DIFF
--- a/esti/golden/lakectl_repo_create_not_unique.golden
+++ b/esti/golden/lakectl_repo_create_not_unique.golden
@@ -1,3 +1,3 @@
 Repository: lakefs://${REPO}
-repository already exists
+error creating repository: not unique
 409 Conflict

--- a/esti/golden/lakectl_repo_create_not_unique.golden
+++ b/esti/golden/lakectl_repo_create_not_unique.golden
@@ -1,3 +1,3 @@
 Repository: lakefs://${REPO}
-error creating repository: not unique
+repository already exists
 409 Conflict

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -1542,7 +1542,10 @@ func (c *Controller) CreateRepository(w http.ResponseWriter, r *http.Request, bo
 	}
 	ctx := r.Context()
 
-	// verify first if there is a repository definition
+	// Verify first if there is a repository definition.
+	// Return conflict if definition already exists, before
+	// creating the repository itself and ensuring (optional) storage namespace holds an object.
+	// Example will be by restoring a repository from a backup or previous bare repository.
 	_, err := c.Catalog.GetRepository(ctx, body.Name)
 	if err == nil {
 		writeError(w, r, http.StatusConflict, "repository already exists")

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -1541,6 +1541,14 @@ func (c *Controller) CreateRepository(w http.ResponseWriter, r *http.Request, bo
 		return
 	}
 	ctx := r.Context()
+
+	// verify first if there is a repository definition
+	_, err := c.Catalog.GetRepository(ctx, body.Name)
+	if err == nil {
+		writeError(w, r, http.StatusConflict, "repository already exists")
+		return
+	}
+
 	sampleData := swag.BoolValue(body.SampleData)
 	c.LogAction(ctx, "create_repo", r, body.Name, "", "")
 	if sampleData {

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -1548,7 +1548,7 @@ func (c *Controller) CreateRepository(w http.ResponseWriter, r *http.Request, bo
 	// Example will be by restoring a repository from a backup or previous bare repository.
 	_, err := c.Catalog.GetRepository(ctx, body.Name)
 	if err == nil {
-		writeError(w, r, http.StatusConflict, "repository already exists")
+		c.handleAPIError(ctx, w, r, fmt.Errorf("error creating repository: %w", graveler.ErrNotUnique))
 		return
 	}
 

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -1003,19 +1003,22 @@ func TestController_CreateRepositoryHandler(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		resp, err := clt.CreateRepositoryWithResponse(ctx, &apigen.CreateRepositoryParams{}, apigen.CreateRepositoryJSONRequestBody{
-			DefaultBranch:    apiutil.Ptr("main"),
-			Name:             repo,
-			StorageNamespace: onBlock(deps, "foo-bucket-2"),
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
-		if resp == nil {
-			t.Fatal("CreateRepository missing response")
-		}
-		if resp.JSON409 == nil {
-			t.Fatal("expected status code 409 creating duplicate repo, got ", resp.StatusCode())
+		const times = 3 // try to create the same repo multiple times
+		for i := 0; i < times; i++ {
+			resp, err := clt.CreateRepositoryWithResponse(ctx, &apigen.CreateRepositoryParams{}, apigen.CreateRepositoryJSONRequestBody{
+				DefaultBranch:    apiutil.Ptr("main"),
+				Name:             repo,
+				StorageNamespace: onBlock(deps, "foo-bucket-2"),
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if resp == nil {
+				t.Fatal("CreateRepository missing response")
+			}
+			if resp.JSON409 == nil {
+				t.Fatal("expected status code 409 creating duplicate repo, got ", resp.StatusCode())
+			}
 		}
 	})
 


### PR DESCRIPTION
Create repository validate storage namespace before checking if repository already exists.

It means that we may have a repository definition in our metadata without why object in the underlying storage.

In this case calling CreateRepository will pass the storage namespace and report an error on duplicate.

Calling CreateRepository again will find the object and ensure will fail with bad request error.

Fix https://github.com/treeverse/lakeFS/issues/6968