### PR TITLE
Python Wrapper: Rename default client

### DIFF
--- a/clients/python-wrapper/lakefs/client.py
+++ b/clients/python-wrapper/lakefs/client.py
@@ -21,7 +21,7 @@ from lakefs.exceptions import NoAuthenticationFound, NotAuthorizedException, Ser
 from lakefs.namedtuple import LenientNamedTuple
 
 # global default client
-DefaultClient: Optional[Client] = None
+DEFAULT_CLIENT: Optional[Client] = None
 
 
 class ServerStorageConfiguration(LenientNamedTuple):
@@ -45,7 +45,7 @@ class ServerConfiguration:
     _conf: lakefs_sdk.Config
     _storage_conf: ServerStorageConfiguration
 
-    def __init__(self, client: Optional[Client] = DefaultClient):
+    def __init__(self, client: Optional[Client] = DEFAULT_CLIENT):
         try:
             self._conf = client.sdk_client.config_api.get_config()
             self._storage_conf = ServerStorageConfiguration(**self._conf.storage_config.__dict__)
@@ -118,15 +118,15 @@ class Client:
 
 
 try:
-    DefaultClient = Client()
+    DEFAULT_CLIENT = Client()
 except NoAuthenticationFound:
     # must call init() explicitly
-    DefaultClient = None  # pylint: disable=C0103
+    DEFAULT_CLIENT = None  # pylint: disable=C0103
 
 
 def init(**kwargs) -> None:
     """
     Initialize DefaultClient using the provided parameters
     """
-    global DefaultClient  # pylint: disable=W0603
-    DefaultClient = Client(**kwargs)
+    global DEFAULT_CLIENT  # pylint: disable=W0603
+    DEFAULT_CLIENT = Client(**kwargs)

