### PR TITLE
Handle empty commit messages

### DIFF
--- a/webui/src/lib/components/repository/commits.jsx
+++ b/webui/src/lib/components/repository/commits.jsx
@@ -127,7 +127,7 @@ const CommitInfo = ({ repo, commit }) => {
 };
 
 export const CommitMessage = ({ commit }) =>
-    commit.message && commit.message.length ?
+    commit.message?.length ?
         <span>{commit.message}</span> : <span className="text-muted">(No commit message)</span>;
 
 export const CommitInfoCard = ({ repo, commit, bare = false }) => {

--- a/webui/src/lib/components/repository/commits.jsx
+++ b/webui/src/lib/components/repository/commits.jsx
@@ -126,12 +126,16 @@ const CommitInfo = ({ repo, commit }) => {
   );
 };
 
+export const CommitMessage = ({ commit }) =>
+    commit.message && commit.message.length ?
+        <span>{commit.message}</span> : <span className="text-muted">(No commit message)</span>;
+
 export const CommitInfoCard = ({ repo, commit, bare = false }) => {
   const content = (
     <>
         <div className="d-flex">
           <div className="flex-grow-1">
-            <h4>{commit.message}</h4>
+            <h4><CommitMessage commit={commit}/></h4>
           </div>
           <div>
             <CommitActions repo={repo} commit={commit}/>

--- a/webui/src/pages/repositories/repository/commits/index.jsx
+++ b/webui/src/pages/repositories/repository/commits/index.jsx
@@ -16,6 +16,7 @@ import {
     LinkButton,
     Loading, RefreshButton
 } from "../../../../lib/components/controls";
+import {CommitMessage} from "../../../../lib/components/repository/commits";
 import {useRefs} from "../../../../lib/hooks/repo";
 import {useAPIWithPagination} from "../../../../lib/hooks/api";
 import {Paginator} from "../../../../lib/components/pagination";
@@ -38,7 +39,7 @@ const CommitWidget = ({ repo, commit }) => {
                             pathname: '/repositories/:repoId/commits/:commitId',
                             params: {repoId: repo.id, commitId: commit.id}
                         }}>
-                            {commit.message}
+                            <CommitMessage commit={commit}/>
                         </Link>
                     </h6>
                     <p>


### PR DESCRIPTION
Closes #5250 

## Change Description

### Background

Empty commit messages were displayed in a confusing way.

### Bug Fix

Resolution for commits list:
<img width="1509" alt="Screenshot 2024-05-16 at 15 32 11" src="https://github.com/treeverse/lakeFS/assets/13402361/6a39f50e-6de4-4d91-8ca3-1588321f5c7b">

Resolution for commit details (empty):
<img width="1511" alt="Screenshot 2024-05-16 at 15 32 21" src="https://github.com/treeverse/lakeFS/assets/13402361/afd1645d-3485-49e2-b4ee-4ad90c7e71d7">

Resolution for commit details (non-empty):
<img width="1511" alt="Screenshot 2024-05-16 at 15 32 29" src="https://github.com/treeverse/lakeFS/assets/13402361/c4974520-4c68-4f0b-b7f4-5a836e5464cb">

