### PR TITLE
7705 retryable http client

### DIFF
--- a/cmd/lakectl/cmd/retry_client.go
+++ b/cmd/lakectl/cmd/retry_client.go
@@ -57,7 +57,6 @@ func lakectlRetryPolicy(ctx context.Context, resp *http.Response, err error) (bo
 				return false, v
 			}
 		}
-
 		return true, nil
 	}
 
@@ -67,6 +66,5 @@ func lakectlRetryPolicy(ctx context.Context, resp *http.Response, err error) (bo
 		resp.StatusCode == http.StatusServiceUnavailable {
 		return true, nil
 	}
-
 	return false, nil
 }

--- a/cmd/lakectl/cmd/retry_client.go
+++ b/cmd/lakectl/cmd/retry_client.go
@@ -1,0 +1,72 @@
+package cmd
+
+import (
+	"context"
+	"crypto/x509"
+	"net/http"
+	"net/url"
+	"regexp"
+	"time"
+
+	"github.com/hashicorp/go-retryablehttp"
+)
+
+var (
+	// these errors aren't typed, so we match by regexp
+	redirectsErrorRe  = regexp.MustCompile(`stopped after \d+ redirects\z`)
+	schemeErrorRe     = regexp.MustCompile(`unsupported protocol scheme`)
+	notTrustedErrorRe = regexp.MustCompile(`certificate is not trusted`)
+)
+
+func NewRetryClient(maxRetries int, retryWaitMin, retryWaitMax time.Duration, transport *http.Transport) *http.Client {
+	retryClient := retryablehttp.NewClient()
+	if transport != nil {
+		retryClient.HTTPClient.Transport = transport
+	}
+	retryClient.RetryMax = maxRetries
+	retryClient.RetryWaitMin = retryWaitMin
+	retryClient.RetryWaitMax = retryWaitMax
+	retryClient.CheckRetry = lakectlRetryPolicy
+	return retryClient.StandardClient()
+}
+
+// lakectl retry policy - we retry in the following cases:
+// HTTP status 429 - too many requests
+// HTTP status 500 - internal server error - could be recoverable
+// HTTP status 503 - service unavailable
+// We retry on all client transport errors except for:
+//   - too many redirects
+//   - invalid http scheme/protocol
+//   - TLS cert verification failure
+func lakectlRetryPolicy(ctx context.Context, resp *http.Response, err error) (bool, error) {
+	// do not retry on context.Canceled or context.DeadlineExceeded
+	if ctx.Err() != nil {
+		return false, ctx.Err()
+	}
+
+	// handle client transport errors
+	if err != nil {
+		if v, ok := err.(*url.Error); ok {
+			if redirectsErrorRe.MatchString(v.Error()) || // too many redirects
+				schemeErrorRe.MatchString(v.Error()) || // invalid http scheme/protocol
+				notTrustedErrorRe.MatchString(v.Error()) { // TLS cert verification failure
+				return false, v
+			}
+
+			if _, ok := v.Err.(x509.UnknownAuthorityError); ok {
+				return false, v
+			}
+		}
+
+		return true, nil
+	}
+
+	// handle HTTP response status code
+	if resp.StatusCode == http.StatusTooManyRequests ||
+		resp.StatusCode == http.StatusInternalServerError ||
+		resp.StatusCode == http.StatusServiceUnavailable {
+		return true, nil
+	}
+
+	return false, nil
+}

--- a/cmd/lakectl/cmd/retry_client.go
+++ b/cmd/lakectl/cmd/retry_client.go
@@ -79,7 +79,9 @@ func lakectlRetryPolicy(ctx context.Context, resp *http.Response, err error) (bo
 }
 
 func customErrorHandler(resp *http.Response, err error, _ int) (*http.Response, error) {
-	defer resp.Body.Close()
-	io.Copy(io.Discard, io.LimitReader(resp.Body, respReadLimit)) //nolint:errcheck
+	if resp != nil {
+		defer resp.Body.Close()
+		io.Copy(io.Discard, io.LimitReader(resp.Body, respReadLimit)) //nolint:errcheck
+	}
 	return resp, err
 }

--- a/cmd/lakectl/cmd/retry_client.go
+++ b/cmd/lakectl/cmd/retry_client.go
@@ -59,7 +59,7 @@ func lakectlRetryPolicy(ctx context.Context, resp *http.Response, err error) (bo
 			}
 		}
 		// The stblib http.Client wraps the above errors in a url.Error
