### PR TITLE
allow lakectl local to be "git data"

### DIFF
--- a/cmd/lakectl/cmd/local_install.go
+++ b/cmd/lakectl/cmd/local_install.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+func currentExecutable() string {
+	ex, err := os.Executable()
+	if err != nil {
+		DieErr(err)
+	}
+	absolute, err := filepath.Abs(ex)
+	if err != nil {
+		DieErr(err)
+	}
+	return absolute
+}
+
+var localInstallGitPluginCmd = &cobra.Command{
+	Use:   "install-git-plugin <directory>",
+	Short: "set up `git data` (directory must exist and be in $PATH)",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		installDir := args[0]
+		if strings.HasPrefix(installDir, "~/") {
+			dirname, _ := os.UserHomeDir()
+			installDir = filepath.Join(dirname, installDir[2:])
+		}
+		info, err := os.Stat(installDir)
+		if err != nil {
+			DieFmt("could not check directory %s: %s\n", installDir, err.Error())
+		}
+		if !info.IsDir() {
+			DieFmt("%s: not a directory.\n", installDir)
+		}
+		fullPath := path.Join(installDir, "git-data")
+		err = os.Symlink(currentExecutable(), fullPath)
+		if err != nil {
+			DieFmt("could not create link %s: %s\n", fullPath, err.Error())
+		}
+	},
+}

--- a/cmd/lakectl/cmd/local_install.go
+++ b/cmd/lakectl/cmd/local_install.go
@@ -23,7 +23,7 @@ func currentExecutable() string {
 	return absolute
 }
 
-var localInstallGitPluginCmd = &cobra.Command{
+var installGitPluginCmd = &cobra.Command{
 	Use:   "install-git-plugin <directory>",
 	Short: "set up `git data` (directory must exist and be in $PATH)",
 	Long: "Add a symlink to lakectl named `git-data`.\n" +
@@ -52,4 +52,9 @@ var localInstallGitPluginCmd = &cobra.Command{
 			DieFmt("could not create link %s: %s\n", fullPath, err.Error())
 		}
 	},
+}
+
+//nolint:gochecknoinits
+func init() {
+	rootCmd.AddCommand(installGitPluginCmd)
 }

