### PR TITLE
Experimental: lakectl local diff compares unix permissions

### DIFF
--- a/cmd/lakectl/cmd/local.go
+++ b/cmd/lakectl/cmd/local.go
@@ -69,7 +69,7 @@ func localDiff(ctx context.Context, client apigen.ClientWithResponsesInterface, 
 
 	includeUnixPermissions := cfg.Experimental.Local.UnixPerm.Enabled
 
-	changes, err := local.DiffLocalWithHead(currentRemoteState, path, includeUnixPermissions)
+	changes, err := local.DiffLocalWithHead(currentRemoteState, path, includeUnixPermissions, includeUnixPermissions)
 	if err != nil {
 		DieErr(err)
 	}

--- a/cmd/lakectl/cmd/local.go
+++ b/cmd/lakectl/cmd/local.go
@@ -67,9 +67,9 @@ func localDiff(ctx context.Context, client apigen.ClientWithResponsesInterface, 
 		return local.ListRemote(ctx, client, remote, currentRemoteState)
 	})
 
-	includeDirectoryMarkers := needsDirectoryMarkers()
+	includeUnixPermissions := cfg.Experimental.Local.UnixPerm.Enabled
 
-	changes, err := local.DiffLocalWithHead(currentRemoteState, path, includeDirectoryMarkers)
+	changes, err := local.DiffLocalWithHead(currentRemoteState, path, includeUnixPermissions)
 	if err != nil {
 		DieErr(err)
 	}
@@ -79,12 +79,6 @@ func localDiff(ctx context.Context, client apigen.ClientWithResponsesInterface, 
 	}
 
 	return changes
