### PR TITLE
Azure: Add support for Gov Cloud

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -35,9 +35,6 @@ This reference uses `.` to denote the nesting of values.
 * `actions.lua.net_http_enabled` `(bool : false)` - Setting this to true will load the `net/http` package.
 * `actions.env.enabled` `(bool : true)` - Environment variables accessible by hooks, disabled values evaluated to empty strings
 * `actions.env.prefix` `(string : "LAKEFSACTION_")` - Access to environment variables is restricted to those with the prefix. When environment access is enabled and no prefix is provided, all variables are accessible.
-
-  **Note:** Deprecated - See `database` section
-  {: .note }
 * `database` - Configuration section for the lakeFS key-value store database
   + `database.type` `(string ["postgres"|"dynamodb"|"cosmosdb"|"local"] : )` - 
     lakeFS database type
@@ -132,7 +129,10 @@ This reference uses `.` to denote the nesting of values.
 * `blockstore.azure.pre_signed_expiry` `(time duration : "15m")` - Expiry of pre-signed URL.
 * `blockstore.azure.disable_pre_signed` `(bool : false)` - Disable use of pre-signed URL.
 * `blockstore.azure.disable_pre_signed_ui` `(bool : true)` - Disable use of pre-signed URL in the UI.
-* `blockstore.azure.china_cloud` `(bool : false)` - Enable for using lakeFS on Azure China Cloud.
+* ~~`blockstore.azure.china_cloud` `(bool : false)`~~ - Enable for using lakeFS on Azure China Cloud.  
+  **Note:** Deprecated - In favor of `blockstore.azure.domain` 
+  {: .note }
+* `blockstore.azure.domain` `(string : blob.core.windows.net)` - Enables support of different Azure cloud domains. Current supported domains: [`blob.core.chinacloudapi.cn`, `blob.core.usgovcloudapi.net`]
 * `blockstore.s3.region` `(string : "us-east-1")` - Default region for lakeFS to use when interacting with S3.
 * `blockstore.s3.profile` `(string : )` - If specified, will be used as a [named credentials profile](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html#cli-configure-files-using-profiles)
 * `blockstore.s3.credentials_file` `(string : )` - If specified, will be used as a [credentials file](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html)

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -132,7 +132,7 @@ This reference uses `.` to denote the nesting of values.
 * ~~`blockstore.azure.china_cloud` `(bool : false)`~~ - Enable for using lakeFS on Azure China Cloud.  
   **Note:** Deprecated - In favor of `blockstore.azure.domain` 
   {: .note }
-* `blockstore.azure.domain` `(string : blob.core.windows.net)` - Enables support of different Azure cloud domains. Current supported domains: [`blob.core.chinacloudapi.cn`, `blob.core.usgovcloudapi.net`]
+* `blockstore.azure.domain` `(string : blob.core.windows.net)` - Enables support of different Azure cloud domains. Current supported domains (in Beta stage): [`blob.core.chinacloudapi.cn`, `blob.core.usgovcloudapi.net`]
 * `blockstore.s3.region` `(string : "us-east-1")` - Default region for lakeFS to use when interacting with S3.
 * `blockstore.s3.profile` `(string : )` - If specified, will be used as a [named credentials profile](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html#cli-configure-files-using-profiles)
 * `blockstore.s3.credentials_file` `(string : )` - If specified, will be used as a [credentials file](https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html)

--- a/pkg/actions/lua/storage/azure/blob.go
+++ b/pkg/actions/lua/storage/azure/blob.go
@@ -27,7 +27,6 @@ func newBlobClient(ctx context.Context) lua.Function {
 	return func(l *lua.State) int {
 		storageAccount := lua.CheckString(l, 1)
 		accessKey := lua.CheckString(l, 2)
-
 		azClient, err := azure.BuildAzureServiceClient(params.Azure{
 			StorageAccount:   storageAccount,
 			StorageAccessKey: accessKey,

--- a/pkg/api/helpers/upload.go
+++ b/pkg/api/helpers/upload.go
@@ -422,6 +422,7 @@ func isAzureBlobURL(u string) bool {
 	if err != nil {
 		return false
 	}
+	// TODO (niro): Handle better
 	return strings.HasSuffix(parsedURL.Host, ".blob.core.")
 }
 

--- a/pkg/api/helpers/upload.go
+++ b/pkg/api/helpers/upload.go
@@ -12,7 +12,6 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/textproto"
-	"net/url"
 	"path/filepath"
 	"strings"
 
@@ -419,11 +418,7 @@ func ClientUploadPreSign(ctx context.Context, client apigen.ClientWithResponsesI
 }
 
 func isAzureBlobURL(u string) bool {
-	parsedURL, err := url.Parse(u)
-	if err != nil {
-		return false
-	}
-	_, _, err = azure.ParseURL(parsedURL.String())
+	_, _, err := azure.ParseURL(u)
 	return err == nil
 }
 

--- a/pkg/api/helpers/upload.go
+++ b/pkg/api/helpers/upload.go
@@ -19,6 +19,7 @@ import (
 	"github.com/go-openapi/swag"
 	"github.com/treeverse/lakefs/pkg/api/apigen"
 	"github.com/treeverse/lakefs/pkg/api/apiutil"
+	"github.com/treeverse/lakefs/pkg/block/azure"
 	"github.com/treeverse/lakefs/pkg/httputil"
 	"golang.org/x/sync/errgroup"
 )
@@ -422,8 +423,8 @@ func isAzureBlobURL(u string) bool {
 	if err != nil {
 		return false
 	}
-	// TODO (niro): Handle better
-	return strings.HasSuffix(parsedURL.Host, ".blob.core.")
+	_, _, err = azure.ParseURL(parsedURL.String())
+	return err == nil
 }
 
 // extractEtagFromResponseHeader extracts the ETag from the response header.

--- a/pkg/api/helpers/upload.go
+++ b/pkg/api/helpers/upload.go
@@ -422,7 +422,7 @@ func isAzureBlobURL(u string) bool {
 	if err != nil {
 		return false
 	}
-	return strings.HasSuffix(parsedURL.Host, ".blob.core.windows.net")
+	return strings.HasSuffix(parsedURL.Host, ".blob.core.")
 }
 
 // extractEtagFromResponseHeader extracts the ETag from the response header.

--- a/pkg/api/helpers/upload.go
+++ b/pkg/api/helpers/upload.go
@@ -12,6 +12,7 @@ import (
 	"mime/multipart"
 	"net/http"
 	"net/textproto"
+	"net/url"
 	"path/filepath"
 	"strings"
 
@@ -348,7 +349,7 @@ func (u *presignUpload) uploadObject(ctx context.Context) (*apigen.ObjectStats, 
 	if u.contentType != "" {
 		req.Header.Set("Content-Type", u.contentType)
 	}
-	if isAzureBlobURL(preSignURL) {
+	if isAzureBlobURL(req.URL) {
 		req.Header.Set("x-ms-blob-type", "BlockBlob")
 	}
 
@@ -417,7 +418,7 @@ func ClientUploadPreSign(ctx context.Context, client apigen.ClientWithResponsesI
 	}
 }
 
-func isAzureBlobURL(u string) bool {
+func isAzureBlobURL(u *url.URL) bool {
 	_, _, err := azure.ParseURL(u)
 	return err == nil
 }

--- a/pkg/block/azure/adapter.go
+++ b/pkg/block/azure/adapter.go
@@ -637,15 +637,21 @@ func (a *Adapter) ListParts(_ context.Context, _ block.ObjectPointer, _ string, 
 // ParseURL - parses url and extracts account name and domain. If either are not found returns an error
 func ParseURL(uri *url.URL) (accountName string, domain string, err error) {
 	u, err := uri.Parse("")
+	if err != nil {
+		return "", "", err
+	}
+
 	u.RawQuery = ""
 	matches := endpointRegex.FindStringSubmatch(u.String())
 	if matches == nil {
 		return "", "", ErrAzureInvalidURL
 	}
+
 	domainIdx := endpointRegex.SubexpIndex("domain")
 	if domainIdx < 0 {
 		return "", "", fmt.Errorf("invalid domain: %w", ErrInvalidDomain)
 	}
+
 	accountIdx := endpointRegex.SubexpIndex("account")
 	if accountIdx < 0 {
 		return "", "", fmt.Errorf("missing storage account: %w", ErrAzureInvalidURL)

--- a/pkg/block/azure/adapter.go
+++ b/pkg/block/azure/adapter.go
@@ -222,7 +222,7 @@ func (a *Adapter) GetWalker(uri *url.URL) (block.Walker, error) {
 		return nil, err
 	}
 
-	storageAccount, domain, err := ParseURL(uri.String())
+	storageAccount, domain, err := ParseURL(uri)
 	if err != nil {
 		return nil, err
 	}
@@ -634,9 +634,11 @@ func (a *Adapter) ListParts(_ context.Context, _ block.ObjectPointer, _ string, 
 	return nil, block.ErrOperationNotSupported
 }
 
-// ParseURL - parses raw string and extracts account name and domain. If either are not found returns an error
-func ParseURL(raw string) (accountName string, domain string, err error) {
-	matches := endpointRegex.FindStringSubmatch(raw)
+// ParseURL - parses url and extracts account name and domain. If either are not found returns an error
+func ParseURL(uri *url.URL) (accountName string, domain string, err error) {
+	u, err := uri.Parse("")
+	u.RawQuery = ""
+	matches := endpointRegex.FindStringSubmatch(u.String())
 	if matches == nil {
 		return "", "", ErrAzureInvalidURL
 	}

--- a/pkg/block/azure/adapter.go
+++ b/pkg/block/azure/adapter.go
@@ -33,6 +33,9 @@ const (
 	udcCacheSize = 5000
 
 	BlobEndpointDefaultDomain = "blob.core.windows.net"
+	BlobEndpointChinaDomain   = "blob.core.chinacloudapi.cn"
+	BlobEndpointUSGovDomain   = "blob.core.usgovcloudapi.net"
+	BlobEndpointTestDomain    = "azurite.test"
 )
 
 var (
@@ -40,10 +43,10 @@ var (
 
 	endpointRegex      = regexp.MustCompile(`https://(?P<account>[\w]+).(?P<domain>[\w.-]+)[/:][\w-/]*$`)
 	supportedEndpoints = []string{
-		"blob.core.windows.net",
-		"blob.core.chinacloudapi.cn",
-		"blob.core.usgovcloudapi.net",
-		"azurite.test",
+		BlobEndpointDefaultDomain,
+		BlobEndpointChinaDomain,
+		BlobEndpointUSGovDomain,
+		BlobEndpointTestDomain,
 	}
 )
 

--- a/pkg/block/azure/adapter.go
+++ b/pkg/block/azure/adapter.go
@@ -60,17 +60,18 @@ func NewAdapter(ctx context.Context, params params.Azure) (*Adapter, error) {
 	if preSignedExpiry == 0 {
 		preSignedExpiry = block.DefaultPreSignExpiryDuration
 	}
+
 	if params.Domain == "" {
 		params.Domain = BlobEndpointDefaultDomain
-	} else {
-		if !slices.Contains(supportedEndpoints, params.Domain) {
-			return nil, ErrInvalidDomain
-		}
+	} else if !slices.Contains(supportedEndpoints, params.Domain) {
+		return nil, ErrInvalidDomain
 	}
+
 	cache, err := NewCache(params)
 	if err != nil {
 		return nil, err
 	}
+
 	return &Adapter{
 		clientCache:        cache,
 		preSignedExpiry:    preSignedExpiry,

--- a/pkg/block/azure/adapter.go
+++ b/pkg/block/azure/adapter.go
@@ -41,8 +41,8 @@ const (
 var (
 	ErrInvalidDomain = errors.New("invalid Azure Domain")
 
-	endpointRegex      = regexp.MustCompile(`https://(?P<account>[\w]+).(?P<domain>[\w.-]+)[/:][\w-/]*$`)
-	supportedEndpoints = []string{
+	endpointRegex    = regexp.MustCompile(`https://(?P<account>[\w]+).(?P<domain>[\w.-]+)[/:][\w-/]*$`)
+	supportedDomains = []string{
 		BlobEndpointDefaultDomain,
 		BlobEndpointChinaDomain,
 		BlobEndpointUSGovDomain,
@@ -66,7 +66,7 @@ func NewAdapter(ctx context.Context, params params.Azure) (*Adapter, error) {
 
 	if params.Domain == "" {
 		params.Domain = BlobEndpointDefaultDomain
-	} else if !slices.Contains(supportedEndpoints, params.Domain) {
+	} else if !slices.Contains(supportedDomains, params.Domain) {
 		return nil, ErrInvalidDomain
 	}
 

--- a/pkg/block/azure/adapter_test.go
+++ b/pkg/block/azure/adapter_test.go
@@ -44,6 +44,13 @@ func TestAdapterNamespace(t *testing.T) {
 			Success:   true,
 		},
 		{
+			Name: "valid_https_presign",
+			Namespace: "https://esti.blob.core.windows.net/esti-system-testing/11484/29538/coddo7tpocvujsvjhhjg/repo-coddo7tpocvujsvjhhj0/data/ggq2f8tpocvs73ftd1qg/" +
+				"coddo7tpocvs73ftd7u0?se=2024-04-13T19%3A40%3A19Z&sig=r%2BV3wR16PUG74U7wxZ1KknhRT%2BO2JqVJM0EVTuJbz8U%3D&ske=2024-04-13T20%3A40%3A19Z&" +
+				"skoid=d8193925-4108-40a0-8d76-0c6d3ceb1f61&sks=b&skt=2024-04-13T19%3A25%3A09Z&sktid=***&skv=2023-08-03&sp=raw&spr=https&sr=b&sv=2021-12-02",
+			Success: true,
+		},
+		{
 			Name:      "valid_https",
 			Namespace: "https://test.blob.core.windows.net/container1/repo1",
 			Success:   false,
@@ -133,6 +140,72 @@ func TestAdapterNamespace(t *testing.T) {
 			require.NoError(t, err)
 
 			require.Equal(t, tt.Success, expr.MatchString(tt.Namespace))
+		})
+	}
+}
+
+func TestAzureParseURL(t *testing.T) {
+	tests := []struct {
+		Name          string
+		Url           string
+		Account       string
+		Domain        string
+		InvalidDomain bool
+	}{
+		{
+			Name:    "valid_https",
+			Url:     "https://account1.blob.core.windows.net/container1/repo1",
+			Account: "account1",
+			Domain:  azure.BlobEndpointDefaultDomain,
+		},
+		{
+			Name: "valid_https_presign",
+			Url: "https://test.blob.core.windows.net/esti-system-testing/11484/29538/coddo7tpocvujsvjhhjg/repo-coddo7tpocvujsvjhhj0/data/ggq2f8tpocvs73ftd1qg/coddo7tpocvs73ftd7u0?" +
+				"se=2024-04-13T19%3A40%3A19Z&sig=r%2BV3wR16PUG74U7wxZ1KknhRT%2BO2JqVJM0EVTuJbz8U%3D&ske=2024-04-13T20%3A40%3A19Z&skoid=d8193925-4108-40a0-8d76-0c6d3ceb1f61&" +
+				"sks=b&skt=2024-04-13T19%3A25%3A09Z&sktid=***&skv=2023-08-03&sp=raw&spr=https&sr=b&sv=2021-12-02",
+			Account: "test",
+			Domain:  azure.BlobEndpointDefaultDomain,
+		},
+		{
+			Name:    "valid_china_https",
+			Url:     "https://china.blob.core.chinacloudapi.cn/container1/repo1",
+			Account: "china",
+			Domain:  azure.BlobEndpointChinaDomain,
+		},
+		{
+			Name:    "valid_usgov_https",
+			Url:     "https://mygov.blob.core.usgovcloudapi.net/container1/repo1",
+			Account: "mygov",
+			Domain:  azure.BlobEndpointUSGovDomain,
+		},
+		{
+			Name:    "valid_other_https",
+			Url:     "https://koala.blob.core.australiacloudapi.net/container1/repo1",
+			Account: "koala",
+			Domain:  "blob.core.australiacloudapi.net",
+		},
+		{
+			Name:          "invalid_http",
+			Url:           "http://mygov.blob.core.usgovcloudapi.net/container1/repo1",
+			InvalidDomain: true,
+		},
+		{
+			Name:          "invalid_url_s3",
+			Url:           "s3://example/bar/baz",
+			InvalidDomain: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.Name, func(t *testing.T) {
+			uri, err := url.Parse(tt.Url)
+			account, dom, err := azure.ParseURL(uri)
+			if tt.InvalidDomain {
+				require.ErrorIs(t, err, azure.ErrAzureInvalidURL)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tt.Account, account)
+				require.Equal(t, tt.Domain, dom)
+			}
 		})
 	}
 }

--- a/pkg/block/azure/client_cache.go
+++ b/pkg/block/azure/client_cache.go
@@ -3,7 +3,6 @@ package azure
 import (
 	"context"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -125,13 +124,10 @@ func BuildAzureServiceClient(params params.Azure) (*service.Client, error) {
 	var endpoint string
 	if params.Domain == "" {
 		params.Domain = BlobEndpointDefaultDomain
-	} else {
-		domain := strings.TrimSuffix(params.Domain, "/")
-		if !slices.Contains(supportedEndpoints, domain) {
-			return nil, ErrInvalidDomain
-		}
-		params.Domain = domain
+	} else if !slices.Contains(supportedEndpoints, params.Domain) {
+		return nil, ErrInvalidDomain
 	}
+
 	if params.TestEndpointURL != "" { // For testing purposes - override default endpoint template
 		endpoint = params.TestEndpointURL
 	} else {

--- a/pkg/block/azure/client_cache.go
+++ b/pkg/block/azure/client_cache.go
@@ -124,7 +124,7 @@ func BuildAzureServiceClient(params params.Azure) (*service.Client, error) {
 	var endpoint string
 	if params.Domain == "" {
 		params.Domain = BlobEndpointDefaultDomain
-	} else if !slices.Contains(supportedEndpoints, params.Domain) {
+	} else if !slices.Contains(supportedDomains, params.Domain) {
 		return nil, ErrInvalidDomain
 	}
 

--- a/pkg/block/azure/main_test.go
+++ b/pkg/block/azure/main_test.go
@@ -19,6 +19,7 @@ const (
 	containerName                  = "container1"
 	accountName                    = "account1"
 	accountKey                     = "key1"
+	domain                         = "azurite.test" // TLD for test
 )
 
 var (
@@ -26,7 +27,7 @@ var (
 	blockURL string
 )
 
-func createDNSResolver(domain string) {
+func createDNSResolver() {
 	zone := dns.Zone{
 		Origin: domain + ".",
 		TTL:    5 * time.Minute,
@@ -59,10 +60,8 @@ func runAzurite(dockerPool *dockertest.Pool) (string, func()) {
 		panic(err)
 	}
 
-	domain := "azurite.test" // TLD for test
 	accountHost := accountName + "." + domain
-
-	createDNSResolver(domain)
+	createDNSResolver()
 
 	// set cleanup
 	closer := func() {

--- a/pkg/block/azure/main_test.go
+++ b/pkg/block/azure/main_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 	"github.com/benburkert/dns"
 	"github.com/ory/dockertest/v3"
+	"github.com/treeverse/lakefs/pkg/block/azure"
 )
 
 const (
@@ -19,7 +20,7 @@ const (
 	containerName                  = "container1"
 	accountName                    = "account1"
 	accountKey                     = "key1"
-	domain                         = "azurite.test" // TLD for test
+	domain                         = azure.BlobEndpointTestDomain // TLD for test
 )
 
 var (

--- a/pkg/block/params/block.go
+++ b/pkg/block/params/block.go
@@ -77,8 +77,8 @@ type Azure struct {
 	PreSignedExpiry    time.Duration
 	DisablePreSigned   bool
 	DisablePreSignedUI bool
-	// Azure China Cloud has different endpoints, different services and it's isolated from Azure Global Cloud
-	ChinaCloud bool
 	// TestEndpointURL - For testing purposes, provide a custom URL to override the default URL template
 	TestEndpointURL string
+	// Domain - Azure cloud domain
+	Domain string
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -259,9 +259,11 @@ type Config struct {
 			PreSignedExpiry    time.Duration `mapstructure:"pre_signed_expiry"`
 			DisablePreSigned   bool          `mapstructure:"disable_pre_signed"`
 			DisablePreSignedUI bool          `mapstructure:"disable_pre_signed_ui"`
-			ChinaCloud         bool          `mapstructure:"china_cloud"`
-			// TestEndpointURL for testing purposes
+			// Deprecated: Value ignored
+			ChinaCloud      bool   `mapstructure:"china_cloud"`
 			TestEndpointURL string `mapstructure:"test_endpoint_url"`
+			// Domain by default points to Azure default domain blob.core.windows.net, can be set to other Azure domains (China/Gov)
+			Domain string `mapstructure:"domain"`
 		} `mapstructure:"azure"`
 		GS *struct {
 			S3Endpoint         string        `mapstructure:"s3_endpoint"`
@@ -509,7 +511,7 @@ func (c *Config) BlockstoreAzureParams() (blockparams.Azure, error) {
 		logging.ContextUnavailable().Warn("blockstore.azure.auth_method is deprecated. Value is no longer used.")
 	}
 	if c.Blockstore.Azure.ChinaCloud {
-		logging.ContextUnavailable().Warn("blockstore.azure.china_cloud is enabled. lakeFS will only function on Azure China Cloud")
+		logging.ContextUnavailable().Warn("blockstore.azure.china_cloud is deprecated. Value is no longer used.")
 	}
 	return blockparams.Azure{
 		StorageAccount:     c.Blockstore.Azure.StorageAccount,
@@ -517,9 +519,9 @@ func (c *Config) BlockstoreAzureParams() (blockparams.Azure, error) {
 		TryTimeout:         c.Blockstore.Azure.TryTimeout,
 		PreSignedExpiry:    c.Blockstore.Azure.PreSignedExpiry,
 		TestEndpointURL:    c.Blockstore.Azure.TestEndpointURL,
+		Domain:             c.Blockstore.Azure.Domain,
 		DisablePreSigned:   c.Blockstore.Azure.DisablePreSigned,
 		DisablePreSignedUI: c.Blockstore.Azure.DisablePreSignedUI,
-		ChinaCloud:         c.Blockstore.Azure.ChinaCloud,
 	}, nil
 }
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -260,8 +260,8 @@ type Config struct {
 			DisablePreSigned   bool          `mapstructure:"disable_pre_signed"`
 			DisablePreSignedUI bool          `mapstructure:"disable_pre_signed_ui"`
 			// Deprecated: Value ignored
-			ChinaCloud      bool   `mapstructure:"china_cloud"`
-			TestEndpointURL string `mapstructure:"test_endpoint_url"`
+			ChinaCloudDeprecated bool   `mapstructure:"china_cloud"`
+			TestEndpointURL      string `mapstructure:"test_endpoint_url"`
 			// Domain by default points to Azure default domain blob.core.windows.net, can be set to other Azure domains (China/Gov)
 			Domain string `mapstructure:"domain"`
 		} `mapstructure:"azure"`
@@ -510,8 +510,9 @@ func (c *Config) BlockstoreAzureParams() (blockparams.Azure, error) {
 	if c.Blockstore.Azure.AuthMethod != "" {
 		logging.ContextUnavailable().Warn("blockstore.azure.auth_method is deprecated. Value is no longer used.")
 	}
-	if c.Blockstore.Azure.ChinaCloud {
-		logging.ContextUnavailable().Warn("blockstore.azure.china_cloud is deprecated. Value is no longer used.")
+	if c.Blockstore.Azure.ChinaCloudDeprecated {
+		logging.ContextUnavailable().Warn("blockstore.azure.china_cloud is deprecated. Value is no longer used. Please pass Domain = 'blob.core.chinacloudapi.cn'")
+		c.Blockstore.Azure.Domain = "blob.core.chinacloudapi.cn"
 	}
 	return blockparams.Azure{
 		StorageAccount:     c.Blockstore.Azure.StorageAccount,


### PR DESCRIPTION
Closes #7662 

## Change Description

### Background

Add support for Azure users using the Gov Cloud endpoint
      
### New Feature

Add support for additional Azure cloud endpoints in a more modular way

### Testing Details

Added tests for the namespace and endpoint validations
Very hard to actually test usage as we have no access to the gov cloud endpoint

### Breaking Change?

No - but we have depracated the China cloud configuration flag

