### PR TITLE
Unconditionally assign body in ServerException constructor

### DIFF
--- a/clients/python-wrapper/lakefs/exceptions.py
+++ b/clients/python-wrapper/lakefs/exceptions.py
@@ -30,8 +30,10 @@ class ServerException(LakeFSException):
         if body is not None:
             try:  # Try to get message from body
                 self.body = json.loads(body)
-            except ValueError:
-                pass
+            except json.JSONDecodeError:
+                self.body = {}
+        else:
+            self.body = {}
 
     def __str__(self):
         return f"code: {self.status_code}, reason: {self.reason}, body: {self.body}"


### PR DESCRIPTION
Previously, in case a non-empty body was returned, the `body` field of `ServerException` would be undefined in case of a JSON body parsing error. The same would occur if body is None, since that branch avoids setting the `self.body` field entirely.

Consequently, the `ServerException.__str__()` method, which unconditionally accesses `self.body`, fails if a non-JSON-parseable (or None) body was given to the constructor.

The fix is to assign an empty dict as per the class attribute type hints in the two cases, so that the `ServerException.body` field is defined in any case.

### Background

We observed this in https://github.com/aai-institute/lakefs-spec/issues/255, and first thought this was our error handling code, but it turns out to be the mentioned assignment problem in the lakefs wrapper.

A follow-up question is why the lakeFS API does not return a JSON body at all in that case (attempting to overwrite a file on a protected branch).