-}
-
-// needsDirectoryMarkers returns true if cfg requires directory markers.
-func needsDirectoryMarkers() bool {
-	// POSIX permissions support applies to directories and requires directory markers.
-	return cfg.Experimental.Local.UnixPerm.Enabled
 }
 
 func localHandleSyncInterrupt(ctx context.Context, idx *local.Index, operation string) context.Context {

--- a/pkg/local/diff.go
+++ b/pkg/local/diff.go
@@ -265,7 +265,7 @@ func WalkS3(root string, callbackFunc func(p string, info fs.FileInfo, err error
 // DiffLocalWithHead Checks changes between a local directory and the head it is pointing to. The diff check assumes the remote
 // is an immutable set so any changes found resulted from changes in the local directory
 // left is an object channel which contains results from a remote source. rightPath is the local directory to diff with
-func DiffLocalWithHead(left <-chan apigen.ObjectStats, rightPath string, includeUnixPermissions bool) (Changes, error) {
+func DiffLocalWithHead(left <-chan apigen.ObjectStats, rightPath string, includeDirs, includeUnixPermissions bool) (Changes, error) {
 	// left should be the base commit
 	changes := make([]*Change, 0)
 
@@ -278,7 +278,7 @@ func DiffLocalWithHead(left <-chan apigen.ObjectStats, rightPath string, include
 			return err
 		}
 
-		if !includeInDiff(info, includeUnixPermissions) {
+		if !includeInDiff(info, includeDirs) {
 			return nil
 		}
 

--- a/pkg/local/diff.go
+++ b/pkg/local/diff.go
@@ -312,8 +312,11 @@ func DiffLocalWithHead(left <-chan apigen.ObjectStats, rightPath string, include
 				mtimeChanged := localMtime != remoteMtime
 				permissionsChanged := includeUnixPermissions && isPermissionsChanged(info, currentRemoteFile)
 				if sizeChanged || mtimeChanged || permissionsChanged {
+					// TODO: this is only temp, for debugging! should be removed!
+					uo := getUnixOwnership(info)
+					change := fmt.Sprintf("%s [local: %s %d %d]", localPath, info.Mode().Perm(), uo.UID, uo.GID)
 					// we made a change!
-					changes = append(changes, &Change{ChangeSourceLocal, localPath, ChangeTypeModified})
+					changes = append(changes, &Change{ChangeSourceLocal, change, ChangeTypeModified})
 				}
 				currentRemoteFile.Path = ""
 				return nil

--- a/pkg/local/diff.go
+++ b/pkg/local/diff.go
@@ -312,11 +312,8 @@ func DiffLocalWithHead(left <-chan apigen.ObjectStats, rightPath string, include
 				mtimeChanged := localMtime != remoteMtime
 				permissionsChanged := includeUnixPermissions && isPermissionsChanged(info, currentRemoteFile)
 				if sizeChanged || mtimeChanged || permissionsChanged {
-					// TODO: this is only temp, for debugging! should be removed!
-					uo := getUnixOwnership(info)
-					change := fmt.Sprintf("%s [local: %s %d %d]", localPath, info.Mode().Perm(), uo.UID, uo.GID)
 					// we made a change!
-					changes = append(changes, &Change{ChangeSourceLocal, change, ChangeTypeModified})
+					changes = append(changes, &Change{ChangeSourceLocal, localPath, ChangeTypeModified})
 				}
 				currentRemoteFile.Path = ""
 				return nil

--- a/pkg/local/diff.go
+++ b/pkg/local/diff.go
@@ -278,8 +278,7 @@ func DiffLocalWithHead(left <-chan apigen.ObjectStats, rightPath string, include
 			return err
 		}
 
-		includeDirs := includeUnixPermissions
-		if !includeInDiff(info, includeDirs) {
+		if !includeInDiff(info, includeUnixPermissions) {
 			return nil
 		}
 

--- a/pkg/local/diff_test.go
+++ b/pkg/local/diff_test.go
@@ -267,7 +267,7 @@ func TestDiffLocal(t *testing.T) {
 			lc := make(chan apigen.ObjectStats, len(left))
 			makeChan(lc, left)
 
-			changes, err := local.DiffLocalWithHead(lc, tt.LocalPath, tt.IncludeUnixPermissions)
+			changes, err := local.DiffLocalWithHead(lc, tt.LocalPath, tt.IncludeUnixPermissions, tt.IncludeUnixPermissions)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/local/diff_test.go
+++ b/pkg/local/diff_test.go
@@ -215,6 +215,39 @@ func TestDiffLocal(t *testing.T) {
 				},
 			},
 		},
+		{
+			Name:                   "t1_unix_permissions_modified",
+			IncludeUnixPermissions: true,
+			LocalPath:              "testdata/localdiff/t1/sub",
+			RemoteList: []apigen.ObjectStats{
+				{
+					Path:      "f.txt",
+					SizeBytes: swag.Int64(3),
+					Mtime:     diffTestCorrectTime,
+					Metadata:  getPermissionsMetadata(501, 20, 755),
+				}, {
+					Path:      "folder/",
+					SizeBytes: swag.Int64(1),
+					Mtime:     diffTestCorrectTime,
+					Metadata:  getPermissionsMetadata(501, 20, 644),
+				}, {
+					Path:      "folder/f.txt",
+					SizeBytes: swag.Int64(6),
+					Mtime:     diffTestCorrectTime,
+					Metadata:  getPermissionsMetadata(501, 20, 420),
+				},
+			},
+			Expected: []*local.Change{
+				{
+					Path: "f.txt",
+					Type: local.ChangeTypeModified,
+				},
+				{
+					Path: "folder/",
+					Type: local.ChangeTypeModified,
+				},
+			},
+		},
 	}
 
 	for _, tt := range cases {

--- a/pkg/local/diff_test.go
+++ b/pkg/local/diff_test.go
@@ -19,8 +19,8 @@ import (
 
 const (
 	diffTestCorrectTime = 1691570412
-	filePermModeFile    = 33188
-	localPermModeFolder = 16877
+	filePermModeFile    = 0o100644
+	localPermModeFolder = 0o40755
 )
 
 func TestDiffLocal(t *testing.T) {

--- a/pkg/local/diff_test.go
+++ b/pkg/local/diff_test.go
@@ -19,6 +19,8 @@ import (
 
 const (
 	diffTestCorrectTime = 1691570412
+	filePermModeFile    = 33188
+	localPermModeFolder = 16877
 )
 
 func TestDiffLocal(t *testing.T) {
@@ -58,27 +60,27 @@ func TestDiffLocal(t *testing.T) {
 					Path:      ".hidden-file",
 					SizeBytes: swag.Int64(64),
 					Mtime:     diffTestCorrectTime,
-					Metadata:  getPermissionsMetadata(os.Getuid(), os.Getgid(), 420),
+					Metadata:  getPermissionsMetadata(os.Getuid(), os.Getgid(), filePermModeFile),
 				}, {
 					Path:      "sub/",
 					SizeBytes: swag.Int64(1),
 					Mtime:     diffTestCorrectTime,
-					Metadata:  getPermissionsMetadata(os.Getuid(), os.Getgid(), 493),
+					Metadata:  getPermissionsMetadata(os.Getuid(), os.Getgid(), localPermModeFolder),
 				}, {
 					Path:      "sub/f.txt",
 					SizeBytes: swag.Int64(3),
 					Mtime:     diffTestCorrectTime,
-					Metadata:  getPermissionsMetadata(os.Getuid(), os.Getgid(), 420),
+					Metadata:  getPermissionsMetadata(os.Getuid(), os.Getgid(), filePermModeFile),
 				}, {
 					Path:      "sub/folder/",
 					SizeBytes: swag.Int64(1),
 					Mtime:     diffTestCorrectTime,
-					Metadata:  getPermissionsMetadata(os.Getuid(), os.Getgid(), 493),
+					Metadata:  getPermissionsMetadata(os.Getuid(), os.Getgid(), localPermModeFolder),
 				}, {
 					Path:      "sub/folder/f.txt",
 					SizeBytes: swag.Int64(6),
 					Mtime:     diffTestCorrectTime,
-					Metadata:  getPermissionsMetadata(os.Getuid(), os.Getgid(), 420),
+					Metadata:  getPermissionsMetadata(os.Getuid(), os.Getgid(), filePermModeFile),
 				},
 			},
 			Expected: []*local.Change{},
@@ -229,12 +231,12 @@ func TestDiffLocal(t *testing.T) {
 					Path:      "folder/",
 					SizeBytes: swag.Int64(1),
 					Mtime:     diffTestCorrectTime,
-					Metadata:  getPermissionsMetadata(os.Getuid()+1, os.Getgid(), 493),
+					Metadata:  getPermissionsMetadata(os.Getuid()+1, os.Getgid(), localPermModeFolder),
 				}, {
 					Path:      "folder/f.txt",
 					SizeBytes: swag.Int64(6),
 					Mtime:     diffTestCorrectTime,
-					Metadata:  getPermissionsMetadata(os.Getuid(), os.Getgid(), 420),
+					Metadata:  getPermissionsMetadata(os.Getuid(), os.Getgid(), filePermModeFile),
 				},
 			},
 			Expected: []*local.Change{

--- a/pkg/local/diff_test.go
+++ b/pkg/local/diff_test.go
@@ -24,6 +24,9 @@ const (
 )
 
 func TestDiffLocal(t *testing.T) {
+	osUid := os.Getuid()
+	osGid := os.Getgid()
+
 	cases := []struct {
 		Name                   string
 		IncludeUnixPermissions bool
@@ -60,27 +63,27 @@ func TestDiffLocal(t *testing.T) {
 					Path:      ".hidden-file",
 					SizeBytes: swag.Int64(64),
 					Mtime:     diffTestCorrectTime,
-					Metadata:  getPermissionsMetadata(os.Getuid(), os.Getgid(), filePermModeFile),
+					Metadata:  getPermissionsMetadata(osUid, osGid, filePermModeFile),
 				}, {
 					Path:      "sub/",
 					SizeBytes: swag.Int64(1),
 					Mtime:     diffTestCorrectTime,
-					Metadata:  getPermissionsMetadata(os.Getuid(), os.Getgid(), localPermModeFolder),
+					Metadata:  getPermissionsMetadata(osUid, osGid, localPermModeFolder),
 				}, {
 					Path:      "sub/f.txt",
 					SizeBytes: swag.Int64(3),
 					Mtime:     diffTestCorrectTime,
-					Metadata:  getPermissionsMetadata(os.Getuid(), os.Getgid(), filePermModeFile),
+					Metadata:  getPermissionsMetadata(osUid, osGid, filePermModeFile),
 				}, {
 					Path:      "sub/folder/",
 					SizeBytes: swag.Int64(1),
 					Mtime:     diffTestCorrectTime,
-					Metadata:  getPermissionsMetadata(os.Getuid(), os.Getgid(), localPermModeFolder),
+					Metadata:  getPermissionsMetadata(osUid, osGid, localPermModeFolder),
 				}, {
 					Path:      "sub/folder/f.txt",
 					SizeBytes: swag.Int64(6),
 					Mtime:     diffTestCorrectTime,
-					Metadata:  getPermissionsMetadata(os.Getuid(), os.Getgid(), filePermModeFile),
+					Metadata:  getPermissionsMetadata(osUid, osGid, filePermModeFile),
 				},
 			},
 			Expected: []*local.Change{},
@@ -226,17 +229,17 @@ func TestDiffLocal(t *testing.T) {
 					Path:      "f.txt",
 					SizeBytes: swag.Int64(3),
 					Mtime:     diffTestCorrectTime,
-					Metadata:  getPermissionsMetadata(os.Getuid(), os.Getgid(), 755),
+					Metadata:  getPermissionsMetadata(osUid, osGid, 755),
 				}, {
 					Path:      "folder/",
 					SizeBytes: swag.Int64(1),
 					Mtime:     diffTestCorrectTime,
-					Metadata:  getPermissionsMetadata(os.Getuid()+1, os.Getgid(), localPermModeFolder),
+					Metadata:  getPermissionsMetadata(osUid+1, osGid, localPermModeFolder),
 				}, {
 					Path:      "folder/f.txt",
 					SizeBytes: swag.Int64(6),
 					Mtime:     diffTestCorrectTime,
-					Metadata:  getPermissionsMetadata(os.Getuid(), os.Getgid(), filePermModeFile),
+					Metadata:  getPermissionsMetadata(osUid, osGid, filePermModeFile),
 				},
 			},
 			Expected: []*local.Change{

--- a/pkg/local/unix_permissions.go
+++ b/pkg/local/unix_permissions.go
@@ -44,20 +44,20 @@ func getUmask() int {
 	return umask
 }
 
-func getUnixOwnership(info os.FileInfo) unixOwnership {
-	if stat, ok := info.Sys().(*syscall.Stat_t); ok {
-		return unixOwnership{
-			UID: int(stat.Uid),
-			GID: int(stat.Gid),
-		}
-	} else {
-		// we are not in linux, this won't work anyway in windows, but maybe you want to log warnings
-		return unixOwnership{
-			UID: os.Getuid(),
-			GID: os.Getgid(),
-		}
-	}
-}
+//func getUnixOwnership(info os.FileInfo) unixOwnership {
+//	if stat, ok := info.Sys().(*syscall.Stat_t); ok {
+//		return unixOwnership{
+//			UID: int(stat.Uid),
+//			GID: int(stat.Gid),
+//		}
+//	} else {
+//		// we are not in linux, this won't work anyway in windows, but maybe you want to log warnings
+//		return unixOwnership{
+//			UID: os.Getuid(),
+//			GID: os.Getgid(),
+//		}
+//	}
+//}
 
 func getDefaultPermissions(isDir bool) UnixPermissions {
 	getOwnershipMutex.Lock()
@@ -95,14 +95,12 @@ func getUnixPermissionFromStats(stats apigen.ObjectStats) (*UnixPermissions, err
 }
 
 func isPermissionsChanged(local os.FileInfo, remoteFileStats apigen.ObjectStats) bool {
-	localOwnership := getUnixOwnership(local)
+	//localOwnership := getUnixOwnership(local)
 
 	remote, err := getUnixPermissionFromStats(remoteFileStats)
 	if err != nil {
 		return true
 	}
 
-	return local.Mode().Perm() != remote.Mode.Perm() ||
-		localOwnership.UID != remote.unixOwnership.UID ||
-		localOwnership.GID != remote.unixOwnership.GID
+	return local.Mode().Perm() != remote.Mode.Perm()
 }

--- a/pkg/local/unix_permissions.go
+++ b/pkg/local/unix_permissions.go
@@ -44,20 +44,20 @@ func getUmask() int {
 	return umask
 }
 
-//func getUnixOwnership(info os.FileInfo) unixOwnership {
-//	if stat, ok := info.Sys().(*syscall.Stat_t); ok {
-//		return unixOwnership{
-//			UID: int(stat.Uid),
-//			GID: int(stat.Gid),
-//		}
-//	} else {
-//		// we are not in linux, this won't work anyway in windows, but maybe you want to log warnings
-//		return unixOwnership{
-//			UID: os.Getuid(),
-//			GID: os.Getgid(),
-//		}
-//	}
-//}
+func getUnixOwnership(info os.FileInfo) unixOwnership {
+	if stat, ok := info.Sys().(*syscall.Stat_t); ok {
+		return unixOwnership{
+			UID: int(stat.Uid),
+			GID: int(stat.Gid),
+		}
+	} else {
+		// we are not in linux, this won't work anyway in windows, but maybe you want to log warnings
+		return unixOwnership{
+			UID: os.Getuid(),
+			GID: os.Getgid(),
+		}
+	}
+}
 
 func getDefaultPermissions(isDir bool) UnixPermissions {
 	getOwnershipMutex.Lock()
@@ -95,12 +95,14 @@ func getUnixPermissionFromStats(stats apigen.ObjectStats) (*UnixPermissions, err
 }
 
 func isPermissionsChanged(local os.FileInfo, remoteFileStats apigen.ObjectStats) bool {
-	//localOwnership := getUnixOwnership(local)
+	localOwnership := getUnixOwnership(local)
 
 	remote, err := getUnixPermissionFromStats(remoteFileStats)
 	if err != nil {
 		return true
 	}
 
-	return local.Mode().Perm() != remote.Mode.Perm()
+	return local.Mode().Perm() != remote.Mode.Perm() ||
+		localOwnership.UID != remote.unixOwnership.UID ||
+		localOwnership.GID != remote.unixOwnership.GID
 }

--- a/pkg/local/unix_permissions.go
+++ b/pkg/local/unix_permissions.go
@@ -102,7 +102,5 @@ func isPermissionsChanged(local os.FileInfo, remoteFileStats apigen.ObjectStats)
 		return true
 	}
 
-	return local.Mode().Perm() != remote.Mode.Perm() ||
-		localOwnership.UID != remote.unixOwnership.UID ||
-		localOwnership.GID != remote.unixOwnership.GID
+	return local.Mode().Perm() != remote.Mode.Perm() || localOwnership != remote.unixOwnership
 }


### PR DESCRIPTION
Compare unix permissions when using `lakectl local diff` (if requested).
