### PR TITLE
Experimental: Support pre-signed redirects for S3A

### DIFF
--- a/.github/workflows/esti.yaml
+++ b/.github/workflows/esti.yaml
@@ -512,6 +512,7 @@ jobs:
         run: docker-compose logs --tail=2500 lakefs      
 
       - name: Spark${{ matrix.spark.tag }} + lakeFS GW + Redirect
+        if: env.SPARK_TAG == '3'
         timeout-minutes: 8
         working-directory: test/spark
         run: |

--- a/.github/workflows/esti.yaml
+++ b/.github/workflows/esti.yaml
@@ -481,6 +481,7 @@ jobs:
           LAKEFS_BLOCKSTORE_S3_CREDENTIALS_SECRET_ACCESS_KEY: ${{ secrets.ESTI_AWS_SECRET_ACCESS_KEY }}
 
       - name: Spark${{ matrix.spark.tag }} + S3 gateway
+        timeout-minutes: 8
         working-directory: test/spark
         run: |
           python ./run-test.py \
@@ -504,21 +505,22 @@ jobs:
             --access_mode hadoopfs \
             --aws_access_key ${{ secrets.ESTI_AWS_ACCESS_KEY_ID }} \
             --aws_secret_key ${{ secrets.ESTI_AWS_SECRET_ACCESS_KEY }}
+      - name: lakeFS Logs on HadoopFS test failure
+        if: ${{ failure() }}
+        continue-on-error: true
+        working-directory: test/spark
+        run: docker-compose logs --tail=2500 lakefs      
 
-      - name: Spark${{ matrix.spark.tag }} + lakeFS HadoopFS + Redirect
+      - name: Spark${{ matrix.spark.tag }} + lakeFS GW + Redirect
         timeout-minutes: 8
         working-directory: test/spark
         run: |
           python ./run-test.py \
-            --storage_namespace s3://esti-system-testing/${{ github.run_number }}-spark${{ matrix.spark.tag }}-redirect/${{ steps.unique.outputs.value }} \
-            --repository lakefsfs-redirect-test-spark \
+            --storage_namespace s3://esti-system-testing/${{ github.run_number }}-spark${{ matrix.spark.tag }}-gw-redirect/${{ steps.unique.outputs.value }} \
+            --repository gateway-redirect-test-spark${{ matrix.spark.tag }} \
             --sonnet_jar ${{ matrix.spark.sonnet_jar }} \
-            --access_mode hadoopfs \
-            --aws_access_key ${{ secrets.ESTI_AWS_ACCESS_KEY_ID }} \
-            --aws_secret_key ${{ secrets.ESTI_AWS_SECRET_ACCESS_KEY }} \
             --redirect
-
-      - name: lakeFS Logs on HadoopFS test failure
+      - name: lakeFS Logs on Spark with gateway redirect failure
         if: ${{ failure() }}
         continue-on-error: true
         working-directory: test/spark

--- a/.github/workflows/esti.yaml
+++ b/.github/workflows/esti.yaml
@@ -484,7 +484,7 @@ jobs:
         working-directory: test/spark
         run: |
           python ./run-test.py \
-            --storage_namespace s3://esti-system-testing/${{ github.run_number }}-spark${{ matrix.spark.tag }}/${{ steps.unique.outputs.value }} \
+            --storage_namespace s3://esti-system-testing/${{ github.run_number }}-spark${{ matrix.spark.tag }}-gw/${{ steps.unique.outputs.value }} \
             --repository gateway-test-spark${{ matrix.spark.tag }} \
             --sonnet_jar ${{ matrix.spark.sonnet_jar }}
       - name: lakeFS Logs on Spark with gateway failure
@@ -498,12 +498,26 @@ jobs:
         working-directory: test/spark
         run: |
           python ./run-test.py \
