### PR TITLE
(fix) Add `w`rite to opening mode in object writer

### DIFF
--- a/clients/python-wrapper/lakefs/object.py
+++ b/clients/python-wrapper/lakefs/object.py
@@ -409,7 +409,7 @@ class ObjectWriter(LakeFSIOBase):
 
         open_kwargs = {
             "encoding": "utf-8" if 'b' not in mode else None,
-            "mode": 'b+',  # Always write to file in binary mode (bug in urllib3 < 2.0,
+            "mode": 'wb+',  # Always write to file in binary mode (bug in urllib3 < 2.0,
             "max_size": _WRITER_BUFFER_SIZE,
         }
         self._fd = tempfile.SpooledTemporaryFile(**open_kwargs)  # pylint: disable=consider-using-with

--- a/clients/python-wrapper/lakefs/object.py
+++ b/clients/python-wrapper/lakefs/object.py
@@ -408,7 +408,7 @@ class ObjectWriter(LakeFSIOBase):
         self.metadata = metadata
 
         open_kwargs = {
-            "encoding": "utf-8" if 'b' not in mode else None,
+            "encoding": None,  # Must be none for binary write modes. "utf-8" otherwise
             "mode": 'wb+',  # Always write to file in binary mode (bug in urllib3 < 2.0,
             "max_size": _WRITER_BUFFER_SIZE,
         }

--- a/clients/python-wrapper/lakefs/object.py
+++ b/clients/python-wrapper/lakefs/object.py
@@ -408,7 +408,8 @@ class ObjectWriter(LakeFSIOBase):
         self.metadata = metadata
 
         open_kwargs = {
-            # TODO: Once the upstream urllib3 < 2.0 is out of support, pass the specified writemode and conditional encoding (None, utf-8).
+            # TODO: Once the upstream urllib3 < 2.0 is out of support,
+            # pass the specified write mode and conditional encoding (None, utf-8).
             "encoding": None,  # Must be none for binary write modes. "utf-8" otherwise
             "mode": 'wb+',  # Always write to file in binary mode (bug in urllib3 < 2.0,
             "max_size": _WRITER_BUFFER_SIZE,

--- a/clients/python-wrapper/lakefs/object.py
+++ b/clients/python-wrapper/lakefs/object.py
@@ -408,6 +408,7 @@ class ObjectWriter(LakeFSIOBase):
         self.metadata = metadata
 
         open_kwargs = {
+            # TODO: Once the upstream urllib3 < 2.0 is out of support, pass the specified writemode and conditional encoding (None, utf-8).
             "encoding": None,  # Must be none for binary write modes. "utf-8" otherwise
             "mode": 'wb+',  # Always write to file in binary mode (bug in urllib3 < 2.0,
             "max_size": _WRITER_BUFFER_SIZE,

--- a/clients/python-wrapper/tests/integration/test_object.py
+++ b/clients/python-wrapper/tests/integration/test_object.py
@@ -11,10 +11,16 @@ import yaml
 import pytest
 from PIL import Image
 
+from lakefs.exceptions import NotFoundException, ObjectExistsException
+from lakefs.object import (
+    ObjectWriter,
+    ReadModes,
+    StoredObject,
+    WriteableObject,
+    WriteModes,
+)
 from tests.integration.conftest import TEST_DATA
 from tests.utests.common import expect_exception_context
-from lakefs.exceptions import ObjectExistsException, NotFoundException
-from lakefs.object import WriteableObject, WriteModes, ReadModes
 
 
 @pytest.mark.parametrize("pre_sign", (True, False), indirect=True)

--- a/clients/python-wrapper/tests/integration/test_object.py
+++ b/clients/python-wrapper/tests/integration/test_object.py
@@ -473,7 +473,10 @@ def test_large_file_object_write(setup_repo, w_mode):
     writer = ObjectWriter(stored_obj, mode=w_mode)
 
     # Create file of size greater than _WRITER_BUFFER_SIZE (32 MB)
-    # set in SpooledTemporaryFile to force disk write
+    # set in SpooledTemporaryFile (in python-wrapper/lakefs/object.py)
+    # to force disk write
+    #
+    # TODO(arielshaqed/n-o-z): set a smaller spool size.
     binary_data = b"\x00" * (32 * 1024 * 1024 + 1)
 
     writer._fd.write(binary_data)


### PR DESCRIPTION
Python's `open` needs a specification of one of
create/read/write/append.

Closes #7928

## Change Description
Add `w`rite mode to binary open.

### Background

Share context and relevant information for the PR: offline discussions, considerations, design decisions etc.

### Bug Fix

If this PR is a bug fix, please let us know about:

1. Problem - 
Python needs specification of create/read/write/append.
2. Root cause - Discovered root cause after investigation
The opening mode specification was missing.
3. Solution - How the bug was fixed
  Added the opening mode specification
