### PR TITLE
Python Wrapper: Add examples to documentation + prettify

### DIFF
--- a/clients/python-wrapper/README.md
+++ b/clients/python-wrapper/README.md
@@ -1,29 +1,31 @@
-# lakeFS Python SDK (Pre-release Beta)
+# lakeFS High-Level Python SDK (Pre-release Beta)
 
-lakeFS Software Development Kit (SDK) for Python, provides developers with the following features:
+lakeFS High Level SDK for Python, provides developers with the following features:
 1. Simpler programming interface with less configuration
 2. Inferring identity from environment 
 3. Better abstractions for common, more complex operations (I/O, transactions, imports)
 
-## Requirements.
+## Requirements
 
 Python 3.9+
 
 ## Installation & Usage
+
 ### pip install
 
 ```sh
 pip install lakefs
 ```
 
-Then import the package:
+### Import the package
+
 ```python
 import lakefs
 ```
 
 ## Getting Started
 
-Please follow the [installation procedure](#installation--usage) and then run the following:
+Please follow the [installation procedure](#installation--usage) and afterward refer to the following example snippet for a quick start:
 
 ```python
 

--- a/clients/python-wrapper/docs/_static/custom.css
+++ b/clients/python-wrapper/docs/_static/custom.css
@@ -1,0 +1,7 @@
+.sphinxsidebarwrapper {
+    overflow-x: scroll;
+}
+
+div.sphinxsidebarwrapper {
+    padding: 10px 5px 10px 10px;
+}

--- a/clients/python-wrapper/docs/conf.py
+++ b/clients/python-wrapper/docs/conf.py
@@ -25,8 +25,6 @@ extensions = [
     'sphinx_autodoc_typehints',
 ]
 
-templates_path = ['_templates']
-
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
 language = 'en'
@@ -34,9 +32,15 @@ language = 'en'
 # -- Options for HTML output -------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
 
-html_theme = 'alabaster'
 html_static_path = ['_static']
-html_sidebars = {'**': ['localtoc.html', 'searchbox.html']}
+html_css_files = ["custom.css"]
+html_theme = 'classic'
+html_theme_options = {
+    "body_min_width": 1000,
+    "body_max_width": "75%",
+    "sidebarwidth": 300,
+    "stickysidebar": "true"
+}
 
 # -- Options for todo extension ----------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/extensions/todo.html#configuration

--- a/clients/python-wrapper/docs/index.rst
+++ b/clients/python-wrapper/docs/index.rst
@@ -3,19 +3,18 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-Welcome to lakeFS's Python SDK Library Documentation!
-=====================================================
-
-.. toctree::
-   :maxdepth: 4
-   :caption: Contents:
-   
-   lakefs
-
 .. include:: ../README.md
    :parser: markdown
 
-Indices and tables
+API Reference
+=============
+
+.. toctree::
+   :maxdepth: 1
+   
+   lakefs
+
+Indices and Tables
 ==================
 
 * :ref:`genindex`

--- a/clients/python-wrapper/lakefs/branch.py
+++ b/clients/python-wrapper/lakefs/branch.py
@@ -183,7 +183,7 @@ class Branch(Reference):
 
             branch = lakefs.repository("<repository_name>").branch("<branch_name>")
             # list objects on a common prefix
-            objs = branch.objects(prefix="my-object-prefix/")
+            objs = branch.objects(prefix="my-object-prefix/", max_amount=100)
             # delete objects which have "foo" in their name
             branch.delete_objects([o.path for o in objs if "foo" in o.path])
 

--- a/clients/python-wrapper/lakefs/branch.py
+++ b/clients/python-wrapper/lakefs/branch.py
@@ -13,7 +13,7 @@ from lakefs.object import StoredObject
 from lakefs.import_manager import ImportManager
 from lakefs.reference import Reference, generate_listing
 from lakefs.models import Change
-from lakefs.exceptions import api_exception_handler, ConflictException, LakeFSException
+from lakefs.exceptions import api_exception_handler, ConflictException, LakeFSException, UnsupportedOperationException
 
 
 class Branch(Reference):
@@ -32,15 +32,22 @@ class Branch(Reference):
         """
         Create a new branch in lakeFS from this object
 
+        Example of creating a new branch:
+
+        .. code-block:: python
+
+            import lakefs
+
+            branch = lakefs.repository("<repository_name>").branch("<branch_name>").create("<source_reference>")
+
         :param source_reference_id: The reference to create the branch from
         :param exist_ok: If False will throw an exception if a branch by this name already exists. Otherwise,
             return the existing branch without creating a new one
         :return: The lakeFS SDK object representing the branch
-        :raises:
-            NotFoundException if repo, branch or source reference id does not exist
-            ConflictException if branch already exists and exist_ok is False
-            NotAuthorizedException if user is not authorized to perform this operation
-            ServerException for any other errors
+        :raise NotFoundException: if repo, branch or source reference id does not exist
+        :raise ConflictException: if branch already exists and exist_ok is False
+        :raise NotAuthorizedException: if user is not authorized to perform this operation
+        :raise ServerException: for any other errors
         """
 
         def handle_conflict(e: LakeFSException):
@@ -58,10 +65,9 @@ class Branch(Reference):
         Get the commit reference this branch is pointing to
 
         :return: The commit reference this branch is pointing to
-        :raises:
-            NotFoundException if branch by this id does not exist
-            NotAuthorizedException if user is not authorized to perform this operation
-            ServerException for any other errors
+        :raise NotFoundException: if branch by this id does not exist
+        :raise NotAuthorizedException: if user is not authorized to perform this operation
+        :raise ServerException: for any other errors
         """
         with api_exception_handler():
             branch = self._client.sdk_client.branches_api.get_branch(self._repo_id, self._id)
@@ -74,11 +80,10 @@ class Branch(Reference):
         :param message: Commit message
         :param metadata: Metadata to attach to the commit
         :return: The new reference after the commit
-        :raises:
-            NotFoundException if branch by this id does not exist
-            ForbiddenException if commit is not allowed on this branch
-            NotAuthorizedException if user is not authorized to perform this operation
-            ServerException for any other errors
+        :raise NotFoundException: if branch by this id does not exist
+        :raise ForbiddenException: if commit is not allowed on this branch
+        :raise NotAuthorizedException: if user is not authorized to perform this operation
+        :raise ServerException: for any other errors
         """
 
         commits_creation = lakefs_sdk.CommitCreation(message=message, metadata=metadata)
@@ -90,11 +95,10 @@ class Branch(Reference):
         """
         Delete branch from lakeFS server
 
-        :raises:
-            NotFoundException if branch or repository do not exist
-            NotAuthorizedException if user is not authorized to perform this operation
-            ForbiddenException for branches that are protected
-            ServerException for any other errors
+        :raise NotFoundException: if branch or repository do not exist
+        :raise NotAuthorizedException: if user is not authorized to perform this operation
+        :raise ForbiddenException: for branches that are protected
+        :raise ServerException: for any other errors
         """
         with api_exception_handler():
             return self._client.sdk_client.branches_api.delete_branch(self._repo_id, self._id)
@@ -107,10 +111,9 @@ class Branch(Reference):
             perform the revert.
         :param reference_id: the reference to revert
         :return: The new reference after the revert
-        :raises:
-            NotFoundException if branch by this id does not exist
-            NotAuthorizedException if user is not authorized to perform this operation
-            ServerException for any other errors
+        :raise NotFoundException: if branch by this id does not exist
+        :raise NotAuthorizedException: if user is not authorized to perform this operation
+        :raise ServerException: for any other errors
         """
         if parent_number is None:
             parent_number = 0
@@ -142,10 +145,9 @@ class Branch(Reference):
         :param after: Return items after this value
         :param prefix: Return items prefixed with this value
         :param kwargs: Additional Keyword Arguments to send to the server
-        :raises:
-            NotFoundException if branch or repository do not exist
-            NotAuthorizedException if user is not authorized to perform this operation
-            ServerException for any other errors
+        :raise NotFoundException: if branch or repository do not exist
+        :raise NotAuthorizedException: if user is not authorized to perform this operation
+        :raise ServerException: for any other errors
         """
 
         for diff in generate_listing(self._client.sdk_client.branches_api.diff_branch,
@@ -167,11 +169,27 @@ class Branch(Reference):
         """
         Delete objects from lakeFS
 
+        This method can be used to delete single/multiple objects from branch. It accepts both str and StoredObject
+        types as well as Iterables of these types.
+        Using this method is more performant than sequentially calling delete on objects as it saves the back and forth
+        from the server.
+
+        This can also be used in combination with object listing. For example:
+
+        .. code-block:: python
+
+            import lakefs
+
+            branch = lakefs.repository("<repository_name>").branch("<branch_name>")
+            # list objects on a common prefix
+            objs = branch.objects(prefix="my-object-prefix/")
+            # delete objects which have "foo" in their name
+            branch.delete_objects([o.path for o in objs if "foo" in o.path])
+
         :param object_paths: a single path or an iterable of paths to delete
-        :raises:
-            NotFoundException if branch or repository do not exist
-            NotAuthorizedException if user is not authorized to perform this operation
-            ServerException for any other errors
+        :raise NotFoundException: if branch or repository do not exist
+        :raise NotAuthorizedException: if user is not authorized to perform this operation
+        :raise ServerException: for any other errors
         """
         if isinstance(object_paths, (str, StoredObject)):
             object_paths = [str(object_paths)]
@@ -191,7 +209,7 @@ class Branch(Reference):
         :param commit_message: once the transaction is committed, a commit is created with this message
         :return: a Transaction object to perform operations on
         """
-        return Transaction(self._repo_id, self.id, commit_message, self._client)
+        raise UnsupportedOperationException("Transaction not yet implemented")
 
     def reset_changes(self, path_type: Literal["common_prefix", "object", "reset"] = "reset",
                       path: Optional[str] = None) -> None:
@@ -200,11 +218,10 @@ class Branch(Reference):
 
         :param path_type: the type of path to reset ('common_prefix', 'object', 'reset' - for all changes)
         :param path: the path to reset (optional) - if path_type is 'reset' this parameter is ignored
-        :raises:
-            ValidationError if path_type is not one of the allowed values
-            NotFoundException if branch or repository do not exist
-            NotAuthorizedException if user is not authorized to perform this operation
-            ServerException for any other errors
+        :raise ValidationError: if path_type is not one of the allowed values
+        :raise NotFoundException: if branch or repository do not exist
+        :raise NotAuthorizedException: if user is not authorized to perform this operation
+        :raise ServerException: for any other errors
         """
 
         reset_creation = lakefs_sdk.ResetCreation(path=path, type=path_type)
@@ -213,7 +230,7 @@ class Branch(Reference):
 
 class Transaction(Branch):
     """
-    Manage a transactions on a given branch
+    Manage a transactions on a given branch (TBD)
     """
 
     def __init__(self, repository_id: str, branch_id: str, commit_message: str, client: Client = DEFAULT_CLIENT):

--- a/clients/python-wrapper/lakefs/client.py
+++ b/clients/python-wrapper/lakefs/client.py
@@ -59,6 +59,16 @@ class Client:
     """
     Wrapper around lakefs_sdk's client object
     Takes care of instantiating it from the environment
+
+    Example of initializing a Client object:
+
+    .. code-block:: python
+
+        from lakefs import Client
+
+        client = Client(username="<access_key_id>", password="<secret_access_key>", host="<lakefs_endpoint>")
+        print(client.version)
+
     """
 
     _client: Optional[LakeFSClient] = None

--- a/clients/python-wrapper/lakefs/config.py
+++ b/clients/python-wrapper/lakefs/config.py
@@ -22,6 +22,7 @@ class ClientConfig:
     """
     Configuration class for the SDK Client.
     Instantiation will try to get authentication methods using the following chain:
+
     1. Provided kwargs to __init__ func (should contain necessary credentials as defined in lakefs_sdk.Configuration)
     2. Use LAKECTL_SERVER_ENDPOINT_URL, LAKECTL_ACCESS_KEY_ID and LAKECTL_ACCESS_SECRET_KEY if set
     3. Try to read ~/.lakectl.yaml if exists

--- a/clients/python-wrapper/lakefs/exceptions.py
+++ b/clients/python-wrapper/lakefs/exceptions.py
@@ -112,9 +112,10 @@ _STATUS_CODE_TO_EXCEPTION = {
 def api_exception_handler(custom_handler: Optional[Callable[[LakeFSException], LakeFSException]] = None):
     """
     Contexts which converts lakefs_sdk API exceptions to LakeFS exceptions and handles them.
+
     :param custom_handler: Optional handler which can be used to provide custom behavior for specific exceptions.
-    If custom_handler returns an exception, this function will raise the exception at the end of the 
-    custom_handler invocation.
+        If custom_handler returns an exception, this function will raise the exception at the end of the
+        custom_handler invocation.
     """
     try:
         yield
@@ -130,6 +131,7 @@ def api_exception_handler(custom_handler: Optional[Callable[[LakeFSException], L
 def handle_http_error(resp: BaseHTTPResponse) -> None:
     """
     Handles http response and raises the appropriate lakeFS exception if needed
+
     :param resp: The response to parse
     """
     if not http.HTTPStatus.OK <= resp.status < http.HTTPStatus.MULTIPLE_CHOICES:

--- a/clients/python-wrapper/lakefs/import_manager.py
+++ b/clients/python-wrapper/lakefs/import_manager.py
@@ -49,9 +49,6 @@ class ImportManager:
 
     def __init__(self, repository_id: str, branch_id: str, commit_message: Optional[str] = "",
                  commit_metadata: Optional[Dict] = None, client: Optional[Client] = DEFAULT_CLIENT) -> None:
-        self.prefix(object_store_uri="s3://import-bucket/data1/",
-                    destination="import-prefix/").object(object_store_uri="s3://import-bucket/data2/imported_file",
-                                                         destination="import-prefix/imported_file")
         self._client = client
         self._repo_id = repository_id
         self._branch_id = branch_id

--- a/clients/python-wrapper/lakefs/import_manager.py
+++ b/clients/python-wrapper/lakefs/import_manager.py
@@ -20,6 +20,23 @@ class ImportManager:
     ImportManager provides an easy-to-use interface to perform imports with multiple sources.
     It provides both synchronous and asynchronous functionality allowing the user to start an import process,
     continue executing logic and poll for the import completion.
+
+    ImportManager usage example:
+
+    .. code-block:: python
+
+        import lakefs
+
+        branch = lakefs.repository("<repository_name>").branch("<branch_name>")
+        mgr = branch.import_data(commit_message="my imported data", metadata={"foo": "bar"})
+
+        # add sources for import
+        mgr.prefix(object_store_uri="s3://import-bucket/data1/",
+                   destination="import-prefix/").object(object_store_uri="s3://import-bucket/data2/imported_file",
+                                                        destination="import-prefix/imported_file")
+        # start import and wait
+        mgr.run()
+
     """
     _client: Client
     _repo_id: str
@@ -32,6 +49,9 @@ class ImportManager:
 
     def __init__(self, repository_id: str, branch_id: str, commit_message: Optional[str] = "",
                  commit_metadata: Optional[Dict] = None, client: Optional[Client] = DEFAULT_CLIENT) -> None:
+        self.prefix(object_store_uri="s3://import-bucket/data1/",
+                    destination="import-prefix/").object(object_store_uri="s3://import-bucket/data2/imported_file",
+                                                         destination="import-prefix/imported_file")
         self._client = client
         self._repo_id = repository_id
         self._branch_id = branch_id
@@ -74,12 +94,11 @@ class ImportManager:
         Start import, reporting back (and storing) a process id
 
         :return: The import process identifier in lakeFS
-        :raises:
-            ImportManagerException if an import process is already in progress
-            NotFoundException if branch or repository do not exist
-            NotAuthorizedException if user is not authorized to perform this operation
-            ValidationError if path_type is not one of the allowed values
-            ServerException for any other errors
+        :raise ImportManagerException: if an import process is already in progress
+        :raise NotFoundException: if branch or repository do not exist
+        :raise NotAuthorizedException: if user is not authorized to perform this operation
+        :raise ValidationError: if path_type is not one of the allowed values
+        :raise ServerException: for any other errors
         """
         if self._in_progress:
             raise ImportManagerException("Import in progress")
@@ -115,11 +134,10 @@ class ImportManager:
 
         :param poll_interval: The interval for polling the import status.
         :return: Import status as returned by the lakeFS server
-        :raises:
-            ImportManagerException if no import is in progress
-            NotFoundException if branch, repository or import id do not exist
-            NotAuthorizedException if user is not authorized to perform this operation
-            ServerException for any other errors
+        :raise ImportManagerException: if no import is in progress
+        :raise NotFoundException: if branch, repository or import id do not exist
+        :raise NotAuthorizedException: if user is not authorized to perform this operation
+        :raise ServerException: for any other errors
         """
         if not self._in_progress:
             raise ImportManagerException("No import in progress")
@@ -135,8 +153,7 @@ class ImportManager:
 
         :param poll_interval: The interval for polling the import status.
         :return: Import status as returned by the lakeFS server
-        :raises:
-            See start(), wait()
+        :raises: See start(), wait()
         """
         self.start()
         wait_kwargs = {} if poll_interval is None else {"poll_interval": poll_interval}
@@ -146,11 +163,10 @@ class ImportManager:
         """
         Cancel an ongoing import process
 
-        :raises:
-            NotFoundException if branch, repository or import id do not exist
-            NotAuthorizedException if user is not authorized to perform this operation
-            ConflictException if the import was already completed
-            ServerException for any other errors
+        :raise NotFoundException: if branch, repository or import id do not exist
+        :raise NotAuthorizedException: if user is not authorized to perform this operation
+        :raise ConflictException: if the import was already completed
+        :raise ServerException: for any other errors
         """
         if self._import_id is None:  # Can't cancel on no id
             raise ImportManagerException("No import in progress")
@@ -167,11 +183,10 @@ class ImportManager:
         Get the current import status
 
         :return: Import status as returned by the lakeFS server
-        :raises:
-            ImportManagerException if no import is in progress
-            NotFoundException if branch, repository or import id do not exist
-            NotAuthorizedException if user is not authorized to perform this operation
-            ServerException for any other errors
+        :raise ImportManagerException: if no import is in progress
+        :raise NotFoundException: if branch, repository or import id do not exist
+        :raise NotAuthorizedException: if user is not authorized to perform this operation
+        :raise ServerException: for any other errors
         """
 
         if self._import_id is None:

--- a/clients/python-wrapper/lakefs/object.py
+++ b/clients/python-wrapper/lakefs/object.py
@@ -258,7 +258,7 @@ class ObjectReader(LakeFSIOBase):
             If current position + read_bytes > object size.
         :return: The bytes read
         :raise OSError: if read_bytes is non-positive
-        :raise ObjectNotFoundException: if repo id, reference id or object path does not exist
+        :raise ObjectNotFoundException: if repository id, reference id or object path does not exist
         :raise PermissionException: if user is not authorized to perform this operation, or operation is forbidden
         :raise ServerException: for any other errors
         """
@@ -552,7 +552,7 @@ class StoredObject:
                 # print every other 10 chars
                 while fd.tell() < file_size
                     print(fd.read(10))
-                    fd.seek(10)
+                    fd.seek(10, os.SEEK_CUR)
 
         :param mode: Read mode - as supported by ReadModes
         :param pre_sign: (Optional), enforce the pre_sign mode on the lakeFS server. If not set, will probe server for
@@ -687,9 +687,8 @@ class WriteableObject(StoredObject):
 
             obj = lakefs.repository("<repository_name>").branch("<branch_name>").object("my_image")
 
-            with open("my_local_image", mode='rb') as reader:
-                with obj.writer("wb") as writer:
-                    writer.write(reader.read())
+            with open("my_local_image", mode='rb') as reader, obj.writer("wb") as writer:
+                writer.write(reader.read())
 
         :param mode: Write mode - as supported by WriteModes
         :param pre_sign: (Optional), enforce the pre_sign mode on the lakeFS server. If not set, will probe server for
@@ -698,9 +697,6 @@ class WriteableObject(StoredObject):
         :param metadata: (Optional) User defined metadata to save on the object
         :return: A Writer object
         """
-        with open("my_file", mode='rb') as reader:
-            with self.writer("wb") as writer:
-                writer.write(reader.read())
         return ObjectWriter(self,
                             mode=mode,
                             pre_sign=pre_sign,

--- a/clients/python-wrapper/lakefs/object.py
+++ b/clients/python-wrapper/lakefs/object.py
@@ -236,7 +236,7 @@ class ObjectReader(LakeFSIOBase):
             other values are os.SEEK_CUR or 1 (seek relative to the current position) and os.SEEK_END or 2
             (seek relative to the file’s end)
             os.SEEK_END is not supported
-        :raises: OSError if calculated new position is negative
+        :raise OSError: if calculated new position is negative
         """
         if whence == os.SEEK_SET:
             pos = offset
@@ -257,12 +257,10 @@ class ObjectReader(LakeFSIOBase):
         :param n: How many bytes to read. If read_bytes is None, will read from current position to end.
             If current position + read_bytes > object size.
         :return: The bytes read
-        :raises:
-            EOFError if current position is after object size
-            OSError if read_bytes is non-positive
-            ObjectNotFoundException if repo id, reference id or object path does not exist
-            PermissionException if user is not authorized to perform this operation, or operation is forbidden
-            ServerException for any other errors
+        :raise OSError: if read_bytes is non-positive
+        :raise ObjectNotFoundException: if repo id, reference id or object path does not exist
+        :raise PermissionException: if user is not authorized to perform this operation, or operation is forbidden
+        :raise ServerException: for any other errors
         """
         if n and n <= 0:
             raise OSError("read_bytes must be a positive integer")
@@ -539,7 +537,22 @@ class StoredObject:
 
     def reader(self, mode: ReadModes = 'rb', pre_sign: Optional[bool] = None) -> ObjectReader:
         """
-        Context manager which provide a file-descriptor like object that allow reading the given object
+        Context manager which provide a file-descriptor like object that allow reading the given object.
+
+        Usage Example:
+
+        .. code-block:: python
+
+            import lakefs
+
+            obj = lakefs.repository("<repository_name>").branch("<branch_name>").object("file.txt")
+            file_size = obj.stat().size_bytes
+
+            with obj.reader(mode='r', pre_sign=True) as fd:
+                # print every other 10 chars
+                while fd.tell() < file_size
+                    print(fd.read(10))
+                    fd.seek(10)
 
         :param mode: Read mode - as supported by ReadModes
         :param pre_sign: (Optional), enforce the pre_sign mode on the lakeFS server. If not set, will probe server for
@@ -583,10 +596,9 @@ class StoredObject:
         :param destination_branch_id: The destination branch to copy the object to
         :param destination_path: The path of the copied object in the destination branch
         :return: The newly copied Object
-        :raises:
-            ObjectNotFoundException if repo id,reference id, destination branch id or object path does not exist
-            PermissionException if user is not authorized to perform this operation, or operation is forbidden
-            ServerException for any other errors
+        :raise ObjectNotFoundException: if repo id,reference id, destination branch id or object path does not exist
+        :raise PermissionException: if user is not authorized to perform this operation, or operation is forbidden
+        :raise ServerException: for any other errors
         """
 
         with api_exception_handler():
@@ -621,20 +633,23 @@ class WriteableObject(StoredObject):
 
         :param data: The contents of the object to write (can be bytes or string)
         :param mode: Write mode:
+
             'x'     - Open for exclusive creation
+
             'xb'    - Open for exclusive creation in binary mode
+
             'w'     - Create a new object or truncate if exists
+
             'wb'    - Create or truncate in binary mode
         :param pre_sign: (Optional) Explicitly state whether to use pre_sign mode when uploading the object.
             If None, will be taken from pre_sign property.
         :param content_type: (Optional) Explicitly set the object Content-Type
         :param metadata: (Optional) User metadata
         :return: The Stat object representing the newly created object
-        :raises:
-            ObjectExistsException if object exists and mode is exclusive ('x')
-            ObjectNotFoundException if repo id, reference id or object path does not exist
-            PermissionException if user is not authorized to perform this operation, or operation is forbidden
-            ServerException for any other errors
+        :raise ObjectExistsException: if object exists and mode is exclusive ('x')
+        :raise ObjectNotFoundException: if repo id, reference id or object path does not exist
+        :raise PermissionException: if user is not authorized to perform this operation, or operation is forbidden
+        :raise ServerException: for any other errors
         """
         with ObjectWriter(self, mode, pre_sign, content_type, metadata, self._client) as writer:
             writer.write(data)
@@ -645,10 +660,9 @@ class WriteableObject(StoredObject):
         """
         Delete object from lakeFS
 
-        :raises:
-            ObjectNotFoundException if repo id, reference id or object path does not exist
-            PermissionException if user is not authorized to perform this operation, or operation is forbidden
-            ServerException for any other errors
+        :raise ObjectNotFoundException: if repo id, reference id or object path does not exist
+        :raise PermissionException: if user is not authorized to perform this operation, or operation is forbidden
+        :raise ServerException: for any other errors
         """
         with api_exception_handler(_io_exception_handler):
             self._client.sdk_client.objects_api.delete_object(self._repo_id, self._ref_id, self._path)
@@ -665,6 +679,18 @@ class WriteableObject(StoredObject):
         lakeFS. The optional parameters can be modified by accessing the respective fields as long as the writer is
         still open.
 
+        Usage example of reading a file from local file system and writing it to lakeFS:
+
+        .. code-block:: python
+
+            import lakefs
+
+            obj = lakefs.repository("<repository_name>").branch("<branch_name>").object("my_image")
+
+            with open("my_local_image", mode='rb') as reader:
+                with obj.writer("wb") as writer:
+                    writer.write(reader.read())
+
         :param mode: Write mode - as supported by WriteModes
         :param pre_sign: (Optional), enforce the pre_sign mode on the lakeFS server. If not set, will probe server for
             information.
@@ -672,6 +698,9 @@ class WriteableObject(StoredObject):
         :param metadata: (Optional) User defined metadata to save on the object
         :return: A Writer object
         """
+        with open("my_file", mode='rb') as reader:
+            with self.writer("wb") as writer:
+                writer.write(reader.read())
         return ObjectWriter(self,
                             mode=mode,
                             pre_sign=pre_sign,

--- a/clients/python-wrapper/lakefs/reference.py
+++ b/clients/python-wrapper/lakefs/reference.py
@@ -57,10 +57,9 @@ class Reference:
         :param prefix: Return items prefixed with this value
         :param delimiter: Group common prefixes by this delimiter
         :param kwargs: Additional Keyword Arguments to send to the server
-        :raises:
-            NotFoundException if this reference or other_ref does not exist
-            NotAuthorizedException if user is not authorized to perform this operation
-            ServerException for any other errors
+        :raise NotFoundException: if this reference or other_ref does not exist
+        :raise NotAuthorizedException: if user is not authorized to perform this operation
+        :raise ServerException: for any other errors
         """
 
         for res in generate_listing(self._client.sdk_client.objects_api.list_objects,
@@ -80,10 +79,9 @@ class Reference:
 
         :param max_amount: (Optional) limits the amount of results to return from the server
         :param kwargs: Additional Keyword Arguments to send to the server
-        :raises:
-            NotFoundException if reference by this id does not exist
-            NotAuthorizedException if user is not authorized to perform this operation
-            ServerException for any other errors
+        :raise NotFoundException: if reference by this id does not exist
+        :raise NotAuthorizedException: if user is not authorized to perform this operation
+        :raise ServerException: for any other errors
         """
         for res in generate_listing(self._client.sdk_client.refs_api.log_commits, self._repo_id, self._id,
                                     max_amount=max_amount, **kwargs):
@@ -130,10 +128,9 @@ class Reference:
         :param prefix: Return items prefixed with this value
         :param delimiter: Group common prefixes by this delimiter
         :param kwargs: Additional Keyword Arguments to send to the server
-        :raises:
-            NotFoundException if this reference or other_ref does not exist
-            NotAuthorizedException if user is not authorized to perform this operation
-            ServerException for any other errors
+        :raise NotFoundException: if this reference or other_ref does not exist
+        :raise NotAuthorizedException: if user is not authorized to perform this operation
+        :raise ServerException: for any other errors
         """
         for diff in generate_listing(self._client.sdk_client.refs_api.diff_refs,
                                      repository=self._repo_id,
@@ -153,10 +150,9 @@ class Reference:
         :param destination_branch_id: The ID of the merge destination
         :param kwargs: Additional Keyword Arguments to send to the server
         :return: The reference id of the merge commit
-        :raises:
-            NotFoundException if reference by this id does not exist, or branch doesn't exist
-            NotAuthorizedException if user is not authorized to perform this operation
-            ServerException for any other errors
+        :raise NotFoundException: if reference by this id does not exist, or branch doesn't exist
+        :raise NotAuthorizedException: if user is not authorized to perform this operation
+        :raise ServerException: for any other errors
         """
         with api_exception_handler():
             merge = lakefs_sdk.Merge(**kwargs)

--- a/clients/python-wrapper/lakefs/repository.py
+++ b/clients/python-wrapper/lakefs/repository.py
@@ -137,7 +137,6 @@ class Repository:
         :raise NotAuthorizedException: if user is not authorized to perform this operation
         :raise ServerException: for any other errors
         """
-
         for res in generate_listing(self._client.sdk_client.tags_api.list_tags, self._id,
                                     max_amount=max_amount, after=after, prefix=prefix, **kwargs):
             yield Tag(self._id, res.id, client=self._client)

--- a/clients/python-wrapper/lakefs/repository.py
+++ b/clients/python-wrapper/lakefs/repository.py
@@ -46,9 +46,8 @@ class Repository:
             return the existing repository without creating a new one
         :param kwargs: Additional Keyword Arguments to send to the server
         :return: The lakeFS SDK object representing the repository
-        :raises:
-            NotAuthorizedException if user is not authorized to perform this operation
-            ServerException for any other errors
+        :raise NotAuthorizedException: if user is not authorized to perform this operation
+        :raise ServerException: for any other errors
         """
         repository_creation = lakefs_sdk.RepositoryCreation(name=self._id,
                                                             storage_namespace=storage_namespace,
@@ -72,10 +71,9 @@ class Repository:
         """
         Delete repository from lakeFS server
 
-        :raises:
-            NotFoundException if repository by this id does not exist
-            NotAuthorizedException if user is not authorized to perform this operation
-            ServerException for any other errors
+        :raise NotFoundException: if repository by this id does not exist
+        :raise NotAuthorizedException: if user is not authorized to perform this operation
+        :raise ServerException: for any other errors
         """
         with api_exception_handler():
             self._client.sdk_client.repositories_api.delete_repository(self._id)
@@ -117,10 +115,9 @@ class Repository:
         :param after: Return items after this value
         :param prefix: Return items prefixed with this value
         :param kwargs: Additional Keyword Arguments to send to the server
-        :raises:
-            NotFoundException if repository does not exist
-            NotAuthorizedException if user is not authorized to perform this operation
-            ServerException for any other errors
+        :raise NotFoundException: if repository does not exist
+        :raise NotAuthorizedException: if user is not authorized to perform this operation
+        :raise ServerException: for any other errors
         """
 
         for res in generate_listing(self._client.sdk_client.branches_api.list_branches, self._id,
@@ -136,10 +133,9 @@ class Repository:
         :param after: Return items after this value
         :param prefix: Return items prefixed with this value
         :param kwargs: Additional Keyword Arguments to send to the server
-        :raises:
-            NotFoundException if repository does not exist
-            NotAuthorizedException if user is not authorized to perform this operation
-            ServerException for any other errors
+        :raise NotFoundException: if repository does not exist
+        :raise NotAuthorizedException: if user is not authorized to perform this operation
+        :raise ServerException: for any other errors
         """
 
         for res in generate_listing(self._client.sdk_client.tags_api.list_tags, self._id,

--- a/clients/python-wrapper/lakefs/tag.py
+++ b/clients/python-wrapper/lakefs/tag.py
@@ -23,10 +23,9 @@ class Tag(Reference):
         :param source_ref_id: The reference id to create the tag on
         :param exist_ok: If True returns the existing Tag reference otherwise raises exception
         :return: A lakeFS SDK Tag object
-        :raises:
-            NotAuthorizedException if user is not authorized to perform this operation
-            NotFoundException if source_ref_id doesn't exist on the lakeFS server
-            ServerException for any other errors.
+        :raise NotAuthorizedException: if user is not authorized to perform this operation
+        :raise NotFoundException: if source_ref_id doesn't exist on the lakeFS server
+        :raise ServerException: for any other errors.
         """
         tag_creation = lakefs_sdk.TagCreation(id=self.id, ref=str(source_ref_id))
 
@@ -44,10 +43,9 @@ class Tag(Reference):
         """
         Delete the tag from the lakeFS server
 
-        :raises:
-            NotAuthorizedException if user is not authorized to perform this operation
-            NotFoundException if source_ref_id doesn't exist on the lakeFS server
-            ServerException for any other errors
+        :raise NotAuthorizedException: if user is not authorized to perform this operation
+        :raise NotFoundException: if source_ref_id doesn't exist on the lakeFS server
+        :raise ServerException: for any other errors
         """
         with api_exception_handler():
             self._client.sdk_client.tags_api.delete_tag(self._repo_id, self.id)

--- a/clients/python-wrapper/tests/integration/test_import.py
+++ b/clients/python-wrapper/tests/integration/test_import.py
@@ -61,7 +61,7 @@ def test_import_manager_cancel(setup_repo):
     expected_commit_id = branch.commit_id()
     expected_commit_message = branch.commit_message()
 
-    mgr = branch.import_data("my imported data", metadata={"foo": "bar"})
+    mgr = branch.import_data(commit_message="my imported data", metadata={"foo": "bar"})
     mgr.prefix(_IMPORT_PATH, "import/")
 
     mgr.start()


### PR DESCRIPTION
Closes #7068
Closes #7040

## Change Description

- Improve documentation, layout and formatting.
- Add code examples in documentation.

To deploy the html version of the documentation run:
`make python-wrapper-gen-docs`
And then use your preferred tool to deploy the create site locally from _site:
(caddy example):
`caddy file-server --listen :2015`