### PR TITLE
fix: fail `revert` operation in the Python wrapper in case both `rerfence` and `reference_id` args are provided

### DIFF
--- a/clients/python-wrapper/lakefs/branch.py
+++ b/clients/python-wrapper/lakefs/branch.py
@@ -246,6 +246,11 @@ class Branch(_BaseBranch):
             warnings.warn(
                 "reference_id is deprecated, please use the `reference` argument.", DeprecationWarning
             )
+            # We show the error in case both are provided only after showing the deprecation warning, in order
+            # for the user to have the most contextual clarity.
+            if reference is not None:
+                raise ValueError("`reference_id` and `reference` cannot both be provided. "
+                                 "Use only the `reference` argument.")
 
         # Handle reference_id as a deprecated alias to reference.
         reference = reference or reference_id

--- a/clients/python-wrapper/tests/utests/test_branch.py
+++ b/clients/python-wrapper/tests/utests/test_branch.py
@@ -116,7 +116,7 @@ def test_branch_revert(monkeypatch):
     branch = get_test_branch()
     ref_id = "ab1234"
     expected_parent = 0
-    with monkeypatch.context():
+    with ((monkeypatch.context())):
         def monkey_revert_branch(repo_name, branch_name, revert_branch_creation, *_):
             assert repo_name == branch.repo_id
             assert branch_name == branch.id
@@ -157,9 +157,9 @@ def test_branch_revert(monkeypatch):
             branch.revert(None)
 
         # both are passed, prefer ``reference_id``
-        with pytest.warns(DeprecationWarning, match="reference_id is deprecated.*"):
+        with pytest.raises(ValueError, match="`reference_id` and `reference` cannot both be provided.*"), \
+                pytest.warns(DeprecationWarning, match="reference_id is deprecated.*"):
             # this is not a high-quality test, but it would throw if the revert API
             # was called with reference "hello" due to the monkey-patching above
             # always returning "ab1234" as ref ID.
-            c = branch.revert(ref_id, reference_id="hello")
-            assert c.id == ref_id
+            branch.revert(ref_id, reference_id="hello")


### PR DESCRIPTION
Closes #7981

### Change Description
Raise an error in case both `reference` and `reference_id` arguments are provided to the revert operation, as they are mutually exclusive - only one should be used at a time, and it should be `reference`, as `reference_id` is deprecated.

### Testing Details

Re-running the same code from the issue now fails:
```
$ python3 reprod-revert.py                                                   
Traceback (most recent call last):
  File "/home/yoni/workspace/playground/reprod-revert.py", line 31, in <module>
    res = lakefs.Repository("iceberg-revert-test").branch("main").revert(reference="main", reference_id="main")
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/yoni/workspace/playground/myenv/lib/python3.11/site-packages/lakefs/branch.py", line 252, in revert
    raise ValueError("`reference_id` and `reference` cannot both be provided. "
ValueError: `reference_id` and `reference` cannot both be provided. Use only the `reference` argument.
```


### Breaking Change?
Yes - existing code that passes both arguments will now raise a runtime error.
