### PR TITLE
Use the go action build-in cache

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -11,58 +11,36 @@ jobs:
     steps:
       - name: Check-out code
         uses: actions/checkout@v4
-        with:
-          fetch-depth: "1"
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
           go-version: "1.21.4"
-        id: go
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "18.17.0"
+          cache: "npm"
+          cache-dependency-path: webui/package-lock.json
       - uses: bufbuild/buf-setup-action@v1.27.1
       - name: Generate code
         env:
           NODE_OPTIONS: "--max-old-space-size=4096"
         run: make gen
       - name: Checks validator
-        run: make checks-validator
         env:
           GOLANGCI_LINT_FLAGS: --out-format github-actions
-          NODE_OPTIONS: "--max-old-space-size=4096"
+        run: make checks-validator
 
   test-go:
     name: Run Go tests
     runs-on: ubuntu-20.04
     steps:
-      - name: Check out code into the Go module directory
+      - name: Check-out code
         uses: actions/checkout@v4
       - name: Setup Go
         uses: actions/setup-go@v4
         with:
           go-version: "1.21.4"
-        id: go
-      # No way to share code between workflows :-( If you change this, find and change the
-      # same code wherever "Find Go module and build caches" appears!
-      - name: Find Go module and build caches
-        run: |
-          echo GOMODCACHE=`go env GOMODCACHE` >> $GITHUB_ENV
-          echo GOCACHE=`go env GOCACHE` >> $GITHUB_ENV
-          cat $GITHUB_ENV
-      - name: Cache Go modules and builds
-        uses: actions/cache@v3
-        env:
-          cache-name: cache-go-modules
-        with:
-          path: |
-            ${{ env.GOMODCACHE }}
-            ${{ env.GOCACHE }}
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ hashFiles('go.mod', 'go.sum') }}
-          restore-keys: ${{ runner.os }}-build-${{ env.cache-name }}-
-            ${{ runner.os }}-build-
-            ${{ runner.os }}-
-
-      - name: Run tests
-        env:
-          NODE_OPTIONS: "--max-old-space-size=4096"
+      - name: Run Go tests
         run: |
           mkdir ./webui/dist
           touch ./webui/dist/index.html         


### PR DESCRIPTION
Update github action test workflow:
- Use Go action builtin cache mechanism.
- Use NodeJS for codegen step with cache based on our webui packages.
- Remove NODE_OPTIONS when it is not neeed.