### PR TITLE
Configurable persistence of friendly name to KV

### DIFF
--- a/api/authorization.yml
+++ b/api/authorization.yml
@@ -515,6 +515,8 @@ paths:
         content:
           application/json:
             schema:
+              required:
+                - friendly_name
               type: object
               properties:
                 friendly_name:

--- a/api/authorization.yml
+++ b/api/authorization.yml
@@ -508,7 +508,7 @@ paths:
     put:
       tags:
         - auth
-      operationId: updateFriendlyName
+      operationId: updateUserFriendlyName
       summary: update users friendly name
       requestBody:
         required: true

--- a/api/authorization.yml
+++ b/api/authorization.yml
@@ -498,6 +498,37 @@ paths:
         default:
           $ref: "#/components/responses/ServerError"
 
+  /auth/users/{userId}/friendly_name:
+    parameters:
+      - in: path
+        name: userId
+        required: true
+        schema:
+          type: string
+    put:
+      tags:
+        - auth
+      operationId: updateFriendlyName
+      summary: update users friendly name
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                friendly_name:
+                  type: string
+      responses:
+        204:
+          description: friendly name updated succesfully
+        400:
+          $ref: "#/components/responses/ValidationError"
+        401:
+          $ref: "#/components/responses/Unauthorized"
+        default:
+          $ref: "#/components/responses/ServerError"
+
   /auth/groups:
     get:
       tags:

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -101,7 +101,7 @@ This reference uses `.` to denote the nesting of values.
 * `auth.cookie_auth_verification.default_initial_groups` (string[] : [])` - By default, users will be assigned to these groups
 * `auth.cookie_auth_verification.initial_groups_claim_name` `(string[] : [])` - Use this claim from the ID token to provide the initial group for new users. This will take priority if `auth.cookie_auth_verification.default_initial_groups` is also set.
 * `auth.cookie_auth_verification.friendly_name_claim_name` `(string[] : )` - If specified, the value from the claim with this name will be used as the user's display name.
-* `auth.cookie_auth_verification.persist_friendly_name` `(string : false)` - If set to `true`, the friendly name is persisted to the KV store and can be displayed in the user list. This is meant to be used in conjunction with `auth.oidc.friendly_name_claim_name`.
+* `auth.cookie_auth_verification.persist_friendly_name` `(string : false)` - If set to `true`, the friendly name is persisted to the KV store and can be displayed in the user list. This is meant to be used in conjunction with `auth.cookie_auth_verification.friendly_name_claim_name`.
 * `auth.cookie_auth_verification.external_user_id_claim_name` - `(string : )` - If specified, the value from the claim with this name will be used as the user's id name.
 * `auth.cookie_auth_verification.auth_source` - `(string : )` - If specified, user will be labeled with this auth source.
 * `auth.oidc.default_initial_groups` `(string[] : [])` - By default, OIDC users will be assigned to these groups

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -101,11 +101,13 @@ This reference uses `.` to denote the nesting of values.
 * `auth.cookie_auth_verification.default_initial_groups` (string[] : [])` - By default, users will be assigned to these groups
 * `auth.cookie_auth_verification.initial_groups_claim_name` `(string[] : [])` - Use this claim from the ID token to provide the initial group for new users. This will take priority if `auth.cookie_auth_verification.default_initial_groups` is also set.
 * `auth.cookie_auth_verification.friendly_name_claim_name` `(string[] : )` - If specified, the value from the claim with this name will be used as the user's display name.
+* `auth.cookie_auth_verification.persist_friendly_name` `(string : false)` - If set to `true`, the friendly name is persisted to the KV store and can be displayed in the user list. This is meant to be used in conjunction with `auth.oidc.friendly_name_claim_name`.
 * `auth.cookie_auth_verification.external_user_id_claim_name` - `(string : )` - If specified, the value from the claim with this name will be used as the user's id name.
 * `auth.cookie_auth_verification.auth_source` - `(string : )` - If specified, user will be labeled with this auth source.
 * `auth.oidc.default_initial_groups` `(string[] : [])` - By default, OIDC users will be assigned to these groups
 * `auth.oidc.initial_groups_claim_name` `(string[] : [])` - Use this claim from the ID token to provide the initial group for new users. This will take priority if `auth.oidc.default_initial_groups` is also set.
 * `auth.oidc.friendly_name_claim_name` `(string[] : )` - If specified, the value from the claim with this name will be used as the user's display name.
