### PR TITLE
lakectl - HTTP Client Supporting Retries

### DIFF
--- a/cmd/lakectl/cmd/retry_client.go
+++ b/cmd/lakectl/cmd/retry_client.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	"context"
+	"crypto/x509"
+	"net/http"
+	"net/url"
+	"regexp"
+	"time"
+
+	"github.com/hashicorp/go-retryablehttp"
+)
+
+var (
+	// these errors aren't typed, so we match by regexp
+	redirectsErrorRe  = regexp.MustCompile(`stopped after \d+ redirects\z`)
+	schemeErrorRe     = regexp.MustCompile(`unsupported protocol scheme`)
+	notTrustedErrorRe = regexp.MustCompile(`certificate is not trusted`)
+)
+
+func NewRetryClient(maxRetries int, retryWaitMin, retryWaitMax time.Duration, transport *http.Transport) *http.Client {
+	retryClient := retryablehttp.NewClient()
+	if transport != nil {
+		retryClient.HTTPClient.Transport = transport
+	}
+	retryClient.RetryMax = maxRetries
+	retryClient.RetryWaitMin = retryWaitMin
+	retryClient.RetryWaitMax = retryWaitMax
+	retryClient.CheckRetry = lakectlRetryPolicy
+	return retryClient.StandardClient()
+}
+
+// lakectl retry policy - we retry in the following cases:
+// HTTP status 429 - too many requests
+// HTTP status 500 - internal server error - could be recoverable
+// HTTP status 503 - service unavailable
+// We retry on all client transport errors except for:
+//   - too many redirects
+//   - invalid http scheme/protocol
+//   - TLS cert verification failure
+func lakectlRetryPolicy(ctx context.Context, resp *http.Response, err error) (bool, error) {
+	// do not retry on context.Canceled or context.DeadlineExceeded
+	if ctx.Err() != nil {
+		return false, ctx.Err()
+	}
+
+	// handle client transport errors
+	if err != nil {
+		if v, ok := err.(*url.Error); ok {
+			if redirectsErrorRe.MatchString(v.Error()) || // too many redirects
+				schemeErrorRe.MatchString(v.Error()) || // invalid http scheme/protocol
+				notTrustedErrorRe.MatchString(v.Error()) { // TLS cert verification failure
+				return false, v
+			}
+
+			if _, ok := v.Err.(x509.UnknownAuthorityError); ok {
+				return false, v
+			}
+		}
+
+		return true, nil
+	}
+
+	// handle HTTP response status code
+	if resp.StatusCode == http.StatusTooManyRequests ||
+		resp.StatusCode == http.StatusInternalServerError ||
+		resp.StatusCode == http.StatusServiceUnavailable {
+		return true, nil
+	}
+
+	return false, nil
+}

