### PR TITLE
Check lakeFSFS works with lakeFS 1.12.1 not 1.12.0

### DIFF
--- a/.github/workflows/compatibility-tests.yaml
+++ b/.github/workflows/compatibility-tests.yaml
@@ -121,7 +121,7 @@ jobs:
       matrix:
         # Removing a version from this list means the published client is no longer compatible with
         # that lakeFS version.
-        lakefs_version: [ 0.108.0, 0.109.0, 0.110.0, 0.111.0, 0.111.1, 0.112.1, 0.113.0, 1.0.0, 1.1.0, 1.2.0, 1.3.0, 1.3.1, 1.4.0, 1.5.0, 1.6.0, 1.7.0, 1.8.0, 1.9.0, 1.9.1, 1.10.0, 1.11.0, 1.11.1, 1.12.0, 1.12.1, 1.13.0 ]
+        lakefs_version: [ 0.108.0, 0.109.0, 0.110.0, 0.111.0, 0.111.1, 0.112.1, 0.113.0, 1.0.0, 1.1.0, 1.2.0, 1.3.0, 1.3.1, 1.4.0, 1.5.0, 1.6.0, 1.7.0, 1.8.0, 1.9.0, 1.9.1, 1.10.0, 1.11.0, 1.11.1, 1.12.1, 1.13.0 ]
     runs-on: ubuntu-20.04
     env:
       TAG: ${{ matrix.lakefs_version }}


### PR DESCRIPTION
- They're the same anyway, except for a permissions check which we fixed
- People should not be using 1.12.0