### PR TITLE
Python Wrapper: Add ID field to repository model

### DIFF
--- a/clients/python-wrapper/lakefs/branch.py
+++ b/clients/python-wrapper/lakefs/branch.py
@@ -228,9 +228,6 @@ class Branch(Reference):
         reset_creation = lakefs_sdk.ResetCreation(path=path, type=path_type)
         return self._client.sdk_client.branches_api.reset_branch(self._repo_id, self.id, reset_creation)
 
-    def __repr__(self):
-        return f'Branch(repository="{self.repo_id}", id="{self.id}")'
-
 
 class Transaction(Branch):
     """
@@ -243,6 +240,3 @@ class Transaction(Branch):
 
     # TODO: Implement and check if we are OK with transaction returning a branch
     #  with capabilities such as commit and transaction
-
-    def __repr__(self):
-        return f'Transaction(repository="{self.repo_id}", branch_id="{self.id}")'

--- a/clients/python-wrapper/lakefs/branch.py
+++ b/clients/python-wrapper/lakefs/branch.py
@@ -228,6 +228,9 @@ class Branch(Reference):
         reset_creation = lakefs_sdk.ResetCreation(path=path, type=path_type)
         return self._client.sdk_client.branches_api.reset_branch(self._repo_id, self.id, reset_creation)
 
+    def __repr__(self):
+        return f'Branch(repository="{self.repo_id}", id="{self.id}")'
+
 
 class Transaction(Branch):
     """
@@ -240,3 +243,6 @@ class Transaction(Branch):
 
     # TODO: Implement and check if we are OK with transaction returning a branch
     #  with capabilities such as commit and transaction
+
+    def __repr__(self):
+        return f'Transaction(repository="{self.repo_id}", branch_id="{self.id}")'

--- a/clients/python-wrapper/lakefs/models.py
+++ b/clients/python-wrapper/lakefs/models.py
@@ -35,6 +35,9 @@ class Change(LenientNamedTuple):
     path_type: Literal["common_prefix", "object"]
     size_bytes: Optional[int]
 
+    def __repr__(self):
+        return f'Change(type="{self.type}", path="{self.path}", path_type="{self.path_type}")'
+
 
 class ImportStatus(LenientNamedTuple):
     """
@@ -90,12 +93,18 @@ class ObjectInfo(LenientNamedTuple):
     metadata: Optional[dict[str, str]] = None
     content_type: Optional[str] = None
 
+    def __repr__(self):
+        return f'ObjectInfo(path="{self.path}")'
+
 
 class CommonPrefix(LenientNamedTuple):
     """
     Represents a common prefix in lakeFS
     """
     path: str
+
+    def __repr__(self):
+        return f'CommonPrefix(path="{self.path}")'
 
 
 class RepositoryProperties(LenientNamedTuple):

--- a/clients/python-wrapper/lakefs/namedtuple.py
+++ b/clients/python-wrapper/lakefs/namedtuple.py
@@ -27,6 +27,12 @@ class LenientNamedTuple:
         self.__initialized = True
         super().__init__()
 
+    def __repr__(self):
+        class_name = self.__class__.__name__
+        if hasattr(self, 'id'):
+            return f'{class_name}(id="{self.id}")'
+        return f'{class_name}()'
+
     def __setattr__(self, name, value):
         if self.__initialized:
             raise AttributeError("can't set attribute")

--- a/clients/python-wrapper/lakefs/object.py
+++ b/clients/python-wrapper/lakefs/object.py
@@ -289,6 +289,12 @@ class ObjectReader(LakeFSIOBase):
             return f"bytes={start}-"
         return f"bytes={start}-{start + read_bytes - 1}"
 
+    def __str__(self):
+        return self._obj.path
+
+    def __repr__(self):
+        return f'ObjectReader(path="{self._obj.path}")'
+
 
 class ObjectWriter(LakeFSIOBase):
     """
@@ -489,6 +495,9 @@ class ObjectWriter(LakeFSIOBase):
         """
         raise io.UnsupportedOperation
 
+    def __repr__(self):
+        return f'ObjectWriter(path="{self._obj.path}")'
+
 
 class StoredObject(_BaseLakeFSObject):
     """
@@ -509,7 +518,7 @@ class StoredObject(_BaseLakeFSObject):
         return self.path
 
     def __repr__(self):
-        return f"lakefs://{self._repo_id}/{self._ref_id}/{self._path}"
+        return f'StoredObject(repository="{self.repo}", reference="{self.ref}", path="{self.path}")'
 
     @property
     def repo(self) -> str:
@@ -619,6 +628,9 @@ class WriteableObject(StoredObject):
     def __init__(self, repository: str, reference: str, path: str,
                  client: Optional[Client] = None) -> None:
         super().__init__(repository, reference, path, client=client)
