### PR TITLE
Introduce support of GCS encryption for both CMEK and CSEK

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -128,6 +128,8 @@ This reference uses `.` to denote the nesting of values.
 * `blockstore.gs.pre_signed_expiry` `(time duration : "15m")` - Expiry of pre-signed URL.
 * `blockstore.gs.disable_pre_signed` `(bool : false)` - Disable use of pre-signed URL.
 * `blockstore.gs.disable_pre_signed_ui` `(bool : true)` - Disable use of pre-signed URL in the UI.
+* `blockstore.gs.server_side_encryption_customer_supplied` `(string : )` - Server side encryption with AES key in hex format, exclusive with key ID below
+* `blockstore.gs.server_side_encryption_kms_key_id` `(string : )` - Server side encryption KMS key ID, exclusive with above
 * `blockstore.azure.storage_account` `(string : )` - If specified, will be used as the Azure storage account
 * `blockstore.azure.storage_access_key` `(string : )` - If specified, will be used as the Azure storage access key
 * `blockstore.azure.pre_signed_expiry` `(time duration : "15m")` - Expiry of pre-signed URL.

--- a/pkg/block/factory/build.go
+++ b/pkg/block/factory/build.go
@@ -132,11 +132,18 @@ func buildGSAdapter(ctx context.Context, params params.GS) (*gs.Adapter, error) 
 	if err != nil {
 		return nil, err
 	}
-	adapter := gs.NewAdapter(client,
+	opts := []gs.AdapterOption{
 		gs.WithPreSignedExpiry(params.PreSignedExpiry),
 		gs.WithDisablePreSigned(params.DisablePreSigned),
 		gs.WithDisablePreSignedUI(params.DisablePreSignedUI),
-	)
+	}
+	switch {
+	case params.ServerSideEncryptionCustomerSupplied != nil:
+		opts = append(opts, gs.WithServerSideEncryptionCustomerSupplied(params.ServerSideEncryptionCustomerSupplied))
+	case params.ServerSideEncryptionKmsKeyID != "":
+		opts = append(opts, gs.WithServerSideEncryptionKmsKeyID(params.ServerSideEncryptionKmsKeyID))
+	}
+	adapter := gs.NewAdapter(client, opts...)
 	logging.FromContext(ctx).WithField("type", "gs").Info("initialized blockstore adapter")
 	return adapter, nil
 }

