### PR TITLE
Exclude specific-version docs from search engines

### DIFF
--- a/.github/workflows/docs-release.yaml
+++ b/.github/workflows/docs-release.yaml
@@ -35,7 +35,7 @@ jobs:
 
       - name: Build release
         working-directory: docs
-        run: bundle exec jekyll build --config _config.yml -d _site/${{ steps.version.outputs.tag }} -b /${{ steps.version.outputs.tag }}
+        run: bundle exec jekyll build --config _config.yml,_config.version.yml -d _site/${{ steps.version.outputs.tag }} -b /${{ steps.version.outputs.tag }}
 
       - name: Remove robots.txt
         working-directory: docs/_site/${{ steps.version.outputs.tag }}

--- a/docs/_config.version.yml
+++ b/docs/_config.version.yml
@@ -1,0 +1,1 @@
+robots_exclude_from_indexes: true

--- a/docs/_includes/head_custom.html
+++ b/docs/_includes/head_custom.html
@@ -6,6 +6,9 @@
         'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
     })(window,document,'script','dataLayer','GTM-KTZBZW9');</script>
 <!-- End Google Tag Manager Head -->
+{% if site.robots_exclude_from_indexes %}
+<meta name="robots" content="noindex">
+{% endif %}
 <meta property="og:image" content="{{ site.baseurl }}{{ site.image }}">
 <link rel="preload" href="/assets/fonts/Rene Bieder - Galano Grotesque.otf" as="font" type="font/otf" crossorigin>
 <link rel="preload" href="/assets/fonts/Rene Bieder - Galano Grotesque Medium.otf" as="font" type="font/otf" crossorigin>

--- a/docs/robots.txt
+++ b/docs/robots.txt
@@ -3,4 +3,8 @@ layout: null
 sitemap: false
 ---
 User-agent: *
+# blocking older versions of the API.
+# note: this prevents direct indexing and access, but these pages are still available via refs from other sites.
+Disallow: /v0.*
+Disallow: /v1.*
 Sitemap: {{ site.url }}{{ site.baseurl }}/sitemap.xml


### PR DESCRIPTION
Closes #8008 .

## Change Description

In order to exclude our version-specific docs from the search engines, this PR does two things:
1. Disallows `/v0.*` and `/v1.*` in `robots.txt`.
2. Adds `<meta name="robots" content="noindex">` to all version folders, in build time (meaning, as part of the release actions).

Another [PR](https://github.com/treeverse/docs-lakeFS/pull/167) adds `<meta name="robots" content="noindex">` to all relevant existing html files in our `docs-lakeFS` repo.

## Testing

This change will affect only the next released lakeFS version, so I'll validate it after it's released that the `<meta>` tag is added to the `/v1.31/*` directory htmls (but not to the "latest" docs).
After this PR will be merged, I will be able to validate that for the latest docs, it *won't* add this `<meta>` tag.

Also, it'll be monitored with Yuval, our SEO expert.
