### PR TITLE
Remove leftover page layout components

### DIFF
--- a/webui/src/pages/auth/users/user/effectivePolicies.jsx
+++ b/webui/src/pages/auth/users/user/effectivePolicies.jsx
@@ -1,6 +1,6 @@
-import React, {useState} from "react";
+import React, {useEffect, useState} from "react";
+import {useOutletContext} from "react-router-dom";
 
-import {AuthLayout} from "../../../../lib/components/auth/layout";
 import {UserHeaderWithContext} from "./userHeaderWithContext";
 import {useAPIWithPagination} from "../../../../lib/hooks/api";
 import {auth} from "../../../../lib/api";
@@ -85,11 +85,9 @@ const UserEffectivePoliciesContainer = () => {
 };
 
 const UserEffectivePoliciesPage = () => {
-    return (
-        <AuthLayout activeTab="users">
-            <UserEffectivePoliciesContainer/>
-        </AuthLayout>
-    );
+    const {setActiveTab} = useOutletContext();
+    useEffect(() => setActiveTab("users"), [setActiveTab]);
+    return <UserEffectivePoliciesContainer/>;
 };
 
 export default UserEffectivePoliciesPage;

--- a/webui/src/pages/auth/users/user/policies.jsx
+++ b/webui/src/pages/auth/users/user/policies.jsx
@@ -1,6 +1,5 @@
-import React from "react";
-
-import {AuthLayout} from "../../../../lib/components/auth/layout";
+import React, {useEffect} from "react";
+import {useOutletContext} from "react-router-dom";
 import {UserHeaderWithContext} from "./userHeaderWithContext";
 import {
     ActionGroup,
@@ -117,11 +116,9 @@ const UserPoliciesContainer = () => {
 };
 
 const UserPoliciesPage = () => {
-    return (
-        <AuthLayout activeTab="users">
-            <UserPoliciesContainer />
-        </AuthLayout>
-    );
+    const {setActiveTab} = useOutletContext();
+    useEffect(() => setActiveTab("users"), [setActiveTab]);
+    return <UserPoliciesContainer/>;
 };
 
 export default UserPoliciesPage;

--- a/webui/src/pages/repositories/repository/actions/run/index.jsx
+++ b/webui/src/pages/repositories/repository/actions/run/index.jsx
@@ -1,6 +1,6 @@
-import React, {useState} from "react";
+import React, {useEffect, useState} from "react";
+import {useOutletContext} from "react-router-dom";
 
-import {RepositoryPageLayout} from "../../../../../lib/components/repository/layout";
 import {AlertError, FormattedDate, Loading, Na} from "../../../../../lib/components/controls";
 import {useRefs} from "../../../../../lib/hooks/repo";
 import {useAPI} from "../../../../../lib/hooks/api";
@@ -245,11 +245,9 @@ const ActionContainer = () => {
 }
 
 const RepositoryActionPage = () => {
-    return (
-            <RepositoryPageLayout activePage={'actions'} fluid>
-                <ActionContainer/>
-            </RepositoryPageLayout>
-    );
+    const [setActivePage] = useOutletContext();
+  useEffect(() => setActivePage('actions'), [setActivePage]);
+    return <ActionContainer/>;
 };
 
 export default RepositoryActionPage;


### PR DESCRIPTION
Closes #7011 

Remove leftover layout components from the `<Outlet />` nav tree refactor.