### PR TITLE
Fixed Insufficient permissions ("unauthorized") bug

### DIFF
--- a/webui/src/lib/api/index.js
+++ b/webui/src/lib/api/index.js
@@ -71,7 +71,7 @@ const apiRequest = async (uri, requestData = {}, additionalHeaders = {}) => {
             cache.delete('user');
             throw new AuthenticationError('Authentication Error', response.status);
         }
-        throw new AuthorizationError(errorMessage || 'Insufficient Permissions', response.status);
+        throw new AuthorizationError(errorMessage || 'Unauthorized', response.status);
     }
 
     return response;

--- a/webui/src/lib/api/index.js
+++ b/webui/src/lib/api/index.js
@@ -71,10 +71,7 @@ const apiRequest = async (uri, requestData = {}, additionalHeaders = {}) => {
             cache.delete('user');
             throw new AuthenticationError('Authentication Error', response.status);
         }
-        if (errorMessage === '') {
-            throw new AuthorizationError("Insufficient Permissions", response.status);
-        }
-        throw new AuthorizationError(errorMessage, response.status);
+        throw new AuthorizationError(errorMessage || 'Insufficient Permissions', response.status);
     }
 
     return response;

--- a/webui/src/lib/api/index.js
+++ b/webui/src/lib/api/index.js
@@ -71,6 +71,9 @@ const apiRequest = async (uri, requestData = {}, additionalHeaders = {}) => {
             cache.delete('user');
             throw new AuthenticationError('Authentication Error', response.status);
         }
+        if (errorMessage === '') {
+            throw new AuthorizationError("Insufficient Permissions", response.status);
+        }
         throw new AuthorizationError(errorMessage, response.status);
     }
 


### PR DESCRIPTION
Closes #(Insert issue number closed by this PR)

## Change Description
Added an if statement checking whether the `errorMessage` comes back empty (which it always does) in that case we call the `AuthorizationError()` with the string "Insufficient Permissions".

### Background

 While there is no access for reading a file through the web ui client, a weird error jumped saying "Gn" instead of stating that this is an Authorization error due to insufficient permissions.

### Bug Fix

1. Problem - While there is no access for reading a file through the web ui client, a weird error jumped saying "Gn"
2. Root cause - The `extractError` func returned an empty string
3. Solution - checking if the string is empty, if so calling `AuthorizationError()` with the string "Insufficient Permissions"
      

### Testing Details
The code was tested in an dev environment 

