### PR TITLE
kv dynamodb check if table exists before we try to create

### DIFF
--- a/pkg/kv/dynamodb/store.go
+++ b/pkg/kv/dynamodb/store.go
@@ -113,7 +113,8 @@ func (d *Driver) Open(ctx context.Context, kvParams kvparams.Config) (kv.Store, 
 		}
 	})
 
-	// Create table if not exists
+	// Create table if not exists.
+	// To avoid potential errors in restricted environments, we confirmed the existence of the table beforehand.
 	success, _ := isTableExist(ctx, svc, params.TableName)
 	if !success {
 		err := setupKeyValueDatabase(ctx, svc, params)

--- a/pkg/kv/dynamodb/store.go
+++ b/pkg/kv/dynamodb/store.go
@@ -113,9 +113,13 @@ func (d *Driver) Open(ctx context.Context, kvParams kvparams.Config) (kv.Store, 
 		}
 	})
 
-	err = setupKeyValueDatabase(ctx, svc, params)
-	if err != nil {
-		return nil, fmt.Errorf("%w: %s", kv.ErrSetupFailed, err)
+	// Create table if not exists
+	success, _ := isTableExist(ctx, svc, params.TableName)
+	if !success {
+		err := setupKeyValueDatabase(ctx, svc, params)
+		if err != nil {
+			return nil, fmt.Errorf("%w: %s", kv.ErrSetupFailed, err)
+		}
 	}
 
 	logger := logging.FromContext(ctx).WithField("store", DriverName)


### PR DESCRIPTION
This is a revert of previous behaviour we had for kv Open in lakeFS - checking the table current state before creation.
In order to support running lakeFS in environment without permissions to create, checking before trying to create, will prevent errors.

Close https://github.com/treeverse/lakeFS/issues/7059