### PR TITLE
Bump Ruby version for python client workflow

### DIFF
--- a/.github/workflows/python-api-client.yaml
+++ b/.github/workflows/python-api-client.yaml
@@ -51,7 +51,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         working-directory: clients/python
-        ruby-version: '2.7'
+        ruby-version: '3.2'
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
     - name: Build release as latest
@@ -114,7 +114,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         working-directory: clients/python-legacy
-        ruby-version: '2.7'
+        ruby-version: '3.2'
         bundler-cache: true # runs 'bundle install' and caches installed gems automatically
 
     - name: Build legacy release as latest

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -24,7 +24,7 @@ nav_order: 20
 
 - [Spark Metadata Client]({% link reference/spark-client.md %})
 - [lakeFS Hadoop FileSystem]({% link integrations/spark.md%}#lakefs-hadoop-filesystem)
-- [Python Client](https://pydocs.lakefs.io/)
+- [Python Client]({% link integrations/python.md %})
 
 ## Security
 


### PR DESCRIPTION
Dependabot update broke dependencies for the workflow.
Bumping the Ruby version for the workflow