### PR TITLE
lakectl presign large presigned download using multipart

### DIFF
--- a/cmd/lakectl/cmd/fs_download.go
+++ b/cmd/lakectl/cmd/fs_download.go
@@ -44,7 +44,8 @@ var fsDownloadCmd = &cobra.Command{
 				dest += filepath.Base(remotePath)
 			}
 
-			err := helpers.Download(ctx, client, syncFlags.Presign, src, dest)
+			d := helpers.NewDownloader(client, syncFlags.Presign, cfg.Download.UseTmpDir)
+			err := d.Download(ctx, src, dest)
 			if err != nil {
 				DieErr(err)
 			}

--- a/cmd/lakectl/cmd/fs_download.go
+++ b/cmd/lakectl/cmd/fs_download.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -37,6 +38,7 @@ var fsDownloadCmd = &cobra.Command{
 				Ref:        remote.Ref,
 				Path:       remote.Path,
 			}
+			// if dest is a directory, add the file name
 			if s, _ := os.Stat(dest); s != nil && s.IsDir() {
 				dest += uri.PathSeparator
 			}
@@ -49,6 +51,7 @@ var fsDownloadCmd = &cobra.Command{
 			if err != nil {
 				DieErr(err)
 			}
+			fmt.Printf("download: %s to %s\n", src.String(), dest)
 			return
 		}
 

--- a/cmd/lakectl/cmd/fs_download.go
+++ b/cmd/lakectl/cmd/fs_download.go
@@ -44,7 +44,7 @@ var fsDownloadCmd = &cobra.Command{
 				dest += filepath.Base(remotePath)
 			}
 
