### PR TITLE
Report statistics for commit metadata button clicks

### DIFF
--- a/webui/src/pages/repositories/repository/commits/commit/metadata.tsx
+++ b/webui/src/pages/repositories/repository/commits/commit/metadata.tsx
@@ -1,7 +1,8 @@
-import React from "react";
+import React, {useCallback} from "react";
 import Button from 'react-bootstrap/Button';
+import {statistics} from "../../../../../lib/api";
 
-const keyIsClickableUrl = /::lakefs::(.*)::url\[url:ui\]$/;
+const keyIsClickableUrl = /::lakefs::(.*)::url\[ur[il]:ui\]$/;
 
 export const MetadataRow = ({ metadata_key, metadata_value }) => {
     return <tr>
@@ -10,14 +11,27 @@ export const MetadataRow = ({ metadata_key, metadata_value }) => {
            </tr>;
 };
 
+export const gotoMetadata = async (typ, url) => {
+    const event = {
+	class: "integration",
+	name: 'link',
+	type: typ,
+	count: 1,
+    };
+    // Just ignore any errors ins statistics.
+    await statistics.postStatsEvents([event]).catch(() => null);
+    window.location = url;
+}
+
 export const MetadataUIButton = ({ metadata_key, metadata_value }) => {
     const m = metadata_key.match(keyIsClickableUrl);
     if (!m) {
         return null;
     }
+    const click = useCallback(() => gotoMetadata(m[1], metadata_value), [m[1], metadata_value]);
     return <tr key={metadata_key}>
                <td colSpan={2}>
-                   <Button variant="success" href={metadata_value}>Open {m[1]} UI</Button>
+                   <Button variant="success" onClick={click}>Open {m[1]} UI</Button>
                </td>
            </tr>;
 };


### PR DESCRIPTION
Will reflect e.g. Airflow integration.

Tested manually by examining requests when clicking on sample.

Fixes #7174.