### PR TITLE
Add "allow-empty" flag to Merge

### DIFF
--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -645,7 +645,8 @@ components:
         force:
           type: boolean
           default: false
-        allow_no_changes:
+          description: TBD
+        allow_empty:
           type: boolean
           default: false
           description: Allow merge when the branches have the same content

--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -645,6 +645,10 @@ components:
         force:
           type: boolean
           default: false
+        allow_no_changes:
+          type: boolean
+          default: false
+          description: Allow merge when the branches have the same content
 
     BranchCreation:
       type: object

--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -645,7 +645,7 @@ components:
         force:
           type: boolean
           default: false
-          description: TBD
+          description: Allow merge into a read-only branch or into a branch with the same content
         allow_empty:
           type: boolean
           default: false

--- a/clients/java-legacy/api/openapi.yaml
+++ b/clients/java-legacy/api/openapi.yaml
@@ -7762,6 +7762,7 @@ components:
         force: false
         message: message
         strategy: strategy
+        allow_empty: false
       properties:
         message:
           type: string
@@ -7777,6 +7778,11 @@ components:
           type: string
         force:
           default: false
+          description: TBD
+          type: boolean
+        allow_empty:
+          default: false
+          description: Allow merge when the branches have the same content
           type: boolean
       type: object
     BranchCreation:

--- a/clients/java-legacy/api/openapi.yaml
+++ b/clients/java-legacy/api/openapi.yaml
@@ -7778,7 +7778,8 @@ components:
           type: string
         force:
           default: false
-          description: TBD
+          description: Allow merge into a read-only branch or into a branch with the
+            same content
           type: boolean
         allow_empty:
           default: false

