### PR TITLE
Change jekyll version for document contribution

### DIFF
--- a/docs/project/docs/index.md
+++ b/docs/project/docs/index.md
@@ -104,7 +104,7 @@ The alternative is to use Docker which has the benefit of handling all the depen
               --volume="$PWD/docs:/srv/jekyll:Z" \
               --volume="$PWD/docs/.jekyll-bundle-cache:/usr/local/bundle:Z" \
               --interactive --tty \
-              jekyll/jekyll:3.8 \
+              jekyll/jekyll:4.2.2 \
               jekyll serve --livereload
    ```
 

--- a/docs/project/docs/index.md
+++ b/docs/project/docs/index.md
@@ -169,3 +169,4 @@ When making a pull request to lakeFS that involves a `docs/*` file, a [GitHub ac
    ```
 
 3. Review the `lychee_report.md` in your local `/tmp` folder
+ 


### PR DESCRIPTION
## Change Description
Got following error when using "docker run" command to test the docs changes locally: 
activesupport-7.0.8 requires ruby version >= 2.7.0, which is incompatible with the current version, ruby 2.6.3p62

### Background
Changed jekyll version to 4.2.2 from 3.8 to fix the issue.
