### PR TITLE
fix revert reference which does not exist on the branch

### DIFF
--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -2256,7 +2256,8 @@ func (c *Controller) handleAPIErrorCallback(ctx context.Context, w http.Response
 		errors.Is(err, graveler.ErrCherryPickMergeNoParent),
 		errors.Is(err, graveler.ErrInvalidMergeStrategy),
 		errors.Is(err, block.ErrInvalidAddress),
-		errors.Is(err, block.ErrOperationNotSupported):
+		errors.Is(err, block.ErrOperationNotSupported),
+		errors.Is(err, graveler.ErrInvalidCommitID):
 		log.Debug("Bad request")
 		cb(w, r, http.StatusBadRequest, err)
 


### PR DESCRIPTION
Closes #6917

## Change Description

### Background
This pull request introduces a new function, `checkCommitExistsInTargetBranch`, to the Graveler codebase. The function is designed to validate whether a specified commit exists in the commit list of a given target branch.

### Bug Fix
#### 1. Problem 
Currently, it is possible to revert an existent commit that belongs to a different branch

#### 2. Root cause 
There was a lack of validation to ensure the commit being reverted belongs to the target branch. The revert branch validations only validate against the existence of the target branch and the reference

#### 3. Solution 
Your text is clear, but I've made a small adjustment for improved readability:
3. Solution

I implemented validation in Graveler to check whether the target branch points to the reference being reverted or if the reference being reverted is contained in the parent references of the target branch.

### Testing Details
- Added a new test in controller_test to validate if the controller responds with a 400 error
- Introduced a new test in graveler_v2_test to validate whether Graveler's Revert function behaves as expected.
- Modified two existing tests for Graveler's Revert function since they had become stale

### Breaking Change?

Does this change break any existing functionality? (API, CLI, Clients)

## Additional info

### Step to reproduce
``` bash
$ lakectl repo create lakefs://my-repo local://my-repo
Repository: lakefs://my-repo
Repository 'my-repo' created:
storage namespace: local://my-repo
default branch: main
timestamp: 1700597925

$ lakectl branch create lakefs://my-repo/revert-issue -s lakefs://my-repo/main
Source ref: lakefs://my-repo/main
created branch 'revert-issue' b4b3a0f6714c0a077ee5a182c0f92dc6be6977b33dfb3d8d3350bbb7b9795436

$ lakectl fs upload lakefs://my-repo/revert-issue/change.txt -s /home/lakefs/change.txt
Path: change.txt
Modified Time: 2023-11-21 20:26:05 +0000 UTC
Size: 10 bytes
Human Size: 10 B
Physical Address: local:///home/lakefs/lakefs/data/block/my-repo/data/gjov4ts98dkc73f23ds0/cleh4nc98dkc73f23dug
Checksum: 6265b22b66502d70d5f004f08238ac3c
Content-Type: application/octet-stream

$ lakectl commit lakefs://my-repo/revert-issue -m "to be reverted"
Branch: lakefs://my-repo/revert-issue
Commit for branch "revert-issue" completed.

ID: 855524d036f6a3fbdcf01bb2d30cde21765b40594f6bc5fa61d82e4c150e76a6
Message: to be reverted
Timestamp: 2023-11-21 20:26:47 +0000 UTC
Parents: b4b3a0f6714c0a077ee5a182c0f92dc6be6977b33dfb3d8d3350bbb7b9795436

$ lakectl branch revert lakefs://my-repo/main 855524d036f6a3fbdcf01bb2d30cde21765b40594f6bc5fa61d82e4c150e76a6
Branch: lakefs://my-repo/main
Are you sure you want to revert the effect of commits 855524d036f6a3fbdcf01bb2d30cde21765b40594f6bc5fa61d82e4c150e76a6: y
commit 855524d036f6a3fbdcf01bb2d30cde21765b40594f6bc5fa61d82e4c150e76a6 successfully reverted
```

## After the fix
``` bash
# omited repeated steps

$ lakectl commit lakefs://my-repo/revert-issue -m "to be reverted"
Branch: lakefs://my-repo/revert-issue
Commit for branch "revert-issue" completed.

ID: 2d7f7092679e95bc7da97c46d8cbc44721b241984ca8158290052d05917c4844
Message: to be reverted
Timestamp: 2023-11-21 20:31:43 +0000 UTC
Parents: 1c9965a5f0bc9436155ea203b9e517bbfd4fff66b20c751c7034bfb1d458c8f5

$ lakectl branch revert lakefs://my-repo/main 2d7f7092679e95bc7da97c46d8cbc44721b241984ca8158290052d05917c4844
Branch: lakefs://my-repo/main
Are you sure you want to revert the effect of commits 2d7f7092679e95bc7da97c46d8cbc44721b241984ca8158290052d05917c4844: y
invalid ref 2d7f7092679e95bc7da97c46d8cbc44721b241984ca8158290052d05917c4844: commit id: invalid value: validation error
400 Bad Request
```

### Contact Details

How can we get in touch with you if we need more info? (ex.sullyvan.nunes@yahoo.com.br)
