### PR TITLE
Handle KV slow down error

### DIFF
--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -2697,6 +2697,9 @@ func (c *Controller) handleAPIErrorCallback(ctx context.Context, w http.Response
 	case errors.Is(err, graveler.ErrTooManyTries):
 		log.Debug("Retried too many times")
 		cb(w, r, http.StatusLocked, "Too many attempts, try again later")
+	case errors.Is(err, kv.ErrSlowDown):
+		log.Debug("KV Throttling")
+		cb(w, r, http.StatusServiceUnavailable, "Throughput exceeded. Slow down and retry")
 	case errors.Is(err, graveler.ErrPreconditionFailed):
 		log.Debug("Precondition failed")
 		cb(w, r, http.StatusPreconditionFailed, "Precondition failed")


### PR DESCRIPTION
Closes #7742 

This PR corrects the handling of KV throttling/slow-down errors. Instead of returning generic HTTP status 500, it returns HTTP status 503. This will allow client implementations to detect this error, slow down, and retry. This behavior is aligned with that in the S3 gateway.  
Also, it returns a succinct, informative, and user-readable status text to clients.
