### PR TITLE
Fix lakectl local commits remote changes outside synced prefix

### DIFF
--- a/cmd/lakectl/cmd/local_commit.go
+++ b/cmd/lakectl/cmd/local_commit.go
@@ -122,7 +122,7 @@ var localCommitCmd = &cobra.Command{
 			d := make(chan apigen.Diff, maxDiffPageSize)
 			var wg errgroup.Group
 			wg.Go(func() error {
-				return diff.StreamRepositoryDiffs(cmd.Context(), client, baseRemote, newRemote, swag.StringValue(remote.Path), d, true)
+				return diff.StreamRepositoryDiffs(cmd.Context(), client, baseRemote, newRemote, swag.StringValue(remote.Path), d, false)
 			})
 
 			var remoteChanges local.Changes

--- a/cmd/lakectl/cmd/local_commit.go
+++ b/cmd/lakectl/cmd/local_commit.go
@@ -1,18 +1,26 @@
 package cmd
 
 import (
+	"context"
 	"fmt"
 	"net/http"
+	"path/filepath"
+	"slices"
 	"strings"
 
 	"github.com/go-openapi/swag"
 	"github.com/spf13/cobra"
 	"github.com/treeverse/lakefs/pkg/api/apigen"
+	"github.com/treeverse/lakefs/pkg/api/apiutil"
 	"github.com/treeverse/lakefs/pkg/diff"
 	"github.com/treeverse/lakefs/pkg/git"
 	"github.com/treeverse/lakefs/pkg/local"
 	"github.com/treeverse/lakefs/pkg/uri"
 	"golang.org/x/sync/errgroup"
+)
+
+const (
+	asciiCharAfterSlash = "0"
 )
 
 func findConflicts(changes local.Changes) (conflicts []string) {
@@ -24,6 +32,47 @@ func findConflicts(changes local.Changes) (conflicts []string) {
 	return
 }
 
+func hasUncommittedOutsideLocalPrefix(ctx context.Context, client *apigen.ClientWithResponses, remote *uri.URI, idx *local.Index) bool {
+	currentURI, err := idx.GetCurrentURI()
+	if err != nil {
+		DieErr(err)
+	}
+
+	// Get first uncommitted change. If it's outside the local prefix, we're done
+	dirtyResp, err := client.DiffBranchWithResponse(ctx, remote.Repository, remote.Ref, &apigen.DiffBranchParams{
+		Amount: apiutil.Ptr(apigen.PaginationAmount(1)),
+	})
+	DieOnErrorOrUnexpectedStatusCode(dirtyResp, err, http.StatusOK)
+
+	if len(dirtyResp.JSON200.Results) == 0 {
+		return false
+	}
+	if slices.ContainsFunc(dirtyResp.JSON200.Results, func(diff apigen.Diff) bool {
+		return diff.PathType == "object" && !strings.HasPrefix(diff.Path, *currentURI.Path)
+	}) {
+		return true
+	}
+
+	// Get the first uncommitted change after the prefix. If it exists, we're also done
+	nextPrefix := fmt.Sprintf("%s%s", filepath.Clean(*currentURI.Path), asciiCharAfterSlash)
+	dirtyResp, err = client.DiffBranchWithResponse(ctx, remote.Repository, remote.Ref, &apigen.DiffBranchParams{
+		Amount: apiutil.Ptr(apigen.PaginationAmount(1)),
+		After:  apiutil.Ptr(apigen.PaginationAfter(nextPrefix)),
+	})
+	DieOnErrorOrUnexpectedStatusCode(dirtyResp, err, http.StatusOK)
+
+	// The above gives us SeekGT. Since we need SeekGE, we do another stat for exact match
+	statResp, err := client.StatObjectWithResponse(ctx, remote.Repository, remote.Ref, &apigen.StatObjectParams{
+		Path: nextPrefix,
+	})
+
+	if len(dirtyResp.JSON200.Results) > 0 || statResp.StatusCode() == http.StatusOK {
+		return true
+	}
+
+	return false
+}
+
 var localCommitCmd = &cobra.Command{
 	Use:   "commit [directory]",
 	Short: "Commit changes from local directory to the lakeFS branch it tracks.",
@@ -33,6 +82,7 @@ var localCommitCmd = &cobra.Command{
 		_, localPath := getSyncArgs(args, false, false)
 		syncFlags := getSyncFlags(cmd, client)
 		message, kvPairs := getCommitFlags(cmd)
+		force := Must(cmd.Flags().GetBool(localForceFlagName))
 
 		idx, err := local.ReadIndex(localPath)
 		if err != nil {
@@ -56,6 +106,11 @@ var localCommitCmd = &cobra.Command{
 		resp, err := client.GetBranchWithResponse(cmd.Context(), remote.Repository, remote.Ref)
 		DieOnErrorOrUnexpectedStatusCode(resp, err, http.StatusOK)
 
+		hasChangesOutsideSyncedPrefix := hasUncommittedOutsideLocalPrefix(cmd.Context(), client, remote, idx)
+		if hasChangesOutsideSyncedPrefix && !force {
+			DieFmt("The branch you are trying to commit to contains uncommitted changes outside the lakeFS path your local directory '%s' is synced with.\nTo proceed, use the --force flag.", localPath)
+		}
+
 		// Diff local with current head
 		baseRemote := remote.WithRef(idx.AtHead)
 		changes := localDiff(cmd.Context(), client, baseRemote, idx.LocalPath())
@@ -67,7 +122,7 @@ var localCommitCmd = &cobra.Command{
 			d := make(chan apigen.Diff, maxDiffPageSize)
 			var wg errgroup.Group
 			wg.Go(func() error {
-				return diff.StreamRepositoryDiffs(cmd.Context(), client, baseRemote, newRemote, swag.StringValue(remote.Path), d, false)
+				return diff.StreamRepositoryDiffs(cmd.Context(), client, baseRemote, newRemote, swag.StringValue(remote.Path), d, true)
 			})
 
 			var remoteChanges local.Changes
@@ -170,6 +225,7 @@ var localCommitCmd = &cobra.Command{
 
 //nolint:gochecknoinits
 func init() {
+	withForceFlag(localCommitCmd, "Commit changes even if remote branch includes uncommitted changes outside the synced directory")
 	withCommitFlags(localCommitCmd, false)
 	withSyncFlags(localCommitCmd)
 	localCmd.AddCommand(localCommitCmd)

--- a/cmd/lakectl/cmd/local_commit_test.go
+++ b/cmd/lakectl/cmd/local_commit_test.go
@@ -1,0 +1,216 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/deepmap/oapi-codegen/pkg/securityprovider"
+	"github.com/stretchr/testify/require"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
+	"github.com/treeverse/lakefs/pkg/api/apiutil"
+	"github.com/treeverse/lakefs/pkg/local"
+	"github.com/treeverse/lakefs/pkg/uri"
+)
+
+const (
+	defaultAdminAccessKeyID     = "AKIAIOSFDNN7EXAMPLEQ"
+	defaultAdminSecretAccessKey = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+)
+
+func getTestClient(t *testing.T, endpoint string) *apigen.ClientWithResponses {
+	t.Helper()
+	transport := http.DefaultTransport.(*http.Transport).Clone()
+	transport.MaxIdleConnsPerHost = DefaultMaxIdleConnsPerHost
+	httpClient := &http.Client{
+		Transport: transport,
+	}
+	basicAuthProvider, err := securityprovider.NewSecurityProviderBasicAuth(string(defaultAdminAccessKeyID), string(defaultAdminSecretAccessKey))
+	require.NoError(t, err)
+
+	serverEndpoint, err := apiutil.NormalizeLakeFSEndpoint(endpoint)
+	require.NoError(t, err)
+
+	client, err := apigen.NewClientWithResponses(
+		serverEndpoint,
+		apigen.WithHTTPClient(httpClient),
+		apigen.WithRequestEditorFn(basicAuthProvider.Intercept),
+	)
+	require.NoError(t, err)
+
+	return client
+}
+
+func TestUncommittedOutsideOfPrefix(t *testing.T) {
+	prefix := "xyzzy/"
+	remote := &uri.URI{
+		Repository: "test",
+		Ref:        "test",
+	}
+	idx := &local.Index{
+		PathURI:         fmt.Sprintf("lakefs://test/test/%s", prefix),
+		ActiveOperation: "",
+	}
+
+	testCases := []struct {
+		name           string
+		h              http.HandlerFunc
+		expectedResult bool
+	}{
+		{
+			name: "Uncommitted changes - none",
+			h: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				res := &apigen.DiffList{
+					Results: []apigen.Diff{},
+				}
+				w.Header().Set("Content-Type", "application/json")
+				w.Header().Set("X-Content-Type-Options", "nosniff")
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(res)
+			}),
+			expectedResult: false,
+		},
+		{
+			name: "Uncommitted changes - outside",
+			h: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				res := &apigen.DiffList{
+					Results: []apigen.Diff{
+						{
+							PathType: "object",
+							Path:     "otherPrefix/a",
+						},
+					},
+				}
+				w.Header().Set("Content-Type", "application/json")
+				w.Header().Set("X-Content-Type-Options", "nosniff")
+				w.WriteHeader(http.StatusOK)
+				json.NewEncoder(w).Encode(res)
+			}),
+			expectedResult: true,
+		},
+		{
+			name: "Uncommitted changes - inside",
+			h: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var res *apigen.DiffList
+				w.Header().Set("Content-Type", "application/json")
+				w.Header().Set("X-Content-Type-Options", "nosniff")
+				if strings.Contains(r.RequestURI, "/diff?amount") {
+					res = &apigen.DiffList{
+						Results: []apigen.Diff{
+							{
+								PathType: "object",
+								Path:     fmt.Sprintf("%sa", prefix),
+							},
+						},
+					}
+					w.WriteHeader(http.StatusOK)
+				}
+
+				if strings.Contains(r.RequestURI, "/diff?after") {
+					res = &apigen.DiffList{
+						Results: []apigen.Diff{},
+					}
+					w.WriteHeader(http.StatusOK)
+				}
+
+				if strings.Contains(r.RequestURI, "/stat?path") {
+					res = &apigen.DiffList{}
+					w.WriteHeader(http.StatusNotFound)
+				}
+				require.NotNil(t, res, "Unexpected request")
+				json.NewEncoder(w).Encode(res)
+			}),
+			expectedResult: false,
+		},
+		{
+			name: "Uncommitted changes - inside before outside",
+			h: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var res *apigen.DiffList
+				w.Header().Set("Content-Type", "application/json")
+				w.Header().Set("X-Content-Type-Options", "nosniff")
+				if strings.Contains(r.RequestURI, "/diff?amount") {
+					res = &apigen.DiffList{
+						Results: []apigen.Diff{
+							{
+								PathType: "object",
+								Path:     fmt.Sprintf("%sa", prefix),
+							},
+						},
+					}
+					w.WriteHeader(http.StatusOK)
+				}
+
+				if strings.Contains(r.RequestURI, "/diff?after") {
+					res = &apigen.DiffList{
+						Results: []apigen.Diff{
+							{
+								PathType: "object",
+								Path:     "zzz/a",
+							},
+						},
+					}
+					w.WriteHeader(http.StatusOK)
+				}
+
+				if strings.Contains(r.RequestURI, "/stat?path") {
+					res = &apigen.DiffList{}
+					w.WriteHeader(http.StatusNotFound)
+				}
+
+				require.NotNil(t, res, "Unexpected request")
+				json.NewEncoder(w).Encode(res)
+			}),
+			expectedResult: true,
+		},
+		{
+			name: "Uncommitted changes - on the boundry",
+			h: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				var res *apigen.DiffList
+				w.Header().Set("Content-Type", "application/json")
+				w.Header().Set("X-Content-Type-Options", "nosniff")
+				if strings.Contains(r.RequestURI, "/diff?amount") {
+					res = &apigen.DiffList{
+						Results: []apigen.Diff{
+							{
+								PathType: "object",
+								Path:     fmt.Sprintf("%sa", prefix),
+							},
+						},
+					}
+					w.WriteHeader(http.StatusOK)
+				}
+
+				if strings.Contains(r.RequestURI, "/diff?after") {
+					res = &apigen.DiffList{
+						Results: []apigen.Diff{},
+					}
+					w.WriteHeader(http.StatusOK)
+				}
+
+				if strings.Contains(r.RequestURI, "/stat?path") {
+					// we only look at the status, so we don't care about the body
+					res = &apigen.DiffList{}
+					w.WriteHeader(http.StatusOK)
+				}
+
+				require.NotNil(t, res, "Unexpected request")
+				json.NewEncoder(w).Encode(res)
+			}),
+			expectedResult: true,
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			server := httptest.NewServer(tc.h)
+			defer server.Close()
+
+			testClient := getTestClient(t, server.URL)
+			res := hasUncommittedOutsideLocalPrefix(context.Background(), testClient, remote, idx)
+			require.Equal(t, tc.expectedResult, res)
+		})
+	}
+}