-            --storage_namespace s3://esti-system-testing/${{ github.run_number }}-spark${{ matrix.spark.tag }}-client/${{ steps.unique.outputs.value }} \
-            --repository thick-client-test \
+            --storage_namespace s3://esti-system-testing/${{ github.run_number }}-spark${{ matrix.spark.tag }}-lakefsfs/${{ steps.unique.outputs.value }} \
+            --repository lakefsfs-test-spark \
             --sonnet_jar ${{ matrix.spark.sonnet_jar }} \
             --access_mode hadoopfs \
             --aws_access_key ${{ secrets.ESTI_AWS_ACCESS_KEY_ID }} \
             --aws_secret_key ${{ secrets.ESTI_AWS_SECRET_ACCESS_KEY }}
+
+      - name: Spark${{ matrix.spark.tag }} + lakeFS HadoopFS + Redirect
+        timeout-minutes: 8
+        working-directory: test/spark
+        run: |
+          python ./run-test.py \
+            --storage_namespace s3://esti-system-testing/${{ github.run_number }}-spark${{ matrix.spark.tag }}-redirect/${{ steps.unique.outputs.value }} \
+            --repository lakefsfs-redirect-test-spark \
+            --sonnet_jar ${{ matrix.spark.sonnet_jar }} \
+            --access_mode hadoopfs \
+            --aws_access_key ${{ secrets.ESTI_AWS_ACCESS_KEY_ID }} \
+            --aws_secret_key ${{ secrets.ESTI_AWS_SECRET_ACCESS_KEY }} \
+            --redirect
+
       - name: lakeFS Logs on HadoopFS test failure
         if: ${{ failure() }}
         continue-on-error: true

--- a/docs/integrations/spark.md
+++ b/docs/integrations/spark.md
@@ -421,9 +421,10 @@ SELECT * FROM delta.`s3a://example-repo/main/datasets/delta-table/` LIMIT 100
 ```
 ### ⚠️ Experimental: Pre-signed mode for S3A
 
-As of Hadoop 3.3.1 (and most likely, older versions as well), it is possible to use pre-signed URLs as return values from the lakeFS S3 Gateway.
+In Hadoop 3.1.4 version and above (as tested using our lakeFS Hadoop FS), it is possible to use pre-signed URLs as return values from the lakeFS S3 Gateway.
 
-This has the immediate benefit of reducing the amount of traffic that has to go through the lakeFS server. To read more about pre-signed URLs, see [this guide](../reference/security/presigned-url.html).
+This has the immediate benefit of reducing the amount of traffic that has to go through the lakeFS server thus improving IO performance. 
+To read more about pre-signed URLs, see [this guide](../reference/security/presigned-url.html).
 
 Here's an example Spark configuration to enable this support:
 

--- a/docs/integrations/spark.md
+++ b/docs/integrations/spark.md
@@ -444,7 +444,7 @@ spark.hadoop.fs.s3a.bucket.example-repo.user.agent.prefix s3RedirectionSupport
 Once configured, requests will include the string `s3RedirectionSupport` in the `User-Agent` HTTP header sent with GetObject requests, resulting in lakeFS responding with a pre-signed URL.
 Setting the `signing-algorithm` to `QueryStringSignerType` is required to stop S3A from signing a pre-signed URL, since the existence of more than one signature method will return an error from S3.
 
-ℹ This feature requires a lakeFS server of version `>1.17.0`
+ℹ This feature requires a lakeFS server of version `>1.18.0`
 {: .note }
 
 ## lakeFS Hadoop FileSystem

--- a/docs/integrations/spark.md
+++ b/docs/integrations/spark.md
@@ -434,8 +434,11 @@ spark.hadoop.fs.s3a.bucket.example-repo.secret.key wJalrXUtnFEMI/K7MDENG/bPxRfiC
 spark.hadoop.fs.s3a.path.style.access true
 spark.hadoop.fs.s3a.bucket.example-repo.signing-algorithm QueryStringSignerType
 spark.hadoop.fs.s3a.bucket.example-repo.user.agent.prefix s3RedirectionSupport
-
 ```
+
+`user.agent.prefix` should **contain** the string `s3RedirectionSupport` but does not have to match the string exactly.
+{: .note }
+
 
 Once configured, requests will include the string `s3RedirectionSupport` in the `User-Agent` HTTP header sent with GetObject requests, resulting in lakeFS responding with a pre-signed URL.
 Setting the `signing-algorithm` to `QueryStringSignerType` is required to stop S3A from signing a pre-signed URL, since the existence of more than one signature method will return an error from S3.