-		// If we got a different error, it's likely a retryable transport error like Timeout or Context Cancelation
+		// They aren't retryable. Other errors are retryable.
 		return true, nil
 	}
 

--- a/cmd/lakectl/cmd/retry_client.go
+++ b/cmd/lakectl/cmd/retry_client.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"crypto/x509"
+	"errors"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -50,11 +51,11 @@ func lakectlRetryPolicy(ctx context.Context, resp *http.Response, err error) (bo
 			if redirectsErrorRe.MatchString(v.Error()) || // too many redirects
 				schemeErrorRe.MatchString(v.Error()) || // invalid http scheme/protocol
 				notTrustedErrorRe.MatchString(v.Error()) { // TLS cert verification failure
-				return false, v
+				return false, errors.Unwrap(v)
 			}
 
 			if _, ok := v.Err.(x509.UnknownAuthorityError); ok {
-				return false, v
+				return false, errors.Unwrap(v)
 			}
 		}
 		// The stblib http.Client wraps the above errors in a url.Error

--- a/cmd/lakectl/cmd/retry_client.go
+++ b/cmd/lakectl/cmd/retry_client.go
@@ -23,6 +23,7 @@ func NewRetryClient(maxRetries int, retryWaitMin, retryWaitMax time.Duration, tr
 	if transport != nil {
 		retryClient.HTTPClient.Transport = transport
 	}
+	retryClient.Logger = nil
 	retryClient.RetryMax = maxRetries
 	retryClient.RetryWaitMin = retryWaitMin
 	retryClient.RetryWaitMax = retryWaitMax

--- a/cmd/lakectl/cmd/retry_client_test.go
+++ b/cmd/lakectl/cmd/retry_client_test.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"context"
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"testing"
@@ -61,7 +60,7 @@ func TestLakectlRetryPolicy(t *testing.T) {
 			resp:                nil,
 			err:                 &url.Error{Op: http.MethodGet, URL: testURL, Err: errors.New(tooManyRedirectsErrorMessage)},
 			expectedShouldRetry: false,
-			expectedError:       fmt.Sprintf(`%s "%s": %s`, http.MethodGet, testURL, tooManyRedirectsErrorMessage),
+			expectedError:       tooManyRedirectsErrorMessage,
 		},
 		{
 			name: "Transport Error - Random Transport Error",

--- a/cmd/lakectl/cmd/retry_client_test.go
+++ b/cmd/lakectl/cmd/retry_client_test.go
@@ -1,0 +1,236 @@
+package cmd
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	tooManyRedirectsErrorMessage = "stopped after 5 redirects"
+	someRandomErrorMessage       = "random error message"
+	testURL                      = "https://example.com"
+)
+
+func TestLakectlRetryPolicy(t *testing.T) {
+	testCases := []struct {
+		name                string
+		getTestContext      func() context.Context
+		resp                *http.Response
+		err                 error
+		expectedShouldRetry bool
+		expectedError       string
+	}{
+		{
+			name: "Context Error - Context Deadline Exceeded",
+			getTestContext: func() context.Context {
+				ctx := context.Background()
+				ctx, c := context.WithDeadline(ctx, time.Now().Add(-7*time.Hour))
+				c()
+				return ctx
+			},
+			resp:                nil,
+			err:                 nil,
+			expectedShouldRetry: false,
+			expectedError:       context.DeadlineExceeded.Error(),
+		},
+		{
+			name: "Context Error - Context Cancelation",
+			getTestContext: func() context.Context {
+				ctx := context.Background()
+				ctx, c := context.WithCancel(ctx)
+				c()
+				return ctx
+			},
+			resp:                nil,
+			err:                 nil,
+			expectedShouldRetry: false,
+			expectedError:       context.Canceled.Error(),
+		},
+		{
+			name: "Transport Error - Too Many Redirects",
+			getTestContext: func() context.Context {
+				return context.Background()
+			},
+			resp:                nil,
+			err:                 &url.Error{Op: http.MethodGet, URL: testURL, Err: errors.New(tooManyRedirectsErrorMessage)},
+			expectedShouldRetry: false,
+			expectedError:       fmt.Sprintf(`%s "%s": %s`, http.MethodGet, testURL, tooManyRedirectsErrorMessage),
+		},
+		{
+			name: "Transport Error - Random Transport Error",
+			getTestContext: func() context.Context {
+				return context.Background()
+			},
+			resp:                nil,
+			err:                 &url.Error{Op: http.MethodGet, URL: testURL, Err: errors.New(someRandomErrorMessage)},
+			expectedShouldRetry: true,
+			expectedError:       "",
+		},
+		{
+			name: "HTTP Status - 429 Too Many Requests",
+			getTestContext: func() context.Context {
+				return context.Background()
+			},
+			resp: &http.Response{
+				StatusCode: http.StatusTooManyRequests,
+			},
+			err:                 nil,
+			expectedShouldRetry: true,
+			expectedError:       "",
+		},
+		{
+			name: "HTTP Status - 500 Internal Server Error",
+			getTestContext: func() context.Context {
+				return context.Background()
+			},
+			resp: &http.Response{
+				StatusCode: http.StatusInternalServerError,
+			},
+			err:                 nil,
+			expectedShouldRetry: true,
+			expectedError:       "",
+		},
+		{
+			name: "HTTP Status - 503 Service Unavailable",
+			getTestContext: func() context.Context {
+				return context.Background()
+			},
+			resp: &http.Response{
+				StatusCode: http.StatusServiceUnavailable,
+			},
+			err:                 nil,
+			expectedShouldRetry: true,
+			expectedError:       "",
+		},
+		{
+			name: "HTTP Status - 401 Unauthorized",
+			getTestContext: func() context.Context {
+				return context.Background()
+			},
+			resp: &http.Response{
+				StatusCode: http.StatusUnauthorized,
+			},
+			err:                 nil,
+			expectedShouldRetry: false,
+			expectedError:       "",
+		},
+		{
+			name: "HTTP Status - 404 Not Found",
+			getTestContext: func() context.Context {
+				return context.Background()
+			},
+			resp: &http.Response{
+				StatusCode: http.StatusNotFound,
+			},
+			err:                 nil,
+			expectedShouldRetry: false,
+			expectedError:       "",
+		},
+		{
+			name: "HTTP Status - 200 Ok",
+			getTestContext: func() context.Context {
+				return context.Background()
+			},
+			resp: &http.Response{
+				StatusCode: http.StatusOK,
+			},
+			err:                 nil,
+			expectedShouldRetry: false,
+			expectedError:       "",
+		},
+		{
+			name: "HTTP Status - 201 Created",
+			getTestContext: func() context.Context {
+				return context.Background()
+			},
+			resp: &http.Response{
+				StatusCode: http.StatusCreated,
+			},
+			err:                 nil,
+			expectedShouldRetry: false,
+			expectedError:       "",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// if tc.err != nil {
+			// 	errStr := tc.err.Error()
+			// 	fmt.Sprintf("%s", errStr)
+			// }
+			shouldRetry, err := lakectlRetryPolicy(tc.getTestContext(), tc.resp, tc.err)
+			require.Equal(t, tc.expectedShouldRetry, shouldRetry)
+			if tc.expectedError != "" {
+				require.EqualError(t, err, tc.expectedError)
+			}
+		})
+	}
+}
+
+func TestRetryHTTPClient(t *testing.T) {
+	retryCount := -1
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.MaxIdleConnsPerHost = DefaultMaxIdleConnsPerHost
+	retryClient := NewRetryClient(10, 10*time.Millisecond, 30*time.Millisecond, transport)
+
+	httpCode := int64(http.StatusTooManyRequests)
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		retryCount++
+		w.WriteHeader(int(atomic.LoadInt64(&httpCode)))
+	}))
+	defer server.Close()
+
+	req, err := http.NewRequest(http.MethodGet, server.URL, nil)
+	if err != nil {
+		t.Fatal("failed to create request")
+	}
+
+	var resp *http.Response
+	doneCh := make(chan struct{})
+	errCh := make(chan error, 1)
+	go func() {
+		defer close(doneCh)
+		defer close(errCh)
+		var err error
+		resp, err = retryClient.Do(req)
+		errCh <- err
+	}()
+
+	select {
+	case <-doneCh:
+		t.Fatal("should retry on 429 http status")
+	case <-time.After(200 * time.Millisecond):
+		// Client should be retrying
+	}
+
+	// change response status to 200
+	atomic.StoreInt64(&httpCode, http.StatusOK)
+
+	select {
+	case <-doneCh:
+	case <-time.After(time.Second):
+		t.Fatal("timed out")
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got: %d", resp.StatusCode)
+	}
+
+	if retryCount < 0 {
+		t.Fatal("client did not retry the request")
+	}
+
+	err = <-errCh
+	if err != nil {
+		t.Fatalf("err: %v", err)
+	}
+}

