### PR TITLE
Fix: Controller handle Hook errors

### DIFF
--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -2225,6 +2225,14 @@ func (c *Controller) handleAPIErrorCallback(ctx context.Context, w http.Response
 
 	log := c.Logger.WithContext(ctx).WithError(err)
 
+	// Handle Hook Errors
+	var hookAbortErr *graveler.HookAbortError
+	if errors.As(err, &hookAbortErr) {
+		log.WithField("run_id", hookAbortErr.RunID).Warn("aborted by hooks")
+		cb(w, r, http.StatusPreconditionFailed, err)
+		return true
+	}
+
 	// order of case is important, more specific errors should be first
 	switch {
 	case errors.Is(err, graveler.ErrLinkAddressNotFound),
@@ -2503,15 +2511,6 @@ func (c *Controller) Commit(w http.ResponseWriter, r *http.Request, body apigen.
 	}
 
 	newCommit, err := c.Catalog.Commit(ctx, repository, branch, body.Message, user.Committer(), metadata, body.Date, params.SourceMetarange)
-	var hookAbortErr *graveler.HookAbortError
-	if errors.As(err, &hookAbortErr) {
-		c.Logger.
-			WithError(err).
-			WithField("run_id", hookAbortErr.RunID).
-			Warn("aborted by hooks")
-		writeError(w, r, http.StatusPreconditionFailed, err)
-		return
-	}
 	if c.handleAPIError(ctx, w, r, err) {
 		return
 	}
@@ -4134,13 +4133,7 @@ func (c *Controller) MergeIntoBranch(w http.ResponseWriter, r *http.Request, bod
 		metadata,
 		swag.StringValue(body.Strategy))
 
-	var hookAbortErr *graveler.HookAbortError
-	switch {
-	case errors.As(err, &hookAbortErr):
-		c.Logger.WithError(err).WithField("run_id", hookAbortErr.RunID).Warn("aborted by hooks")
-		writeError(w, r, http.StatusPreconditionFailed, err)
-		return
-	case errors.Is(err, graveler.ErrConflictFound):
+	if errors.Is(err, graveler.ErrConflictFound) {
 		writeResponse(w, r, http.StatusConflict, apigen.MergeResult{
 			Reference: reference,
 		})


### PR DESCRIPTION
Closes #7075

## Change Description

### Background

Some operations handled pre hook failures returning the appropriate error code and some operations (such as create branch) did not handle HookAbort Errors and as a result server returned 500

### Bug Fix

Fixed by moving the hook error handling to a central location under `handleAPIError`
      
### Testing Details

Added new system test to cover the scenario
