### PR TITLE
fix esti tests incorrect regex matching in command output sanitization

### DIFF
--- a/esti/lakectl_util.go
+++ b/esti/lakectl_util.go
@@ -130,12 +130,12 @@ func sanitize(output string, vars map[string]string) string {
 	if _, ok := vars["DATE"]; !ok {
 		s = normalizeProgramTimestamp(s)
 	}
-	s = normalizeCommitID(s)
-	s = normalizeChecksum(s)
-	s = normalizeShortCommitID(s)
 	s = normalizeEndpoint(s, vars["LAKEFS_ENDPOINT"])
 	s = normalizePreSignURL(s)                       // should be after storage and endpoint to enable non pre-sign url on azure
 	s = normalizeRandomObjectKey(s, vars["STORAGE"]) // should be after pre-sign on azure in order not to break the pre-sign url
+	s = normalizeCommitID(s)
+	s = normalizeChecksum(s)
+	s = normalizeShortCommitID(s)
 	return s
 }
 


### PR DESCRIPTION
Closes #7730

# Changes Description
## The Bug
The issue is the order in which the sanitizing regex-es are evaluated:
- The `rePhysicalAddress` regex allows for an optional of extra "/" followed by `[0-9a-v]{20}` (20 chars, either numbers or letters from a to v).
- The `reShortCommitID` regex allows for `[\d|a-f]{16}` (16 chars, either numbers or letters from a to f).

Notice that the short commit regex is a subset of the physical address regex.

Currently (in main), the short commit regex is evaluated before the physical address one - so when sanitizing a string that happens to contain a substring of 16 chars that satisfy the short commit regex, it will be wrongly sanitized. \
For example, a path like: \
`"s3://some/bucket/.../data/<hash>/zzz12345123451234512345zzz"` \
 will be sanitized to: \
`"s3://some/bucket/.../data/<OBJECT_KEY>zzz<COMMIT_ID_16>2345zzz"` \
While the correct result should have been: \
`"s3://some/bucket/.../data/<OBJECT_KEY>"` \
i.e., all the suffix of the path should've been captured by the physical address regex.

## Solution
Rearrange the order of regex evaluation such that the commit regex-es will be evaluated after the physical address one - following the logic that the most "capturing" regex should be evaluated first.

I verified my solution with the following test:
```go
func TestSanitize(t * testing.T) {
  text: = "s3://esti-system-testing/11610/13408/cosd4vq2c39ei6oj7r90/repo-cosd4vq2c39ei6oj7r8g/data/ggb32tq2c39c73dff130/zzz12345123451234512345zzz"
  s: = sanitize(text, nil)

  if !strings.HasSuffix(s, "<OBJECT_KEY>") {
    t.Fatalf("expected <OBJECT_KEY> at the end, got %s", s)
  }
}

``` 
It fails on main and passes after the changes in this pr.