### PR TITLE
Explicitly make ObjectReader a context

### DIFF
--- a/.github/workflows/python-wrapper-unit-tests.yaml
+++ b/.github/workflows/python-wrapper-unit-tests.yaml
@@ -1,4 +1,4 @@
-name: Unit Test Python SDK Wrapper      
+name: Unit Test Python SDK Wrapper
 on:
   push:
     branches:

--- a/clients/python-wrapper/lakefs/object.py
+++ b/clients/python-wrapper/lakefs/object.py
@@ -8,7 +8,10 @@ import base64
 import binascii
 import io
 import os
-from typing import AnyStr, AsyncIterable, IO, Iterable, Iterator, List, Literal, NamedTuple, Optional, Self, Union, get_args
+from typing import (
+    AnyStr, AsyncIterable, IO, Iterable, Iterator,
+    List, Literal, NamedTuple, Optional, TypeVar, Union,
+    get_args)
 
 import lakefs_sdk
 from lakefs_sdk import StagingMetadata
@@ -278,10 +281,10 @@ class ObjectReader(IO):
         """
         raise io.UnsupportedOperation
 
-    def __enter__(self) -> Self:
+    def __enter__(self) -> TypeVar("Self", bound="ObjectReader"):
         return self
 
-    def __exit__(self, type, value, traceback) -> boolean:
+    def __exit__(self, typ, value, traceback) -> bool:
         self.close()
         return False            # Don't suppress an exception
 


### PR DESCRIPTION
This is actually easier than using a context manager wrapper decorator.

Fixes #7032.