--- a/cmd/lakectl/cmd/local_install.go
+++ b/cmd/lakectl/cmd/local_install.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"runtime"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -38,7 +39,11 @@ var localInstallGitPluginCmd = &cobra.Command{
 		if !info.IsDir() {
 			DieFmt("%s: not a directory.\n", installDir)
 		}
+
 		fullPath := path.Join(installDir, "git-data")
+		if runtime.GOOS == "windows" {
+			fullPath += ".exe"
+		}
 		err = os.Symlink(currentExecutable(), fullPath)
 		if err != nil {
 			DieFmt("could not create link %s: %s\n", fullPath, err.Error())

--- a/cmd/lakectl/cmd/local_install.go
+++ b/cmd/lakectl/cmd/local_install.go
@@ -5,7 +5,8 @@ import (
 	"path"
 	"path/filepath"
 	"runtime"
-	"strings"
+
+	"github.com/mitchellh/go-homedir"
 
 	"github.com/spf13/cobra"
 )
@@ -25,12 +26,14 @@ func currentExecutable() string {
 var localInstallGitPluginCmd = &cobra.Command{
 	Use:   "install-git-plugin <directory>",
 	Short: "set up `git data` (directory must exist and be in $PATH)",
-	Args:  cobra.ExactArgs(1),
+	Long: "Add a symlink to lakectl named `git-data`.\n" +
+		"This allows calling `git data` and having it act as the `lakectl local` command\n" +
+		"(as long as the symlink is within the executing users' $PATH environment variable",
+	Args: cobra.ExactArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
-		installDir := args[0]
-		if strings.HasPrefix(installDir, "~/") {
-			dirname, _ := os.UserHomeDir()
-			installDir = filepath.Join(dirname, installDir[2:])
+		installDir, err := homedir.Expand(args[0])
+		if err != nil {
+			DieFmt("could not get directory path %s: %s\n", args[0], err.Error())
 		}
 		info, err := os.Stat(installDir)
 		if err != nil {

--- a/cmd/lakectl/cmd/local_pull.go
+++ b/cmd/lakectl/cmd/local_pull.go
@@ -31,7 +31,7 @@ var localPullCmd = &cobra.Command{
 			DieErr(err)
 		}
 
-		dieOnInterruptedOperation(LocalOperation(idx.ActiveOperation), force)
+		dieOnInterruptedOperation(cmd.Context(), LocalOperation(idx.ActiveOperation), force)
 
 		currentBase := remote.WithRef(idx.AtHead)
 		// make sure no local changes

--- a/cmd/lakectl/cmd/local_status.go
+++ b/cmd/lakectl/cmd/local_status.go
@@ -37,7 +37,7 @@ var localStatusCmd = &cobra.Command{
 			DieErr(err)
 		}
 
-		dieOnInterruptedOperation(LocalOperation(idx.ActiveOperation), false)
+		dieOnInterruptedOperation(cmd.Context(), LocalOperation(idx.ActiveOperation), false)
 
 		remoteBase := remote.WithRef(idx.AtHead)
 		client := getClient()

--- a/cmd/lakectl/cmd/root.go
+++ b/cmd/lakectl/cmd/root.go
@@ -480,7 +480,6 @@ func Execute() {
 		cmd.SetContext(context.WithValue(ctx, lakectlLocalCommandNameKey, baseName))
 	default:
 		rootCmd.AddCommand(localCmd)
-		localCmd.AddCommand(localInstallGitPluginCmd)
 		cmd = rootCmd
 		cmd.SetContext(context.WithValue(ctx, lakectlLocalCommandNameKey, "lakectl local"))
 	}

--- a/cmd/lakectl/cmd/root.go
+++ b/cmd/lakectl/cmd/root.go
@@ -49,6 +49,8 @@ lakeFS version: {{.LakeFSVersion}}
 Get the latest release {{ .UpgradeURL|blue }}
 {{- end }}
 `
+
+	lakectlLocalCommandNameKey = "lakectl-local-command-name"
 )
 
 // Configuration is the user-visible configuration structure in Golang form.
@@ -282,63 +284,64 @@ func getKV(cmd *cobra.Command, name string) (map[string]string, error) { //nolin
 	return kv, nil
 }
 
+func preRun(cmd *cobra.Command) {
+	logging.SetLevel(logLevel)
+	logging.SetOutputFormat(logFormat)
+	err := logging.SetOutputs(logOutputs, 0, 0)
+	if err != nil {
+		DieFmt("Failed to setup logging: %s", err)
+	}
+	if noColorRequested {
+		DisableColors()
+	}
+	if cmd == configCmd {
+		return
+	}
+
+	if cfgErr == nil {
+		logging.ContextUnavailable().
+			WithField("file", viper.ConfigFileUsed()).
+			Debug("loaded configuration from file")
+	} else if errors.As(cfgErr, &viper.ConfigFileNotFoundError{}) {
+		if cfgFile != "" {
+			// specific message in case the file isn't found
+			DieFmt("config file not found, please run \"lakectl config\" to create one\n%s\n", cfgErr)
+		}
+		// if the config file wasn't provided, try to run using the default values + env vars
+	} else if cfgErr != nil {
+		// other errors while reading the config file
+		DieFmt("error reading configuration file: %v", cfgErr)
+	}
+
+	err = viper.UnmarshalExact(&cfg, viper.DecodeHook(
+		mapstructure.ComposeDecodeHookFunc(
+			lakefsconfig.DecodeOnlyString,
+			mapstructure.StringToTimeDurationHookFunc())))
+	if err != nil {
+		DieFmt("error unmarshal configuration: %v", err)
+	}
+
+	if cmd.HasParent() {
+		// Don't send statistics for root command or if one of the excluding
+		var cmdName string
+		for curr := cmd; curr.HasParent(); curr = curr.Parent() {
+			if cmdName != "" {
+				cmdName = curr.Name() + "_" + cmdName
+			} else {
+				cmdName = curr.Name()
+			}
+		}
+		if !slices.Contains(excludeStatsCmds, cmdName) {
+			sendStats(cmd.Context(), getClient(), cmdName)
+		}
+	}
+}
+
 // rootCmd represents the base command when called without any sub-commands
 var rootCmd = &cobra.Command{
 	Use:   "lakectl",
 	Short: "A cli tool to explore manage and work with lakeFS",
 	Long:  `lakectl is a CLI tool allowing exploration and manipulation of a lakeFS environment`,
-	PersistentPreRun: func(cmd *cobra.Command, args []string) {
-		logging.SetLevel(logLevel)
-		logging.SetOutputFormat(logFormat)
-		err := logging.SetOutputs(logOutputs, 0, 0)
-		if err != nil {
-			DieFmt("Failed to setup logging: %s", err)
-		}
-		if noColorRequested {
-			DisableColors()
-		}
-		if cmd == configCmd {
-			return
-		}
-
-		if cfgErr == nil {
-			logging.ContextUnavailable().
-				WithField("file", viper.ConfigFileUsed()).
-				Debug("loaded configuration from file")
-		} else if errors.As(cfgErr, &viper.ConfigFileNotFoundError{}) {
-			if cfgFile != "" {
-				// specific message in case the file isn't found
-				DieFmt("config file not found, please run \"lakectl config\" to create one\n%s\n", cfgErr)
-			}
-			// if the config file wasn't provided, try to run using the default values + env vars
-		} else if cfgErr != nil {
-			// other errors while reading the config file
-			DieFmt("error reading configuration file: %v", cfgErr)
-		}
-
-		err = viper.UnmarshalExact(&cfg, viper.DecodeHook(
-			mapstructure.ComposeDecodeHookFunc(
-				lakefsconfig.DecodeOnlyString,
-				mapstructure.StringToTimeDurationHookFunc())))
-		if err != nil {
-			DieFmt("error unmarshal configuration: %v", err)
-		}
-
-		if cmd.HasParent() {
-			// Don't send statistics for root command or if one of the excluding
-			var cmdName string
-			for curr := cmd; curr.HasParent(); curr = curr.Parent() {
-				if cmdName != "" {
-					cmdName = curr.Name() + "_" + cmdName
-				} else {
-					cmdName = curr.Name()
-				}
-			}
-			if !slices.Contains(excludeStatsCmds, cmdName) {
-				sendStats(cmd.Context(), getClient(), cmdName)
-			}
-		}
-	},
 	Run: func(cmd *cobra.Command, args []string) {
 		if !Must(cmd.Flags().GetBool("version")) {
 			if err := cmd.Help(); err != nil {
@@ -459,29 +462,45 @@ func getClient() *apigen.ClientWithResponses {
 	return client
 }
 
+func getBasename() string {
+	return strings.ToLower(filepath.Base(os.Args[0]))
+}
+
 // Execute adds all child commands to the root command and sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	err := rootCmd.Execute()
+	ctx := context.Background()
+
+	var cmd *cobra.Command
+	baseName := getBasename()
+	switch baseName {
+	case "git", "git.exe", "git-data", "git-data.exe":
+		cmd = localCmd
+		cmd.Use = baseName
+		cmd.SetContext(context.WithValue(ctx, lakectlLocalCommandNameKey, baseName))
+	default:
+		rootCmd.AddCommand(localCmd)
+		cmd = rootCmd
+		cmd.SetContext(context.WithValue(ctx, lakectlLocalCommandNameKey, "lakectl local"))
+	}
+	setupRootCommand(cmd)
+	initConfig()
+	preRun(cmd)
+	err := cmd.Execute()
 	if err != nil {
 		DieErr(err)
 	}
 }
 
-//nolint:gochecknoinits
-func init() {
-	// Here you will define your flags and configuration settings.
-	// Cobra supports persistent flags, which, if defined here,
-	// will be global for your application.
-	cobra.OnInitialize(initConfig)
-	rootCmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", "config file (default is $HOME/.lakectl.yaml)")
-	rootCmd.PersistentFlags().BoolVar(&noColorRequested, "no-color", getEnvNoColor(), "don't use fancy output colors (default value can be set by NO_COLOR environment variable)")
-	rootCmd.PersistentFlags().StringVarP(&baseURI, "base-uri", "", os.Getenv("LAKECTL_BASE_URI"), "base URI used for lakeFS address parse")
-	rootCmd.PersistentFlags().StringVarP(&logLevel, "log-level", "", "none", "set logging level")
-	rootCmd.PersistentFlags().StringVarP(&logFormat, "log-format", "", "", "set logging output format")
-	rootCmd.PersistentFlags().StringSliceVarP(&logOutputs, "log-output", "", []string{}, "set logging output(s)")
-	rootCmd.PersistentFlags().BoolVar(&verboseMode, "verbose", false, "run in verbose mode")
-	rootCmd.Flags().BoolP("version", "v", false, "version for lakectl")
+func setupRootCommand(cmd *cobra.Command) {
+	cmd.PersistentFlags().StringVarP(&cfgFile, "config", "c", "", "config file (default is $HOME/.lakectl.yaml)")
+	cmd.PersistentFlags().BoolVar(&noColorRequested, "no-color", getEnvNoColor(), "don't use fancy output colors (default value can be set by NO_COLOR environment variable)")
+	cmd.PersistentFlags().StringVarP(&baseURI, "base-uri", "", os.Getenv("LAKECTL_BASE_URI"), "base URI used for lakeFS address parse")
+	cmd.PersistentFlags().StringVarP(&logLevel, "log-level", "", "none", "set logging level")
+	cmd.PersistentFlags().StringVarP(&logFormat, "log-format", "", "", "set logging output format")
+	cmd.PersistentFlags().StringSliceVarP(&logOutputs, "log-output", "", []string{}, "set logging output(s)")
+	cmd.PersistentFlags().BoolVar(&verboseMode, "verbose", false, "run in verbose mode")
+	cmd.Flags().BoolP("version", "v", false, "version for lakectl")
 }
 
 func getEnvNoColor() bool {

--- a/cmd/lakectl/cmd/root.go
+++ b/cmd/lakectl/cmd/root.go
@@ -284,7 +284,7 @@ func getKV(cmd *cobra.Command, name string) (map[string]string, error) { //nolin
 	return kv, nil
 }
 
-func preRun(cmd *cobra.Command) {
+func rootPreRun(cmd *cobra.Command, _ []string) {
 	logging.SetLevel(logLevel)
 	logging.SetOutputFormat(logFormat)
 	err := logging.SetOutputs(logOutputs, 0, 0)
@@ -484,9 +484,11 @@ func Execute() {
 		cmd = rootCmd
 		cmd.SetContext(context.WithValue(ctx, lakectlLocalCommandNameKey, "lakectl local"))
 	}
+	// make sure config is properly initialize
 	setupRootCommand(cmd)
-	initConfig()
-	preRun(cmd)
+	cobra.OnInitialize(initConfig)
+	cmd.PersistentPreRun = rootPreRun
+	// run!
 	err := cmd.Execute()
 	if err != nil {
 		DieErr(err)

--- a/cmd/lakectl/cmd/root.go
+++ b/cmd/lakectl/cmd/root.go
@@ -480,6 +480,7 @@ func Execute() {
 		cmd.SetContext(context.WithValue(ctx, lakectlLocalCommandNameKey, baseName))
 	default:
 		rootCmd.AddCommand(localCmd)
+		localCmd.AddCommand(localInstallGitPluginCmd)
 		cmd = rootCmd
 		cmd.SetContext(context.WithValue(ctx, lakectlLocalCommandNameKey, "lakectl local"))
 	}

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2507,6 +2507,30 @@ lakectl ingest --from <object store URI> --to <lakeFS path URI> [--dry-run] [fla
 
 
 
+### lakectl install-git-plugin
+
+set up `git data` (directory must exist and be in $PATH)
+
+#### Synopsis
+{:.no_toc}
+
+Add a symlink to lakectl named `git-data`.
+This allows calling `git data` and having it act as the `lakectl local` command
+(as long as the symlink is within the executing users' $PATH environment variable
+
+```
+lakectl install-git-plugin <directory> [flags]
+```
+
+#### Options
+{:.no_toc}
+
+```
+  -h, --help   help for install-git-plugin
+```
+
+
+
 ### lakectl local
 
 Sync local directories with lakeFS paths
@@ -2622,23 +2646,6 @@ lakectl local init <path URI> [directory] [flags]
       --force       Overwrites if directory already linked to a lakeFS path
       --gitignore   Update .gitignore file when working in a git repository context (default true)
   -h, --help        help for init
-```
-
-
-
-### lakectl local install-git-plugin
-
-set up `git data` (directory must exist and be in $PATH)
-
-```
-lakectl local install-git-plugin <directory> [flags]
-```
-
-#### Options
-{:.no_toc}
-
-```
-  -h, --help   help for install-git-plugin
 ```
 
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2626,6 +2626,23 @@ lakectl local init <path URI> [directory] [flags]
 
 
 
+### lakectl local install-git-plugin
+
+set up `git data` (directory must exist and be in $PATH)
+
+```
+lakectl local install-git-plugin <directory> [flags]
+```
+
+#### Options
+{:.no_toc}
+
+```
+  -h, --help   help for install-git-plugin
+```
+
+
+
 ### lakectl local list
 
 find and list directories that are synced with lakeFS.

--- a/esti/golden/lakectl_help.golden
+++ b/esti/golden/lakectl_help.golden
@@ -5,27 +5,28 @@ Usage:
   lakectl [command]
 
 Available Commands:
-  actions         Manage Actions commands
-  annotate        List entries under a given path, annotating each with the latest modifying commit
-  auth            Manage authentication and authorization
-  branch          Create and manage branches within a repository
-  branch-protect  Create and manage branch protection rules
-  cherry-pick     Apply the changes introduced by an existing commit
-  commit          Commit changes on a given branch
-  completion      Generate completion script
-  config          Create/update local lakeFS configuration
-  diff            Show changes between two commits, or the currently uncommitted changes
-  doctor          Run a basic diagnosis of the LakeFS configuration
-  fs              View and manipulate objects
-  gc              Manage the garbage collection policy
-  help            Help about any command
-  import          Import data from external source to a destination branch
-  local           Sync local directories with lakeFS paths
-  log             Show log of commits
-  merge           Merge & commit changes from source branch into destination branch
-  repo            Manage and explore repos
-  show            See detailed information about an entity
-  tag             Create and manage tags within a repository
+  actions            Manage Actions commands
+  annotate           List entries under a given path, annotating each with the latest modifying commit
+  auth               Manage authentication and authorization
+  branch             Create and manage branches within a repository
+  branch-protect     Create and manage branch protection rules
+  cherry-pick        Apply the changes introduced by an existing commit
+  commit             Commit changes on a given branch
+  completion         Generate completion script
+  config             Create/update local lakeFS configuration
+  diff               Show changes between two commits, or the currently uncommitted changes
+  doctor             Run a basic diagnosis of the LakeFS configuration
+  fs                 View and manipulate objects
+  gc                 Manage the garbage collection policy
+  help               Help about any command
+  import             Import data from external source to a destination branch
+  install-git-plugin set up `git data` (directory must exist and be in $PATH)
+  local              Sync local directories with lakeFS paths
+  log                Show log of commits
+  merge              Merge & commit changes from source branch into destination branch
+  repo               Manage and explore repos
+  show               See detailed information about an entity
+  tag                Create and manage tags within a repository
 
 Flags:
       --base-uri string      base URI used for lakeFS address parse

--- a/esti/lakectl_local_test.go
+++ b/esti/lakectl_local_test.go
@@ -355,6 +355,24 @@ func TestLakectlLocal_pull(t *testing.T) {
 	}
 }
 
+func TestLakectlLocalInstallGitPlugin(t *testing.T) {
+	tmpDir := t.TempDir()
+	fd, err := os.CreateTemp(tmpDir, "")
+	require.NoError(t, err)
+	require.NoError(t, fd.Close())
+	vars := make(map[string]string)
+	RunCmdAndVerifySuccess(t, Lakectl()+" local install-git-plugin "+tmpDir, false, "", vars)
+	pluginPath := path.Join(tmpDir, "git-data")
+	// check it exists
+	if _, err = os.Stat(pluginPath); err != nil {
+		t.Errorf("expected `git-data` plugin to exist at path: %s - got error checking: %v", pluginPath, err)
+		return
+	}
+	// try to run it
+	RunCmdAndVerifySuccess(t, LakectlWithPath(pluginPath),
+		false, "Sync local directories with lakeFS paths", vars)
+}
+
 func TestLakectlLocal_commit(t *testing.T) {
 	tmpDir := t.TempDir()
 	fd, err := os.CreateTemp(tmpDir, "")

--- a/esti/lakectl_local_test.go
+++ b/esti/lakectl_local_test.go
@@ -361,7 +361,7 @@ func TestLakectlLocalInstallGitPlugin(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, fd.Close())
 	vars := make(map[string]string)
-	RunCmdAndVerifySuccess(t, Lakectl()+" local install-git-plugin "+tmpDir, false, "", vars)
+	RunCmdAndVerifySuccess(t, Lakectl()+" install-git-plugin "+tmpDir, false, "", vars)
 	pluginPath := path.Join(tmpDir, "git-data")
 	// check it exists
 	if _, err = os.Stat(pluginPath); err != nil {
@@ -369,7 +369,8 @@ func TestLakectlLocalInstallGitPlugin(t *testing.T) {
 		return
 	}
 	// try to run it
-	RunCmdAndVerifySuccess(t, LakectlWithPath(pluginPath),
+	RunCmdAndVerifyContainsText(t,
+		LakectlWithPath(pluginPath),
 		false, "Sync local directories with lakeFS paths", vars)
 }
 

--- a/esti/lakectl_util.go
+++ b/esti/lakectl_util.go
@@ -41,16 +41,30 @@ func lakectlLocation() string {
 }
 
 func LakectlWithParams(accessKeyID, secretAccessKey, endPointURL string) string {
+	return LakectlWithPathAndParams(lakectlLocation(), accessKeyID, secretAccessKey, endPointURL)
+}
+
+func LakectlWithPathAndParams(lakectlExecutable, accessKeyID, secretAccessKey, endPointURL string) string {
 	lakectlCmdline := "LAKECTL_CREDENTIALS_ACCESS_KEY_ID=" + accessKeyID +
 		" LAKECTL_CREDENTIALS_SECRET_ACCESS_KEY=" + secretAccessKey +
 		" LAKECTL_SERVER_ENDPOINT_URL=" + endPointURL +
-		" " + lakectlLocation()
+		" " + lakectlExecutable
 
 	return lakectlCmdline
 }
 
 func Lakectl() string {
-	return LakectlWithParams(viper.GetString("access_key_id"), viper.GetString("secret_access_key"), viper.GetString("endpoint_url"))
+	return LakectlWithParams(
+		viper.GetString("access_key_id"),
+		viper.GetString("secret_access_key"),
+		viper.GetString("endpoint_url"))
+}
+
+func LakectlWithPath(lakectlExecutable string) string {
+	return LakectlWithPathAndParams(lakectlExecutable,
+		viper.GetString("access_key_id"),
+		viper.GetString("secret_access_key"),
+		viper.GetString("endpoint_url"))
 }
 
 func runShellCommand(t *testing.T, command string, isTerminal bool) ([]byte, error) {


### PR DESCRIPTION
Allow symlinking lakectl --> `git-data` which would trigger `lakectl local` as `git data`.

This enables calling:

```shell
$ git data clone ...
$ git data status
$ git data commit -m "..."
```

And so on. 

Set up:

```shell
lakectl local install-git-plugin ~/bin  # or any other location in users' path
```
Will put a symlink called `git-data` into that path. Calling lakectl by that name will automatically execute the `lakectl local` subcommand. By default, calling `git <subcommand>` where `<subcommand>` isn't an existing git command will execute `git-<subcommand>`.