-			d := helpers.NewDownloader(client, syncFlags.Presign, cfg.Download.UseTmpDir)
+			d := helpers.NewDownloader(client, syncFlags.Presign)
 			err := d.Download(ctx, src, dest)
 			if err != nil {
 				DieErr(err)

--- a/cmd/lakectl/cmd/root.go
+++ b/cmd/lakectl/cmd/root.go
@@ -84,6 +84,9 @@ type Configuration struct {
 		// setting FixSparkPlaceholder to true will change spark placeholder with the actual location. for more information see https://github.com/treeverse/lakeFS/issues/2213
 		FixSparkPlaceholder bool `mapstructure:"fix_spark_placeholder"`
 	}
+	Download struct {
+		UseTmpDir bool `mapstructure:"use_tmp_dir"` // Use system tmp dir for downloads
+	} `mapstructure:"download"`
 }
 
 type versionInfo struct {

--- a/cmd/lakectl/cmd/root.go
+++ b/cmd/lakectl/cmd/root.go
@@ -84,9 +84,6 @@ type Configuration struct {
 		// setting FixSparkPlaceholder to true will change spark placeholder with the actual location. for more information see https://github.com/treeverse/lakeFS/issues/2213
 		FixSparkPlaceholder bool `mapstructure:"fix_spark_placeholder"`
 	}
-	Download struct {
-		UseTmpDir bool `mapstructure:"use_tmp_dir"` // Use system tmp dir for downloads
-	} `mapstructure:"download"`
 }
 
 type versionInfo struct {

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2132,6 +2132,7 @@ lakectl fs download <path URI> [<destination path>] [flags]
 ```
   -h, --help              help for download
   -p, --parallelism int   Max concurrent operations to perform (default 25)
+      --part-size int     part size in bytes for multipart download (default 8388608)
       --pre-sign          Use pre-signed URLs when downloading/uploading data (recommended) (default true)
   -r, --recursive         recursively download all objects under path
 ```

--- a/esti/lakectl_test.go
+++ b/esti/lakectl_test.go
@@ -497,7 +497,7 @@ func TestLakectlFsDownload(t *testing.T) {
 		src := "lakefs://" + repoName + "/" + mainBranch + "/data/ro/ro_1k.0"
 		sanitizedResult := runCmd(t, Lakectl()+" fs download "+src+" ./", false, false, map[string]string{})
 		require.Contains(t, sanitizedResult, "download: "+src)
-		require.Contains(t, sanitizedResult, currDir+"/ro_1k.0")
+		require.Contains(t, sanitizedResult, dest+"/ro_1k.0")
 	})
 
 	t.Run("single_with_recursive_flag", func(t *testing.T) {

--- a/esti/lakectl_test.go
+++ b/esti/lakectl_test.go
@@ -476,11 +476,11 @@ func TestLakectlFsDownload(t *testing.T) {
 	})
 
 	t.Run("single_with_dest", func(t *testing.T) {
-		src := "lakefs://"+repoName+"/"+mainBranch+"/data/ro/ro_1k.0"
+		src := "lakefs://" + repoName + "/" + mainBranch + "/data/ro/ro_1k.0"
 		dest := t.TempDir()
-		sanitizedResult := runCmd(t, Lakectl()+" fs download "src+" "+dest, false, false, map[string]string{})
+		sanitizedResult := runCmd(t, Lakectl()+" fs download "+src+" "+dest, false, false, map[string]string{})
 		require.Contains(t, sanitizedResult, "download: "+src)
-		require.Contains(t, sanitizedResult, dest + "/" + "ro_1k.0")
+		require.Contains(t, sanitizedResult, dest+"/"+"ro_1k.0")
 	})
 
 	t.Run("single_with_rel_dest", func(t *testing.T) {
@@ -494,7 +494,7 @@ func TestLakectlFsDownload(t *testing.T) {
 			require.NoError(t, os.Chdir(currDir))
 		}()
 
-		src := "lakefs://"+repoName+"/"+mainBranch+"/data/ro/ro_1k.0"
+		src := "lakefs://" + repoName + "/" + mainBranch + "/data/ro/ro_1k.0"
 		sanitizedResult := runCmd(t, Lakectl()+" fs download "+src+" ./", false, false, map[string]string{})
 		require.Contains(t, sanitizedResult, "download: "+src)
 		require.Contains(t, sanitizedResult, currDir+"/ro_1k.0")

--- a/esti/lakectl_test.go
+++ b/esti/lakectl_test.go
@@ -470,22 +470,17 @@ func TestLakectlFsDownload(t *testing.T) {
 		RunCmdAndVerifySuccessWithFile(t, Lakectl()+" fs upload -s files/ro_1k lakefs://"+repoName+"/"+mainBranch+"/"+vars["FILE_PATH"], false, "lakectl_fs_upload", vars)
 	}
 	t.Run("single", func(t *testing.T) {
-		sanitizedResult := runCmd(t, Lakectl()+" fs download lakefs://"+repoName+"/"+mainBranch+"/data/ro/ro_1k.0", false, false, map[string]string{})
-		require.Contains(t, sanitizedResult, "download ro_1k.0")
-		require.Contains(t, sanitizedResult, "Download Summary:")
-		require.Contains(t, sanitizedResult, "Downloaded: 1")
-		require.Contains(t, sanitizedResult, "Uploaded: 0")
-		require.Contains(t, sanitizedResult, "Removed: 0")
+		src := "lakefs://" + repoName + "/" + mainBranch + "/data/ro/ro_1k.0"
+		sanitizedResult := runCmd(t, Lakectl()+" fs download "+src, false, false, map[string]string{})
+		require.Contains(t, sanitizedResult, "download: "+src)
 	})
 
 	t.Run("single_with_dest", func(t *testing.T) {
+		src := "lakefs://"+repoName+"/"+mainBranch+"/data/ro/ro_1k.0"
 		dest := t.TempDir()
-		sanitizedResult := runCmd(t, Lakectl()+" fs download lakefs://"+repoName+"/"+mainBranch+"/data/ro/ro_1k.0 "+dest, false, false, map[string]string{})
-		require.Contains(t, sanitizedResult, "download ro_1k.0")
-		require.Contains(t, sanitizedResult, "Download Summary:")
-		require.Contains(t, sanitizedResult, "Downloaded: 1")
-		require.Contains(t, sanitizedResult, "Uploaded: 0")
-		require.Contains(t, sanitizedResult, "Removed: 0")
+		sanitizedResult := runCmd(t, Lakectl()+" fs download "src+" "+dest, false, false, map[string]string{})
+		require.Contains(t, sanitizedResult, "download: "+src)
+		require.Contains(t, sanitizedResult, dest + "/" + "ro_1k.0")
 	})
 
 	t.Run("single_with_rel_dest", func(t *testing.T) {
@@ -499,12 +494,10 @@ func TestLakectlFsDownload(t *testing.T) {
 			require.NoError(t, os.Chdir(currDir))
 		}()
 
-		sanitizedResult := runCmd(t, Lakectl()+" fs download lakefs://"+repoName+"/"+mainBranch+"/data/ro/ro_1k.0 ./", false, false, map[string]string{})
-		require.Contains(t, sanitizedResult, "download ro_1k.0")
-		require.Contains(t, sanitizedResult, "Download Summary:")
-		require.Contains(t, sanitizedResult, "Downloaded: 1")
-		require.Contains(t, sanitizedResult, "Uploaded: 0")
-		require.Contains(t, sanitizedResult, "Removed: 0")
+		src := "lakefs://"+repoName+"/"+mainBranch+"/data/ro/ro_1k.0"
+		sanitizedResult := runCmd(t, Lakectl()+" fs download "+src+" ./", false, false, map[string]string{})
+		require.Contains(t, sanitizedResult, "download: "+src)
+		require.Contains(t, sanitizedResult, currDir+"/ro_1k.0")
 	})
 
 	t.Run("single_with_recursive_flag", func(t *testing.T) {
@@ -540,7 +533,7 @@ func TestLakectlFsDownload(t *testing.T) {
 	})
 
 	t.Run("directory_without_recursive", func(t *testing.T) {
-		RunCmdAndVerifyFailure(t, Lakectl()+" fs download --parallelism 1 lakefs://"+repoName+"/"+mainBranch+"/data", false, "download data failed: (stat: HTTP 404, message: not found): error downloading file\nError executing command.\n", map[string]string{})
+		RunCmdAndVerifyFailure(t, Lakectl()+" fs download --parallelism 1 lakefs://"+repoName+"/"+mainBranch+"/data", false, "download failed: request failed: 404 Not Found\nError executing command.\n", map[string]string{})
 	})
 }
 

--- a/pkg/api/helpers/download.go
+++ b/pkg/api/helpers/download.go
@@ -1,0 +1,131 @@
+package helpers
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+
+	"github.com/go-openapi/swag"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
+	"github.com/treeverse/lakefs/pkg/uri"
+	"golang.org/x/sync/errgroup"
+)
+
+func Download(ctx context.Context, client *apigen.ClientWithResponses, preSign bool, src uri.URI, dst string) error {
+	// create destination dir if needed
+	dir := filepath.Dir(dst)
+	_ = os.MkdirAll(dir, os.ModePerm)
+
+	// download object
+	if preSign {
+		return downloadPresigned(ctx, client, src, dst)
+	}
+	return downloadObject(ctx, client, false, src, dst)
+}
+
+func downloadPresigned(ctx context.Context, client *apigen.ClientWithResponses, src uri.URI, dst string) error {
+	// get object metadata
+	statResp, err := client.StatObjectWithResponse(ctx, src.Repository, src.Ref, &apigen.StatObjectParams{
+		Path:    *src.Path,
+		Presign: swag.Bool(true),
+	})
+	if err != nil {
+		return err
+	}
+	if statResp.JSON200 == nil || statResp.JSON200.SizeBytes == nil {
+		return fmt.Errorf("bad response from server")
+	}
+
+	// check if the object is small enough to download in one request
+	if *statResp.JSON200.SizeBytes < DefaultUploadPartSize {
+		return downloadObject(ctx, client, true, src, dst)
+	}
+
+	// check if object support ranges in bytes
+	// TODO(barak): can we assume accept ranges is supported?
+
+	// create and copy object content
+	f, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+
+	// download the file using ranges and concurrency
+	httpClient := &http.Client{}
+	physicalAddress := statResp.JSON200.PhysicalAddress
+	size := swag.Int64Value(statResp.JSON200.SizeBytes)
+	var nextPart atomic.Int64
+	g, grpCtx := errgroup.WithContext(context.Background())
+	for i := 0; i < DefaultUploadConcurrency; i++ {
+		g.Go(func() error {
+			for {
+				partNumber := nextPart.Add(1)
+				start := (partNumber - 1) * DefaultUploadPartSize
+				if start >= size {
+					return nil
+				}
+				partSize := DefaultUploadPartSize
+				if start+partSize > size {
+					partSize = size - start
+				}
+
+				if err := downloadPresignedPart(grpCtx, httpClient, physicalAddress, start, size, partSize, partNumber, f); err != nil {
+					return err
+				}
+			}
+		})
+	}
+	return g.Wait()
+}
+
+func downloadPresignedPart(ctx context.Context, httpClient *http.Client, physicalAddress string, start int64, size int64, partSize int64, partNumber int64, f *os.File) error {
+	end := start + partSize - 1
+	rangeHeader := fmt.Sprintf("bytes=%d-%d", start, end)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, physicalAddress, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Range", rangeHeader)
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return err
+	}
+	if resp.StatusCode != http.StatusPartialContent {
+		return fmt.Errorf("%w: %s", ErrRequestFailed, resp.Status)
+	}
+	if resp.ContentLength != partSize {
+		return fmt.Errorf("part %d expected %d bytes, got %d", partNumber, partSize, resp.ContentLength)
+	}
+	writer := io.NewOffsetWriter(f, start)
+	_, err = io.Copy(writer, resp.Body)
+	return err
+}
+
+func downloadObject(ctx context.Context, client *apigen.ClientWithResponses, preSign bool, src uri.URI, dst string) error {
+	// get object content
+	resp, err := client.GetObject(ctx, src.Repository, src.Ref, &apigen.GetObjectParams{
+		Path:    *src.Path,
+		Presign: swag.Bool(preSign),
+	})
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("%w: %s", ErrRequestFailed, resp.Status)
+	}
+
+	// create and copy object content
+	f, err := os.Create(dst)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+	_, err = io.Copy(f, resp.Body)
+	return err
+}

