### PR TITLE
Implement the Quickstart walkthrough with Playwright

### DIFF
--- a/.github/workflows/esti.yaml
+++ b/.github/workflows/esti.yaml
@@ -974,9 +974,15 @@ jobs:
           ESTI_AZURE_STORAGE_ACCOUNT: esti4hns
           ESTI_AZURE_STORAGE_ACCESS_KEY: ${{ secrets.LAKEFS_BLOCKSTORE_AZURE_STORAGE_GEN2_ACCESS_KEY }}
 
+      - name: Az CLI login
+        if: always()
+        uses: azure/login@v1
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       - name: cleanup cosmos db container
         if: always()
-        continue-on-error: true
         run: |
           echo "Delete database container: ${{ github.run_number }}-${{ steps.unique.outputs.value }}"
           az cosmosdb sql container delete -a ${{ env.COSMOSDB_ACCOUNT }} -g ${{ env.COSMOSDB_ACCOUNT }} -d ${{ env.COSMOSDB_DATABASE }} -n ${{ github.run_number }}-${{ steps.unique.outputs.value }} --yes

--- a/.github/workflows/esti.yaml
+++ b/.github/workflows/esti.yaml
@@ -978,7 +978,7 @@ jobs:
         if: always()
         uses: azure/login@v1
         with:
-          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          client-id: ${{ secrets.AZURE_COSMOSDB_CLEANUP_CLIENT_ID }}
           tenant-id: ${{ secrets.AZURE_TENANT_ID }}
           subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
       - name: cleanup cosmos db container

--- a/.github/workflows/esti.yaml
+++ b/.github/workflows/esti.yaml
@@ -1166,3 +1166,123 @@ jobs:
                 body: output
               })
             }
+
+  quickstart:
+    name: Quickstart
+    needs: 
+      - deploy-image
+      - login-to-amazon-ecr
+    runs-on: ubuntu-latest-8-cores
+    timeout-minutes: 20
+    services:
+      dynamodb:
+        image: amazon/dynamodb-local:1.13.6
+      lakefs:
+        image: ${{ needs.login-to-amazon-ecr.outputs.registry }}/lakefs:${{ needs.deploy-image.outputs.tag }}
+        credentials:
+          username: ${{ needs.login-to-amazon-ecr.outputs.docker_username }}
+          password: ${{ needs.login-to-amazon-ecr.outputs.docker_password }}
+        ports:
+          - '8000:8000'
+        env:
+          LAKEFS_DATABASE_TYPE: dynamodb
+          LAKEFS_DATABASE_DYNAMODB_ENDPOINT: http://dynamodb:8000
+          LAKEFS_DATABASE_DYNAMODB_AWS_ACCESS_KEY_ID: AKIAIOSFDNN7EXAMPLEQ
+          LAKEFS_DATABASE_DYNAMODB_AWS_SECRET_ACCESS_KEY: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+          LAKEFS_BLOCKSTORE_TYPE: local
+          LAKEFS_EMAIL_SUBSCRIPTION_ENABLED: true
+          LAKEFS_AUTH_ENCRYPT_SECRET_KEY: some random secret string
+          LAKEFS_STATS_ENABLED: false
+          LAKEFS_LOGGING_LEVEL: DEBUG
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 18
+          cache: "npm"
+          cache-dependency-path: webui/package-lock.json
+      - name: Install dependencies
+        working-directory: webui
+        run: npm ci
+      - name: Get installed Playwright version
+        id: playwright-version
+        working-directory: webui
+        run: echo "PLAYWRIGHT_VERSION=$(node -e "console.log(require('./package-lock.json').dependencies['@playwright/test'].version)")" >> $GITHUB_ENV
+      - name: Cache Playwright binaries
+        uses: actions/cache@v3
+        id: playwright-cache
+        with:
+          path: |
+            ~/.cache/ms-playwright
+            ~/.cache/ms-playwright-*
+          key: ${{ runner.os }}-playwright-${{ env.PLAYWRIGHT_VERSION }}
+          restore-keys: |
+            ${{ runner.os }}-playwright-
+      - name: Install browsers (no cache)
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        working-directory: webui
+        run: npx playwright install --with-deps chromium
+      - name: Install browsers (with cache)
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        working-directory: webui
+        run: npx playwright install-deps chromium
+      - name: Playwright run
+        env:
+          BASE_URL: http://localhost:8000
+        working-directory: webui
+        run: npx playwright test --project=quickstart
+      - uses: actions/upload-artifact@v3
+        if: (success() || failure())
+        with:
+          name: playwright-report
+          path: webui/test-results/
+          retention-days: 7
+      - uses: test-summary/action@v2
+        if: ${{ github.event_name == 'pull_request' && (success() || failure()) }}
+        with:
+          paths: webui/test-results.xml
+          output: "quickstart-test-results.md"
+      # will test and move to using the composite action once it's merged to master (GH limitation)
+      - uses: actions/github-script@v6
+        if: ${{ github.event_name == 'pull_request' && (success() || failure()) }}
+        env:
+          PLAYWRIGHT_PROJECT: "Quickstart"
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const fs = require("fs");
+            // 1. Retrieve existing bot comments for the PR
+            const { data: comments } = await github.rest.issues.listComments({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.issue.number,
+            })
+            const botComment = comments.find(comment => {
+              return comment.user.type === 'Bot' && comment.body.includes(`E2E Test Results - ${process.env.PLAYWRIGHT_PROJECT}`)
+            })
+            // 2. Read markdown files
+            const content = fs.readFileSync("quickstart-test-results.md");
+            // 3. Prepare format of the comment
+            const output = `
+              # E2E Test Results - ${process.env.PLAYWRIGHT_PROJECT}
+              
+              ${content}
+            `;
+
+            // 4. If we have a comment, update it, otherwise create a new one
+            if (botComment) {
+              github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: botComment.id,
+                body: output
+              })
+            } else {
+              github.rest.issues.createComment({
+                issue_number: context.issue.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: output
+              })
+            }
+

