### PR TITLE
HL Python SDK: Expose allow_empty flag for Merge

### DIFF
--- a/clients/python-wrapper/setup.py
+++ b/clients/python-wrapper/setup.py
@@ -11,7 +11,7 @@ VERSION = "0.6.1"
 
 PYTHON_REQUIRES = ">=3.9"
 REQUIRES = [
-    "lakefs-sdk >= 1.20, < 2",
+    "lakefs-sdk >= 1.25, < 2",
     "pyyaml ~= 6.0.1",
 ]
 TEST_REQUIRES = [

--- a/clients/python-wrapper/tests/integration/test_reference.py
+++ b/clients/python-wrapper/tests/integration/test_reference.py
@@ -52,14 +52,13 @@ def test_reference_merge_into(setup_branch_with_commits):
 
     # test merging into same branch
 
-    other_but_same_branch = repo.branch("test_reference_merge_into_no_changes").create(branch)
-    changes = list(branch.diff(other_but_same_branch))
-    assert len(changes) == 0
+    branch_a = repo.branch("test_branch_merge_into_a").create(branch)
+    branch_b = repo.branch("test_branch_merge_into_b").create(branch)
 
     with pytest.raises(BadRequestException, match=r'.+no changes.+'):
-        branch.merge_into(other_but_same_branch, message="MergeNoChanges")
+        branch_a.merge_into(branch_b, message="MergeNoChanges")
 
-    branch.merge_into(other_but_same_branch, message="MergeNoChangesWithFlag", allow_empty=True)
+    branch_a.merge_into(branch_b, message="MergeNoChangesWithFlag", allow_empty=True)
 
     # test merging into other branch
 

--- a/clients/python-wrapper/tests/integration/test_reference.py
+++ b/clients/python-wrapper/tests/integration/test_reference.py
@@ -51,7 +51,6 @@ def test_reference_merge_into(setup_branch_with_commits):
     main = repo.branch("main")
 
     # test merging into same branch
-
     branch_a = repo.branch("test_branch_merge_into_a").create(branch)
     branch_b = repo.branch("test_branch_merge_into_b").create(branch)
 
@@ -61,7 +60,6 @@ def test_reference_merge_into(setup_branch_with_commits):
     branch_a.merge_into(branch_b, message="MergeNoChangesWithFlag", allow_empty=True)
 
     # test merging into other branch
-
     commits = list(branch.log(max_amount=2))
     other_branch = repo.branch("test_reference_merge_into").create(main)
     ref = repo.ref(commits[1].id)


### PR DESCRIPTION
Closes #7528 

## Change Description

Exposing the `allow_empty` flag for Merge, by pointing to the relevant `lakefs-sdk` version.

