### PR TITLE
FIX: Object diff to use pre-sign when presign ui is enabled

### DIFF
--- a/docs/reference/security/presigned-url.md
+++ b/docs/reference/security/presigned-url.md
@@ -13,13 +13,13 @@ redirect_from:
 
 With lakeFS, you can access data directly from the storage and not through lakeFS using a presigned URL.
 Based on the user's access to an object in the object store, the presigned URL will get read or write access.
-The presign support is enabled for block adapter that supports it (S3, GCP, Azure), and can be disabled by the [configuration]({% link reference/configuration.md %}) (`blockstore.blockstore-name.disable_pre_signed`). Note that the UI support is disabled by default.
+The presign support is enabled for block adapter that supports it (S3, GCP, Azure), and can be disabled by the [configuration]({% link reference/configuration.md %}) (`blockstore.<blockstore_type>.disable_pre_signed`). Note that the UI support is disabled by default.
 
 ## Using presigned URLs in the UI
 For using presigned URLs in the UI:
-1. Enable the presigned URL support UI in the lakeFS [configuration]({% link reference/configuration.md %}) (`blockstore.blockstore-name.disable_pre_signed_ui`).
+1. Enable the presigned URL support UI in the lakeFS [configuration]({% link reference/configuration.md %}) (`blockstore.<blockstore_type>.disable_pre_signed_ui`   ).
 2. Add CORS (Cross-Origin Resource Sharing) permissions to the bucket for the UI to fetch objects using a presigned URL (instead of through lakeFS).
-3. The `disable_pre_signed` needs to be enabled to enable it in the UI.
+3. The `blockstore.<blockstore_type>.disable_pre_signed` must be false to enable it in the UI.
 
 **⚠️ Note** Currently DuckDB fetching data from lakeFS does not support fetching data using presigned URL.
 
@@ -33,7 +33,8 @@ For using presigned URLs in the UI:
         ],
         "AllowedMethods": [
             "GET",
-            "PUT"
+            "PUT",
+            "HEAD"
         ],
         "AllowedOrigins": [
             "lakefs.endpoint"
@@ -53,7 +54,7 @@ For using presigned URLs in the UI:
     {
         "origin": ["lakefs.endpoint"],
         "responseHeader": ["ETag"],
-        "method": ["PUT", "GET"],
+        "method": ["PUT", "GET", "HEAD"],
         "maxAgeSeconds": 3600
     }
    ]
@@ -66,7 +67,7 @@ For using presigned URLs in the UI:
   <Cors>
       <CorsRule>  
           <AllowedOrigins>lakefs.endpoint</AllowedOrigins>  
-          <AllowedMethods>PUT,GET</AllowedMethods>  
+          <AllowedMethods>PUT,GET,HEAD</AllowedMethods>  
           <AllowedHeaders>*</AllowedHeaders>  
           <ExposedHeaders>ETag,x-ms-*</ExposedHeaders>  
           <MaxAgeInSeconds>3600</MaxAgeInSeconds>  

--- a/webui/src/lib/components/repository/ObjectsDiff.jsx
+++ b/webui/src/lib/components/repository/ObjectsDiff.jsx
@@ -6,11 +6,13 @@ import {AlertError, Loading} from "../controls";
 import {humanSize} from "./tree";
 import Alert from "react-bootstrap/Alert";
 import {InfoIcon} from "@primer/octicons-react";
+import {useStorageConfig} from "../../hooks/storageConfig";
 
 const maxDiffSizeBytes = 120 << 10;
 const supportedReadableFormats = ["txt", "text", "csv", "tsv", "yaml", "yml", "json"];
 
 export const ObjectsDiff = ({diffType, repoId, leftRef, rightRef, path}) => {
+    const config = useStorageConfig();
     const readable = readableObject(path);
     let left;
     let right;
@@ -50,7 +52,7 @@ export const ObjectsDiff = ({diffType, repoId, leftRef, rightRef, path}) => {
     }
     const leftSize = leftStat && leftStat.size_bytes;
     const rightSize = rightStat && rightStat.size_bytes;
-    return <ContentDiff repoId={repoId} path={path} leftRef={left && leftRef} rightRef={right && rightRef}
+    return <ContentDiff config={config} repoId={repoId} path={path} leftRef={left && leftRef} rightRef={right && rightRef}
                         leftSize={leftSize} rightSize={rightSize} diffType={diffType}/>;
 }
 
@@ -71,10 +73,10 @@ const NoContentDiff = ({left, right, diffType}) => {
     </div>;
 }
 
-const ContentDiff = ({repoId, path, leftRef, rightRef, leftSize, rightSize, diffType}) => {
-    const left = leftRef && useAPI(async () => objects.get(repoId, leftRef, path),
+const ContentDiff = ({config, repoId, path, leftRef, rightRef, leftSize, rightSize, diffType}) => {
+    const left = leftRef && useAPI(async () => objects.get(repoId, leftRef, path, config.pre_sign_support_ui),
         [repoId, leftRef, path]);
-    const right = rightRef && useAPI(async () => objects.get(repoId, rightRef, path),
+    const right = rightRef && useAPI(async () => objects.get(repoId, rightRef, path, config.pre_sign_support_ui),
         [repoId, rightRef, path]);
 
     if ((left && left.loading) || (right && right.loading)) return <Loading/>;


### PR DESCRIPTION
Closes #7693

## Change Description

### Background

Use presign mode when reading object for diff in the UI
Fixed documentation on the way

### Bug Fix

Pass configuration to the ContentDiff module and pass the pre_sign_support_ui value to get object

### Testing Details

Tested manually on AWS

### Breaking Change?

No

