### PR TITLE
Bugfix: UI: restore colors in diff view

### DIFF
--- a/webui/src/styles/globals.css
+++ b/webui/src/styles/globals.css
@@ -288,23 +288,23 @@ td.tree-path {
   width: 30%;
 }
 
-.diff-changed {
+.diff-changed td {
   background-color: var(--color-bg-changed);
 }
 
-.diff-added {
+.diff-added td {
   background-color: var(--color-bg-added)
 }
 
-.diff-removed {
+.diff-removed td {
   background-color: var(--color-bg-removed);
 }
 
-.diff-conflict {
+.diff-conflict td {
   background-color: var(--color-bg-conflict);
 }
 
-.diff-more {
+.diff-more td {
   background-color: #ffffff;
 }
 


### PR DESCRIPTION
closes #7807 

I believe this changed in one of the bootstrap.css upgrades - there's a modifier that is more specific that overwrites the cell colors.


Before fix:

![image](https://github.com/treeverse/lakeFS/assets/205955/c7e4ae77-9f4b-405a-8426-c330eb87cedd)

After fix:

![image](https://github.com/treeverse/lakeFS/assets/205955/522ae1ce-07d4-4cdf-b481-4ab8f2b6b67d)