--- a/cmd/lakectl/cmd/retry_client_test.go
+++ b/cmd/lakectl/cmd/retry_client_test.go
@@ -161,10 +161,6 @@ func TestLakectlRetryPolicy(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			// if tc.err != nil {
-			// 	errStr := tc.err.Error()
-			// 	fmt.Sprintf("%s", errStr)
-			// }
 			shouldRetry, err := lakectlRetryPolicy(tc.getTestContext(), tc.resp, tc.err)
 			require.Equal(t, tc.expectedShouldRetry, shouldRetry)
 			if tc.expectedError != "" {
@@ -173,30 +169,3 @@ func TestLakectlRetryPolicy(t *testing.T) {
 		})
 	}
 }
-
-// func TestWithMockLakeFS(t *testing.T) {
-// 	retryCount := 0
-// 	httpCode := int64(http.StatusInternalServerError)
-// 	l, err := net.Listen("tcp", "127.0.0.1:8000")
-// 	if err != nil {
-// 		log.Fatal(err)
-// 	}
-// 	handler := http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-// 		retryCount++
-// 		w.WriteHeader(int(atomic.LoadInt64(&httpCode)))
-// 	})
-// 	ts := httptest.NewUnstartedServer(handler)
-
-// 	ts.Listener.Close()
-// 	ts.Listener = l
-// 	ts.Start()
-// 	defer ts.Close()
-
-// 	output := new(bytes.Buffer)
-// 	rootCmd.SetArgs([]string{"repo", "list"})
-// 	rootCmd.SetOut(output)
-// 	rootCmd.SetErr(output)
-// 	err = rootCmd.Execute()
-// 	fmt.Printf("Total retries: %d", retryCount)
-// 	require.Equal(t, 4, retryCount)
-// }

