### PR TITLE
Return revert commit from `Branch.revert()` instead of None

### DIFF
--- a/clients/python-wrapper/lakefs/branch.py
+++ b/clients/python-wrapper/lakefs/branch.py
@@ -220,7 +220,7 @@ class Branch(_BaseBranch):
         with api_exception_handler():
             return self._client.sdk_client.branches_api.delete_branch(self._repo_id, self._id)
 
-    def revert(self, reference: Optional[ReferenceType], parent_number: int = 1, *,
+    def revert(self, reference: Optional[ReferenceType], parent_number: int = 0, *,
                reference_id: Optional[str] = None) -> Commit:
         """
         revert the changes done by the provided reference on the current branch
@@ -231,15 +231,15 @@ class Branch(_BaseBranch):
                 Use ``reference`` instead.
 
         :param parent_number: when reverting a merge commit, the parent number (starting from 1) relative to which to
-            perform the revert.
+            perform the revert. The default for non merge commits is 0
         :param reference: the reference to revert
         :return: The commit created by the revert
         :raise NotFoundException: if branch by this id does not exist
         :raise NotAuthorizedException: if user is not authorized to perform this operation
         :raise ServerException: for any other errors
         """
-        if parent_number <= 0:
-            raise ValueError("parent_number must be a positive integer")
+        if parent_number < 0:
+            raise ValueError("parent_number must be a non-negative integer")
 
         if reference_id is not None:
             warnings.warn(

--- a/clients/python-wrapper/lakefs/branch.py
+++ b/clients/python-wrapper/lakefs/branch.py
@@ -220,26 +220,25 @@ class Branch(_BaseBranch):
         with api_exception_handler():
             return self._client.sdk_client.branches_api.delete_branch(self._repo_id, self._id)
 
-    def revert(self, reference: Optional[ReferenceType], parent_number: Optional[int] = None, *,
+    def revert(self, reference: Optional[ReferenceType], parent_number: int = 1, *,
                reference_id: Optional[str] = None) -> Commit:
         """
         revert the changes done by the provided reference on the current branch
 
+        :param reference_id: (Optional) The reference ID to revert
+
+            .. deprecated:: 0.4.0
+                Use ``reference`` instead.
+
         :param parent_number: when reverting a merge commit, the parent number (starting from 1) relative to which to
             perform the revert.
         :param reference: the reference to revert
-        :param reference_id: Backwards-compatible alias for ``reference``, do not use.
-
-            .. deprecated:: 0.4.0
-                Use `reference` instead.
         :return: The commit created by the revert
         :raise NotFoundException: if branch by this id does not exist
         :raise NotAuthorizedException: if user is not authorized to perform this operation
         :raise ServerException: for any other errors
         """
-        if parent_number is None:
-            parent_number = 0
-        elif parent_number <= 0:
+        if parent_number <= 0:
             raise ValueError("parent_number must be a positive integer")
 
         if reference_id is not None:

--- a/clients/python-wrapper/lakefs/branch.py
+++ b/clients/python-wrapper/lakefs/branch.py
@@ -5,6 +5,7 @@ Module containing lakeFS branch implementation
 from __future__ import annotations
 
 import uuid
+import warnings
 from contextlib import contextmanager
 from typing import Optional, Generator, Iterable, Literal, Dict
 
@@ -219,14 +220,19 @@ class Branch(_BaseBranch):
         with api_exception_handler():
             return self._client.sdk_client.branches_api.delete_branch(self._repo_id, self._id)
 
-    def revert(self, reference_id: str, parent_number: Optional[int] = None) -> None:
+    def revert(self, reference: Optional[ReferenceType], parent_number: Optional[int] = None, *,
+               reference_id: Optional[str] = None) -> Commit:
         """
         revert the changes done by the provided reference on the current branch
 
         :param parent_number: when reverting a merge commit, the parent number (starting from 1) relative to which to
             perform the revert.
-        :param reference_id: the reference to revert
-        :return: The new reference after the revert
+        :param reference: the reference to revert
+        :param reference_id: Backwards-compatible alias for ``reference``, do not use.
+
+            .. deprecated:: 0.4.0
+                Use `reference` instead.
+        :return: The commit created by the revert
         :raise NotFoundException: if branch by this id does not exist
         :raise NotAuthorizedException: if user is not authorized to perform this operation
         :raise ServerException: for any other errors
@@ -236,12 +242,25 @@ class Branch(_BaseBranch):
         elif parent_number <= 0:
             raise ValueError("parent_number must be a positive integer")
 
+        if reference_id is not None:
+            warnings.warn(
+                "reference_id is deprecated, please use the `reference` argument.", DeprecationWarning
+            )
+
+        # Handle reference_id as a deprecated alias to reference.
+        reference = reference or reference_id
+        if reference is None:
+            raise ValueError("reference to revert must be specified")
+        ref = reference if isinstance(reference, str) else reference.id
+
         with api_exception_handler():
-            return self._client.sdk_client.branches_api.revert_branch(
+            self._client.sdk_client.branches_api.revert_branch(
                 self._repo_id,
                 self._id,
-                lakefs_sdk.RevertCreation(ref=reference_id, parent_number=parent_number)
+                lakefs_sdk.RevertCreation(ref=ref, parent_number=parent_number)
             )
+            commit = self._client.sdk_client.commits_api.get_commit(self._repo_id, self._id)
+            return Commit(**commit.dict())
 
     def import_data(self, commit_message: str = "", metadata: Optional[dict] = None) -> ImportManager:
         """

--- a/clients/python-wrapper/tests/integration/test_branch.py
+++ b/clients/python-wrapper/tests/integration/test_branch.py
@@ -20,7 +20,8 @@ def test_revert(setup_repo):
     with obj.reader(mode='r') as fd:
         assert fd.read() == override_content
 
-    test_branch.revert(test_branch.head.id)
+    c = test_branch.revert(test_branch.head)
+    assert c.message.startswith("Revert")
 
     with obj.reader(mode='r') as fd:
         assert fd.read() == initial_content

--- a/clients/python-wrapper/tests/utests/test_branch.py
+++ b/clients/python-wrapper/tests/utests/test_branch.py
@@ -114,7 +114,7 @@ def test_branch_delete(monkeypatch):
 def test_branch_revert(monkeypatch):
     branch = get_test_branch()
     ref_id = "ab1234"
-    expected_parent = 0
+    expected_parent = 1
     with monkeypatch.context():
         def monkey_revert_branch(repo_name, branch_name, revert_branch_creation, *_):
             assert repo_name == branch.repo_id
@@ -146,7 +146,7 @@ def test_branch_revert(monkeypatch):
         with expect_exception_context(ValueError):
             branch.revert(ref_id, 0)
 
-        expected_parent = 0
+        expected_parent = 1
         # reference_id passed, but not reference
         with pytest.warns(DeprecationWarning, match="reference_id is deprecated.*"):
             branch.revert(None, reference_id=ref_id)

--- a/clients/python-wrapper/tests/utests/test_branch.py
+++ b/clients/python-wrapper/tests/utests/test_branch.py
@@ -114,7 +114,7 @@ def test_branch_delete(monkeypatch):
 def test_branch_revert(monkeypatch):
     branch = get_test_branch()
     ref_id = "ab1234"
-    expected_parent = 1
+    expected_parent = 0
     with monkeypatch.context():
         def monkey_revert_branch(repo_name, branch_name, revert_branch_creation, *_):
             assert repo_name == branch.repo_id
@@ -144,9 +144,9 @@ def test_branch_revert(monkeypatch):
 
         # Test set invalid parent number
         with expect_exception_context(ValueError):
-            branch.revert(ref_id, 0)
+            branch.revert(ref_id, -1)
 
-        expected_parent = 1
+        expected_parent = 0
         # reference_id passed, but not reference
         with pytest.warns(DeprecationWarning, match="reference_id is deprecated.*"):
             branch.revert(None, reference_id=ref_id)

--- a/clients/python-wrapper/tests/utests/test_branch.py
+++ b/clients/python-wrapper/tests/utests/test_branch.py
@@ -1,6 +1,7 @@
 import http
 
 import lakefs_sdk
+import pytest
 
 from tests.utests.common import get_test_client, expect_exception_context
 from lakefs.repository import Repository
@@ -121,8 +122,21 @@ def test_branch_revert(monkeypatch):
             assert revert_branch_creation.ref == ref_id
             assert revert_branch_creation.parent_number == expected_parent  # default value
 
+        def monkey_get_commit(repo_name, ref_name, **_):
+            assert repo_name == branch.repo_id
+            assert ref_name == branch.id
+            return lakefs_sdk.Commit(
+                id=ref_id,
+                parents=[""],
+                committer="Committer",
+                message="Message",
+                creation_date=0,
+                meta_range_id=""
+            )
+
         # Test default parent number
         monkeypatch.setattr(branch._client.sdk_client.branches_api, "revert_branch", monkey_revert_branch)
+        monkeypatch.setattr(branch._client.sdk_client.commits_api, "get_commit", monkey_get_commit)
         branch.revert(ref_id)
         expected_parent = 2
         # Test set parent number
@@ -131,3 +145,20 @@ def test_branch_revert(monkeypatch):
         # Test set invalid parent number
         with expect_exception_context(ValueError):
             branch.revert(ref_id, 0)
+
+        expected_parent = 0
+        # reference_id passed, but not reference
+        with pytest.warns(DeprecationWarning, match="reference_id is deprecated.*"):
+            branch.revert(None, reference_id=ref_id)
+
+        # neither reference nor reference_id passed
+        with pytest.raises(ValueError, match=".* must be specified"):
+            branch.revert(None)
+
+        # both are passed, prefer ``reference_id``
+        with pytest.warns(DeprecationWarning, match="reference_id is deprecated.*"):
+            # this is not a high-quality test, but it would throw if the revert API
+            # was called with reference "hello" due to the monkey-patching above
+            # always returning "ab1234" as ref ID.
+            c = branch.revert(ref_id, reference_id="hello")
+            assert c.id == ref_id


### PR DESCRIPTION
This makes it easier to analyze the new state of the repository after the revert. Obtains the commit by querying `Branch.head` after the revert API request, which incurs another branch API call.

Said `Branch.head` call cannot incur any error that wouldn't already fly on the revert attempt, so this does not need any more error handling.

Also allows passing `ReferenceType`s to Branch.revert() to get it up to par with other branch methods.

Part of #7347.
