### PR TITLE
Docs: Removing backslashes from examples to better support Windows users

### DIFF
--- a/docs/quickstart/actions-and-hooks.md
+++ b/docs/quickstart/actions-and-hooks.md
@@ -26,10 +26,7 @@ _Hooks_ can be either a [Lua]({% link howto/hooks/lua.md %}) script that lakeFS 
 1. In lakeFS create a new branch called `add_action`. You can do this through the UI or with `lakectl`: 
 
     ```bash
-    docker exec lakefs \
-        lakectl branch create \
-                lakefs://quickstart/add_action \
-                        --source lakefs://quickstart/main
+    docker exec lakefs lakectl branch create lakefs://quickstart/add_action --source lakefs://quickstart/main
     ```
 
 2. Open up your favorite text editor (or emacs), and paste the following YAML: 
@@ -79,10 +76,7 @@ _Hooks_ can be either a [Lua]({% link howto/hooks/lua.md %}) script that lakeFS 
 4. Upload the `check_commit_metadata.yml` file to the `add_action` branch under `_lakefs_actions/`. As above, you can use the UI (make sure you select the correct branch when you do), or with `lakectl`:
 
     ```bash
-    docker exec lakefs \
-        lakectl fs upload \
-            lakefs://quickstart/add_action/_lakefs_actions/check_commit_metadata.yml \
-            --source /tmp/check_commit_metadata.yml
+    docker exec lakefs lakectl fs upload lakefs://quickstart/add_action/_lakefs_actions/check_commit_metadata yml --source /tmp/check_commit_metadata.yml
     ```
 
 5. Go to the **Uncommitted Changes** tab in the UI, and make sure that you see the new file in the path shown: 

--- a/docs/quickstart/actions-and-hooks.md
+++ b/docs/quickstart/actions-and-hooks.md
@@ -76,7 +76,7 @@ _Hooks_ can be either a [Lua]({% link howto/hooks/lua.md %}) script that lakeFS 
 4. Upload the `check_commit_metadata.yml` file to the `add_action` branch under `_lakefs_actions/`. As above, you can use the UI (make sure you select the correct branch when you do), or with `lakectl`:
 
     ```bash
-    docker exec lakefs lakectl fs upload lakefs://quickstart/add_action/_lakefs_actions/check_commit_metadata yml --source /tmp/check_commit_metadata.yml
+    docker exec lakefs lakectl fs upload lakefs://quickstart/add_action/_lakefs_actions/check_commit_metadata.yml --source /tmp/check_commit_metadata.yml
     ```
 
 5. Go to the **Uncommitted Changes** tab in the UI, and make sure that you see the new file in the path shown: 

--- a/docs/quickstart/branch.md
+++ b/docs/quickstart/branch.md
@@ -24,10 +24,7 @@ Follow the prompts to enter the credentials that you got in the first step. Leav
 Now that lakectl is configured, we can use it to create the branch. Run the following:
 
 ```bash
-docker exec lakefs \
-    lakectl branch create \
-            lakefs://quickstart/denmark-lakes \
-		    --source lakefs://quickstart/main
+docker exec lakefs lakectl branch create lakefs://quickstart/denmark-lakes --source lakefs://quickstart/main
 ```
 
 You should get a confirmation message like this:

--- a/docs/quickstart/commit-and-merge.md
+++ b/docs/quickstart/commit-and-merge.md
@@ -14,9 +14,7 @@ _In the previous step we branched our data from `main` into a new `denmark-lakes
 Having make the change to the datafile in the `denmark-lakes` branch, we now want to commit it. There are various options for interacting with the lakeFS API, including the web interface, [a Python client](https://pydocs.lakefs.io/), and `lakectl` which is what we'll use here. Run the following from a terminal window:
 
 ```bash
-docker exec lakefs \
-    lakectl commit lakefs://quickstart/denmark-lakes \
-	    -m "Create a dataset of just the lakes in Denmark"
+docker exec lakefs lakectl commit lakefs://quickstart/denmark-lakes -m "Create a dataset of just the lakes in Denmark"
 ```
 
 You will get confirmation of the commit including its hash.
@@ -37,10 +35,7 @@ With our change committed, it's now time to merge it to back to the `main` branc
 As above, we'll use `lakectl` to do this too. The syntax just requires us to specify the source and target of the merge. Run this from a terminal window.
 
 ```bash
-docker exec lakefs \
-	lakectl merge \
-		lakefs://quickstart/denmark-lakes \
-		lakefs://quickstart/main
+docker exec lakefs lakectl merge lakefs://quickstart/denmark-lakes lakefs://quickstart/main
 ```
 
 We can confirm that this has worked by returning to the same object view of `lakes.parquet` as before and clicking on **Execute** to rerun the same query. You'll see that the country row counts have changed, and only Denmark is left in the data: 

--- a/docs/quickstart/launch.md
+++ b/docs/quickstart/launch.md
@@ -17,10 +17,7 @@ _The quickstart uses Docker to bring up the lakeFS container, pre-populate it wi
 Launch the lakeFS container:
 
 ```bash
