### PR TITLE
fix: show deprecation warnings from the Python wrapper by default

### DIFF
--- a/clients/python-wrapper/lakefs/branch.py
+++ b/clients/python-wrapper/lakefs/branch.py
@@ -4,6 +4,7 @@ Module containing lakeFS branch implementation
 
 from __future__ import annotations
 
+import sys
 import uuid
 import warnings
 from contextlib import contextmanager
@@ -23,6 +24,9 @@ from lakefs.exceptions import (
     TransactionException
 )
 
+# Unless stated otherwise by passing `-W <something>` to Python, we display `DeprecationWarning`s by default.
+if not sys.warnoptions:
+    warnings.simplefilter('always', DeprecationWarning)
 
 class _BaseBranch(Reference):
 


### PR DESCRIPTION
Closes #7982

## Change Description
According to the [documentation](https://docs.python.org/3/library/exceptions.html#DeprecationWarning), deprecation warnings are ignored by default:
> ...Ignored by the default warning filters, except in the `__main__` module

The solution is also inspired by the documentation - see ["Overriding the default filter"](https://docs.python.org/3/library/warnings.html#overriding-the-default-filter) section.

Unless the user explicitly wants to ignore the warnings, it will be shown by default. 

### Testing Details
Working with a Python file with the following code:
```python
res = lakefs.Repository("my-repo").branch("main").revert(reference="main", reference_id="main")
print(res.id)
```
When running `python3 my-file.py`, I get the following output:
```
/home/yoni/workspace/playground/myenv/lib/python3.11/site-packages/lakefs/branch.py:250: DeprecationWarning: reference_id is deprecated, please use the `reference` argument.
  warnings.warn(
Traceback (most recent call last):
  File "/home/yoni/workspace/playground/reprod-revert.py", line 31, in <module>
    res = lakefs.Repository("my-repo").branch("main").revert(reference="main", reference_id="main")
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/yoni/workspace/playground/myenv/lib/python3.11/site-packages/lakefs/branch.py", line 256, in revert
    raise ValueError("`reference_id` and `reference` both provided "
ValueError: `reference_id` and `reference` both provided Use only the `reference` argument.
```
Notice the warning in the first line.

When running `python3 -W ignore::DeprecationWarning my-file.py`, I don't get this warning any more:
```
Traceback (most recent call last):
  File "/home/yoni/workspace/playground/reprod-revert.py", line 31, in <module>
    res = lakefs.Repository("my-repo").branch("main").revert(reference="main", reference_id="main")
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/yoni/workspace/playground/myenv/lib/python3.11/site-packages/lakefs/branch.py", line 256, in revert
    raise ValueError("`reference_id` and `reference` both provided "
ValueError: `reference_id` and `reference` both provided Use only the `reference` argument.
```

This is also showing very nicely in a Jupyter Notebook:
![image](https://github.com/treeverse/lakeFS/assets/51454184/b8319222-ea09-4176-9a47-5fc5fe62864f)

### Breaking Change?

No
