### PR TITLE
[Bug]: Spark client panics when reading DataFrame from entire repository / storageNamespace

### DIFF
--- a/clients/spark/build.sbt
+++ b/clients/spark/build.sbt
@@ -1,4 +1,4 @@
-lazy val projectVersion = "0.14.0"
+lazy val projectVersion = "0.14.1"
 version := projectVersion
 lazy val hadoopVersion = "3.2.1"
 ThisBuild / isSnapshot := false

--- a/clients/spark/src/main/scala/io/treeverse/clients/LakeFSInputFormat.scala
+++ b/clients/spark/src/main/scala/io/treeverse/clients/LakeFSInputFormat.scala
@@ -243,12 +243,12 @@ class LakeFSAllRangesInputFormat extends LakeFSBaseInputFormat {
     if (StringUtils.isBlank(storageNamespace)) {
       storageNamespace = apiClient.getStorageNamespace(repoName, StorageClientType.HadoopFS)
     }
-    val namespaceURI = URI.create(if (storageNamespace.endsWith("/")) storageNamespace else storageNamespace + "/")
+    val namespaceURI =
+      URI.create(if (storageNamespace.endsWith("/")) storageNamespace else storageNamespace + "/")
     val fs = fileSystemGetter(namespaceURI, conf)
     fs.getStatus(new Path(namespaceURI)) // Will throw an exception if namespace doesn't exist
 
     val metadataURI = namespaceURI.resolve("_lakefs")
-    System.out.println("@@@@@ metadataURI: " + metadataURI)
     val metadataPath = new Path(metadataURI)
     if (!fs.exists(metadataPath)) {
       return ListBuffer.empty[InputSplit].asJava

--- a/clients/spark/src/main/scala/io/treeverse/clients/LakeFSInputFormat.scala
+++ b/clients/spark/src/main/scala/io/treeverse/clients/LakeFSInputFormat.scala
@@ -243,15 +243,12 @@ class LakeFSAllRangesInputFormat extends LakeFSBaseInputFormat {
     if (StringUtils.isBlank(storageNamespace)) {
       storageNamespace = apiClient.getStorageNamespace(repoName, StorageClientType.HadoopFS)
     }
-    val namespaceURI = URI.create(storageNamespace)
+    val namespaceURI = URI.create(if (storageNamespace.endsWith("/")) storageNamespace else storageNamespace + "/")
     val fs = fileSystemGetter(namespaceURI, conf)
     fs.getStatus(new Path(namespaceURI)) // Will throw an exception if namespace doesn't exist
 
-    val metadataURI =
-      namespaceURI.resolve(
-        if (storageNamespace.endsWith("/")) namespaceURI.getPath() + "_lakefs"
-        else namespaceURI.getPath() + "/_lakefs"
-      )
+    val metadataURI = namespaceURI.resolve("_lakefs")
+    System.out.println("@@@@@ metadataURI: " + metadataURI)
     val metadataPath = new Path(metadataURI)
     if (!fs.exists(metadataPath)) {
       return ListBuffer.empty[InputSplit].asJava

--- a/clients/spark/src/main/scala/io/treeverse/clients/LakeFSInputFormat.scala
+++ b/clients/spark/src/main/scala/io/treeverse/clients/LakeFSInputFormat.scala
@@ -248,7 +248,7 @@ class LakeFSAllRangesInputFormat extends LakeFSBaseInputFormat {
     fs.getStatus(new Path(namespaceURI)) // Will throw an exception if namespace doesn't exist
 
     val metadataURI =
-      namespaceURI.resolve(if (storageNamespace.endsWith("/")) "_lakefs" else "/_lakefs")
+      namespaceURI.resolve(if (storageNamespace.endsWith("/")) namespaceURI.getPath() + "_lakefs" else namespaceURI.getPath() + "/_lakefs")
     val metadataPath = new Path(metadataURI)
     if (!fs.exists(metadataPath)) {
       return ListBuffer.empty[InputSplit].asJava

--- a/clients/spark/src/main/scala/io/treeverse/clients/LakeFSInputFormat.scala
+++ b/clients/spark/src/main/scala/io/treeverse/clients/LakeFSInputFormat.scala
@@ -248,7 +248,10 @@ class LakeFSAllRangesInputFormat extends LakeFSBaseInputFormat {
     fs.getStatus(new Path(namespaceURI)) // Will throw an exception if namespace doesn't exist
 
     val metadataURI =
-      namespaceURI.resolve(if (storageNamespace.endsWith("/")) namespaceURI.getPath() + "_lakefs" else namespaceURI.getPath() + "/_lakefs")
+      namespaceURI.resolve(
+        if (storageNamespace.endsWith("/")) namespaceURI.getPath() + "_lakefs"
+        else namespaceURI.getPath() + "/_lakefs"
+      )
     val metadataPath = new Path(metadataURI)
     if (!fs.exists(metadataPath)) {
       return ListBuffer.empty[InputSplit].asJava


### PR DESCRIPTION
Closes #7914 

The issue was that `resolve` overrides the URI path completely. 
So if `metadataURI` the value expected to be: `s3a://<bucket>/<path>/_lakefs` it instead became `s3a://<bucket>/_lakefs`. 
When I was testing the issue there was such path so I saw very strange results and parsing errors. 

```scala
namespaceURI.resolve(...)
```