-docker run --name lakefs --pull always \
-             --rm --publish 8000:8000 \
-             treeverse/lakefs:latest \
-             run --quickstart
+docker run --name lakefs --pull always --rm --publish 8000:8000 treeverse/lakefs:latest run --quickstart
 ```
 
 After a few moments you should see the lakeFS container ready to use: 

--- a/docs/quickstart/rollback.md
+++ b/docs/quickstart/rollback.md
@@ -16,10 +16,7 @@ The good news for them (you) is that lakeFS can revert changes made, similar to 
 From your terminal window run `lakectl` with the `revert` command:
 
 ```bash
-docker exec -it lakefs \
-    lakectl branch revert \
-	    lakefs://quickstart/main \
-	    main --parent-number 1 --yes
+docker exec -it lakefs lakectl branch revert lakefs://quickstart/main main --parent-number 1 --yes
 ```
 You should see a confirmation of a successful rollback:
 ```

--- a/docs/quickstart/work-with-data-locally.md
+++ b/docs/quickstart/work-with-data-locally.md
@@ -22,37 +22,31 @@ container and edit an image dataset used for ML model development.
 1. In lakeFS create a new branch called `my-experiment`. You can do this through the UI or with `lakectl`:
 
     ```bash
-    docker exec lakefs \
-        lakectl branch create \
-            lakefs://quickstart/my-experiment \
-            --source lakefs://quickstart/main
+    docker exec lakefs lakectl branch create lakefs://quickstart/my-experiment --source lakefs://quickstart/main
     ```
 
 2. Clone images from your quickstart repository into a local directory named `my_local_dir` within your container:   
 
     ```bash
-    docker exec lakefs \
-        lakectl local clone lakefs://quickstart/my-experiment/images my_local_dir
+    docker exec lakefs lakectl local clone lakefs://quickstart/my-experiment/images my_local_dir
     ```
 
 3. Verify that `my_local_dir` is linked to the correct path in your lakeFS remote: 
   
     ```bash
-    docker exec lakefs \
-        lakectl local list
+    docker exec lakefs lakectl local list
     ```
 
    You should see confirmation that my_local_dir is tracking the desired lakeFS path.:    
    
    ```bash
-       my_local_dir	lakefs://quickstart/my-experiment/images/	8614575b5488b47a094163bd17a12ed0b82e0bcbfd22ed1856151c671f1faa53
+       my_local_dir	lakefs://quickstart/my-experiment/images/8614575b5488b47a094163bd17a12ed0b82e0bcbfd22ed1856151c671f1faa53
    ```
 
 4. Verify that your local environment is up-to-date with its remote path:
     
    ```bash
-    docker exec lakefs \
-        lakectl local status my_local_dir
+    docker exec lakefs lakectl local status my_local_dir
     ```
     You should get a confirmation message like this showing that there is no difference between your local environment and the lakeFS remote:
 
@@ -75,14 +69,12 @@ container and edit an image dataset used for ML model development.
 
 2. Clean the dataset by removing images larger than 225 KB:
     ```bash  
-    docker exec lakefs \
-        find my_local_dir -type f -size +225k -delete
+    docker exec lakefs find my_local_dir -type f -size +225k -delete
     ```
    
 3. Check the status of your local changes compared to the lakeFS remote path:
     ```bash
-    docker exec lakefs \
-        lakectl local status my_local_dir
+    docker exec lakefs lakectl local status my_local_dir
     ```
    
     You should get a confirmation message like this, showing the modifications you made locally: 
@@ -108,9 +100,7 @@ the improved dataset is shared and versioned.
 1. Commit your local changes to lakeFS: 
 
     ```bash
-    docker exec lakefs \
-        lakectl local commit \
-            -m 'Deleted images larger than 225KB in size and changed the Axolotl image' my_local_dir
+    docker exec lakefs lakectl local commit -m 'Deleted images larger than 225KB in size and changed the Axolotl image' my_local_dir
     ```
     
     In your branch, you should see the commit including your local changes:


### PR DESCRIPTION
Closes #7946
## Change Description
Removed Unix new line characters to support both Unix and Windows
### Background
Following best practices as observed in Docker Postgres(https://hub.docker.com/_/postgres), MongoDB(https://www.mongodb.com/resources/products/compatibilities/docker), and Elastic(https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html). 

### Bug Fix

Removed new line characters throughout quickstart. 
      
### Testing Details

Ran through Windows PowerShell, deleted Unix newline whenever an error came up. 



