### PR TITLE
fix: close resp body in lua s3 client

### DIFF
--- a/pkg/actions/lua/storage/aws/s3.go
+++ b/pkg/actions/lua/storage/aws/s3.go
@@ -150,6 +150,7 @@ func (c *S3Client) GetObject(l *lua.State) int {
 		lua.Errorf(l, "%s", err.Error())
 		panic("unreachable")
 	}
+	defer resp.Body.Close()
 	data, err := io.ReadAll(resp.Body)
 	if err != nil {
 		lua.Errorf(l, "%s", err.Error())


### PR DESCRIPTION
Body response is not closed in lua aws s3 client