### PR TITLE
Add internal API endpoint to download meta-ranges and ranges (w/pre-signed support)

### DIFF
--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -5159,6 +5159,66 @@ paths:
         default:
           $ref: "#/components/responses/ServerError"
 
+  /repositories/{repository}/metadata/object/{type}/{object_id}:
+    parameters:
+      - in: path
+        name: repository
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: object_id
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: type
+        required: true
+        schema:
+          type: string
+          enum:
+            - range
+            - meta_range
+    get:
+      tags:
+        - internal
+      operationId: getMetadataObject
+      summary: return a lakeFS metadata object by ID
+      parameters:
+        - in: query
+          name: presign
+          required: false
+          schema:
+            type: boolean
+      responses:
+        200:
+          description: object content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+          headers:
+            Content-Length:
+              schema:
+                type: integer
+                format: int64
+        302:
+          description: Redirect to a pre-signed URL for the object
+          headers:
+            Location:
+              schema:
+                type: string
+        401:
+          $ref: "#/components/responses/Unauthorized"
+        404:
+          $ref: "#/components/responses/NotFound"
+        420:
+          description: too many requests
+        default:
+          $ref: "#/components/responses/ServerError"
+
+
   /repositories/{repository}/metadata/meta_range/{meta_range}:
     parameters:
       - in: path

