### PR TITLE
Fix: lakectl local diff slowness

### DIFF
--- a/pkg/local/diff.go
+++ b/pkg/local/diff.go
@@ -3,17 +3,15 @@ package local
 import (
 	"context"
 	"fmt"
+	"io/fs"
 	"net/http"
-	"net/url"
-	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/go-openapi/swag"
 	"github.com/treeverse/lakefs/pkg/api/apigen"
-	"github.com/treeverse/lakefs/pkg/block"
-	"github.com/treeverse/lakefs/pkg/block/local"
-	"github.com/treeverse/lakefs/pkg/block/params"
+	"github.com/treeverse/lakefs/pkg/gateway/path"
 	"github.com/treeverse/lakefs/pkg/uri"
 )
 
@@ -188,6 +186,59 @@ func Undo(c Changes) Changes {
 	return reversed
 }
 
+// WalkS3 - walk like an Egyptian... ¯\_(ツ)¯\_
+// This walker function simulates the way object listing is performed by S3. Contrary to how a standard FS walk function behaves, S3
+// does not take into consideration the directory hierarchy. Instead, object paths include the entire path relative to the root and as a result
+// the directory or "path separator" is also taken into account when providing the listing in a lexicographical order.
+func WalkS3(root string, callbackFunc func(p string, info fs.FileInfo, err error) error) error {
+	var dirQueue []string
+	err := filepath.Walk(root, func(p string, info fs.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		if p == root {
+			return nil
+		}
+		if info.IsDir() {
+			// TODO: We don't return dir results for the listing, how will this effect directory markers, and can we even support directory markers?
+			// Save encountered directories in a queue and compare them with the first appearance of an file in that level
+			dirQueue = append(dirQueue, p+path.Separator) // add path separator to dir name and sort it later
+			return filepath.SkipDir
+		}
+
+		// Sort the queue since adding the suffix might the order might change after adding the suffix
+		sort.Strings(dirQueue)
+		// It is enough to compare the file with the last encountered directory (suffixed by the PathSeparator)
+		// if file > last_dir + "/" then by transitiveness it is also > than all previous directories
+		queueLen := len(dirQueue)
+		if queueLen > 0 && p > dirQueue[len(dirQueue)-1] {
+			// if file > dirs, handle the dirs first
+			for _, dir := range dirQueue {
+				if err = WalkS3(dir, callbackFunc); err != nil {
+					return err
+				}
+			}
+			dirQueue = []string{} // Empty queue once finished processing dirs
+		}
+		// Process the after we finished processing all the dirs that precede it
+		if err = callbackFunc(p, info, err); err != nil {
+			return err
+		}
+		return nil
+	})
+	if err != nil {
+		return err
+	}
+
+	// Finally, finished walking over FS, handle remaining dirs
+	for _, dir := range dirQueue {
+		if err = WalkS3(dir, callbackFunc); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // DiffLocalWithHead Checks changes between a local directory and the head it is pointing to. The diff check assumes the remote
 // is an immutable set so any changes found resulted from changes in the local directory
 // left is an object channel which contains results from a remote source. rightPath is the local directory to diff with
@@ -198,25 +249,14 @@ func DiffLocalWithHead(left <-chan apigen.ObjectStats, rightPath string) (Change
 		currentRemoteFile apigen.ObjectStats
 		hasMore           bool
 	)
-	absPath, err := filepath.Abs(rightPath)
-	if err != nil {
-		return nil, err
-	}
-	uri := url.URL{Scheme: "local", Path: absPath}
-	reader := local.NewLocalWalker(params.Local{
-		ImportEnabled:           false,
-		ImportHidden:            true,
-		AllowedExternalPrefixes: []string{absPath},
-	})
-	err = reader.Walk(context.Background(), &uri, block.WalkOptions{}, func(e block.ObjectStoreEntry) error {
-		info, err := os.Stat(e.FullKey)
+	err := WalkS3(rightPath, func(p string, info fs.FileInfo, err error) error {
 		if err != nil {
 			return err
 		}
-		if info.IsDir() || diffShouldIgnore(info.Name()) {
+		if diffShouldIgnore(info.Name()) {
 			return nil
 		}
-		localPath := e.RelativeKey
+		localPath := strings.TrimPrefix(p, rightPath)
 		localPath = strings.TrimPrefix(localPath, string(filepath.Separator))
 		localPath = filepath.ToSlash(localPath) // normalize to use "/" always
 
@@ -288,18 +328,18 @@ func ListRemote(ctx context.Context, client apigen.ClientWithResponsesInterface,
 			return fmt.Errorf("list remote failed. HTTP %d: %w", listResp.StatusCode(), ErrRemoteFailure)
 		}
 		for _, o := range listResp.JSON200.Results {
-			path := strings.TrimPrefix(o.Path, loc.GetPath())
+			p := strings.TrimPrefix(o.Path, loc.GetPath())
 			// skip directory markers
-			if path == "" || (strings.HasSuffix(path, uri.PathSeparator) && swag.Int64Value(o.SizeBytes) == 0) {
+			if p == "" || (strings.HasSuffix(p, uri.PathSeparator) && swag.Int64Value(o.SizeBytes) == 0) {
 				continue
 			}
-			path = strings.TrimPrefix(path, uri.PathSeparator)
+			p = strings.TrimPrefix(p, uri.PathSeparator)
 			objects <- apigen.ObjectStats{
 				Checksum:        o.Checksum,
 				ContentType:     o.ContentType,
 				Metadata:        o.Metadata,
 				Mtime:           o.Mtime,
-				Path:            path,
+				Path:            p,
 				PathType:        o.PathType,
 				PhysicalAddress: o.PhysicalAddress,
 				SizeBytes:       o.SizeBytes,


### PR DESCRIPTION
Closes #7643

## Change Description

### Background

lakectl local had a bug due to the different way standard FS lists files recursively in comparison with object stores (S3).
A fix was introduced which used the local adapter file walker to be used also for lakectl local, in order to diff between local and remote.
Due to the mentioned change, the local diff performance was greatly impacted.

### Bug Fix

Improve local diff performance by creating a new walk functions that simulates the order in which object stores list files.
Relying on the FS walk implementation and modifying the behavior when iterating over directories

### Testing Details

Manually testing the scenario of ~500K file diff. Operation time was reduced **from 18s to 3s**
Existing test verify correctness was not broken

### Breaking Change?

No

## Additional info

**before:**
```
lakectl local status -l  17.47s user 2.41s system 256% cpu 7.765 total
```

**after:**
```
lakectl local status -l  2.97s user 1.00s system 94% cpu 4.212 total
```
