### PR TITLE
UI: calculate total size of common prefix

### DIFF
--- a/webui/src/lib/components/controls.jsx
+++ b/webui/src/lib/components/controls.jsx
@@ -63,9 +63,9 @@ export const DebouncedFormControl = React.forwardRef((props, ref) => {
 });
 DebouncedFormControl.displayName = "DebouncedFormControl";
 
-export const Loading = () => {
+export const Loading = ({message = "Loading..."}) => {
     return (
-        <Alert variant={"info"}>Loading...</Alert>
+        <Alert variant={"info"}>{message}</Alert>
     );
 };
 


### PR DESCRIPTION
This adds a "Calculate Size" context button to common prefixes shown in the UI, which would show a total of all objects under a prefix. 

It paginates serially on the client-side, similar to S3's UI.
