### PR TITLE
Use If-None-Match in LakeFSLinker

### DIFF
--- a/clients/hadoopfs/pom.xml
+++ b/clients/hadoopfs/pom.xml
@@ -272,13 +272,11 @@ To export to S3:
             </plugin>
         </plugins>
     </build>
-
     <dependencies>
         <dependency>
             <groupId>io.lakefs</groupId>
-            <!-- TODO(ariels): Publish an actual sdk-client version and use *that*! -->
             <artifactId>sdk</artifactId>
-            <version>1.0.0</version>
+            <version>1.12.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/clients/hadoopfs/src/main/java/io/lakefs/storage/PresignedStorageAccessStrategy.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/storage/PresignedStorageAccessStrategy.java
@@ -28,12 +28,6 @@ public class PresignedStorageAccessStrategy implements StorageAccessStrategy {
         this.lakeFSFileSystem = lakeFSFileSystem;
         this.lfsClient = lfsClient;
     }
-
-    @Override
-    public FSDataOutputStream createDataOutputStream(ObjectLocation objectLocation,
-                                                     CreateOutputStreamParams params) throws ApiException, IOException {
-        return createDataOutputStream(objectLocation, params, true);
-    }
     
     @Override
     public FSDataOutputStream createDataOutputStream(ObjectLocation objectLocation,

--- a/clients/hadoopfs/src/main/java/io/lakefs/storage/SimpleStorageAccessStrategy.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/storage/SimpleStorageAccessStrategy.java
@@ -34,12 +34,6 @@ public class SimpleStorageAccessStrategy implements StorageAccessStrategy {
         this.conf = conf;
         this.physicalAddressTranslator = physicalAddressTranslator;
     }
-
-    @Override
-    public FSDataOutputStream createDataOutputStream(ObjectLocation objectLocation,
-                                                     CreateOutputStreamParams params) throws ApiException, IOException {
-        return createDataOutputStream(objectLocation, params, true);
-    }
     
     @Override
     public FSDataOutputStream createDataOutputStream(ObjectLocation objectLocation,

--- a/clients/hadoopfs/src/main/java/io/lakefs/storage/StorageAccessStrategy.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/storage/StorageAccessStrategy.java
@@ -1,10 +1,6 @@
 package io.lakefs.storage;
 
 import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.ProtocolException;
-import java.net.URI;
-
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
 
@@ -12,11 +8,13 @@ import io.lakefs.clients.sdk.ApiException;
 import io.lakefs.utils.ObjectLocation;
 
 public interface StorageAccessStrategy {
-    public FSDataOutputStream createDataOutputStream(ObjectLocation objectLocation, CreateOutputStreamParams params)
+    default FSDataOutputStream createDataOutputStream(ObjectLocation objectLocation,
+                                                     CreateOutputStreamParams params) throws ApiException, IOException {
+        return createDataOutputStream(objectLocation, params, true);
+    }
+
+    FSDataOutputStream createDataOutputStream(ObjectLocation objectLocation, CreateOutputStreamParams params, boolean overwrite)
             throws ApiException, IOException;
 
-    public FSDataOutputStream createDataOutputStream(ObjectLocation objectLocation, CreateOutputStreamParams params, boolean overwrite)
-            throws ApiException, IOException;
-
-    public FSDataInputStream createDataInputStream(ObjectLocation objectLocation, int bufSize) throws ApiException, IOException;
+    FSDataInputStream createDataInputStream(ObjectLocation objectLocation, int bufSize) throws ApiException, IOException;
 }

--- a/clients/hadoopfs/src/main/java/io/lakefs/storage/StorageAccessStrategy.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/storage/StorageAccessStrategy.java
@@ -15,5 +15,8 @@ public interface StorageAccessStrategy {
     public FSDataOutputStream createDataOutputStream(ObjectLocation objectLocation, CreateOutputStreamParams params)
             throws ApiException, IOException;
 
+    public FSDataOutputStream createDataOutputStream(ObjectLocation objectLocation, CreateOutputStreamParams params, boolean overwrite)
+            throws ApiException, IOException;
+
     public FSDataInputStream createDataInputStream(ObjectLocation objectLocation, int bufSize) throws ApiException, IOException;
 }


### PR DESCRIPTION
Closes #7488

## Change Description

### Background

Allow creating Data/Output/InputStream with conditional overwrite on the last stage of creating the lakeFS entry by supporting the If-None-Match in the LakeFSLinker

### Testing Details

Should be covered by the Hadoop contractual testing

### Breaking Change?

No