--- a/cmd/lakectl/cmd/local_commit_test.go
+++ b/cmd/lakectl/cmd/local_commit_test.go
@@ -209,7 +209,7 @@ func TestUncommittedOutsideOfPrefix(t *testing.T) {
 			defer server.Close()
 
 			testClient := getTestClient(t, server.URL)
-			res := hasUncommittedOutsideLocalPrefix(context.Background(), testClient, remote, idx)
+			res := hasExternalChange(context.Background(), testClient, remote, idx)
 			require.Equal(t, tc.expectedResult, res)
 		})
 	}

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2575,6 +2575,7 @@ lakectl local commit [directory] [flags]
 
 ```
       --allow-empty-message   allow an empty commit message
+      --force                 Commit changes even if remote branch includes uncommitted changes external to the synced path
   -h, --help                  help for commit
   -m, --message string        commit message
       --meta strings          key value pair in the form of key=value

--- a/esti/lakectl_local_test.go
+++ b/esti/lakectl_local_test.go
@@ -488,7 +488,7 @@ func TestLakectlLocal_commit_remote_uncommitted(t *testing.T) {
 		expectedMessage   string
 	}{
 		{
-			name:              "uncommitted changes - none",
+			name:              "uncommitted_changes_-_none",
 			uncommittedRemote: []string{},
 			uncommittedLocal: []string{
 				"test.data",
@@ -496,7 +496,7 @@ func TestLakectlLocal_commit_remote_uncommitted(t *testing.T) {
 			expectedMessage: "Commit for branch \"${BRANCH}\" completed",
 		},
 		{
-			name: "uncommitted changes - outside",
+			name: "uncommitted_changes_-_outside",
 			uncommittedRemote: []string{
 				"otherPrefix/a",
 			},
@@ -506,7 +506,7 @@ func TestLakectlLocal_commit_remote_uncommitted(t *testing.T) {
 			expectedMessage: "Branch ${BRANCH} contains uncommitted changes outside of local path '${LOCAL_DIR}'.\nTo proceed, use the --force flag.",
 		},
 		{
-			name: "uncommitted changes - inside",
+			name: "uncommitted_changes_-_inside",
 			uncommittedRemote: []string{
 				fmt.Sprintf("%s/a", vars["PREFIX"]),
 			},
@@ -516,7 +516,7 @@ func TestLakectlLocal_commit_remote_uncommitted(t *testing.T) {
 			expectedMessage: "Commit for branch \"${BRANCH}\" completed",
 		},
 		{
-			name: "uncommitted changes - inside before outside",
+			name: "uncommitted_changes_-_inside_before_outside",
 			uncommittedRemote: []string{
 				"zzz/a",
 			},
@@ -526,7 +526,7 @@ func TestLakectlLocal_commit_remote_uncommitted(t *testing.T) {
 			expectedMessage: "Branch ${BRANCH} contains uncommitted changes outside of local path '${LOCAL_DIR}'.\nTo proceed, use the --force flag.",
 		},
 		{
-			name: "uncommitted changes - on boundry",
+			name: "uncommitted_changes_-_on_boundry",
 			uncommittedRemote: []string{
 				fmt.Sprintf("%s0", vars["PREFIX"]),
 			},

--- a/esti/lakectl_local_test.go
+++ b/esti/lakectl_local_test.go
@@ -485,6 +485,7 @@ func TestLakectlLocal_commit_remote_uncommitted(t *testing.T) {
 		name              string
 		uncommittedRemote []string
 		uncommittedLocal  []string
+		expectFailure     bool
 		expectedMessage   string
 	}{
 		{
@@ -493,6 +494,7 @@ func TestLakectlLocal_commit_remote_uncommitted(t *testing.T) {
 			uncommittedLocal: []string{
 				"test.data",
 			},
+			expectFailure:   false,
 			expectedMessage: "Commit for branch \"${BRANCH}\" completed",
 		},
 		{
@@ -503,6 +505,7 @@ func TestLakectlLocal_commit_remote_uncommitted(t *testing.T) {
 			uncommittedLocal: []string{
 				"test.data",
 			},
+			expectFailure:   true,
 			expectedMessage: "Branch ${BRANCH} contains uncommitted changes outside of local path '${LOCAL_DIR}'.\nTo proceed, use the --force flag.",
 		},
 		{
@@ -513,6 +516,7 @@ func TestLakectlLocal_commit_remote_uncommitted(t *testing.T) {
 			uncommittedLocal: []string{
 				"test.data",
 			},
+			expectFailure:   false,
 			expectedMessage: "Commit for branch \"${BRANCH}\" completed",
 		},
 		{
@@ -523,6 +527,7 @@ func TestLakectlLocal_commit_remote_uncommitted(t *testing.T) {
 			uncommittedLocal: []string{
 				"test.data",
 			},
+			expectFailure:   true,
 			expectedMessage: "Branch ${BRANCH} contains uncommitted changes outside of local path '${LOCAL_DIR}'.\nTo proceed, use the --force flag.",
 		},
 		{
@@ -533,6 +538,7 @@ func TestLakectlLocal_commit_remote_uncommitted(t *testing.T) {
 			uncommittedLocal: []string{
 				"test.data",
 			},
+			expectFailure:   true,
 			expectedMessage: "Branch ${BRANCH} contains uncommitted changes outside of local path '${LOCAL_DIR}'.\nTo proceed, use the --force flag.",
 		},
 	}
@@ -564,7 +570,12 @@ func TestLakectlLocal_commit_remote_uncommitted(t *testing.T) {
 					require.NoError(t, fd.Close())
 				}
 			}
-			RunCmdAndVerifyContainsText(t, fmt.Sprintf("%s local commit -m test %s", Lakectl(), dataDir), false, tc.expectedMessage, vars)
+			cmd := fmt.Sprintf("%s local commit -m test %s", Lakectl(), dataDir)
+			if tc.expectFailure {
+				RunCmdAndVerifyFailure(t, cmd, false, tc.expectedMessage, vars)
+			} else {
+				RunCmdAndVerifyContainsText(t, cmd, false, tc.expectedMessage, vars)
+			}
 		})
 	}
 }

--- a/esti/lakectl_local_test.go
+++ b/esti/lakectl_local_test.go
@@ -545,7 +545,7 @@ func TestLakectlLocal_commit_remote_uncommitted(t *testing.T) {
 			vars["LOCAL_DIR"] = dataDir
 			vars["BRANCH"] = tc.name
 			vars["REF"] = tc.name
-			RunCmdAndVerifyContainsText(t, fmt.Sprintf("%s local clone lakefs://%s/%s/%s %s", Lakectl(), repoName, vars["BRANCH"], vars["PREFIX"], dataDir), false, "Successfully cloned lakefs://${REPO}/${REF}/${PREFIX} to ${LOCAL_DIR}.", vars)
+			RunCmdAndVerifyContainsText(t, fmt.Sprintf("%s local clone lakefs://%s/%s/%s %s", Lakectl(), repoName, vars["BRANCH"], vars["PREFIX"], dataDir), false, "Successfully cloned lakefs://${REPO}/${REF}/${PREFIX}/ to ${LOCAL_DIR}.", vars)
 
 			// add remote files
 			if len(tc.uncommittedRemote) > 0 {

--- a/esti/lakectl_local_test.go
+++ b/esti/lakectl_local_test.go
@@ -572,7 +572,7 @@ func TestLakectlLocal_commit_remote_uncommitted(t *testing.T) {
 			}
 			cmd := fmt.Sprintf("%s local commit -m test %s", Lakectl(), dataDir)
 			if tc.expectFailure {
-				RunCmdAndVerifyFailure(t, cmd, false, tc.expectedMessage, vars)
+				RunCmdAndVerifyFailureContainsText(t, cmd, false, tc.expectedMessage, vars)
 			} else {
 				RunCmdAndVerifyContainsText(t, cmd, false, tc.expectedMessage, vars)
 			}

--- a/esti/lakectl_util.go
+++ b/esti/lakectl_util.go
@@ -146,10 +146,20 @@ func RunCmdAndVerifySuccessWithFile(t *testing.T, cmd string, isTerminal bool, g
 
 func RunCmdAndVerifyContainsText(t *testing.T, cmd string, isTerminal bool, expectedRaw string, vars map[string]string) {
 	t.Helper()
+	runCmdAndVerifyContainsText(t, cmd, false, isTerminal, expectedRaw, vars)
+}
+
+func RunCmdAndVerifyFailureContainsText(t *testing.T, cmd string, isTerminal bool, expectedRaw string, vars map[string]string) {
+	t.Helper()
+	runCmdAndVerifyContainsText(t, cmd, true, isTerminal, expectedRaw, vars)
+}
+
+func runCmdAndVerifyContainsText(t *testing.T, cmd string, expectFail, isTerminal bool, expectedRaw string, vars map[string]string) {
+	t.Helper()
 	s := sanitize(expectedRaw, vars)
 	expected, err := expandVariables(s, vars)
-	require.NoErrorf(t, err, "Variable embed failed - %s", err)
-	sanitizedResult := runCmd(t, cmd, false, isTerminal, vars)
+	require.NoError(t, err, "Variable embed failed - %s", err)
+	sanitizedResult := runCmd(t, cmd, expectFail, isTerminal, vars)
 	require.Contains(t, sanitizedResult, expected)
 }
 


### PR DESCRIPTION
Closes #7687 

## Change Description

### Bug Fix

#### The Problem

Please see the associated issue for the full description of the problem.

#### Root Cause

lakeFS, unlike Git, doesn't support the concept of committing only staged changes. A commit operation will commit any uncommitted diffs between the refs or fail if conflicts occur (all or nothing).  
`lakectl local` isn't special in this regard. However, being able to sync with any arbitrary prefix creates the expectation that any operations will be scoped to that prefix. In practice, this isn't the case. Merging a ref in `lakectl local` unexpectedly merges all changes in the remote ref, regardless of prefix.

#### Solution

This PR adds to `lakectl local commit` a check for existing uncommitted changes on the remote ref, which are outside of the synced prefix. If such changes are found, the operation is aborted and an informative error message is shown. This behavior can be overridden by adding the the `--force` flag to the commit command.
      
### Testing Details

These changes were tested manually and with unit tests included in this PR.  

**Note to reviewers:** I believe the included tests cover the possible cases. I would like your feedback if you think that any additional tests are needed for better coverage.

### Breaking Change?

**This is a breaking change!**  
Although this behavior is unexpected and considered a bug, it will change following this PR. `lakectl local` users relying on this behavior will see an error message instead of the operation completed successfully and will need to add the `--force` flag to get back the previous behavior.

Special thanks to @arielshaqed for the refresher course on `char` ordinals and string sort order 😅👑
