### PR TITLE
Reduce abuse amount and parallelism in abuse test

### DIFF
--- a/esti/lakectl_test.go
+++ b/esti/lakectl_test.go
@@ -861,6 +861,7 @@ func TestLakectlBranchProtection(t *testing.T) {
 	RunCmdAndVerifySuccessWithFile(t, Lakectl()+" branch-protect list lakefs://"+repoName, false, "lakectl_branch_protection_list.term", vars)
 }
 
+// TestLakectlAbuse runs a series of abuse commands to test the functionality of lakectl abuse (not in order to test how lakeFS handles abuse)
 func TestLakectlAbuse(t *testing.T) {
 	repoName := generateUniqueRepositoryName()
 	storage := generateUniqueStorageNamespace(repoName)

--- a/esti/lakectl_test.go
+++ b/esti/lakectl_test.go
@@ -884,6 +884,10 @@ func TestLakectlAbuse(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, f.Close())
 
+	const (
+		abuseAmount      = 1000
+		abuseParallelism = 3
+	)
 	tests := []struct {
 		Cmd            string
 		Amount         int
@@ -894,30 +898,34 @@ func TestLakectlAbuse(t *testing.T) {
 			Amount: 10,
 		},
 		{
-			Cmd:    "create-branches",
-			Amount: 1000,
+			Cmd:            "create-branches",
+			Amount:         abuseAmount,
+			AdditionalArgs: fmt.Sprintf("--parallelism %d", abuseParallelism),
 		},
 		{
-			Cmd:    "link-same-object",
-			Amount: 1000,
+			Cmd:            "link-same-object",
+			Amount:         abuseAmount,
+			AdditionalArgs: fmt.Sprintf("--parallelism %d", abuseParallelism),
 		},
 		{
-			Cmd:    "list",
-			Amount: 1000,
+			Cmd:            "list",
+			Amount:         abuseAmount,
+			AdditionalArgs: fmt.Sprintf("--parallelism %d", abuseParallelism),
 		},
 		{
 			Cmd:            "random-read",
-			Amount:         1000,
-			AdditionalArgs: "--from-file " + f.Name(),
+			Amount:         abuseAmount,
+			AdditionalArgs: fmt.Sprintf("--parallelism %d --from-file %s", abuseParallelism, f.Name()),
 		},
 		{
 			Cmd:            "random-delete",
-			Amount:         1000,
-			AdditionalArgs: "--from-file " + f.Name(),
+			Amount:         abuseAmount,
+			AdditionalArgs: fmt.Sprintf("--parallelism %d --from-file %s", abuseParallelism, f.Name()),
 		},
 		{
-			Cmd:    "random-write",
-			Amount: 1000,
+			Cmd:            "random-write",
+			Amount:         abuseAmount,
+			AdditionalArgs: fmt.Sprintf("--parallelism %d", abuseParallelism),
 		},
 	}
 	for _, tt := range tests {

--- a/esti/lakectl_test.go
+++ b/esti/lakectl_test.go
@@ -885,7 +885,7 @@ func TestLakectlAbuse(t *testing.T) {
 	require.NoError(t, f.Close())
 
 	const (
-		abuseAmount      = 1000
+		abuseAmount      = 50
 		abuseParallelism = 3
 	)
 	tests := []struct {


### PR DESCRIPTION
### Description

The abuse tests were added to the esti tests in order to validate that the `lakectl abuse` commands don't break. There is no intent to validate lakeFS by running `lakectl abuse` commands.
In order to simplify the test this PR:
- Reduces the number of parallelism from 100 to 3
- Reduces the amount used in the abuse commands from 1000 to 50
