### PR TITLE
Fix object access of uninitialized client

### DIFF
--- a/clients/python-wrapper/lakefs/object.py
+++ b/clients/python-wrapper/lakefs/object.py
@@ -57,9 +57,10 @@ class LakeFSIOBase(_BaseLakeFSObject, IO):
                  client: Optional[Client] = None) -> None:
         self._obj = obj
         self._mode = mode
-        self._pre_sign = pre_sign if pre_sign is not None else client.storage_config.pre_sign_support
         self._pos = 0
         super().__init__(client)
+        # must be set after super().__init__ to ensure the client is properly initialized.
+        self._pre_sign = pre_sign if pre_sign is not None else self._client.storage_config.pre_sign_support
 
     @property
     def mode(self) -> str:


### PR DESCRIPTION
In the `LakeFSIOBase` class, the `storage_config` attribute is unconditionally accessed on the `client` input, even if that is optional.

This leads to an illegal attribute access in case of implicit configuration, where the client is sourced from the environment or a configuration file.

To fix, run `super.__init__()` first, after which the `LakeFSIOBase._client` property has been initialized to a `Client`, and then query its presign support status.