### PR TITLE
Remove ADLS hint from import

### DIFF
--- a/.github/workflows/esti.yaml
+++ b/.github/workflows/esti.yaml
@@ -956,7 +956,6 @@ jobs:
           LAKEFS_BLOCKSTORE_TYPE: azure
           ESTI_BLOCKSTORE_TYPE: azure
           ESTI_STORAGE_NAMESPACE: https://esti4hns.blob.core.windows.net/esti-system-testing/${{ github.run_number }}/${{ steps.unique.outputs.value }}
-          ESTI_ADLS_IMPORT_BASE_URL: https://esti4hns.adls.core.windows.net/esti-system-testing-data/
           ESTI_AZURE_STORAGE_ACCOUNT: esti4hns
           ESTI_AZURE_STORAGE_ACCESS_KEY: ${{ secrets.LAKEFS_BLOCKSTORE_AZURE_STORAGE_GEN2_ACCESS_KEY }}
 

--- a/cmd/lakectl/cmd/common_helpers.go
+++ b/cmd/lakectl/cmd/common_helpers.go
@@ -34,6 +34,7 @@ const (
 	LakectlInteractive     = "LAKECTL_INTERACTIVE"
 	DeathMessage           = "{{.Error|red}}\nError executing command.\n"
 	DeathMessageWithFields = "{{.Message|red}}\n{{.Status}}\n"
+	WarnMessage            = "{{.Warning|yellow}}\n\n"
 )
 
 const (
@@ -176,6 +177,10 @@ func WriteIfVerbose(tpl string, data interface{}) {
 	if verboseMode {
 		WriteTo(tpl, data, os.Stdout)
 	}
+}
+
+func Warning(message string) {
+	WriteTo(WarnMessage, struct{ Warning string }{Warning: "Warning: " + message}, os.Stderr)
 }
 
 func Die(errMsg string, code int) {

--- a/cmd/lakectl/cmd/import.go
+++ b/cmd/lakectl/cmd/import.go
@@ -163,8 +163,8 @@ func newImportProgressBar(visible bool) *progressbar.ProgressBar {
 func verifySourceMatchConfiguredStorage(ctx context.Context, client *apigen.ClientWithResponses, source string) {
 	// Adds backwards compatibility for ADLS Gen2 storage import `hint`
 	if strings.Contains(source, "adls.core.windows.net") {
-		Warning("'adls' hint is deprecated, please use the original source url for import")
 		source = strings.Replace(source, "adls.core.windows.net", "blob.core.windows.net", 1)
+		Warning(fmt.Sprintf("'adls' hint is deprecated\n Using %s", source))
 	}
 
 	confResp, err := client.GetConfigWithResponse(ctx)

--- a/cmd/lakectl/cmd/import.go
+++ b/cmd/lakectl/cmd/import.go
@@ -163,7 +163,7 @@ func newImportProgressBar(visible bool) *progressbar.ProgressBar {
 func verifySourceMatchConfiguredStorage(ctx context.Context, client *apigen.ClientWithResponses, source string) {
 	// Adds backwards compatibility for ADLS Gen2 storage import `hint`
 	if strings.Contains(source, "adls.core.windows.net") {
-		Warning("'adls' hint will be deprecated soon, please use the original source url for import")
+		Warning("'adls' hint is deprecated, please use the original source url for import")
 		source = strings.Replace(source, "adls.core.windows.net", "blob.core.windows.net", 1)
 	}
 

--- a/cmd/lakectl/cmd/import.go
+++ b/cmd/lakectl/cmd/import.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"os/signal"
 	"regexp"
+	"strings"
 	"syscall"
 	"time"
 
@@ -160,6 +161,12 @@ func newImportProgressBar(visible bool) *progressbar.ProgressBar {
 }
 
 func verifySourceMatchConfiguredStorage(ctx context.Context, client *apigen.ClientWithResponses, source string) {
+	// Adds backwards compatibility for ADLS Gen2 storage import `hint`
+	if strings.Contains(source, "adls.core.windows.net") {
+		Warning("'adls' hint will be deprecated soon, please use the original source url for import")
+		source = strings.Replace(source, "adls.core.windows.net", "blob.core.windows.net", 1)
+	}
+
 	confResp, err := client.GetConfigWithResponse(ctx)
 	DieOnErrorOrUnexpectedStatusCode(confResp, err, http.StatusOK)
 	storageConfig := confResp.JSON200.StorageConfig

--- a/docs/howto/import.md
+++ b/docs/howto/import.md
@@ -106,7 +106,6 @@ In addition, the following for provider-specific permissions may be required:
 </ul>
 <div markdown="1" id="aws-s3">
 
-
 ## AWS S3: Importing from public buckets
 {:.no_toc}
 
@@ -149,6 +148,10 @@ the following policy needs to be attached to the lakeFS S3 service-account to al
 
 </div>
 <div markdown="1" id="azure-storage">
+
+**Note:** The use of the `alds` hint for ADLS Gen2 storage accounts is deprecated, please use the original source url for import.
+{: .note}
+
 See [Azure deployment][deploy-azure-storage-account-creds] on limitations when using account credentials.
 
 </div>

--- a/docs/howto/import.md
+++ b/docs/howto/import.md
@@ -151,19 +151,6 @@ the following policy needs to be attached to the lakeFS S3 service-account to al
 <div markdown="1" id="azure-storage">
 See [Azure deployment][deploy-azure-storage-account-creds] on limitations when using account credentials.
 
-### Azure Data Lake Gen2
-{:.no_toc}
-
-lakeFS requires a hint in the import source URL to understand that the provided storage account is ADLS Gen2
-
-```
-   For source account URL:
-      https://<my-account>.core.windows.net/path/to/import/
-
-   Please add the *adls* subdomain to the URL as follows:
-      https://<my-account>.adls.core.windows.net/path/to/import/
-```
-
 </div>
 <div markdown="1" id="gcs">
 No specific prerequisites

--- a/esti/ops/docker-compose-external-db.yaml
+++ b/esti/ops/docker-compose-external-db.yaml
@@ -51,7 +51,6 @@ services:
       - ESTI_GOTEST_FLAGS
       - ESTI_FLAGS
       - ESTI_FORCE_PATH_STYLE
-      - ESTI_ADLS_IMPORT_BASE_URL
       - ESTI_AZURE_STORAGE_ACCOUNT
       - ESTI_AZURE_STORAGE_ACCESS_KEY
     working_dir: /lakefs

--- a/esti/ops/docker-compose.yaml
+++ b/esti/ops/docker-compose.yaml
@@ -59,7 +59,6 @@ services:
       - ESTI_GOTEST_FLAGS
       - ESTI_FLAGS
       - ESTI_FORCE_PATH_STYLE
-      - ESTI_ADLS_IMPORT_BASE_URL
       - ESTI_AZURE_STORAGE_ACCOUNT
       - ESTI_AZURE_STORAGE_ACCESS_KEY
     working_dir: /lakefs

--- a/pkg/actions/lua/storage/azure/blob.go
+++ b/pkg/actions/lua/storage/azure/blob.go
@@ -128,7 +128,7 @@ func transformPathToAbfss(l *lua.State) int {
 	path := lua.CheckString(l, 1)
 	const numOfParts = 3
 	// Added adls for backwards compatibility in imports created pre fix of bug: https://github.com/treeverse/lakeFS/issues/7580
-	r := regexp.MustCompile(`^https://(\w+)\.[blob|alds]\.core\.windows\.net/([^/]*)/(.+)$`)
+	r := regexp.MustCompile(`^https://(\w+)\.(?:blob|adls)\.core\.windows\.net/([^/]*)/(.+)$`)
 	parts := r.FindStringSubmatch(path)
 	if len(parts) != numOfParts+1 {
 		lua.Errorf(l, "expected valid Azure https URL: %s", path)

--- a/pkg/actions/lua/storage/azure/blob.go
+++ b/pkg/actions/lua/storage/azure/blob.go
@@ -127,7 +127,8 @@ func parsePath(l *lua.State, path string) (string, string) {
 func transformPathToAbfss(l *lua.State) int {
 	path := lua.CheckString(l, 1)
 	const numOfParts = 3
-	r := regexp.MustCompile(`^https://(\w+)\.blob\.core\.windows\.net/([^/]*)/(.+)$`)
+	// Added adls for backwards compatibility in imports created pre fix of bug: https://github.com/treeverse/lakeFS/issues/7580
+	r := regexp.MustCompile(`^https://(\w+)\.[blob|alds]\.core\.windows\.net/([^/]*)/(.+)$`)
 	parts := r.FindStringSubmatch(path)
 	if len(parts) != numOfParts+1 {
 		lua.Errorf(l, "expected valid Azure https URL: %s", path)

--- a/pkg/block/azure/adapter.go
+++ b/pkg/block/azure/adapter.go
@@ -209,7 +209,7 @@ func (a *Adapter) GetWalker(uri *url.URL) (block.Walker, error) {
 		return nil, err
 	}
 
-	return NewAzureBlobWalker(client)
+	return NewAzureDataLakeWalker(client, false)
 }
 
 func (a *Adapter) GetPreSignedURL(ctx context.Context, obj block.ObjectPointer, mode block.PreSignMode) (string, time.Time, error) {
@@ -568,11 +568,11 @@ func (a *Adapter) CompleteMultiPartUpload(ctx context.Context, obj block.ObjectP
 
 func (a *Adapter) GetStorageNamespaceInfo() block.StorageNamespaceInfo {
 	info := block.DefaultStorageNamespaceInfo(block.BlockstoreTypeAzure)
-	info.ImportValidityRegex = `^https?://[a-z0-9_-]+\.(blob|adls)\.core\.windows\.net` // added adls for import hint validation in UI
+	info.ImportValidityRegex = `^https?://[a-z0-9_-]+\.blob\.core\.windows\.net`
 	info.ValidityRegex = `^https?://[a-z0-9_-]+\.blob\.core\.windows\.net`
 
 	if a.chinaCloud {
-		info.ImportValidityRegex = `^https?://[a-z0-9_-]+\.(blob|adls)\.core\.chinacloudapi\.cn`
+		info.ImportValidityRegex = `^https?://[a-z0-9_-]+\.blob\.core\.chinacloudapi\.cn`
 		info.ValidityRegex = `^https?://[a-z0-9_-]+\.blob\.core\.chinacloudapi\.cn`
 	}
 
@@ -598,6 +598,6 @@ func (a *Adapter) newPreSignedTime() time.Time {
 	return time.Now().UTC().Add(a.preSignedExpiry)
 }
 
-func (a *Adapter) GetPresignUploadPartURL(ctx context.Context, obj block.ObjectPointer, uploadID string, partNumber int) (string, error) {
+func (a *Adapter) GetPresignUploadPartURL(_ context.Context, _ block.ObjectPointer, _ string, _ int) (string, error) {
 	return "", block.ErrOperationNotSupported
 }

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -805,11 +805,11 @@ func (c *Catalog) GetBranchReference(ctx context.Context, repositoryID string, b
 
 func (c *Catalog) HardResetBranch(ctx context.Context, repositoryID, branch, refExpr string, opts ...graveler.SetOptionsFunc) error {
 	branchID := graveler.BranchID(branch)
-	ref := graveler.Ref(refExpr)
+	reference := graveler.Ref(refExpr)
 	if err := validator.Validate([]validator.ValidateArg{
 		{Name: "repository", Value: repositoryID, Fn: graveler.ValidateRepositoryID},
 		{Name: "branch", Value: branchID, Fn: graveler.ValidateBranchID},
-		{Name: "ref", Value: ref, Fn: graveler.ValidateRef},
+		{Name: "ref", Value: reference, Fn: graveler.ValidateRef},
 	}); err != nil {
 		return err
 	}
@@ -817,7 +817,7 @@ func (c *Catalog) HardResetBranch(ctx context.Context, repositoryID, branch, ref
 	if err != nil {
 		return err
 	}
-	return c.Store.ResetHard(ctx, repository, branchID, ref, opts...)
+	return c.Store.ResetHard(ctx, repository, branchID, reference, opts...)
 }
 
 func (c *Catalog) ResetBranch(ctx context.Context, repositoryID string, branch string, opts ...graveler.SetOptionsFunc) error {

--- a/pkg/ingest/store/factory.go
+++ b/pkg/ingest/store/factory.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"strings"
 
 	"cloud.google.com/go/storage"
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -128,22 +127,7 @@ func (f *WalkerFactory) buildAzureWalker(importURL *url.URL, skipOutOfOrder bool
 		return nil, err
 	}
 
-	isHNS := isHierarchicalNamespaceEnabled(importURL)
-	if isHNS {
-		return azure.NewAzureDataLakeWalker(client, skipOutOfOrder)
-	}
-	return azure.NewAzureBlobWalker(client)
-}
-
-// isHierarchicalNamespaceEnabled - identify if hns enabled on the account,
-// based on the import URL.
-// Until we enable a way to extract the account information, we assume it based on the domain used in import:
-// https://<account>.<blob|adls>.core.windows.net/
-// adls - azure data lake storage
-func isHierarchicalNamespaceEnabled(u *url.URL) bool {
-	const importURLParts = 3
-	n := strings.SplitN(u.Host, ".", importURLParts)
-	return len(n) == importURLParts && n[1] == "adls"
+	return azure.NewAzureDataLakeWalker(client, skipOutOfOrder)
 }
 
 func (f *WalkerFactory) GetWalker(ctx context.Context, opts WalkerOptions) (*WalkerWrapper, error) {


### PR DESCRIPTION
Closes #7580

## Change Description

Remove ADLS hint from import

### Background

We are saving the physical address of imported objects in ADLS Gen2 accounts wrong which creates issues when using the physical address (to export tables for example)

### Bug Fix

1. Problem detected when trying to export tables of data that was imported from and adls gen 2 account
2. On investigation we detected that the physical address is saved incorrectly for these type of accounts due to the hint (change in the url from `blob` to `adls`
3. The hint is not longer necessary due to improvements of the import mechanism, we can use only one adapter for it.
4. The quickest and best way to fix was to remove the hint and the old Azure BlobWalker

### Testing Details

Verified by current unit and system tests

### Breaking Change?

Yes - will require users who use the adls hint to stop using it

