### PR TITLE
Python Wrapper: Bug bash fixes

### DIFF
--- a/clients/python-wrapper/docs/conf.py
+++ b/clients/python-wrapper/docs/conf.py
@@ -12,7 +12,7 @@ sys.path.insert(0, os.path.abspath('../'))
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
 
 project = 'python-lakefs'
-copyright = '2023, Treeverse'
+project_copyright = '2023, Treeverse'
 author = 'Treeverse'
 
 # -- General configuration ---------------------------------------------------

--- a/clients/python-wrapper/lakefs/namedtuple.py
+++ b/clients/python-wrapper/lakefs/namedtuple.py
@@ -10,6 +10,7 @@ class LenientNamedTuple:
     """
 
     __initialized: bool = False
+    unknown: dict = None
 
     def __init__(self, **kwargs):
         fields = list(self.__class__.__dict__["__annotations__"].keys())

--- a/clients/python-wrapper/lakefs/object.py
+++ b/clients/python-wrapper/lakefs/object.py
@@ -416,7 +416,7 @@ class ObjectWriter(LakeFSIOBase):
         etag = headers.get("ETag", "").strip(' "')
         return etag
 
-    def _upload_raw(self) -> ObjectStats:
+    def _upload_raw(self) -> lakefs_sdk.ObjectStats:
         """
         Use raw upload API call to bypass validation of content parameter
         """
@@ -446,7 +446,7 @@ class ObjectWriter(LakeFSIOBase):
         handle_http_error(resp)
         return lakefs_sdk.ObjectStats(**json.loads(resp.data))
 
-    def _upload_presign(self) -> ObjectStats:
+    def _upload_presign(self) -> lakefs_sdk.ObjectStats:
         staging_location = self._client.sdk_client.staging_api.get_physical_address(self._obj.repo,
                                                                                     self._obj.ref,
                                                                                     self._obj.path,
@@ -546,7 +546,7 @@ class StoredObject:
         """
         return self._path
 
-    def reader(self, mode: ReadModes = 'r', pre_sign: Optional[bool] = None) -> ObjectReader:
+    def reader(self, mode: ReadModes = 'rb', pre_sign: Optional[bool] = None) -> ObjectReader:
         """
         Context manager which provide a file-descriptor like object that allow reading the given object
 

--- a/clients/python-wrapper/lakefs/repository.py
+++ b/clients/python-wrapper/lakefs/repository.py
@@ -68,8 +68,8 @@ class Repository:
         def handle_conflict(e: LakeFSException):
             if isinstance(e, ConflictException) and exist_ok:
                 with api_exception_handler():
-                    repo = self._client.sdk_client.repositories_api.get_repository(self._id)
-                    self._properties = RepositoryProperties(**repo.dict())
+                    get_repo = self._client.sdk_client.repositories_api.get_repository(self._id)
+                    self._properties = RepositoryProperties(**get_repo.dict())
                     return None
             return e
 

--- a/clients/python-wrapper/setup.py
+++ b/clients/python-wrapper/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 NAME = "lakefs"
-VERSION = "0.1.0-beta"
+VERSION = "0.1.0-beta.1"
 # To install the library, run the following
 #
 # python setup.py install

--- a/clients/python-wrapper/tests/integration/test_object.py
+++ b/clients/python-wrapper/tests/integration/test_object.py
@@ -11,7 +11,7 @@ from lakefs.object import WriteableObject, WriteModes, ReadModes
 @pytest.mark.parametrize("pre_sign", (True, False), indirect=True)
 def test_object_read_seek(setup_repo, pre_sign):
     clt, repo = setup_repo
-    data = "test_data"
+    data = b"test_data"
     obj = WriteableObject(repository=repo.properties.id, reference="main", path="test_obj", client=clt).upload(
         data=data, pre_sign=pre_sign)
 
@@ -29,7 +29,7 @@ def test_object_read_seek(setup_repo, pre_sign):
 
         fd.seek(0)
         for c in data:
-            assert fd.read(1) == c
+            assert ord(fd.read(1)) == c
         # This should raise an exception
         with expect_exception_context(InvalidRangeException):
             fd.read(1)
@@ -37,7 +37,7 @@ def test_object_read_seek(setup_repo, pre_sign):
 
 def test_object_upload_exists(setup_repo):
     clt, repo = setup_repo
-    data = "test_data"
+    data = b"test_data"
     obj = WriteableObject(repository=repo.properties.id, reference="main", path="test_obj", client=clt).upload(
         data=data)
     with expect_exception_context(ObjectExistsException):
@@ -47,7 +47,7 @@ def test_object_upload_exists(setup_repo):
         assert fd.read() == data
 
     # Create - overwrite
-    new_data = "new_data"
+    new_data = b"new_data"
     obj2 = obj.upload(data=new_data, mode='w')
 
     with obj.reader() as fd:
@@ -113,7 +113,7 @@ def test_writer(setup_repo):
         with expect_exception_context(NotFoundException):
             obj.stat()
 
-    assert obj.reader().read() == "Hello World!"
+    assert obj.reader().read() == b"Hello World!"
 
 
 @pytest.mark.parametrize("w_mode", get_args(WriteModes))

--- a/clients/python-wrapper/tests/integration/test_sanity.py
+++ b/clients/python-wrapper/tests/integration/test_sanity.py
@@ -43,11 +43,11 @@ def test_branch_sanity(storage_namespace, setup_repo):
     assert new_branch.id == branch_name
     assert new_branch.head().id == main_branch.head().id
 
-    initial_content = "test_content"
+    initial_content = b"test_content"
     new_branch.object("test_object").upload(initial_content)
     new_branch.commit("test_commit", {"test_key": "test_value"})
 
-    override_content = "override_test_content"
+    override_content = b"override_test_content"
     obj = new_branch.object("test_object").upload(override_content)
     new_branch.commit("override_data")
     with obj.reader() as fd:
@@ -112,7 +112,7 @@ def test_tag_sanity(setup_repo):
 
 def test_object_sanity(setup_repo):
     clt, repo = setup_repo
-    data = "test_data"
+    data = b"test_data"
     path = "test_obj"
     metadata = {"foo": "bar"}
     obj = WriteableObject(repository=repo.properties.id, reference="main", path=path, client=clt).upload(

--- a/clients/python-wrapper/tests/utests/test_object.py
+++ b/clients/python-wrapper/tests/utests/test_object.py
@@ -103,7 +103,8 @@ class TestObjectReader:
             with obj.reader() as fd:
                 assert fd.tell() == 0
 
-    def verify_reader(self, fd, patch_setattr, test_kwargs, data):
+    @staticmethod
+    def verify_reader(fd, patch_setattr, test_kwargs, data):
         object_stats = ObjectTestStats()
         object_stats.path = test_kwargs.path
         object_stats.size_bytes = len(data)


### PR DESCRIPTION
## Change Description

### Background

test_object.py
- verify_reader can be static **- DONE**
conf.py
- copyright shadows built-in name **- DONE**
test_object.py
- range - build-in name **- NOT DONE this is a mock of the lakefs-sdk function signature**
repository.py
- `repo` used from outer scope **- DONE**
- unknown property - dynamic attribute will be marked as trying to set as error **- DONE**
object.py
- close - stat object is not the from the API, so there is no dict. **- DONE - modified return values**
