### PR TITLE
ariels' clone of 7961 for running esti [(fix) Add `w`rite to opening mode in object writer]

### DIFF
--- a/clients/python-wrapper/lakefs/object.py
+++ b/clients/python-wrapper/lakefs/object.py
@@ -409,7 +409,7 @@ class ObjectWriter(LakeFSIOBase):
 
         open_kwargs = {
             "encoding": "utf-8" if 'b' not in mode else None,
-            "mode": 'b+',  # Always write to file in binary mode (bug in urllib3 < 2.0,
+            "mode": 'wb+',  # Always write to file in binary mode (bug in urllib3 < 2.0,
             "max_size": _WRITER_BUFFER_SIZE,
         }
         self._fd = tempfile.SpooledTemporaryFile(**open_kwargs)  # pylint: disable=consider-using-with


### PR DESCRIPTION
Clone of #7961, only in order to run Esti safely.