--- a/webui/playwright.config.ts
+++ b/webui/playwright.config.ts
@@ -49,8 +49,6 @@ export default defineConfig({
       use: {
         ...devices["Desktop Chrome"],
         storageState: COMMON_STORAGE_STATE_PATH,
-        headless: false,
-        video: "on",
       },
       testMatch: "test/e2e/common/**/quickstart.spec.ts",
       testIgnore: "test/e2e/common/setup.spec.ts",

--- a/webui/playwright.config.ts
+++ b/webui/playwright.config.ts
@@ -9,37 +9,51 @@ import { COMMON_STORAGE_STATE_PATH } from "./test/e2e/consts";
 const BASE_URL = process.env.BASE_URL || "http://localhost:8000";
 
 export default defineConfig({
-    testDir: "test/e2e",
-    fullyParallel: true,
-    forbidOnly: !!process.env.CI,
-    retries: 0,
-    workers: 1,
-    reporter: process.env.CI ? [
-        ["github"],
-        ["junit", { outputFile: "test-results.xml" }],
-    ] : [["list", { printSteps: true }]],
-    use: {
-        baseURL: BASE_URL,
-        "trace": "retain-on-failure",
+  testDir: "test/e2e",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: 0,
+  workers: 1,
+  reporter: process.env.CI
+    ? [["github"], ["junit", { outputFile: "test-results.xml" }]]
+    : [["list", { printSteps: true }]],
+  use: {
+    baseURL: BASE_URL,
+    trace: "retain-on-failure",
+  },
+  projects: [
+    {
+      name: "common-setup",
+      use: {
+        ...devices["Desktop Chrome"],
+      },
+      testMatch: "test/e2e/common/setup.spec.ts",
     },
-    projects: [
-        {
-            name: "common-setup",
-            use: {
-                ...devices["Desktop Chrome"],
-            },
-            testMatch: "test/e2e/common/setup.spec.ts",
-        },
-        {
-            // common tests are applicable to any combination of database and block adapter
-            name: "common",
-            dependencies: ["common-setup"],
-            use: {
-                ...devices["Desktop Chrome"],
-                storageState: COMMON_STORAGE_STATE_PATH,
-            },
-            testMatch: "test/e2e/common/**/*.spec.ts",
-            testIgnore: "test/e2e/common/setup.spec.ts",
-        },
-    ],
+    {
+      // common tests are applicable to any combination of database and block adapter
+      name: "common",
+      dependencies: ["common-setup"],
+      use: {
+        ...devices["Desktop Chrome"],
+        storageState: COMMON_STORAGE_STATE_PATH,
+      },
+      testMatch: "test/e2e/common/**/*.spec.ts",
+      testIgnore: [
+        "test/e2e/common/setup.spec.ts",
+        "test/e2e/common/quickstart.spec.ts",
+      ],
+    },
+    {
+      name: "quickstart",
+      dependencies: ["common-setup"],
+      use: {
+        ...devices["Desktop Chrome"],
+        storageState: COMMON_STORAGE_STATE_PATH,
+        headless: false,
+        video: "on",
+      },
+      testMatch: "test/e2e/common/**/quickstart.spec.ts",
+      testIgnore: "test/e2e/common/setup.spec.ts",
+    },
+  ],
 });

--- a/webui/test/e2e/common/quickstart.spec.ts
+++ b/webui/test/e2e/common/quickstart.spec.ts
@@ -48,7 +48,7 @@ test.describe("Quickstart", () => {
     const repositoryPage = new RepositoryPage(page);
     await repositoryPage.createBranch(NEW_BRANCH_NAME);
 
-    await repositoryPage.gototObjectsTab();
+    await repositoryPage.gotoObjectsTab();
     await repositoryPage.clickObject(PARQUET_OBJECT_NAME);
     await expect(page.getByText("Loading...")).not.toBeVisible();
 

--- a/webui/test/e2e/common/quickstart.spec.ts
+++ b/webui/test/e2e/common/quickstart.spec.ts
@@ -1,0 +1,102 @@
+import { test, expect } from "@playwright/test";
+import { RepositoriesPage } from "../poms/repositoriesPage";
+import { RepositoryPage } from "../poms/repositoryPage";
+import { ObjectViewerPage } from "../poms/objectViewerPage";
+
+const QUICKSTART_REPO_NAME = "quickstart";
+const PARQUET_OBJECT_NAME = "lakes.parquet";
+const NEW_BRANCH_NAME = "denmark-lakes";
+
+const SELECT_QUERY =
+  "SELECT country, COUNT(*) FROM READ_PARQUET('lakefs://quickstart/main/lakes.parquet') GROUP BY country ORDER BY COUNT(*) DESC LIMIT 5;";
+const CREATE_TABLE_QUERY =
+  "CREATE OR REPLACE TABLE lakes AS SELECT * FROM READ_PARQUET('lakefs://quickstart/denmark-lakes/lakes.parquet');";
+const DELETE_QUERY = "DELETE FROM lakes WHERE Country != 'Denmark';";
+const COPY_QUERY =
+  "COPY lakes TO 'lakefs://quickstart/denmark-lakes/lakes.parquet';";
+const SELECT_NEW_BRANCH =
+  "DROP TABLE lakes; SELECT country, COUNT(*) FROM READ_PARQUET('lakefs://quickstart/denmark-lakes/lakes.parquet') GROUP BY country ORDER BY COUNT(*) DESC LIMIT 5;";
+
+test.describe("Quickstart", () => {
+  test.describe.configure({ mode: "serial" });
+  test("create repo w/ sample data", async ({ page }) => {
+    const repositoriesPage = new RepositoriesPage(page);
+    await repositoriesPage.goto();
+    await repositoriesPage.createRepository(QUICKSTART_REPO_NAME, true);
+  });
+
+  test("view and query parquet object", async ({ page }) => {
+    const repositoriesPage = new RepositoriesPage(page);
+    await repositoriesPage.goto();
+    await repositoriesPage.goToRepository(QUICKSTART_REPO_NAME);
+
+    const repositoryPage = new RepositoryPage(page);
+    await repositoryPage.clickObject(PARQUET_OBJECT_NAME);
+    await expect(page.getByText("Loading...")).not.toBeVisible();
+
+    const objectViewerPage = new ObjectViewerPage(page);
+    await objectViewerPage.enterQuery(SELECT_QUERY);
+    await objectViewerPage.clickExecuteButton();
+    await expect(await objectViewerPage.getResultRowCount()).toEqual(5);
+  });
+
+  test("transforming data", async ({ page }) => {
+    const repositoriesPage = new RepositoriesPage(page);
+    await repositoriesPage.goto();
+    await repositoriesPage.goToRepository(QUICKSTART_REPO_NAME);
+
+    const repositoryPage = new RepositoryPage(page);
+    await repositoryPage.createBranch(NEW_BRANCH_NAME);
+
+    await repositoryPage.gototObjectsTab();
+    await repositoryPage.clickObject(PARQUET_OBJECT_NAME);
+    await expect(page.getByText("Loading...")).not.toBeVisible();
+
+    const objectViewerPage = new ObjectViewerPage(page);
+    await objectViewerPage.enterQuery(CREATE_TABLE_QUERY);
+    await objectViewerPage.clickExecuteButton();
+
+    await objectViewerPage.enterQuery(DELETE_QUERY);
+    await objectViewerPage.clickExecuteButton();
+
+    await objectViewerPage.enterQuery(COPY_QUERY);
+    await objectViewerPage.clickExecuteButton();
+
+    await objectViewerPage.enterQuery(SELECT_NEW_BRANCH);
+    await objectViewerPage.clickExecuteButton();
+    await expect(await objectViewerPage.getResultRowCount()).toEqual(1);
+  });
+
+  test("commit and merge", async ({ page }) => {
+    const repositoriesPage = new RepositoriesPage(page);
+    await repositoriesPage.goto();
+    await repositoriesPage.goToRepository(QUICKSTART_REPO_NAME);
+
+    const repositoryPage = new RepositoryPage(page);
+    await repositoryPage.gotoUncommittedChangeTab();
+    await repositoryPage.switchBranch(NEW_BRANCH_NAME);
+    await expect(
+      await page.getByText("Showing changes for branch")
+    ).toBeVisible();
+    await expect(await repositoryPage.getUncommittedCount()).toEqual(1);
+
+    await repositoryPage.commitChanges("denmark");
+    await expect(page.getByText("No changes")).toBeVisible();
+
+    await repositoryPage.gotoCompareTab();
+    await repositoryPage.switchBaseBranch("main");
+    await expect(await page.getByText("Showing changes between")).toBeVisible();
+    await expect(await repositoryPage.getUncommittedCount()).toEqual(1);
+    await repositoryPage.merge("merge commit");
+    await expect(page.getByText("No changes")).toBeVisible();
+
+    await repositoriesPage.goto();
+    await repositoriesPage.goToRepository(QUICKSTART_REPO_NAME);
+    await repositoryPage.clickObject(PARQUET_OBJECT_NAME);
+    await expect(page.getByText("Loading...")).not.toBeVisible();
+    const objectViewerPage = new ObjectViewerPage(page);
+    await objectViewerPage.enterQuery(SELECT_QUERY);
+    await objectViewerPage.clickExecuteButton();
+    await expect(await objectViewerPage.getResultRowCount()).toEqual(1);
+  });
+});

--- a/webui/test/e2e/poms/objectViewerPage.ts
+++ b/webui/test/e2e/poms/objectViewerPage.ts
@@ -1,0 +1,30 @@
+import { Page } from "@playwright/test";
+
+export class ObjectViewerPage {
+  private page: Page;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  async enterQuery(query: string): Promise<void> {
+    await this.page
+      .locator("div.syntax-editor")
+      .locator("textarea")
+      .fill(query);
+  }
+
+  async clickExecuteButton(): Promise<void> {
+    await this.page.getByRole("button", { name: "Execute" }).click();
+    await this.page.getByRole("button", { name: "Execute" }).isDisabled();
+    await this.page.getByRole("button", { name: "Execute" }).isEnabled();
+  }
+
+  async getResultRowCount(): Promise<number> {
+    return this.page
+      .locator("table.table")
+      .locator("tbody")
+      .locator("tr")
+      .count();
+  }
+}

--- a/webui/test/e2e/poms/repositoryPage.ts
+++ b/webui/test/e2e/poms/repositoryPage.ts
@@ -1,20 +1,89 @@
-import {Locator, Page} from "@playwright/test";
+import { Locator, Page } from "@playwright/test";
 
 export class RepositoryPage {
-    private page: Page;
+  private page: Page;
 
-    public readOnlyIndicatorLocator: Locator;
+  public readOnlyIndicatorLocator: Locator;
 
-    constructor(page: Page) {
-        this.page = page;
-        this.readOnlyIndicatorLocator = this.page.locator("text=Read-only");
+  constructor(page: Page) {
+    this.page = page;
+    this.readOnlyIndicatorLocator = this.page.locator("text=Read-only");
+  }
+
+  async goto(repoName: string): Promise<void> {
+    await this.page.goto(`/repositories/${repoName}`);
+  }
+
+  async clickObject(objectName: string): Promise<void> {
+    await this.page
+      .getByRole("cell", { name: objectName })
+      .getByRole("link")
+      .click();
+  }
+
+  async createBranch(name: string): Promise<void> {
+    await this.page
+      .getByRole("link", { name: "Branches", exact: false })
+      .click();
+    await this.page.getByRole("button", { name: "Create Branch" }).click();
+    await this.page.getByPlaceholder("Branch Name").fill(name);
+    await this.page
+      .getByRole("button", { name: "Create", exact: true })
+      .click();
+  }
+
+  async switchBranch(name: string): Promise<void> {
+    await this.page.getByRole("button", { name: "branch: " }).click();
+    await this.page.getByRole("button", { name }).click();
+  }
+
+  async getUncommittedCount(): Promise<number> {
+    await this.page.locator("div.card").isVisible();
+    return this.page
+      .locator("table.table")
+      .locator("tbody")
+      .locator("tr")
+      .count();
+  }
+
+  async commitChanges(commitMsg: string): Promise<void> {
+    await this.page.getByRole("button", { name: "Commit Changes" }).click();
+    if (commitMsg?.length) {
+      await this.page.getByPlaceholder("Commit Message").fill(commitMsg);
     }
+    await this.page
+      .getByRole("dialog")
+      .getByRole("button", { name: "Commit Changes" })
+      .click();
+  }
 
-    async goto(repoName: string): Promise<void> {
-        await this.page.goto(`/repositories/${repoName}`);
+  async merge(commitMsg: string): Promise<void> {
+    await this.page.getByRole("button", { name: "Merge" }).click();
+    if (commitMsg?.length) {
+      await this.page
+        .getByPlaceholder("Commit Message (Optional)")
+        .fill(commitMsg);
     }
+    await this.page
+      .getByRole("dialog")
+      .getByRole("button", { name: "Merge" })
+      .click();
+  }
 
-    async clickObject(objectName: string): Promise<void> {
-        await this.page.getByRole('cell', { name: objectName }).getByRole('link').click();
-    }
+  async switchBaseBranch(name: string): Promise<void> {
+    await this.page.getByRole("button", { name: "Base branch: " }).click();
+    await this.page.getByRole("button", { name }).click();
+  }
+
+  async gototObjectsTab(): Promise<void> {
+    await this.page.getByRole("link", { name: "Objects" }).click();
+  }
+
+  async gotoUncommittedChangeTab(): Promise<void> {
+    await this.page.getByRole("link", { name: "Uncommitted Changes" }).click();
+  }
+
+  async gotoCompareTab(): Promise<void> {
+    await this.page.getByRole("link", { name: "Compare" }).click();
+  }
 }

--- a/webui/test/e2e/poms/repositoryPage.ts
+++ b/webui/test/e2e/poms/repositoryPage.ts
@@ -75,7 +75,7 @@ export class RepositoryPage {
     await this.page.getByRole("button", { name }).click();
   }
 
-  async gototObjectsTab(): Promise<void> {
+  async gotoObjectsTab(): Promise<void> {
     await this.page.getByRole("link", { name: "Objects" }).click();
   }
 


### PR DESCRIPTION
Closes #7973 
## Change Description

### Background

See related issue for background.
      
### New Feature

Implement the quickstart walkthrough as a Playwright-based E2E test. This includes all of the quickstart guide steps except revert, which isn't available via the UI. To complete coverage, a revert test should be done using other test layers.

