### PR TITLE
HL Python SDK: Fix Client SSL configuration

### DIFF
--- a/clients/python-wrapper/lakefs/client.py
+++ b/clients/python-wrapper/lakefs/client.py
@@ -70,7 +70,7 @@ class Client:
 
     def __init__(self, **kwargs):
         self._conf = ClientConfig(**kwargs)
-        self._client = LakeFSClient(self._conf.configuration, header_name='X-Lakefs-Client',
+        self._client = LakeFSClient(self._conf, header_name='X-Lakefs-Client',
                                     header_value='python-lakefs')
 
     @property
@@ -78,7 +78,7 @@ class Client:
         """
         Return the underlying lakefs_sdk configuration
         """
-        return self._conf.configuration
+        return self._conf
 
     @property
     def sdk_client(self):

--- a/clients/python-wrapper/lakefs/config.py
+++ b/clients/python-wrapper/lakefs/config.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 
 import os
 from pathlib import Path
+from typing import Optional
 
 import yaml
 from lakefs_sdk import Configuration
@@ -18,7 +19,7 @@ _LAKECTL_ACCESS_KEY_ID_ENV = "LAKECTL_CREDENTIALS_ACCESS_KEY_ID"
 _LAKECTL_SECRET_ACCESS_KEY_ENV = "LAKECTL_CREDENTIALS_SECRET_ACCESS_KEY"
 
 
-class ClientConfig:
+class ClientConfig(Configuration):
     """
     Configuration class for the SDK Client.
     Instantiation will try to get authentication methods using the following chain:
@@ -45,12 +46,16 @@ class ClientConfig:
         access_key_id: str
         secret_access_key: str
 
-    configuration: Configuration
     server: Server
     credentials: Credentials
 
-    def __init__(self, **kwargs):
-        self.configuration = Configuration(**kwargs)
+    def __init__(self, verify_ssl: Optional[bool] = None, proxy: Optional[str] = None, **kwargs):
+        super().__init__(**kwargs)
+        if verify_ssl is not None:
+            self.verify_ssl = verify_ssl
+        if proxy is not None:
+            self.proxy = proxy
+
         if kwargs:
             return
 
@@ -71,10 +76,10 @@ class ClientConfig:
         key_env = os.getenv(_LAKECTL_ACCESS_KEY_ID_ENV)
         secret_env = os.getenv(_LAKECTL_SECRET_ACCESS_KEY_ENV)
 
-        self.configuration.host = endpoint_env if endpoint_env is not None else self.server.endpoint_url
-        self.configuration.username = key_env if key_env is not None else self.credentials.access_key_id
-        self.configuration.password = secret_env if secret_env is not None else self.credentials.secret_access_key
-        if len(self.configuration.username) > 0 and len(self.configuration.password) > 0:
+        self.host = endpoint_env if endpoint_env is not None else self.server.endpoint_url
+        self.username = key_env if key_env is not None else self.credentials.access_key_id
+        self.password = secret_env if secret_env is not None else self.credentials.secret_access_key
+        if len(self.username) > 0 and len(self.password) > 0:
             found = True
 
         # TODO: authentication via IAM Role

--- a/docs/integrations/python.md
+++ b/docs/integrations/python.md
@@ -59,7 +59,12 @@ clt = Client(
 For testing SSL endpoints you may wish to use a self-signed certificate.  If you do this and receive an `SSL: CERTIFICATE_VERIFY_FAILED` error message you might add the following configuration to your client:
 
 ```python
-clt.config.verify_ssl= False
+clt = Client(
+    host="http://localhost:8000",
+    username="AKIAIOSFODNN7EXAMPLE",
+    password="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+    verify_ssl=False,
+)
 ```
 
 {: .warning }
@@ -70,8 +75,13 @@ production setting.
 Optionally, to enable communication via proxies, simply set the proxy configuration:
 
 ```python
-clt.config.ssl_ca_cert = <path to a file of concatenated CA certificates in PEM format> # Set this to customize the certificate file to verify the peer
-clt.config.proxy = <proxy server URL>
+clt = Client(
+    host="http://localhost:8000",
+    username="AKIAIOSFODNN7EXAMPLE",
+    password="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+    ssl_ca_cert="<path to a file of concatenated CA certificates in PEM format>",  # Set this to customize the certificate file to verify the peer
+    proxy="<proxy server URL>",
+)
 ```
 
 ### Usage Examples


### PR DESCRIPTION
Closes #7513

## Change Description

Propagate ssl configuration properly to the lakeFS client

### Background

The lakeFS configuration is updated dynamically, but unfortunately once the client is initialized, it initializes the underlying RESTClient with the initial values.
This in addition to the fact that the auto generated configuration class does not provide passing the ssl state and proxy configurations.

### Bug Fix

ClientConfig to inherit from SDK Configuration class, and load the additional configuration on it.
Updated documentation accordingly 

### Testing Details

Added sanity test

