### PR TITLE
Return an informative error message when using 'api/v1' for S3 GW endpoint

### DIFF
--- a/esti/catalog_export_test.go
+++ b/esti/catalog_export_test.go
@@ -177,7 +177,7 @@ func testSymlinkS3Exporter(t *testing.T, ctx context.Context, repo string, tmplD
 	storageURL, err := url.Parse(symlinksPrefix)
 	require.NoError(t, err, "failed extracting bucket name")
 
-	s3Client, err := testutil.SetupTestS3Client("https://s3.amazonaws.com", testData.AWSAccessKeyID, testData.AWSSecretAccessKey)
+	s3Client, err := testutil.SetupTestS3Client("https://s3.amazonaws.com", testData.AWSAccessKeyID, testData.AWSSecretAccessKey, viper.GetBool("force_path_style"))
 
 	require.NoError(t, err, "failed creating s3 client")
 

--- a/esti/catalog_export_test.go
+++ b/esti/catalog_export_test.go
@@ -177,7 +177,11 @@ func testSymlinkS3Exporter(t *testing.T, ctx context.Context, repo string, tmplD
 	storageURL, err := url.Parse(symlinksPrefix)
 	require.NoError(t, err, "failed extracting bucket name")
 
-	s3Client, err := testutil.SetupTestS3Client("https://s3.amazonaws.com", testData.AWSAccessKeyID, testData.AWSSecretAccessKey, viper.GetBool("force_path_style"))
+	key := testData.AWSAccessKeyID
+	secret := testData.AWSSecretAccessKey
+	endpoint := "https://s3.amazonaws.com"
+	forcePathStyle := viper.GetBool("force_path_style")
+	s3Client, err := testutil.SetupTestS3Client(endpoint, key, secret, forcePathStyle)
 
 	require.NoError(t, err, "failed creating s3 client")
 

--- a/esti/delete_objects_test.go
+++ b/esti/delete_objects_test.go
@@ -87,7 +87,8 @@ func TestDeleteObjects_Viewer(t *testing.T) {
 	key := resCreateCreds.JSON201.AccessKeyId
 	secret := resCreateCreds.JSON201.SecretAccessKey
 	s3Endpoint := viper.GetString("s3_endpoint")
-	s3Client, err := testutil.SetupTestS3Client(s3Endpoint, key, secret)
+	forcePathStyle := viper.GetBool("force_path_style")
+	s3Client, err := testutil.SetupTestS3Client(s3Endpoint, key, secret, forcePathStyle)
 	require.NoError(t, err)
 
 	// delete objects using viewer

--- a/esti/s3_gateway_test.go
+++ b/esti/s3_gateway_test.go
@@ -671,13 +671,13 @@ func TestPossibleAPIEndpointError(t *testing.T) {
 	defer tearDownTest(repo)
 
 	t.Run("use_open_api_for_client_endpoint", func(t *testing.T) {
-		s3Client := createS3Client(viper.GetString("s3_endpoint")+apiutil.BaseURL, t)
+		s3Client := createS3Client(endpointURL+apiutil.BaseURL, t)
 		_, listErr := s3Client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{Bucket: aws.String("not-exists")})
 		require.ErrorContains(t, listErr, gtwerrors.ErrNoSuchBucketPossibleAPIEndpoint.Error())
 	})
 
 	t.Run("use_proper_client_endpoint", func(t *testing.T) {
-		s3Client := createS3Client(viper.GetString("s3_endpoint"), t)
+		s3Client := createS3Client(endpointURL, t)
 		_, listErr := s3Client.ListObjectsV2(ctx, &s3.ListObjectsV2Input{Bucket: aws.String("not-exists")})
 		require.ErrorContains(t, listErr, gtwerrors.ErrNoSuchBucket.Error())
 	})

--- a/esti/s3_gateway_test.go
+++ b/esti/s3_gateway_test.go
@@ -661,7 +661,7 @@ func TestS3ReadObjectRedirect(t *testing.T) {
 func createS3Client(endpoint string, t *testing.T) *s3.Client {
 	accessKeyID := viper.GetString("access_key_id")
 	secretAccessKey := viper.GetString("secret_access_key")
-	s3Client, err := testutil.SetupTestS3Client(endpoint, accessKeyID, secretAccessKey)
+	s3Client, err := testutil.SetupTestS3ClientWithForcePathStyle(endpoint, accessKeyID, secretAccessKey, true)
 	require.NoError(t, err, "failed creating s3 client")
 	return s3Client
 }

--- a/esti/s3_gateway_test.go
+++ b/esti/s3_gateway_test.go
@@ -676,6 +676,6 @@ func TestPossibleAPIEndpointError(t *testing.T) {
 	t.Run("use_open_api_for_client_endpoint", func(t *testing.T) {
 		_, err := minioClient.GetObject(ctx, repo, "main/some", minio.GetObjectOptions{})
 		require.NotNil(t, err)
-		require.Contains(t, err.Error(), "Using lakeFS API URI as the endpoint")
+		require.Contains(t, err.Error(), `Repository "api" not found`)
 	})
 }

--- a/esti/s3_gateway_test.go
+++ b/esti/s3_gateway_test.go
@@ -662,7 +662,7 @@ func TestPossibleAPIEndpointError(t *testing.T) {
 
 	accessKeyID := viper.GetString("access_key_id")
 	secretAccessKey := viper.GetString("secret_access_key")
-	endpoint := "/api/v1" + viper.GetString("s3_endpoint")
+	endpoint := viper.GetString("s3_endpoint") + apiutil.BaseURL
 	endpointSecure := viper.GetBool("s3_endpoint_secure")
 
 	minioClient, err := minio.New(endpoint, &minio.Options{
@@ -673,8 +673,9 @@ func TestPossibleAPIEndpointError(t *testing.T) {
 		t.Fatalf("minio.New: %s", err)
 	}
 
-	t.Run("use_api_v1_for_client_endpoint", func(t *testing.T) {
+	t.Run("use_open_api_for_client_endpoint", func(t *testing.T) {
 		_, err := minioClient.GetObject(ctx, repo, "main/some", minio.GetObjectOptions{})
+		require.NotNil(t, err)
 		require.Contains(t, err.Error(), "Using lakeFS API URI as the endpoint")
 	})
 }

--- a/esti/s3_gateway_test.go
+++ b/esti/s3_gateway_test.go
@@ -661,7 +661,7 @@ func TestS3ReadObjectRedirect(t *testing.T) {
 func createS3Client(endpoint string, t *testing.T) *s3.Client {
 	accessKeyID := viper.GetString("access_key_id")
 	secretAccessKey := viper.GetString("secret_access_key")
-	s3Client, err := testutil.SetupTestS3ClientWithForcePathStyle(endpoint, accessKeyID, secretAccessKey, true)
+	s3Client, err := testutil.SetupTestS3Client(endpoint, accessKeyID, secretAccessKey, true)
 	require.NoError(t, err, "failed creating s3 client")
 	return s3Client
 }

--- a/pkg/gateway/errors/errors.go
+++ b/pkg/gateway/errors/errors.go
@@ -80,6 +80,7 @@ const (
 	ErrNoSuchBucket
 	ErrNoSuchBucketPolicy
 	ErrNoSuchBucketLifecycle
+	ErrNoSuchBucketPossibleAPIEndpoint
 	ErrNoSuchKey
 	ErrNoSuchUpload
 	ErrNoSuchVersion
@@ -339,6 +340,11 @@ var Codes = errorCodeMap{
 	ErrNoSuchBucketLifecycle: {
 		Code:           "NoSuchBucketLifecycle",
 		Description:    "The bucket lifecycle configuration does not exist",
+		HTTPStatusCode: http.StatusNotFound,
+	},
+	ErrNoSuchBucketPossibleAPIEndpoint: {
+		Code:           "ErrNoSuchBucketPossibleAPIEndpoint",
+		Description:    "Using lakeFS API URI as the endpoint. Try removing the 'api/v1/' part from the endpoint.",
 		HTTPStatusCode: http.StatusNotFound,
 	},
 	ErrNoSuchKey: {

--- a/pkg/gateway/errors/errors.go
+++ b/pkg/gateway/errors/errors.go
@@ -2,6 +2,7 @@ package errors
 
 import (
 	"encoding/xml"
+	"github.com/treeverse/lakefs/pkg/api/apiutil"
 	"net/http"
 )
 
@@ -344,7 +345,7 @@ var Codes = errorCodeMap{
 	},
 	ErrNoSuchBucketPossibleAPIEndpoint: {
 		Code:           "ErrNoSuchBucketPossibleAPIEndpoint",
-		Description:    "Using lakeFS API URI as the endpoint. Try removing the 'api/v1/' part from the endpoint.",
+		Description:    `Repository "api" not found; this can happen if your endpoint URL mistakenly ends in "` + apiutil.BaseURL + `".`,
 		HTTPStatusCode: http.StatusNotFound,
 	},
 	ErrNoSuchKey: {

--- a/pkg/gateway/errors/errors.go
+++ b/pkg/gateway/errors/errors.go
@@ -2,8 +2,9 @@ package errors
 
 import (
 	"encoding/xml"
-	"github.com/treeverse/lakefs/pkg/api/apiutil"
 	"net/http"
+
+	"github.com/treeverse/lakefs/pkg/api/apiutil"
 )
 
 /*

--- a/pkg/gateway/middleware.go
+++ b/pkg/gateway/middleware.go
@@ -184,6 +184,13 @@ func EnrichWithRepositoryOrFallback(c *catalog.Catalog, authService auth.Gateway
 				fallbackProxy.ServeHTTP(w, req)
 				return
 			}
+
+			// see: github.com/treeverse/lakeFS/issues/3082
+			if strings.HasPrefix(req.RequestURI, "/api/v1") {
+				_ = o.EncodeError(w, req, err, gatewayerrors.ErrNoSuchBucketPossibleAPIEndpoint.ToAPIErr())
+				return
+			}
+
 			_ = o.EncodeError(w, req, err, gatewayerrors.ErrNoSuchBucket.ToAPIErr())
 			return
 		}

--- a/pkg/gateway/middleware.go
+++ b/pkg/gateway/middleware.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/treeverse/lakefs/pkg/api/apiutil"
 	"github.com/treeverse/lakefs/pkg/auth"
 	"github.com/treeverse/lakefs/pkg/catalog"
 	gatewayerrors "github.com/treeverse/lakefs/pkg/gateway/errors"
@@ -185,8 +186,9 @@ func EnrichWithRepositoryOrFallback(c *catalog.Catalog, authService auth.Gateway
 				return
 			}
 
-			// see: github.com/treeverse/lakeFS/issues/3082
-			if strings.HasPrefix(req.RequestURI, "/api/v1") {
+			// users often set the gateway endpoint in the clients with /api/v1/ which is the openAPI endpoint.
+			// returning a more informative error in such case.
+			if strings.HasPrefix(req.RequestURI, apiutil.BaseURL) {
 				_ = o.EncodeError(w, req, err, gatewayerrors.ErrNoSuchBucketPossibleAPIEndpoint.ToAPIErr())
 				return
 			}

--- a/pkg/testutil/setup.go
+++ b/pkg/testutil/setup.go
@@ -128,18 +128,15 @@ func SetupTestingEnv(params *SetupTestingEnvParams) (logging.Logger, apigen.Clie
 	}
 
 	s3Endpoint := viper.GetString("s3_endpoint")
-	svc, err := SetupTestS3Client(s3Endpoint, key, secret)
+	forcePathStyle := viper.GetBool("force_path_style")
+	svc, err := SetupTestS3Client(s3Endpoint, key, secret, forcePathStyle)
 	if err != nil {
 		logger.WithError(err).Fatal("could not initialize S3 client")
 	}
 	return logger, client, svc, endpointURL
 }
 
-func SetupTestS3Client(endpoint, key, secret string) (*s3.Client, error) {
-	return SetupTestS3ClientWithForcePathStyle(endpoint, key, secret, viper.GetBool("force_path_style"))
-}
-
-func SetupTestS3ClientWithForcePathStyle(endpoint, key, secret string, forcePathStyle bool) (*s3.Client, error) {
+func SetupTestS3Client(endpoint, key, secret string, forcePathStyle bool) (*s3.Client, error) {
 	if !strings.HasPrefix(endpoint, "http") {
 		endpoint = "http://" + endpoint
 	}

--- a/pkg/testutil/setup.go
+++ b/pkg/testutil/setup.go
@@ -136,6 +136,10 @@ func SetupTestingEnv(params *SetupTestingEnvParams) (logging.Logger, apigen.Clie
 }
 
 func SetupTestS3Client(endpoint, key, secret string) (*s3.Client, error) {
+	return SetupTestS3ClientWithForcePathStyle(endpoint, key, secret, viper.GetBool("force_path_style"))
+}
+
+func SetupTestS3ClientWithForcePathStyle(endpoint, key, secret string, forcePathStyle bool) (*s3.Client, error) {
 	if !strings.HasPrefix(endpoint, "http") {
 		endpoint = "http://" + endpoint
 	}
@@ -146,10 +150,9 @@ func SetupTestS3Client(endpoint, key, secret string) (*s3.Client, error) {
 	if err != nil {
 		return nil, err
 	}
-	forcePathStyleS3Client := viper.GetBool("force_path_style")
 	svc := s3.NewFromConfig(cfg, func(options *s3.Options) {
 		options.BaseEndpoint = aws.String(endpoint)
-		options.UsePathStyle = forcePathStyleS3Client
+		options.UsePathStyle = forcePathStyle
 	})
 	return svc, nil
 }


### PR DESCRIPTION
Closes #3082 

## Change Description

Quite a few users are trying sometimes to access the S3 Gateway using an endpoint starting with `/api/v1`.
This used to lead to a `NoSuchBucket` 404 error.

After the fix, such scenario leads to a 404 error, but with a different message:
> Using lakeFS API URI as the endpoint. Try removing the 'api/v1/' part from the endpoint.