--- a/pkg/block/params/block.go
+++ b/pkg/block/params/block.go
@@ -63,11 +63,13 @@ type S3 struct {
 }
 
 type GS struct {
-	CredentialsFile    string
-	CredentialsJSON    string
-	PreSignedExpiry    time.Duration
-	DisablePreSigned   bool
-	DisablePreSignedUI bool
+	CredentialsFile                      string
+	CredentialsJSON                      string
+	PreSignedExpiry                      time.Duration
+	DisablePreSigned                     bool
+	DisablePreSignedUI                   bool
+	ServerSideEncryptionCustomerSupplied []byte
+	ServerSideEncryptionKmsKeyID         string
 }
 
 type Azure struct {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"reflect"
@@ -17,9 +18,11 @@ import (
 )
 
 var (
-	ErrBadConfiguration    = errors.New("bad configuration")
-	ErrBadDomainNames      = fmt.Errorf("%w: domain names are prefixes", ErrBadConfiguration)
-	ErrMissingRequiredKeys = fmt.Errorf("%w: missing required keys", ErrBadConfiguration)
+	ErrBadConfiguration      = errors.New("bad configuration")
+	ErrBadDomainNames        = fmt.Errorf("%w: domain names are prefixes", ErrBadConfiguration)
+	ErrMissingRequiredKeys   = fmt.Errorf("%w: missing required keys", ErrBadConfiguration)
+	ErrBadGCPCSEKValue       = fmt.Errorf("value of customer-supplied server side encryption is not a valid %d bytes AES key", gcpAESKeyLength)
+	ErrGCPEncryptKeyConflict = errors.New("setting both kms and customer supplied encryption will result failure when reading/writing object")
 )
 
 // UseLocalConfiguration set to true will add defaults that enable a lakeFS run
@@ -272,12 +275,14 @@ type Config struct {
 			Domain string `mapstructure:"domain"`
 		} `mapstructure:"azure"`
 		GS *struct {
-			S3Endpoint         string        `mapstructure:"s3_endpoint"`
-			CredentialsFile    string        `mapstructure:"credentials_file"`
-			CredentialsJSON    string        `mapstructure:"credentials_json"`
-			PreSignedExpiry    time.Duration `mapstructure:"pre_signed_expiry"`
-			DisablePreSigned   bool          `mapstructure:"disable_pre_signed"`
-			DisablePreSignedUI bool          `mapstructure:"disable_pre_signed_ui"`
+			S3Endpoint                           string        `mapstructure:"s3_endpoint"`
+			CredentialsFile                      string        `mapstructure:"credentials_file"`
+			CredentialsJSON                      string        `mapstructure:"credentials_json"`
+			PreSignedExpiry                      time.Duration `mapstructure:"pre_signed_expiry"`
+			DisablePreSigned                     bool          `mapstructure:"disable_pre_signed"`
+			DisablePreSignedUI                   bool          `mapstructure:"disable_pre_signed_ui"`
+			ServerSideEncryptionCustomerSupplied string        `mapstructure:"server_side_encryption_customer_supplied"`
+			ServerSideEncryptionKmsKeyID         string        `mapstructure:"server_side_encryption_kms_key_id"`
 		} `mapstructure:"gs"`
 	} `mapstructure:"blockstore"`
 	Committed struct {
@@ -499,17 +504,38 @@ func (c *Config) BlockstoreLocalParams() (blockparams.Local, error) {
 	return params, nil
 }
 
+const (
+	gcpAESKeyLength = 32
+)
+
 func (c *Config) BlockstoreGSParams() (blockparams.GS, error) {
+	var customerSuppliedKey []byte = nil
+	if c.Blockstore.GS.ServerSideEncryptionCustomerSupplied != "" {
+		v, err := hex.DecodeString(c.Blockstore.GS.ServerSideEncryptionCustomerSupplied)
+		if err != nil {
+			return blockparams.GS{}, err
+		}
+		if len(v) != gcpAESKeyLength {
+			return blockparams.GS{}, ErrBadGCPCSEKValue
+		}
+		customerSuppliedKey = v
+		if c.Blockstore.GS.ServerSideEncryptionKmsKeyID != "" {
+			return blockparams.GS{}, ErrGCPEncryptKeyConflict
+		}
+	}
+
 	credPath, err := homedir.Expand(c.Blockstore.GS.CredentialsFile)
 	if err != nil {
 		return blockparams.GS{}, fmt.Errorf("parse GS credentials path '%s': %w", c.Blockstore.GS.CredentialsFile, err)
 	}
 	return blockparams.GS{
-		CredentialsFile:    credPath,
-		CredentialsJSON:    c.Blockstore.GS.CredentialsJSON,
-		PreSignedExpiry:    c.Blockstore.GS.PreSignedExpiry,
-		DisablePreSigned:   c.Blockstore.GS.DisablePreSigned,
-		DisablePreSignedUI: c.Blockstore.GS.DisablePreSignedUI,
+		CredentialsFile:                      credPath,
+		CredentialsJSON:                      c.Blockstore.GS.CredentialsJSON,
+		PreSignedExpiry:                      c.Blockstore.GS.PreSignedExpiry,
+		DisablePreSigned:                     c.Blockstore.GS.DisablePreSigned,
+		DisablePreSignedUI:                   c.Blockstore.GS.DisablePreSignedUI,
+		ServerSideEncryptionCustomerSupplied: customerSuppliedKey,
+		ServerSideEncryptionKmsKeyID:         c.Blockstore.GS.ServerSideEncryptionKmsKeyID,
 	}, nil
 }
 


### PR DESCRIPTION
Closes #7557

## Change Description

### Background

Provide the support of GCS encryption for both CMEK and CSEK
Original PR and discussion: https://github.com/treeverse/lakeFS/pull/7608
      
### New Feature

Issue link: https://github.com/treeverse/lakeFS/issues/7557

- Configuration of CMEK supported
- Configuration of CSEK supported
- Throw an error for generating PreSignedURL of GCS with CSEK as the user must have the key in the configuration file
  - Frontend change is required
  - If user must have the key in configuration, then the CSEK make not much sense for PreSignedURL

### Testing Details

How were the changes tested?
* CMEK and CSEK cannot be configured at the same time, or the server will fail to start
* server will failed to start if CSEK is not a valid AES256 32bytes value
* CSEK encrypted object will fail to read when CSEK is not configured or wrong key
* CMEK encrypted object will fail to read when CMEK is not configured or wrong key
* Upload the file to a CMEK enabled bucket with CMEK configuration will be success
* Check the content of the CMEK encrypted file with CMEK configured
* Upload the file with CSEK will be success
* Check the content of the CSEK encrypted file with CSEK configured
* When the CSEK is configured and PreSignedURL is enabled, generating a PreSignedURL of a CSEK encrypted object is failed

### Breaking Change?

Does this change break any existing functionality? (API, CLI, Clients)

No breaking change as there's no API changed, only the server configuration is required

## Additional info

Logs, outputs, screenshots of changes if applicable (CLI / GUI changes)

### Contact Details

By GitHub  account
