### PR TITLE
Python Wrapper: Refactor object create

### DIFF
--- a/clients/python-wrapper/lakefs/object.py
+++ b/clients/python-wrapper/lakefs/object.py
@@ -367,8 +367,8 @@ class WriteableObject(StoredObject):
     def __init__(self, repository: str, reference: str, path: str, client: Optional[Client] = DEFAULT_CLIENT) -> None:
         super().__init__(repository, reference, path, client=client)
 
-    def create(self,
-               data: UploadContentType,
+    def upload(self,
+               data: str | bytes,
                mode: WriteModes = 'wb',
                pre_sign: Optional[bool] = None,
                content_type: Optional[str] = None,
@@ -398,7 +398,6 @@ class WriteableObject(StoredObject):
         if 'x' in mode and self.exists():  # Requires explicit create
             raise ObjectExistsException
 
-        # TODO: handle streams
         binary_mode = 'b' in mode
         if binary_mode and isinstance(data, str):
             content = data.encode('utf-8')

--- a/clients/python-wrapper/tests/integration/test_object.py
+++ b/clients/python-wrapper/tests/integration/test_object.py
@@ -10,7 +10,7 @@ from lakefs.object import WriteableObject, WriteModes, OpenModes
 def test_object_read_seek(setup_repo):
     clt, repo = setup_repo
     data = "test_data"
-    obj = WriteableObject(repository=repo.properties.id, reference="main", path="test_obj", client=clt).create(
+    obj = WriteableObject(repository=repo.properties.id, reference="main", path="test_obj", client=clt).upload(
         data=data)
 
     with obj.open() as fd:
@@ -33,20 +33,20 @@ def test_object_read_seek(setup_repo):
             fd.read(1)
 
 
-def test_object_create_exists(setup_repo):
+def test_object_upload_exists(setup_repo):
     clt, repo = setup_repo
     data = "test_data"
-    obj = WriteableObject(repository=repo.properties.id, reference="main", path="test_obj", client=clt).create(
+    obj = WriteableObject(repository=repo.properties.id, reference="main", path="test_obj", client=clt).upload(
         data=data)
     with expect_exception_context(ObjectExistsException):
-        obj.create(data="some_other_data", mode='xb')
+        obj.upload(data="some_other_data", mode='xb')
 
     with obj.open() as fd:
         assert fd.read() == data
 
     # Create - overwrite
     new_data = "new_data"
-    obj2 = obj.create(data=new_data, mode='w')
+    obj2 = obj.upload(data=new_data, mode='w')
 
     with obj.open() as fd:
         assert fd.read() == new_data
@@ -57,10 +57,10 @@ def test_object_create_exists(setup_repo):
 @pytest.mark.parametrize("w_mode", get_args(WriteModes))
 @pytest.mark.parametrize("pre_sign", (True, False))
 @pytest.mark.parametrize("r_mode", get_args(OpenModes))
-def test_object_create_read_different_params(setup_repo, w_mode, pre_sign, r_mode):
+def test_object_upload_read_different_params(setup_repo, w_mode, pre_sign, r_mode):
     clt, repo = setup_repo
     data = b'test \xcf\x84o\xcf\x81\xce\xbdo\xcf\x82'
-    obj = WriteableObject(repository=repo.properties.id, reference="main", path="test_obj", client=clt).create(
+    obj = WriteableObject(repository=repo.properties.id, reference="main", path="test_obj", client=clt).upload(
         data=data, mode=w_mode, pre_sign=pre_sign)
 
     with obj.open(mode=r_mode) as fd:
@@ -78,7 +78,7 @@ def test_object_create_read_different_params(setup_repo, w_mode, pre_sign, r_mod
 def test_object_copy(setup_repo):
     clt, repo = setup_repo
     data = "test_data"
-    obj = WriteableObject(repository=repo.properties.id, reference="main", path="test_obj", client=clt).create(
+    obj = WriteableObject(repository=repo.properties.id, reference="main", path="test_obj", client=clt).upload(
         data=data, metadata={"foo": "bar"})
 
     copy_name = "copy_obj"

--- a/clients/python-wrapper/tests/integration/test_sanity.py
+++ b/clients/python-wrapper/tests/integration/test_sanity.py
@@ -44,11 +44,11 @@ def test_branch_sanity(storage_namespace, setup_repo):
     assert new_branch.head().id == main_branch.head().id
 
     initial_content = "test_content"
-    new_branch.object("test_object").create(initial_content)
+    new_branch.object("test_object").upload(initial_content)
     new_branch.commit("test_commit", {"test_key": "test_value"})
 
     override_content = "override_test_content"
-    obj = new_branch.object("test_object").create(override_content)
+    obj = new_branch.object("test_object").upload(override_content)
     new_branch.commit("override_data")
     with obj.open() as fd:
         assert fd.read() == override_content
@@ -115,7 +115,7 @@ def test_object_sanity(setup_repo):
     data = "test_data"
     path = "test_obj"
     metadata = {"foo": "bar"}
-    obj = WriteableObject(repository=repo.properties.id, reference="main", path=path, client=clt).create(
+    obj = WriteableObject(repository=repo.properties.id, reference="main", path=path, client=clt).upload(
         data=data, metadata=metadata)
     with obj.open() as fd:
         assert fd.read() == data

--- a/clients/python-wrapper/tests/utests/test_object.py
+++ b/clients/python-wrapper/tests/utests/test_object.py
@@ -222,10 +222,10 @@ class TestWriteableObject:
             monkeypatch.setattr(lakefs_sdk.api.StagingApi, "link_physical_address", monkey_link_physical_address)
             # Test string
             data = "test_data"
-            obj.create(data=data)
+            obj.upload(data=data)
 
     def test_create_invalid_mode(self, monkeypatch, tmp_path):
         test_kwargs = ObjectTestKWArgs()
         with writeable_object_context(monkeypatch, **test_kwargs.__dict__) as obj:
             with expect_exception_context(ValueError):
-                obj.create(data="", mode="invalid")
+                obj.upload(data="", mode="invalid")


### PR DESCRIPTION
Closes #7043

## Change Description

### Background

Refactor `create` method as part of https://github.com/treeverse/lakeFS/issues/7033