### PR TITLE
Make Hadoop 2/3 compatible with Java SDK for IAM

### DIFF
--- a/clients/hadoopfs/src/main/java/io/lakefs/auth/AWSLakeFSTokenProvider.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/auth/AWSLakeFSTokenProvider.java
@@ -15,7 +15,7 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 
-import com.amazonaws.util.json.JSONObject;
+//import com.amazonaws.util.json.JSONObject;
 import org.apache.hadoop.conf.Configuration;
 
 
@@ -109,14 +109,15 @@ public class AWSLakeFSTokenProvider implements LakeFSTokenProvider {
     public String newPresignedGetCallerIdentityToken() throws Exception {
         Request<GeneratePresignGetCallerIdentityRequest> signedRequest = this.newPresignedRequest();
         // generate token parameters object
-        JSONObject identityTokenParams = new JSONObject();
-        identityTokenParams.put("method", signedRequest.getHttpMethod().name());
-        identityTokenParams.put("endpoint", signedRequest.getEndpoint().toString());
-        identityTokenParams.put("signedHeaders", signedRequest.getHeaders().keySet().toArray());
-        identityTokenParams.put("expiration", this.stsExpirationInSeconds);
-        identityTokenParams.put("signedParams", signedRequest.getParameters());
-        // base64 encode
-        return Base64.encodeBase64String(identityTokenParams.toString().getBytes());
+        return "";
+//        JSONObject identityTokenParams = new JSONObject();
+//        identityTokenParams.put("method", signedRequest.getHttpMethod().name());
+//        identityTokenParams.put("endpoint", signedRequest.getEndpoint().toString());
+//        identityTokenParams.put("signedHeaders", signedRequest.getHeaders().keySet().toArray());
+//        identityTokenParams.put("expiration", this.stsExpirationInSeconds);
+//        identityTokenParams.put("signedParams", signedRequest.getParameters());
+//        // base64 encode
+//        return Base64.encodeBase64String(identityTokenParams.toString().getBytes());
     }
 
     private void newToken() throws Exception {

--- a/clients/hadoopfs/src/main/java/io/lakefs/auth/AWSLakeFSTokenProvider.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/auth/AWSLakeFSTokenProvider.java
@@ -5,19 +5,16 @@ import com.amazonaws.auth.*;
 import io.lakefs.Constants;
 import io.lakefs.FSConfiguration;
 import io.lakefs.clients.sdk.ApiClient;
-import io.lakefs.clients.sdk.ApiException;
-import io.lakefs.clients.sdk.AuthApi;
 import io.lakefs.clients.sdk.model.AuthenticationToken;
 import org.apache.commons.codec.binary.Base64;
+
 import java.io.IOException;
 import java.net.URI;
 import java.net.URL;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 
-//import com.amazonaws.util.json.JSONObject;
 import org.apache.hadoop.conf.Configuration;
 
 
@@ -112,7 +109,7 @@ public class AWSLakeFSTokenProvider implements LakeFSTokenProvider {
         Request<GeneratePresignGetCallerIdentityRequest> signedRequest = this.newPresignedRequest();
         Map<String, String> params = signedRequest.getParameters();
         String securityToken = null;
-        if(this.awsProvider.getCredentials() instanceof AWSSessionCredentials) {
+        if (this.awsProvider.getCredentials() instanceof AWSSessionCredentials) {
             AWSSessionCredentials sessionCredentials = (AWSSessionCredentials) this.awsProvider.getCredentials();
 
         }

--- a/clients/hadoopfs/src/main/java/io/lakefs/auth/AWSLakeFSTokenProvider.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/auth/AWSLakeFSTokenProvider.java
@@ -107,13 +107,20 @@ public class AWSLakeFSTokenProvider implements LakeFSTokenProvider {
 
     public String newPresignedGetCallerIdentityToken() throws Exception {
         Request<GeneratePresignGetCallerIdentityRequest> signedRequest = this.newPresignedRequest();
-        Map<String, String> params = signedRequest.getParameters();
-        String securityToken = null;
-        if (this.awsProvider.getCredentials() instanceof AWSSessionCredentials) {
-            AWSSessionCredentials sessionCredentials = (AWSSessionCredentials) this.awsProvider.getCredentials();
-
+        Map<String, ?> rawQueryParams = signedRequest.getParameters();
+        Map<String, String> params = new HashMap<>();
+        // check if the value is an array and join it with commas depends on the AWS SDK version
+        for (Map.Entry<String, ?> entry : rawQueryParams.entrySet()) {
+            String key = entry.getKey();
+            Object value = entry.getValue();
+            if (value instanceof String[]) {
+                String[] arrayValue = (String[]) value;
+                String joinedValue = String.join(",", arrayValue);
+                params.put(key, joinedValue);
+            } else {
+                params.put(key, value.toString());
+            }
         }
-
 
         // generate token parameters object
         LakeFSExternalPrincipalIdentityRequest identityTokenParams = new LakeFSExternalPrincipalIdentityRequest(

--- a/clients/hadoopfs/src/main/java/io/lakefs/auth/GeneratePresignGetCallerIdentityRequest.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/auth/GeneratePresignGetCallerIdentityRequest.java
@@ -1,6 +1,6 @@
 package io.lakefs.auth;
 
-import com.amazonaws.auth.*;
+import com.amazonaws.auth.AWSCredentials;
 
 import java.net.URI;
 import java.util.Map;

--- a/clients/hadoopfs/src/main/java/io/lakefs/auth/GeneratePresignGetCallerIdentityResponse.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/auth/GeneratePresignGetCallerIdentityResponse.java
@@ -1,0 +1,100 @@
+package io.lakefs.auth;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+
+public class GeneratePresignGetCallerIdentityResponse {
+    private Map<String, String> signedQueryParams;
+    private GeneratePresignGetCallerIdentityRequest req;
+    private Map<String, String> signedHeaders;
+    private String signature;
+    private String region;
+    public GeneratePresignGetCallerIdentityResponse(GeneratePresignGetCallerIdentityRequest req, String region, Map<String, String> signedQueryParams, Map<String, String> signedHeaders, String signature) {
+        this.signedQueryParams = signedQueryParams;
+        this.req = req;
+        this.signedHeaders = signedHeaders;
+        this.signature = signature;
+        this.region = region;
+    }
+    public Map<String, String> getSignedQueryParams() {
+        return signedQueryParams;
+    }
+    public GeneratePresignGetCallerIdentityRequest getRequest() {
+        return req;
+    }
+    public Map<String, String> getSignedHeaders() {
+        return signedHeaders;
+    }
+    public String getSignature() {
+        return signature;
+    }
+    public String getHTTPMethod(){
+        return "POST";
+    }
+    public String getRegion() {
+        return region;
+    }
+    public String getHost() {
+        return req.getStsEndpoint().getHost();
+    }
+    public String getAction(){
+        return signedQueryParams.get(STSGetCallerIdentityPresigner.AMZ_ACTION_PARAM_NAME);
+    }
+    public String getDate(){
+        return signedQueryParams.get(STSGetCallerIdentityPresigner.AMZ_DATE_PARAM_NAME);
+    }
+    public String getExpires(){
+        return signedQueryParams.get(STSGetCallerIdentityPresigner.AMZ_EXPIRES_PARAM_NAME);
+    }
+    public String getAccessKeyId(){
+        return req.getCredentials().getAWSAccessKeyId();
+    }
+    public String getVersion(){
+        return signedQueryParams.get(STSGetCallerIdentityPresigner.AMZ_VERSION_PARAM_NAME);
+    }
+    public String getAlgorithm(){
+        return signedQueryParams.get(STSGetCallerIdentityPresigner.AMZ_ALGORITHM_PARAM_NAME);
+    }
+    public String getSecurityToken(){
+        return signedQueryParams.get(STSGetCallerIdentityPresigner.AMZ_SECURITY_TOKEN_PARAM_NAME);
+    }
+    public String getSignedHeadersParam(){
+        return signedQueryParams.get(STSGetCallerIdentityPresigner.AMZ_SIGNED_HEADERS_PARAM_NAME);
+    }
+    public String convertToURL(){
+        Map<String, String> allQueryParams = new HashMap<>();
+        allQueryParams.putAll(signedQueryParams);
+        allQueryParams.put(STSGetCallerIdentityPresigner.AMZ_SIGNATURE_PARAM_NAME, getSignature());
+        return URLBuilder(allQueryParams, req.getStsEndpoint());
+    }
+    public static String URLBuilder(Map<String, String> params, URI endpoint) {
+        StringBuilder query = new StringBuilder();
+        for (Map.Entry<String, String> entry : params.entrySet()) {
+            String key = entry.getKey();
+            String value = entry.getValue();
+            if (value != null) {
+                if (query.length() > 0) {
+                    query.append("&");
+                }
+                try {
+
+                    String encodedValue = URLEncoder.encode(value, StandardCharsets.UTF_8.toString());
+                    query.append(key).append("=").append(encodedValue);
+                } catch (UnsupportedEncodingException ex) {
+                    throw new RuntimeException(ex);
+                }
+            }
+        }
+        try {
+            String url = String.format("%s?%s", endpoint, query.toString());
+            return new URI(url).toString();
+        } catch (Exception e) {
+            e.printStackTrace();
+            return null;
+        }
+    }
+}

--- a/clients/hadoopfs/src/main/java/io/lakefs/auth/GetCallerIdentityV4Presigner.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/auth/GetCallerIdentityV4Presigner.java
@@ -1,5 +1,4 @@
 package io.lakefs.auth;
-//import org.joda.time.format.DateTimeFormat;
 
 import com.amazonaws.DefaultRequest;
 import com.amazonaws.Request;
@@ -7,7 +6,7 @@ import com.amazonaws.auth.*;
 import com.amazonaws.http.HttpMethodName;
 import com.amazonaws.util.AwsHostNameUtils;
 import com.amazonaws.util.BinaryUtils;
-//import com.amazonaws.util.HttpUtils;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
@@ -184,9 +183,11 @@ public class GetCallerIdentityV4Presigner extends AWS4Signer implements STSGetCa
         return AwsHostNameUtils.parseRegionName(endpoint.getHost(),
                 serviceName);
     }
-    public String getSignedRegion(Request<GeneratePresignGetCallerIdentityRequest> r){
+
+    public String getSignedRegion(Request<GeneratePresignGetCallerIdentityRequest> r) {
         return overriddenExtractRegionName(r.getEndpoint());
     }
+
     // copy from https://github.com/aws/aws-sdk-java/blob/d1790c78af50488f38d758fd1f654d035b505150/src/main/java/com/amazonaws/auth/AWS4Signer.java#L190
     protected String overriddenExtractServiceName(URI endpoint) {
         if (serviceName != null) return serviceName;

--- a/clients/hadoopfs/src/main/java/io/lakefs/auth/GetCallerIdentityV4Presigner.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/auth/GetCallerIdentityV4Presigner.java
@@ -1,14 +1,21 @@
 package io.lakefs.auth;
-
+//import org.joda.time.format.DateTimeFormat;
 import com.amazonaws.DefaultRequest;
 import com.amazonaws.Request;
 import com.amazonaws.auth.*;
 import com.amazonaws.http.HttpMethodName;
+import com.amazonaws.util.AwsHostNameUtils;
 import com.amazonaws.util.BinaryUtils;
-
+//import com.amazonaws.util.HttpUtils;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.URI;
+import java.net.URLEncoder;
+import java.util.Date;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * GetCallerIdentityV4Presigner is that knows how to generate a presigned URL for the GetCallerIdentity API.
@@ -16,11 +23,199 @@ import java.util.Map;
  * TODO: when we move to AWS SDK v2, we can use the AWS SDK's implementation of this (depends on hadoop-aws upgrading their own AWS SDK dependency).
  */
 public class GetCallerIdentityV4Presigner extends AWS4Signer implements STSGetCallerIdentityPresigner {
-
+    protected static final String COMPATIBLE_ALGORITHM = "AWS4-HMAC-SHA256";
+    protected static final String COMPATIBLE_TERMINATOR = "aws4_request";
+    private static final String DEFAULT_ENCODING = "UTF-8";
+//    private static final DateTimeFormatter compatibleTimeFormatter = DateTimeFormat
+//            .forPattern("yyyyMMdd'T'HHmmss'Z'").withZoneUTC();
+//    private static final DateTimeFormatter compatibleDateFormatter = DateTimeFormat
+//            .forPattern("yyyyMMdd").withZoneUTC();
     GetCallerIdentityV4Presigner() {
         super(false);
     }
 
+    /**
+     * Regex which matches any of the sequences that we need to fix up after
+     * URLEncoder.encode().
+     */
+    private static final Pattern ENCODED_CHARACTERS_PATTERN;
+    static {
+        StringBuilder pattern = new StringBuilder();
+
+        pattern
+                .append(Pattern.quote("+"))
+                .append("|")
+                .append(Pattern.quote("*"))
+                .append("|")
+                .append(Pattern.quote("%7E"))
+                .append("|")
+                .append(Pattern.quote("%2F"));
+
+        ENCODED_CHARACTERS_PATTERN = Pattern.compile(pattern.toString());
+    }
+    /**
+     * Encode a string for use in the path of a URL; uses URLEncoder.encode,
+     * (which encodes a string for use in the query portion of a URL), then
+     * applies some postfilters to fix things up per the RFC. Can optionally
+     * handle strings which are meant to encode a path (ie include '/'es
+     * which should NOT be escaped).
+     *
+     * @param value the value to encode
+     * @param path true if the value is intended to represent a path
+     * @return the encoded value
+     */
+    public static String urlEncode(final String value, final boolean path) {
+        if (value == null) {
+            return "";
+        }
+
+        try {
+            String encoded = URLEncoder.encode(value, DEFAULT_ENCODING);
+
+            Matcher matcher = ENCODED_CHARACTERS_PATTERN.matcher(encoded);
+            StringBuffer buffer = new StringBuffer(encoded.length());
+
+            while (matcher.find()) {
+                String replacement = matcher.group(0);
+
+                if ("+".equals(replacement)) {
+                    replacement = "%20";
+                } else if ("*".equals(replacement)) {
+                    replacement = "%2A";
+                } else if ("%7E".equals(replacement)) {
+                    replacement = "~";
+                } else if (path && "%2F".equals(replacement)) {
+                    replacement = "/";
+                }
+
+                matcher.appendReplacement(buffer, replacement);
+            }
+
+            matcher.appendTail(buffer);
+            return buffer.toString();
+
+        } catch (UnsupportedEncodingException ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+    /**
+     * Append the given path to the given baseUri.
+     *
+     * <p>This method will encode the given path but not the given
+     * baseUri.</p>
+     *
+     * @param baseUri The URI to append to (required, may be relative)
+     * @param path The path to append (may be null or empty)
+     * @param escapeDoubleSlash Whether double-slash in the path should be escaped to "/%2F"
+     * @return The baseUri with the (encoded) path appended
+     */
+    public static String appendUri(final String baseUri, String path, final boolean escapeDoubleSlash ) {
+        String resultUri = baseUri;
+        if (path != null && path.length() > 0) {
+            if (path.startsWith("/")) {
+                // trim the trailing slash in baseUri, since the path already starts with a slash
+                if (resultUri.endsWith("/")) {
+                    resultUri = resultUri.substring(0, resultUri.length() - 1);
+                }
+            } else if (!resultUri.endsWith("/")) {
+                resultUri += "/";
+            }
+            String encodedPath = GetCallerIdentityV4Presigner.urlEncode(path, true);
+            if (escapeDoubleSlash) {
+                encodedPath = encodedPath.replace("//", "/%2F");
+            }
+            resultUri += encodedPath;
+        } else if (!resultUri.endsWith("/")) {
+            resultUri += "/";
+        }
+
+        return resultUri;
+    }
+    protected final String compatibleGetTimeStamp(long dateMilli) {
+        //return compatibleTimeFormatter.print(dateMilli);
+        return ";";
+    }
+    protected final String compatibleGetDateStamp(long dateMilli) {
+        //return compatibleDateFormatter.print(dateMilli);
+        return ";";
+    }
+    protected final long compatibleGetDateFromRequest(Request<?> request) {
+        int timeOffset = getTimeOffset(request);
+        Date date = getSignatureDate(timeOffset);
+        if (overriddenDate != null) date = overriddenDate;
+        return date.getTime();
+    }
+    protected String compatibleExtractRegionName(URI endpoint) {
+        if (regionName != null) return regionName;
+
+        return AwsHostNameUtils.parseRegionName(endpoint.getHost(),
+                serviceName);
+    }
+    protected String compatibleExtractServiceName(URI endpoint) {
+        if (serviceName != null) return serviceName;
+
+        // This should never actually be called, as we should always be setting
+        // a service name on the signer; retain it for now in case anyone is
+        // using the AWS4Signer directly and not setting a service name
+        // explicitly.
+
+        return AwsHostNameUtils.parseServiceName(endpoint);
+    }
+    protected String compatiobleGetScope(Request<?> request, String dateStamp) {
+        String regionName = compatibleExtractRegionName(request.getEndpoint());
+        String serviceName = compatibleExtractServiceName(request.getEndpoint());
+        String scope =  dateStamp + "/" + regionName + "/" + serviceName + "/" + COMPATIBLE_TERMINATOR;
+        return scope;
+    }
+    protected String compatibleGetCanonicalRequest(Request<?> request, String contentSha256) {
+        /* This would url-encode the resource path for the first time */
+        //String path = HttpUtils.appendUri(request.getEndpoint().getPath(), request.getResourcePath());
+        String path = GetCallerIdentityV4Presigner.appendUri(request.getEndpoint().getPath(), request.getResourcePath(), false);
+        String canonicalRequest =
+                request.getHttpMethod().toString() + "\n" +
+                        /* This would optionally double url-encode the resource path */
+                        getCanonicalizedResourcePath(path, doubleUrlEncode) + "\n" +
+                        getCanonicalizedQueryString(request) + "\n" +
+                        getCanonicalizedHeaderString(request) + "\n" +
+                        getSignedHeadersString(request) + "\n" +
+                        contentSha256;
+        log.debug("AWS4 Canonical Request: '\"" + canonicalRequest + "\"");
+        return canonicalRequest;
+    }
+    protected String compatibleGetStringToSign(String algorithm, String dateTime, String scope, String canonicalRequest) {
+        String stringToSign =
+                algorithm + "\n" +
+                        dateTime + "\n" +
+                        scope + "\n" +
+                        BinaryUtils.toHex(hash(canonicalRequest));
+        log.debug("AWS4 String to Sign: '\"" + stringToSign + "\"");
+        return stringToSign;
+    }
+    protected final byte[] compatibleComputeSignature(
+            Request<?> request,
+            String dateStamp,
+            String timeStamp,
+            String algorithm,
+            String contentSha256,
+            AWSCredentials sanitizedCredentials)
+    {
+        String regionName = compatibleExtractRegionName(request.getEndpoint());
+        String serviceName = compatibleExtractServiceName(request.getEndpoint());
+        String scope =  dateStamp + "/" + regionName + "/" + serviceName + "/" + COMPATIBLE_TERMINATOR;
+
+        String stringToSign = compatibleGetStringToSign(algorithm, timeStamp, scope, compatibleGetCanonicalRequest(request,contentSha256 ));
+
+        // AWS4 uses a series of derived keys, formed by hashing different
+        // pieces of data
+        byte[] kSecret = ("AWS4" + sanitizedCredentials.getAWSSecretKey()).getBytes();
+        byte[] kDate = sign(dateStamp, kSecret, SigningAlgorithm.HmacSHA256);
+        byte[] kRegion = sign(regionName, kDate, SigningAlgorithm.HmacSHA256);
+        byte[] kService = sign(serviceName, kRegion, SigningAlgorithm.HmacSHA256);
+        byte[] kSigning = sign(COMPATIBLE_TERMINATOR, kService, SigningAlgorithm.HmacSHA256);
+
+        byte[] signature = sign(stringToSign.getBytes(), kSigning, SigningAlgorithm.HmacSHA256);
+        return signature;
+    }
     public Request<GeneratePresignGetCallerIdentityRequest> presignRequest(GeneratePresignGetCallerIdentityRequest input) throws IOException {
         Request request = new DefaultRequest("sts");
         request.setEndpoint(input.getStsEndpoint());
@@ -52,16 +247,18 @@ public class GetCallerIdentityV4Presigner extends AWS4Signer implements STSGetCa
 
         // Add required parameters for v4 signing
         long now = System.currentTimeMillis();
-        final String timeStamp = getTimeStamp(now);
-        request.addParameter("X-Amz-Algorithm", ALGORITHM);
+
+        final String timeStamp = compatibleGetTimeStamp(now);
+        request.addParameter("X-Amz-Algorithm", COMPATIBLE_ALGORITHM);
         request.addParameter("X-Amz-Date", timeStamp);
         request.addParameter("X-Amz-SignedHeaders", getSignedHeadersString(request));
         request.addParameter("X-Amz-Expires", String.valueOf(input.getExpirationInSeconds()));
 
         // add X-Amz-Credential header (e.g <AccessKeyId>/<date>/<region>>/sts/aws4_request)
-        long dateMilli = getDateFromRequest(request);
-        final String dateStamp = getDateStamp(dateMilli);
-        String scope = getScope(request, dateStamp);
+
+        long dateMilli = compatibleGetDateFromRequest(request);
+        final String dateStamp = compatibleGetDateStamp(dateMilli);
+        String scope = compatiobleGetScope(request, dateStamp);
         String signingCredentials = sanitizedCredentials.getAWSAccessKeyId() + "/" + scope;
 
         request.addParameter("X-Amz-Credential", signingCredentials);
@@ -70,9 +267,9 @@ public class GetCallerIdentityV4Presigner extends AWS4Signer implements STSGetCa
         byte[] contentDigest = this.hash(request.getContent());
         String contentSha256 = BinaryUtils.toHex(contentDigest);
 
-        HeaderSigningResult headerSigningResult = computeSignature(request, dateStamp, timeStamp, ALGORITHM, contentSha256, sanitizedCredentials);
+        byte[] signature = compatibleComputeSignature(request, dateStamp, timeStamp, COMPATIBLE_ALGORITHM, contentSha256, sanitizedCredentials);
 
-        request.addParameter("X-Amz-Signature", BinaryUtils.toHex(headerSigningResult.getSignature()));
+        request.addParameter("X-Amz-Signature", BinaryUtils.toHex(signature));
 
         return request;
     }

--- a/clients/hadoopfs/src/main/java/io/lakefs/auth/GetCallerIdentityV4Presigner.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/auth/GetCallerIdentityV4Presigner.java
@@ -24,9 +24,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * GetCallerIdentityV4Presigner is that knows how to generate a presigned URL for the GetCallerIdentity API. The presigned URL is signed using SigV4.
- * This class is extending AWS4Signer of AWS SDK version 1.7.4 and copies some functions from https://github.com/aws/aws-sdk-java/blob/1.7.4/src/main/java/com/amazonaws/auth/AWS4Signer.java
- * The reason we copy some functions is that we need to support aws-hadoop-2 which depends on aws sdk 1.7.4 while aws-hadoop-3 depends on aws sdk 1.11.375.
+ *  * GetCallerIdentityV4Presigner is generates a presigned URL for the GetCallerIdentity API, signed using SigV4.
+ *  * This class extends AWS4Signer of AWS SDK version 1.7.4 and copies some functions from https://github.com/aws/aws-sdk-java/blob/1.7.4/src/main/java/com/amazonaws/auth/AWS4Signer.java
+ *    * The copied functions exist in AWS SDK 1.7.4 but not AWS SDK 1.11.375, so they are
+ *      not available on Hadoop AWS 3.
  */
 public class GetCallerIdentityV4Presigner implements STSGetCallerIdentityPresigner {
     private static final String DEFAULT_ENCODING = "UTF-8";

--- a/clients/hadoopfs/src/main/java/io/lakefs/auth/GetCallerIdentityV4Presigner.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/auth/GetCallerIdentityV4Presigner.java
@@ -1,5 +1,6 @@
 package io.lakefs.auth;
 //import org.joda.time.format.DateTimeFormat;
+
 import com.amazonaws.DefaultRequest;
 import com.amazonaws.Request;
 import com.amazonaws.auth.*;
@@ -21,27 +22,24 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 
 /**
- * GetCallerIdentityV4Presigner is that knows how to generate a presigned URL for the GetCallerIdentity API.
- * The presigned URL is signed using SigV4.
- * TODO: when we move to AWS SDK v2, we can use the AWS SDK's implementation of this (depends on hadoop-aws upgrading their own AWS SDK dependency).
+ * GetCallerIdentityV4Presigner is that knows how to generate a presigned URL for the GetCallerIdentity API. The presigned URL is signed using SigV4.
+ * This class is extending AWS4Signer of AWS SDK version 1.7.4 and copies some functions from https://github.com/aws/aws-sdk-java/blob/1.7.4/src/main/java/com/amazonaws/auth/AWS4Signer.java
+ * The reason we copy some functions is that we need to support aws-hadoop-2 which depends on aws sdk 1.7.4 while aws-hadoop-3 depends on aws sdk 1.11.375.
+ * Everything that is copied starts with "overridden" prefix, a reasonable alternative would be to use @Override but, AWS made those functions final.
  */
 public class GetCallerIdentityV4Presigner extends AWS4Signer implements STSGetCallerIdentityPresigner {
-    protected static final String COMPATIBLE_ALGORITHM = "AWS4-HMAC-SHA256";
-    protected static final String COMPATIBLE_TERMINATOR = "aws4_request";
+    protected static final String OVERRIDDEN_ALGORITHM = "AWS4-HMAC-SHA256";
+    protected static final String OVERRIDDEN_TERMINATOR = "aws4_request";
     private static final String DEFAULT_ENCODING = "UTF-8";
-//    private static final DateTimeFormatter compatibleTimeFormatter = DateTimeFormat
-//            .forPattern("yyyyMMdd'T'HHmmss'Z'").withZoneUTC();
-//    private static final DateTimeFormatter compatibleDateFormatter = DateTimeFormat
-//            .forPattern("yyyyMMdd").withZoneUTC();
-    GetCallerIdentityV4Presigner() {
-        super(false);
-    }
 
+
+    // copy from https://github.com/aws/aws-sdk-java/blob/679abaebd371b09e887afaa5386dc182be4c6498/aws-java-sdk-core/src/main/java/com/amazonaws/util/SdkHttpUtils.java#L39
     /**
      * Regex which matches any of the sequences that we need to fix up after
      * URLEncoder.encode().
      */
-    private static final Pattern ENCODED_CHARACTERS_PATTERN;
+    private static final Pattern OVERRIDDEN_ENCODED_CHARACTERS_PATTERN;
+
     static {
         StringBuilder pattern = new StringBuilder();
 
@@ -54,8 +52,14 @@ public class GetCallerIdentityV4Presigner extends AWS4Signer implements STSGetCa
                 .append("|")
                 .append(Pattern.quote("%2F"));
 
-        ENCODED_CHARACTERS_PATTERN = Pattern.compile(pattern.toString());
+        OVERRIDDEN_ENCODED_CHARACTERS_PATTERN = Pattern.compile(pattern.toString());
     }
+
+    GetCallerIdentityV4Presigner() {
+        super(false);
+    }
+    // copy from https://github.com/aws/aws-sdk-java/blob/679abaebd371b09e887afaa5386dc182be4c6498/aws-java-sdk-core/src/main/java/com/amazonaws/util/SdkHttpUtils.java#L66
+
     /**
      * Encode a string for use in the path of a URL; uses URLEncoder.encode,
      * (which encodes a string for use in the query portion of a URL), then
@@ -64,9 +68,10 @@ public class GetCallerIdentityV4Presigner extends AWS4Signer implements STSGetCa
      * which should NOT be escaped).
      *
      * @param value the value to encode
-     * @param path true if the value is intended to represent a path
+     * @param path  true if the value is intended to represent a path
      * @return the encoded value
      */
+
     public static String urlEncode(final String value, final boolean path) {
         if (value == null) {
             return "";
@@ -75,7 +80,7 @@ public class GetCallerIdentityV4Presigner extends AWS4Signer implements STSGetCa
         try {
             String encoded = URLEncoder.encode(value, DEFAULT_ENCODING);
 
-            Matcher matcher = ENCODED_CHARACTERS_PATTERN.matcher(encoded);
+            Matcher matcher = OVERRIDDEN_ENCODED_CHARACTERS_PATTERN.matcher(encoded);
             StringBuffer buffer = new StringBuffer(encoded.length());
 
             while (matcher.find()) {
@@ -101,18 +106,21 @@ public class GetCallerIdentityV4Presigner extends AWS4Signer implements STSGetCa
             throw new RuntimeException(ex);
         }
     }
+
+    // copy from https://github.com/aws/aws-sdk-java/blob/679abaebd371b09e887afaa5386dc182be4c6498/aws-java-sdk-core/src/main/java/com/amazonaws/util/SdkHttpUtils.java#L194
+
     /**
      * Append the given path to the given baseUri.
      *
      * <p>This method will encode the given path but not the given
      * baseUri.</p>
      *
-     * @param baseUri The URI to append to (required, may be relative)
-     * @param path The path to append (may be null or empty)
+     * @param baseUri           The URI to append to (required, may be relative)
+     * @param path              The path to append (may be null or empty)
      * @param escapeDoubleSlash Whether double-slash in the path should be escaped to "/%2F"
      * @return The baseUri with the (encoded) path appended
      */
-    public static String appendUri(final String baseUri, String path, final boolean escapeDoubleSlash ) {
+    public static String appendUri(final String baseUri, String path, final boolean escapeDoubleSlash) {
         String resultUri = baseUri;
         if (path != null && path.length() > 0) {
             if (path.startsWith("/")) {
@@ -134,9 +142,9 @@ public class GetCallerIdentityV4Presigner extends AWS4Signer implements STSGetCa
 
         return resultUri;
     }
-    protected final String compatibleGetTimeStamp(long dateMilli) {
-        //return compatibleTimeFormatter.print(dateMilli);
 
+    // copy from https://github.com/aws/aws-sdk-java/blob/d1790c78af50488f38d758fd1f654d035b505150/src/main/java/com/amazonaws/auth/AWS4Signer.java#L294
+    protected final String overriddenGetTimeStamp(long dateMilli) {
         // Convert milliseconds to Instant
         Instant instant = Instant.ofEpochMilli(dateMilli);
 
@@ -146,7 +154,9 @@ public class GetCallerIdentityV4Presigner extends AWS4Signer implements STSGetCa
         String formattedDateTime = formatter.format(instant);
         return formattedDateTime;
     }
-    protected final String compatibleGetDateStamp(long dateMilli) {
+
+    // copy from https://github.com/aws/aws-sdk-java/blob/d1790c78af50488f38d758fd1f654d035b505150/src/main/java/com/amazonaws/auth/AWS4Signer.java#L298
+    protected final String overriddenGetDateStamp(long dateMilli) {
 
         // Convert milliseconds to Instant
         Instant instant = Instant.ofEpochMilli(dateMilli);
@@ -158,19 +168,27 @@ public class GetCallerIdentityV4Presigner extends AWS4Signer implements STSGetCa
 
         return formattedDate;
     }
-    protected final long compatibleGetDateFromRequest(Request<?> request) {
+
+    // copy from https://github.com/aws/aws-sdk-java/blob/d1790c78af50488f38d758fd1f654d035b505150/src/main/java/com/amazonaws/auth/AWS4Signer.java#L302
+    protected final long overriddenGetDateFromRequest(Request<?> request) {
         int timeOffset = getTimeOffset(request);
         Date date = getSignatureDate(timeOffset);
         if (overriddenDate != null) date = overriddenDate;
         return date.getTime();
     }
-    protected String compatibleExtractRegionName(URI endpoint) {
+
+    // copy from https://github.com/aws/aws-sdk-java/blob/d1790c78af50488f38d758fd1f654d035b505150/src/main/java/com/amazonaws/auth/AWS4Signer.java#L183
+    protected String overriddenExtractRegionName(URI endpoint) {
         if (regionName != null) return regionName;
 
         return AwsHostNameUtils.parseRegionName(endpoint.getHost(),
                 serviceName);
     }
-    protected String compatibleExtractServiceName(URI endpoint) {
+    public String getSignedRegion(Request<GeneratePresignGetCallerIdentityRequest> r){
+        return overriddenExtractRegionName(r.getEndpoint());
+    }
+    // copy from https://github.com/aws/aws-sdk-java/blob/d1790c78af50488f38d758fd1f654d035b505150/src/main/java/com/amazonaws/auth/AWS4Signer.java#L190
+    protected String overriddenExtractServiceName(URI endpoint) {
         if (serviceName != null) return serviceName;
 
         // This should never actually be called, as we should always be setting
@@ -180,13 +198,17 @@ public class GetCallerIdentityV4Presigner extends AWS4Signer implements STSGetCa
 
         return AwsHostNameUtils.parseServiceName(endpoint);
     }
-    protected String compatiobleGetScope(Request<?> request, String dateStamp) {
-        String regionName = compatibleExtractRegionName(request.getEndpoint());
-        String serviceName = compatibleExtractServiceName(request.getEndpoint());
-        String scope =  dateStamp + "/" + regionName + "/" + serviceName + "/" + COMPATIBLE_TERMINATOR;
+
+    // copy from https://github.com/aws/aws-sdk-java/blob/d1790c78af50488f38d758fd1f654d035b505150/src/main/java/com/amazonaws/auth/AWS4Signer.java#L320
+    protected String overriddenGetScope(Request<?> request, String dateStamp) {
+        String regionName = overriddenExtractRegionName(request.getEndpoint());
+        String serviceName = overriddenExtractServiceName(request.getEndpoint());
+        String scope = dateStamp + "/" + regionName + "/" + serviceName + "/" + OVERRIDDEN_TERMINATOR;
         return scope;
     }
-    protected String compatibleGetCanonicalRequest(Request<?> request, String contentSha256) {
+
+    // copy from https://github.com/aws/aws-sdk-java/blob/d1790c78af50488f38d758fd1f654d035b505150/src/main/java/com/amazonaws/auth/AWS4Signer.java#L241
+    protected String overriddenGetCanonicalRequest(Request<?> request, String contentSha256) {
         /* This would url-encode the resource path for the first time */
         //String path = HttpUtils.appendUri(request.getEndpoint().getPath(), request.getResourcePath());
         String path = GetCallerIdentityV4Presigner.appendUri(request.getEndpoint().getPath(), request.getResourcePath(), false);
@@ -201,7 +223,9 @@ public class GetCallerIdentityV4Presigner extends AWS4Signer implements STSGetCa
         log.debug("AWS4 Canonical Request: '\"" + canonicalRequest + "\"");
         return canonicalRequest;
     }
-    protected String compatibleGetStringToSign(String algorithm, String dateTime, String scope, String canonicalRequest) {
+
+    // copy from https://github.com/aws/aws-sdk-java/blob/d1790c78af50488f38d758fd1f654d035b505150/src/main/java/com/amazonaws/auth/AWS4Signer.java#L257C22-L257C37
+    protected String overriddenGetStringToSign(String algorithm, String dateTime, String scope, String canonicalRequest) {
         String stringToSign =
                 algorithm + "\n" +
                         dateTime + "\n" +
@@ -210,19 +234,20 @@ public class GetCallerIdentityV4Presigner extends AWS4Signer implements STSGetCa
         log.debug("AWS4 String to Sign: '\"" + stringToSign + "\"");
         return stringToSign;
     }
-    protected final byte[] compatibleComputeSignature(
+
+    // copy from https://github.com/aws/aws-sdk-java/blob/d1790c78af50488f38d758fd1f654d035b505150/src/main/java/com/amazonaws/auth/AWS4Signer.java#L268
+    protected final byte[] overriddenComputeSignature(
             Request<?> request,
             String dateStamp,
             String timeStamp,
             String algorithm,
             String contentSha256,
-            AWSCredentials sanitizedCredentials)
-    {
-        String regionName = compatibleExtractRegionName(request.getEndpoint());
-        String serviceName = compatibleExtractServiceName(request.getEndpoint());
-        String scope =  dateStamp + "/" + regionName + "/" + serviceName + "/" + COMPATIBLE_TERMINATOR;
+            AWSCredentials sanitizedCredentials) {
+        String regionName = overriddenExtractRegionName(request.getEndpoint());
+        String serviceName = overriddenExtractServiceName(request.getEndpoint());
+        String scope = dateStamp + "/" + regionName + "/" + serviceName + "/" + OVERRIDDEN_TERMINATOR;
 
-        String stringToSign = compatibleGetStringToSign(algorithm, timeStamp, scope, compatibleGetCanonicalRequest(request,contentSha256 ));
+        String stringToSign = overriddenGetStringToSign(algorithm, timeStamp, scope, overriddenGetCanonicalRequest(request, contentSha256));
 
         // AWS4 uses a series of derived keys, formed by hashing different
         // pieces of data
@@ -230,16 +255,17 @@ public class GetCallerIdentityV4Presigner extends AWS4Signer implements STSGetCa
         byte[] kDate = sign(dateStamp, kSecret, SigningAlgorithm.HmacSHA256);
         byte[] kRegion = sign(regionName, kDate, SigningAlgorithm.HmacSHA256);
         byte[] kService = sign(serviceName, kRegion, SigningAlgorithm.HmacSHA256);
-        byte[] kSigning = sign(COMPATIBLE_TERMINATOR, kService, SigningAlgorithm.HmacSHA256);
+        byte[] kSigning = sign(OVERRIDDEN_TERMINATOR, kService, SigningAlgorithm.HmacSHA256);
 
         byte[] signature = sign(stringToSign.getBytes(), kSigning, SigningAlgorithm.HmacSHA256);
         return signature;
     }
+
     public Request<GeneratePresignGetCallerIdentityRequest> presignRequest(GeneratePresignGetCallerIdentityRequest input) throws IOException {
         Request request = new DefaultRequest("sts");
         request.setEndpoint(input.getStsEndpoint());
-        request.addParameter("Action", "GetCallerIdentity");
-        request.addParameter("Version", "2011-06-15");
+        request.addParameter(STSGetCallerIdentityPresigner.AMZ_ACTION_PARAM_NAME, "GetCallerIdentity");
+        request.addParameter(STSGetCallerIdentityPresigner.AMZ_VERSION_PARAM_NAME, "2011-06-15");
         // we want to support generating only POST requests, adding an empty stream is a hack
         // to make it use query params when Signer calls this.usePayloadForQueryParameters returns false for an empty POST request.
         request.setContent(new InputStream() {
@@ -256,7 +282,7 @@ public class GetCallerIdentityV4Presigner extends AWS4Signer implements STSGetCa
         if (sanitizedCredentials instanceof AWSSessionCredentials) {
             // For SigV4 presigning URL, we need to add "x-amz-security-token"
             // as a query string parameter, before constructing the canonical request.
-            request.addParameter("X-Amz-Security-Token", ((AWSSessionCredentials) sanitizedCredentials).getSessionToken());
+            request.addParameter(STSGetCallerIdentityPresigner.AMZ_SECURITY_TOKEN_PARAM_NAME, ((AWSSessionCredentials) sanitizedCredentials).getSessionToken());
         }
 
         // add additional headers to sign (i.e X-lakeFS-Server-ID)
@@ -267,28 +293,28 @@ public class GetCallerIdentityV4Presigner extends AWS4Signer implements STSGetCa
         // Add required parameters for v4 signing
         long now = System.currentTimeMillis();
 
-        final String timeStamp = compatibleGetTimeStamp(now);
-        request.addParameter("X-Amz-Algorithm", COMPATIBLE_ALGORITHM);
-        request.addParameter("X-Amz-Date", timeStamp);
-        request.addParameter("X-Amz-SignedHeaders", getSignedHeadersString(request));
-        request.addParameter("X-Amz-Expires", String.valueOf(input.getExpirationInSeconds()));
+        final String timeStamp = overriddenGetTimeStamp(now);
+        request.addParameter(STSGetCallerIdentityPresigner.AMZ_ALGORITHM_PARAM_NAME, OVERRIDDEN_ALGORITHM);
+        request.addParameter(STSGetCallerIdentityPresigner.AMZ_DATE_PARAM_NAME, timeStamp);
+        request.addParameter(STSGetCallerIdentityPresigner.AMZ_SIGNED_HEADERS_PARAM_NAME, getSignedHeadersString(request));
+        request.addParameter(STSGetCallerIdentityPresigner.AMZ_EXPIRES_PARAM_NAME, String.valueOf(input.getExpirationInSeconds()));
 
         // add X-Amz-Credential header (e.g <AccessKeyId>/<date>/<region>>/sts/aws4_request)
 
-        long dateMilli = compatibleGetDateFromRequest(request);
-        final String dateStamp = compatibleGetDateStamp(dateMilli);
-        String scope = compatiobleGetScope(request, dateStamp);
+        long dateMilli = overriddenGetDateFromRequest(request);
+        final String dateStamp = overriddenGetDateStamp(dateMilli);
+        String scope = overriddenGetScope(request, dateStamp);
         String signingCredentials = sanitizedCredentials.getAWSAccessKeyId() + "/" + scope;
 
-        request.addParameter("X-Amz-Credential", signingCredentials);
+        request.addParameter(STSGetCallerIdentityPresigner.AMZ_CREDENTIAL_PARAM_NAME, signingCredentials);
 
         // contentSha256 is HashedPayload Hex(SHA256Hash("")) see https://docs.aws.amazon.com/IAM/latest/UserGuide/create-signed-request.html#create-string-to-sign
         byte[] contentDigest = this.hash(request.getContent());
         String contentSha256 = BinaryUtils.toHex(contentDigest);
 
-        byte[] signature = compatibleComputeSignature(request, dateStamp, timeStamp, COMPATIBLE_ALGORITHM, contentSha256, sanitizedCredentials);
+        byte[] signature = overriddenComputeSignature(request, dateStamp, timeStamp, OVERRIDDEN_ALGORITHM, contentSha256, sanitizedCredentials);
 
-        request.addParameter("X-Amz-Signature", BinaryUtils.toHex(signature));
+        request.addParameter(STSGetCallerIdentityPresigner.AMZ_SIGNATURE_PARAM_NAME, BinaryUtils.toHex(signature));
 
         return request;
     }

--- a/clients/hadoopfs/src/main/java/io/lakefs/auth/GetCallerIdentityV4Presigner.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/auth/GetCallerIdentityV4Presigner.java
@@ -16,6 +16,9 @@ import java.util.Date;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 
 /**
  * GetCallerIdentityV4Presigner is that knows how to generate a presigned URL for the GetCallerIdentity API.
@@ -133,11 +136,29 @@ public class GetCallerIdentityV4Presigner extends AWS4Signer implements STSGetCa
     }
     protected final String compatibleGetTimeStamp(long dateMilli) {
         //return compatibleTimeFormatter.print(dateMilli);
-        return ";";
+
+        // Convert milliseconds to Instant
+        Instant instant = Instant.ofEpochMilli(dateMilli);
+
+        // Format Instant to String in UTC time zone
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd'T'HHmmss'Z'")
+                .withZone(ZoneId.of("UTC"));
+        String formattedDateTime = formatter.format(instant);
+        return formattedDateTime;
     }
     protected final String compatibleGetDateStamp(long dateMilli) {
         //return compatibleDateFormatter.print(dateMilli);
-        return ";";
+        long millis = System.currentTimeMillis();
+
+        // Convert milliseconds to Instant
+        Instant instant = Instant.ofEpochMilli(millis);
+
+        // Format Instant to String in UTC time zone
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd")
+                .withZone(ZoneId.of("UTC"));
+        String formattedDate = formatter.format(instant);
+
+        return formattedDate;
     }
     protected final long compatibleGetDateFromRequest(Request<?> request) {
         int timeOffset = getTimeOffset(request);

--- a/clients/hadoopfs/src/main/java/io/lakefs/auth/GetCallerIdentityV4Presigner.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/auth/GetCallerIdentityV4Presigner.java
@@ -147,11 +147,9 @@ public class GetCallerIdentityV4Presigner extends AWS4Signer implements STSGetCa
         return formattedDateTime;
     }
     protected final String compatibleGetDateStamp(long dateMilli) {
-        //return compatibleDateFormatter.print(dateMilli);
-        long millis = System.currentTimeMillis();
 
         // Convert milliseconds to Instant
-        Instant instant = Instant.ofEpochMilli(millis);
+        Instant instant = Instant.ofEpochMilli(dateMilli);
 
         // Format Instant to String in UTC time zone
         DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyyMMdd")

--- a/clients/hadoopfs/src/main/java/io/lakefs/auth/GetCallerIdentityV4Presigner.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/auth/GetCallerIdentityV4Presigner.java
@@ -24,7 +24,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- *  * GetCallerIdentityV4Presigner is generates a presigned URL for the GetCallerIdentity API, signed using SigV4.
+ *  * GetCallerIdentityV4Presigner generates a presigned URL for the GetCallerIdentity API, signed using SigV4.
  *  * This class extends AWS4Signer of AWS SDK version 1.7.4 and copies some functions from https://github.com/aws/aws-sdk-java/blob/1.7.4/src/main/java/com/amazonaws/auth/AWS4Signer.java
  *    * The copied functions exist in AWS SDK 1.7.4 but not AWS SDK 1.11.375, so they are
  *      not available on Hadoop AWS 3.

--- a/clients/hadoopfs/src/main/java/io/lakefs/auth/LakeFSExternalPrincipalIdentityRequest.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/auth/LakeFSExternalPrincipalIdentityRequest.java
@@ -1,0 +1,98 @@
+package io.lakefs.auth;
+import com.google.gson.Gson;
+import com.google.gson.annotations.SerializedName;
+
+import java.util.List;
+
+public class LakeFSExternalPrincipalIdentityRequest {
+ private final String method;
+ private final String host;
+ private final String region;
+ private final String action;
+ private final String date;
+ @SerializedName("expiration_duration")
+ private final String expirationDuration;
+ @SerializedName("access_key_id")
+ private final String accessKeyId;
+ private final String signature;
+ @SerializedName("signed_headers")
+ private final List<String> signedHeaders;
+ private final String version;
+ private final String algorithm;
+ @SerializedName("security_token")
+ private final String securityToken;
+
+ public LakeFSExternalPrincipalIdentityRequest(String method, String host, String region, String action, String date, String expirationDuration, String accessKeyId, String signature, List<String> signedHeaders, String version, String algorithm, String securityToken) {
+  this.method = method;
+  this.host = host;
+  this.region = region;
+  this.action = action;
+  this.date = date;
+  this.expirationDuration = expirationDuration;
+  this.accessKeyId = accessKeyId;
+  this.signature = signature;
+  this.signedHeaders = signedHeaders;
+  this.version = version;
+  this.algorithm = algorithm;
+  this.securityToken = securityToken;
+ }
+ public static LakeFSExternalPrincipalIdentityRequest fromJSON(String jsonString){
+  Gson gson = new Gson();
+  LakeFSExternalPrincipalIdentityRequest request = gson.fromJson(jsonString, LakeFSExternalPrincipalIdentityRequest.class);
+  return request;
+ }
+ public String toJSON(){
+  Gson gson = new Gson();
+  String jsonString = gson.toJson(this);
+  return jsonString;
+ }
+
+ public String getMethod() {
+  return this.method;
+ }
+
+ public String getHost() {
+  return this.host;
+ }
+
+ public String getRegion() {
+  return this.region;
+ }
+
+ public String getAction() {
+  return this.action;
+ }
+
+ public String getDate() {
+  return this.date;
+ }
+
+ public String getExpirationDuration() {
+  return this.expirationDuration;
+ }
+
+ public String getAccessKeyId() {
+  return this.accessKeyId;
+ }
+
+ public String getSignature() {
+  return this.signature;
+ }
+
+ public List<String> getSignedHeaders() {
+  return this.signedHeaders;
+ }
+
+ public String getVersion() {
+  return this.version;
+ }
+
+ public String getAlgorithm() {
+  return this.algorithm;
+ }
+
+ public String getSecurityToken() {
+  return this.securityToken;
+ }
+}
+

--- a/clients/hadoopfs/src/main/java/io/lakefs/auth/STSGetCallerIdentityPresigner.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/auth/STSGetCallerIdentityPresigner.java
@@ -8,8 +8,18 @@ import java.io.IOException;
 import java.net.URL;
 
 public interface STSGetCallerIdentityPresigner {
-    Request<GeneratePresignGetCallerIdentityRequest> presignRequest(GeneratePresignGetCallerIdentityRequest r) throws IOException;
+    String AMZ_DATE_PARAM_NAME = "X-Amz-Date";
+    String AMZ_SECURITY_TOKEN_PARAM_NAME = "X-Amz-Security-Token";
+    String AMZ_ALGORITHM_PARAM_NAME = "X-Amz-Algorithm";
+    String AMZ_CREDENTIAL_PARAM_NAME = "X-Amz-Credential";
+    String AMZ_SIGNED_HEADERS_PARAM_NAME = "X-Amz-SignedHeaders";
+    String AMZ_SIGNATURE_PARAM_NAME = "X-Amz-Signature";
+    String AMZ_EXPIRES_PARAM_NAME = "X-Amz-Expires";
+    String AMZ_ACTION_PARAM_NAME = "Action";
+    String AMZ_VERSION_PARAM_NAME = "Version";
 
+    Request<GeneratePresignGetCallerIdentityRequest> presignRequest(GeneratePresignGetCallerIdentityRequest r) throws IOException;
+    String getSignedRegion(Request<GeneratePresignGetCallerIdentityRequest> r);
     static URL convertRequestToUrl(Request<GeneratePresignGetCallerIdentityRequest> r) {
         return ServiceUtils.convertRequestToUrl(r, false);
     }

--- a/clients/hadoopfs/src/main/java/io/lakefs/auth/STSGetCallerIdentityPresigner.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/auth/STSGetCallerIdentityPresigner.java
@@ -1,12 +1,5 @@
 package io.lakefs.auth;
 
-import com.amazonaws.Request;
-import com.amazonaws.services.s3.internal.ServiceUtils;
-
-
-import java.io.IOException;
-import java.net.URL;
-
 public interface STSGetCallerIdentityPresigner {
     String AMZ_DATE_PARAM_NAME = "X-Amz-Date";
     String AMZ_SECURITY_TOKEN_PARAM_NAME = "X-Amz-Security-Token";
@@ -17,10 +10,5 @@ public interface STSGetCallerIdentityPresigner {
     String AMZ_EXPIRES_PARAM_NAME = "X-Amz-Expires";
     String AMZ_ACTION_PARAM_NAME = "Action";
     String AMZ_VERSION_PARAM_NAME = "Version";
-
-    Request<GeneratePresignGetCallerIdentityRequest> presignRequest(GeneratePresignGetCallerIdentityRequest r) throws IOException;
-    String getSignedRegion(Request<GeneratePresignGetCallerIdentityRequest> r);
-    static URL convertRequestToUrl(Request<GeneratePresignGetCallerIdentityRequest> r) {
-        return ServiceUtils.convertRequestToUrl(r, false);
-    }
+    GeneratePresignGetCallerIdentityResponse presignRequest(GeneratePresignGetCallerIdentityRequest input);
 }

--- a/clients/hadoopfs/src/main/java/io/lakefs/auth/TemporaryAWSCredentialsLakeFSTokenProvider.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/auth/TemporaryAWSCredentialsLakeFSTokenProvider.java
@@ -28,7 +28,7 @@ public class TemporaryAWSCredentialsLakeFSTokenProvider extends AWSLakeFSTokenPr
         }
         AWSCredentialsProvider awsProvider = new AWSCredentialsProvider() {
             @Override
-            public AWSCredentials getCredentials() {    
+            public AWSCredentials getCredentials() {
                 return new BasicSessionCredentials(
                         accessKey,
                         secretKey,

--- a/clients/hadoopfs/src/main/java/io/lakefs/auth/TemporaryAWSCredentialsLakeFSTokenProvider.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/auth/TemporaryAWSCredentialsLakeFSTokenProvider.java
@@ -28,7 +28,7 @@ public class TemporaryAWSCredentialsLakeFSTokenProvider extends AWSLakeFSTokenPr
         }
         AWSCredentialsProvider awsProvider = new AWSCredentialsProvider() {
             @Override
-            public AWSCredentials getCredentials() {
+            public AWSCredentials getCredentials() {    
                 return new BasicSessionCredentials(
                         accessKey,
                         secretKey,

--- a/clients/hadoopfs/src/test/java/io/lakefs/auth/AWSLakeFSTokenProviderTest.java
+++ b/clients/hadoopfs/src/test/java/io/lakefs/auth/AWSLakeFSTokenProviderTest.java
@@ -1,6 +1,6 @@
 package io.lakefs.auth;
 
-import com.amazonaws.util.json.JSONObject;
+//import com.amazonaws.util.json.JSONObject;
 import io.lakefs.Constants;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.hadoop.conf.Configuration;
@@ -20,11 +20,11 @@ public class AWSLakeFSTokenProviderTest {
         AWSLakeFSTokenProvider provider = (AWSLakeFSTokenProvider)LakeFSTokenProviderFactory.newLakeFSTokenProvider(Constants.DEFAULT_SCHEME, conf);
         String identityToken = provider.newPresignedGetCallerIdentityToken();
         String decodedToken = new String(Base64.decodeBase64(identityToken.getBytes()));
-        JSONObject identityParams = new JSONObject(decodedToken);
-        // TODO(isan) finallize this test to check all the fields as expected in the identity token
-        // that is the request object that lakeFS will recieve and pass to the auth service
-        identityParams.keys().forEachRemaining(key -> {
-            Assert.assertTrue(identityParams.has((String) key));
-        });
+//        JSONObject identityParams = new JSONObject(decodedToken);
+//        // TODO(isan) finallize this test to check all the fields as expected in the identity token
+//        // that is the request object that lakeFS will recieve and pass to the auth service
+//        identityParams.keys().forEachRemaining(key -> {
+//            Assert.assertTrue(identityParams.has((String) key));
+//        });
     }
 }

--- a/clients/hadoopfs/src/test/java/io/lakefs/auth/AWSLakeFSTokenProviderTest.java
+++ b/clients/hadoopfs/src/test/java/io/lakefs/auth/AWSLakeFSTokenProviderTest.java
@@ -2,12 +2,17 @@ package io.lakefs.auth;
 
 //import com.amazonaws.util.json.JSONObject;
 import io.lakefs.Constants;
+import io.lakefs.FSConfiguration;
 import org.apache.commons.codec.binary.Base64;
 import org.apache.hadoop.conf.Configuration;
 import org.junit.Assert;
 import org.junit.Test;
 
 public class AWSLakeFSTokenProviderTest {
+    @Test
+    public void name() {
+    }
+
     @Test
     public void testProviderIdentityTokenSerde() throws Exception {
         Configuration conf = new Configuration(false);
@@ -20,11 +25,19 @@ public class AWSLakeFSTokenProviderTest {
         AWSLakeFSTokenProvider provider = (AWSLakeFSTokenProvider)LakeFSTokenProviderFactory.newLakeFSTokenProvider(Constants.DEFAULT_SCHEME, conf);
         String identityToken = provider.newPresignedGetCallerIdentityToken();
         String decodedToken = new String(Base64.decodeBase64(identityToken.getBytes()));
-//        JSONObject identityParams = new JSONObject(decodedToken);
-//        // TODO(isan) finallize this test to check all the fields as expected in the identity token
-//        // that is the request object that lakeFS will recieve and pass to the auth service
-//        identityParams.keys().forEachRemaining(key -> {
-//            Assert.assertTrue(identityParams.has((String) key));
-//        });
+        LakeFSExternalPrincipalIdentityRequest request = LakeFSExternalPrincipalIdentityRequest.fromJSON(decodedToken);
+        Assert.assertEquals("POST", request.getMethod());
+        Assert.assertEquals("sts.amazonaws.com", request.getHost());
+        Assert.assertEquals("us-east-1", request.getRegion());
+        Assert.assertEquals("GetCallerIdentity", request.getAction());
+        Assert.assertTrue(request.getDate().matches("\\d{8}T\\d{6}Z"));
+        Assert.assertEquals("60", request.getExpirationDuration());
+        Assert.assertEquals(FSConfiguration.get(conf, "lakefs",Constants.TOKEN_AWS_CREDENTIALS_PROVIDER_ACCESS_KEY_SUFFIX), request.getAccessKeyId());
+        Assert.assertTrue(request.getSignature().matches("[0-9a-fA-F]{64}"));
+        Assert.assertEquals("host", request.getSignedHeaders().get(0));
+        Assert.assertEquals("x-lakefs-server-id", request.getSignedHeaders().get(1));
+        Assert.assertEquals("2011-06-15", request.getVersion());
+        Assert.assertEquals("AWS4-HMAC-SHA256", request.getAlgorithm());
+        Assert.assertEquals(FSConfiguration.get(conf, "lakefs", Constants.TOKEN_AWS_CREDENTIALS_PROVIDER_SESSION_TOKEN_KEY_SUFFIX), request.getSecurityToken());
     }
 }

--- a/clients/hadoopfs/src/test/java/io/lakefs/auth/AWSLakeFSTokenProviderTest.java
+++ b/clients/hadoopfs/src/test/java/io/lakefs/auth/AWSLakeFSTokenProviderTest.java
@@ -8,9 +8,6 @@ import org.junit.Assert;
 import org.junit.Test;
 
 public class AWSLakeFSTokenProviderTest {
-    @Test
-    public void name() {
-    }
 
     @Test
     public void testProviderIdentityTokenSerde() throws Exception {

--- a/clients/hadoopfs/src/test/java/io/lakefs/auth/AWSLakeFSTokenProviderTest.java
+++ b/clients/hadoopfs/src/test/java/io/lakefs/auth/AWSLakeFSTokenProviderTest.java
@@ -1,6 +1,5 @@
 package io.lakefs.auth;
 
-//import com.amazonaws.util.json.JSONObject;
 import io.lakefs.Constants;
 import io.lakefs.FSConfiguration;
 import org.apache.commons.codec.binary.Base64;
@@ -22,7 +21,7 @@ public class AWSLakeFSTokenProviderTest {
         conf.set("fs.lakefs." + Constants.TOKEN_AWS_CREDENTIALS_PROVIDER_SESSION_TOKEN_KEY_SUFFIX, "sessionToken");
         conf.set("fs.lakefs." + Constants.TOKEN_AWS_STS_ENDPOINT, "https://sts.amazonaws.com");
 
-        AWSLakeFSTokenProvider provider = (AWSLakeFSTokenProvider)LakeFSTokenProviderFactory.newLakeFSTokenProvider(Constants.DEFAULT_SCHEME, conf);
+        AWSLakeFSTokenProvider provider = (AWSLakeFSTokenProvider) LakeFSTokenProviderFactory.newLakeFSTokenProvider(Constants.DEFAULT_SCHEME, conf);
         String identityToken = provider.newPresignedGetCallerIdentityToken();
         String decodedToken = new String(Base64.decodeBase64(identityToken.getBytes()));
         LakeFSExternalPrincipalIdentityRequest request = LakeFSExternalPrincipalIdentityRequest.fromJSON(decodedToken);
@@ -32,7 +31,7 @@ public class AWSLakeFSTokenProviderTest {
         Assert.assertEquals("GetCallerIdentity", request.getAction());
         Assert.assertTrue(request.getDate().matches("\\d{8}T\\d{6}Z"));
         Assert.assertEquals("60", request.getExpirationDuration());
-        Assert.assertEquals(FSConfiguration.get(conf, "lakefs",Constants.TOKEN_AWS_CREDENTIALS_PROVIDER_ACCESS_KEY_SUFFIX), request.getAccessKeyId());
+        Assert.assertEquals(FSConfiguration.get(conf, "lakefs", Constants.TOKEN_AWS_CREDENTIALS_PROVIDER_ACCESS_KEY_SUFFIX), request.getAccessKeyId());
         Assert.assertTrue(request.getSignature().matches("[0-9a-fA-F]{64}"));
         Assert.assertEquals("host", request.getSignedHeaders().get(0));
         Assert.assertEquals("x-lakefs-server-id", request.getSignedHeaders().get(1));

--- a/clients/hadoopfs/src/test/java/io/lakefs/auth/GetCallerIdentityV4PresignerTest.java
+++ b/clients/hadoopfs/src/test/java/io/lakefs/auth/GetCallerIdentityV4PresignerTest.java
@@ -62,8 +62,10 @@ public class GetCallerIdentityV4PresignerTest {
                 }},
                 60
         );
-        Request<GeneratePresignGetCallerIdentityRequest> req = stsPresigner.presignRequest(stsReq);
-        URL url = STSGetCallerIdentityPresigner.convertRequestToUrl(req);
+
+        GeneratePresignGetCallerIdentityResponse signedRequest = stsPresigner.presignRequest(stsReq);
+        URL url = new URL(signedRequest.convertToURL());
+
         Assert.assertEquals("https", url.getProtocol());
         Assert.assertEquals("sts.amazonaws.com", url.getHost());
         Map<String, String> generatedQueryParams = GetCallerIdentityV4PresignerTest.getQueryParams(url.getQuery());
@@ -75,7 +77,7 @@ public class GetCallerIdentityV4PresignerTest {
             put("X-Amz-Signature", "[a-f0-9]{64}");
             put("Version", "2011-06-15");
             put("X-Amz-SignedHeaders", "host%3Bx-lakefs-server-id");
-            put("X-Amz-Security-Token", awsCreds.getSessionToken());
+            put("X-Amz-Security-Token", GetCallerIdentityV4Presigner.urlEncode(awsCreds.getSessionToken(), false));
             put("X-Amz-Credential", awsCreds.getAWSAccessKeyId() + "%2F\\d{8}%2Fus-east-1%2Fsts%2Faws4_request");
             put("X-Amz-Expires", "60");
         }};
@@ -84,7 +86,7 @@ public class GetCallerIdentityV4PresignerTest {
         for (Map.Entry<String, String> entry : paramsExpected.entrySet()) {
             String expectedKey = entry.getKey();
             String expectedValuePattern = entry.getValue();
-            Assert.assertEquals(String.format("URL %s does not contain param %s", url, expectedKey), true, generatedQueryParams.containsKey(expectedKey));
+            Assert.assertEquals(String.format("missing param %s in URL %s", expectedKey, url), true, generatedQueryParams.containsKey(expectedKey));
             Pattern compiledPattern = Pattern.compile(expectedValuePattern);
             Matcher matcher = compiledPattern.matcher(generatedQueryParams.get(expectedKey));
             Assert.assertEquals(String.format("Query param %s does not match \npattern: %s", generatedQueryParams.get(expectedKey), expectedValuePattern), true, matcher.matches());


### PR DESCRIPTION
Our hadoop-lakeFS supports hadoop 2 and 3 contracts and introduces the following dependencies: 
1. Hadoop-AWS 2 - AWS SDK 1.7.7 
2. Hadoop-AWS 3 - AWS SDK 1.11+ 

Those AWS SDK versions has breaking changes between them. 
When working with AWS SDK that means the code will not compile. 
To solve this issue I copied the minimal as possible code required to make it work on both versions. 
