### PR TITLE
fix: added auto detect content type

### DIFF
--- a/cmd/lakectl/cmd/fs_download.go
+++ b/cmd/lakectl/cmd/fs_download.go
@@ -88,7 +88,7 @@ var fsDownloadCmd = &cobra.Command{
 		}
 
 		s := local.NewSyncManager(ctx, client, syncFlags)
-		err := s.Sync(dest, remote, ch)
+		err := s.Sync(dest, remote, ch, false)
 		if err != nil {
 			DieErr(err)
 		}

--- a/cmd/lakectl/cmd/fs_upload.go
+++ b/cmd/lakectl/cmd/fs_upload.go
@@ -61,7 +61,7 @@ var fsUploadCmd = &cobra.Command{
 		if err != nil {
 			DieErr(err)
 		}
-		err = s.Sync(fullPath, pathURI, c)
+		err = s.Sync(fullPath, pathURI, c, false)
 		if err != nil {
 			DieErr(err)
 		}

--- a/cmd/lakectl/cmd/local_checkout.go
+++ b/cmd/lakectl/cmd/local_checkout.go
@@ -100,7 +100,7 @@ func localCheckout(cmd *cobra.Command, localPath string, specifiedRef string, co
 			}
 		}
 	}()
-	err = syncMgr.Sync(idx.LocalPath(), currentBase, c)
+	err = syncMgr.Sync(idx.LocalPath(), currentBase, c, false)
 	if err != nil {
 		DieErr(err)
 	}

--- a/cmd/lakectl/cmd/local_clone.go
+++ b/cmd/lakectl/cmd/local_clone.go
@@ -88,7 +88,7 @@ var localCloneCmd = &cobra.Command{
 		}
 		sigCtx := localHandleSyncInterrupt(ctx, idx, string(cloneOperation))
 		s := local.NewSyncManager(sigCtx, client, syncFlags)
-		err = s.Sync(localPath, stableRemote, ch)
+		err = s.Sync(localPath, stableRemote, ch, false)
 		if err != nil {
 			DieErr(err)
 		}

--- a/cmd/lakectl/cmd/local_commit.go
+++ b/cmd/lakectl/cmd/local_commit.go
@@ -33,7 +33,7 @@ var localCommitCmd = &cobra.Command{
 		_, localPath := getSyncArgs(args, false, false)
 		syncFlags := getSyncFlags(cmd, client)
 		message, kvPairs := getCommitFlags(cmd)
-
+		detectContentTypeFlag := getDetectContentTypeFlag(cmd)
 		idx, err := local.ReadIndex(localPath)
 		if err != nil {
 			DieErr(err)
@@ -112,7 +112,7 @@ var localCommitCmd = &cobra.Command{
 		}()
 		sigCtx := localHandleSyncInterrupt(cmd.Context(), idx, string(commitOperation))
 		s := local.NewSyncManager(sigCtx, client, syncFlags)
-		err = s.Sync(idx.LocalPath(), remote, c)
+		err = s.Sync(idx.LocalPath(), remote, c, detectContentTypeFlag)
 		if err != nil {
 			DieErr(err)
 		}
@@ -172,5 +172,6 @@ var localCommitCmd = &cobra.Command{
 func init() {
 	withCommitFlags(localCommitCmd, false)
 	withSyncFlags(localCommitCmd)
+	withDetectContentFlag(localCommitCmd, false)
 	localCmd.AddCommand(localCommitCmd)
 }

--- a/cmd/lakectl/cmd/local_pull.go
+++ b/cmd/lakectl/cmd/local_pull.go
@@ -67,7 +67,7 @@ var localPullCmd = &cobra.Command{
 		})
 		sigCtx := localHandleSyncInterrupt(cmd.Context(), idx, string(pullOperation))
 		s := local.NewSyncManager(sigCtx, client, syncFlags)
-		err = s.Sync(idx.LocalPath(), newBase, c)
+		err = s.Sync(idx.LocalPath(), newBase, c, false)
 		if err != nil {
 			DieErr(err)
 		}

--- a/cmd/lakectl/cmd/root.go
+++ b/cmd/lakectl/cmd/root.go
@@ -140,6 +140,7 @@ const (
 	allowEmptyMsgFlagName = "allow-empty-message"
 	fmtErrEmptyMsg        = `commit with no message without specifying the "--allow-empty-message" flag`
 	metaFlagName          = "meta"
+	detectContentType     = "detect-content-type"
 )
 
 func withRecursiveFlag(cmd *cobra.Command, usage string) {
@@ -222,6 +223,10 @@ func withMetadataFlag(cmd *cobra.Command) {
 	cmd.Flags().StringSlice(metaFlagName, []string{}, "key value pair in the form of key=value")
 }
 
+func withDetectContentFlag(cmd *cobra.Command, detectContentFlag bool) {
+	cmd.Flags().Bool(detectContentType, detectContentFlag, "detect content type")
+}
+
 func withCommitFlags(cmd *cobra.Command, allowEmptyMessage bool) {
 	withMessageFlags(cmd, allowEmptyMessage)
 	withMetadataFlag(cmd)
@@ -240,6 +245,10 @@ func getCommitFlags(cmd *cobra.Command) (string, map[string]string) {
 	}
 
 	return message, kvPairs
+}
+
+func getDetectContentTypeFlag(cmd *cobra.Command) bool {
+	return Must(cmd.Flags().GetBool(detectContentType))
 }
 
 func getKV(cmd *cobra.Command, name string) (map[string]string, error) { //nolint:unparam


### PR DESCRIPTION
Closes #6584 

## Change Description

### Background

As from previous discussions [detect-content-type](https://github.com/treeverse/lakeFS/pull/6644#pullrequestreview-1649020735) and [controllable auto detect ](https://github.com/treeverse/lakeFS/pull/6616#discussion_r1329721088), user can add a detect-content-flag.

### Bug Fix

If this PR is a bug fix, please let us know about:

Problem - lakectl local didnt support --detect-content-type flag.
Solution - added user controllable detect-content-type support.

### Testing Details

How were the changes tested?

They were tested by running lakectl local to upload files with content-type flag

### Contact Details

[chaitubhojane@gmail.com](mailto:chaitubhojane@gmail.com))