--- a/clients/python-wrapper/lakefs/object.py
+++ b/clients/python-wrapper/lakefs/object.py
@@ -16,7 +16,7 @@ from typing import (
 import lakefs_sdk
 from lakefs_sdk import StagingMetadata
 
-from lakefs.client import Client, DefaultClient
+from lakefs.client import Client, DEFAULT_CLIENT
 from lakefs.exceptions import (
     api_exception_handler,
     LakeFSException,
@@ -61,7 +61,7 @@ class StoredObject:
     _path: str
     _stats: Optional[ObjectStats] = None
 
-    def __init__(self, repository: str, reference: str, path: str, client: Optional[Client] = DefaultClient):
+    def __init__(self, repository: str, reference: str, path: str, client: Optional[Client] = DEFAULT_CLIENT):
         self._client = client
         self._repo_id = repository
         self._ref_id = reference
@@ -163,7 +163,7 @@ class ObjectReader(IO):
     _is_closed: bool = False
 
     def __init__(self, obj: StoredObject, mode: OpenModes, pre_sign: Optional[bool] = None,
-                 client: Optional[Client] = DefaultClient) -> None:
+                 client: Optional[Client] = DEFAULT_CLIENT) -> None:
         if mode not in get_args(OpenModes):
             raise ValueError(f"invalid read mode: '{mode}'. ReadModes: {OpenModes}")
 
@@ -286,7 +286,7 @@ class ObjectReader(IO):
 
     def __exit__(self, typ, value, traceback) -> bool:
         self.close()
-        return False            # Don't suppress an exception
+        return False  # Don't suppress an exception
 
     def seek(self, offset: int, whence: int = 0) -> int:
         """
@@ -364,7 +364,7 @@ class WriteableObject(StoredObject):
     This Object is instantiated and returned upon invoking open() on Branch reference type.
     """
 
-    def __init__(self, repository: str, reference: str, path: str, client: Optional[Client] = DefaultClient) -> None:
+    def __init__(self, repository: str, reference: str, path: str, client: Optional[Client] = DEFAULT_CLIENT) -> None:
         super().__init__(repository, reference, path, client=client)
 
     def create(self,

--- a/clients/python-wrapper/lakefs/reference.py
+++ b/clients/python-wrapper/lakefs/reference.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 
 from typing import Optional, Generator, Literal
 
-from lakefs.client import Client, DefaultClient
+from lakefs.client import Client, DEFAULT_CLIENT
 from lakefs.exceptions import api_exception_handler
 from lakefs.object import StoredObject
 from lakefs.namedtuple import LenientNamedTuple
@@ -45,7 +45,7 @@ class Reference:
     _id: str
     _commit: Optional[Commit] = None
 
-    def __init__(self, repo_id: str, ref_id: str, client: Optional[Client] = DefaultClient) -> None:
+    def __init__(self, repo_id: str, ref_id: str, client: Optional[Client] = DEFAULT_CLIENT) -> None:
         self._client = client
         self._repo_id = repo_id
         self._id = ref_id

--- a/clients/python-wrapper/lakefs/repository.py
+++ b/clients/python-wrapper/lakefs/repository.py
@@ -10,7 +10,7 @@ import lakefs_sdk
 from lakefs.tag import Tag
 from lakefs.branch import Branch
 from lakefs.branch_manager import BranchManager
-from lakefs.client import Client, DefaultClient
+from lakefs.client import Client, DEFAULT_CLIENT
 from lakefs.exceptions import api_exception_handler, ConflictException, LakeFSException
 from lakefs.namedtuple import LenientNamedTuple
 from lakefs.reference import Reference
@@ -37,7 +37,7 @@ class Repository:
     _id: str
     _properties: RepositoryProperties = None
 
-    def __init__(self, repository_id: str, client: Optional[Client] = DefaultClient) -> None:
+    def __init__(self, repository_id: str, client: Optional[Client] = DEFAULT_CLIENT) -> None:
         self._id = repository_id
         self._client = client
 

--- a/clients/python-wrapper/tests/integration/conftest.py
+++ b/clients/python-wrapper/tests/integration/conftest.py
@@ -22,7 +22,7 @@ def fixture_storage_namespace(test_name):
 
 @pytest.fixture()
 def setup_repo(storage_namespace, test_name, default_branch="main"):
-    clt = client.DefaultClient
+    clt = client.DEFAULT_CLIENT
     repo_name = test_name + str(int(time.time()))
     repo = Repository(repo_name, clt)
     repo.create(storage_namespace=storage_namespace, default_branch=default_branch)

--- a/clients/python-wrapper/tests/utests/common.py
+++ b/clients/python-wrapper/tests/utests/common.py
@@ -44,7 +44,7 @@ def lakectl_test_config_context(monkey, tmp_path):
         try:
             yield client
         finally:
-            client.DefaultClient = None
+            client.DEFAULT_CLIENT = None
 
 
 @contextmanager

--- a/clients/python-wrapper/tests/utests/test_client.py
+++ b/clients/python-wrapper/tests/utests/test_client.py
@@ -23,14 +23,14 @@ TEST_CONFIG_KWARGS: dict[str, str] = {
 class TestClient:
     def test_client_no_config(self, monkeypatch):
         with lakectl_no_config_context(monkeypatch) as client:
-            client.DefaultClient = None
+            client.DEFAULT_CLIENT = None
             client = importlib.reload(client)
             assert client.DefaultClient is None
 
     def test_client_no_kwargs(self, monkeypatch, tmp_path):
         with lakectl_test_config_context(monkeypatch, tmp_path) as client:
-            assert client.DefaultClient is not None
-            config = client.DefaultClient.config
+            assert client.DEFAULT_CLIENT is not None
+            config = client.DEFAULT_CLIENT.config
             assert config.host == TEST_SERVER + TEST_ENDPOINT_PATH
             assert config.username == TEST_ACCESS_KEY_ID
             assert config.password == TEST_SECRET_ACCESS_KEY
@@ -42,7 +42,7 @@ class TestClient:
                 os.environ[client_config._LAKECTL_ENDPOINT_ENV] = env_endpoint
                 os.environ[client_config._LAKECTL_SECRET_ACCESS_KEY_ENV] = env_secret
                 clt = client.Client()
-                assert clt is not client.DefaultClient
+                assert clt is not client.DEFAULT_CLIENT
                 config = clt.config
                 assert config.host == env_endpoint
                 assert config.username == TEST_ACCESS_KEY_ID
@@ -60,11 +60,11 @@ class TestClient:
 
     def test_client_init(self, monkeypatch, tmp_path):
         with lakectl_no_config_context(monkeypatch) as client:
-            assert client.DefaultClient is None
+            assert client.DEFAULT_CLIENT is None
             from lakefs.client import init
             init(**TEST_CONFIG_KWARGS)
-            assert client.DefaultClient is not None
-            config = client.DefaultClient.config
+            assert client.DEFAULT_CLIENT is not None
+            config = client.DEFAULT_CLIENT.config
             assert config.host == TEST_CONFIG_KWARGS["host"] + TEST_ENDPOINT_PATH
             assert config.username == TEST_CONFIG_KWARGS["username"]
             assert config.password == TEST_CONFIG_KWARGS["password"]

--- a/clients/python-wrapper/tests/utests/test_client.py
+++ b/clients/python-wrapper/tests/utests/test_client.py
@@ -25,7 +25,7 @@ class TestClient:
         with lakectl_no_config_context(monkeypatch) as client:
             client.DEFAULT_CLIENT = None
             client = importlib.reload(client)
-            assert client.DefaultClient is None
+            assert client.DEFAULT_CLIENT is None
 
     def test_client_no_kwargs(self, monkeypatch, tmp_path):
         with lakectl_test_config_context(monkeypatch, tmp_path) as client:


### PR DESCRIPTION
Closes #6998

## Change Description

Rename default client to adhere to PEP8 conventions