### PR TITLE
CI: verify no untracked files in the clients folder

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,7 +26,7 @@ jobs:
       - name: Generate code
         env:
           NODE_OPTIONS: "--max-old-space-size=4096"
-        run:
+        run: |
           make gen
           scripts/verify_clients_untracked_files.sh
       - name: Checks validator

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -26,7 +26,9 @@ jobs:
       - name: Generate code
         env:
           NODE_OPTIONS: "--max-old-space-size=4096"
-        run: make gen
+        run:
+          make gen
+          scripts/verify_clients_untracked_files.sh
       - name: Checks validator
         env:
           GOLANGCI_LINT_FLAGS: --out-format github-actions

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -28,7 +28,7 @@ jobs:
           NODE_OPTIONS: "--max-old-space-size=4096"
         run: |
           make gen
-          scripts/verify_clients_untracked_files.sh
+          make validate-clients-untracked-files
       - name: Checks validator
         env:
           GOLANGCI_LINT_FLAGS: --out-format github-actions

--- a/Makefile
+++ b/Makefile
@@ -357,3 +357,6 @@ help:  ## Show Help menu
 
 # helpers
 gen: gen-ui gen-api gen-code clients gen-docs
+
+validate-clients-untracked-files:
+	scripts/verify_clients_untracked_files.sh	

--- a/scripts/verify_clients_untracked_files.sh
+++ b/scripts/verify_clients_untracked_files.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -e
+
+# `--porcelain` gives the output in an easy-to-parse format for scripts
+git_status_output=$(git status clients/ --porcelain)
+
+untracked_files_found=false
+
+while IFS= read -r line; do
+    if [[ $line == \?\?* ]]; then
+        untracked_files_found=true
+	break
+    fi
+done <<< "$git_status_output"
+
+if $untracked_files_found; then
+    cat << EOF 
+Error: Untracked files found in the 'clients/' directory.
+
+The 'clients/' directory contains auto-generated code that must be tracked in Git. Untracked files suggest new files were created and need to be added.
+
+To resolve this:
+
+1. Remove the 'clients/' directory:
+   rm -fr clients/
+
+2. Restore 'clients/' to the last commit:
+   git restore -- clients/
+
+3. Regenerate files in 'clients/':
+   make gen
+
+4. Stage the regenerated files:
+   git add clients/
+
+5. Commit the changes:
+   git commit -m 'Regenerate clients/ files'
+EOF
+    exit 1
+else
+    exit 0
+fi

--- a/scripts/verify_clients_untracked_files.sh
+++ b/scripts/verify_clients_untracked_files.sh
@@ -1,21 +1,11 @@
 #!/bin/bash
 
-set -e
+set -euo pipefail
 
-# `--porcelain` gives the output in an easy-to-parse format for scripts
-git_status_output=$(git status clients/ --porcelain)
+echo "Checking for untracked files in 'clients/'..."
 
-untracked_files_found=false
-
-while IFS= read -r line; do
-    if [[ $line == \?\?* ]]; then
-        untracked_files_found=true
-	break
-    fi
-done <<< "$git_status_output"
-
-if $untracked_files_found; then
-    cat << EOF 
+if git status --porcelain clients/ | grep -E '^\?\?'; then
+    cat << EOF
 Error: Untracked files found in the 'clients/' directory.
 
 The 'clients/' directory contains auto-generated code that must be tracked in Git. Untracked files suggest new files were created and need to be added.
@@ -39,5 +29,6 @@ To resolve this:
 EOF
     exit 1
 else
+    echo "No untracked files found." 
     exit 0
 fi


### PR DESCRIPTION
Closes #7900

## Change Description
Adding a CI check that ensures no untracked files are created when running `make gen`.
If the check fails, a helpful error message is printed (after less than 3 minutes):
![image](https://github.com/treeverse/lakeFS/assets/51454184/83ae9df6-61ca-455d-8c60-9ad4a9873e26)


### Testing
I created a [test PR](https://github.com/treeverse/lakeFS/pull/7907) that adds a new object in `swagger.yaml`, and does not contain the newly generated files. 
See [failed job](https://github.com/treeverse/lakeFS/actions/runs/9596499678/job/26463493185?pr=7907)