### PR TITLE
Expose user metadata in Spark client

### DIFF
--- a/clients/spark/src/main/scala/io/treeverse/clients/LakeFSContext.scala
+++ b/clients/spark/src/main/scala/io/treeverse/clients/LakeFSContext.scala
@@ -170,6 +170,7 @@ object LakeFSContext {
           new java.sql.Timestamp(TimeUnit.SECONDS.toMillis(entry.getLastModified.seconds)),
           entry.size,
           new String(v.rangeID),
+          entry.metadata,
           entry.addressType.toString()
         )
       }
@@ -180,6 +181,7 @@ object LakeFSContext {
       .add(StructField("last_modified", TimestampType))
       .add(StructField("size", LongType))
       .add(StructField("range_id", StringType))
+      .add(StructField("user_metadata", MapType(StringType, StringType)))
       .add(StructField("address_type", StringType))
     spark.createDataFrame(rdd, schema)
   }
@@ -207,9 +209,6 @@ object LakeFSContext {
       repoName: String,
       commitID: String = ""
   ): DataFrame = {
-    val inputFormatClass =
-      if (StringUtils.isNotBlank(commitID)) classOf[LakeFSCommitInputFormat]
-      else classOf[LakeFSAllRangesInputFormat]
     newDF(spark, LakeFSJobParams.forCommit(repoName, commitID))
   }
 }


### PR DESCRIPTION
Closes #7849 

## Change Description

Expose user provided metadata in the commit dataframe, to allow users to query for objects based on tags, labels, etc.

### Background

[PRD](https://docs.google.com/document/d/1BukAwxvM8_JUxEYtF1QAZDGfHKFMzocdPDHg6tOnUd8/edit#heading=h.c25v2lwf69r8)
      
### New Feature

Adding `user_metadata` to the columns of the dataframe returned by `LakeFSContext.newDF()`.

### Testing Details

Tested manually (in Databricks) by uploading a file with user metadata to a lakeFS cloud instance,
And querying it (using `LakeFSContext.newDF()`), verifying that user_metadata is returned as expected (and that files with no metadata are shown with an empty map).

## Additional info

Test script:
```
import io.treeverse.clients.LakeFSContext
    
val commitID = "8903231a02bcdca2aa42688cf4a392cde268edcc85079d80a75d2ebd989f292b"
val df = LakeFSContext.newDF(spark, "gilo-test", commitID)
df.select("key", "user_metadata").show(truncate=false)
```

Script output:
```
+-------+--------------------------------------------------+
|key    |user_metadata                                     |
+-------+--------------------------------------------------+
|a.txt  |{X-Amz-Meta-Key2 -> note, X-Amz-Meta-Key1 -> blue}|
|aaa.txt|{}                                                |
+-------+--------------------------------------------------+
```

