### PR TITLE
UI Etag support for embedded content

### DIFF
--- a/pkg/api/etag_middleware.go
+++ b/pkg/api/etag_middleware.go
@@ -1,0 +1,77 @@
+package api
+
+import (
+	"crypto/md5"
+	"encoding/hex"
+	"io"
+	"io/fs"
+	"net/http"
+	"path"
+	"strings"
+)
+
+// EtagMiddleware returns a new Etag middleware handler.
+// It designs to work on embedded FS, where the content doesn't change.
+// It calculates the Etag for each file on startup and serves it on each request.
+func EtagMiddleware(root fs.FS, next http.Handler) http.Handler {
+	etags, err := scanFSEtags(root)
+	if err != nil {
+		panic(err)
+	}
+	return &etagHandler{
+		root:  root,
+		next:  next,
+		etags: etags,
+	}
+}
+
+type etagHandler struct {
+	root  fs.FS
+	next  http.Handler
+	etags map[string]string
+}
+
+func (e *etagHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	upath := r.URL.Path
+	if !strings.HasPrefix(upath, "/") {
+		upath = "/" + upath
+	}
+	upath = path.Clean(upath)
+	if strings.HasSuffix(upath, "/") {
+		upath += "index.html"
+	}
+	etag, ok := e.etags[upath]
+	if ok {
+		w.Header().Set("Etag", "\""+etag+"\"")
+	}
+	e.next.ServeHTTP(w, r)
+}
+
+func scanFSEtags(fSys fs.FS) (map[string]string, error) {
+	etags := make(map[string]string)
+	err := fs.WalkDir(fSys, ".", func(fpath string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() {
+			return nil
+		}
+
+		f, err := fSys.Open(fpath)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = f.Close() }()
+
+		h := md5.New()
+		if _, err := io.Copy(h, f); err != nil {
+			return err
+		}
+		etags["/"+fpath] = hex.EncodeToString(h.Sum(nil))
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return etags, nil
+}

--- a/pkg/api/etag_middleware.go
+++ b/pkg/api/etag_middleware.go
@@ -1,7 +1,7 @@
 package api
 
 import (
-	"crypto/md5"
+	"crypto/md5" //nolint:gosec
 	"encoding/hex"
 	"io"
 	"io/fs"
@@ -63,11 +63,12 @@ func scanFSEtags(fSys fs.FS) (map[string]string, error) {
 		}
 		defer func() { _ = f.Close() }()
 
-		h := md5.New()
+		h := md5.New() //nolint:gosec
 		if _, err := io.Copy(h, f); err != nil {
 			return err
 		}
-		etags["/"+fpath] = hex.EncodeToString(h.Sum(nil))
+		hashValue := hex.EncodeToString(h.Sum(nil))
+		etags["/"+fpath] = hashValue
 		return nil
 	})
 	if err != nil {

--- a/pkg/api/ui_handler.go
+++ b/pkg/api/ui_handler.go
@@ -33,8 +33,8 @@ func NewUIHandler(gatewayDomains []string, snippets []params.CodeSnippet) http.H
 		panic(err)
 	}
 	fileSystem := http.FS(injectedContent)
-	nocacheContent := EtagMiddleware(injectedContent, http.StripPrefix("/", http.FileServer(fileSystem)))
-	return NewHandlerWithDefault(fileSystem, nocacheContent, gatewayDomains)
+	etagHandler := EtagMiddleware(injectedContent, http.StripPrefix("/", http.FileServer(fileSystem)))
+	return NewHandlerWithDefault(fileSystem, etagHandler, gatewayDomains)
 }
 
 func NewS3GatewayEndpointErrorHandler(gatewayDomains []string) http.Handler {

--- a/pkg/api/ui_handler.go
+++ b/pkg/api/ui_handler.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	gomime "github.com/cubewise-code/go-mime"
-	"github.com/go-chi/chi/v5/middleware"
 	"github.com/treeverse/lakefs/pkg/api/params"
 	gwerrors "github.com/treeverse/lakefs/pkg/gateway/errors"
 	"github.com/treeverse/lakefs/pkg/gateway/operations"
@@ -34,7 +33,7 @@ func NewUIHandler(gatewayDomains []string, snippets []params.CodeSnippet) http.H
 		panic(err)
 	}
 	fileSystem := http.FS(injectedContent)
-	nocacheContent := middleware.NoCache(http.StripPrefix("/", http.FileServer(fileSystem)))
+	nocacheContent := EtagMiddleware(injectedContent, http.StripPrefix("/", http.FileServer(fileSystem)))
 	return NewHandlerWithDefault(fileSystem, nocacheContent, gatewayDomains)
 }
 
@@ -45,7 +44,7 @@ func NewS3GatewayEndpointErrorHandler(gatewayDomains []string) http.Handler {
 			return
 		}
 
-		// For other requests, return generic not found error
+		// For other requests, return generic "not found" error
 		w.WriteHeader(http.StatusNotFound)
 	})
 }


### PR DESCRIPTION
Scan embedded content on startup and serve etag header to FileServer. FileServer will use the Etag and provide no content change if needed.

This will allow cache all static resources, which allow better performance after the first load, in the web ui.

Close https://github.com/treeverse/lakeFS/issues/7131