### PR TITLE
Fix gateway handle list objects versions

### DIFF
--- a/cmd/lakefs/cmd/run.go
+++ b/cmd/lakefs/cmd/run.go
@@ -298,6 +298,7 @@ var runCmd = &cobra.Command{
 			s3FallbackURL,
 			cfg.Logging.AuditLogLevel,
 			cfg.Logging.TraceRequestHeaders,
+			cfg.Gateways.S3.SkipVerifyUnsupported,
 		)
 		s3gatewayHandler = apiAuthenticator(s3gatewayHandler)
 

--- a/cmd/lakefs/cmd/run.go
+++ b/cmd/lakefs/cmd/run.go
@@ -298,7 +298,7 @@ var runCmd = &cobra.Command{
 			s3FallbackURL,
 			cfg.Logging.AuditLogLevel,
 			cfg.Logging.TraceRequestHeaders,
-			cfg.Gateways.S3.SkipVerifyUnsupported,
+			cfg.Gateways.S3.VerifyUnsupported,
 		)
 		s3gatewayHandler = apiAuthenticator(s3gatewayHandler)
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -195,6 +195,7 @@ This reference uses `.` to denote the nesting of values.
   local development, if using [virtual-host addressing](https://docs.aws.amazon.com/AmazonS3/latest/userguide/VirtualHosting.html).
 * `gateways.s3.region` `(string : "us-east-1")` - AWS region we're pretending to be in, it should match the region configuration used in AWS SDK clients
 * `gateways.s3.fallback_url` `(string)` - If specified, requests with a non-existing repository will be forwarded to this URL. This can be useful for using lakeFS side-by-side with S3, with the URL pointing at an [S3Proxy](https://github.com/gaul/s3proxy) instance.
+* `gateways.s3.verify_unsupported` `(bool : true)` - The S3 gateway errors on unsupported requests, but when disabled, defers to target-based handlers.
 * `stats.enabled` `(bool : true)` - Whether to periodically collect anonymous usage statistics
 * `stats.flush_interval` `(duration : 30s)` - Interval used to post anonymous statistics collected
 * `stats.flush_size` `(int : 100)` - A size (in records) of anonymous statistics collected in which we post

--- a/esti/s3_gateway_test.go
+++ b/esti/s3_gateway_test.go
@@ -82,15 +82,13 @@ func TestS3UploadAndDownload(t *testing.T) {
 				go func() {
 					defer wg.Done()
 					for o := range objects {
-						_, err := client.PutObject(
-							ctx, repo, o.Path, strings.NewReader(o.Content), int64(len(o.Content)), minio.PutObjectOptions{})
+						_, err := client.PutObject(ctx, repo, o.Path, strings.NewReader(o.Content), int64(len(o.Content)), minio.PutObjectOptions{})
 						if err != nil {
 							t.Errorf("minio.Client.PutObject(%s): %s", o.Path, err)
 							continue
 						}
 
-						download, err := client.GetObject(
-							ctx, repo, o.Path, minio.GetObjectOptions{})
+						download, err := client.GetObject(ctx, repo, o.Path, minio.GetObjectOptions{})
 						if err != nil {
 							t.Errorf("minio.Client.GetObject(%s): %s", o.Path, err)
 							continue

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -320,9 +320,10 @@ type Config struct {
 	} `mapstructure:"graveler"`
 	Gateways struct {
 		S3 struct {
-			DomainNames Strings `mapstructure:"domain_name"`
-			Region      string  `mapstructure:"region"`
-			FallbackURL string  `mapstructure:"fallback_url"`
+			DomainNames           Strings `mapstructure:"domain_name"`
+			Region                string  `mapstructure:"region"`
+			FallbackURL           string  `mapstructure:"fallback_url"`
+			SkipVerifyUnsupported bool    `mapstructure:"skip_verify_unsupported"`
 		} `mapstructure:"s3"`
 	}
 	Stats struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -320,10 +320,10 @@ type Config struct {
 	} `mapstructure:"graveler"`
 	Gateways struct {
 		S3 struct {
-			DomainNames           Strings `mapstructure:"domain_name"`
-			Region                string  `mapstructure:"region"`
-			FallbackURL           string  `mapstructure:"fallback_url"`
-			SkipVerifyUnsupported bool    `mapstructure:"skip_verify_unsupported"`
+			DomainNames       Strings `mapstructure:"domain_name"`
+			Region            string  `mapstructure:"region"`
+			FallbackURL       string  `mapstructure:"fallback_url"`
+			VerifyUnsupported bool    `mapstructure:"verify_unsupported"`
 		} `mapstructure:"s3"`
 	}
 	Stats struct {

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -85,6 +85,7 @@ func setDefaults(cfgType string) {
 
 	viper.SetDefault("gateways.s3.domain_name", "s3.local.lakefs.io")
 	viper.SetDefault("gateways.s3.region", "us-east-1")
+	viper.SetDefault("gateways.s3.verify_unsupported", true)
 
 	viper.SetDefault("blockstore.gs.s3_endpoint", "https://storage.googleapis.com")
 	viper.SetDefault("blockstore.gs.pre_signed_expiry", 15*time.Minute)

--- a/pkg/gateway/handler.go
+++ b/pkg/gateway/handler.go
@@ -49,18 +49,18 @@ type handler struct {
 }
 
 type ServerContext struct {
-	region                string
-	bareDomains           []string
-	catalog               *catalog.Catalog
-	multipartTracker      multipart.Tracker
-	blockStore            block.Adapter
-	authService           auth.GatewayService
-	stats                 stats.Collector
-	pathProvider          upload.PathProvider
-	skipVerifyUnsupported bool
+	region            string
+	bareDomains       []string
+	catalog           *catalog.Catalog
+	multipartTracker  multipart.Tracker
+	blockStore        block.Adapter
+	authService       auth.GatewayService
+	stats             stats.Collector
+	pathProvider      upload.PathProvider
+	verifyUnsupported bool
 }
 
-func NewHandler(region string, catalog *catalog.Catalog, multipartTracker multipart.Tracker, blockStore block.Adapter, authService auth.GatewayService, bareDomains []string, stats stats.Collector, pathProvider upload.PathProvider, fallbackURL *url.URL, auditLogLevel string, traceRequestHeaders bool, skipVerifyUnsupported bool) http.Handler {
+func NewHandler(region string, catalog *catalog.Catalog, multipartTracker multipart.Tracker, blockStore block.Adapter, authService auth.GatewayService, bareDomains []string, stats stats.Collector, pathProvider upload.PathProvider, fallbackURL *url.URL, auditLogLevel string, traceRequestHeaders bool, verifyUnsupported bool) http.Handler {
 	var fallbackHandler http.Handler
 	if fallbackURL != nil {
 		fallbackProxy := gohttputil.NewSingleHostReverseProxy(fallbackURL)
@@ -76,15 +76,15 @@ func NewHandler(region string, catalog *catalog.Catalog, multipartTracker multip
 		})
 	}
 	sc := &ServerContext{
-		catalog:               catalog,
-		multipartTracker:      multipartTracker,
-		region:                region,
-		bareDomains:           bareDomains,
-		blockStore:            blockStore,
-		authService:           authService,
-		stats:                 stats,
-		pathProvider:          pathProvider,
-		skipVerifyUnsupported: skipVerifyUnsupported,
+		catalog:           catalog,
+		multipartTracker:  multipartTracker,
+		region:            region,
+		bareDomains:       bareDomains,
+		blockStore:        blockStore,
+		authService:       authService,
+		stats:             stats,
+		pathProvider:      pathProvider,
+		verifyUnsupported: verifyUnsupported,
 	}
 
 	// setup routes

--- a/pkg/gateway/handler.go
+++ b/pkg/gateway/handler.go
@@ -49,17 +49,18 @@ type handler struct {
 }
 
 type ServerContext struct {
-	region           string
-	bareDomains      []string
-	catalog          *catalog.Catalog
-	multipartTracker multipart.Tracker
-	blockStore       block.Adapter
-	authService      auth.GatewayService
-	stats            stats.Collector
-	pathProvider     upload.PathProvider
+	region                string
+	bareDomains           []string
+	catalog               *catalog.Catalog
+	multipartTracker      multipart.Tracker
+	blockStore            block.Adapter
+	authService           auth.GatewayService
+	stats                 stats.Collector
+	pathProvider          upload.PathProvider
+	skipVerifyUnsupported bool
 }
 
-func NewHandler(region string, catalog *catalog.Catalog, multipartTracker multipart.Tracker, blockStore block.Adapter, authService auth.GatewayService, bareDomains []string, stats stats.Collector, pathProvider upload.PathProvider, fallbackURL *url.URL, auditLogLevel string, traceRequestHeaders bool) http.Handler {
+func NewHandler(region string, catalog *catalog.Catalog, multipartTracker multipart.Tracker, blockStore block.Adapter, authService auth.GatewayService, bareDomains []string, stats stats.Collector, pathProvider upload.PathProvider, fallbackURL *url.URL, auditLogLevel string, traceRequestHeaders bool, skipVerifyUnsupported bool) http.Handler {
 	var fallbackHandler http.Handler
 	if fallbackURL != nil {
 		fallbackProxy := gohttputil.NewSingleHostReverseProxy(fallbackURL)
@@ -75,14 +76,15 @@ func NewHandler(region string, catalog *catalog.Catalog, multipartTracker multip
 		})
 	}
 	sc := &ServerContext{
-		catalog:          catalog,
-		multipartTracker: multipartTracker,
-		region:           region,
-		bareDomains:      bareDomains,
-		blockStore:       blockStore,
-		authService:      authService,
-		stats:            stats,
-		pathProvider:     pathProvider,
+		catalog:               catalog,
+		multipartTracker:      multipartTracker,
+		region:                region,
+		bareDomains:           bareDomains,
+		blockStore:            blockStore,
+		authService:           authService,
+		stats:                 stats,
+		pathProvider:          pathProvider,
+		skipVerifyUnsupported: skipVerifyUnsupported,
 	}
 
 	// setup routes

--- a/pkg/gateway/middleware.go
+++ b/pkg/gateway/middleware.go
@@ -112,13 +112,13 @@ func EnrichWithOperation(sc *ServerContext, next http.Handler) http.Handler {
 		ctx := req.Context()
 		client := httputil.GetRequestLakeFSClient(req)
 		o := &operations.Operation{
-			Region:                sc.region,
-			FQDN:                  getBareDomain(stripPort(req.Host), sc.bareDomains),
-			Catalog:               sc.catalog,
-			MultipartTracker:      sc.multipartTracker,
-			BlockStore:            sc.blockStore,
-			Auth:                  sc.authService,
-			SkipVerifyUnsupported: sc.skipVerifyUnsupported,
+			Region:            sc.region,
+			FQDN:              getBareDomain(stripPort(req.Host), sc.bareDomains),
+			Catalog:           sc.catalog,
+			MultipartTracker:  sc.multipartTracker,
+			BlockStore:        sc.blockStore,
+			Auth:              sc.authService,
+			VerifyUnsupported: sc.verifyUnsupported,
 			Incr: func(action, userID, repository, ref string) {
 				logging.FromContext(ctx).
 					WithFields(logging.Fields{

--- a/pkg/gateway/middleware.go
+++ b/pkg/gateway/middleware.go
@@ -112,12 +112,13 @@ func EnrichWithOperation(sc *ServerContext, next http.Handler) http.Handler {
 		ctx := req.Context()
 		client := httputil.GetRequestLakeFSClient(req)
 		o := &operations.Operation{
-			Region:           sc.region,
-			FQDN:             getBareDomain(stripPort(req.Host), sc.bareDomains),
-			Catalog:          sc.catalog,
-			MultipartTracker: sc.multipartTracker,
-			BlockStore:       sc.blockStore,
-			Auth:             sc.authService,
+			Region:                sc.region,
+			FQDN:                  getBareDomain(stripPort(req.Host), sc.bareDomains),
+			Catalog:               sc.catalog,
+			MultipartTracker:      sc.multipartTracker,
+			BlockStore:            sc.blockStore,
+			Auth:                  sc.authService,
+			SkipVerifyUnsupported: sc.skipVerifyUnsupported,
 			Incr: func(action, userID, repository, ref string) {
 				logging.FromContext(ctx).
 					WithFields(logging.Fields{

--- a/pkg/gateway/middleware.go
+++ b/pkg/gateway/middleware.go
@@ -199,8 +199,6 @@ func OperationLookupHandler(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()
 		o := ctx.Value(ContextKeyOperation).(*operations.Operation)
-		o.OperationID = operations.OperationIDOperationNotFound
-
 		repoID := ctx.Value(ContextKeyRepositoryID).(string)
 		ref := ctx.Value(ContextKeyRef).(string)
 		pth := ctx.Value(ContextKeyPath).(string)
@@ -213,6 +211,8 @@ func OperationLookupHandler(next http.Handler) http.Handler {
 			o.OperationID = pathBasedOperationID(req.Method)
 		case ref == "" && pth == "":
 			o.OperationID = repositoryBasedOperationID(req.Method)
+		default:
+			o.OperationID = operations.OperationIDOperationNotFound
 		}
 
 		req = req.WithContext(logging.AddFields(ctx, logging.Fields{"operation_id": o.OperationID}))

--- a/pkg/gateway/operations/base.go
+++ b/pkg/gateway/operations/base.go
@@ -45,16 +45,17 @@ const (
 type ActionIncr func(action, userID, repository, ref string)
 
 type Operation struct {
-	OperationID      OperationID
-	Region           string
-	FQDN             string
-	Catalog          *catalog.Catalog
-	MultipartTracker multipart.Tracker
-	BlockStore       block.Adapter
-	Auth             auth.GatewayService
-	Incr             ActionIncr
-	MatchedHost      bool
-	PathProvider     upload.PathProvider
+	OperationID           OperationID
+	Region                string
+	FQDN                  string
+	Catalog               *catalog.Catalog
+	MultipartTracker      multipart.Tracker
+	BlockStore            block.Adapter
+	Auth                  auth.GatewayService
+	Incr                  ActionIncr
+	MatchedHost           bool
+	PathProvider          upload.PathProvider
+	SkipVerifyUnsupported bool
 }
 
 func StorageClassFromHeader(header http.Header) *string {
@@ -86,6 +87,9 @@ func (o *Operation) EncodeXMLBytes(w http.ResponseWriter, req *http.Request, t [
 }
 
 func (o *Operation) HandleUnsupported(w http.ResponseWriter, req *http.Request, keys ...string) bool {
+	if o.SkipVerifyUnsupported {
+		return false
+	}
 	query := req.URL.Query()
 	if slices.ContainsFunc(keys, query.Has) {
 		_ = o.EncodeError(w, req, nil, gwerrors.ERRLakeFSNotSupported.ToAPIErr())

--- a/pkg/gateway/operations/base.go
+++ b/pkg/gateway/operations/base.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
 
 	"github.com/treeverse/lakefs/pkg/auth"
 	"github.com/treeverse/lakefs/pkg/auth/keys"
@@ -82,6 +83,15 @@ func (o *Operation) EncodeXMLBytes(w http.ResponseWriter, req *http.Request, t [
 	if err != nil {
 		o.Log(req).WithError(err).Error("failed to encode XML to response")
 	}
+}
+
+func (o *Operation) HandleUnsupported(w http.ResponseWriter, req *http.Request, keys ...string) bool {
+	query := req.URL.Query()
+	if slices.ContainsFunc(keys, query.Has) {
+		_ = o.EncodeError(w, req, nil, gwerrors.ERRLakeFSNotSupported.ToAPIErr())
+		return true
+	}
+	return false
 }
 
 func EncodeResponse(w http.ResponseWriter, entity interface{}, statusCode int) error {

--- a/pkg/gateway/operations/base.go
+++ b/pkg/gateway/operations/base.go
@@ -45,17 +45,17 @@ const (
 type ActionIncr func(action, userID, repository, ref string)
 
 type Operation struct {
-	OperationID           OperationID
-	Region                string
-	FQDN                  string
-	Catalog               *catalog.Catalog
-	MultipartTracker      multipart.Tracker
-	BlockStore            block.Adapter
-	Auth                  auth.GatewayService
-	Incr                  ActionIncr
-	MatchedHost           bool
-	PathProvider          upload.PathProvider
-	SkipVerifyUnsupported bool
+	OperationID       OperationID
+	Region            string
+	FQDN              string
+	Catalog           *catalog.Catalog
+	MultipartTracker  multipart.Tracker
+	BlockStore        block.Adapter
+	Auth              auth.GatewayService
+	Incr              ActionIncr
+	MatchedHost       bool
+	PathProvider      upload.PathProvider
+	VerifyUnsupported bool
 }
 
 func StorageClassFromHeader(header http.Header) *string {
@@ -87,7 +87,7 @@ func (o *Operation) EncodeXMLBytes(w http.ResponseWriter, req *http.Request, t [
 }
 
 func (o *Operation) HandleUnsupported(w http.ResponseWriter, req *http.Request, keys ...string) bool {
-	if o.SkipVerifyUnsupported {
+	if !o.VerifyUnsupported {
 		return false
 	}
 	query := req.URL.Query()

--- a/pkg/gateway/operations/deleteobject.go
+++ b/pkg/gateway/operations/deleteobject.go
@@ -60,10 +60,11 @@ func (controller *DeleteObject) HandleAbortMultipartUpload(w http.ResponseWriter
 }
 
 func (controller *DeleteObject) Handle(w http.ResponseWriter, req *http.Request, o *PathOperation) {
+	if o.HandleUnsupported(w, req, "tagging", "acl", "torrent") {
+		return
+	}
 	query := req.URL.Query()
-
-	_, hasUploadID := query[QueryParamUploadID]
-	if hasUploadID {
+	if query.Has(QueryParamUploadID) {
 		controller.HandleAbortMultipartUpload(w, req, o)
 		return
 	}

--- a/pkg/gateway/operations/deleteobjects.go
+++ b/pkg/gateway/operations/deleteobjects.go
@@ -27,6 +27,13 @@ func (controller *DeleteObjects) RequiredPermissions(_ *http.Request, _ string) 
 }
 
 func (controller *DeleteObjects) Handle(w http.ResponseWriter, req *http.Request, o *RepoOperation) {
+	// verify we only handle delete request
+	query := req.URL.Query()
+	if !query.Has("delete") {
+		_ = o.EncodeError(w, req, nil, gerrors.ERRLakeFSNotSupported.ToAPIErr())
+		return
+	}
+
 	o.Incr("delete_objects", o.Principal, o.Repository.Name, "")
 	decodedXML := &serde.Delete{}
 	err := DecodeXMLBody(req.Body, decodedXML)

--- a/pkg/gateway/operations/getobject.go
+++ b/pkg/gateway/operations/getobject.go
@@ -28,7 +28,6 @@ func (controller *GetObject) RequiredPermissions(_ *http.Request, repoID, _, pat
 }
 
 func (controller *GetObject) Handle(w http.ResponseWriter, req *http.Request, o *PathOperation) {
-	// TODO(barak): do we like to reject tagging or return empty tagging?
 	if o.HandleUnsupported(w, req, "torrent", "acl", "retention", "legal-hold", "lambdaArn") {
 		return
 	}

--- a/pkg/gateway/operations/getobject.go
+++ b/pkg/gateway/operations/getobject.go
@@ -28,6 +28,10 @@ func (controller *GetObject) RequiredPermissions(_ *http.Request, repoID, _, pat
 }
 
 func (controller *GetObject) Handle(w http.ResponseWriter, req *http.Request, o *PathOperation) {
+	// TODO(barak): do we like to reject tagging or return empty tagging?
+	if o.HandleUnsupported(w, req, "torrent", "acl", "retention", "legal-hold", "lambdaArn") {
+		return
+	}
 	o.Incr("get_object", o.Principal, o.Repository.Name, o.Reference)
 	ctx := req.Context()
 	query := req.URL.Query()

--- a/pkg/gateway/operations/headbucket.go
+++ b/pkg/gateway/operations/headbucket.go
@@ -17,7 +17,10 @@ func (controller *HeadBucket) RequiredPermissions(_ *http.Request, repoID string
 	}, nil
 }
 
-func (controller *HeadBucket) Handle(w http.ResponseWriter, _ *http.Request, o *RepoOperation) {
+func (controller *HeadBucket) Handle(w http.ResponseWriter, req *http.Request, o *RepoOperation) {
+	if o.HandleUnsupported(w, req, "acl") {
+		return
+	}
 	o.Incr("get_repo", o.Principal, o.Repository.Name, "")
 	w.WriteHeader(http.StatusOK)
 }

--- a/pkg/gateway/operations/listbuckets.go
+++ b/pkg/gateway/operations/listbuckets.go
@@ -21,6 +21,10 @@ func (controller *ListBuckets) RequiredPermissions(_ *http.Request) (permissions
 
 // Handle - list buckets (repositories)
 func (controller *ListBuckets) Handle(w http.ResponseWriter, req *http.Request, o *AuthorizedOperation) {
+	if o.HandleUnsupported(w, req, "events") {
+		return
+	}
+
 	o.Incr("list_repos", o.Principal, "", "")
 
 	buckets := make([]serde.Bucket, 0)

--- a/pkg/gateway/operations/listobjects.go
+++ b/pkg/gateway/operations/listobjects.go
@@ -349,13 +349,22 @@ func (controller *ListObjects) ListV1(w http.ResponseWriter, req *http.Request, 
 }
 
 func (controller *ListObjects) Handle(w http.ResponseWriter, req *http.Request, o *RepoOperation) {
+	// TODO(barak): do we like to reject "versioning" or return empty response?
+	// TODO(barak): do we like to support "location" (getbucketlocation)?
+	if o.HandleUnsupported(w, req, "inventory", "metrics", "publicAccessBlock", "ownershipControls",
+		"intelligent-tiering", "analytics", "location", "policy", "lifecycle", "encryption", "object-lock", "replication",
+		"notification", "events", "acl", "cors", "website", "accelerate",
+		"requestPayment", "logging", "tagging", "uploads", "versions", "policyStatus") {
+		return
+	}
+
 	o.Incr("list_objects", o.Principal, o.Repository.Name, "")
 	// parse request parameters
 	// GET /example?list-type=2&prefix=main%2F&delimiter=%2F&encoding-type=url HTTP/1.1
 
 	// handle GET /?versions
 	query := req.URL.Query()
-	if _, found := query["versions"]; found {
+	if query.Has("versioning") {
 		o.EncodeXMLBytes(w, req, []byte(serde.VersioningResponse), http.StatusOK)
 		return
 	}

--- a/pkg/gateway/operations/listobjects.go
+++ b/pkg/gateway/operations/listobjects.go
@@ -18,6 +18,9 @@ import (
 
 const (
 	ListObjectMaxKeys = 1000
+
+	// defaultBucketLocation used to identify if we need to specify the location constraint
+	defaultBucketLocation = "us-east-1"
 )
 
 type ListObjects struct{}
@@ -349,25 +352,34 @@ func (controller *ListObjects) ListV1(w http.ResponseWriter, req *http.Request, 
 }
 
 func (controller *ListObjects) Handle(w http.ResponseWriter, req *http.Request, o *RepoOperation) {
-	// TODO(barak): do we like to reject "versioning" or return empty response?
-	// TODO(barak): do we like to support "location" (getbucketlocation)?
 	if o.HandleUnsupported(w, req, "inventory", "metrics", "publicAccessBlock", "ownershipControls",
-		"intelligent-tiering", "analytics", "location", "policy", "lifecycle", "encryption", "object-lock", "replication",
+		"intelligent-tiering", "analytics", "policy", "lifecycle", "encryption", "object-lock", "replication",
 		"notification", "events", "acl", "cors", "website", "accelerate",
 		"requestPayment", "logging", "tagging", "uploads", "versions", "policyStatus") {
 		return
 	}
-
-	o.Incr("list_objects", o.Principal, o.Repository.Name, "")
-	// parse request parameters
-	// GET /example?list-type=2&prefix=main%2F&delimiter=%2F&encoding-type=url HTTP/1.1
-
-	// handle GET /?versions
 	query := req.URL.Query()
+
+	// getbucketlocation support
+	if query.Has("location") {
+		o.Incr("get_bucket_location", o.Principal, o.Repository.Name, "")
+		response := serde.LocationResponse{}
+		if o.Region != "" && o.Region != defaultBucketLocation {
+			response.Location = o.Region
+		}
+		o.EncodeResponse(w, req, response, http.StatusOK)
+		return
+	}
+
+	// getbucketversioing support
 	if query.Has("versioning") {
 		o.EncodeXMLBytes(w, req, []byte(serde.VersioningResponse), http.StatusOK)
 		return
 	}
+	o.Incr("list_objects", o.Principal, o.Repository.Name, "")
+
+	// parse request parameters
+	// GET /example?list-type=2&prefix=main%2F&delimiter=%2F&encoding-type=url HTTP/1.1
 
 	// handle ListObjects versions
 	listType := query.Get("list-type")

--- a/pkg/gateway/operations/listobjects.go
+++ b/pkg/gateway/operations/listobjects.go
@@ -353,9 +353,9 @@ func (controller *ListObjects) Handle(w http.ResponseWriter, req *http.Request, 
 	// parse request parameters
 	// GET /example?list-type=2&prefix=main%2F&delimiter=%2F&encoding-type=url HTTP/1.1
 
-	// handle GET /?versioning
+	// handle GET /?versions
 	query := req.URL.Query()
-	if _, found := query["versioning"]; found {
+	if _, found := query["versions"]; found {
 		o.EncodeXMLBytes(w, req, []byte(serde.VersioningResponse), http.StatusOK)
 		return
 	}

--- a/pkg/gateway/operations/postobject.go
+++ b/pkg/gateway/operations/postobject.go
@@ -163,20 +163,20 @@ func normalizeMultipartUploadCompletion(list *block.MultipartUploadCompletion) {
 }
 
 func (controller *PostObject) Handle(w http.ResponseWriter, req *http.Request, o *PathOperation) {
-	// POST is only supported for CreateMultipartUpload/CompleteMultipartUpload
-	// https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html
-	// https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html
-	_, mpuCreateParamExist := req.URL.Query()[CreateMultipartUploadQueryParam]
-	if mpuCreateParamExist {
-		controller.HandleCreateMultipartUpload(w, req, o)
+	if o.HandleUnsupported(w, req, "select", "restore") {
 		return
 	}
 
-	_, mpuCompleteParamExist := req.URL.Query()[CompleteMultipartUploadQueryParam]
-	if mpuCompleteParamExist {
+	// POST is only supported for CreateMultipartUpload/CompleteMultipartUpload
+	// https://docs.aws.amazon.com/AmazonS3/latest/API/API_CreateMultipartUpload.html
+	// https://docs.aws.amazon.com/AmazonS3/latest/API/API_CompleteMultipartUpload.html
+	query := req.URL.Query()
+	switch {
+	case query.Has(CreateMultipartUploadQueryParam):
+		controller.HandleCreateMultipartUpload(w, req, o)
+	case query.Has(CompleteMultipartUploadQueryParam):
 		controller.HandleCompleteMultipartUpload(w, req, o)
-		return
+	default:
+		w.WriteHeader(http.StatusMethodNotAllowed)
 	}
-	// otherwise
-	w.WriteHeader(http.StatusMethodNotAllowed)
 }

--- a/pkg/gateway/operations/putbucket.go
+++ b/pkg/gateway/operations/putbucket.go
@@ -25,11 +25,12 @@ func (controller *PutBucket) RequiredPermissions(_ *http.Request, repoID string)
 }
 
 func (controller *PutBucket) Handle(w http.ResponseWriter, req *http.Request, o *RepoOperation) {
-	o.Incr("put_repo", o.Principal, o.Repository.Name, "")
-	if o.Repository == nil {
-		// No repo, would have to create it, but not enough
-		// information -- so not supported.
-		o.EncodeError(w, req, nil, gatewayerrors.ERRLakeFSNotSupported.ToAPIErr())
+	if o.HandleUnsupported(w, req, "cors", "metrics", "website", "logging", "accelerate",
+		"requestPayment", "acl", "publicAccessBlock", "ownershipControls", "intelligent-tiering", "analytics",
+		"lifecycle", "replication", "encryption", "policy", "object-lock", "tagging", "versioning") {
+		return
 	}
+
+	o.Incr("put_repo", o.Principal, o.Repository.Name, "")
 	o.EncodeError(w, req, nil, gatewayerrors.ErrBucketAlreadyExists.ToAPIErr())
 }

--- a/pkg/gateway/operations/putobject.go
+++ b/pkg/gateway/operations/putobject.go
@@ -214,6 +214,10 @@ func handleUploadPart(w http.ResponseWriter, req *http.Request, o *PathOperation
 }
 
 func (controller *PutObject) Handle(w http.ResponseWriter, req *http.Request, o *PathOperation) {
+	if o.HandleUnsupported(w, req, "torrent", "acl") {
+		return
+	}
+
 	// verify branch before we upload data - fail early
 	branchExists, err := o.Catalog.BranchExists(req.Context(), o.Repository.Name, o.Reference)
 	if err != nil {
@@ -230,8 +234,7 @@ func (controller *PutObject) Handle(w http.ResponseWriter, req *http.Request, o 
 	query := req.URL.Query()
 
 	// check if this is a multipart upload creation call
-	_, hasUploadID := query[QueryParamUploadID]
-	if hasUploadID {
+	if query.Has(QueryParamUploadID) {
 		handleUploadPart(w, req, o)
 		return
 	}

--- a/pkg/gateway/serde/xml.go
+++ b/pkg/gateway/serde/xml.go
@@ -168,3 +168,8 @@ type Tagging struct {
 	XMLName xml.Name `xml:"http://s3.amazonaws.com/doc/2006-03-01/ Tagging"`
 	TagSet  TagSet   `xml:"TagSet"`
 }
+
+type LocationResponse struct {
+	XMLName  xml.Name `xml:"http://s3.amazonaws.com/doc/2006-03-01/ LocationConstraint"`
+	Location string   `xml:",chardata"`
+}

--- a/pkg/gateway/testutil/gateway_setup.go
+++ b/pkg/gateway/testutil/gateway_setup.go
@@ -63,19 +63,7 @@ func GetBasicHandler(t *testing.T, authService *FakeAuthService, repoName string
 	_, err = c.CreateRepository(ctx, repoName, storageNamespace, "main")
 	testutil.Must(t, err)
 
-	handler := gateway.NewHandler(
-		authService.Region,
-		c,
-		multipartTracker,
-		blockAdapter,
-		authService,
-		[]string{authService.BareDomain},
-		&stats.NullCollector{},
-		upload.DefaultPathProvider,
-		nil,
-		config.DefaultLoggingAuditLogLevel,
-		true,
-	)
+	handler := gateway.NewHandler(authService.Region, c, multipartTracker, blockAdapter, authService, []string{authService.BareDomain}, &stats.NullCollector{}, upload.DefaultPathProvider, nil, config.DefaultLoggingAuditLogLevel, true, false)
 
 	return handler, &Dependencies{
 		blocks:  blockAdapter,


### PR DESCRIPTION
Fix https://github.com/treeverse/lakeFS/issues/7025

- Handle `getbucketlocation` API call based on s3 configured region
- Configurable option to disable unsupported operations
