### PR TITLE
Fix S3 bucket validation for inter-region storage

### DIFF
--- a/pkg/block/s3/adapter.go
+++ b/pkg/block/s3/adapter.go
@@ -872,7 +872,7 @@ func (a *Adapter) ResolveNamespace(storageNamespace, key string, identifierType 
 func (a *Adapter) GetRegion(ctx context.Context, storageNamespace string) (string, error) {
 	namespaceUrl, err := url.Parse(storageNamespace)
 	if err != nil {
-		return "", fmt.Errorf(`invalid namespace %s: %w`, storageNamespace, block.ErrInvalidNamespace)
+		return "", fmt.Errorf(`%w: %s isn't a valid url'`, block.ErrInvalidNamespace, storageNamespace)
 	}
 
 	return a.clients.GetBucketRegionFromAWS(ctx, namespaceUrl.Host)

--- a/pkg/block/s3/adapter.go
+++ b/pkg/block/s3/adapter.go
@@ -870,14 +870,12 @@ func (a *Adapter) ResolveNamespace(storageNamespace, key string, identifierType 
 }
 
 func (a *Adapter) GetRegion(ctx context.Context, storageNamespace string) (string, error) {
-	namespace, found := strings.CutPrefix(storageNamespace, fmt.Sprintf("%s://", block.BlockstoreTypeS3))
-	if !found {
-		return "", fmt.Errorf(`%w: "s3://" prefix not found %s`, block.ErrInvalidNamespace, storageNamespace)
+	namespaceUrl, err := url.Parse(storageNamespace)
+	if err != nil {
+		return "", fmt.Errorf(`invalid namespace %s: %w`, storageNamespace, block.ErrInvalidNamespace)
 	}
 
-	bucket, _, _ := strings.Cut(namespace, "/")
-
-	return a.clients.GetBucketRegionFromAWS(ctx, bucket)
+	return a.clients.GetBucketRegionFromAWS(ctx, namespaceUrl.Host)
 }
 
 func (a *Adapter) RuntimeStats() map[string]string {

--- a/pkg/block/s3/adapter.go
+++ b/pkg/block/s3/adapter.go
@@ -872,7 +872,7 @@ func (a *Adapter) ResolveNamespace(storageNamespace, key string, identifierType 
 func (a *Adapter) GetRegion(ctx context.Context, storageNamespace string) (string, error) {
 	namespaceURL, err := url.Parse(storageNamespace)
 	if err != nil {
-		return "", fmt.Errorf(`%w: %s isn't a valid url'`, block.ErrInvalidNamespace, storageNamespace)
+		return "", fmt.Errorf(`%s isn't a valid url': %w`, storageNamespace, block.ErrInvalidNamespace)
 	}
 
 	return a.clients.GetBucketRegionFromAWS(ctx, namespaceURL.Host)

--- a/pkg/block/s3/adapter.go
+++ b/pkg/block/s3/adapter.go
@@ -870,10 +870,12 @@ func (a *Adapter) ResolveNamespace(storageNamespace, key string, identifierType 
 }
 
 func (a *Adapter) GetRegion(ctx context.Context, storageNamespace string) (string, error) {
-	bucket, found := strings.CutPrefix(storageNamespace, fmt.Sprintf("%s://", block.BlockstoreTypeS3))
+	namespace, found := strings.CutPrefix(storageNamespace, fmt.Sprintf("%s://", block.BlockstoreTypeS3))
 	if !found {
 		return "", fmt.Errorf(`%w: "s3://" prefix not found %s`, block.ErrInvalidNamespace, storageNamespace)
 	}
+
+	bucket, _, _ := strings.Cut(namespace, "/")
 
 	return a.clients.GetBucketRegionFromAWS(ctx, bucket)
 }

--- a/pkg/block/s3/adapter.go
+++ b/pkg/block/s3/adapter.go
@@ -870,12 +870,12 @@ func (a *Adapter) ResolveNamespace(storageNamespace, key string, identifierType 
 }
 
 func (a *Adapter) GetRegion(ctx context.Context, storageNamespace string) (string, error) {
-	namespaceUrl, err := url.Parse(storageNamespace)
+	namespaceURL, err := url.Parse(storageNamespace)
 	if err != nil {
 		return "", fmt.Errorf(`%w: %s isn't a valid url'`, block.ErrInvalidNamespace, storageNamespace)
 	}
 
-	return a.clients.GetBucketRegionFromAWS(ctx, namespaceUrl.Host)
+	return a.clients.GetBucketRegionFromAWS(ctx, namespaceURL.Host)
 }
 
 func (a *Adapter) RuntimeStats() map[string]string {


### PR DESCRIPTION
Closes #7846 

## Change Description

For the validation of inter-region storage (if it's not allowed):
When getting storage namespace region from S3, the code was trying to get the region (from the S3 API) for the whole namespace (for example, `bucket-name/path-1/`), instead of using only the bucket name (i.e `bucket-name`).

This fix is about getting the region only for the bucket name (which the S3 API can handle).

### Testing Details

Tested this manually on a local server (configured with S3 of course).