+* `auth.oidc.persist_friendly_name` `(string : false)` - If set to `true`, the friendly name is persisted to the KV store and can be displayed in the user list. This is meant to be used in conjunction with `auth.oidc.friendly_name_claim_name`.
 * `auth.oidc.validate_id_token_claims` `(map[string]string : )` - When a user tries to access lakeFS, validate that the ID token contains these claims with the corresponding values.
 * `auth.ui_config.rbac` `(string: "simplified")` - "simplified", "external" or "internal" (enterprise feature).  In simplified mode, do not display policy in GUI.
   If you have configured an external auth server you can set this to "external" to support the policy editor.

--- a/docs/reference/security/authentication.md
+++ b/docs/reference/security/authentication.md
@@ -78,7 +78,8 @@ auth:
     callback_base_url: https://lakefs.example.com       # The scheme, domain (and port) of your lakeFS installation
     url: https://my-account.oidc-provider-example.com
     default_initial_groups: ["Developers"]
-    friendly_name_claim_name: name                      #  Optional: use the value from this claim as the user's display name 
+    friendly_name_claim_name: name                      #  Optional: use the value from this claim as the user's display name
+    persist_friendly_name: true                         #  Optional: persist friendly name to KV store so it can be displayed in the user list
 ```
 
 Your login page will now include a link to sign in using the 

--- a/docs/reference/security/authentication.md
+++ b/docs/reference/security/authentication.md
@@ -85,6 +85,11 @@ auth:
 Your login page will now include a link to sign in using the 
 OIDC provider. When a user first logs in through the provider, a corresponding user is created in lakeFS.
 
+#### Friendly Name Persistence
+
+When the `persist_friendly_name` configuration property is set to `true` **and** `friendly_name_claim_name` is set to a valid claim name, which exists in the incoming `id_token`, the friendly name will be persisted to the KV store. This will allow users with access to the lakeFS administration section to see friendly names in the users list, when listing group members, and when adding/removing group members.  
+The friendly name stored in KV is updated with each successful login, if the incoming value is different than the stored value. This means it will be kept up-to-date with changes to the user's profile or if `friendly_name_claim_name` is re-configured.
+
 #### Notes
 {: .no_toc}
 1. As always, you may choose to provide these configurations using [environment variables]({% link reference/configuration.md %}).

--- a/docs/reference/security/sso.md
+++ b/docs/reference/security/sso.md
@@ -179,6 +179,7 @@ auth:
   cookie_auth_verification:
     auth_source: saml
     friendly_name_claim_name: displayName
+    persist_friendly_name: true
     external_user_id_claim_name: samName
     default_initial_groups:
       - "Developers"
@@ -243,6 +244,7 @@ auth:
     secret_key: shared-secrey-key
   oidc:
     friendly_name_claim_name: "name"
+    persist_friendly_name: true
     default_initial_groups: ["Developers"]
   ui_config:
     login_url: /oidc/login

--- a/pkg/api/auth_middleware.go
+++ b/pkg/api/auth_middleware.go
@@ -195,12 +195,11 @@ func checkSecurityRequirements(r *http.Request,
 }
 
 func enhanceWithFriendlyName(ctx context.Context, user *model.User, friendlyName string, persistFriendlyName bool, authService auth.Service, logger logging.Logger) *model.User {
-	if friendlyName != "" {
-		user.FriendlyName = &friendlyName
-		if persistFriendlyName && swag.StringValue(user.FriendlyName) != friendlyName {
-			err := authService.UpdateUserFriendlyName(ctx, user.Username, friendlyName)
-			if err != nil {
-				logger.WithError(err).Error("update user friendly name")
+	if swag.StringValue(user.FriendlyName) != friendlyName {
+		user.FriendlyName = swag.String(friendlyName)
+		if persistFriendlyName {
+			if err := authService.UpdateUserFriendlyName(ctx, user.Username, friendlyName); err != nil {
+				logger.WithError(err).Error("failed to update user friendly name")
 			}
 		}
 	}

--- a/pkg/auth/mock/mock_auth_client.go
+++ b/pkg/auth/mock/mock_auth_client.go
@@ -796,46 +796,6 @@ func (mr *MockClientWithResponsesInterfaceMockRecorder) ListUsersWithResponse(ar
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListUsersWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).ListUsersWithResponse), varargs...)
 }
 
-// UpdateFriendlyNameWithBodyWithResponse mocks base method.
-func (m *MockClientWithResponsesInterface) UpdateFriendlyNameWithBodyWithResponse(arg0 context.Context, arg1, arg2 string, arg3 io.Reader, arg4 ...auth.RequestEditorFn) (*auth.UpdateFriendlyNameResponse, error) {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1, arg2, arg3}
-	for _, a := range arg4 {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "UpdateFriendlyNameWithBodyWithResponse", varargs...)
-	ret0, _ := ret[0].(*auth.UpdateFriendlyNameResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// UpdateFriendlyNameWithBodyWithResponse indicates an expected call of UpdateFriendlyNameWithBodyWithResponse.
-func (mr *MockClientWithResponsesInterfaceMockRecorder) UpdateFriendlyNameWithBodyWithResponse(arg0, arg1, arg2, arg3 interface{}, arg4 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1, arg2, arg3}, arg4...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateFriendlyNameWithBodyWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).UpdateFriendlyNameWithBodyWithResponse), varargs...)
-}
-
-// UpdateFriendlyNameWithResponse mocks base method.
-func (m *MockClientWithResponsesInterface) UpdateFriendlyNameWithResponse(arg0 context.Context, arg1 string, arg2 auth.UpdateFriendlyNameJSONRequestBody, arg3 ...auth.RequestEditorFn) (*auth.UpdateFriendlyNameResponse, error) {
-	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1, arg2}
-	for _, a := range arg3 {
-		varargs = append(varargs, a)
-	}
-	ret := m.ctrl.Call(m, "UpdateFriendlyNameWithResponse", varargs...)
-	ret0, _ := ret[0].(*auth.UpdateFriendlyNameResponse)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// UpdateFriendlyNameWithResponse indicates an expected call of UpdateFriendlyNameWithResponse.
-func (mr *MockClientWithResponsesInterfaceMockRecorder) UpdateFriendlyNameWithResponse(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateFriendlyNameWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).UpdateFriendlyNameWithResponse), varargs...)
-}
-
 // UpdatePasswordWithBodyWithResponse mocks base method.
 func (m *MockClientWithResponsesInterface) UpdatePasswordWithBodyWithResponse(arg0 context.Context, arg1, arg2 string, arg3 io.Reader, arg4 ...auth.RequestEditorFn) (*auth.UpdatePasswordResponse, error) {
 	m.ctrl.T.Helper()
@@ -914,4 +874,44 @@ func (mr *MockClientWithResponsesInterfaceMockRecorder) UpdatePolicyWithResponse
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdatePolicyWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).UpdatePolicyWithResponse), varargs...)
+}
+
+// UpdateUserFriendlyNameWithBodyWithResponse mocks base method.
+func (m *MockClientWithResponsesInterface) UpdateUserFriendlyNameWithBodyWithResponse(arg0 context.Context, arg1, arg2 string, arg3 io.Reader, arg4 ...auth.RequestEditorFn) (*auth.UpdateUserFriendlyNameResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1, arg2, arg3}
+	for _, a := range arg4 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "UpdateUserFriendlyNameWithBodyWithResponse", varargs...)
+	ret0, _ := ret[0].(*auth.UpdateUserFriendlyNameResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateUserFriendlyNameWithBodyWithResponse indicates an expected call of UpdateUserFriendlyNameWithBodyWithResponse.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) UpdateUserFriendlyNameWithBodyWithResponse(arg0, arg1, arg2, arg3 interface{}, arg4 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1, arg2, arg3}, arg4...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateUserFriendlyNameWithBodyWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).UpdateUserFriendlyNameWithBodyWithResponse), varargs...)
+}
+
+// UpdateUserFriendlyNameWithResponse mocks base method.
+func (m *MockClientWithResponsesInterface) UpdateUserFriendlyNameWithResponse(arg0 context.Context, arg1 string, arg2 auth.UpdateUserFriendlyNameJSONRequestBody, arg3 ...auth.RequestEditorFn) (*auth.UpdateUserFriendlyNameResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1, arg2}
+	for _, a := range arg3 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "UpdateUserFriendlyNameWithResponse", varargs...)
+	ret0, _ := ret[0].(*auth.UpdateUserFriendlyNameResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateUserFriendlyNameWithResponse indicates an expected call of UpdateUserFriendlyNameWithResponse.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) UpdateUserFriendlyNameWithResponse(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateUserFriendlyNameWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).UpdateUserFriendlyNameWithResponse), varargs...)
 }

--- a/pkg/auth/mock/mock_auth_client.go
+++ b/pkg/auth/mock/mock_auth_client.go
@@ -796,6 +796,46 @@ func (mr *MockClientWithResponsesInterfaceMockRecorder) ListUsersWithResponse(ar
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListUsersWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).ListUsersWithResponse), varargs...)
 }
 
+// UpdateFriendlyNameWithBodyWithResponse mocks base method.
+func (m *MockClientWithResponsesInterface) UpdateFriendlyNameWithBodyWithResponse(arg0 context.Context, arg1, arg2 string, arg3 io.Reader, arg4 ...auth.RequestEditorFn) (*auth.UpdateFriendlyNameResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1, arg2, arg3}
+	for _, a := range arg4 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "UpdateFriendlyNameWithBodyWithResponse", varargs...)
+	ret0, _ := ret[0].(*auth.UpdateFriendlyNameResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateFriendlyNameWithBodyWithResponse indicates an expected call of UpdateFriendlyNameWithBodyWithResponse.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) UpdateFriendlyNameWithBodyWithResponse(arg0, arg1, arg2, arg3 interface{}, arg4 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1, arg2, arg3}, arg4...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateFriendlyNameWithBodyWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).UpdateFriendlyNameWithBodyWithResponse), varargs...)
+}
+
+// UpdateFriendlyNameWithResponse mocks base method.
+func (m *MockClientWithResponsesInterface) UpdateFriendlyNameWithResponse(arg0 context.Context, arg1 string, arg2 auth.UpdateFriendlyNameJSONRequestBody, arg3 ...auth.RequestEditorFn) (*auth.UpdateFriendlyNameResponse, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1, arg2}
+	for _, a := range arg3 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "UpdateFriendlyNameWithResponse", varargs...)
+	ret0, _ := ret[0].(*auth.UpdateFriendlyNameResponse)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateFriendlyNameWithResponse indicates an expected call of UpdateFriendlyNameWithResponse.
+func (mr *MockClientWithResponsesInterfaceMockRecorder) UpdateFriendlyNameWithResponse(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateFriendlyNameWithResponse", reflect.TypeOf((*MockClientWithResponsesInterface)(nil).UpdateFriendlyNameWithResponse), varargs...)
+}
+
 // UpdatePasswordWithBodyWithResponse mocks base method.
 func (m *MockClientWithResponsesInterface) UpdatePasswordWithBodyWithResponse(arg0 context.Context, arg1, arg2 string, arg3 io.Reader, arg4 ...auth.RequestEditorFn) (*auth.UpdatePasswordResponse, error) {
 	m.ctrl.T.Helper()

--- a/pkg/auth/service.go
+++ b/pkg/auth/service.go
@@ -1374,7 +1374,7 @@ func (a *APIAuthService) ListUsers(ctx context.Context, params *model.Pagination
 
 func (a *APIAuthService) UpdateUserFriendlyName(ctx context.Context, userID string, friendlyName string) error {
 	resp, err := a.apiClient.UpdateFriendlyNameWithResponse(ctx, userID, UpdateFriendlyNameJSONRequestBody{
-		FriendlyName: swag.String(friendlyName),
+		FriendlyName: friendlyName,
 	})
 	if err != nil {
 		a.logger.WithError(err).WithField("userID", userID).Error("update user friendly name")

--- a/pkg/auth/service.go
+++ b/pkg/auth/service.go
@@ -1373,7 +1373,7 @@ func (a *APIAuthService) ListUsers(ctx context.Context, params *model.Pagination
 }
 
 func (a *APIAuthService) UpdateUserFriendlyName(ctx context.Context, userID string, friendlyName string) error {
-	resp, err := a.apiClient.UpdateFriendlyNameWithResponse(ctx, userID, UpdateFriendlyNameJSONRequestBody{
+	resp, err := a.apiClient.UpdateUserFriendlyNameWithResponse(ctx, userID, UpdateUserFriendlyNameJSONRequestBody{
 		FriendlyName: friendlyName,
 	})
 	if err != nil {

--- a/pkg/auth/service.go
+++ b/pkg/auth/service.go
@@ -99,6 +99,7 @@ type Service interface {
 	GetUserByExternalID(ctx context.Context, externalID string) (*model.User, error)
 	GetUserByEmail(ctx context.Context, email string) (*model.User, error)
 	ListUsers(ctx context.Context, params *model.PaginationParams) ([]*model.User, *model.Paginator, error)
+	UpdateUserFriendlyName(ctx context.Context, userID string, friendlyName string) error
 
 	ExternalPrincipalsService
 
@@ -358,6 +359,10 @@ func (s *AuthService) ListUsers(ctx context.Context, params *model.PaginationPar
 		return nil, paginator, err
 	}
 	return model.ConvertUsersDataList(msgs), paginator, err
+}
+
+func (s *AuthService) UpdateUserFriendlyName(ctx context.Context, userID string, friendlyName string) error {
+	return ErrNotImplemented
 }
 
 func (s *AuthService) ListUserCredentials(ctx context.Context, username string, params *model.PaginationParams) ([]*model.Credential, *model.Paginator, error) {
@@ -1365,6 +1370,17 @@ func (a *APIAuthService) ListUsers(ctx context.Context, params *model.Pagination
 		}
 	}
 	return users, toPagination(pagination), nil
+}
+
+func (a *APIAuthService) UpdateUserFriendlyName(ctx context.Context, userID string, friendlyName string) error {
+	resp, err := a.apiClient.UpdateFriendlyNameWithResponse(ctx, userID, UpdateFriendlyNameJSONRequestBody{
+		FriendlyName: swag.String(friendlyName),
+	})
+	if err != nil {
+		a.logger.WithError(err).WithField("userID", userID).Error("update user friendly name")
+		return err
+	}
+	return a.validateResponse(resp, http.StatusNoContent)
 }
 
 func (a *APIAuthService) CreateGroup(ctx context.Context, group *model.Group) (*model.Group, error) {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -35,6 +35,7 @@ type OIDC struct {
 	DefaultInitialGroups   []string          `mapstructure:"default_initial_groups"`
 	InitialGroupsClaimName string            `mapstructure:"initial_groups_claim_name"`
 	FriendlyNameClaimName  string            `mapstructure:"friendly_name_claim_name"`
+	PersistFriendlyName    bool              `mapstructure:"persist_friendly_name"`
 }
 
 // CookieAuthVerification is related to auth based on a cookie set by an external service
@@ -52,6 +53,8 @@ type CookieAuthVerification struct {
 	ExternalUserIDClaimName string `mapstructure:"external_user_id_claim_name"`
 	// AuthSource tag each user with label of the IDP
 	AuthSource string `mapstructure:"auth_source"`
+	// PersistFriendlyName should we persist the friendly name in the KV store
+	PersistFriendlyName bool `mapstructure:"persist_friendly_name"`
 }
 
 // S3AuthInfo holds S3-style authentication.

--- a/pkg/config/defaults.go
+++ b/pkg/config/defaults.go
@@ -64,6 +64,8 @@ func setDefaults(cfgType string) {
 	viper.SetDefault("auth.remote_authenticator.request_timeout", 10*time.Second)
 
 	viper.SetDefault("auth.api.health_check_timeout", DefaultAuthAPIHealthCheckTimeout)
+	viper.SetDefault("auth.oidc.persist_friendly_name", false)
+	viper.SetDefault("auth.cookie_auth_verification.persist_friendly_name", false)
 
 	viper.SetDefault("blockstore.local.path", "~/lakefs/data/block")
 	viper.SetDefault("blockstore.s3.region", "us-east-1")

--- a/webui/src/lib/utils.ts
+++ b/webui/src/lib/utils.ts
@@ -1,0 +1,12 @@
+interface User {
+  id: string;
+  email: string;
+  friendly_name: string;
+}
+
+export const resolveDisplayName = (user: User): string => {
+  if (!user) return "";
+  if (user?.email?.length) return user.email;
+  if (user?.friendly_name?.length) return user.friendly_name;
+  return user.id;
+};

--- a/webui/src/pages/auth/credentials.jsx
+++ b/webui/src/pages/auth/credentials.jsx
@@ -1,114 +1,88 @@
-import React, { useEffect } from "react";
+import React, {useEffect} from "react";
 import { useOutletContext } from "react-router-dom";
 import {
-  ActionGroup,
-  ActionsBar,
-  AlertError,
-  RefreshButton,
+    ActionGroup,
+    ActionsBar,
+    AlertError,
+    RefreshButton
 } from "../../lib/components/controls";
-import { ConfirmationButton } from "../../lib/components/modals";
+import {ConfirmationButton} from "../../lib/components/modals";
 import useUser from "../../lib/hooks/user";
-import { auth } from "../../lib/api";
-import { useState } from "react";
-import {
-  CredentialsShowModal,
-  CredentialsTable,
-} from "../../lib/components/auth/credentials";
-import { useRouter } from "../../lib/hooks/router";
-import { resolveDisplayName } from "../../lib/utils";
+import {auth} from "../../lib/api";
+import {useState} from "react";
+import {CredentialsShowModal, CredentialsTable} from "../../lib/components/auth/credentials";
+import {useRouter} from "../../lib/hooks/router";
+import {resolveDisplayName} from "../../lib/utils";
 
 const CredentialsContainer = () => {
-  const router = useRouter();
-  const { user } = useUser();
-  const [refreshToken, setRefreshToken] = useState(false);
-  const [createError, setCreateError] = useState(null);
-  const [createdKey, setCreatedKey] = useState(null);
-  const { after } = router.query;
+    const router = useRouter();
+    const { user } = useUser();
+    const [refreshToken, setRefreshToken] = useState(false);
+    const [createError, setCreateError] = useState(null);
+    const [createdKey, setCreatedKey] = useState(null);
+    const { after } = router.query;
 
-  const createKey = () => {
-    return auth
-      .createCredentials(user.id)
-      .catch((err) => {
-        setCreateError(err);
-      })
-      .then((key) => {
-        setCreateError(null);
-        setRefreshToken(!refreshToken);
-        return key;
-      });
-  };
-
-  return (
-    <>
-      <ActionsBar>
-        <ActionGroup orientation="left">
-          <ConfirmationButton
-            variant="success"
-            modalVariant="success"
-            msg={
-              <span>
-                Create a new Access Key for user{" "}
-                <strong>{resolveDisplayName(user)}</strong>?
-              </span>
-            }
-            onConfirm={(hide) => {
-              createKey()
-                .then((key) => {
-                  setCreatedKey(key);
-                })
-                .finally(hide);
-            }}
-          >
-            Create Access Key
-          </ConfirmationButton>
-        </ActionGroup>
-        <ActionGroup orientation="right">
-          <RefreshButton onClick={() => setRefreshToken(!refreshToken)} />
-        </ActionGroup>
-      </ActionsBar>
-      <div className="auth-learn-more">
-        An access key-pair is the set of credentials used to access lakeFS.{" "}
-        <a
-          href="https://docs.lakefs.io/reference/authorization.html#authentication"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
-          Learn more.
-        </a>
-      </div>
-
-      {!!createError && <AlertError error={createError} />}
-
-      <CredentialsShowModal
-        credentials={createdKey}
-        show={!!createdKey}
-        onHide={() => {
-          setCreatedKey(null);
-        }}
-      />
-
-      {!!user && (
-        <CredentialsTable
-          userId={user.id}
-          currentAccessKey={user.accessKeyId}
-          refresh={refreshToken}
-          after={after ? after : ""}
-          onPaginate={(after) =>
-            router.push({
-              pathname: "/auth/credentials",
-              query: { after },
+    const createKey = () => {
+        return auth.createCredentials(user.id)
+            .catch(err => {
+                setCreateError(err);
+            }).then(key => {
+                setCreateError(null);
+                setRefreshToken(!refreshToken);
+                return key;
             })
-          }
-        />
-      )}
-    </>
-  );
+    }
+
+    return (
+        <>
+            <ActionsBar>
+                <ActionGroup orientation="left">
+                    <ConfirmationButton
+                        variant="success"
+                        modalVariant="success"
+                        msg={<span>Create a new Access Key for user <strong>{resolveDisplayName(user)}</strong>?</span>}
+                        onConfirm={hide => {
+                            createKey()
+                                .then(key => { setCreatedKey(key) })
+                                .finally(hide);
+                        }}>
+                        Create Access Key
+                    </ConfirmationButton>
+                </ActionGroup>
+                <ActionGroup orientation="right">
+                    <RefreshButton onClick={() => setRefreshToken(!refreshToken)}/>
+                </ActionGroup>
+            </ActionsBar>
+            <div className="auth-learn-more">
+                An access key-pair is the set of credentials used to access lakeFS. <a href="https://docs.lakefs.io/reference/authorization.html#authentication" target="_blank" rel="noopener noreferrer">Learn more.</a>
+            </div>
+
+            {(!!createError) && <AlertError error={createError}/>}
+
+            <CredentialsShowModal
+                credentials={createdKey}
+                show={(!!createdKey)}
+                onHide={() => { setCreatedKey(null) }}/>
+
+            {(!!user) && <CredentialsTable
+                userId={user.id}
+                currentAccessKey={user.accessKeyId}
+                refresh={refreshToken}
+                after={(after) ? after : ""}
+                onPaginate={after => router.push({
+                    pathname: '/auth/credentials',
+                    query: {after}
+                })}
+            />}
+        </>
+    );
 };
 
 const CredentialsPage = () => {
-  const [setActiveTab] = useOutletContext();
-  useEffect(() => setActiveTab("credentials"), [setActiveTab]);
-  return <CredentialsContainer />;
+    const [setActiveTab] = useOutletContext();
+    useEffect(() => setActiveTab("credentials"), [setActiveTab]);
+    return <CredentialsContainer/>;
 };
+
 
 export default CredentialsPage;

--- a/webui/src/pages/auth/credentials.jsx
+++ b/webui/src/pages/auth/credentials.jsx
@@ -1,93 +1,114 @@
-import React, {useEffect} from "react";
+import React, { useEffect } from "react";
 import { useOutletContext } from "react-router-dom";
 import {
-    ActionGroup,
-    ActionsBar,
-    AlertError,
-    RefreshButton
+  ActionGroup,
+  ActionsBar,
+  AlertError,
+  RefreshButton,
 } from "../../lib/components/controls";
-import {ConfirmationButton} from "../../lib/components/modals";
+import { ConfirmationButton } from "../../lib/components/modals";
 import useUser from "../../lib/hooks/user";
-import {auth} from "../../lib/api";
-import {useState} from "react";
-import {CredentialsShowModal, CredentialsTable} from "../../lib/components/auth/credentials";
-import {useRouter} from "../../lib/hooks/router";
-
-const resolveDisplayName = (user) => {
-    if (!user) return "";
-    if (user?.email?.length) return user.email;
-    return user.id;
-}
+import { auth } from "../../lib/api";
+import { useState } from "react";
+import {
+  CredentialsShowModal,
+  CredentialsTable,
+} from "../../lib/components/auth/credentials";
+import { useRouter } from "../../lib/hooks/router";
+import { resolveDisplayName } from "../../lib/utils";
 
 const CredentialsContainer = () => {
-    const router = useRouter();
-    const { user } = useUser();
-    const [refreshToken, setRefreshToken] = useState(false);
-    const [createError, setCreateError] = useState(null);
-    const [createdKey, setCreatedKey] = useState(null);
-    const { after } = router.query;
+  const router = useRouter();
+  const { user } = useUser();
+  const [refreshToken, setRefreshToken] = useState(false);
+  const [createError, setCreateError] = useState(null);
+  const [createdKey, setCreatedKey] = useState(null);
+  const { after } = router.query;
 
-    const createKey = () => {
-        return auth.createCredentials(user.id)
-            .catch(err => {
-                setCreateError(err);
-            }).then(key => {
-                setCreateError(null);
-                setRefreshToken(!refreshToken);
-                return key;
+  const createKey = () => {
+    return auth
+      .createCredentials(user.id)
+      .catch((err) => {
+        setCreateError(err);
+      })
+      .then((key) => {
+        setCreateError(null);
+        setRefreshToken(!refreshToken);
+        return key;
+      });
+  };
+
+  return (
+    <>
+      <ActionsBar>
+        <ActionGroup orientation="left">
+          <ConfirmationButton
+            variant="success"
+            modalVariant="success"
+            msg={
+              <span>
+                Create a new Access Key for user{" "}
+                <strong>{resolveDisplayName(user)}</strong>?
+              </span>
+            }
+            onConfirm={(hide) => {
+              createKey()
+                .then((key) => {
+                  setCreatedKey(key);
+                })
+                .finally(hide);
+            }}
+          >
+            Create Access Key
+          </ConfirmationButton>
+        </ActionGroup>
+        <ActionGroup orientation="right">
+          <RefreshButton onClick={() => setRefreshToken(!refreshToken)} />
+        </ActionGroup>
+      </ActionsBar>
+      <div className="auth-learn-more">
+        An access key-pair is the set of credentials used to access lakeFS.{" "}
+        <a
+          href="https://docs.lakefs.io/reference/authorization.html#authentication"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
+          Learn more.
+        </a>
+      </div>
+
+      {!!createError && <AlertError error={createError} />}
+
+      <CredentialsShowModal
+        credentials={createdKey}
+        show={!!createdKey}
+        onHide={() => {
+          setCreatedKey(null);
+        }}
+      />
+
+      {!!user && (
+        <CredentialsTable
+          userId={user.id}
+          currentAccessKey={user.accessKeyId}
+          refresh={refreshToken}
+          after={after ? after : ""}
+          onPaginate={(after) =>
+            router.push({
+              pathname: "/auth/credentials",
+              query: { after },
             })
-    }
-
-    return (
-        <>
-            <ActionsBar>
-                <ActionGroup orientation="left">
-                    <ConfirmationButton
-                        variant="success"
-                        modalVariant="success"
-                        msg={<span>Create a new Access Key for user <strong>{resolveDisplayName(user)}</strong>?</span>}
-                        onConfirm={hide => {
-                            createKey()
-                                .then(key => { setCreatedKey(key) })
-                                .finally(hide);
-                        }}>
-                        Create Access Key
-                    </ConfirmationButton>
-                </ActionGroup>
-                <ActionGroup orientation="right">
-                    <RefreshButton onClick={() => setRefreshToken(!refreshToken)}/>
-                </ActionGroup>
-            </ActionsBar>
-            <div className="auth-learn-more">
-                An access key-pair is the set of credentials used to access lakeFS. <a href="https://docs.lakefs.io/reference/authorization.html#authentication" target="_blank" rel="noopener noreferrer">Learn more.</a>
-            </div>
-
-            {(!!createError) && <AlertError error={createError}/>}
-
-            <CredentialsShowModal
-                credentials={createdKey}
-                show={(!!createdKey)}
-                onHide={() => { setCreatedKey(null) }}/>
-
-            {(!!user) && <CredentialsTable
-                userId={user.id}
-                currentAccessKey={user.accessKeyId}
-                refresh={refreshToken}
-                after={(after) ? after : ""}
-                onPaginate={after => router.push({
-                    pathname: '/auth/credentials',
-                    query: {after}
-                })}
-            />}
-        </>
-    );
+          }
+        />
+      )}
+    </>
+  );
 };
 
 const CredentialsPage = () => {
-    const [setActiveTab] = useOutletContext();
-    useEffect(() => setActiveTab("credentials"), [setActiveTab]);
-    return <CredentialsContainer/>;
+  const [setActiveTab] = useOutletContext();
+  useEffect(() => setActiveTab("credentials"), [setActiveTab]);
+  return <CredentialsContainer />;
 };
-
 
 export default CredentialsPage;

--- a/webui/src/pages/auth/groups/group/members.jsx
+++ b/webui/src/pages/auth/groups/group/members.jsx
@@ -19,6 +19,7 @@ import {
 } from "../../../../lib/components/controls";
 import {useRouter} from "../../../../lib/hooks/router";
 import {Link} from "../../../../lib/components/nav";
+import {resolveDisplayName} from "../../../../lib/utils";
 
 
 const GroupMemberList = ({ groupId, after, onPaginate }) => {
@@ -44,7 +45,7 @@ const GroupMemberList = ({ groupId, after, onPaginate }) => {
                 <DataTable
                     keyFn={user => user.id}
                     rowFn={user => [
-                        <Link href={{pathname: '/auth/users/:userId', params: {userId: user.id}}}>{user.email || user.id}</Link>,
+                        <Link href={{pathname: '/auth/users/:userId', params: {userId: user.id}}}>{resolveDisplayName(user)}</Link>,
                         <FormattedDate dateValue={user.creation_date}/>
                     ]}
                     headers={['User ID', 'Created At']}
@@ -53,7 +54,7 @@ const GroupMemberList = ({ groupId, after, onPaginate }) => {
                         buttonFn: user => <ConfirmationButton
                             size="sm"
                             variant="outline-danger"
-                            msg={<span>Are you sure you{'\''}d like to remove user <strong>{user.email || user.id}</strong> from group <strong>{groupId}</strong>?</span>}
+                            msg={<span>Are you sure you{'\''}d like to remove user <strong>{resolveDisplayName(user)}</strong> from group <strong>{groupId}</strong>?</span>}
                             onConfirm={() => {
                                 auth.removeUserFromGroup(user.id, groupId)
                                     .catch(error => alert(error))

--- a/webui/src/pages/auth/users/index.jsx
+++ b/webui/src/pages/auth/users/index.jsx
@@ -24,6 +24,7 @@ import {
 } from "../../../lib/components/controls";
 import validator from "validator/es";
 import { disallowPercentSign, INVALID_USER_NAME_ERROR_MESSAGE } from "../validation";
+import { resolveDisplayName } from "../../../lib/utils";
 
 const USER_NOT_FOUND = "unknown";
 export const GetUserEmailByIdContext = createContext();
@@ -118,7 +119,7 @@ const UsersContainer = ({nextPage, refresh, setRefresh, error, loading, userList
                         onRemove={() => setSelected(selected.filter(u => u !== user))}
                     />,
                     <Link href={{pathname: '/auth/users/:userId', params: {userId: user.id}}}>
-                        {user.email || user.id}
+                        { resolveDisplayName(user) }
                     </Link>,
                     <FormattedDate dateValue={user.creation_date}/>
                 ]}/>


### PR DESCRIPTION
Closes #7562 

## Change Description

### Background

Please see the linked issue for context.

### New Feature

This PR adds two new configuration flags with a default value of `false`:

1. `cookie_auth_verification.persist_friendly_name` - SAML-based auth API
2. `oidc.persist_friendly_name` - OIDC-based auth API

When this flag is set to `true`, the friendly name claim pointed to by `friendly_name_claim_name` is saved with the user's record in the KV store. Each of the flags is only relevant to its respective authentication method.

Before:
![Screenshot 2024-03-18 at 13 06 17](https://github.com/treeverse/lakeFS/assets/110764839/2765f055-d2cc-478f-b32a-12d94ced781d)

After:
![after-screenshot](https://github.com/treeverse/lakeFS/assets/110764839/9f5b46cc-d256-4693-a9b3-55ae594349ef)
**Note: domain prefix intentionally removed.**



### Testing Details

Both positive and negative tests were done manually.

### Breaking Change?

None.
