### PR TITLE
fix client is None

### DIFF
--- a/clients/python-wrapper/lakefs/reference.py
+++ b/clients/python-wrapper/lakefs/reference.py
@@ -171,7 +171,7 @@ class Reference:
 
         :param path: The object's path
         """
-        return StoredObject(self._repo_id, self._id, path)
+        return StoredObject(self._repo_id, self._id, path,self._client)
 
     def __str__(self) -> str:
         return self._id

--- a/clients/python-wrapper/lakefs/reference.py
+++ b/clients/python-wrapper/lakefs/reference.py
@@ -148,7 +148,7 @@ class Reference:
 
         :param path: The object's path
         """
-        return StoredObject(self._repo_id, self._id, path,self._client)
+        return StoredObject(self._repo_id, self._id, path, self._client)
 
     def __str__(self) -> str:
         return self._id


### PR DESCRIPTION
Closes #7111
## Change Description
`
def get_client():
    from lakefs.client import Client
    clt = Client(username=username, password=password, host=host)
    return clt


clt = get_client()

repo = lakefs.Repository(repository_id="datalab",client=clt)

ref = repo.ref(ref_id="main")

stored_object = ref.object(path="coco/coco128.zip")

fd = stored_object.reader()


filedata = fd.read()
save_obj = open("coco128.zip","wb")
save_obj.write(filedata)
save_obj.close()
`

### Background

(dinov2) dongzf@dongzf-LEGION-REN7000P-26AMR:/mnt/sda/code/lakeFS-master$  cd /mnt/sda/code/lakeFS-master ; /usr/bin/env /home/dongzf/miniconda3/envs/dinov2/bin/python /home/dongzf/.vscode/extensions/ms-python.python-2023.20.0/pythonFiles/lib/python/debugpy/adapter/../../debugpy/launcher 50565 -- /mnt/sda/code/lakeFS-master/clients/python-wrapper/study.py 
Traceback (most recent call last):
  File "/home/dongzf/miniconda3/envs/dinov2/lib/python3.8/runpy.py", line 194, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/home/dongzf/miniconda3/envs/dinov2/lib/python3.8/runpy.py", line 87, in _run_code
    exec(code, run_globals)
  File "/home/dongzf/.vscode/extensions/ms-python.python-2023.20.0/pythonFiles/lib/python/debugpy/adapter/../../debugpy/launcher/../../debugpy/__main__.py", line 39, in <module>
    cli.main()
  File "/home/dongzf/.vscode/extensions/ms-python.python-2023.20.0/pythonFiles/lib/python/debugpy/adapter/../../debugpy/launcher/../../debugpy/../debugpy/server/cli.py", line 430, in main
    run()
  File "/home/dongzf/.vscode/extensions/ms-python.python-2023.20.0/pythonFiles/lib/python/debugpy/adapter/../../debugpy/launcher/../../debugpy/../debugpy/server/cli.py", line 284, in run_file
    runpy.run_path(target, run_name="__main__")
  File "/home/dongzf/.vscode/extensions/ms-python.python-2023.20.0/pythonFiles/lib/python/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_runpy.py", line 321, in run_path
    return _run_module_code(code, init_globals, run_name,
  File "/home/dongzf/.vscode/extensions/ms-python.python-2023.20.0/pythonFiles/lib/python/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_runpy.py", line 135, in _run_module_code
    _run_code(code, mod_globals, init_globals,
  File "/home/dongzf/.vscode/extensions/ms-python.python-2023.20.0/pythonFiles/lib/python/debugpy/_vendored/pydevd/_pydevd_bundle/pydevd_runpy.py", line 124, in _run_code
    exec(code, run_globals)
  File "/mnt/sda/code/lakeFS-master/clients/python-wrapper/study.py", line 28, in <module>
    fd = stored_object.reader()
  File "/mnt/sda/code/lakeFS-master/clients/python-wrapper/lakefs/object.py", line 564, in reader
    return ObjectReader(self, mode=mode, pre_sign=pre_sign, client=self._client)
  File "/mnt/sda/code/lakeFS-master/clients/python-wrapper/lakefs/object.py", line 209, in __init__
    super().__init__(obj, mode, pre_sign, client)
  File "/mnt/sda/code/lakeFS-master/clients/python-wrapper/lakefs/object.py", line 75, in __init__
    self._pre_sign = pre_sign if pre_sign is not None else client.storage_config.pre_sign_support
AttributeError: 'NoneType' object has no attribute 'storage_config'
### Bug Fix

If this PR is a bug fix, please let us know about:

1. Problem - The reason for opening the bug
2. Root cause - Discovered root cause after investigation
3. Solution - How the bug was fixed
      
### New Feature

If this PR introduces a new feature, describe it here.

### Testing Details

How were the changes tested?

### Breaking Change?

Does this change break any existing functionality? (API, CLI, Clients)

## Additional info

Logs, outputs, screenshots of changes if applicable (CLI / GUI changes)

### Contact Details

How can we get in touch with you if we need more info? (ex. email@example.com)
