### PR TITLE
Add videos to docs

### DIFF
--- a/docs/howto/hooks/index.md
+++ b/docs/howto/hooks/index.md
@@ -31,7 +31,7 @@ Like other version control systems, lakeFS allows you to configure _Actions_ to 
 
 For step-by-step examples of hooks in action check out the [lakeFS Quickstart]({% link quickstart/actions-and-hooks.md %}) and the [lakeFS samples repository](https://github.com/treeverse/lakeFS-samples/).
 
-<iframe width="420" height="315" src="https://www.youtube.com/embed/e5cOMPFLl25RBPYp&t=2158"></iframe>
+<iframe width="420" height="315" src="https://www.youtube.com/embed/Joare70FlIA"></iframe>
 
 ## Overview
 

--- a/docs/howto/hooks/index.md
+++ b/docs/howto/hooks/index.md
@@ -31,6 +31,8 @@ Like other version control systems, lakeFS allows you to configure _Actions_ to 
 
 For step-by-step examples of hooks in action check out the [lakeFS Quickstart]({% link quickstart/actions-and-hooks.md %}) and the [lakeFS samples repository](https://github.com/treeverse/lakeFS-samples/).
 
+<iframe width="420" height="315" src="https://www.youtube.com/embed/e5cOMPFLl25RBPYp&t=2158"></iframe>
+
 ## Overview
 
 An _action_ defines one or more _hooks_ to execute. lakeFS supports three types of hook: 

--- a/docs/howto/local-checkouts.md
+++ b/docs/howto/local-checkouts.md
@@ -37,6 +37,8 @@ GPU usage and prevent them from sitting idle. Many deep learning tasks involve a
 same images are accessed multiple times. Localizing the data can eliminate redundant round trip times to access remote 
 storage, resulting in cost savings.
 
+<iframe width="420" height="315" src="https://www.youtube.com/embed/afgQnmesLZM"></iframe>
+
 ## **lakectl local**: The way to work with lakeFS data locally  
 
 The _local_ command of lakeFS' CLI _lakectl_ enables working with lakeFS data locally.

--- a/docs/howto/mirroring.md
+++ b/docs/howto/mirroring.md
@@ -28,6 +28,7 @@ Unlike conventional mirroring, data isn't simply copied between regions - lakeFS
 
 ![mirroring architecture](../assets/img/mirroring/arch.png)
 
+<iframe width="420" height="315" src="https://www.youtube.com/embed/NhOWGVjQrrA"></iframe>
 
 ## Uses cases
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,9 +16,9 @@ lakeFS provides version control over the data lake, and uses Git-like semantics 
 
 With lakeFS, you can use concepts on your data lake such as **branch** to create an isolated version of the data, **commit** to create a reproducible point in time, and **merge** in order to incorporate your changes in one atomic action.
 
-<div style="text-align: center">
-  [![Data Version Control at Scale](https://img.youtube.com/vi/GTxsyeoLccw/0.jpg)](https://www.youtube.com/watch?v=GTxsyeoLccw)
-</div>
+
+[![Data Version Control at Scale](https://img.youtube.com/vi/GTxsyeoLccw/0.jpg)](https://www.youtube.com/watch?v=GTxsyeoLccw)
+
 
 ## How Do I Get Started? 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,9 +16,7 @@ lakeFS provides version control over the data lake, and uses Git-like semantics 
 
 With lakeFS, you can use concepts on your data lake such as **branch** to create an isolated version of the data, **commit** to create a reproducible point in time, and **merge** in order to incorporate your changes in one atomic action.
 
-
-[![Data Version Control at Scale](https://img.youtube.com/vi/GTxsyeoLccw/0.jpg)](https://www.youtube.com/watch?v=GTxsyeoLccw)
-
+<iframe width="420" height="315" src="https://www.youtube.com/embed/GTxsyeoLccw"></iframe>
 
 ## How Do I Get Started? 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,6 +16,8 @@ lakeFS provides version control over the data lake, and uses Git-like semantics 
 
 With lakeFS, you can use concepts on your data lake such as **branch** to create an isolated version of the data, **commit** to create a reproducible point in time, and **merge** in order to incorporate your changes in one atomic action.
 
+[![Data Version Control at Scale](https://img.youtube.com/vi/GTxsyeoLccw/0.jpg)](https://www.youtube.com/watch?v=GTxsyeoLccw)
+
 ## How Do I Get Started? 
 
 **[The hands-on quickstart](./quickstart) guides you through some core features of lakeFS**. 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,7 +16,9 @@ lakeFS provides version control over the data lake, and uses Git-like semantics 
 
 With lakeFS, you can use concepts on your data lake such as **branch** to create an isolated version of the data, **commit** to create a reproducible point in time, and **merge** in order to incorporate your changes in one atomic action.
 
-[![Data Version Control at Scale](https://img.youtube.com/vi/GTxsyeoLccw/0.jpg)](https://www.youtube.com/watch?v=GTxsyeoLccw)
+<div style="text-align: center">
+  [![Data Version Control at Scale](https://img.youtube.com/vi/GTxsyeoLccw/0.jpg)](https://www.youtube.com/watch?v=GTxsyeoLccw)
+</div>
 
 ## How Do I Get Started? 
 

--- a/docs/integrations/airflow.md
+++ b/docs/integrations/airflow.md
@@ -9,6 +9,8 @@ redirect_from: /using/airflow.html
 
 [Apache Airflow](https://airflow.apache.org/) is a platform that allows users to programmatically author, schedule, and monitor workflows.
 
+<iframe width="420" height="315" src="https://www.youtube.com/embed/HuQQUvmVjhU"></iframe>
+
 To run Airflow with lakeFS, you need to follow a few steps.
 
 ## Create a lakeFS connection on Airflow

--- a/docs/integrations/delta.md
+++ b/docs/integrations/delta.md
@@ -86,6 +86,8 @@ Here, 'main' is the name of the lakeFS branch from which the delta table was exp
 
 To enable Delta table exports to Unity catalog use the Unity [catalog integration guide](unity-catalog.md).
 
+<iframe width="420" height="315" src="https://www.youtube.com/embed/rMDsnh7S2O0"></iframe>
+
 ## Limitations
 
 ### Multi-Writer Support in lakeFS for Delta Lake Tables

--- a/docs/quickstart/index.md
+++ b/docs/quickstart/index.md
@@ -115,5 +115,5 @@ This quickstart will introduce you to some of the core ideas in lakeFS and show 
 {: .note}
 You can use the [30-day free trial of lakeFS Cloud](https://lakefs.cloud/register) if you want to try out lakeFS without installing anything. 
 
-[![What is lakeFS?](https://img.youtube.com/vi/R1r023CsTOw/0.jpg)](https://www.youtube.com/watch?v=R1r023CsTOw)
+<iframe width="420" height="315" src="https://www.youtube.com/embed/R1r023CsTOw"></iframe>
 

--- a/docs/quickstart/index.md
+++ b/docs/quickstart/index.md
@@ -114,3 +114,6 @@ This quickstart will introduce you to some of the core ideas in lakeFS and show 
 
 {: .note}
 You can use the [30-day free trial of lakeFS Cloud](https://lakefs.cloud/register) if you want to try out lakeFS without installing anything. 
+
+[![What is lakeFS?](https://img.youtube.com/vi/R1r023CsTOw/0.jpg)](https://www.youtube.com/watch?v=R1r023CsTOw)
+

--- a/docs/reference/security/rbac.md
+++ b/docs/reference/security/rbac.md
@@ -25,6 +25,8 @@ lakeFS Enterprise
 
 {% include toc.html %}
 
+<iframe width="420" height="315" src="https://www.youtube.com/embed/Ekjv9FumIPg"></iframe>
+
 ## RBAC Model
 
 Access to resources is managed very much like [AWS IAM](https://docs.aws.amazon.com/IAM/latest/UserGuide/intro-structure.html){:target="_blank"}.

--- a/docs/understand/architecture.md
+++ b/docs/understand/architecture.md
@@ -39,6 +39,8 @@ lakeFS exposes a frontend UI, an [OpenAPI server](#openapi-server), as well as a
 lakeFS uses a single port that serves all three endpoints, so for most use cases a single load balancer pointing
 to lakeFS server(s) would do.
 
+<iframe width="420" height="315" src="https://www.youtube.com/embed/1vNQXFceFx4"></iframe>
+
 ## lakeFS Components
 
 ### S3 Gateway


### PR DESCRIPTION
Closes #7792 

## Change Description

Added links to YouTube where relevant for some videos to help understand lakeFS. 

### Background

Share context and relevant information for the PR: offline discussions, considerations, design decisions etc.

Since I'm not sure how easy it will be to track the videos (although I assume it will be simple with the YouTube admin) I've added a [doc containing the current views of the videos today](https://docs.google.com/spreadsheets/d/1ej29QVBdlu8hxv3lk62pXE5_DyL3vL-ar1xQmOwSyQg/edit?usp=sharing) - so we can compare down the line. 
      
### New Feature

We have a lot of videos out there already describing usage and integration of lakeFS.
Some individuals prefer to consume videos as they learn software.
Would be good to sprinkle those into the docs where relevant.