### PR TITLE
HL Python SDK: ObjectWriter write buffer as binary always

### DIFF
--- a/clients/python-wrapper/lakefs/object.py
+++ b/clients/python-wrapper/lakefs/object.py
@@ -409,7 +409,7 @@ class ObjectWriter(LakeFSIOBase):
 
         open_kwargs = {
             "encoding": "utf-8" if 'b' not in mode else None,
-            "mode": 'wb+' if 'b' in mode else 'w+',
+            "mode": 'b+',  # Always write to file in binary mode (bug in urllib3 < 2.0,
             "max_size": _WRITER_BUFFER_SIZE,
         }
         self._fd = tempfile.SpooledTemporaryFile(**open_kwargs)  # pylint: disable=consider-using-with
@@ -464,14 +464,7 @@ class ObjectWriter(LakeFSIOBase):
         :return: The number of bytes written to buffer
         :raise ValueError: if writer is closed
         """
-        binary_mode = 'b' in self._mode
-        if binary_mode and isinstance(s, str):
-            contents = s.encode('utf-8')
-        elif not binary_mode and isinstance(s, bytes):
-            contents = s.decode('utf-8')
-        else:
-            contents = s
-
+        contents = s.encode('utf-8') if isinstance(s, str) else s
         count = self._fd.write(contents)
         self._pos += count
         return count

--- a/clients/python-wrapper/requirements.txt
+++ b/clients/python-wrapper/requirements.txt
@@ -1,5 +1,5 @@
 aenum~=3.1.15
-lakefs-sdk>=1.20.0, < 2
+lakefs-sdk>=1.25.0, < 2
 python-dateutil~=2.8.2
 PyYAML~=6.0.1
 six~=1.16.0
@@ -13,3 +13,4 @@ pandas~=2.1.4
 pyarrow~=14.0.1
 pillow~=10.2.0
 setuptools~=68.2.2
+boto3>=1.26.0

--- a/clients/python-wrapper/setup.py
+++ b/clients/python-wrapper/setup.py
@@ -42,6 +42,7 @@ setup(
     long_description=long_description,
     long_description_content_type='text/markdown',
     extras_require={
-        'aws-iam': ["boto3 >= 1.26.0"],
+        "all": ["boto3 >= 1.26.0"],
+        "aws-iam": ["boto3 >= 1.26.0"],
     },
 )


### PR DESCRIPTION
Closes #7902

## Change Description

### Background

Due to the introduction of boto3 dependency for the iam role, Python < 3.10 users will experience a bug due to the constraints of using urllib3 < 2.0.

```
    def sendall(self, data, flags=0):
        self._checkClosed()
        if self._sslobj is not None:
            if flags != 0:
                raise ValueError(
                    "non-zero flags not allowed in calls to sendall() on %s" %
                    self.__class__)
            count = 0
>           with memoryview(data) as view, view.cast("B") as byte_view:
E           TypeError: memoryview: a bytes-like object is required, not 'str'
```

### Bug Fix

Modify ObjectWriter buffer (SpooledTemporaryFile) to always write in binary mode to overcome the issue
      
### New Feature

If this PR introduces a new feature, describe it here.

### Testing Details

Integration tests

### Breaking Change?

No

