### PR TITLE
Add nil check on flows that can cause panic

### DIFF
--- a/pkg/auth/service.go
+++ b/pkg/auth/service.go
@@ -163,8 +163,11 @@ func (s *AuthService) ListKVPaged(ctx context.Context, protoType protoreflect.Me
 	p := &model.Paginator{}
 	for len(entries) < amount && it.Next() {
 		entry := it.Entry()
-		value := entry.Value
-		entries = append(entries, value)
+		// skip nil entries (deleted), kv can hold nil values
+		if entry == nil {
+			continue
+		}
+		entries = append(entries, entry.Value)
 		if len(entries) == amount {
 			p.NextPageToken = strings.TrimPrefix(string(entry.Key), string(prefix))
 			break

--- a/pkg/graveler/committed/manager.go
+++ b/pkg/graveler/committed/manager.go
@@ -75,7 +75,11 @@ func (c *committedManager) WriteRange(ctx context.Context, ns graveler.StorageNa
 	}()
 
 	for it.Next() {
-		record := *it.Value()
+		record := it.Value()
+		// skip nil value (kv can hold value nil) and tombstones
+		if record == nil || record.Value == nil {
+			continue
+		}
 		v, err := MarshalValue(record.Value)
 		if err != nil {
 			return nil, err

--- a/pkg/graveler/committed/value.go
+++ b/pkg/graveler/committed/value.go
@@ -53,7 +53,7 @@ func MarshalValue(v *graveler.Value) ([]byte, error) {
 	return ret, nil
 }
 
-// MustMarshalValue an MarshalValue that will panic on error
+// MustMarshalValue a MarshalValue that will panic on error
 func MustMarshalValue(v *graveler.Value) []byte {
 	val, err := MarshalValue(v)
 	if err != nil {


### PR DESCRIPTION
As kv can hold nil is possible value (example tombstone) add nil check for specific code flows to handle the case.