### PR TITLE
Revert "Bump nokogiri from 1.15.4 to 1.16.2 in /clients/python"

### DIFF
--- a/clients/python/Gemfile.lock
+++ b/clients/python/Gemfile.lock
@@ -222,11 +222,7 @@ GEM
       jekyll-seo-tag (~> 2.1)
     minitest (5.20.0)
     mutex_m (0.1.2)
-    nokogiri (1.16.2-arm64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.16.2-x86_64-darwin)
-      racc (~> 1.4)
-    nokogiri (1.16.2-x86_64-linux)
+    nokogiri (1.15.4-arm64-darwin)
       racc (~> 1.4)
     octokit (4.25.1)
       faraday (>= 1, < 3)
@@ -234,7 +230,7 @@ GEM
     pathutil (0.16.2)
       forwardable-extended (~> 2.6)
     public_suffix (4.0.7)
-    racc (1.7.3)
+    racc (1.7.1)
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
@@ -266,8 +262,8 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  ruby
   universal-darwin-20
-  x86_64-linux
 
 DEPENDENCIES
   github-pages


### PR DESCRIPTION
Reverts treeverse/lakeFS#7440

It breaks the Python documentation builder.  Given that there is no untrusted input, there is no clear path for attackers to use this.

We will handle this separately.