### PR TITLE
Propagate request ID from context to API auth service calls

### DIFF
--- a/pkg/api/serve.go
+++ b/pkg/api/serve.go
@@ -28,8 +28,7 @@ import (
 )
 
 const (
-	RequestIDHeaderName = "X-Request-ID"
-	LoggerServiceName   = "rest_api"
+	LoggerServiceName = "rest_api"
 
 	extensionValidationExcludeBody = "x-validation-exclude-body"
 )
@@ -49,7 +48,7 @@ func Serve(cfg *config.Config, catalog *catalog.Catalog, middlewareAuthenticator
 			AuthenticationFunc: openapi3filter.NoopAuthenticationFunc,
 		}),
 		httputil.LoggingMiddleware(
-			RequestIDHeaderName,
+			httputil.RequestIDHeaderName,
 			logging.Fields{logging.ServiceNameFieldKey: LoggerServiceName},
 			cfg.Logging.AuditLogLevel,
 			cfg.Logging.TraceRequestHeaders),

--- a/pkg/auth/client_trace.go
+++ b/pkg/auth/client_trace.go
@@ -1,0 +1,22 @@
+package auth
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/treeverse/lakefs/pkg/httputil"
+)
+
+// AddRequestID returns a RequestEditorFn that puts the RequestID from the
+// context logging field on every client request.
+func AddRequestID(headerName string) RequestEditorFn {
+	return func(ctx context.Context, req *http.Request) error {
+		reqIDField := ctx.Value(httputil.RequestIDContextKey)
+		if reqIDField == nil {
+			return nil
+		}
+		reqID := reqIDField.(string)
+		req.Header.Add(headerName, reqID)
+		return nil
+	}
+}

--- a/pkg/auth/service.go
+++ b/pkg/auth/service.go
@@ -25,6 +25,7 @@ import (
 	"github.com/treeverse/lakefs/pkg/auth/model"
 	"github.com/treeverse/lakefs/pkg/auth/params"
 	"github.com/treeverse/lakefs/pkg/auth/wildcard"
+	"github.com/treeverse/lakefs/pkg/httputil"
 	"github.com/treeverse/lakefs/pkg/kv"
 	"github.com/treeverse/lakefs/pkg/logging"
 	"github.com/treeverse/lakefs/pkg/permissions"
@@ -2079,6 +2080,7 @@ func NewAPIAuthService(apiEndpoint, token string, externalPrincipalseEnabled boo
 	client, err := NewClientWithResponses(
 		apiEndpoint,
 		WithRequestEditorFn(bearerToken.Intercept),
+		WithRequestEditorFn(AddRequestID(httputil.RequestIDHeaderName)),
 		WithHTTPClient(httpClient),
 	)
 	if err != nil {

--- a/pkg/httputil/headers.go
+++ b/pkg/httputil/headers.go
@@ -1,0 +1,5 @@
+package httputil
+
+const (
+	RequestIDHeaderName = "X-Request-ID"
+)


### PR DESCRIPTION
Allows tracing into external auth.  (Also good request ID hygiene, of course...)