--- a/cmd/lakectl/cmd/root.go
+++ b/cmd/lakectl/cmd/root.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"strings"
+	"time"
 
 	"github.com/deepmap/oapi-codegen/pkg/securityprovider"
 	"github.com/go-openapi/swag"
@@ -60,6 +61,12 @@ type Configuration struct {
 	} `mapstructure:"credentials"`
 	Server struct {
 		EndpointURL lakefsconfig.OnlyString `mapstructure:"endpoint_url"`
+		Retries     struct {
+			Enabled         bool          `mapstructure:"enabled"`
+			MaxRetries      int           `mapstructure:"max_retries"`
+			MinWaitInterval time.Duration `mapstructure:"min_wait_interval"`
+			MaxWaitInterval time.Duration `mapstructure:"max_wait_interval"`
+		} `mapstructure:"retries"`
 	} `mapstructure:"server"`
 	Metastore struct {
 		Type lakefsconfig.OnlyString `mapstructure:"type"`
@@ -140,6 +147,10 @@ const (
 	allowEmptyMsgFlagName = "allow-empty-message"
 	fmtErrEmptyMsg        = `commit with no message without specifying the "--allow-empty-message" flag`
 	metaFlagName          = "meta"
+
+	defaultMaxRetries       = 3
+	defaultMaxRetryInterval = 1 * time.Second
+	defaultMinRetryInterval = 200 * time.Millisecond
 )
 
 func withRecursiveFlag(cmd *cobra.Command, usage string) {
@@ -428,8 +439,14 @@ func getClient() *apigen.ClientWithResponses {
 	// see: https://stackoverflow.com/a/39834253
 	transport := http.DefaultTransport.(*http.Transport).Clone()
 	transport.MaxIdleConnsPerHost = DefaultMaxIdleConnsPerHost
-	httpClient := &http.Client{
-		Transport: transport,
+	var httpClient *http.Client
+	if !cfg.Server.Retries.Enabled {
+		httpClient = &http.Client{
+			Transport: transport,
+		}
+	} else {
+		httpClient = NewRetryClient(cfg.Server.Retries.MaxRetries,
+			cfg.Server.Retries.MinWaitInterval, cfg.Server.Retries.MaxWaitInterval, transport)
 	}
 
 	accessKeyID := cfg.Credentials.AccessKeyID
@@ -521,6 +538,10 @@ func initConfig() {
 	// set defaults
 	viper.SetDefault("metastore.hive.db_location_uri", "file:/user/hive/warehouse/")
 	viper.SetDefault("server.endpoint_url", "http://127.0.0.1:8000")
+	viper.SetDefault("server.retries.enabled", true)
+	viper.SetDefault("server.retries.max_retries", defaultMaxRetries)
+	viper.SetDefault("server.retries.max_wait_interval", defaultMaxRetryInterval)
+	viper.SetDefault("server.retries.min_wait_interval", defaultMinRetryInterval)
 
 	cfgErr = viper.ReadInConfig()
 	if errors.Is(cfgErr, viper.ConfigFileNotFoundError{}) {

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -87,7 +87,7 @@ lakectl [flags]
 {:.no_toc}
 
 ```
-      --base-uri string      base URI used for lakeFS address parse
+      --base-uri string      base URI used for lakeFS address parse (default "https://treeverse-proper-boar-yjz5us.us-east-1.lakefscloud.ninja/api/v1")
   -c, --config string        config file (default is $HOME/.lakectl.yaml)
   -h, --help                 help for lakectl
       --log-format string    set logging output format

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -87,7 +87,7 @@ lakectl [flags]
 {:.no_toc}
 
 ```
-      --base-uri string      base URI used for lakeFS address parse (default "https://treeverse-proper-boar-yjz5us.us-east-1.lakefscloud.ninja/api/v1")
+      --base-uri string      base URI used for lakeFS address parse
   -c, --config string        config file (default is $HOME/.lakectl.yaml)
   -h, --help                 help for lakectl
       --log-format string    set logging output format

--- a/go.mod
+++ b/go.mod
@@ -90,7 +90,7 @@ require (
 	github.com/golang-jwt/jwt/v4 v4.5.0
 	github.com/gorilla/securecookie v1.1.1
 	github.com/gorilla/sessions v1.2.1
-	github.com/hashicorp/go-retryablehttp v0.7.4
+	github.com/hashicorp/go-retryablehttp v0.7.5
 	github.com/hashicorp/go-version v1.6.0
 	github.com/jackc/pgx/v5 v5.4.3
 	github.com/puzpuzpuz/xsync v1.5.2

--- a/go.sum
+++ b/go.sum
@@ -638,6 +638,8 @@ github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+l
 github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-retryablehttp v0.7.4 h1:ZQgVdpTdAL7WpMIwLzCfbalOcSUdkDZnpUv3/+BxzFA=
 github.com/hashicorp/go-retryablehttp v0.7.4/go.mod h1:Jy/gPYAdjqffZ/yFGCFV2doI5wjtH1ewM9u8iYVjtX8=
+github.com/hashicorp/go-retryablehttp v0.7.5 h1:bJj+Pj19UZMIweq/iie+1u5YCdGrnxCT9yvm0e+Nd5M=
+github.com/hashicorp/go-retryablehttp v0.7.5/go.mod h1:Jy/gPYAdjqffZ/yFGCFV2doI5wjtH1ewM9u8iYVjtX8=
 github.com/hashicorp/go-uuid v0.0.0-20180228145832-27454136f036/go.mod h1:6SBZvOh/SIDV7/2o3Jml5SYk/TvGqwFJ/bN7x4byOro=
 github.com/hashicorp/go-version v1.2.0/go.mod h1:fltr4n8CU8Ke44wwGCBoEymUuxUHl09ZGVZPK5anwXA=
 github.com/hashicorp/go-version v1.6.0 h1:feTTfFNnjP967rlCxM/I9g701jU+RN74YKx2mOkIeek=


### PR DESCRIPTION
Closes #7705 
## Change Description

### Background

See the associated issue for context.
      
### New Feature

This PR creates a new HTTP client for lakectl, based on [go-retryablehttp](https://github.com/hashicorp/go-retryablehttp/tree/main). It supports retries with a custom retry policy tailored for lakeFS and an exponential backoff retry strategy. Its constructor func includes several parameters to tune the retry max count and intervals and the option to provide a custom http.Transport. For seamless integration, the constructor returns a standard *http.Client.

### Testing Details

This PR includes a suite of tests for the custom retry policy. The retry mechanism was tested using the abuse command with a playground installation, a modified DDB table, and a small number of RCUs/WCUs.

The abuse command:
```sh
./lakectl abuse random-write  lakefs://sample-repo/main --parallelism 100 --prefix abuse-3/
```

Without retries, this command fails with HTTP 500 errors. With retires it retries the failures and completes successfully.

Thanks @itaiad200 for the abuse command ✌🏻