### PR TITLE
HL Python SDK: Fix urllib3 dependency

### DIFF
--- a/clients/python-wrapper/CHANGELOG.md
+++ b/clients/python-wrapper/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+:bug: Bugs fixed:
+
+- Fix urllib3 dependency (#7170)
+
 ## v0.1.1
 
 :new: What's new:

--- a/clients/python-wrapper/lakefs/exceptions.py
+++ b/clients/python-wrapper/lakefs/exceptions.py
@@ -6,7 +6,7 @@ from contextlib import contextmanager
 from typing import Optional, Callable
 
 import lakefs_sdk.exceptions
-from urllib3 import BaseHTTPResponse
+from urllib3 import HTTPResponse
 
 
 class LakeFSException(Exception):
@@ -128,7 +128,7 @@ def api_exception_handler(custom_handler: Optional[Callable[[LakeFSException], L
             raise lakefs_ex from e
 
 
-def handle_http_error(resp: BaseHTTPResponse) -> None:
+def handle_http_error(resp: HTTPResponse) -> None:
     """
     Handles http response and raises the appropriate lakeFS exception if needed
 

--- a/clients/python-wrapper/setup.py
+++ b/clients/python-wrapper/setup.py
@@ -15,7 +15,7 @@ REQUIRES = [
     "setuptools == 68.2.2",
     "lakefs-sdk ~= 1.0",
     "pyyaml ~= 6.0.1",
-    "urllib3 ~= 2.0.7"
+    "urllib3 >= 1.26"
 ]
 
 with open('README.md') as f:

--- a/clients/python-wrapper/setup.py
+++ b/clients/python-wrapper/setup.py
@@ -15,6 +15,7 @@ REQUIRES = [
     "setuptools == 68.2.2",
     "lakefs-sdk ~= 1.0",
     "pyyaml ~= 6.0.1",
+    "urllib3 ~= 2.0.7"
 ]
 
 with open('README.md') as f:


### PR DESCRIPTION
Closes #7169

Missing explicit dependency on setup.py
Changed class to use backwards compatible HTTPResponse instead of BaseHTTPResponse