### PR TITLE
Fix build constraints export from flare package

### DIFF
--- a/pkg/flare/flare.go
+++ b/pkg/flare/flare.go
@@ -171,6 +171,12 @@ func (f *Flare) ProcessEnvVars(outPath, fileName string, getWriterFunc GetFileWr
 	return nil
 }
 
+// SetBaselinePermissions sets the Umask for all files created by flare for posix operating systems
+// on Windows this is a noop as permissions are set according to the parent directory
+func SetBaselinePermissions(mask int) {
+	setBaselinePermissions(mask)
+}
+
 func (f *Flare) processEnvVars(w io.Writer) error {
 	for _, e := range os.Environ() {
 		for _, p := range f.envVarPrefixes {

--- a/pkg/flare/permissions_darwin.go
+++ b/pkg/flare/permissions_darwin.go
@@ -2,6 +2,6 @@ package flare
 
 import "syscall"
 
-func SetBaselinePermissions(mask int) {
+func setBaselinePermissions(mask int) {
 	syscall.Umask(mask)
 }

--- a/pkg/flare/permissions_freebsd.go
+++ b/pkg/flare/permissions_freebsd.go
@@ -2,6 +2,6 @@ package flare
 
 import "syscall"
 
-func SetBaselinePermissions(mask int) {
+func setBaselinePermissions(mask int) {
 	syscall.Umask(mask)
 }

--- a/pkg/flare/permissions_linux.go
+++ b/pkg/flare/permissions_linux.go
@@ -2,6 +2,6 @@ package flare
 
 import "syscall"
 
-func SetBaselinePermissions(mask int) {
+func setBaselinePermissions(mask int) {
 	syscall.Umask(mask)
 }

--- a/pkg/flare/permissions_openbsd.go
+++ b/pkg/flare/permissions_openbsd.go
@@ -2,6 +2,6 @@ package flare
 
 import "syscall"
 
-func SetBaselinePermissions(mask int) {
+func setBaselinePermissions(mask int) {
 	syscall.Umask(mask)
 }

--- a/pkg/flare/permissions_windows.go
+++ b/pkg/flare/permissions_windows.go
@@ -1,5 +1,5 @@
 package flare
 
-func SetBaselinePermissions(_ int) {
+func setBaselinePermissions(_ int) {
 	return
 }


### PR DESCRIPTION
Exported funcs from build constraints files aren't visible when importing the package.  
The implementation in this PR is more in line with how it's done in packages like `os` from the standard library.