--- a/cmd/lakectl/cmd/retry_client_test.go
+++ b/cmd/lakectl/cmd/retry_client_test.go
@@ -1,0 +1,236 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	tooManyRedirectsErrorMessage = "stopped after 5 redirects"
+	someRandomErrorMessage       = "random error message"
+	testURL                      = "https://example.com"
+)
+
+func TestLakectlRetryPolicy(t *testing.T) {
+	testCases := []struct {
+		name                string
+		getTestContext      func() context.Context
+		resp                *http.Response
+		err                 error
+		expectedShouldRetry bool
+		expectedError       string
+	}{
+		{
+			name: "Context Error - Context Deadline Exceeded",
+			getTestContext: func() context.Context {
+				ctx := context.Background()
+				ctx, c := context.WithDeadline(ctx, time.Now().Add(-7*time.Hour))
+				c()
+				return ctx
+			},
+			resp:                nil,
+			err:                 nil,
+			expectedShouldRetry: false,
+			expectedError:       context.DeadlineExceeded.Error(),
+		},
+		{
+			name: "Context Error - Context Cancelation",
+			getTestContext: func() context.Context {
+				ctx := context.Background()
+				ctx, c := context.WithCancel(ctx)
+				c()
+				return ctx
+			},
+			resp:                nil,
+			err:                 nil,
+			expectedShouldRetry: false,
+			expectedError:       context.Canceled.Error(),
+		},
+		{
+			name: "Transport Error - Too Many Redirects",
+			getTestContext: func() context.Context {
+				return context.Background()
+			},
+			resp:                nil,
+			err:                 &url.Error{Op: http.MethodGet, URL: testURL, Err: errors.New(tooManyRedirectsErrorMessage)},
+			expectedShouldRetry: false,
+			expectedError:       fmt.Sprintf(`%s "%s": %s`, http.MethodGet, testURL, tooManyRedirectsErrorMessage),
+		},
+		{
+			name: "Transport Error - Random Transport Error",
+			getTestContext: func() context.Context {
+				return context.Background()
+			},
+			resp:                nil,
+			err:                 &url.Error{Op: http.MethodGet, URL: testURL, Err: errors.New(someRandomErrorMessage)},
+			expectedShouldRetry: true,
+			expectedError:       "",
+		},
+		{
+			name: "HTTP Status - 429 Too Many Requests",
+			getTestContext: func() context.Context {
+				return context.Background()
+			},
+			resp: &http.Response{
+				StatusCode: http.StatusTooManyRequests,
+			},
+			err:                 nil,
+			expectedShouldRetry: true,
+			expectedError:       "",
+		},
+		{
+			name: "HTTP Status - 500 Internal Server Error",
+			getTestContext: func() context.Context {
+				return context.Background()
+			},
+			resp: &http.Response{
+				StatusCode: http.StatusInternalServerError,
+			},
+			err:                 nil,
+			expectedShouldRetry: true,
+			expectedError:       "",
+		},
+		{
+			name: "HTTP Status - 503 Service Unavailable",
+			getTestContext: func() context.Context {
+				return context.Background()
+			},
+			resp: &http.Response{
+				StatusCode: http.StatusServiceUnavailable,
+			},
+			err:                 nil,
+			expectedShouldRetry: true,
+			expectedError:       "",
+		},
+		{
+			name: "HTTP Status - 401 Unauthorized",
+			getTestContext: func() context.Context {
+				return context.Background()
+			},
+			resp: &http.Response{
+				StatusCode: http.StatusUnauthorized,
+			},
+			err:                 nil,
+			expectedShouldRetry: false,
+			expectedError:       "",
+		},
+		{
+			name: "HTTP Status - 404 Not Found",
+			getTestContext: func() context.Context {
+				return context.Background()
+			},
+			resp: &http.Response{
+				StatusCode: http.StatusNotFound,
+			},
+			err:                 nil,
+			expectedShouldRetry: false,
+			expectedError:       "",
+		},
+		{
+			name: "HTTP Status - 200 Ok",
+			getTestContext: func() context.Context {
+				return context.Background()
+			},
+			resp: &http.Response{
+				StatusCode: http.StatusOK,
+			},
+			err:                 nil,
+			expectedShouldRetry: false,
+			expectedError:       "",
+		},
+		{
+			name: "HTTP Status - 201 Created",
+			getTestContext: func() context.Context {
+				return context.Background()
+			},
+			resp: &http.Response{
+				StatusCode: http.StatusCreated,
+			},
+			err:                 nil,
+			expectedShouldRetry: false,
+			expectedError:       "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// if tc.err != nil {
+			// 	errStr := tc.err.Error()
+			// 	fmt.Sprintf("%s", errStr)
+			// }
+			shouldRetry, err := lakectlRetryPolicy(tc.getTestContext(), tc.resp, tc.err)
+			require.Equal(t, tc.expectedShouldRetry, shouldRetry)
+			if tc.expectedError != "" {
+				require.EqualError(t, err, tc.expectedError)
+			}
+		})
+	}
+}
+
+func TestRetryHTTPClient(t *testing.T) {
+	retryCount := -1
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.MaxIdleConnsPerHost = DefaultMaxIdleConnsPerHost
+	retryClient := NewRetryClient(10, 10*time.Millisecond, 30*time.Millisecond, transport)
+
+	httpCode := int64(http.StatusTooManyRequests)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		retryCount++
+		w.WriteHeader(int(atomic.LoadInt64(&httpCode)))
+	}))
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+	if err != nil {
+		t.Fatal("failed to create request")
+	}
+
+	var resp *http.Response
+	doneCh := make(chan struct{})
+	errCh := make(chan error, 1)
+	go func() {
+		defer close(doneCh)
+		defer close(errCh)
+		var err error
+		resp, err = retryClient.Do(req)
+		errCh <- err
+	}()
+
+	select {
+	case <-doneCh:
+		t.Fatal("should retry on 429 http status")
+	case <-time.After(200 * time.Millisecond):
+		// Client should be retrying
+	}
+
+	// change response status to 200
+	atomic.StoreInt64(&httpCode, http.StatusOK)
+
+	select {
+	case <-doneCh:
+	case <-time.After(time.Second):
+		t.Fatal("timed out")
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got: %d", resp.StatusCode)
+	}
+
+	if retryCount < 0 {
+		t.Fatal("client did not retry the request")
+	}
+
+	err = <-errCh
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -90,7 +90,7 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.5.0
 	github.com/gorilla/securecookie v1.1.1
 	github.com/gorilla/sessions v1.2.1
-	github.com/hashicorp/go-retryablehttp v0.7.4
+	github.com/hashicorp/go-retryablehttp v0.7.5
 	github.com/hashicorp/go-version v1.6.0
 	github.com/jackc/pgx/v5 v5.4.3
 	github.com/puzpuzpuz/xsync v1.5.2

--- a/go.sum
+++ b/go.sum
@@ -638,6 +638,8 @@ github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+l
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-retryablehttp v0.7.4 h1:ZQgVdpTdAL7WpMIwLzCfbalOcSUdkDZnpUv3/+BxzFA=
 github.com/hashicorp/go-retryablehttp v0.7.4/go.mod h1:Jy/gPYAdjqffZ/yFGCFV2doI5wjtH1ewM9u8iYVjtX8=
+github.com/hashicorp/go-retryablehttp v0.7.5 h1:bJj+Pj19UZMIweq/iie+1u5YCdGrnxCT9yvm0e+Nd5M=
+github.com/hashicorp/go-retryablehttp v0.7.5/go.mod h1:Jy/gPYAdjqffZ/yFGCFV2doI5wjtH1ewM9u8iYVjtX8=
 github.com/hashicorp/go-uuid v0.0.0-20180228145832-27454136f036/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=


### PR DESCRIPTION
Related to #7705 

## Change Description

### Background

See the associated issue for context

### New Feature

This PR is only part of the implementation of #7705, but I've decided this part is reviewable and mergeable as a standalone unit. Hopefully, this will make this and other PRs of this implementation easier to reason about and review.  

This PR creates a new HTTP client for use in lakectl, based on [go-retryablehttp](https://github.com/hashicorp/go-retryablehttp/tree/main). It supports retries with a custom retry policy tailored for lakeFS and an exponential backoff retry strategy. Its constructor func includes several parameters to tune the retry max count and intervals and the option to provide a custom `http.Transport`. For seamless integration later on the constructor returns a standard `*http.Client`.

### Testing Details

This PR includes a suite of tests for the custom retry policy and a single test of the client itself with an `httptest.Server`. I'm not sure if client tests add any value, or maybe we're just retesting things that are already covered by tests in the source repository. **Would like your feedback on this**.  
If we decide they add some additional value, I can create a few more for better coverage.
