### PR TITLE
Serve GZipped Static Assets

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -105,6 +105,7 @@ require (
 	github.com/Azure/go-autorest v14.2.0+incompatible // indirect
 	github.com/Azure/go-autorest/autorest/to v0.4.0 // indirect
 	github.com/AzureAD/microsoft-authentication-library-for-go v1.2.0 // indirect
+	github.com/NYTimes/gziphandler v1.1.1 // indirect
 	github.com/ahmetb/go-linq/v3 v3.2.0 // indirect
 	github.com/apache/arrow/go/arrow v0.0.0-20200730104253-651201b0f516 // indirect
 	github.com/aws/aws-sdk-go v1.48.11 // indirect

--- a/go.sum
+++ b/go.sum
@@ -158,6 +158,8 @@ github.com/Joker/jade v1.0.1-0.20190614124447-d475f43051e7/go.mod h1:6E6s8o2AE4K
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Microsoft/go-winio v0.6.1 h1:9/kr64B9VUZrLm5YYwbGtUJnMgqWVOdUAXu6Migciow=
 github.com/Microsoft/go-winio v0.6.1/go.mod h1:LRdKpFKfdobln8UmuiYcKPot9D2v6svN5+sAH+4kjUM=
+github.com/NYTimes/gziphandler v1.1.1 h1:ZUDjpQae29j0ryrS0u/B8HZfJBtBQHjqw2rQ2cqUQ3I=
+github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5 h1:TngWCqHvy9oXAN6lEVMRuU21PR1EtLVZJmdB18Gu3Rw=
 github.com/Nvveen/Gotty v0.0.0-20120604004816-cd527374f1e5/go.mod h1:lmUJ/7eu/Q8D7ML55dXQrVaamCz2vxCfdQBasLZfHKk=
 github.com/OneOfOne/xxhash v1.2.2/go.mod h1:HSdplMjZKSmBqAxg5vPj2TmRDmfkzw+cTzAElWljhcU=

--- a/pkg/api/ui_handler.go
+++ b/pkg/api/ui_handler.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
+	"github.com/NYTimes/gziphandler"
 	gomime "github.com/cubewise-code/go-mime"
 	"github.com/treeverse/lakefs/pkg/api/params"
 	gwerrors "github.com/treeverse/lakefs/pkg/gateway/errors"
@@ -33,7 +34,8 @@ func NewUIHandler(gatewayDomains []string, snippets []params.CodeSnippet) http.H
 		panic(err)
 	}
 	fileSystem := http.FS(injectedContent)
-	etagHandler := EtagMiddleware(injectedContent, http.StripPrefix("/", http.FileServer(fileSystem)))
+	gzipHandler := gziphandler.GzipHandler(http.FileServer(fileSystem))
+	etagHandler := EtagMiddleware(injectedContent, http.StripPrefix("/", gzipHandler))
 	return NewHandlerWithDefault(fileSystem, etagHandler, gatewayDomains)
 }
 


### PR DESCRIPTION
## Change Description

Added a Gzip handler to gzip files served by the embedded filesystem handler. This results in a ~63% reduction in transferred bytes.

Before:

![Screenshot 2024-05-21 at 10 21 21](https://github.com/treeverse/lakeFS/assets/110764839/10b199af-3720-4582-a242-71a5cb4b3d76)

After:

![Screenshot 2024-05-21 at 10 23 25](https://github.com/treeverse/lakeFS/assets/110764839/af8624ec-a7e3-41c5-8250-d774023e9dac)

