### PR TITLE
Python Wrapper: Allow passing args/kwargs to `lakefs.repository()`

### DIFF
--- a/clients/python-wrapper/lakefs/__init__.py
+++ b/clients/python-wrapper/lakefs/__init__.py
@@ -19,7 +19,7 @@ from lakefs.branch import Branch
 from lakefs.object import StoredObject, WriteableObject, ObjectReader
 
 
-def repository(repository_id: str) -> Repository:
+def repository(repository_id: str, *args, **kwargs) -> Repository:
     """
     Wrapper for getting a Repository object from the lakefs module.
     Enable more fluid syntax (lakefs.repository("x").branch("y") instead of lakefs.Repository("x").branch("y"))
@@ -27,4 +27,4 @@ def repository(repository_id: str) -> Repository:
     :param repository_id: The repository name
     :return: Repository object representing a lakeFS repository with the give repository_id
     """
-    return Repository(repository_id)
+    return Repository(repository_id, *args, **kwargs)


### PR DESCRIPTION
Main use case - support adding a custom client:

```python
>>> import lakefs
>>> from lakefs.client import Client
>>> c = Client(...)
>>> repo = lakefs.repository('foo', client=c)
```

This currently requires another import in order to initialize a `lakefs.repository.Repository`