--- a/docs/integrations/spark.md
+++ b/docs/integrations/spark.md
@@ -440,7 +440,7 @@ spark.hadoop.fs.s3a.bucket.example-repo.user.agent.prefix s3RedirectionSupport
 Once configured, requests will include the string `s3RedirectionSupport` in the `User-Agent` HTTP header sent with GetObject requests, resulting in lakeFS responding with a pre-signed URL.
 Setting the `signing-algorithm` to `QueryStringSignerType` is required to stop S3A from signing a pre-signed URL, since the existence of more than one signature method will return an error from S3.
 
-ℹ This feature requires a lakeFS server of version `>=1.17.0`
+ℹ This feature requires a lakeFS server of version `>1.17.0`
 {: .note }
 
 ## lakeFS Hadoop FileSystem

--- a/docs/integrations/spark.md
+++ b/docs/integrations/spark.md
@@ -421,7 +421,7 @@ SELECT * FROM delta.`s3a://example-repo/main/datasets/delta-table/` LIMIT 100
 ```
 ### ⚠️ Experimental: Pre-signed mode for S3A
 
-As of Hadoop 3.3.1 (and most likely, older versions as well), it is possible possible to use pre-signed URLs as return values from the lakeFS S3 Gateway.
+As of Hadoop 3.3.1 (and most likely, older versions as well), it is possible to use pre-signed URLs as return values from the lakeFS S3 Gateway.
 
 This has the immediate benefit of reducing the amount of traffic that has to go through the lakeFS server. To read more about pre-signed URLs, see [this guide](../reference/security/presigned-url.html).
 

--- a/esti/s3_gateway_test.go
+++ b/esti/s3_gateway_test.go
@@ -637,7 +637,7 @@ func TestS3ReadObjectRedirect(t *testing.T) {
 	defer tearDownTest(repo)
 
 	// Upload an object
-	minioClient := newMinioClient(t, credentials.NewStaticV2)
+	minioClient := newMinioClient(t, credentials.NewStaticV4)
 
 	_, err := minioClient.PutObject(ctx, repo, goodPath, strings.NewReader(contents), int64(len(contents)), minio.PutObjectOptions{})
 	if err != nil {

--- a/esti/s3_gateway_test.go
+++ b/esti/s3_gateway_test.go
@@ -626,3 +626,32 @@ func TestS3CopyObjectErrors(t *testing.T) {
 		require.Contains(t, err.Error(), "NoSuchKey")
 	})
 }
+
+func TestS3ReadObjectRedirect(t *testing.T) {
+	const (
+		contents = "the quick brown fox jumps over the lazy dog"
+		goodPath = "main/exists.txt"
+	)
+
+	ctx, _, repo := setupTest(t)
+	defer tearDownTest(repo)
+
+	// Upload an object
+	minioClient := newMinioClient(t, credentials.NewStaticV2)
+
+	_, err := minioClient.PutObject(ctx, repo, goodPath, strings.NewReader(contents), int64(len(contents)), minio.PutObjectOptions{})
+	if err != nil {
+		t.Errorf("PutObject(%s, %s): %s", repo, goodPath, err)
+	}
+
+	t.Run("get_exists", func(t *testing.T) {
+		opts := minio.GetObjectOptions{}
+		opts.Set("User-Agent", "s3RedirectionSupport")
+		res, err := minioClient.GetObject(ctx, repo, goodPath, opts)
+		require.NoError(t, err)
+
+		// Verify we got redirect
+		_, err = io.ReadAll(res)
+		require.Contains(t, err.Error(), "307 Temporary Redirect")
+	})
+}

--- a/esti/s3_gateway_test.go
+++ b/esti/s3_gateway_test.go
@@ -646,7 +646,7 @@ func TestS3ReadObjectRedirect(t *testing.T) {
 
 	t.Run("get_exists", func(t *testing.T) {
 		opts := minio.GetObjectOptions{}
-		opts.Set("User-Agent", "s3RedirectionSupport")
+		opts.Set("User-Agent", "client with s3RedirectionSupport set")
 		res, err := minioClient.GetObject(ctx, repo, goodPath, opts)
 		require.NoError(t, err)
 

--- a/pkg/gateway/middleware.go
+++ b/pkg/gateway/middleware.go
@@ -36,6 +36,7 @@ func AuthenticationHandler(authService auth.GatewayService, next http.Handler) h
 		authenticator := sig.ChainedAuthenticator(
 			sig.NewV4Authenticator(req),
 			sig.NewV2SigAuthenticator(req, o.FQDN),
+			sig.NewJavaV2SigAuthenticator(req, o.FQDN),
 		)
 		authContext, err := authenticator.Parse()
 		if err != nil {

--- a/pkg/gateway/operations/getobject.go
+++ b/pkg/gateway/operations/getobject.go
@@ -44,7 +44,7 @@ func (controller *GetObject) Handle(w http.ResponseWriter, req *http.Request, o 
 		return
 	}
 	userAgent := req.Header.Get("User-Agent")
-	redirect := strings.Contains(userAgent, s3RedirectionSupportUserAgent)
+	redirect := strings.Contains(userAgent, s3RedirectionSupportUserAgentTag)
 	if redirect {
 		req = req.WithContext(logging.AddFields(req.Context(), logging.Fields{"S3_redirect": true}))
 	}

--- a/pkg/gateway/operations/getobject.go
+++ b/pkg/gateway/operations/getobject.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
-	"strings"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/treeverse/lakefs/pkg/block"
@@ -23,9 +23,8 @@ import (
 const (
 	QueryParamMaxParts = "max-parts"
 	// QueryParamPartNumberMarker Specifies the part after which listing should begin. Only parts with higher part numbers will be listed.
-	QueryParamPartNumberMarker = "part-number-marker"
-	s3RedirectionSupportUserAgent = "s3RedirectionSupport"
-
+	QueryParamPartNumberMarker       = "part-number-marker"
+	s3RedirectionSupportUserAgentTag = "s3RedirectionSupport"
 )
 
 type GetObject struct{}

--- a/pkg/gateway/operations/putobject_test.go
+++ b/pkg/gateway/operations/putobject_test.go
@@ -21,7 +21,7 @@ const (
 	cheapString     = "CHEAP"
 )
 
-func TestReadBlob(t *testing.T) {
+func TestWriteBlob(t *testing.T) {
 	tt := []struct {
 		name         string
 		size         int64

--- a/pkg/gateway/sig/javav2.go
+++ b/pkg/gateway/sig/javav2.go
@@ -1,0 +1,146 @@
+package sig
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"net/http"
+	"net/url"
+	"sort"
+	"strings"
+
+	"github.com/treeverse/lakefs/pkg/auth/model"
+	"github.com/treeverse/lakefs/pkg/gateway/errors"
+	"github.com/treeverse/lakefs/pkg/logging"
+)
+
+// Implements the "signing protocol" as exists at aws-sdk-java @ 1.12.390 (commit 07926f08a70).
+// This should never have worked, on any version of S3, but the implementation is there, unmodified since 2015.
+// The code is below, for reference
+/*
+
+private String calculateStringToSignV2(SignableRequest<?> request) throws SdkClientException {
+   URI endpoint = request.getEndpoint();
+
+   StringBuilder data = new StringBuilder();
+   data.append("POST")
+	   .append("\n")
+	   .append(getCanonicalizedEndpoint(endpoint)) // <----- bare host, lower-cased
+	   .append("\n")
+	   .append(getCanonicalizedResourcePath(request)) // <----- path relative to the endpoint
+	   .append("\n")
+	   .append(getCanonicalizedQueryString(request.getParameters()));  // <----- ordered query string parameters
+   return data.toString();
+}
+
+*/
+
+func canonicalJavaV2String(host string, query url.Values, path string) string {
+	cs := strings.ToUpper(http.MethodPost) // so weird.
+	cs += "\n"
+	cs += host
+	cs += "\n"
+	cs += path
+	cs += "\n"
+	cs += canonicalJavaV2Query(query)
+	return cs
+}
+
+func canonicalJavaV2Query(q url.Values) string {
+	escaped := make([][2]string, 0)
+	for k, vs := range q {
+		if strings.EqualFold(k, "signature") {
+			continue
+		}
+		escapedKey := url.QueryEscape(k)
+		for _, v := range vs {
+			pair := [2]string{escapedKey, url.QueryEscape(v)}
+			escaped = append(escaped, pair)
+		}
+	}
+	// sort
+	sort.Slice(escaped, func(i, j int) bool {
+		return escaped[i][0] < escaped[j][0]
+	})
+	// output
+	out := ""
+	for i, pair := range escaped {
+		out += pair[0] + "=" + pair[1]
+		isLast := i == len(escaped)-1
+		if !isLast {
+			out += "&"
+		}
+	}
+	return out
+}
+
+type JavaV2Signer struct {
+	bareDomain string
+	req        *http.Request
+	sigCtx     *JavaV2SignerContext
+}
+
+type JavaV2SignerContext struct {
+	awsAccessKeyID string
+	signature      []byte
+}
+
+func NewJavaV2SigAuthenticator(r *http.Request, bareDomain string) *JavaV2Signer {
+	return &JavaV2Signer{
+		req:        r,
+		bareDomain: bareDomain,
+	}
+}
+
+func (j *JavaV2SignerContext) GetAccessKeyID() string {
+	return j.awsAccessKeyID
+}
+
+func (j *JavaV2Signer) Parse() (SigContext, error) {
+	ctx := j.req.Context()
+	awsAccessKeyID := j.req.URL.Query().Get("AWSAccessKeyId")
+	if awsAccessKeyID == "" {
+		return nil, ErrHeaderMalformed
+	}
+	signature := j.req.URL.Query().Get("Signature")
+	if signature == "" {
+		return nil, ErrHeaderMalformed
+	}
+	sig, err := base64.StdEncoding.DecodeString(signature)
+	if err != nil {
+		logging.FromContext(ctx).Error("log header does not match v2 structure (isn't proper base64)")
+		return nil, ErrHeaderMalformed
+	}
+	sigMethod := j.req.URL.Query().Get("SignatureMethod")
+	if sigMethod != "HmacSHA256" {
+		return nil, ErrHeaderMalformed
+	}
+	sigVersion := j.req.URL.Query().Get("SignatureVersion")
+	if sigVersion != "2" {
+		return nil, ErrHeaderMalformed
+	}
+	sigCtx := &JavaV2SignerContext{
+		awsAccessKeyID: awsAccessKeyID,
+		signature:      sig,
+	}
+	j.sigCtx = sigCtx
+	return sigCtx, nil
+}
+
+func signCanonicalJavaV2String(msg string, signature []byte) []byte {
+	h := hmac.New(sha256.New, signature)
+	_, _ = h.Write([]byte(msg))
+	return h.Sum(nil)
+}
+
+func (j *JavaV2Signer) Verify(creds *model.Credential) error {
+	rawPath := j.req.URL.EscapedPath()
+
+	path := buildPath(j.req.Host, j.bareDomain, rawPath)
+	stringToSign := canonicalJavaV2String(j.req.Host, j.req.URL.Query(), path)
+	digest := signCanonicalJavaV2String(stringToSign, []byte(creds.SecretAccessKey))
+	if !Equal(digest, j.sigCtx.signature) {
+		return errors.ErrSignatureDoesNotMatch
+	}
+	return nil
+}

--- a/pkg/gateway/sig/v2.go
+++ b/pkg/gateway/sig/v2.go
@@ -111,9 +111,10 @@ func (a *V2SigAuthenticator) Parse() (SigContext, error) {
 			return sigCtx, ErrHeaderMalformed
 		}
 		sigCtx.signature = sig
+		a.sigCtx = sigCtx
+		return sigCtx, nil
 	}
-	a.sigCtx = sigCtx
-	return sigCtx, nil
+	return nil, ErrHeaderMalformed
 }
 
 func headerValueToString(val []string) string {

--- a/pkg/gateway/sig/v2.go
+++ b/pkg/gateway/sig/v2.go
@@ -89,13 +89,12 @@ func NewV2SigAuthenticator(r *http.Request, bareDomain string) *V2SigAuthenticat
 
 func (a *V2SigAuthenticator) Parse() (SigContext, error) {
 	ctx := a.req.Context()
-	var sigCtx v2Context
 	headerValue := a.req.Header.Get(v2authHeaderName)
 	if len(headerValue) > 0 {
 		match := V2AuthHeaderRegexp.FindStringSubmatch(headerValue)
 		if len(match) == 0 {
 			logging.FromContext(ctx).Error("log header does not match v2 structure")
-			return sigCtx, ErrHeaderMalformed
+			return nil, ErrHeaderMalformed
 		}
 		result := make(map[string]string)
 		for i, name := range V2AuthHeaderRegexp.SubexpNames() {
@@ -103,12 +102,14 @@ func (a *V2SigAuthenticator) Parse() (SigContext, error) {
 				result[name] = match[i]
 			}
 		}
-		sigCtx.accessKeyID = result["AccessKeyId"]
+		sigCtx := v2Context{
+			accessKeyID: result["AccessKeyId"],
+		}
 		// parse signature
 		sig, err := base64.StdEncoding.DecodeString(result["Signature"])
 		if err != nil {
 			logging.FromContext(ctx).Error("log header does not match v2 structure (isn't proper base64)")
-			return sigCtx, ErrHeaderMalformed
+			return nil, ErrHeaderMalformed
 		}
 		sigCtx.signature = sig
 		a.sigCtx = sigCtx

--- a/test/spark/docker-compose.yaml
+++ b/test/spark/docker-compose.yaml
@@ -1,4 +1,3 @@
-version: '3.9'
 x-lakefs-common:
   &lakefs-common
   image: "${REPO:-treeverse}/lakefs:${TAG:-latest}"

--- a/test/spark/run-test.py
+++ b/test/spark/run-test.py
@@ -90,6 +90,7 @@ def main():
                          "spark.hadoop.fs.s3a.endpoint": "s3.docker.lakefs.io:8000",
                          "spark.hadoop.fs.s3a.connection.ssl.enabled": "false"}
         if args.redirect:
+            spark_configs["spark.hadoop.fs.s3a.path.style.access"] = "true"
             spark_configs[f"spark.hadoop.fs.s3a.signing-algorithm"] = "QueryStringSignerType"
             spark_configs[f"spark.hadoop.fs.s3a.user.agent.prefix"] = "s3RedirectionSupport"
 

--- a/test/spark/run-test.py
+++ b/test/spark/run-test.py
@@ -76,9 +76,6 @@ def main():
             "spark.hadoop.fs.s3a.secret.key": args.aws_secret_key,
             "spark.hadoop.fs.s3a.region": args.region,
         }
-        if args.redirect:
-            spark_configs[f"spark.hadoop.fs.s3a.bucket.{args.repository}.signing-algorithm"] = "QueryStringSignerType"
-            spark_configs[f"spark.hadoop.fs.s3a.bucket.{args.repository}.user.agent.prefix"] = "s3RedirectionSupport"
 
     elif args.access_mode == 'hadoopfs_presigned':
         scheme = "lakefs"
@@ -92,6 +89,10 @@ def main():
                          "spark.hadoop.fs.s3a.secret.key": lakefs_secret_key,
                          "spark.hadoop.fs.s3a.endpoint": "s3.docker.lakefs.io:8000",
                          "spark.hadoop.fs.s3a.connection.ssl.enabled": "false"}
+        if args.redirect:
+            spark_configs["spark.hadoop.fs.s3a.path.style.access"] = "true"
+            spark_configs[f"spark.hadoop.fs.s3a.signing-algorithm"] = "QueryStringSignerType"
+            spark_configs[f"spark.hadoop.fs.s3a.user.agent.prefix"] = "s3RedirectionSupport"
 
     generator = docker.compose.run("spark-submit",
                                    get_spark_submit_cmd(submit_flags, spark_configs, args.sonnet_jar,

--- a/test/spark/run-test.py
+++ b/test/spark/run-test.py
@@ -35,8 +35,9 @@ def main():
     parser.add_argument("--client_version")
     parser.add_argument("--aws_access_key")
     parser.add_argument("--aws_secret_key")
-    parser.add_argument("--region")
+    parser.add_argument("--redirect", action='store_true')
     parser.add_argument("--access_mode", choices=["s3_gateway", "hadoopfs", "hadoopfs_presigned"], default="s3_gateway")
+    parser.add_argument("--region",)
     lakefs_access_key = 'AKIAIOSFODNN7EXAMPLE'
     lakefs_secret_key = 'wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'
 
@@ -66,6 +67,7 @@ def main():
         "spark.hadoop.fs.lakefs.access.key": lakefs_access_key,
         "spark.hadoop.fs.lakefs.secret.key": lakefs_secret_key,
     }
+
     if args.access_mode == 'hadoopfs':
         scheme = "lakefs"
         spark_configs = {
@@ -74,6 +76,10 @@ def main():
             "spark.hadoop.fs.s3a.secret.key": args.aws_secret_key,
             "spark.hadoop.fs.s3a.region": args.region,
         }
+        if args.redirect:
+            spark_configs[f"spark.hadoop.fs.s3a.bucket.{args.repository}.signing-algorithm"] = "QueryStringSignerType"
+            spark_configs[f"spark.hadoop.fs.s3a.bucket.{args.repository}.user.agent.prefix"] = "s3RedirectionSupport"
+
     elif args.access_mode == 'hadoopfs_presigned':
         scheme = "lakefs"
         spark_configs = {

--- a/test/spark/run-test.py
+++ b/test/spark/run-test.py
@@ -90,7 +90,6 @@ def main():
                          "spark.hadoop.fs.s3a.endpoint": "s3.docker.lakefs.io:8000",
                          "spark.hadoop.fs.s3a.connection.ssl.enabled": "false"}
         if args.redirect:
-            spark_configs["spark.hadoop.fs.s3a.path.style.access"] = "true"
             spark_configs[f"spark.hadoop.fs.s3a.signing-algorithm"] = "QueryStringSignerType"
             spark_configs[f"spark.hadoop.fs.s3a.user.agent.prefix"] = "s3RedirectionSupport"
 


### PR DESCRIPTION
closes #7646 
This PR introduces a special mode for the S3 gateway, that returns HTTP 307 redirects from the S3 Gateway.

Since most clients (in fact, probably anything other than `aws-sdk-java`) will see that as an error, it requires a special `User-Agent` to activate: it must include the string `"s3RedirectionSupport"`.

S3A, however, is based on the Java SDK which [for historical reasons](https://github.com/aws/aws-sdk-java/blob/b4ec2abf4911be236d3eb08e3f915dba738f265d/aws-java-sdk-core/src/main/java/com/amazonaws/http/AmazonHttpClient.java#L1404) supports 307 redirects using its request retry mechanism.

This PR triggers that support. 

Since this is done through the Java SDK's retry mechanism, the SDK will always try to sign the outgoing request, even if we're redirecting to a pre-signed URL, that already has a signature in its query string. This fails on S3 because requests that have multiple signatures result in a Bad Request error (and even if this wasn't the case - the signature would still be based on a lakeFS access key and secret which the underlying object store will not respect!)

To avoid doubly signing the request, we're using a [`QueryStringSigner`](https://github.com/aws/aws-sdk-java/blob/1.12.390/aws-java-sdk-core/src/main/java/com/amazonaws/auth/QueryStringSigner.java) - which in the presence of existing query string signature will not re-sign the request!

This comes with its own caveat - the [signing code](https://github.com/aws/aws-sdk-java/blob/1.12.390/aws-java-sdk-core/src/main/java/com/amazonaws/auth/QueryStringSigner.java#L139) used by `QueryStringSigner` is non-standard. It seems to be subset of historical Sigv2, with `"POST"` hard-coded as the HTTP method and no treatment of request bodies or headers. For that, this PR also includes a new "JavaV2" signer that implements that piece of archeology.