### PR TITLE
Docs/deprecate delta sharing

### DIFF
--- a/docs/howto/unity-delta-sharing.md
+++ b/docs/howto/unity-delta-sharing.md
@@ -12,6 +12,10 @@ redirect_from:
 lakeFS Cloud
 {: .label .label-green }
 
+
+{: .warning }
+> Please note, as of June 15th 2024, the Unity Delta Sharing feature will be removed. To integrate lakeFS with Unity Catalog, refer to the [Unity integration](../integrations/unity-catalog.md) docs.
+
 ## Introduction
 
 lakeFS Unity Delta Sharing provides a read-only experience from Unity Catalog for lakeFS customers.  Currently, this is available as a private

--- a/docs/understand/lakefs-cloud.md
+++ b/docs/understand/lakefs-cloud.md
@@ -17,7 +17,7 @@ redirect_from:
 * [Single-Sign-On]({% link reference/security/sso.md %}#sso-for-lakefs-cloud) (including support for SAML, OIDC, AD FS, Okta, and Azure AD)
 * [Managed Garbage Collection]({% link howto/garbage-collection/managed-gc.md %})
 * [Private-Link]({% link howto/private-link.md %})
-* [Unity Delta Sharing]({% link howto/unity-delta-sharing.md %})
+* [Transactional Mirroring]({% link howto/mirroring.md %})
 * SOC 2 Type II Compliance
 
 ## How lakeFS Cloud interacts with your infrastructure


### PR DESCRIPTION
1. Update the docs with a deprecation notice for lakeFS' Unity catalog integration using Delta Sharing 
2. Add Mirroring to lakeFS Cloud index page