### PR TITLE
lakectl: get presigned url for object

### DIFF
--- a/cmd/lakectl/cmd/fs_presign.go
+++ b/cmd/lakectl/cmd/fs_presign.go
@@ -1,0 +1,42 @@
+package cmd
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/go-openapi/swag"
+	"github.com/spf13/cobra"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
+)
+
+var fsPresignCmd = &cobra.Command{
+	Use:               "presign <path URI>",
+	Short:             "return a pre-signed URL for the specified object",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: ValidArgsRepository,
+	Run: func(cmd *cobra.Command, args []string) {
+		pathURI := MustParsePathURI("path URI", args[0])
+		client := getClient()
+		preSignMode := getServerPreSignMode(cmd.Context(), client)
+		if !preSignMode.Enabled {
+			Die("Pre-signed URL support is currently disabled for this lakeFS server", 1)
+		}
+
+		resp, err := client.StatObjectWithResponse(cmd.Context(), pathURI.Repository, pathURI.Ref, &apigen.StatObjectParams{
+			Path:         *pathURI.Path,
+			Presign:      swag.Bool(preSignMode.Enabled),
+			UserMetadata: swag.Bool(true),
+		})
+		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusOK)
+		if resp.JSON200 == nil {
+			Die("Bad response from server", 1)
+		}
+
+		fmt.Printf("%s\n", resp.JSON200.PhysicalAddress)
+	},
+}
+
+//nolint:gochecknoinits
+func init() {
+	fsCmd.AddCommand(fsPresignCmd)
+}

--- a/cmd/lakectl/cmd/fs_presign.go
+++ b/cmd/lakectl/cmd/fs_presign.go
@@ -11,7 +11,7 @@ import (
 
 var fsPresignCmd = &cobra.Command{
 	Use:               "presign <path URI>",
-	Short:             "return a pre-signed URL for the specified object",
+	Short:             "return a pre-signed URL for reading the specified object",
 	Args:              cobra.ExactArgs(1),
 	ValidArgsFunction: ValidArgsRepository,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -31,7 +31,6 @@ var fsPresignCmd = &cobra.Command{
 		if resp.JSON200 == nil {
 			Die("Bad response from server", 1)
 		}
-
 		fmt.Printf("%s\n", resp.JSON200.PhysicalAddress)
 	},
 }

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2203,7 +2203,7 @@ lakectl fs ls <path URI> [flags]
 
 ### lakectl fs presign
 
-return a pre-signed URL for the specified object
+return a pre-signed URL for reading the specified object
 
 ```
 lakectl fs presign <path URI> [flags]

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2201,6 +2201,23 @@ lakectl fs ls <path URI> [flags]
 
 
 
+### lakectl fs presign
+
+return a pre-signed URL for the specified object
+
+```
+lakectl fs presign <path URI> [flags]
+```
+
+#### Options
+{:.no_toc}
+
+```
+  -h, --help   help for presign
+```
+
+
+
 ### lakectl fs rm
 
 Delete object

--- a/esti/golden/lakectl_fs_presign.golden
+++ b/esti/golden/lakectl_fs_presign.golden
@@ -1,0 +1,1 @@
+<PRE_SIGN_URL>

--- a/esti/lakectl_test.go
+++ b/esti/lakectl_test.go
@@ -602,6 +602,37 @@ func getStorageConfig(t *testing.T) *apigen.StorageConfig {
 	return storageResp.JSON200
 }
 
+func TestLakectlFsPresign(t *testing.T) {
+	config := getStorageConfig(t)
+	if !config.PreSignSupport {
+		t.Skip()
+	}
+	repoName := generateUniqueRepositoryName()
+	storage := generateUniqueStorageNamespace(repoName)
+	vars := map[string]string{
+		"REPO":    repoName,
+		"STORAGE": storage,
+		"BRANCH":  mainBranch,
+	}
+	RunCmdAndVerifySuccessWithFile(t, Lakectl()+" repo create lakefs://"+repoName+" "+storage, false, "lakectl_repo_create", vars)
+
+	// upload some data
+	const totalObjects = 2
+	for i := 0; i < totalObjects; i++ {
+		vars["FILE_PATH"] = fmt.Sprintf("data/ro/ro_1k.%d", i)
+		RunCmdAndVerifySuccessWithFile(t, Lakectl()+" fs upload -s files/ro_1k lakefs://"+repoName+"/"+mainBranch+"/"+vars["FILE_PATH"], false, "lakectl_fs_upload", vars)
+	}
+
+	goldenFile := "lakectl_stat_pre_sign"
+	RunCmdAndVerifySuccessWithFile(t, Lakectl()+" fs presign lakefs://"+repoName+"/"+mainBranch+"/data/ro/ro_1k.0", false, goldenFile, map[string]string{
+		"REPO":    repoName,
+		"STORAGE": storage,
+		"BRANCH":  mainBranch,
+		"PATH":    "data/ro",
+		"FILE":    "ro_1k.0",
+	})
+}
+
 func TestLakectlFsStat(t *testing.T) {
 	repoName := generateUniqueRepositoryName()
 	storage := generateUniqueStorageNamespace(repoName)

--- a/esti/lakectl_test.go
+++ b/esti/lakectl_test.go
@@ -623,7 +623,7 @@ func TestLakectlFsPresign(t *testing.T) {
 		RunCmdAndVerifySuccessWithFile(t, Lakectl()+" fs upload -s files/ro_1k lakefs://"+repoName+"/"+mainBranch+"/"+vars["FILE_PATH"], false, "lakectl_fs_upload", vars)
 	}
 
-	goldenFile := "lakectl_stat_pre_sign"
+	goldenFile := "lakectl_fs_presign"
 	RunCmdAndVerifySuccessWithFile(t, Lakectl()+" fs presign lakefs://"+repoName+"/"+mainBranch+"/data/ro/ro_1k.0", false, goldenFile, map[string]string{
 		"REPO":    repoName,
 		"STORAGE": storage,


### PR DESCRIPTION
## Change Description

Add a new lakectl sub-command (`lakectl fs presign`) that returns only a presigned URL for the specified object. This is similar to `aws s3 presign`.

### Background

While it's possible to get a presigned URL by calling `lakectl fs stat --pre-sign=true`, it requires parsing the output to extract the url itself.

This makes it harder to used in scripts:

```bash
lakectl fs presign lakefs://repo/main/object | wget -i -
```

vs

```bash
lakectl fs stat --pre-sign=true lakefs://repo/main/object  | grep '^Physical Address:' | awk '{print $3}' | wget -i -
```

Which is both longer and more brittle.