+
+    def __repr__(self):
+        return f'WriteableObject(repository="{self.repo}", reference="{self.ref}", path="{self.path}")'
 
     def upload(self,
                data: str | bytes,

--- a/clients/python-wrapper/lakefs/reference.py
+++ b/clients/python-wrapper/lakefs/reference.py
@@ -170,7 +170,8 @@ class Reference(_BaseLakeFSObject):
         return StoredObject(self._repo_id, self._id, path, self._client)
 
     def __repr__(self):
-        return f'Reference(repository="{self.repo_id}", id="{self.id}")'
+        class_name = self.__class__.__name__
+        return f'{class_name}(repository="{self.repo_id}", id="{self.id}")'
 
 
 def generate_listing(func, *args, max_amount: Optional[int] = None, **kwargs):

--- a/clients/python-wrapper/lakefs/reference.py
+++ b/clients/python-wrapper/lakefs/reference.py
@@ -169,11 +169,8 @@ class Reference(_BaseLakeFSObject):
         """
         return StoredObject(self._repo_id, self._id, path, self._client)
 
-    def __str__(self) -> str:
-        return self._id
-
     def __repr__(self):
-        return f"lakefs://{self._repo_id}/{self._id}"
+        return f'Reference(repository="{self.repo_id}", id="{self.id}")'
 
 
 def generate_listing(func, *args, max_amount: Optional[int] = None, **kwargs):

--- a/clients/python-wrapper/lakefs/reference.py
+++ b/clients/python-wrapper/lakefs/reference.py
@@ -131,10 +131,13 @@ class Reference(_BaseLakeFSObject):
         :raise NotAuthorizedException: if user is not authorized to perform this operation
         :raise ServerException: for any other errors
         """
+        other_ref_id = other_ref
+        if isinstance(other_ref, Reference):
+            other_ref_id = other_ref.id
         for diff in generate_listing(self._client.sdk_client.refs_api.diff_refs,
                                      repository=self._repo_id,
                                      left_ref=self._id,
-                                     right_ref=str(other_ref),
+                                     right_ref=other_ref_id,
                                      after=after,
                                      max_amount=max_amount,
                                      prefix=prefix,
@@ -153,11 +156,13 @@ class Reference(_BaseLakeFSObject):
         :raise NotAuthorizedException: if user is not authorized to perform this operation
         :raise ServerException: for any other errors
         """
+        if isinstance(destination_branch_id, Reference):
+            destination_branch_id = destination_branch_id.id
         with api_exception_handler():
             merge = lakefs_sdk.Merge(**kwargs)
             res = self._client.sdk_client.refs_api.merge_into_branch(self._repo_id,
                                                                      self._id,
-                                                                     str(destination_branch_id),
+                                                                     destination_branch_id,
                                                                      merge=merge)
             return res.reference
 

--- a/clients/python-wrapper/lakefs/repository.py
+++ b/clients/python-wrapper/lakefs/repository.py
@@ -151,7 +151,7 @@ class Repository(_BaseLakeFSObject):
     @property
     def properties(self) -> RepositoryProperties:
         """
-        Return the repositories properties object
+        Return the repository's properties object
         """
         if self._properties is None:
             with api_exception_handler():
@@ -163,9 +163,10 @@ class Repository(_BaseLakeFSObject):
 
     @property
     def id(self) -> str:
-        if self._id:
-            return self._id
-        return self.properties.id
+        """
+        Returns the repository's id
+        """
+        return self._id
 
     def __repr__(self) -> str:
         return f'Repository(id="{self.id}")'

--- a/clients/python-wrapper/lakefs/repository.py
+++ b/clients/python-wrapper/lakefs/repository.py
@@ -161,6 +161,15 @@ class Repository(_BaseLakeFSObject):
 
         return self._properties
 
+    @property
+    def id(self) -> str:
+        if self._id:
+            return self._id
+        return self.properties.id
+
+    def __repr__(self) -> str:
+        return f'Repository(id="{self.id}")'
+
 
 def repositories(client: Client = None,
                  prefix: Optional[str] = None,

--- a/clients/python-wrapper/lakefs/tag.py
+++ b/clients/python-wrapper/lakefs/tag.py
@@ -50,3 +50,6 @@ class Tag(Reference):
         with api_exception_handler():
             self._client.sdk_client.tags_api.delete_tag(self._repo_id, self.id)
             self._commit = None
+
+    def __repr__(self):
+        return f'Tag(repository="{self.repo_id}", id="{self.id}")'

--- a/clients/python-wrapper/lakefs/tag.py
+++ b/clients/python-wrapper/lakefs/tag.py
@@ -50,6 +50,3 @@ class Tag(Reference):
         with api_exception_handler():
             self._client.sdk_client.tags_api.delete_tag(self._repo_id, self.id)
             self._commit = None
-
-    def __repr__(self):
-        return f'Tag(repository="{self.repo_id}", id="{self.id}")'

--- a/clients/python-wrapper/lakefs/tag.py
+++ b/clients/python-wrapper/lakefs/tag.py
@@ -27,7 +27,9 @@ class Tag(Reference):
         :raise NotFoundException: if source_ref_id doesn't exist on the lakeFS server
         :raise ServerException: for any other errors.
         """
-        tag_creation = lakefs_sdk.TagCreation(id=self.id, ref=str(source_ref_id))
+        if isinstance(source_ref_id, Reference):
+            source_ref_id = source_ref_id.id
+        tag_creation = lakefs_sdk.TagCreation(id=self.id, ref=source_ref_id)
 
         def handle_conflict(e: LakeFSException):
             if not (isinstance(e, ConflictException) and exist_ok):


### PR DESCRIPTION
Use case:

```python
for repo in lakefs.repositories():
    print(repo.id)
```
And getting back useful information - otherwise, holding a Repository instance doesn't provide a way to know **which** repository this is.