### PR TITLE
Walk over hidden files in `lakectl local`

### DIFF
--- a/pkg/local/diff.go
+++ b/pkg/local/diff.go
@@ -13,6 +13,7 @@ import (
 	"github.com/treeverse/lakefs/pkg/api/apigen"
 	"github.com/treeverse/lakefs/pkg/block"
 	"github.com/treeverse/lakefs/pkg/block/local"
+	"github.com/treeverse/lakefs/pkg/block/params"
 	"github.com/treeverse/lakefs/pkg/uri"
 )
 
@@ -202,14 +203,11 @@ func DiffLocalWithHead(left <-chan apigen.ObjectStats, rightPath string) (Change
 		return nil, err
 	}
 	uri := url.URL{Scheme: "local", Path: absPath}
-	adapter, err := local.NewAdapter("", local.WithRemoveEmptyDir(false), local.WithAllowedExternalPrefixes([]string{absPath}))
-	if err != nil {
-		return nil, err
-	}
-	reader, err := adapter.GetWalker(&uri)
-	if err != nil {
-		return nil, err
-	}
+	reader := local.NewLocalWalker(params.Local{
+		ImportEnabled:           false,
+		ImportHidden:            true,
+		AllowedExternalPrefixes: []string{absPath},
+	})
 	err = reader.Walk(context.Background(), &uri, block.WalkOptions{}, func(e block.ObjectStoreEntry) error {
 		info, err := os.Stat(e.FullKey)
 		if err != nil {

--- a/pkg/local/diff_test.go
+++ b/pkg/local/diff_test.go
@@ -30,11 +30,14 @@ func TestDiffLocal(t *testing.T) {
 			LocalPath: "testdata/localdiff/t1",
 			RemoteList: []apigen.ObjectStats{
 				{
+					Path:      ".hidden-file",
+					SizeBytes: swag.Int64(64),
+					Mtime:     diffTestCorrectTime,
+				}, {
 					Path:      "sub/f.txt",
 					SizeBytes: swag.Int64(3),
 					Mtime:     diffTestCorrectTime,
-				},
-				{
+				}, {
 					Path:      "sub/folder/f.txt",
 					SizeBytes: swag.Int64(6),
 					Mtime:     diffTestCorrectTime,
@@ -47,11 +50,14 @@ func TestDiffLocal(t *testing.T) {
 			LocalPath: "testdata/localdiff/t1",
 			RemoteList: []apigen.ObjectStats{
 				{
+					Path:      ".hidden-file",
+					SizeBytes: swag.Int64(64),
+					Mtime:     diffTestCorrectTime,
+				}, {
 					Path:      "sub/f.txt",
 					SizeBytes: swag.Int64(3),
 					Mtime:     169095766,
-				},
-				{
+				}, {
 					Path:      "sub/folder/f.txt",
 					SizeBytes: swag.Int64(12),
 					Mtime:     1690957665,
@@ -61,8 +67,7 @@ func TestDiffLocal(t *testing.T) {
 				{
 					Path: "sub/f.txt",
 					Type: local.ChangeTypeModified,
-				},
-				{
+				}, {
 					Path: "sub/folder/f.txt",
 					Type: local.ChangeTypeModified,
 				},
@@ -73,6 +78,10 @@ func TestDiffLocal(t *testing.T) {
 			LocalPath: "testdata/localdiff/t1",
 			RemoteList: []apigen.ObjectStats{
 				{
+					Path:      ".hidden-file",
+					SizeBytes: swag.Int64(64),
+					Mtime:     diffTestCorrectTime,
+				}, {
 					Path:      "sub/folder/f.txt",
 					SizeBytes: swag.Int64(6),
 					Mtime:     diffTestCorrectTime,
@@ -88,12 +97,15 @@ func TestDiffLocal(t *testing.T) {
 		{
 			Name:      "t1_local_after",
 			LocalPath: "testdata/localdiff/t1",
-			RemoteList: []apigen.ObjectStats{
-				{
-					Path:      "tub/r.txt",
-					SizeBytes: swag.Int64(6),
-					Mtime:     1690957665,
-				},
+			RemoteList: []apigen.ObjectStats{{
+				Path:      ".hidden-file",
+				SizeBytes: swag.Int64(64),
+				Mtime:     diffTestCorrectTime,
+			}, {
+				Path:      "tub/r.txt",
+				SizeBytes: swag.Int64(6),
+				Mtime:     1690957665,
+			},
 			},
 			Expected: []*local.Change{
 				{
@@ -107,6 +119,31 @@ func TestDiffLocal(t *testing.T) {
 				{
 					Path: "tub/r.txt",
 					Type: local.ChangeTypeRemoved,
+				},
+			},
+		},
+		{
+			Name:      "t1_hidden_changed",
+			LocalPath: "testdata/localdiff/t1",
+			RemoteList: []apigen.ObjectStats{
+				{
+					Path:      ".hidden-file",
+					SizeBytes: swag.Int64(17),
+					Mtime:     diffTestCorrectTime,
+				}, {
+					Path:      "sub/f.txt",
+					SizeBytes: swag.Int64(3),
+					Mtime:     diffTestCorrectTime,
+				}, {
+					Path:      "sub/folder/f.txt",
+					SizeBytes: swag.Int64(6),
+					Mtime:     diffTestCorrectTime,
+				},
+			},
+			Expected: []*local.Change{
+				{
+					Path: ".hidden-file",
+					Type: local.ChangeTypeModified,
 				},
 			},
 		},

--- a/pkg/local/testdata/localdiff/t1/.hidden-file
+++ b/pkg/local/testdata/localdiff/t1/.hidden-file
@@ -1,0 +1,1 @@
+This file is hidden in POSIX.  It still counts for diff, though!


### PR DESCRIPTION

This was mistakenly removed.  Tests in next commit.

Fixes #7641.
