### PR TITLE
Add base-url to sitemap.xml

### DIFF
--- a/.github/workflows/docs-latest.yaml
+++ b/.github/workflows/docs-latest.yaml
@@ -34,7 +34,7 @@ jobs:
         run: |
           sed -i 's/^Sitemap: /Sitemap: https:\/\/docs.lakefs.io/' robots.txt
 
-      - name: Update sitemap.xml
+      - name: Add base-url to sitemap.xml
         working-directory: docs/_site
         run: |
           sed -i 's/<loc>/<loc>https:\/\/docs.lakefs.io/' sitemap.xml

--- a/.github/workflows/docs-latest.yaml
+++ b/.github/workflows/docs-latest.yaml
@@ -34,6 +34,11 @@ jobs:
         run: |
           sed -i 's/^Sitemap: /Sitemap: https:\/\/docs.lakefs.io/' robots.txt
 
+      - name: Update sitemap.xml
+        working-directory: docs/_site
+        run: |
+          sed -i 's/<loc>/<loc>https:\/\/docs.lakefs.io/' sitemap.xml
+
       - name: Publish to docs repository
         uses: dmnemec/copy_file_to_another_repo_action@v1.1.1
         env:


### PR DESCRIPTION
Closes #8072.

## Change Description

Adds a base-url to the sitemap.xml.

### New Feature

Our sitemap is of the following form:
```
<url>
    <loc>/howto/deploy/</loc>
</url>
<url>
    <loc>/quickstart/</loc>
</url>
...
```

But as requested from our SEO expert, this PR changes it to the following form, to improve searches:
```
<url>
    <loc>https://docs.lakefs.io/howto/deploy/</loc>
</url>
<url>
    <loc>https://docs.lakefs.io/quickstart/</loc>
</url>
...
```

### Testing Details

I've tested the `sed` command locally - 
But I need to validate this works fine after ~~the next release~~ it's merged to `master`.
 