--- a/clients/java-legacy/docs/Merge.md
+++ b/clients/java-legacy/docs/Merge.md
@@ -10,7 +10,7 @@ Name | Type | Description | Notes
 **message** | **String** |  |  [optional]
 **metadata** | **Map&lt;String, String&gt;** |  |  [optional]
 **strategy** | **String** | In case of a merge conflict, this option will force the merge process to automatically favor changes from the dest branch (&#39;dest-wins&#39;) or from the source branch(&#39;source-wins&#39;). In case no selection is made, the merge process will fail in case of a conflict |  [optional]
-**force** | **Boolean** | TBD |  [optional]
+**force** | **Boolean** | Allow merge into a read-only branch or into a branch with the same content |  [optional]
 **allowEmpty** | **Boolean** | Allow merge when the branches have the same content |  [optional]
 
 

--- a/clients/java-legacy/docs/Merge.md
+++ b/clients/java-legacy/docs/Merge.md
@@ -10,7 +10,8 @@ Name | Type | Description | Notes
 **message** | **String** |  |  [optional]
 **metadata** | **Map&lt;String, String&gt;** |  |  [optional]
 **strategy** | **String** | In case of a merge conflict, this option will force the merge process to automatically favor changes from the dest branch (&#39;dest-wins&#39;) or from the source branch(&#39;source-wins&#39;). In case no selection is made, the merge process will fail in case of a conflict |  [optional]
-**force** | **Boolean** |  |  [optional]
+**force** | **Boolean** | TBD |  [optional]
+**allowEmpty** | **Boolean** | Allow merge when the branches have the same content |  [optional]
 
 
 

--- a/clients/java-legacy/src/main/java/io/lakefs/clients/api/model/Merge.java
+++ b/clients/java-legacy/src/main/java/io/lakefs/clients/api/model/Merge.java
@@ -137,11 +137,11 @@ public class Merge {
   }
 
    /**
-   * TBD
+   * Allow merge into a read-only branch or into a branch with the same content
    * @return force
   **/
   @javax.annotation.Nullable
-  @ApiModelProperty(value = "TBD")
+  @ApiModelProperty(value = "Allow merge into a read-only branch or into a branch with the same content")
 
   public Boolean getForce() {
     return force;

--- a/clients/java-legacy/src/main/java/io/lakefs/clients/api/model/Merge.java
+++ b/clients/java-legacy/src/main/java/io/lakefs/clients/api/model/Merge.java
@@ -48,6 +48,10 @@ public class Merge {
   @SerializedName(SERIALIZED_NAME_FORCE)
   private Boolean force = false;
 
+  public static final String SERIALIZED_NAME_ALLOW_EMPTY = "allow_empty";
+  @SerializedName(SERIALIZED_NAME_ALLOW_EMPTY)
+  private Boolean allowEmpty = false;
+
 
   public Merge message(String message) {
     
@@ -133,11 +137,11 @@ public class Merge {
   }
 
    /**
-   * Get force
+   * TBD
    * @return force
   **/
   @javax.annotation.Nullable
-  @ApiModelProperty(value = "")
+  @ApiModelProperty(value = "TBD")
 
   public Boolean getForce() {
     return force;
@@ -146,6 +150,29 @@ public class Merge {
 
   public void setForce(Boolean force) {
     this.force = force;
+  }
+
+
+  public Merge allowEmpty(Boolean allowEmpty) {
+    
+    this.allowEmpty = allowEmpty;
+    return this;
+  }
+
+   /**
+   * Allow merge when the branches have the same content
+   * @return allowEmpty
+  **/
+  @javax.annotation.Nullable
+  @ApiModelProperty(value = "Allow merge when the branches have the same content")
+
+  public Boolean getAllowEmpty() {
+    return allowEmpty;
+  }
+
+
+  public void setAllowEmpty(Boolean allowEmpty) {
+    this.allowEmpty = allowEmpty;
   }
 
 
@@ -161,12 +188,13 @@ public class Merge {
     return Objects.equals(this.message, merge.message) &&
         Objects.equals(this.metadata, merge.metadata) &&
         Objects.equals(this.strategy, merge.strategy) &&
-        Objects.equals(this.force, merge.force);
+        Objects.equals(this.force, merge.force) &&
+        Objects.equals(this.allowEmpty, merge.allowEmpty);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(message, metadata, strategy, force);
+    return Objects.hash(message, metadata, strategy, force, allowEmpty);
   }
 
   @Override
@@ -177,6 +205,7 @@ public class Merge {
     sb.append("    metadata: ").append(toIndentedString(metadata)).append("\n");
     sb.append("    strategy: ").append(toIndentedString(strategy)).append("\n");
     sb.append("    force: ").append(toIndentedString(force)).append("\n");
+    sb.append("    allowEmpty: ").append(toIndentedString(allowEmpty)).append("\n");
     sb.append("}");
     return sb.toString();
   }

--- a/clients/java-legacy/src/test/java/io/lakefs/clients/api/model/MergeTest.java
+++ b/clients/java-legacy/src/test/java/io/lakefs/clients/api/model/MergeTest.java
@@ -75,4 +75,12 @@ public class MergeTest {
         // TODO: test force
     }
 
+    /**
+     * Test the property 'allowEmpty'
+     */
+    @Test
+    public void allowEmptyTest() {
+        // TODO: test allowEmpty
+    }
+
 }

--- a/clients/java/api/openapi.yaml
+++ b/clients/java/api/openapi.yaml
@@ -7752,7 +7752,8 @@ components:
           type: string
         force:
           default: false
-          description: TBD
+          description: Allow merge into a read-only branch or into a branch with the
+            same content
           type: boolean
         allow_empty:
           default: false

--- a/clients/java/api/openapi.yaml
+++ b/clients/java/api/openapi.yaml
@@ -7736,6 +7736,7 @@ components:
         force: false
         message: message
         strategy: strategy
+        allow_empty: false
       properties:
         message:
           type: string
@@ -7751,6 +7752,11 @@ components:
           type: string
         force:
           default: false
+          description: TBD
+          type: boolean
+        allow_empty:
+          default: false
+          description: Allow merge when the branches have the same content
           type: boolean
       type: object
     BranchCreation:

--- a/clients/java/docs/Merge.md
+++ b/clients/java/docs/Merge.md
@@ -10,7 +10,8 @@
 |**message** | **String** |  |  [optional] |
 |**metadata** | **Map&lt;String, String&gt;** |  |  [optional] |
 |**strategy** | **String** | In case of a merge conflict, this option will force the merge process to automatically favor changes from the dest branch (&#39;dest-wins&#39;) or from the source branch(&#39;source-wins&#39;). In case no selection is made, the merge process will fail in case of a conflict |  [optional] |
-|**force** | **Boolean** |  |  [optional] |
+|**force** | **Boolean** | TBD |  [optional] |
+|**allowEmpty** | **Boolean** | Allow merge when the branches have the same content |  [optional] |
 
 
 

--- a/clients/java/docs/Merge.md
+++ b/clients/java/docs/Merge.md
@@ -10,7 +10,7 @@
 |**message** | **String** |  |  [optional] |
 |**metadata** | **Map&lt;String, String&gt;** |  |  [optional] |
 |**strategy** | **String** | In case of a merge conflict, this option will force the merge process to automatically favor changes from the dest branch (&#39;dest-wins&#39;) or from the source branch(&#39;source-wins&#39;). In case no selection is made, the merge process will fail in case of a conflict |  [optional] |
-|**force** | **Boolean** | TBD |  [optional] |
+|**force** | **Boolean** | Allow merge into a read-only branch or into a branch with the same content |  [optional] |
 |**allowEmpty** | **Boolean** | Allow merge when the branches have the same content |  [optional] |
 
 

--- a/clients/java/src/main/java/io/lakefs/clients/sdk/model/Merge.java
+++ b/clients/java/src/main/java/io/lakefs/clients/sdk/model/Merge.java
@@ -155,7 +155,7 @@ public class Merge {
   }
 
    /**
-   * TBD
+   * Allow merge into a read-only branch or into a branch with the same content
    * @return force
   **/
   @javax.annotation.Nullable

--- a/clients/java/src/main/java/io/lakefs/clients/sdk/model/Merge.java
+++ b/clients/java/src/main/java/io/lakefs/clients/sdk/model/Merge.java
@@ -70,6 +70,10 @@ public class Merge {
   @SerializedName(SERIALIZED_NAME_FORCE)
   private Boolean force = false;
 
+  public static final String SERIALIZED_NAME_ALLOW_EMPTY = "allow_empty";
+  @SerializedName(SERIALIZED_NAME_ALLOW_EMPTY)
+  private Boolean allowEmpty = false;
+
   public Merge() {
   }
 
@@ -151,7 +155,7 @@ public class Merge {
   }
 
    /**
-   * Get force
+   * TBD
    * @return force
   **/
   @javax.annotation.Nullable
@@ -162,6 +166,27 @@ public class Merge {
 
   public void setForce(Boolean force) {
     this.force = force;
+  }
+
+
+  public Merge allowEmpty(Boolean allowEmpty) {
+    
+    this.allowEmpty = allowEmpty;
+    return this;
+  }
+
+   /**
+   * Allow merge when the branches have the same content
+   * @return allowEmpty
+  **/
+  @javax.annotation.Nullable
+  public Boolean getAllowEmpty() {
+    return allowEmpty;
+  }
+
+
+  public void setAllowEmpty(Boolean allowEmpty) {
+    this.allowEmpty = allowEmpty;
   }
 
   /**
@@ -222,13 +247,14 @@ public class Merge {
     return Objects.equals(this.message, merge.message) &&
         Objects.equals(this.metadata, merge.metadata) &&
         Objects.equals(this.strategy, merge.strategy) &&
-        Objects.equals(this.force, merge.force)&&
+        Objects.equals(this.force, merge.force) &&
+        Objects.equals(this.allowEmpty, merge.allowEmpty)&&
         Objects.equals(this.additionalProperties, merge.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(message, metadata, strategy, force, additionalProperties);
+    return Objects.hash(message, metadata, strategy, force, allowEmpty, additionalProperties);
   }
 
   @Override
@@ -239,6 +265,7 @@ public class Merge {
     sb.append("    metadata: ").append(toIndentedString(metadata)).append("\n");
     sb.append("    strategy: ").append(toIndentedString(strategy)).append("\n");
     sb.append("    force: ").append(toIndentedString(force)).append("\n");
+    sb.append("    allowEmpty: ").append(toIndentedString(allowEmpty)).append("\n");
     sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
@@ -266,6 +293,7 @@ public class Merge {
     openapiFields.add("metadata");
     openapiFields.add("strategy");
     openapiFields.add("force");
+    openapiFields.add("allow_empty");
 
     // a set of required properties/fields (JSON key names)
     openapiRequiredFields = new HashSet<String>();

--- a/clients/java/src/test/java/io/lakefs/clients/sdk/model/MergeTest.java
+++ b/clients/java/src/test/java/io/lakefs/clients/sdk/model/MergeTest.java
@@ -71,4 +71,12 @@ public class MergeTest {
         // TODO: test force
     }
 
+    /**
+     * Test the property 'allowEmpty'
+     */
+    @Test
+    public void allowEmptyTest() {
+        // TODO: test allowEmpty
+    }
+
 }

--- a/clients/python-legacy/docs/Merge.md
+++ b/clients/python-legacy/docs/Merge.md
@@ -7,7 +7,7 @@ Name | Type | Description | Notes
 **message** | **str** |  | [optional] 
 **metadata** | **{str: (str,)}** |  | [optional] 
 **strategy** | **str** | In case of a merge conflict, this option will force the merge process to automatically favor changes from the dest branch (&#39;dest-wins&#39;) or from the source branch(&#39;source-wins&#39;). In case no selection is made, the merge process will fail in case of a conflict | [optional] 
-**force** | **bool** | TBD | [optional]  if omitted the server will use the default value of False
+**force** | **bool** | Allow merge into a read-only branch or into a branch with the same content | [optional]  if omitted the server will use the default value of False
 **allow_empty** | **bool** | Allow merge when the branches have the same content | [optional]  if omitted the server will use the default value of False
 **any string name** | **bool, date, datetime, dict, float, int, list, str, none_type** | any string name can be used but the value must be the correct type | [optional]
 

--- a/clients/python-legacy/docs/Merge.md
+++ b/clients/python-legacy/docs/Merge.md
@@ -7,7 +7,8 @@ Name | Type | Description | Notes
 **message** | **str** |  | [optional] 
 **metadata** | **{str: (str,)}** |  | [optional] 
 **strategy** | **str** | In case of a merge conflict, this option will force the merge process to automatically favor changes from the dest branch (&#39;dest-wins&#39;) or from the source branch(&#39;source-wins&#39;). In case no selection is made, the merge process will fail in case of a conflict | [optional] 
-**force** | **bool** |  | [optional]  if omitted the server will use the default value of False
+**force** | **bool** | TBD | [optional]  if omitted the server will use the default value of False
+**allow_empty** | **bool** | Allow merge when the branches have the same content | [optional]  if omitted the server will use the default value of False
 **any string name** | **bool, date, datetime, dict, float, int, list, str, none_type** | any string name can be used but the value must be the correct type | [optional]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/clients/python-legacy/docs/RefsApi.md
+++ b/clients/python-legacy/docs/RefsApi.md
@@ -468,6 +468,7 @@ with lakefs_client.ApiClient(configuration) as api_client:
         },
         strategy="strategy_example",
         force=False,
+        allow_empty=False,
     ) # Merge |  (optional)
 
     # example passing only required values which don't have defaults set

--- a/clients/python-legacy/lakefs_client/model/merge.py
+++ b/clients/python-legacy/lakefs_client/model/merge.py
@@ -146,7 +146,7 @@ class Merge(ModelNormal):
             message (str): [optional]  # noqa: E501
             metadata ({str: (str,)}): [optional]  # noqa: E501
             strategy (str): In case of a merge conflict, this option will force the merge process to automatically favor changes from the dest branch ('dest-wins') or from the source branch('source-wins'). In case no selection is made, the merge process will fail in case of a conflict. [optional]  # noqa: E501
-            force (bool): TBD. [optional] if omitted the server will use the default value of False  # noqa: E501
+            force (bool): Allow merge into a read-only branch or into a branch with the same content. [optional] if omitted the server will use the default value of False  # noqa: E501
             allow_empty (bool): Allow merge when the branches have the same content. [optional] if omitted the server will use the default value of False  # noqa: E501
         """
 
@@ -232,7 +232,7 @@ class Merge(ModelNormal):
             message (str): [optional]  # noqa: E501
             metadata ({str: (str,)}): [optional]  # noqa: E501
             strategy (str): In case of a merge conflict, this option will force the merge process to automatically favor changes from the dest branch ('dest-wins') or from the source branch('source-wins'). In case no selection is made, the merge process will fail in case of a conflict. [optional]  # noqa: E501
-            force (bool): TBD. [optional] if omitted the server will use the default value of False  # noqa: E501
+            force (bool): Allow merge into a read-only branch or into a branch with the same content. [optional] if omitted the server will use the default value of False  # noqa: E501
             allow_empty (bool): Allow merge when the branches have the same content. [optional] if omitted the server will use the default value of False  # noqa: E501
         """
 

--- a/clients/python-legacy/lakefs_client/model/merge.py
+++ b/clients/python-legacy/lakefs_client/model/merge.py
@@ -86,6 +86,7 @@ class Merge(ModelNormal):
             'metadata': ({str: (str,)},),  # noqa: E501
             'strategy': (str,),  # noqa: E501
             'force': (bool,),  # noqa: E501
+            'allow_empty': (bool,),  # noqa: E501
         }
 
     @cached_property
@@ -98,6 +99,7 @@ class Merge(ModelNormal):
         'metadata': 'metadata',  # noqa: E501
         'strategy': 'strategy',  # noqa: E501
         'force': 'force',  # noqa: E501
+        'allow_empty': 'allow_empty',  # noqa: E501
     }
 
     read_only_vars = {
@@ -144,7 +146,8 @@ class Merge(ModelNormal):
             message (str): [optional]  # noqa: E501
             metadata ({str: (str,)}): [optional]  # noqa: E501
             strategy (str): In case of a merge conflict, this option will force the merge process to automatically favor changes from the dest branch ('dest-wins') or from the source branch('source-wins'). In case no selection is made, the merge process will fail in case of a conflict. [optional]  # noqa: E501
-            force (bool): [optional] if omitted the server will use the default value of False  # noqa: E501
+            force (bool): TBD. [optional] if omitted the server will use the default value of False  # noqa: E501
+            allow_empty (bool): Allow merge when the branches have the same content. [optional] if omitted the server will use the default value of False  # noqa: E501
         """
 
         _check_type = kwargs.pop('_check_type', True)
@@ -229,7 +232,8 @@ class Merge(ModelNormal):
             message (str): [optional]  # noqa: E501
             metadata ({str: (str,)}): [optional]  # noqa: E501
             strategy (str): In case of a merge conflict, this option will force the merge process to automatically favor changes from the dest branch ('dest-wins') or from the source branch('source-wins'). In case no selection is made, the merge process will fail in case of a conflict. [optional]  # noqa: E501
-            force (bool): [optional] if omitted the server will use the default value of False  # noqa: E501
+            force (bool): TBD. [optional] if omitted the server will use the default value of False  # noqa: E501
+            allow_empty (bool): Allow merge when the branches have the same content. [optional] if omitted the server will use the default value of False  # noqa: E501
         """
 
         _check_type = kwargs.pop('_check_type', True)

--- a/clients/python/docs/Merge.md
+++ b/clients/python/docs/Merge.md
@@ -8,7 +8,8 @@ Name | Type | Description | Notes
 **message** | **str** |  | [optional] 
 **metadata** | **Dict[str, str]** |  | [optional] 
 **strategy** | **str** | In case of a merge conflict, this option will force the merge process to automatically favor changes from the dest branch (&#39;dest-wins&#39;) or from the source branch(&#39;source-wins&#39;). In case no selection is made, the merge process will fail in case of a conflict | [optional] 
-**force** | **bool** |  | [optional] [default to False]
+**force** | **bool** | TBD | [optional] [default to False]
+**allow_empty** | **bool** | Allow merge when the branches have the same content | [optional] [default to False]
 
 ## Example
 

--- a/clients/python/docs/Merge.md
+++ b/clients/python/docs/Merge.md
@@ -8,7 +8,7 @@ Name | Type | Description | Notes
 **message** | **str** |  | [optional] 
 **metadata** | **Dict[str, str]** |  | [optional] 
 **strategy** | **str** | In case of a merge conflict, this option will force the merge process to automatically favor changes from the dest branch (&#39;dest-wins&#39;) or from the source branch(&#39;source-wins&#39;). In case no selection is made, the merge process will fail in case of a conflict | [optional] 
-**force** | **bool** | TBD | [optional] [default to False]
+**force** | **bool** | Allow merge into a read-only branch or into a branch with the same content | [optional] [default to False]
 **allow_empty** | **bool** | Allow merge when the branches have the same content | [optional] [default to False]
 
 ## Example

--- a/clients/python/lakefs_sdk/models/merge.py
+++ b/clients/python/lakefs_sdk/models/merge.py
@@ -32,8 +32,9 @@ class Merge(BaseModel):
     message: Optional[StrictStr] = None
     metadata: Optional[Dict[str, StrictStr]] = None
     strategy: Optional[StrictStr] = Field(None, description="In case of a merge conflict, this option will force the merge process to automatically favor changes from the dest branch ('dest-wins') or from the source branch('source-wins'). In case no selection is made, the merge process will fail in case of a conflict")
-    force: Optional[StrictBool] = False
-    __properties = ["message", "metadata", "strategy", "force"]
+    force: Optional[StrictBool] = Field(False, description="TBD")
+    allow_empty: Optional[StrictBool] = Field(False, description="Allow merge when the branches have the same content")
+    __properties = ["message", "metadata", "strategy", "force", "allow_empty"]
 
     class Config:
         """Pydantic configuration"""
@@ -74,7 +75,8 @@ class Merge(BaseModel):
             "message": obj.get("message"),
             "metadata": obj.get("metadata"),
             "strategy": obj.get("strategy"),
-            "force": obj.get("force") if obj.get("force") is not None else False
+            "force": obj.get("force") if obj.get("force") is not None else False,
+            "allow_empty": obj.get("allow_empty") if obj.get("allow_empty") is not None else False
         })
         return _obj
 

--- a/clients/python/lakefs_sdk/models/merge.py
+++ b/clients/python/lakefs_sdk/models/merge.py
@@ -32,7 +32,7 @@ class Merge(BaseModel):
     message: Optional[StrictStr] = None
     metadata: Optional[Dict[str, StrictStr]] = None
     strategy: Optional[StrictStr] = Field(None, description="In case of a merge conflict, this option will force the merge process to automatically favor changes from the dest branch ('dest-wins') or from the source branch('source-wins'). In case no selection is made, the merge process will fail in case of a conflict")
-    force: Optional[StrictBool] = Field(False, description="TBD")
+    force: Optional[StrictBool] = Field(False, description="Allow merge into a read-only branch or into a branch with the same content")
     allow_empty: Optional[StrictBool] = Field(False, description="Allow merge when the branches have the same content")
     __properties = ["message", "metadata", "strategy", "force", "allow_empty"]
 

--- a/clients/python/test/test_merge.py
+++ b/clients/python/test/test_merge.py
@@ -44,7 +44,8 @@ class TestMerge(unittest.TestCase):
                     'key' : ''
                     }, 
                 strategy = '', 
-                force = True
+                force = True, 
+                allow_empty = True
             )
         else :
             return Merge(

--- a/clients/rust/docs/Merge.md
+++ b/clients/rust/docs/Merge.md
@@ -7,7 +7,8 @@ Name | Type | Description | Notes
 **message** | Option<**String**> |  | [optional]
 **metadata** | Option<**std::collections::HashMap<String, String>**> |  | [optional]
 **strategy** | Option<**String**> | In case of a merge conflict, this option will force the merge process to automatically favor changes from the dest branch ('dest-wins') or from the source branch('source-wins'). In case no selection is made, the merge process will fail in case of a conflict | [optional]
-**force** | Option<**bool**> |  | [optional][default to false]
+**force** | Option<**bool**> | TBD | [optional][default to false]
+**allow_empty** | Option<**bool**> | Allow merge when the branches have the same content | [optional][default to false]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/clients/rust/docs/Merge.md
+++ b/clients/rust/docs/Merge.md
@@ -7,7 +7,7 @@ Name | Type | Description | Notes
 **message** | Option<**String**> |  | [optional]
 **metadata** | Option<**std::collections::HashMap<String, String>**> |  | [optional]
 **strategy** | Option<**String**> | In case of a merge conflict, this option will force the merge process to automatically favor changes from the dest branch ('dest-wins') or from the source branch('source-wins'). In case no selection is made, the merge process will fail in case of a conflict | [optional]
-**force** | Option<**bool**> | TBD | [optional][default to false]
+**force** | Option<**bool**> | Allow merge into a read-only branch or into a branch with the same content | [optional][default to false]
 **allow_empty** | Option<**bool**> | Allow merge when the branches have the same content | [optional][default to false]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/clients/rust/src/models/merge.rs
+++ b/clients/rust/src/models/merge.rs
@@ -19,8 +19,12 @@ pub struct Merge {
     /// In case of a merge conflict, this option will force the merge process to automatically favor changes from the dest branch ('dest-wins') or from the source branch('source-wins'). In case no selection is made, the merge process will fail in case of a conflict
     #[serde(rename = "strategy", skip_serializing_if = "Option::is_none")]
     pub strategy: Option<String>,
+    /// TBD
     #[serde(rename = "force", skip_serializing_if = "Option::is_none")]
     pub force: Option<bool>,
+    /// Allow merge when the branches have the same content
+    #[serde(rename = "allow_empty", skip_serializing_if = "Option::is_none")]
+    pub allow_empty: Option<bool>,
 }
 
 impl Merge {
@@ -30,6 +34,7 @@ impl Merge {
             metadata: None,
             strategy: None,
             force: None,
+            allow_empty: None,
         }
     }
 }

--- a/clients/rust/src/models/merge.rs
+++ b/clients/rust/src/models/merge.rs
@@ -19,7 +19,7 @@ pub struct Merge {
     /// In case of a merge conflict, this option will force the merge process to automatically favor changes from the dest branch ('dest-wins') or from the source branch('source-wins'). In case no selection is made, the merge process will fail in case of a conflict
     #[serde(rename = "strategy", skip_serializing_if = "Option::is_none")]
     pub strategy: Option<String>,
-    /// TBD
+    /// Allow merge into a read-only branch or into a branch with the same content
     #[serde(rename = "force", skip_serializing_if = "Option::is_none")]
     pub force: Option<bool>,
     /// Allow merge when the branches have the same content

--- a/docs/assets/js/swagger.yml
+++ b/docs/assets/js/swagger.yml
@@ -645,6 +645,11 @@ components:
         force:
           type: boolean
           default: false
+          description: TBD
+        allow_empty:
+          type: boolean
+          default: false
+          description: Allow merge when the branches have the same content
 
     BranchCreation:
       type: object

--- a/docs/assets/js/swagger.yml
+++ b/docs/assets/js/swagger.yml
@@ -645,7 +645,7 @@ components:
         force:
           type: boolean
           default: false
-          description: TBD
+          description: Allow merge into a read-only branch or into a branch with the same content
         allow_empty:
           type: boolean
           default: false

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2737,7 +2737,9 @@ lakectl merge <source ref> <destination ref> [flags]
 {:.no_toc}
 
 ```
+      --allow-empty           Allow merge when the branches have the same content
       --allow-empty-message   allow an empty commit message (default true)
+      --force                 Allow merge into a read-only branch or into a branch with the same content
   -h, --help                  help for merge
   -m, --message string        commit message
       --meta strings          key value pair in the form of key=value

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -4723,7 +4723,9 @@ func (c *Controller) MergeIntoBranch(w http.ResponseWriter, r *http.Request, bod
 		swag.StringValue(body.Message),
 		metadata,
 		swag.StringValue(body.Strategy),
-		graveler.WithForce(swag.BoolValue(body.Force)))
+		graveler.WithForce(swag.BoolValue(body.Force)),
+		graveler.WithAllowEmpty(swag.BoolValue(body.AllowEmpty)),
+	)
 
 	if errors.Is(err, graveler.ErrConflictFound) {
 		writeResponse(w, r, http.StatusConflict, apigen.MergeResult{

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -3842,11 +3842,17 @@ func TestController_MergeBranchWithNoChanges(t *testing.T) {
 		t.Errorf("Merge branches with no changes should fail with ErrNoChanges, got %+v", mergeResp)
 	}
 
-	mergeWithFlagResp, err := clt.MergeIntoBranchWithResponse(ctx, repoName, "branch2", "branch1", apigen.MergeIntoBranchJSONRequestBody{
+	mergeWithAllowEmptyFlagResp, err := clt.MergeIntoBranchWithResponse(ctx, repoName, "branch2", "branch1", apigen.MergeIntoBranchJSONRequestBody{
 		Message:    apiutil.Ptr("Merge branch2 to branch1"),
 		AllowEmpty: swag.Bool(true),
 	})
-	verifyResponseOK(t, mergeWithFlagResp, err)
+	verifyResponseOK(t, mergeWithAllowEmptyFlagResp, err)
+
+	mergeWithForceFlagResp, err := clt.MergeIntoBranchWithResponse(ctx, repoName, "branch2", "branch1", apigen.MergeIntoBranchJSONRequestBody{
+		Message: apiutil.Ptr("Merge branch2 to branch1"),
+		Force:   swag.Bool(true),
+	})
+	verifyResponseOK(t, mergeWithForceFlagResp, err)
 
 	// TODO: upload files to branches and verify the merge
 }

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -3817,27 +3817,16 @@ func TestController_MergeBranchWithNoChanges(t *testing.T) {
 	})
 	verifyResponseOK(t, repoResp, err)
 
-	const content = "awesome content"
-
 	branch1Resp, err := clt.CreateBranchWithResponse(ctx, repoName, apigen.CreateBranchJSONRequestBody{Name: "branch1", Source: "main"})
 	verifyResponseOK(t, branch1Resp, err)
-	//upload1Resp, err := uploadObjectHelper(t, ctx, clt, "file0", strings.NewReader(content), repoName, "branch1")
-	//verifyResponseOK(t, upload1Resp, err)
-	//commit1Resp, err := clt.CommitWithResponse(ctx, repoName, "branch1", &apigen.CommitParams{}, apigen.CommitJSONRequestBody{Message: "Add file0 to branch1"})
-	//verifyResponseOK(t, commit1Resp, err)
 
 	branch2Resp, err := clt.CreateBranchWithResponse(ctx, repoName, apigen.CreateBranchJSONRequestBody{Name: "branch2", Source: "main"})
 	verifyResponseOK(t, branch2Resp, err)
-	//upload2Resp, err := uploadObjectHelper(t, ctx, clt, "file0", strings.NewReader(content), repoName, "branch2")
-	//verifyResponseOK(t, upload2Resp, err)
-	//commit2Resp, err := clt.CommitWithResponse(ctx, repoName, "branch2", &apigen.CommitParams{}, apigen.CommitJSONRequestBody{Message: "Add file0 to branch2"})
-	//verifyResponseOK(t, commit2Resp, err)
 
 	mergeResp, err := clt.MergeIntoBranchWithResponse(ctx, repoName, "branch2", "branch1", apigen.MergeIntoBranchJSONRequestBody{
 		Message: apiutil.Ptr("Merge branch2 to branch1"),
 	})
 	testutil.MustDo(t, "perform merge with no changes", err)
-	// TODO: is there a better way to check this error message?
 	if mergeResp.JSON400 == nil || !strings.HasSuffix(mergeResp.JSON400.Message, graveler.ErrNoChanges.Error()) {
 		t.Errorf("Merge branches with no changes should fail with ErrNoChanges, got %+v", mergeResp)
 	}
@@ -3853,8 +3842,6 @@ func TestController_MergeBranchWithNoChanges(t *testing.T) {
 		Force:   swag.Bool(true),
 	})
 	verifyResponseOK(t, mergeWithForceFlagResp, err)
-
-	// TODO: upload files to branches and verify the merge
 }
 
 func TestController_CreateTag(t *testing.T) {

--- a/pkg/graveler/committed/manager.go
+++ b/pkg/graveler/committed/manager.go
@@ -200,15 +200,23 @@ func (c *committedManager) Import(ctx context.Context, ns graveler.StorageNamesp
 	return c.merge(ctx, mctx)
 }
 
-func (c *committedManager) Merge(ctx context.Context, ns graveler.StorageNamespace, destination, source, base graveler.MetaRangeID, strategy graveler.MergeStrategy, _ ...graveler.SetOptionsFunc) (graveler.MetaRangeID, error) {
-	if source == base {
+func (c *committedManager) Merge(ctx context.Context, ns graveler.StorageNamespace, destination, source, base graveler.MetaRangeID, strategy graveler.MergeStrategy, opts ...graveler.SetOptionsFunc) (graveler.MetaRangeID, error) {
+	// TODO: this repeats a lot (in graveler.go) - can it be encapsulated in a function?
+	options := &graveler.SetOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	if source == base && !options.AllowEmpty {
 		// no changes on source
 		return "", graveler.ErrNoChanges
 	}
+
 	if destination == base {
 		// changes introduced only on source
 		return source, nil
 	}
+
 	mctx := mergeContext{
 		strategy:      strategy,
 		ns:            ns,

--- a/pkg/graveler/committed/manager.go
+++ b/pkg/graveler/committed/manager.go
@@ -207,7 +207,7 @@ func (c *committedManager) Merge(ctx context.Context, ns graveler.StorageNamespa
 		opt(options)
 	}
 
-	if source == base && !options.AllowEmpty {
+	if source == base && !options.AllowEmpty && !options.Force {
 		// no changes on source
 		return "", graveler.ErrNoChanges
 	}

--- a/pkg/graveler/committed/manager.go
+++ b/pkg/graveler/committed/manager.go
@@ -201,11 +201,7 @@ func (c *committedManager) Import(ctx context.Context, ns graveler.StorageNamesp
 }
 
 func (c *committedManager) Merge(ctx context.Context, ns graveler.StorageNamespace, destination, source, base graveler.MetaRangeID, strategy graveler.MergeStrategy, opts ...graveler.SetOptionsFunc) (graveler.MetaRangeID, error) {
-	// TODO: this repeats a lot (in graveler.go) - can it be encapsulated in a function?
-	options := &graveler.SetOptions{}
-	for _, opt := range opts {
-		opt(options)
-	}
+	options := graveler.NewSetOptions(opts)
 
 	if source == base && !options.AllowEmpty && !options.Force {
 		// no changes on source

--- a/pkg/graveler/graveler.go
+++ b/pkg/graveler/graveler.go
@@ -197,6 +197,14 @@ type SetOptions struct {
 
 type SetOptionsFunc func(opts *SetOptions)
 
+func NewSetOptions(opts []SetOptionsFunc) *SetOptions {
+	options := &SetOptions{}
+	for _, opt := range opts {
+		opt(options)
+	}
+	return options
+}
+
 func WithIfAbsent(v bool) SetOptionsFunc {
 	return func(opts *SetOptions) {
 		opts.IfAbsent = v
@@ -1100,10 +1108,7 @@ func (g *Graveler) SetRepositoryMetadata(ctx context.Context, repository *Reposi
 }
 
 func (g *Graveler) WriteRange(ctx context.Context, repository *RepositoryRecord, it ValueIterator, opts ...SetOptionsFunc) (*RangeInfo, error) {
-	options := &SetOptions{}
-	for _, opt := range opts {
-		opt(options)
-	}
+	options := NewSetOptions(opts)
 	if repository.ReadOnly && !options.Force {
 		return nil, ErrReadOnlyRepository
 	}
@@ -1111,10 +1116,7 @@ func (g *Graveler) WriteRange(ctx context.Context, repository *RepositoryRecord,
 }
 
 func (g *Graveler) WriteMetaRange(ctx context.Context, repository *RepositoryRecord, ranges []*RangeInfo, opts ...SetOptionsFunc) (*MetaRangeInfo, error) {
-	options := &SetOptions{}
-	for _, opt := range opts {
-		opt(options)
-	}
+	options := NewSetOptions(opts)
 	if repository.ReadOnly && !options.Force {
 		return nil, ErrReadOnlyRepository
 	}
@@ -1126,10 +1128,7 @@ func (g *Graveler) StageObject(ctx context.Context, stagingToken string, object 
 }
 
 func (g *Graveler) WriteMetaRangeByIterator(ctx context.Context, repository *RepositoryRecord, it ValueIterator, opts ...SetOptionsFunc) (*MetaRangeID, error) {
-	options := &SetOptions{}
-	for _, opt := range opts {
-		opt(options)
-	}
+	options := NewSetOptions(opts)
 	if repository.ReadOnly && !options.Force {
 		return nil, ErrReadOnlyRepository
 	}
@@ -1146,10 +1145,7 @@ func GenerateStagingToken(repositoryID RepositoryID, branchID BranchID) StagingT
 }
 
 func (g *Graveler) CreateBranch(ctx context.Context, repository *RepositoryRecord, branchID BranchID, ref Ref, opts ...SetOptionsFunc) (*Branch, error) {
-	options := &SetOptions{}
-	for _, opt := range opts {
-		opt(options)
-	}
+	options := NewSetOptions(opts)
 	if repository.ReadOnly && !options.Force {
 		return nil, ErrReadOnlyRepository
 	}
@@ -1218,10 +1214,7 @@ func (g *Graveler) CreateBranch(ctx context.Context, repository *RepositoryRecor
 }
 
 func (g *Graveler) UpdateBranch(ctx context.Context, repository *RepositoryRecord, branchID BranchID, ref Ref, opts ...SetOptionsFunc) (*Branch, error) {
-	options := &SetOptions{}
-	for _, opt := range opts {
-		opt(options)
-	}
+	options := NewSetOptions(opts)
 	if repository.ReadOnly && !options.Force {
 		return nil, ErrReadOnlyRepository
 	}
@@ -1314,10 +1307,7 @@ func (g *Graveler) GetTag(ctx context.Context, repository *RepositoryRecord, tag
 }
 
 func (g *Graveler) CreateTag(ctx context.Context, repository *RepositoryRecord, tagID TagID, commitID CommitID, opts ...SetOptionsFunc) error {
-	options := &SetOptions{}
-	for _, opt := range opts {
-		opt(options)
-	}
+	options := NewSetOptions(opts)
 	if repository.ReadOnly && !options.Force {
 		return ErrReadOnlyRepository
 	}
@@ -1377,10 +1367,7 @@ func (g *Graveler) CreateTag(ctx context.Context, repository *RepositoryRecord, 
 }
 
 func (g *Graveler) DeleteTag(ctx context.Context, repository *RepositoryRecord, tagID TagID, opts ...SetOptionsFunc) error {
-	options := &SetOptions{}
-	for _, opt := range opts {
-		opt(options)
-	}
+	options := NewSetOptions(opts)
 	if repository.ReadOnly && !options.Force {
 		return ErrReadOnlyRepository
 	}
@@ -1463,10 +1450,7 @@ func (g *Graveler) ListBranches(ctx context.Context, repository *RepositoryRecor
 }
 
 func (g *Graveler) DeleteBranch(ctx context.Context, repository *RepositoryRecord, branchID BranchID, opts ...SetOptionsFunc) error {
-	options := &SetOptions{}
-	for _, opt := range opts {
-		opt(options)
-	}
+	options := NewSetOptions(opts)
 	if repository.ReadOnly && !options.Force {
 		return ErrReadOnlyRepository
 	}
@@ -1675,10 +1659,7 @@ func (g *Graveler) Set(ctx context.Context, repository *RepositoryRecord, branch
 		return ErrWriteToProtectedBranch
 	}
 
-	options := &SetOptions{}
-	for _, opt := range opts {
-		opt(options)
-	}
+	options := NewSetOptions(opts)
 	if repository.ReadOnly && !options.Force {
 		return ErrReadOnlyRepository
 	}
@@ -1767,10 +1748,7 @@ func (g *Graveler) Delete(ctx context.Context, repository *RepositoryRecord, bra
 		return ErrWriteToProtectedBranch
 	}
 
-	options := &SetOptions{}
-	for _, opt := range opts {
-		opt(options)
-	}
+	options := NewSetOptions(opts)
 	if repository.ReadOnly && !options.Force {
 		return ErrReadOnlyRepository
 	}
@@ -1794,10 +1772,7 @@ func (g *Graveler) DeleteBatch(ctx context.Context, repository *RepositoryRecord
 		return ErrWriteToProtectedBranch
 	}
 
-	options := &SetOptions{}
-	for _, opt := range opts {
-		opt(options)
-	}
+	options := NewSetOptions(opts)
 	if repository.ReadOnly && !options.Force {
 		return ErrReadOnlyRepository
 	}
@@ -1951,10 +1926,7 @@ func (g *Graveler) Commit(ctx context.Context, repository *RepositoryRecord, bra
 		return "", ErrCommitToProtectedBranch
 	}
 
-	options := &SetOptions{}
-	for _, opt := range opts {
-		opt(options)
-	}
+	options := NewSetOptions(opts)
 	if repository.ReadOnly && !options.Force {
 		return "", ErrReadOnlyRepository
 	}
@@ -2086,10 +2058,7 @@ func (g *Graveler) Commit(ctx context.Context, repository *RepositoryRecord, bra
 }
 
 func (g *Graveler) CreateCommitRecord(ctx context.Context, repository *RepositoryRecord, commitID CommitID, commit Commit, opts ...SetOptionsFunc) error {
-	options := &SetOptions{}
-	for _, opt := range opts {
-		opt(options)
-	}
+	options := NewSetOptions(opts)
 	if repository.ReadOnly && !options.Force {
 		return ErrReadOnlyRepository
 	}
@@ -2157,10 +2126,7 @@ func CommitExists(ctx context.Context, repository *RepositoryRecord, commitID Co
 }
 
 func (g *Graveler) AddCommit(ctx context.Context, repository *RepositoryRecord, commit Commit, opts ...SetOptionsFunc) (CommitID, error) {
-	options := &SetOptions{}
-	for _, opt := range opts {
-		opt(options)
-	}
+	options := NewSetOptions(opts)
 	if repository.ReadOnly && !options.Force {
 		return "", ErrReadOnlyRepository
 	}
@@ -2276,10 +2242,7 @@ func (g *Graveler) ResetHard(ctx context.Context, repository *RepositoryRecord, 
 		return ErrWriteToProtectedBranch
 	}
 
-	options := &SetOptions{}
-	for _, opt := range opts {
-		opt(options)
-	}
+	options := NewSetOptions(opts)
 
 	if repository.ReadOnly && !options.Force {
 		return ErrReadOnlyRepository
@@ -2333,10 +2296,7 @@ func (g *Graveler) Reset(ctx context.Context, repository *RepositoryRecord, bran
 		return ErrWriteToProtectedBranch
 	}
 
-	options := &SetOptions{}
-	for _, opt := range opts {
-		opt(options)
-	}
+	options := NewSetOptions(opts)
 	if repository.ReadOnly && !options.Force {
 		return ErrReadOnlyRepository
 	}
@@ -2408,10 +2368,7 @@ func (g *Graveler) ResetKey(ctx context.Context, repository *RepositoryRecord, b
 		return ErrWriteToProtectedBranch
 	}
 
-	options := &SetOptions{}
-	for _, opt := range opts {
-		opt(options)
-	}
+	options := NewSetOptions(opts)
 	if repository.ReadOnly && !options.Force {
 		return ErrReadOnlyRepository
 	}
@@ -2452,10 +2409,7 @@ func (g *Graveler) ResetPrefix(ctx context.Context, repository *RepositoryRecord
 		return ErrWriteToProtectedBranch
 	}
 
-	options := &SetOptions{}
-	for _, opt := range opts {
-		opt(options)
-	}
+	options := NewSetOptions(opts)
 	if repository.ReadOnly && !options.Force {
 		return ErrReadOnlyRepository
 	}
@@ -2517,10 +2471,7 @@ type CommitIDAndSummary struct {
 // That is, try to apply the diff from C2 to C1 on the tip of the branch.
 // If the commit is a merge commit, 'parentNumber' is the parent number (1-based) relative to which the revert is done.
 func (g *Graveler) Revert(ctx context.Context, repository *RepositoryRecord, branchID BranchID, ref Ref, parentNumber int, commitParams CommitParams, opts ...SetOptionsFunc) (CommitID, error) {
-	options := &SetOptions{}
-	for _, opt := range opts {
-		opt(options)
-	}
+	options := NewSetOptions(opts)
 	if repository.ReadOnly && !options.Force {
 		return "", ErrReadOnlyRepository
 	}
@@ -2604,10 +2555,7 @@ func (g *Graveler) Revert(ctx context.Context, repository *RepositoryRecord, bra
 // CherryPick creates a new commit on the given branch, with the changes from the given commit.
 // If the commit is a merge commit, 'parentNumber' is the parent number (1-based) relative to which the cherry-pick is done.
 func (g *Graveler) CherryPick(ctx context.Context, repository *RepositoryRecord, branchID BranchID, ref Ref, parentNumber *int, committer string, opts ...SetOptionsFunc) (CommitID, error) {
-	options := &SetOptions{}
-	for _, opt := range opts {
-		opt(options)
-	}
+	options := NewSetOptions(opts)
 	if repository.ReadOnly && !options.Force {
 		return "", ErrReadOnlyRepository
 	}
@@ -2699,10 +2647,7 @@ func (g *Graveler) CherryPick(ctx context.Context, repository *RepositoryRecord,
 }
 
 func (g *Graveler) Merge(ctx context.Context, repository *RepositoryRecord, destination BranchID, source Ref, commitParams CommitParams, strategy string, opts ...SetOptionsFunc) (CommitID, error) {
-	options := &SetOptions{}
-	for _, opt := range opts {
-		opt(options)
-	}
+	options := NewSetOptions(opts)
 	if repository.ReadOnly && !options.Force {
 		return "", ErrReadOnlyRepository
 	}
@@ -2872,10 +2817,7 @@ func (g *Graveler) retryRepoMetadataUpdate(ctx context.Context, repository *Repo
 }
 
 func (g *Graveler) Import(ctx context.Context, repository *RepositoryRecord, destination BranchID, source MetaRangeID, commitParams CommitParams, prefixes []Prefix, opts ...SetOptionsFunc) (CommitID, error) {
-	options := &SetOptions{}
-	for _, opt := range opts {
-		opt(options)
-	}
+	options := NewSetOptions(opts)
 	if repository.ReadOnly && !options.Force {
 		return "", ErrReadOnlyRepository
 	}
@@ -3125,10 +3067,7 @@ func (g *Graveler) SetHooksHandler(handler HooksHandler) {
 }
 
 func (g *Graveler) LoadCommits(ctx context.Context, repository *RepositoryRecord, metaRangeID MetaRangeID, opts ...SetOptionsFunc) error {
-	options := &SetOptions{}
-	for _, opt := range opts {
-		opt(options)
-	}
+	options := NewSetOptions(opts)
 	if repository.ReadOnly && !options.Force {
 		return ErrReadOnlyRepository
 	}
@@ -3177,10 +3116,7 @@ func (g *Graveler) LoadCommits(ctx context.Context, repository *RepositoryRecord
 }
 
 func (g *Graveler) LoadBranches(ctx context.Context, repository *RepositoryRecord, metaRangeID MetaRangeID, opts ...SetOptionsFunc) error {
-	options := &SetOptions{}
-	for _, opt := range opts {
-		opt(options)
-	}
+	options := NewSetOptions(opts)
 	if repository.ReadOnly && !options.Force {
 		return ErrReadOnlyRepository
 	}
@@ -3213,10 +3149,7 @@ func (g *Graveler) LoadBranches(ctx context.Context, repository *RepositoryRecor
 }
 
 func (g *Graveler) LoadTags(ctx context.Context, repository *RepositoryRecord, metaRangeID MetaRangeID, opts ...SetOptionsFunc) error {
-	options := &SetOptions{}
-	for _, opt := range opts {
-		opt(options)
-	}
+	options := NewSetOptions(opts)
 	if repository.ReadOnly && !options.Force {
 		return ErrReadOnlyRepository
 	}

--- a/pkg/graveler/graveler.go
+++ b/pkg/graveler/graveler.go
@@ -191,6 +191,8 @@ type SetOptions struct {
 	MaxTries int
 	// Force set to true will bypass repository read-only protection.
 	Force bool
+	// AllowEmpty set to true will allow committing an empty commit.
+	AllowEmpty bool
 }
 
 type SetOptionsFunc func(opts *SetOptions)
@@ -204,6 +206,12 @@ func WithIfAbsent(v bool) SetOptionsFunc {
 func WithForce(v bool) SetOptionsFunc {
 	return func(opts *SetOptions) {
 		opts.Force = v
+	}
+}
+
+func WithAllowEmpty(v bool) SetOptionsFunc {
+	return func(opts *SetOptions) {
+		opts.AllowEmpty = v
 	}
 }
 
@@ -2758,7 +2766,7 @@ func (g *Graveler) Merge(ctx context.Context, repository *RepositoryRecord, dest
 			return nil, ErrInvalidMergeStrategy
 		}
 
-		metaRangeID, err := g.CommittedManager.Merge(ctx, storageNamespace, toCommit.MetaRangeID, fromCommit.MetaRangeID, baseCommit.MetaRangeID, mergeStrategy)
+		metaRangeID, err := g.CommittedManager.Merge(ctx, storageNamespace, toCommit.MetaRangeID, fromCommit.MetaRangeID, baseCommit.MetaRangeID, mergeStrategy, opts...)
 		if err != nil {
 			if !errors.Is(err, ErrUserVisible) {
 				err = fmt.Errorf("merge in CommitManager: %w", err)


### PR DESCRIPTION
Closes #7797.

## Change Description

Add `allow_no_changes` flag to branch merge API, to allow merge merging two branches with the same content.

### Background

Currently, when trying to merge two branches with the same content, an "no changes" error is thrown.

### New Feature

Add the flag to the API,
And implement support for it in `lakectl` and in the `python-wrapper` (in addition to the auto-generated clients).

This change should be fully backwards-compatible.