--- a/clients/java-legacy/README.md
+++ b/clients/java-legacy/README.md
@@ -213,6 +213,7 @@ Class | Method | HTTP request | Description
 *InternalApi* | [**getAuthCapabilities**](docs/InternalApi.md#getAuthCapabilities) | **GET** /auth/capabilities | list authentication capabilities supported
 *InternalApi* | [**getGarbageCollectionConfig**](docs/InternalApi.md#getGarbageCollectionConfig) | **GET** /config/garbage-collection | 
 *InternalApi* | [**getLakeFSVersion**](docs/InternalApi.md#getLakeFSVersion) | **GET** /config/version | 
+*InternalApi* | [**getMetadataObject**](docs/InternalApi.md#getMetadataObject) | **GET** /repositories/{repository}/metadata/object/{type}/{object_id} | return a lakeFS metadata object by ID
 *InternalApi* | [**getSetupState**](docs/InternalApi.md#getSetupState) | **GET** /setup_lakefs | check if the lakeFS installation is already set up
 *InternalApi* | [**getStorageConfig**](docs/InternalApi.md#getStorageConfig) | **GET** /config/storage | 
 *InternalApi* | [**getUsageReportSummary**](docs/InternalApi.md#getUsageReportSummary) | **GET** /usage-report/summary | get usage report summary

--- a/clients/java-legacy/api/openapi.yaml
+++ b/clients/java-legacy/api/openapi.yaml
@@ -6112,6 +6112,88 @@ paths:
       tags:
       - actions
       x-accepts: application/json
+  /repositories/{repository}/metadata/object/{type}/{object_id}:
+    get:
+      operationId: getMetadataObject
+      parameters:
+      - explode: false
+        in: path
+        name: repository
+        required: true
+        schema:
+          type: string
+        style: simple
+      - explode: false
+        in: path
+        name: object_id
+        required: true
+        schema:
+          type: string
+        style: simple
+      - explode: false
+        in: path
+        name: type
+        required: true
+        schema:
+          enum:
+          - range
+          - meta_range
+          type: string
+        style: simple
+      - explode: true
+        in: query
+        name: presign
+        required: false
+        schema:
+          type: boolean
+        style: form
+      responses:
+        "200":
+          content:
+            application/octet-stream:
+              schema:
+                format: binary
+                type: string
+          description: object content
+          headers:
+            Content-Length:
+              explode: false
+              schema:
+                format: int64
+                type: integer
+              style: simple
+        "302":
+          description: Redirect to a pre-signed URL for the object
+          headers:
+            Location:
+              explode: false
+              schema:
+                type: string
+              style: simple
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unauthorized
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Resource Not Found
+        "420":
+          description: too many requests
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
+      summary: return a lakeFS metadata object by ID
+      tags:
+      - internal
+      x-accepts: application/json
   /repositories/{repository}/metadata/meta_range/{meta_range}:
     get:
       operationId: getMetaRange

--- a/clients/java-legacy/docs/InternalApi.md
+++ b/clients/java-legacy/docs/InternalApi.md
@@ -12,6 +12,7 @@ Method | HTTP request | Description
 [**getAuthCapabilities**](InternalApi.md#getAuthCapabilities) | **GET** /auth/capabilities | list authentication capabilities supported
 [**getGarbageCollectionConfig**](InternalApi.md#getGarbageCollectionConfig) | **GET** /config/garbage-collection | 
 [**getLakeFSVersion**](InternalApi.md#getLakeFSVersion) | **GET** /config/version | 
+[**getMetadataObject**](InternalApi.md#getMetadataObject) | **GET** /repositories/{repository}/metadata/object/{type}/{object_id} | return a lakeFS metadata object by ID
 [**getSetupState**](InternalApi.md#getSetupState) | **GET** /setup_lakefs | check if the lakeFS installation is already set up
 [**getStorageConfig**](InternalApi.md#getStorageConfig) | **GET** /config/storage | 
 [**getUsageReportSummary**](InternalApi.md#getUsageReportSummary) | **GET** /usage-report/summary | get usage report summary
@@ -734,6 +735,105 @@ This endpoint does not need any parameter.
 |-------------|-------------|------------------|
 **200** | lakeFS version |  -  |
 **401** | Unauthorized |  -  |
+
+<a name="getMetadataObject"></a>
+# **getMetadataObject**
+> File getMetadataObject(repository, objectId, type, presign)
+
+return a lakeFS metadata object by ID
+
+### Example
+```java
+// Import classes:
+import io.lakefs.clients.api.ApiClient;
+import io.lakefs.clients.api.ApiException;
+import io.lakefs.clients.api.Configuration;
+import io.lakefs.clients.api.auth.*;
+import io.lakefs.clients.api.models.*;
+import io.lakefs.clients.api.InternalApi;
+
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("http://localhost/api/v1");
+    
+    // Configure HTTP basic authorization: basic_auth
+    HttpBasicAuth basic_auth = (HttpBasicAuth) defaultClient.getAuthentication("basic_auth");
+    basic_auth.setUsername("YOUR USERNAME");
+    basic_auth.setPassword("YOUR PASSWORD");
+
+    // Configure API key authorization: cookie_auth
+    ApiKeyAuth cookie_auth = (ApiKeyAuth) defaultClient.getAuthentication("cookie_auth");
+    cookie_auth.setApiKey("YOUR API KEY");
+    // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+    //cookie_auth.setApiKeyPrefix("Token");
+
+    // Configure HTTP bearer authorization: jwt_token
+    HttpBearerAuth jwt_token = (HttpBearerAuth) defaultClient.getAuthentication("jwt_token");
+    jwt_token.setBearerToken("BEARER TOKEN");
+
+    // Configure API key authorization: oidc_auth
+    ApiKeyAuth oidc_auth = (ApiKeyAuth) defaultClient.getAuthentication("oidc_auth");
+    oidc_auth.setApiKey("YOUR API KEY");
+    // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+    //oidc_auth.setApiKeyPrefix("Token");
+
+    // Configure API key authorization: saml_auth
+    ApiKeyAuth saml_auth = (ApiKeyAuth) defaultClient.getAuthentication("saml_auth");
+    saml_auth.setApiKey("YOUR API KEY");
+    // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+    //saml_auth.setApiKeyPrefix("Token");
+
+    InternalApi apiInstance = new InternalApi(defaultClient);
+    String repository = "repository_example"; // String | 
+    String objectId = "objectId_example"; // String | 
+    String type = "range"; // String | 
+    Boolean presign = true; // Boolean | 
+    try {
+      File result = apiInstance.getMetadataObject(repository, objectId, type, presign);
+      System.out.println(result);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling InternalApi#getMetadataObject");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
+}
+```
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **repository** | **String**|  |
+ **objectId** | **String**|  |
+ **type** | **String**|  | [enum: range, meta_range]
+ **presign** | **Boolean**|  | [optional]
+
+### Return type
+
+[**File**](File.md)
+
+### Authorization
+
+[basic_auth](../README.md#basic_auth), [cookie_auth](../README.md#cookie_auth), [jwt_token](../README.md#jwt_token), [oidc_auth](../README.md#oidc_auth), [saml_auth](../README.md#saml_auth)
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/octet-stream, application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+**200** | object content |  * Content-Length -  <br>  |
+**302** | Redirect to a pre-signed URL for the object |  * Location - redirect to S3 <br>  |
+**401** | Unauthorized |  -  |
+**404** | Resource Not Found |  -  |
+**420** | too many requests |  -  |
+**0** | Internal Server Error |  -  |
 
 <a name="getSetupState"></a>
 # **getSetupState**

--- a/clients/java-legacy/src/main/java/io/lakefs/clients/api/InternalApi.java
+++ b/clients/java-legacy/src/main/java/io/lakefs/clients/api/InternalApi.java
@@ -33,6 +33,7 @@ import io.lakefs.clients.api.model.CommPrefsInput;
 import io.lakefs.clients.api.model.CommitRecordCreation;
 import io.lakefs.clients.api.model.CredentialsWithSecret;
 import io.lakefs.clients.api.model.Error;
+import java.io.File;
 import io.lakefs.clients.api.model.GarbageCollectionConfig;
 import io.lakefs.clients.api.model.GarbageCollectionPrepareResponse;
 import io.lakefs.clients.api.model.GarbageCollectionRules;
@@ -1082,6 +1083,166 @@ public class InternalApi {
 
         okhttp3.Call localVarCall = getLakeFSVersionValidateBeforeCall(_callback);
         Type localVarReturnType = new TypeToken<VersionConfig>(){}.getType();
+        localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+        return localVarCall;
+    }
+    /**
+     * Build call for getMetadataObject
+     * @param repository  (required)
+     * @param objectId  (required)
+     * @param type  (required)
+     * @param presign  (optional)
+     * @param _callback Callback for upload/download progress
+     * @return Call to execute
+     * @throws ApiException If fail to serialize the request body object
+     * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> object content </td><td>  * Content-Length -  <br>  </td></tr>
+        <tr><td> 302 </td><td> Redirect to a pre-signed URL for the object </td><td>  * Location - redirect to S3 <br>  </td></tr>
+        <tr><td> 401 </td><td> Unauthorized </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Resource Not Found </td><td>  -  </td></tr>
+        <tr><td> 420 </td><td> too many requests </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
+     </table>
+     */
+    public okhttp3.Call getMetadataObjectCall(String repository, String objectId, String type, Boolean presign, final ApiCallback _callback) throws ApiException {
+        Object localVarPostBody = null;
+
+        // create path and map variables
+        String localVarPath = "/repositories/{repository}/metadata/object/{type}/{object_id}"
+            .replaceAll("\\{" + "repository" + "\\}", localVarApiClient.escapeString(repository.toString()))
+            .replaceAll("\\{" + "object_id" + "\\}", localVarApiClient.escapeString(objectId.toString()))
+            .replaceAll("\\{" + "type" + "\\}", localVarApiClient.escapeString(type.toString()));
+
+        List<Pair> localVarQueryParams = new ArrayList<Pair>();
+        List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
+        Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+        Map<String, String> localVarCookieParams = new HashMap<String, String>();
+        Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+        if (presign != null) {
+            localVarQueryParams.addAll(localVarApiClient.parameterToPair("presign", presign));
+        }
+
+        final String[] localVarAccepts = {
+            "application/octet-stream", "application/json"
+        };
+        final String localVarAccept = localVarApiClient.selectHeaderAccept(localVarAccepts);
+        if (localVarAccept != null) {
+            localVarHeaderParams.put("Accept", localVarAccept);
+        }
+
+        final String[] localVarContentTypes = {
+            
+        };
+        final String localVarContentType = localVarApiClient.selectHeaderContentType(localVarContentTypes);
+        localVarHeaderParams.put("Content-Type", localVarContentType);
+
+        String[] localVarAuthNames = new String[] { "basic_auth", "cookie_auth", "jwt_token", "oidc_auth", "saml_auth" };
+        return localVarApiClient.buildCall(localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+    }
+
+    @SuppressWarnings("rawtypes")
+    private okhttp3.Call getMetadataObjectValidateBeforeCall(String repository, String objectId, String type, Boolean presign, final ApiCallback _callback) throws ApiException {
+        
+        // verify the required parameter 'repository' is set
+        if (repository == null) {
+            throw new ApiException("Missing the required parameter 'repository' when calling getMetadataObject(Async)");
+        }
+        
+        // verify the required parameter 'objectId' is set
+        if (objectId == null) {
+            throw new ApiException("Missing the required parameter 'objectId' when calling getMetadataObject(Async)");
+        }
+        
+        // verify the required parameter 'type' is set
+        if (type == null) {
+            throw new ApiException("Missing the required parameter 'type' when calling getMetadataObject(Async)");
+        }
+        
+
+        okhttp3.Call localVarCall = getMetadataObjectCall(repository, objectId, type, presign, _callback);
+        return localVarCall;
+
+    }
+
+    /**
+     * return a lakeFS metadata object by ID
+     * 
+     * @param repository  (required)
+     * @param objectId  (required)
+     * @param type  (required)
+     * @param presign  (optional)
+     * @return File
+     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> object content </td><td>  * Content-Length -  <br>  </td></tr>
+        <tr><td> 302 </td><td> Redirect to a pre-signed URL for the object </td><td>  * Location - redirect to S3 <br>  </td></tr>
+        <tr><td> 401 </td><td> Unauthorized </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Resource Not Found </td><td>  -  </td></tr>
+        <tr><td> 420 </td><td> too many requests </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
+     </table>
+     */
+    public File getMetadataObject(String repository, String objectId, String type, Boolean presign) throws ApiException {
+        ApiResponse<File> localVarResp = getMetadataObjectWithHttpInfo(repository, objectId, type, presign);
+        return localVarResp.getData();
+    }
+
+    /**
+     * return a lakeFS metadata object by ID
+     * 
+     * @param repository  (required)
+     * @param objectId  (required)
+     * @param type  (required)
+     * @param presign  (optional)
+     * @return ApiResponse&lt;File&gt;
+     * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+     * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> object content </td><td>  * Content-Length -  <br>  </td></tr>
+        <tr><td> 302 </td><td> Redirect to a pre-signed URL for the object </td><td>  * Location - redirect to S3 <br>  </td></tr>
+        <tr><td> 401 </td><td> Unauthorized </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Resource Not Found </td><td>  -  </td></tr>
+        <tr><td> 420 </td><td> too many requests </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
+     </table>
+     */
+    public ApiResponse<File> getMetadataObjectWithHttpInfo(String repository, String objectId, String type, Boolean presign) throws ApiException {
+        okhttp3.Call localVarCall = getMetadataObjectValidateBeforeCall(repository, objectId, type, presign, null);
+        Type localVarReturnType = new TypeToken<File>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    /**
+     * return a lakeFS metadata object by ID (asynchronously)
+     * 
+     * @param repository  (required)
+     * @param objectId  (required)
+     * @param type  (required)
+     * @param presign  (optional)
+     * @param _callback The callback to be executed when the API call finishes
+     * @return The request call
+     * @throws ApiException If fail to process the API call, e.g. serializing the request body object
+     * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> object content </td><td>  * Content-Length -  <br>  </td></tr>
+        <tr><td> 302 </td><td> Redirect to a pre-signed URL for the object </td><td>  * Location - redirect to S3 <br>  </td></tr>
+        <tr><td> 401 </td><td> Unauthorized </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Resource Not Found </td><td>  -  </td></tr>
+        <tr><td> 420 </td><td> too many requests </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
+     </table>
+     */
+    public okhttp3.Call getMetadataObjectAsync(String repository, String objectId, String type, Boolean presign, final ApiCallback<File> _callback) throws ApiException {
+
+        okhttp3.Call localVarCall = getMetadataObjectValidateBeforeCall(repository, objectId, type, presign, _callback);
+        Type localVarReturnType = new TypeToken<File>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
     }

--- a/clients/java-legacy/src/test/java/io/lakefs/clients/api/InternalApiTest.java
+++ b/clients/java-legacy/src/test/java/io/lakefs/clients/api/InternalApiTest.java
@@ -20,6 +20,7 @@ import io.lakefs.clients.api.model.CommPrefsInput;
 import io.lakefs.clients.api.model.CommitRecordCreation;
 import io.lakefs.clients.api.model.CredentialsWithSecret;
 import io.lakefs.clients.api.model.Error;
+import java.io.File;
 import io.lakefs.clients.api.model.GarbageCollectionConfig;
 import io.lakefs.clients.api.model.GarbageCollectionPrepareResponse;
 import io.lakefs.clients.api.model.GarbageCollectionRules;
@@ -174,6 +175,24 @@ public class InternalApiTest {
     @Test
     public void getLakeFSVersionTest() throws ApiException {
                 VersionConfig response = api.getLakeFSVersion();
+        // TODO: test validations
+    }
+    
+    /**
+     * return a lakeFS metadata object by ID
+     *
+     * 
+     *
+     * @throws ApiException
+     *          if the Api call fails
+     */
+    @Test
+    public void getMetadataObjectTest() throws ApiException {
+        String repository = null;
+        String objectId = null;
+        String type = null;
+        Boolean presign = null;
+                File response = api.getMetadataObject(repository, objectId, type, presign);
         // TODO: test validations
     }
     

--- a/clients/java/README.md
+++ b/clients/java/README.md
@@ -221,6 +221,7 @@ Class | Method | HTTP request | Description
 *InternalApi* | [**getAuthCapabilities**](docs/InternalApi.md#getAuthCapabilities) | **GET** /auth/capabilities | list authentication capabilities supported
 *InternalApi* | [**getGarbageCollectionConfig**](docs/InternalApi.md#getGarbageCollectionConfig) | **GET** /config/garbage-collection | 
 *InternalApi* | [**getLakeFSVersion**](docs/InternalApi.md#getLakeFSVersion) | **GET** /config/version | 
+*InternalApi* | [**getMetadataObject**](docs/InternalApi.md#getMetadataObject) | **GET** /repositories/{repository}/metadata/object/{type}/{object_id} | return a lakeFS metadata object by ID
 *InternalApi* | [**getSetupState**](docs/InternalApi.md#getSetupState) | **GET** /setup_lakefs | check if the lakeFS installation is already set up
 *InternalApi* | [**getStorageConfig**](docs/InternalApi.md#getStorageConfig) | **GET** /config/storage | 
 *InternalApi* | [**getUsageReportSummary**](docs/InternalApi.md#getUsageReportSummary) | **GET** /usage-report/summary | get usage report summary

--- a/clients/java/api/openapi.yaml
+++ b/clients/java/api/openapi.yaml
@@ -6107,6 +6107,88 @@ paths:
       tags:
       - actions
       x-accepts: application/json
+  /repositories/{repository}/metadata/object/{type}/{object_id}:
+    get:
+      operationId: getMetadataObject
+      parameters:
+      - explode: false
+        in: path
+        name: repository
+        required: true
+        schema:
+          type: string
+        style: simple
+      - explode: false
+        in: path
+        name: object_id
+        required: true
+        schema:
+          type: string
+        style: simple
+      - explode: false
+        in: path
+        name: type
+        required: true
+        schema:
+          enum:
+          - range
+          - meta_range
+          type: string
+        style: simple
+      - explode: true
+        in: query
+        name: presign
+        required: false
+        schema:
+          type: boolean
+        style: form
+      responses:
+        "200":
+          content:
+            application/octet-stream:
+              schema:
+                format: binary
+                type: string
+          description: object content
+          headers:
+            Content-Length:
+              explode: false
+              schema:
+                format: int64
+                type: integer
+              style: simple
+        "302":
+          description: Redirect to a pre-signed URL for the object
+          headers:
+            Location:
+              explode: false
+              schema:
+                type: string
+              style: simple
+        "401":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Unauthorized
+        "404":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Resource Not Found
+        "420":
+          description: too many requests
+        default:
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Internal Server Error
+      summary: return a lakeFS metadata object by ID
+      tags:
+      - internal
+      x-accepts: application/json
   /repositories/{repository}/metadata/meta_range/{meta_range}:
     get:
       operationId: getMetaRange

--- a/clients/java/docs/InternalApi.md
+++ b/clients/java/docs/InternalApi.md
@@ -12,6 +12,7 @@ All URIs are relative to */api/v1*
 | [**getAuthCapabilities**](InternalApi.md#getAuthCapabilities) | **GET** /auth/capabilities | list authentication capabilities supported |
 | [**getGarbageCollectionConfig**](InternalApi.md#getGarbageCollectionConfig) | **GET** /config/garbage-collection |  |
 | [**getLakeFSVersion**](InternalApi.md#getLakeFSVersion) | **GET** /config/version |  |
+| [**getMetadataObject**](InternalApi.md#getMetadataObject) | **GET** /repositories/{repository}/metadata/object/{type}/{object_id} | return a lakeFS metadata object by ID |
 | [**getSetupState**](InternalApi.md#getSetupState) | **GET** /setup_lakefs | check if the lakeFS installation is already set up |
 | [**getStorageConfig**](InternalApi.md#getStorageConfig) | **GET** /config/storage |  |
 | [**getUsageReportSummary**](InternalApi.md#getUsageReportSummary) | **GET** /usage-report/summary | get usage report summary |
@@ -743,6 +744,107 @@ This endpoint does not need any parameter.
 |-------------|-------------|------------------|
 | **200** | lakeFS version |  -  |
 | **401** | Unauthorized |  -  |
+
+<a id="getMetadataObject"></a>
+# **getMetadataObject**
+> File getMetadataObject(repository, objectId, type).presign(presign).execute();
+
+return a lakeFS metadata object by ID
+
+### Example
+```java
+// Import classes:
+import io.lakefs.clients.sdk.ApiClient;
+import io.lakefs.clients.sdk.ApiException;
+import io.lakefs.clients.sdk.Configuration;
+import io.lakefs.clients.sdk.auth.*;
+import io.lakefs.clients.sdk.models.*;
+import io.lakefs.clients.sdk.InternalApi;
+
+public class Example {
+  public static void main(String[] args) {
+    ApiClient defaultClient = Configuration.getDefaultApiClient();
+    defaultClient.setBasePath("/api/v1");
+    
+    // Configure HTTP basic authorization: basic_auth
+    HttpBasicAuth basic_auth = (HttpBasicAuth) defaultClient.getAuthentication("basic_auth");
+    basic_auth.setUsername("YOUR USERNAME");
+    basic_auth.setPassword("YOUR PASSWORD");
+
+    // Configure API key authorization: cookie_auth
+    ApiKeyAuth cookie_auth = (ApiKeyAuth) defaultClient.getAuthentication("cookie_auth");
+    cookie_auth.setApiKey("YOUR API KEY");
+    // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+    //cookie_auth.setApiKeyPrefix("Token");
+
+    // Configure API key authorization: oidc_auth
+    ApiKeyAuth oidc_auth = (ApiKeyAuth) defaultClient.getAuthentication("oidc_auth");
+    oidc_auth.setApiKey("YOUR API KEY");
+    // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+    //oidc_auth.setApiKeyPrefix("Token");
+
+    // Configure API key authorization: saml_auth
+    ApiKeyAuth saml_auth = (ApiKeyAuth) defaultClient.getAuthentication("saml_auth");
+    saml_auth.setApiKey("YOUR API KEY");
+    // Uncomment the following line to set a prefix for the API key, e.g. "Token" (defaults to null)
+    //saml_auth.setApiKeyPrefix("Token");
+
+    // Configure HTTP bearer authorization: jwt_token
+    HttpBearerAuth jwt_token = (HttpBearerAuth) defaultClient.getAuthentication("jwt_token");
+    jwt_token.setBearerToken("BEARER TOKEN");
+
+    InternalApi apiInstance = new InternalApi(defaultClient);
+    String repository = "repository_example"; // String | 
+    String objectId = "objectId_example"; // String | 
+    String type = "range"; // String | 
+    Boolean presign = true; // Boolean | 
+    try {
+      File result = apiInstance.getMetadataObject(repository, objectId, type)
+            .presign(presign)
+            .execute();
+      System.out.println(result);
+    } catch (ApiException e) {
+      System.err.println("Exception when calling InternalApi#getMetadataObject");
+      System.err.println("Status code: " + e.getCode());
+      System.err.println("Reason: " + e.getResponseBody());
+      System.err.println("Response headers: " + e.getResponseHeaders());
+      e.printStackTrace();
+    }
+  }
+}
+```
+
+### Parameters
+
+| Name | Type | Description  | Notes |
+|------------- | ------------- | ------------- | -------------|
+| **repository** | **String**|  | |
+| **objectId** | **String**|  | |
+| **type** | **String**|  | [enum: range, meta_range] |
+| **presign** | **Boolean**|  | [optional] |
+
+### Return type
+
+[**File**](File.md)
+
+### Authorization
+
+[basic_auth](../README.md#basic_auth), [cookie_auth](../README.md#cookie_auth), [oidc_auth](../README.md#oidc_auth), [saml_auth](../README.md#saml_auth), [jwt_token](../README.md#jwt_token)
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/octet-stream, application/json
+
+### HTTP response details
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+| **200** | object content |  * Content-Length -  <br>  |
+| **302** | Redirect to a pre-signed URL for the object |  * Location - redirect to S3 <br>  |
+| **401** | Unauthorized |  -  |
+| **404** | Resource Not Found |  -  |
+| **420** | too many requests |  -  |
+| **0** | Internal Server Error |  -  |
 
 <a id="getSetupState"></a>
 # **getSetupState**

--- a/clients/java/src/main/java/io/lakefs/clients/sdk/InternalApi.java
+++ b/clients/java/src/main/java/io/lakefs/clients/sdk/InternalApi.java
@@ -33,6 +33,7 @@ import io.lakefs.clients.sdk.model.CommPrefsInput;
 import io.lakefs.clients.sdk.model.CommitRecordCreation;
 import io.lakefs.clients.sdk.model.CredentialsWithSecret;
 import io.lakefs.clients.sdk.model.Error;
+import java.io.File;
 import io.lakefs.clients.sdk.model.GarbageCollectionConfig;
 import io.lakefs.clients.sdk.model.GarbageCollectionPrepareResponse;
 import io.lakefs.clients.sdk.model.GarbageCollectionRules;
@@ -1460,6 +1461,217 @@ public class InternalApi {
     @Deprecated
     public APIgetLakeFSVersionRequest getLakeFSVersion() {
         return new APIgetLakeFSVersionRequest();
+    }
+    private okhttp3.Call getMetadataObjectCall(String repository, String objectId, String type, Boolean presign, final ApiCallback _callback) throws ApiException {
+        String basePath = null;
+        // Operation Servers
+        String[] localBasePaths = new String[] {  };
+
+        // Determine Base Path to Use
+        if (localCustomBaseUrl != null){
+            basePath = localCustomBaseUrl;
+        } else if ( localBasePaths.length > 0 ) {
+            basePath = localBasePaths[localHostIndex];
+        } else {
+            basePath = null;
+        }
+
+        Object localVarPostBody = null;
+
+        // create path and map variables
+        String localVarPath = "/repositories/{repository}/metadata/object/{type}/{object_id}"
+            .replace("{" + "repository" + "}", localVarApiClient.escapeString(repository.toString()))
+            .replace("{" + "object_id" + "}", localVarApiClient.escapeString(objectId.toString()))
+            .replace("{" + "type" + "}", localVarApiClient.escapeString(type.toString()));
+
+        List<Pair> localVarQueryParams = new ArrayList<Pair>();
+        List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
+        Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+        Map<String, String> localVarCookieParams = new HashMap<String, String>();
+        Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+        if (presign != null) {
+            localVarQueryParams.addAll(localVarApiClient.parameterToPair("presign", presign));
+        }
+
+        final String[] localVarAccepts = {
+            "application/octet-stream",
+            "application/json"
+        };
+        final String localVarAccept = localVarApiClient.selectHeaderAccept(localVarAccepts);
+        if (localVarAccept != null) {
+            localVarHeaderParams.put("Accept", localVarAccept);
+        }
+
+        final String[] localVarContentTypes = {
+        };
+        final String localVarContentType = localVarApiClient.selectHeaderContentType(localVarContentTypes);
+        if (localVarContentType != null) {
+            localVarHeaderParams.put("Content-Type", localVarContentType);
+        }
+
+        String[] localVarAuthNames = new String[] { "basic_auth", "cookie_auth", "oidc_auth", "saml_auth", "jwt_token" };
+        return localVarApiClient.buildCall(basePath, localVarPath, "GET", localVarQueryParams, localVarCollectionQueryParams, localVarPostBody, localVarHeaderParams, localVarCookieParams, localVarFormParams, localVarAuthNames, _callback);
+    }
+
+    @SuppressWarnings("rawtypes")
+    private okhttp3.Call getMetadataObjectValidateBeforeCall(String repository, String objectId, String type, Boolean presign, final ApiCallback _callback) throws ApiException {
+        // verify the required parameter 'repository' is set
+        if (repository == null) {
+            throw new ApiException("Missing the required parameter 'repository' when calling getMetadataObject(Async)");
+        }
+
+        // verify the required parameter 'objectId' is set
+        if (objectId == null) {
+            throw new ApiException("Missing the required parameter 'objectId' when calling getMetadataObject(Async)");
+        }
+
+        // verify the required parameter 'type' is set
+        if (type == null) {
+            throw new ApiException("Missing the required parameter 'type' when calling getMetadataObject(Async)");
+        }
+
+        return getMetadataObjectCall(repository, objectId, type, presign, _callback);
+
+    }
+
+
+    private ApiResponse<File> getMetadataObjectWithHttpInfo(String repository, String objectId, String type, Boolean presign) throws ApiException {
+        okhttp3.Call localVarCall = getMetadataObjectValidateBeforeCall(repository, objectId, type, presign, null);
+        Type localVarReturnType = new TypeToken<File>(){}.getType();
+        return localVarApiClient.execute(localVarCall, localVarReturnType);
+    }
+
+    private okhttp3.Call getMetadataObjectAsync(String repository, String objectId, String type, Boolean presign, final ApiCallback<File> _callback) throws ApiException {
+
+        okhttp3.Call localVarCall = getMetadataObjectValidateBeforeCall(repository, objectId, type, presign, _callback);
+        Type localVarReturnType = new TypeToken<File>(){}.getType();
+        localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
+        return localVarCall;
+    }
+
+    public class APIgetMetadataObjectRequest {
+        private final String repository;
+        private final String objectId;
+        private final String type;
+        private Boolean presign;
+
+        private APIgetMetadataObjectRequest(String repository, String objectId, String type) {
+            this.repository = repository;
+            this.objectId = objectId;
+            this.type = type;
+        }
+
+        /**
+         * Set presign
+         * @param presign  (optional)
+         * @return APIgetMetadataObjectRequest
+         */
+        public APIgetMetadataObjectRequest presign(Boolean presign) {
+            this.presign = presign;
+            return this;
+        }
+
+        /**
+         * Build call for getMetadataObject
+         * @param _callback ApiCallback API callback
+         * @return Call to execute
+         * @throws ApiException If fail to serialize the request body object
+         * @http.response.details
+         <table summary="Response Details" border="1">
+            <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+            <tr><td> 200 </td><td> object content </td><td>  * Content-Length -  <br>  </td></tr>
+            <tr><td> 302 </td><td> Redirect to a pre-signed URL for the object </td><td>  * Location - redirect to S3 <br>  </td></tr>
+            <tr><td> 401 </td><td> Unauthorized </td><td>  -  </td></tr>
+            <tr><td> 404 </td><td> Resource Not Found </td><td>  -  </td></tr>
+            <tr><td> 420 </td><td> too many requests </td><td>  -  </td></tr>
+            <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
+         </table>
+         */
+        public okhttp3.Call buildCall(final ApiCallback _callback) throws ApiException {
+            return getMetadataObjectCall(repository, objectId, type, presign, _callback);
+        }
+
+        /**
+         * Execute getMetadataObject request
+         * @return File
+         * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+         * @http.response.details
+         <table summary="Response Details" border="1">
+            <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+            <tr><td> 200 </td><td> object content </td><td>  * Content-Length -  <br>  </td></tr>
+            <tr><td> 302 </td><td> Redirect to a pre-signed URL for the object </td><td>  * Location - redirect to S3 <br>  </td></tr>
+            <tr><td> 401 </td><td> Unauthorized </td><td>  -  </td></tr>
+            <tr><td> 404 </td><td> Resource Not Found </td><td>  -  </td></tr>
+            <tr><td> 420 </td><td> too many requests </td><td>  -  </td></tr>
+            <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
+         </table>
+         */
+        public File execute() throws ApiException {
+            ApiResponse<File> localVarResp = getMetadataObjectWithHttpInfo(repository, objectId, type, presign);
+            return localVarResp.getData();
+        }
+
+        /**
+         * Execute getMetadataObject request with HTTP info returned
+         * @return ApiResponse&lt;File&gt;
+         * @throws ApiException If fail to call the API, e.g. server error or cannot deserialize the response body
+         * @http.response.details
+         <table summary="Response Details" border="1">
+            <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+            <tr><td> 200 </td><td> object content </td><td>  * Content-Length -  <br>  </td></tr>
+            <tr><td> 302 </td><td> Redirect to a pre-signed URL for the object </td><td>  * Location - redirect to S3 <br>  </td></tr>
+            <tr><td> 401 </td><td> Unauthorized </td><td>  -  </td></tr>
+            <tr><td> 404 </td><td> Resource Not Found </td><td>  -  </td></tr>
+            <tr><td> 420 </td><td> too many requests </td><td>  -  </td></tr>
+            <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
+         </table>
+         */
+        public ApiResponse<File> executeWithHttpInfo() throws ApiException {
+            return getMetadataObjectWithHttpInfo(repository, objectId, type, presign);
+        }
+
+        /**
+         * Execute getMetadataObject request (asynchronously)
+         * @param _callback The callback to be executed when the API call finishes
+         * @return The request call
+         * @throws ApiException If fail to process the API call, e.g. serializing the request body object
+         * @http.response.details
+         <table summary="Response Details" border="1">
+            <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+            <tr><td> 200 </td><td> object content </td><td>  * Content-Length -  <br>  </td></tr>
+            <tr><td> 302 </td><td> Redirect to a pre-signed URL for the object </td><td>  * Location - redirect to S3 <br>  </td></tr>
+            <tr><td> 401 </td><td> Unauthorized </td><td>  -  </td></tr>
+            <tr><td> 404 </td><td> Resource Not Found </td><td>  -  </td></tr>
+            <tr><td> 420 </td><td> too many requests </td><td>  -  </td></tr>
+            <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
+         </table>
+         */
+        public okhttp3.Call executeAsync(final ApiCallback<File> _callback) throws ApiException {
+            return getMetadataObjectAsync(repository, objectId, type, presign, _callback);
+        }
+    }
+
+    /**
+     * return a lakeFS metadata object by ID
+     * 
+     * @param repository  (required)
+     * @param objectId  (required)
+     * @param type  (required)
+     * @return APIgetMetadataObjectRequest
+     * @http.response.details
+     <table summary="Response Details" border="1">
+        <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
+        <tr><td> 200 </td><td> object content </td><td>  * Content-Length -  <br>  </td></tr>
+        <tr><td> 302 </td><td> Redirect to a pre-signed URL for the object </td><td>  * Location - redirect to S3 <br>  </td></tr>
+        <tr><td> 401 </td><td> Unauthorized </td><td>  -  </td></tr>
+        <tr><td> 404 </td><td> Resource Not Found </td><td>  -  </td></tr>
+        <tr><td> 420 </td><td> too many requests </td><td>  -  </td></tr>
+        <tr><td> 0 </td><td> Internal Server Error </td><td>  -  </td></tr>
+     </table>
+     */
+    public APIgetMetadataObjectRequest getMetadataObject(String repository, String objectId, String type) {
+        return new APIgetMetadataObjectRequest(repository, objectId, type);
     }
     private okhttp3.Call getSetupStateCall(final ApiCallback _callback) throws ApiException {
         String basePath = null;

--- a/clients/java/src/test/java/io/lakefs/clients/sdk/InternalApiTest.java
+++ b/clients/java/src/test/java/io/lakefs/clients/sdk/InternalApiTest.java
@@ -20,6 +20,7 @@ import io.lakefs.clients.sdk.model.CommPrefsInput;
 import io.lakefs.clients.sdk.model.CommitRecordCreation;
 import io.lakefs.clients.sdk.model.CredentialsWithSecret;
 import io.lakefs.clients.sdk.model.Error;
+import java.io.File;
 import io.lakefs.clients.sdk.model.GarbageCollectionConfig;
 import io.lakefs.clients.sdk.model.GarbageCollectionPrepareResponse;
 import io.lakefs.clients.sdk.model.GarbageCollectionRules;
@@ -157,6 +158,23 @@ public class InternalApiTest {
     @Test
     public void getLakeFSVersionTest() throws ApiException {
         VersionConfig response = api.getLakeFSVersion()
+                .execute();
+        // TODO: test validations
+    }
+
+    /**
+     * return a lakeFS metadata object by ID
+     *
+     * @throws ApiException if the Api call fails
+     */
+    @Test
+    public void getMetadataObjectTest() throws ApiException {
+        String repository = null;
+        String objectId = null;
+        String type = null;
+        Boolean presign = null;
+        File response = api.getMetadataObject(repository, objectId, type)
+                .presign(presign)
                 .execute();
         // TODO: test validations
     }

--- a/clients/python-legacy/README.md
+++ b/clients/python-legacy/README.md
@@ -194,6 +194,7 @@ Class | Method | HTTP request | Description
 *InternalApi* | [**get_auth_capabilities**](docs/InternalApi.md#get_auth_capabilities) | **GET** /auth/capabilities | list authentication capabilities supported
 *InternalApi* | [**get_garbage_collection_config**](docs/InternalApi.md#get_garbage_collection_config) | **GET** /config/garbage-collection | 
 *InternalApi* | [**get_lake_fs_version**](docs/InternalApi.md#get_lake_fs_version) | **GET** /config/version | 
+*InternalApi* | [**get_metadata_object**](docs/InternalApi.md#get_metadata_object) | **GET** /repositories/{repository}/metadata/object/{type}/{object_id} | return a lakeFS metadata object by ID
 *InternalApi* | [**get_setup_state**](docs/InternalApi.md#get_setup_state) | **GET** /setup_lakefs | check if the lakeFS installation is already set up
 *InternalApi* | [**get_storage_config**](docs/InternalApi.md#get_storage_config) | **GET** /config/storage | 
 *InternalApi* | [**get_usage_report_summary**](docs/InternalApi.md#get_usage_report_summary) | **GET** /usage-report/summary | get usage report summary

--- a/clients/python-legacy/docs/InternalApi.md
+++ b/clients/python-legacy/docs/InternalApi.md
@@ -12,6 +12,7 @@ Method | HTTP request | Description
 [**get_auth_capabilities**](InternalApi.md#get_auth_capabilities) | **GET** /auth/capabilities | list authentication capabilities supported
 [**get_garbage_collection_config**](InternalApi.md#get_garbage_collection_config) | **GET** /config/garbage-collection | 
 [**get_lake_fs_version**](InternalApi.md#get_lake_fs_version) | **GET** /config/version | 
+[**get_metadata_object**](InternalApi.md#get_metadata_object) | **GET** /repositories/{repository}/metadata/object/{type}/{object_id} | return a lakeFS metadata object by ID
 [**get_setup_state**](InternalApi.md#get_setup_state) | **GET** /setup_lakefs | check if the lakeFS installation is already set up
 [**get_storage_config**](InternalApi.md#get_storage_config) | **GET** /config/storage | 
 [**get_usage_report_summary**](InternalApi.md#get_usage_report_summary) | **GET** /usage-report/summary | get usage report summary
@@ -874,6 +875,129 @@ This endpoint does not need any parameter.
 |-------------|-------------|------------------|
 **200** | lakeFS version |  -  |
 **401** | Unauthorized |  -  |
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **get_metadata_object**
+> file_type get_metadata_object(repository, object_id, type)
+
+return a lakeFS metadata object by ID
+
+### Example
+
+* Basic Authentication (basic_auth):
+* Api Key Authentication (cookie_auth):
+* Bearer (JWT) Authentication (jwt_token):
+* Api Key Authentication (oidc_auth):
+* Api Key Authentication (saml_auth):
+
+```python
+import time
+import lakefs_client
+from lakefs_client.api import internal_api
+from lakefs_client.model.error import Error
+from pprint import pprint
+# Defining the host is optional and defaults to http://localhost/api/v1
+# See configuration.py for a list of all supported configuration parameters.
+configuration = lakefs_client.Configuration(
+    host = "http://localhost/api/v1"
+)
+
+# The client must configure the authentication and authorization parameters
+# in accordance with the API server security policy.
+# Examples for each auth method are provided below, use the example that
+# satisfies your auth use case.
+
+# Configure HTTP basic authorization: basic_auth
+configuration = lakefs_client.Configuration(
+    username = 'YOUR_USERNAME',
+    password = 'YOUR_PASSWORD'
+)
+
+# Configure API key authorization: cookie_auth
+configuration.api_key['cookie_auth'] = 'YOUR_API_KEY'
+
+# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+# configuration.api_key_prefix['cookie_auth'] = 'Bearer'
+
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_client.Configuration(
+    access_token = 'YOUR_BEARER_TOKEN'
+)
+
+# Configure API key authorization: oidc_auth
+configuration.api_key['oidc_auth'] = 'YOUR_API_KEY'
+
+# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+# configuration.api_key_prefix['oidc_auth'] = 'Bearer'
+
+# Configure API key authorization: saml_auth
+configuration.api_key['saml_auth'] = 'YOUR_API_KEY'
+
+# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+# configuration.api_key_prefix['saml_auth'] = 'Bearer'
+
+# Enter a context with an instance of the API client
+with lakefs_client.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = internal_api.InternalApi(api_client)
+    repository = "repository_example" # str | 
+    object_id = "object_id_example" # str | 
+    type = "range" # str | 
+    presign = True # bool |  (optional)
+
+    # example passing only required values which don't have defaults set
+    try:
+        # return a lakeFS metadata object by ID
+        api_response = api_instance.get_metadata_object(repository, object_id, type)
+        pprint(api_response)
+    except lakefs_client.ApiException as e:
+        print("Exception when calling InternalApi->get_metadata_object: %s\n" % e)
+
+    # example passing only required values which don't have defaults set
+    # and optional values
+    try:
+        # return a lakeFS metadata object by ID
+        api_response = api_instance.get_metadata_object(repository, object_id, type, presign=presign)
+        pprint(api_response)
+    except lakefs_client.ApiException as e:
+        print("Exception when calling InternalApi->get_metadata_object: %s\n" % e)
+```
+
+
+### Parameters
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **repository** | **str**|  |
+ **object_id** | **str**|  |
+ **type** | **str**|  |
+ **presign** | **bool**|  | [optional]
+
+### Return type
+
+**file_type**
+
+### Authorization
+
+[basic_auth](../README.md#basic_auth), [cookie_auth](../README.md#cookie_auth), [jwt_token](../README.md#jwt_token), [oidc_auth](../README.md#oidc_auth), [saml_auth](../README.md#saml_auth)
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/octet-stream, application/json
+
+
+### HTTP response details
+
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+**200** | object content |  * Content-Length -  <br>  |
+**302** | Redirect to a pre-signed URL for the object |  * Location - redirect to S3 <br>  |
+**401** | Unauthorized |  -  |
+**404** | Resource Not Found |  -  |
+**420** | too many requests |  -  |
+**0** | Internal Server Error |  -  |
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 

--- a/clients/python-legacy/lakefs_client/api/internal_api.py
+++ b/clients/python-legacy/lakefs_client/api/internal_api.py
@@ -498,6 +498,85 @@ class InternalApi(object):
             },
             api_client=api_client
         )
+        self.get_metadata_object_endpoint = _Endpoint(
+            settings={
+                'response_type': (file_type,),
+                'auth': [
+                    'basic_auth',
+                    'cookie_auth',
+                    'jwt_token',
+                    'oidc_auth',
+                    'saml_auth'
+                ],
+                'endpoint_path': '/repositories/{repository}/metadata/object/{type}/{object_id}',
+                'operation_id': 'get_metadata_object',
+                'http_method': 'GET',
+                'servers': None,
+            },
+            params_map={
+                'all': [
+                    'repository',
+                    'object_id',
+                    'type',
+                    'presign',
+                ],
+                'required': [
+                    'repository',
+                    'object_id',
+                    'type',
+                ],
+                'nullable': [
+                ],
+                'enum': [
+                    'type',
+                ],
+                'validation': [
+                ]
+            },
+            root_map={
+                'validations': {
+                },
+                'allowed_values': {
+                    ('type',): {
+
+                        "RANGE": "range",
+                        "META_RANGE": "meta_range"
+                    },
+                },
+                'openapi_types': {
+                    'repository':
+                        (str,),
+                    'object_id':
+                        (str,),
+                    'type':
+                        (str,),
+                    'presign':
+                        (bool,),
+                },
+                'attribute_map': {
+                    'repository': 'repository',
+                    'object_id': 'object_id',
+                    'type': 'type',
+                    'presign': 'presign',
+                },
+                'location_map': {
+                    'repository': 'path',
+                    'object_id': 'path',
+                    'type': 'path',
+                    'presign': 'query',
+                },
+                'collection_format_map': {
+                }
+            },
+            headers_map={
+                'accept': [
+                    'application/octet-stream',
+                    'application/json'
+                ],
+                'content_type': [],
+            },
+            api_client=api_client
+        )
         self.get_setup_state_endpoint = _Endpoint(
             settings={
                 'response_type': (SetupState,),
@@ -2101,6 +2180,80 @@ class InternalApi(object):
         )
         kwargs['_host_index'] = kwargs.get('_host_index')
         return self.get_lake_fs_version_endpoint.call_with_http_info(**kwargs)
+
+    def get_metadata_object(
+        self,
+        repository,
+        object_id,
+        type,
+        **kwargs
+    ):
+        """return a lakeFS metadata object by ID  # noqa: E501
+
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async_req=True
+
+        >>> thread = api.get_metadata_object(repository, object_id, type, async_req=True)
+        >>> result = thread.get()
+
+        Args:
+            repository (str):
+            object_id (str):
+            type (str):
+
+        Keyword Args:
+            presign (bool): [optional]
+            _return_http_data_only (bool): response data without head status
+                code and headers. Default is True.
+            _preload_content (bool): if False, the urllib3.HTTPResponse object
+                will be returned without reading/decoding response data.
+                Default is True.
+            _request_timeout (int/float/tuple): timeout setting for this request. If
+                one number provided, it will be total request timeout. It can also
+                be a pair (tuple) of (connection, read) timeouts.
+                Default is None.
+            _check_input_type (bool): specifies if type checking
+                should be done one the data sent to the server.
+                Default is True.
+            _check_return_type (bool): specifies if type checking
+                should be done one the data received from the server.
+                Default is True.
+            _host_index (int/None): specifies the index of the server
+                that we want to use.
+                Default is read from the configuration.
+            async_req (bool): execute request asynchronously
+
+        Returns:
+            file_type
+                If the method is called asynchronously, returns the request
+                thread.
+        """
+        kwargs['async_req'] = kwargs.get(
+            'async_req', False
+        )
+        kwargs['_return_http_data_only'] = kwargs.get(
+            '_return_http_data_only', True
+        )
+        kwargs['_preload_content'] = kwargs.get(
+            '_preload_content', True
+        )
+        kwargs['_request_timeout'] = kwargs.get(
+            '_request_timeout', None
+        )
+        kwargs['_check_input_type'] = kwargs.get(
+            '_check_input_type', True
+        )
+        kwargs['_check_return_type'] = kwargs.get(
+            '_check_return_type', True
+        )
+        kwargs['_host_index'] = kwargs.get('_host_index')
+        kwargs['repository'] = \
+            repository
+        kwargs['object_id'] = \
+            object_id
+        kwargs['type'] = \
+            type
+        return self.get_metadata_object_endpoint.call_with_http_info(**kwargs)
 
     def get_setup_state(
         self,

--- a/clients/python-legacy/test/test_internal_api.py
+++ b/clients/python-legacy/test/test_internal_api.py
@@ -77,6 +77,13 @@ class TestInternalApi(unittest.TestCase):
         """
         pass
 
+    def test_get_metadata_object(self):
+        """Test case for get_metadata_object
+
+        return a lakeFS metadata object by ID  # noqa: E501
+        """
+        pass
+
     def test_get_setup_state(self):
         """Test case for get_setup_state
 

--- a/clients/python/README.md
+++ b/clients/python/README.md
@@ -197,6 +197,7 @@ Class | Method | HTTP request | Description
 *InternalApi* | [**get_auth_capabilities**](docs/InternalApi.md#get_auth_capabilities) | **GET** /auth/capabilities | list authentication capabilities supported
 *InternalApi* | [**get_garbage_collection_config**](docs/InternalApi.md#get_garbage_collection_config) | **GET** /config/garbage-collection | 
 *InternalApi* | [**get_lake_fs_version**](docs/InternalApi.md#get_lake_fs_version) | **GET** /config/version | 
+*InternalApi* | [**get_metadata_object**](docs/InternalApi.md#get_metadata_object) | **GET** /repositories/{repository}/metadata/object/{type}/{object_id} | return a lakeFS metadata object by ID
 *InternalApi* | [**get_setup_state**](docs/InternalApi.md#get_setup_state) | **GET** /setup_lakefs | check if the lakeFS installation is already set up
 *InternalApi* | [**get_storage_config**](docs/InternalApi.md#get_storage_config) | **GET** /config/storage | 
 *InternalApi* | [**get_usage_report_summary**](docs/InternalApi.md#get_usage_report_summary) | **GET** /usage-report/summary | get usage report summary

--- a/clients/python/docs/InternalApi.md
+++ b/clients/python/docs/InternalApi.md
@@ -12,6 +12,7 @@ Method | HTTP request | Description
 [**get_auth_capabilities**](InternalApi.md#get_auth_capabilities) | **GET** /auth/capabilities | list authentication capabilities supported
 [**get_garbage_collection_config**](InternalApi.md#get_garbage_collection_config) | **GET** /config/garbage-collection | 
 [**get_lake_fs_version**](InternalApi.md#get_lake_fs_version) | **GET** /config/version | 
+[**get_metadata_object**](InternalApi.md#get_metadata_object) | **GET** /repositories/{repository}/metadata/object/{type}/{object_id} | return a lakeFS metadata object by ID
 [**get_setup_state**](InternalApi.md#get_setup_state) | **GET** /setup_lakefs | check if the lakeFS installation is already set up
 [**get_storage_config**](InternalApi.md#get_storage_config) | **GET** /config/storage | 
 [**get_usage_report_summary**](InternalApi.md#get_usage_report_summary) | **GET** /usage-report/summary | get usage report summary
@@ -859,6 +860,122 @@ This endpoint does not need any parameter.
 |-------------|-------------|------------------|
 **200** | lakeFS version |  -  |
 **401** | Unauthorized |  -  |
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+# **get_metadata_object**
+> bytearray get_metadata_object(repository, object_id, type, presign=presign)
+
+return a lakeFS metadata object by ID
+
+### Example
+
+* Basic Authentication (basic_auth):
+* Api Key Authentication (cookie_auth):
+* Api Key Authentication (oidc_auth):
+* Api Key Authentication (saml_auth):
+* Bearer (JWT) Authentication (jwt_token):
+
+```python
+import time
+import os
+import lakefs_sdk
+from lakefs_sdk.rest import ApiException
+from pprint import pprint
+
+# Defining the host is optional and defaults to /api/v1
+# See configuration.py for a list of all supported configuration parameters.
+configuration = lakefs_sdk.Configuration(
+    host = "/api/v1"
+)
+
+# The client must configure the authentication and authorization parameters
+# in accordance with the API server security policy.
+# Examples for each auth method are provided below, use the example that
+# satisfies your auth use case.
+
+# Configure HTTP basic authorization: basic_auth
+configuration = lakefs_sdk.Configuration(
+    username = os.environ["USERNAME"],
+    password = os.environ["PASSWORD"]
+)
+
+# Configure API key authorization: cookie_auth
+configuration.api_key['cookie_auth'] = os.environ["API_KEY"]
+
+# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+# configuration.api_key_prefix['cookie_auth'] = 'Bearer'
+
+# Configure API key authorization: oidc_auth
+configuration.api_key['oidc_auth'] = os.environ["API_KEY"]
+
+# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+# configuration.api_key_prefix['oidc_auth'] = 'Bearer'
+
+# Configure API key authorization: saml_auth
+configuration.api_key['saml_auth'] = os.environ["API_KEY"]
+
+# Uncomment below to setup prefix (e.g. Bearer) for API key, if needed
+# configuration.api_key_prefix['saml_auth'] = 'Bearer'
+
+# Configure Bearer authorization (JWT): jwt_token
+configuration = lakefs_sdk.Configuration(
+    access_token = os.environ["BEARER_TOKEN"]
+)
+
+# Enter a context with an instance of the API client
+with lakefs_sdk.ApiClient(configuration) as api_client:
+    # Create an instance of the API class
+    api_instance = lakefs_sdk.InternalApi(api_client)
+    repository = 'repository_example' # str | 
+    object_id = 'object_id_example' # str | 
+    type = 'type_example' # str | 
+    presign = True # bool |  (optional)
+
+    try:
+        # return a lakeFS metadata object by ID
+        api_response = api_instance.get_metadata_object(repository, object_id, type, presign=presign)
+        print("The response of InternalApi->get_metadata_object:\n")
+        pprint(api_response)
+    except Exception as e:
+        print("Exception when calling InternalApi->get_metadata_object: %s\n" % e)
+```
+
+
+
+### Parameters
+
+
+Name | Type | Description  | Notes
+------------- | ------------- | ------------- | -------------
+ **repository** | **str**|  | 
+ **object_id** | **str**|  | 
+ **type** | **str**|  | 
+ **presign** | **bool**|  | [optional] 
+
+### Return type
+
+**bytearray**
+
+### Authorization
+
+[basic_auth](../README.md#basic_auth), [cookie_auth](../README.md#cookie_auth), [oidc_auth](../README.md#oidc_auth), [saml_auth](../README.md#saml_auth), [jwt_token](../README.md#jwt_token)
+
+### HTTP request headers
+
+ - **Content-Type**: Not defined
+ - **Accept**: application/octet-stream, application/json
+
+### HTTP response details
+
+| Status code | Description | Response headers |
+|-------------|-------------|------------------|
+**200** | object content |  * Content-Length -  <br>  |
+**302** | Redirect to a pre-signed URL for the object |  * Location - redirect to S3 <br>  |
+**401** | Unauthorized |  -  |
+**404** | Resource Not Found |  -  |
+**420** | too many requests |  -  |
+**0** | Internal Server Error |  -  |
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 

--- a/clients/python/lakefs_sdk/api/internal_api.py
+++ b/clients/python/lakefs_sdk/api/internal_api.py
@@ -24,11 +24,11 @@ except ImportError:
 from typing_extensions import Annotated
 
 try:
-    from pydantic.v1 import Field, StrictStr
+    from pydantic.v1 import Field, StrictBool, StrictStr
 except ImportError:
-    from pydantic import Field, StrictStr
+    from pydantic import Field, StrictBool, StrictStr
 
-from typing import List, Optional
+from typing import List, Optional, Union
 
 from lakefs_sdk.models.auth_capabilities import AuthCapabilities
 from lakefs_sdk.models.branch_protection_rule import BranchProtectionRule
@@ -1190,6 +1190,171 @@ class InternalApi(object):
 
         return self.api_client.call_api(
             '/config/version', 'GET',
+            _path_params,
+            _query_params,
+            _header_params,
+            body=_body_params,
+            post_params=_form_params,
+            files=_files,
+            response_types_map=_response_types_map,
+            auth_settings=_auth_settings,
+            async_req=_params.get('async_req'),
+            _return_http_data_only=_params.get('_return_http_data_only'),  # noqa: E501
+            _preload_content=_params.get('_preload_content', True),
+            _request_timeout=_params.get('_request_timeout'),
+            collection_formats=_collection_formats,
+            _request_auth=_params.get('_request_auth'))
+
+    @validate_arguments
+    def get_metadata_object(self, repository : StrictStr, object_id : StrictStr, type : StrictStr, presign : Optional[StrictBool] = None, **kwargs) -> bytearray:  # noqa: E501
+        """return a lakeFS metadata object by ID  # noqa: E501
+
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async_req=True
+
+        >>> thread = api.get_metadata_object(repository, object_id, type, presign, async_req=True)
+        >>> result = thread.get()
+
+        :param repository: (required)
+        :type repository: str
+        :param object_id: (required)
+        :type object_id: str
+        :param type: (required)
+        :type type: str
+        :param presign:
+        :type presign: bool
+        :param async_req: Whether to execute the request asynchronously.
+        :type async_req: bool, optional
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :return: Returns the result object.
+                 If the method is called asynchronously,
+                 returns the request thread.
+        :rtype: bytearray
+        """
+        kwargs['_return_http_data_only'] = True
+        if '_preload_content' in kwargs:
+            raise ValueError("Error! Please call the get_metadata_object_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data")
+        return self.get_metadata_object_with_http_info(repository, object_id, type, presign, **kwargs)  # noqa: E501
+
+    @validate_arguments
+    def get_metadata_object_with_http_info(self, repository : StrictStr, object_id : StrictStr, type : StrictStr, presign : Optional[StrictBool] = None, **kwargs) -> ApiResponse:  # noqa: E501
+        """return a lakeFS metadata object by ID  # noqa: E501
+
+        This method makes a synchronous HTTP request by default. To make an
+        asynchronous HTTP request, please pass async_req=True
+
+        >>> thread = api.get_metadata_object_with_http_info(repository, object_id, type, presign, async_req=True)
+        >>> result = thread.get()
+
+        :param repository: (required)
+        :type repository: str
+        :param object_id: (required)
+        :type object_id: str
+        :param type: (required)
+        :type type: str
+        :param presign:
+        :type presign: bool
+        :param async_req: Whether to execute the request asynchronously.
+        :type async_req: bool, optional
+        :param _preload_content: if False, the ApiResponse.data will
+                                 be set to none and raw_data will store the 
+                                 HTTP response body without reading/decoding.
+                                 Default is True.
+        :type _preload_content: bool, optional
+        :param _return_http_data_only: response data instead of ApiResponse
+                                       object with status code, headers, etc
+        :type _return_http_data_only: bool, optional
+        :param _request_timeout: timeout setting for this request. If one
+                                 number provided, it will be total request
+                                 timeout. It can also be a pair (tuple) of
+                                 (connection, read) timeouts.
+        :param _request_auth: set to override the auth_settings for an a single
+                              request; this effectively ignores the authentication
+                              in the spec for a single request.
+        :type _request_auth: dict, optional
+        :type _content_type: string, optional: force content-type for the request
+        :return: Returns the result object.
+                 If the method is called asynchronously,
+                 returns the request thread.
+        :rtype: tuple(bytearray, status_code(int), headers(HTTPHeaderDict))
+        """
+
+        _params = locals()
+
+        _all_params = [
+            'repository',
+            'object_id',
+            'type',
+            'presign'
+        ]
+        _all_params.extend(
+            [
+                'async_req',
+                '_return_http_data_only',
+                '_preload_content',
+                '_request_timeout',
+                '_request_auth',
+                '_content_type',
+                '_headers'
+            ]
+        )
+
+        # validate the arguments
+        for _key, _val in _params['kwargs'].items():
+            if _key not in _all_params:
+                raise ApiTypeError(
+                    "Got an unexpected keyword argument '%s'"
+                    " to method get_metadata_object" % _key
+                )
+            _params[_key] = _val
+        del _params['kwargs']
+
+        _collection_formats = {}
+
+        # process the path parameters
+        _path_params = {}
+        if _params['repository']:
+            _path_params['repository'] = _params['repository']
+
+        if _params['object_id']:
+            _path_params['object_id'] = _params['object_id']
+
+        if _params['type']:
+            _path_params['type'] = _params['type']
+
+
+        # process the query parameters
+        _query_params = []
+        if _params.get('presign') is not None:  # noqa: E501
+            _query_params.append(('presign', _params['presign']))
+
+        # process the header parameters
+        _header_params = dict(_params.get('_headers', {}))
+        # process the form parameters
+        _form_params = []
+        _files = {}
+        # process the body parameter
+        _body_params = None
+        # set the HTTP header `Accept`
+        _header_params['Accept'] = self.api_client.select_header_accept(
+            ['application/octet-stream', 'application/json'])  # noqa: E501
+
+        # authentication setting
+        _auth_settings = ['basic_auth', 'cookie_auth', 'oidc_auth', 'saml_auth', 'jwt_token']  # noqa: E501
+
+        _response_types_map = {
+            '200': "bytearray",
+            '302': None,
+            '401': "Error",
+            '404': "Error",
+            '420': None,
+        }
+
+        return self.api_client.call_api(
+            '/repositories/{repository}/metadata/object/{type}/{object_id}', 'GET',
             _path_params,
             _query_params,
             _header_params,

--- a/clients/python/test/test_internal_api.py
+++ b/clients/python/test/test_internal_api.py
@@ -82,6 +82,13 @@ class TestInternalApi(unittest.TestCase):
         """
         pass
 
+    def test_get_metadata_object(self):
+        """Test case for get_metadata_object
+
+        return a lakeFS metadata object by ID  # noqa: E501
+        """
+        pass
+
     def test_get_setup_state(self):
         """Test case for get_setup_state
 

--- a/clients/rust/README.md
+++ b/clients/rust/README.md
@@ -104,6 +104,7 @@ Class | Method | HTTP request | Description
 *InternalApi* | [**get_auth_capabilities**](docs/InternalApi.md#get_auth_capabilities) | **GET** /auth/capabilities | list authentication capabilities supported
 *InternalApi* | [**get_garbage_collection_config**](docs/InternalApi.md#get_garbage_collection_config) | **GET** /config/garbage-collection | 
 *InternalApi* | [**get_lake_fs_version**](docs/InternalApi.md#get_lake_fs_version) | **GET** /config/version | 
+*InternalApi* | [**get_metadata_object**](docs/InternalApi.md#get_metadata_object) | **GET** /repositories/{repository}/metadata/object/{type}/{object_id} | return a lakeFS metadata object by ID
 *InternalApi* | [**get_setup_state**](docs/InternalApi.md#get_setup_state) | **GET** /setup_lakefs | check if the lakeFS installation is already set up
 *InternalApi* | [**get_storage_config**](docs/InternalApi.md#get_storage_config) | **GET** /config/storage | 
 *InternalApi* | [**get_usage_report_summary**](docs/InternalApi.md#get_usage_report_summary) | **GET** /usage-report/summary | get usage report summary

--- a/clients/rust/docs/InternalApi.md
+++ b/clients/rust/docs/InternalApi.md
@@ -12,6 +12,7 @@ Method | HTTP request | Description
 [**get_auth_capabilities**](InternalApi.md#get_auth_capabilities) | **GET** /auth/capabilities | list authentication capabilities supported
 [**get_garbage_collection_config**](InternalApi.md#get_garbage_collection_config) | **GET** /config/garbage-collection | 
 [**get_lake_fs_version**](InternalApi.md#get_lake_fs_version) | **GET** /config/version | 
+[**get_metadata_object**](InternalApi.md#get_metadata_object) | **GET** /repositories/{repository}/metadata/object/{type}/{object_id} | return a lakeFS metadata object by ID
 [**get_setup_state**](InternalApi.md#get_setup_state) | **GET** /setup_lakefs | check if the lakeFS installation is already set up
 [**get_storage_config**](InternalApi.md#get_storage_config) | **GET** /config/storage | 
 [**get_usage_report_summary**](InternalApi.md#get_usage_report_summary) | **GET** /usage-report/summary | get usage report summary
@@ -255,6 +256,37 @@ This endpoint does not need any parameter.
 
 - **Content-Type**: Not defined
 - **Accept**: application/json
+
+[[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
+
+
+## get_metadata_object
+
+> std::path::PathBuf get_metadata_object(repository, object_id, r#type, presign)
+return a lakeFS metadata object by ID
+
+### Parameters
+
+
+Name | Type | Description  | Required | Notes
+------------- | ------------- | ------------- | ------------- | -------------
+**repository** | **String** |  | [required] |
+**object_id** | **String** |  | [required] |
+**r#type** | **String** |  | [required] |
+**presign** | Option<**bool**> |  |  |
+
+### Return type
+
+[**std::path::PathBuf**](std::path::PathBuf.md)
+
+### Authorization
+
+[basic_auth](../README.md#basic_auth), [cookie_auth](../README.md#cookie_auth), [oidc_auth](../README.md#oidc_auth), [saml_auth](../README.md#saml_auth), [jwt_token](../README.md#jwt_token)
+
+### HTTP request headers
+
+- **Content-Type**: Not defined
+- **Accept**: application/octet-stream, application/json
 
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 

--- a/clients/rust/src/apis/internal_api.rs
+++ b/clients/rust/src/apis/internal_api.rs
@@ -98,6 +98,17 @@ pub enum GetLakeFsVersionError {
     UnknownValue(serde_json::Value),
 }
 
+/// struct for typed errors of method [`get_metadata_object`]
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(untagged)]
+pub enum GetMetadataObjectError {
+    Status401(models::Error),
+    Status404(models::Error),
+    Status420(),
+    DefaultResponse(models::Error),
+    UnknownValue(serde_json::Value),
+}
+
 /// struct for typed errors of method [`get_setup_state`]
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
@@ -572,6 +583,42 @@ pub async fn get_lake_fs_version(configuration: &configuration::Configuration, )
         serde_json::from_str(&local_var_content).map_err(Error::from)
     } else {
         let local_var_entity: Option<GetLakeFsVersionError> = serde_json::from_str(&local_var_content).ok();
+        let local_var_error = ResponseContent { status: local_var_status, content: local_var_content, entity: local_var_entity };
+        Err(Error::ResponseError(local_var_error))
+    }
+}
+
+pub async fn get_metadata_object(configuration: &configuration::Configuration, repository: &str, object_id: &str, r#type: &str, presign: Option<bool>) -> Result<std::path::PathBuf, Error<GetMetadataObjectError>> {
+    let local_var_configuration = configuration;
+
+    let local_var_client = &local_var_configuration.client;
+
+    let local_var_uri_str = format!("{}/repositories/{repository}/metadata/object/{type}/{object_id}", local_var_configuration.base_path, repository=crate::apis::urlencode(repository), object_id=crate::apis::urlencode(object_id), type=crate::apis::urlencode(r#type));
+    let mut local_var_req_builder = local_var_client.request(reqwest::Method::GET, local_var_uri_str.as_str());
+
+    if let Some(ref local_var_str) = presign {
+        local_var_req_builder = local_var_req_builder.query(&[("presign", &local_var_str.to_string())]);
+    }
+    if let Some(ref local_var_user_agent) = local_var_configuration.user_agent {
+        local_var_req_builder = local_var_req_builder.header(reqwest::header::USER_AGENT, local_var_user_agent.clone());
+    }
+    if let Some(ref local_var_auth_conf) = local_var_configuration.basic_auth {
+        local_var_req_builder = local_var_req_builder.basic_auth(local_var_auth_conf.0.to_owned(), local_var_auth_conf.1.to_owned());
+    };
+    if let Some(ref local_var_token) = local_var_configuration.bearer_access_token {
+        local_var_req_builder = local_var_req_builder.bearer_auth(local_var_token.to_owned());
+    };
+
+    let local_var_req = local_var_req_builder.build()?;
+    let local_var_resp = local_var_client.execute(local_var_req).await?;
+
+    let local_var_status = local_var_resp.status();
+    let local_var_content = local_var_resp.text().await?;
+
+    if !local_var_status.is_client_error() && !local_var_status.is_server_error() {
+        serde_json::from_str(&local_var_content).map_err(Error::from)
+    } else {
+        let local_var_entity: Option<GetMetadataObjectError> = serde_json::from_str(&local_var_content).ok();
         let local_var_error = ResponseContent { status: local_var_status, content: local_var_content, entity: local_var_entity };
         Err(Error::ResponseError(local_var_error))
     }

--- a/docs/assets/js/swagger.yml
+++ b/docs/assets/js/swagger.yml
@@ -5159,6 +5159,66 @@ paths:
         default:
           $ref: "#/components/responses/ServerError"
 
+  /repositories/{repository}/metadata/object/{type}/{object_id}:
+    parameters:
+      - in: path
+        name: repository
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: object_id
+        required: true
+        schema:
+          type: string
+      - in: path
+        name: type
+        required: true
+        schema:
+          type: string
+          enum:
+            - range
+            - meta_range
+    get:
+      tags:
+        - internal
+      operationId: getMetadataObject
+      summary: return a lakeFS metadata object by ID
+      parameters:
+        - in: query
+          name: presign
+          required: false
+          schema:
+            type: boolean
+      responses:
+        200:
+          description: object content
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary
+          headers:
+            Content-Length:
+              schema:
+                type: integer
+                format: int64
+        302:
+          description: Redirect to a pre-signed URL for the object
+          headers:
+            Location:
+              schema:
+                type: string
+        401:
+          $ref: "#/components/responses/Unauthorized"
+        404:
+          $ref: "#/components/responses/NotFound"
+        420:
+          description: too many requests
+        default:
+          $ref: "#/components/responses/ServerError"
+
+
   /repositories/{repository}/metadata/meta_range/{meta_range}:
     parameters:
       - in: path

--- a/esti/metadata_download_test.go
+++ b/esti/metadata_download_test.go
@@ -1,0 +1,78 @@
+package esti
+
+import (
+	"context"
+	"testing"
+
+	pebblesst "github.com/cockroachdb/pebble/sstable"
+	"github.com/treeverse/lakefs/pkg/graveler/sstable"
+
+	"github.com/treeverse/lakefs/pkg/graveler/committed"
+
+	"github.com/stretchr/testify/require"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
+)
+
+func gravelerIterator(data []byte) (*sstable.Iterator, error) {
+	// read file descriptor
+	reader, err := pebblesst.NewMemReader(data, pebblesst.ReaderOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	// create an iterator over the whole thing
+	iter, err := reader.NewIter(nil, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// wrap it in a Graveler iterator
+	dummyDeref := func() error { return nil }
+	return sstable.NewIterator(iter, dummyDeref), nil
+}
+
+func TestDownloadMetadataObject(t *testing.T) {
+	ctx := context.Background()
+	const numOfRepos = 5
+
+	repo := createRepositoryUnique(ctx, t)
+	uploadFileRandomData(ctx, t, repo, mainBranch, "some/random/path/43543985430548930")
+	commitResp, err := client.CommitWithResponse(ctx, repo, mainBranch, &apigen.CommitParams{}, apigen.CommitJSONRequestBody{
+		Message: "committing just to get a meta range!",
+	})
+	require.NoError(t, err, "failed to commit changes")
+	metarangeId := commitResp.JSON201.MetaRangeId
+
+	// download meta-range
+	response, err := client.GetMetadataObjectWithResponse(ctx, repo, "meta_range", metarangeId, &apigen.GetMetadataObjectParams{})
+	if err != nil {
+		t.Errorf("got unexpected error downloading metarange")
+	}
+	// try reading the meta-range
+	iter, err := gravelerIterator(response.Body)
+	if err != nil {
+		t.Error("could not get an iterator from meta-range body")
+	}
+	if !iter.Next() {
+		t.Error("should have at least one range")
+	}
+	record := iter.Value()
+	gv, err := committed.UnmarshalValue(record.Value)
+	if err != nil {
+		t.Error("could not read range data")
+	}
+	rangeId := committed.ID(gv.Identity)
+
+	// now try the range ID
+	response, err = client.GetMetadataObjectWithResponse(ctx, repo, "range", string(rangeId), &apigen.GetMetadataObjectParams{})
+	require.NoError(t, err, "failed to get range with presign=true")
+
+	// try reading the range
+	iter, err = gravelerIterator(response.Body)
+	if err != nil {
+		t.Error("could not get an iterator from range body")
+	}
+	if !iter.Next() {
+		t.Error("should have at least one record")
+	}
+}

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -2067,7 +2067,7 @@ func (c *Controller) ensureStorageNamespace(ctx context.Context, storageNamespac
 			Identifier:       dummyObjName,
 		}
 
-		if s, err := c.BlockAdapter.Get(ctx, rootObj, objLen); err == nil {
+		if s, err := c.BlockAdapter.Get(ctx, rootObj); err == nil {
 			_ = s.Close()
 			return fmt.Errorf("found lakeFS objects in the storage namespace root(%s): %w",
 				storageNamespace, ErrStorageNamespaceInUse)
@@ -2083,7 +2083,7 @@ func (c *Controller) ensureStorageNamespace(ctx context.Context, storageNamespac
 		Identifier:       dummyKey,
 	}
 
-	if s, err := c.BlockAdapter.Get(ctx, obj, objLen); err == nil {
+	if s, err := c.BlockAdapter.Get(ctx, obj); err == nil {
 		_ = s.Close()
 		return fmt.Errorf("found lakeFS objects in the storage namespace(%s) key(%s): %w",
 			storageNamespace, obj.Identifier, ErrStorageNamespaceInUse)
@@ -2095,7 +2095,7 @@ func (c *Controller) ensureStorageNamespace(ctx context.Context, storageNamespac
 		return err
 	}
 
-	_, err := c.BlockAdapter.Get(ctx, obj, objLen)
+	_, err := c.BlockAdapter.Get(ctx, obj)
 	return err
 }
 
@@ -2526,7 +2526,7 @@ func (c *Controller) GetRunHookOutput(w http.ResponseWriter, r *http.Request, re
 		StorageNamespace: repo.StorageNamespace,
 		IdentifierType:   block.IdentifierTypeRelative,
 		Identifier:       logPath,
-	}, -1)
+	})
 	if c.handleAPIError(ctx, w, r, err) {
 		return
 	}
@@ -4286,6 +4286,94 @@ func (c *Controller) HeadObject(w http.ResponseWriter, r *http.Request, reposito
 	}
 }
 
+func (c *Controller) GetMetadataObject(w http.ResponseWriter, r *http.Request, repository string, objectType string, objectId string, params apigen.GetMetadataObjectParams) {
+	const getTypeMetaRange = "meta_range"
+	const getTypeRange = "range"
+
+	if !c.authorize(w, r, permissions.Node{
+		Type: permissions.NodeTypeAnd,
+		Nodes: []permissions.Node{
+			{
+				Permission: permissions.Permission{
+					Action:   permissions.ListObjectsAction,
+					Resource: permissions.RepoArn(repository),
+				},
+			},
+			{
+				Permission: permissions.Permission{
+					Action:   permissions.ReadRepositoryAction,
+					Resource: permissions.RepoArn(repository),
+				},
+			},
+		},
+	}) {
+		return
+	}
+	ctx := r.Context()
+	c.LogAction(ctx, "get_metadata_object", r, repository, "", "")
+
+	repo, err := c.Catalog.GetRepository(ctx, repository)
+	if c.handleAPIError(ctx, w, r, err) {
+		return
+	}
+
+	var objPath string
+	if objectType == getTypeMetaRange {
+		addr, err := c.Catalog.GetMetaRange(ctx, repository, objectId)
+		if c.handleAPIError(ctx, w, r, err) {
+			return
+		}
+		objPath = string(addr)
+	} else if objectType == getTypeRange {
+		addr, err := c.Catalog.GetRange(ctx, repository, objectId)
+		if c.handleAPIError(ctx, w, r, err) {
+			return
+		}
+		objPath = string(addr)
+	}
+
+	// if pre-sign, return a redirect
+	pointer := block.ObjectPointer{
+		StorageNamespace: repo.StorageNamespace,
+		IdentifierType:   block.IdentifierTypeRelative,
+		Identifier:       objPath,
+	}
+	if swag.BoolValue(params.Presign) {
+		location, _, err := c.BlockAdapter.GetPreSignedURL(ctx, pointer, block.PreSignModeRead)
+		if c.handleAPIError(ctx, w, r, err) {
+			return
+		}
+		w.Header().Set("Location", location)
+		w.WriteHeader(http.StatusFound)
+		return
+	}
+
+	// set response headers
+	w.Header().Set("Content-Type", "application/octet-stream")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	w.Header().Set("X-Frame-Options", "SAMEORIGIN")
+	w.Header().Set("Content-Security-Policy", "default-src 'none'")
+
+	reader, err := c.BlockAdapter.Get(ctx, pointer)
+	if c.handleAPIError(ctx, w, r, err) {
+		return
+	}
+	defer func() {
+		_ = reader.Close()
+	}()
+
+	// copy the content
+	_, err = io.Copy(w, reader)
+	if err != nil {
+		c.Logger.
+			WithError(err).
+			WithFields(logging.Fields{
+				"storage_namespace": repo.StorageNamespace,
+			}).
+			Debug("GetObjectMetadata copy content")
+	}
+}
+
 func (c *Controller) GetObject(w http.ResponseWriter, r *http.Request, repository, ref string, params apigen.GetObjectParams) {
 	if !c.authorize(w, r, permissions.Node{
 		Permission: permissions.Permission{
@@ -4370,7 +4458,7 @@ func (c *Controller) GetObject(w http.ResponseWriter, r *http.Request, repositor
 		w.Header().Set("Content-Length", fmt.Sprintf("%d", rng.EndOffset-rng.StartOffset+1))
 		w.WriteHeader(http.StatusPartialContent)
 	} else {
-		reader, err = c.BlockAdapter.Get(ctx, pointer, entry.Size)
+		reader, err = c.BlockAdapter.Get(ctx, pointer)
 		if c.handleAPIError(ctx, w, r, err) {
 			return
 		}

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -4286,7 +4286,7 @@ func (c *Controller) HeadObject(w http.ResponseWriter, r *http.Request, reposito
 	}
 }
 
-func (c *Controller) GetMetadataObject(w http.ResponseWriter, r *http.Request, repository string, objectType string, objectId string, params apigen.GetMetadataObjectParams) {
+func (c *Controller) GetMetadataObject(w http.ResponseWriter, r *http.Request, repository string, objectType string, objectID string, params apigen.GetMetadataObjectParams) {
 	const getTypeMetaRange = "meta_range"
 	const getTypeRange = "range"
 
@@ -4319,13 +4319,13 @@ func (c *Controller) GetMetadataObject(w http.ResponseWriter, r *http.Request, r
 
 	var objPath string
 	if objectType == getTypeMetaRange {
-		addr, err := c.Catalog.GetMetaRange(ctx, repository, objectId)
+		addr, err := c.Catalog.GetMetaRange(ctx, repository, objectID)
 		if c.handleAPIError(ctx, w, r, err) {
 			return
 		}
 		objPath = string(addr)
 	} else if objectType == getTypeRange {
-		addr, err := c.Catalog.GetRange(ctx, repository, objectId)
+		addr, err := c.Catalog.GetRange(ctx, repository, objectID)
 		if c.handleAPIError(ctx, w, r, err) {
 			return
 		}

--- a/pkg/block/adapter.go
+++ b/pkg/block/adapter.go
@@ -145,7 +145,7 @@ type Properties struct {
 
 type Adapter interface {
 	Put(ctx context.Context, obj ObjectPointer, sizeBytes int64, reader io.Reader, opts PutOpts) error
-	Get(ctx context.Context, obj ObjectPointer, expectedSize int64) (io.ReadCloser, error)
+	Get(ctx context.Context, obj ObjectPointer) (io.ReadCloser, error)
 	GetWalker(uri *url.URL) (Walker, error)
 
 	// GetPreSignedURL returns a pre-signed URL for accessing obj with mode, and the

--- a/pkg/block/azure/adapter.go
+++ b/pkg/block/azure/adapter.go
@@ -210,7 +210,7 @@ func (a *Adapter) Put(ctx context.Context, obj block.ObjectPointer, sizeBytes in
 	return err
 }
 
-func (a *Adapter) Get(ctx context.Context, obj block.ObjectPointer, _ int64) (io.ReadCloser, error) {
+func (a *Adapter) Get(ctx context.Context, obj block.ObjectPointer) (io.ReadCloser, error) {
 	var err error
 	defer reportMetrics("Get", time.Now(), nil, &err)
 

--- a/pkg/block/blocktest/adapter.go
+++ b/pkg/block/blocktest/adapter.go
@@ -57,7 +57,7 @@ func testAdapterPutGet(t *testing.T, adapter block.Adapter, storageNamespace, ex
 			err := adapter.Put(ctx, obj, size, strings.NewReader(contents), block.PutOpts{})
 			require.NoError(t, err)
 
-			reader, err := adapter.Get(ctx, obj, size)
+			reader, err := adapter.Get(ctx, obj)
 			require.NoError(t, err)
 			defer func() {
 				require.NoError(t, reader.Close())
@@ -86,7 +86,7 @@ func testAdapterCopy(t *testing.T, adapter block.Adapter, storageNamespace strin
 	require.NoError(t, adapter.Put(ctx, src, int64(len(contents)), strings.NewReader(contents), block.PutOpts{}))
 
 	require.NoError(t, adapter.Copy(ctx, src, dst))
-	reader, err := adapter.Get(ctx, dst, 0)
+	reader, err := adapter.Get(ctx, dst)
 	require.NoError(t, err)
 	got, err := io.ReadAll(reader)
 	require.NoError(t, err)
@@ -285,7 +285,7 @@ func testAdapterMultipartUpload(t *testing.T, adapter block.Adapter, storageName
 				require.NotNil(t, err)
 			}
 
-			reader, err := adapter.Get(ctx, obj, 0)
+			reader, err := adapter.Get(ctx, obj)
 			require.NoError(t, err)
 
 			got, err := io.ReadAll(reader)

--- a/pkg/block/gs/adapter.go
+++ b/pkg/block/gs/adapter.go
@@ -104,7 +104,7 @@ func (a *Adapter) Put(ctx context.Context, obj block.ObjectPointer, sizeBytes in
 	return nil
 }
 
-func (a *Adapter) Get(ctx context.Context, obj block.ObjectPointer, _ int64) (io.ReadCloser, error) {
+func (a *Adapter) Get(ctx context.Context, obj block.ObjectPointer) (io.ReadCloser, error) {
 	var err error
 	defer reportMetrics("Get", time.Now(), nil, &err)
 	bucket, key, err := a.extractParamsFromObj(obj)

--- a/pkg/block/local/adapter.go
+++ b/pkg/block/local/adapter.go
@@ -237,7 +237,7 @@ func (l *Adapter) UploadCopyPart(ctx context.Context, sourceObj, destinationObj 
 	if err := isValidUploadID(uploadID); err != nil {
 		return nil, err
 	}
-	r, err := l.Get(ctx, sourceObj, 0)
+	r, err := l.Get(ctx, sourceObj)
 	if err != nil {
 		return nil, fmt.Errorf("copy get: %w", err)
 	}
@@ -273,7 +273,7 @@ func (l *Adapter) UploadCopyPartRange(ctx context.Context, sourceObj, destinatio
 	}, err
 }
 
-func (l *Adapter) Get(_ context.Context, obj block.ObjectPointer, _ int64) (reader io.ReadCloser, err error) {
+func (l *Adapter) Get(_ context.Context, obj block.ObjectPointer) (reader io.ReadCloser, err error) {
 	p, err := l.extractParamsFromObj(obj)
 	if err != nil {
 		return nil, err

--- a/pkg/block/mem/adapter.go
+++ b/pkg/block/mem/adapter.go
@@ -94,7 +94,7 @@ func (a *Adapter) Put(_ context.Context, obj block.ObjectPointer, _ int64, reade
 	return nil
 }
 
-func (a *Adapter) Get(_ context.Context, obj block.ObjectPointer, _ int64) (io.ReadCloser, error) {
+func (a *Adapter) Get(_ context.Context, obj block.ObjectPointer) (io.ReadCloser, error) {
 	if err := verifyObjectPointer(obj); err != nil {
 		return nil, err
 	}
@@ -203,7 +203,7 @@ func (a *Adapter) UploadCopyPart(ctx context.Context, sourceObj, _ block.ObjectP
 	if !ok {
 		return nil, ErrMultiPartNotFound
 	}
-	entry, err := a.Get(ctx, sourceObj, 0)
+	entry, err := a.Get(ctx, sourceObj)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/block/s3/adapter.go
+++ b/pkg/block/s3/adapter.go
@@ -323,7 +323,7 @@ func isErrNotFound(err error) bool {
 	return errors.As(err, &errNoSuchKey) || errors.As(err, &errNotFound)
 }
 
-func (a *Adapter) Get(ctx context.Context, obj block.ObjectPointer, _ int64) (io.ReadCloser, error) {
+func (a *Adapter) Get(ctx context.Context, obj block.ObjectPointer) (io.ReadCloser, error) {
 	var err error
 	var sizeBytes int64
 	defer reportMetrics("Get", time.Now(), &sizeBytes, &err)

--- a/pkg/block/transient/adapter.go
+++ b/pkg/block/transient/adapter.go
@@ -14,6 +14,10 @@ import (
 	"github.com/treeverse/lakefs/pkg/block"
 )
 
+const (
+	DefaultReaderSize = 1024 * 1024
+)
+
 type Adapter struct{}
 
 func New(_ context.Context) *Adapter {
@@ -25,11 +29,8 @@ func (a *Adapter) Put(_ context.Context, _ block.ObjectPointer, _ int64, reader 
 	return err
 }
 
-func (a *Adapter) Get(_ context.Context, _ block.ObjectPointer, expectedSize int64) (io.ReadCloser, error) {
-	if expectedSize < 0 {
-		return nil, io.ErrUnexpectedEOF
-	}
-	return io.NopCloser(&io.LimitedReader{R: rand.Reader, N: expectedSize}), nil
+func (a *Adapter) Get(_ context.Context, _ block.ObjectPointer) (io.ReadCloser, error) {
+	return io.NopCloser(&io.LimitedReader{R: rand.Reader, N: DefaultReaderSize}), nil
 }
 
 func (a *Adapter) GetWalker(_ *url.URL) (block.Walker, error) {

--- a/pkg/catalog/actions_source.go
+++ b/pkg/catalog/actions_source.go
@@ -96,7 +96,7 @@ func (s *ActionsSource) load(ctx context.Context, record graveler.HookRecord, na
 		StorageNamespace: repo.StorageNamespace,
 		IdentifierType:   block.IdentifierTypeRelative,
 		Identifier:       ent.PhysicalAddress,
-	}, 0)
+	})
 	if err != nil {
 		return nil, fmt.Errorf("getting action file %s: %w", name, err)
 	}

--- a/pkg/catalog/catalog_test.go
+++ b/pkg/catalog/catalog_test.go
@@ -728,7 +728,7 @@ func readPhysicalAddressesFromParquetObject(t *testing.T, repositoryID string, c
 		Identifier:       obj,
 		IdentifierType:   block.IdentifierTypeFull,
 		StorageNamespace: "mem://" + repositoryID,
-	}, 0)
+	})
 	require.NoError(t, err)
 	defer func() { _ = objReader.Close() }()
 

--- a/pkg/gateway/operations/getobject.go
+++ b/pkg/gateway/operations/getobject.go
@@ -130,7 +130,7 @@ func (controller *GetObject) Handle(w http.ResponseWriter, req *http.Request, o 
 
 	if rangeSpec == "" || err != nil {
 		// assemble a response body (range-less query)
-		data, err = o.BlockStore.Get(ctx, objectPointer, entry.Size)
+		data, err = o.BlockStore.Get(ctx, objectPointer)
 	} else {
 		contentLength = rng.Size()
 		contentRange = fmt.Sprintf("bytes %d-%d/%d", rng.StartOffset, rng.EndOffset, entry.Size)

--- a/pkg/gateway/operations/mock_adapter_test.go
+++ b/pkg/gateway/operations/mock_adapter_test.go
@@ -51,7 +51,7 @@ func (a *mockAdapter) Exists(_ context.Context, _ block.ObjectPointer) (bool, er
 	return false, nil
 }
 
-func (a *mockAdapter) Get(_ context.Context, _ block.ObjectPointer, _ int64) (io.ReadCloser, error) {
+func (a *mockAdapter) Get(_ context.Context, _ block.ObjectPointer) (io.ReadCloser, error) {
 	return nil, nil
 }
 

--- a/pkg/graveler/retention/garbage_collection_manager.go
+++ b/pkg/graveler/retention/garbage_collection_manager.go
@@ -110,7 +110,7 @@ func (m *GarbageCollectionManager) GetRules(ctx context.Context, storageNamespac
 		Identifier:       fmt.Sprintf(configFileSuffixTemplate, m.committedBlockStoragePrefix),
 		IdentifierType:   block.IdentifierTypeRelative,
 	}
-	reader, err := m.blockAdapter.Get(ctx, objectPointer, -1)
+	reader, err := m.blockAdapter.Get(ctx, objectPointer)
 	if errors.Is(err, block.ErrDataNotFound) {
 		return nil, graveler.ErrNotFound
 	}

--- a/pkg/graveler/retention/garbage_collection_manager_test.go
+++ b/pkg/graveler/retention/garbage_collection_manager_test.go
@@ -73,7 +73,7 @@ func TestGarbageCollectionManager_SaveGarbageCollectionUncommitted(t *testing.T)
 		StorageNamespace: "",
 		Identifier:       fmt.Sprintf("%s%s", location, filename),
 		IdentifierType:   block.IdentifierTypeFull,
-	}, 0)
+	})
 	require.NoError(t, err)
 	fileScanner := bufio.NewScanner(reader)
 	line := 0

--- a/pkg/pyramid/main_test.go
+++ b/pkg/pyramid/main_test.go
@@ -34,10 +34,10 @@ func (a *memAdapter) GetCount() int64 {
 	return atomic.LoadInt64(&a.gets)
 }
 
-func (a *memAdapter) Get(ctx context.Context, obj block.ObjectPointer, size int64) (io.ReadCloser, error) {
+func (a *memAdapter) Get(ctx context.Context, obj block.ObjectPointer) (io.ReadCloser, error) {
 	atomic.AddInt64(&a.gets, 1)
 	<-a.wait
-	return a.Adapter.Get(ctx, obj, size)
+	return a.Adapter.Get(ctx, obj)
 }
 
 func createFSWithEviction(ev params.Eviction) (FS, string) {

--- a/pkg/pyramid/tier_fs.go
+++ b/pkg/pyramid/tier_fs.go
@@ -317,7 +317,7 @@ func (tfs *TierFS) openWithLock(ctx context.Context, fileRef localFileRef) (*os.
 				"fullpath":  fileRef.fullPath,
 			}).Trace("get file from block storage")
 		}
-		reader, err := tfs.adapter.Get(ctx, tfs.objPointer(fileRef.namespace, fileRef.filename), 0)
+		reader, err := tfs.adapter.Get(ctx, tfs.objPointer(fileRef.namespace, fileRef.filename))
 		if err != nil {
 			return nil, fmt.Errorf("read from block storage: %w", err)
 		}


### PR DESCRIPTION
Closes #7781

## Change Description

Expose an (internal, for now) API endpoint that returns meta-ranges and ranges. Also supports pre-signed URLs using redirects, similar to getObject.

This PR is a bit invasive, it also removed the size parameter from the BlockAdapter.Get() method - it's unused by all adapters and is typically passed `0` or other undocumented values. I chose not to perpetuate that behavior here. 

If you object strongly to this, I can do the interface change in a different PR.

### Testing Details

Tested using Esti (both direct downloads and pre-signed mode)

### Breaking Change?

No
