### PR TITLE
Align S3 Gateway Prometheus Histogram Buckets with lakeFS API Buckets

### DIFF
--- a/pkg/api/stats.go
+++ b/pkg/api/stats.go
@@ -17,6 +17,6 @@ var requestHistograms = promauto.NewHistogramVec(
 	prometheus.HistogramOpts{
 		Name:    "api_request_duration_seconds",
 		Help:    "request durations for lakeFS API",
-		Buckets: []float64{0.01, 0.05, 0.1, 0.2, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60},
+		Buckets: []float64{0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10, 30, 60},
 	},
 	[]string{"operation", "code"})

--- a/pkg/gateway/stats.go
+++ b/pkg/gateway/stats.go
@@ -9,6 +9,6 @@ var requestHistograms = promauto.NewHistogramVec(
 	prometheus.HistogramOpts{
 		Name:    "gateway_request_duration_seconds",
 		Help:    "request durations for lakeFS storage gateway",
-		Buckets: []float64{0.01, 0.05, 0.1, 0.2, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60},
+		Buckets: []float64{0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10, 30, 60},
 	},
 	[]string{"operation", "code"})

--- a/pkg/gateway/stats.go
+++ b/pkg/gateway/stats.go
@@ -7,7 +7,8 @@ import (
 
 var requestHistograms = promauto.NewHistogramVec(
 	prometheus.HistogramOpts{
-		Name: "gateway_request_duration_seconds",
-		Help: "request durations for lakeFS storage gateway",
+		Name:    "gateway_request_duration_seconds",
+		Help:    "request durations for lakeFS storage gateway",
+		Buckets: []float64{0.01, 0.05, 0.1, 0.2, 0.25, 0.5, 1, 2.5, 5, 10, 30, 60},
 	},
 	[]string{"operation", "code"})


### PR DESCRIPTION
### Description 
The Prometheus histogram buckets currently used for monitoring the lakeFS API (`api_requests_total`) are specifically tailored to the lakeFS service's response times, providing valuable insights into API performance. However, the histogram for the S3 gateway (`gateway_request_duration_seconds`) utilizes the default Prometheus buckets, which may not accurately reflect the performance characteristics of the S3 gateway interactions.

Aligning the S3 gateway's Prometheus histogram buckets with those defined for the lakeFS API can enhance monitoring accuracy and offer better insights into S3 gateway performance. This adjustment would allow for a more consistent and informative analysis of request durations across both interfaces.