--- a/pkg/api/helpers/download.go
+++ b/pkg/api/helpers/download.go
@@ -70,8 +70,10 @@ func (d *Downloader) downloadPresignMultipart(ctx context.Context, src uri.URI, 
 	if err != nil {
 		return err
 	}
+
+	// fallback to download if missing size
 	if statResp.JSON200 == nil || statResp.JSON200.SizeBytes == nil {
-		return fmt.Errorf("%w: missing object size (%s)", ErrRequestFailed, statResp.Status())
+		return d.downloadObject(ctx, src, dst)
 	}
 
 	// check if the object is small enough to download in one request

--- a/pkg/api/helpers/download.go
+++ b/pkg/api/helpers/download.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync/atomic"
+	"time"
 
 	"github.com/go-openapi/swag"
 	"github.com/treeverse/lakefs/pkg/api/apigen"
@@ -15,7 +16,16 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
+const (
+	DefaultDownloadPartSize    int64 = 1024 * 1024 * 8 // 8MB
+	DefaultDownloadConcurrency       = 10
+)
+
 func Download(ctx context.Context, client *apigen.ClientWithResponses, preSign bool, src uri.URI, dst string) error {
+	start := time.Now()
+	defer func() {
+		fmt.Printf("Downloaded %s in %s\n", src.String(), time.Since(start))
+	}()
 	// create destination dir if needed
 	dir := filepath.Dir(dst)
 	_ = os.MkdirAll(dir, os.ModePerm)
@@ -37,11 +47,11 @@ func downloadPresigned(ctx context.Context, client *apigen.ClientWithResponses, 
 		return err
 	}
 	if statResp.JSON200 == nil || statResp.JSON200.SizeBytes == nil {
-		return fmt.Errorf("bad response from server")
+		return fmt.Errorf("%w: missing object size (%s)", ErrRequestFailed, statResp.Status())
 	}
 
 	// check if the object is small enough to download in one request
-	if *statResp.JSON200.SizeBytes < DefaultUploadPartSize {
+	if *statResp.JSON200.SizeBytes < DefaultDownloadPartSize {
 		return downloadObject(ctx, client, true, src, dst)
 	}
 
@@ -56,25 +66,32 @@ func downloadPresigned(ctx context.Context, client *apigen.ClientWithResponses, 
 	defer func() { _ = f.Close() }()
 
 	// download the file using ranges and concurrency
-	httpClient := &http.Client{}
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.MaxIdleConnsPerHost = 10
+	httpClient := &http.Client{
+		Transport: transport,
+	}
+
 	physicalAddress := statResp.JSON200.PhysicalAddress
 	size := swag.Int64Value(statResp.JSON200.SizeBytes)
+
 	var nextPart atomic.Int64
 	g, grpCtx := errgroup.WithContext(context.Background())
-	for i := 0; i < DefaultUploadConcurrency; i++ {
+	for i := 0; i < DefaultDownloadConcurrency; i++ {
 		g.Go(func() error {
 			for {
 				partNumber := nextPart.Add(1)
-				start := (partNumber - 1) * DefaultUploadPartSize
-				if start >= size {
+				rangeStart := (partNumber - 1) * DefaultDownloadPartSize
+				if rangeStart >= size {
 					return nil
 				}
-				partSize := DefaultUploadPartSize
-				if start+partSize > size {
-					partSize = size - start
+				partSize := DefaultDownloadPartSize
+				if rangeStart+partSize > size {
+					partSize = size - rangeStart
 				}
 
-				if err := downloadPresignedPart(grpCtx, httpClient, physicalAddress, start, size, partSize, partNumber, f); err != nil {
+				err := downloadPresignedPart(grpCtx, httpClient, physicalAddress, rangeStart, partSize, partNumber, f)
+				if err != nil {
 					return err
 				}
 			}
@@ -83,9 +100,15 @@ func downloadPresigned(ctx context.Context, client *apigen.ClientWithResponses, 
 	return g.Wait()
 }
 
-func downloadPresignedPart(ctx context.Context, httpClient *http.Client, physicalAddress string, start int64, size int64, partSize int64, partNumber int64, f *os.File) error {
-	end := start + partSize - 1
-	rangeHeader := fmt.Sprintf("bytes=%d-%d", start, end)
+func downloadPresignedPart(ctx context.Context, httpClient *http.Client, physicalAddress string, rangeStart int64, partSize int64, partNumber int64, f *os.File) error {
+	fmt.Printf("Downloading part %d (%d)...\n", partNumber, partSize)
+	start := time.Now()
+	defer func() {
+		fmt.Printf("Finished part %d (%d), took %s.\n", partNumber, partSize, time.Since(start))
+	}()
+
+	rangeEnd := rangeStart + partSize - 1
+	rangeHeader := fmt.Sprintf("bytes=%d-%d", rangeStart, rangeEnd)
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, physicalAddress, nil)
 	if err != nil {
 		return err
@@ -95,13 +118,15 @@ func downloadPresignedPart(ctx context.Context, httpClient *http.Client, physica
 	if err != nil {
 		return err
 	}
+	defer func() { _ = resp.Body.Close() }()
+
 	if resp.StatusCode != http.StatusPartialContent {
 		return fmt.Errorf("%w: %s", ErrRequestFailed, resp.Status)
 	}
 	if resp.ContentLength != partSize {
 		return fmt.Errorf("part %d expected %d bytes, got %d", partNumber, partSize, resp.ContentLength)
 	}
-	writer := io.NewOffsetWriter(f, start)
+	writer := io.NewOffsetWriter(f, rangeStart)
 	_, err = io.Copy(writer, resp.Body)
 	return err
 }

--- a/pkg/api/helpers/download.go
+++ b/pkg/api/helpers/download.go
@@ -106,10 +106,10 @@ func downloadPresigned(ctx context.Context, client *apigen.ClientWithResponses, 
 }
 
 func downloadPresignedPart(ctx context.Context, httpClient *http.Client, physicalAddress string, rangeStart int64, partSize int64, partNumber int64, f *os.File) error {
-	fmt.Printf("Downloading part %d (%d)...\n", partNumber, partSize)
+	// fmt.Printf("Downloading part %d (%d)...\n", partNumber, partSize)
 	start := time.Now()
 	defer func() {
-		fmt.Printf("Finished part %d (%d), took %s.\n", partNumber, partSize, time.Since(start))
+		fmt.Printf("Downloaded part %d (%d), took %s.\n", partNumber, partSize, time.Since(start))
 	}()
 
 	rangeEnd := rangeStart + partSize - 1
@@ -132,7 +132,7 @@ func downloadPresignedPart(ctx context.Context, httpClient *http.Client, physica
 		return fmt.Errorf("part %d expected %d bytes, got %d", partNumber, partSize, resp.ContentLength)
 	}
 	writer := io.NewOffsetWriter(f, rangeStart)
-	_, err = io.Copy(writer, resp.Body)
+	_, err = io.CopyN(writer, resp.Body, partSize)
 	return err
 }
 

--- a/pkg/api/helpers/download.go
+++ b/pkg/api/helpers/download.go
@@ -53,11 +53,17 @@ func (d *Downloader) Download(ctx context.Context, src uri.URI, dst string) erro
 	_ = os.MkdirAll(dir, os.ModePerm)
 
 	// download object
+	var err error
 	if d.PreSign {
 		// download using presigned multipart download, it will fall back to presign single object download if needed
-		return d.downloadPresignMultipart(ctx, src, dst)
+		err = d.downloadPresignMultipart(ctx, src, dst)
+	} else {
+		err = d.downloadObject(ctx, src, dst)
 	}
-	return d.downloadObject(ctx, src, dst)
+	if err != nil {
+		return fmt.Errorf("download failed: %w", err)
+	}
+	return nil
 }
 
 func (d *Downloader) downloadPresignMultipart(ctx context.Context, src uri.URI, dst string) (err error) {


### PR DESCRIPTION
Currently supports only single large file download using presign.

- **Enhanced parallel downloads:** Break large file into multiple segments for simultaneous downloading, optimizing speed and efficiency.
- **Temporary filenames for reliability:** During downloads, use temporary names with unique identifiers to ensure file integrity and prevent overwrites.

Close https://github.com/treeverse/lakeFS/issues/7283