### PR TITLE
Simply WalkS3 callback

### DIFF
--- a/pkg/local/diff.go
+++ b/pkg/local/diff.go
@@ -197,7 +197,7 @@ func WalkS3(root string, callbackFunc func(p string, info fs.FileInfo, err error
 
 	fpWalkErr := filepath.Walk(root, func(p string, info fs.FileInfo, walkErr error) error {
 		if walkErr != nil {
-			return walkErr
+			return callbackFunc(p, nil, walkErr)
 		}
 		if p == root {
 			return nil

--- a/pkg/local/diff_test.go
+++ b/pkg/local/diff_test.go
@@ -369,7 +369,7 @@ func TestWalkS3(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			dir := setupFiles(t, tt.FileList)
 			var walkOrder []string
-			err := local.WalkS3(dir, func(p string, info fs.FileInfo) error {
+			err := local.WalkS3(dir, func(p string, info fs.FileInfo, err error) error {
 				walkOrder = append(walkOrder, strings.TrimPrefix(p, dir))
 				return nil
 			})
@@ -399,7 +399,7 @@ func FuzzWalkS3(f *testing.F) {
 
 		dir := setupFiles(t, files)
 		var walkOrder []string
-		err := local.WalkS3(dir, func(p string, info fs.FileInfo) error {
+		err := local.WalkS3(dir, func(p string, info fs.FileInfo, err error) error {
 			walkOrder = append(walkOrder, strings.TrimPrefix(p, dir))
 			return nil
 		})

--- a/pkg/local/diff_test.go
+++ b/pkg/local/diff_test.go
@@ -369,7 +369,7 @@ func TestWalkS3(t *testing.T) {
 		t.Run(tt.Name, func(t *testing.T) {
 			dir := setupFiles(t, tt.FileList)
 			var walkOrder []string
-			err := local.WalkS3(dir, func(p string, info fs.FileInfo, err error) error {
+			err := local.WalkS3(dir, func(p string, info fs.FileInfo) error {
 				walkOrder = append(walkOrder, strings.TrimPrefix(p, dir))
 				return nil
 			})
@@ -399,7 +399,7 @@ func FuzzWalkS3(f *testing.F) {
 
 		dir := setupFiles(t, files)
 		var walkOrder []string
-		err := local.WalkS3(dir, func(p string, info fs.FileInfo, err error) error {
+		err := local.WalkS3(dir, func(p string, info fs.FileInfo) error {
 			walkOrder = append(walkOrder, strings.TrimPrefix(p, dir))
 			return nil
 		})


### PR DESCRIPTION
The `err` passed to the callback of `WalkS3` is always `null` - 
Removing this param to simplify the code.
 