### PR TITLE
Made few minor changes in Enterprise docs

### DIFF
--- a/docs/enterprise/getstarted/quickstart.md
+++ b/docs/enterprise/getstarted/quickstart.md
@@ -24,8 +24,8 @@ the following containers:
 * lakeFS
 * Fluffy (includes lakeFS Enterprise features)
 * Postgres: used by lakeFS and Fluffy as a shared KV store
-* MinIO container: used as the storage connected to lakFS
-* Jupyter notebooks setup: Pre-populated with [notebooks](https://github.com/treeverse/lakeFS-samples/tree/main/00_notebooks) that demonstrate lakeFS Enterprise' capabilities
+* MinIO container: used as the storage connected to lakeFS
+* Jupyter notebooks setup: Pre-populated with [notebooks](https://github.com/treeverse/lakeFS-samples/blob/main/00_notebooks/00_index.ipynb) that demonstrate lakeFS Enterprise' capabilities
 * Apache Spark: this is useful for interacting with data you'll manage with lakeFS
 
 Checkout the [RBAC demo](https://github.com/treeverse/lakeFS-samples/blob/main/00_notebooks/rbac-demo.ipynb) notebook to see lakeFS Enterprise [Role-Based Access Control]({% link security/access-control-lists.md %}) capabilities in action.

--- a/docs/enterprise/index.md
+++ b/docs/enterprise/index.md
@@ -25,7 +25,7 @@ are not using public clouds, hence they cannot use [lakeFS Cloud]({% link cloud/
 ## What security features does lakeFS Enterprise provide?
 
 With lakeFS Enterprise you’ll receive access to the security package containing the following features:
-1. A rich [Role-Based Access Control]({% link security/access-control-lists.md %}) permission system that allows for fine-grained control by associating permissions with users and groups, granting them specific actions on specific resources. This ensures data security and compliance within an organization.
+1. A rich [Role-Based Access Control]({% link security/rbac.md %}) permission system that allows for fine-grained control by associating permissions with users and groups, granting them specific actions on specific resources. This ensures data security and compliance within an organization.
 2. To easily manage users and groups, lakeFS Enterprise provides SSO integration (including support for SAML, OIDC, ADFS, Okta, and Azure AD), supporting existing credentials from a trusted provider, eliminating separate logins.
 3. lakeFS Enterprise supports [SCIM]({% link howto/scim.md %}) for automatically provisioning and deprovisioning users and group memberships to allow organizations to maintain a single source of truth for their user database.
 4. [STS Auth]({% link security/sts-login.md %}) offers temporary, secure logins using an Identity Provider, simplifying user access and enhancing security.

--- a/docs/enterprise/troubleshooting.md
+++ b/docs/enterprise/troubleshooting.md
@@ -129,9 +129,9 @@ $KUBECTLCMD exec deployment/$FLUFFY_DEPLOYMENT -- ./lakefs flare --stdout > $FLU
 
 After executing the script you should have four files: lakeFS/fluffy logs and lakeFS/fluffy flare output. Before sharing these files, please review them to make sure all secrets were correctly redacted and that all the collected information is shareable.
 
-### Step 4 - Zip Output Files and Attach to HubSpot Ticket
+### Step 4 - Zip Output Files and Attach to Support Ticket
 
-Once you're done inspecting the files, you can zip them into a single file and attach it to a HubSpot issue.
+Once you're done inspecting the files, you can zip them into a single file and attach it to a Support Ticket in the [support portal](https://support.lakefs.io/).
 
 #### New Ticket
 
@@ -141,6 +141,6 @@ When filing a new ticket, you can attach the zip file using the file upload inpu
 
 #### Existing Ticket
 
-To add a file to an existing ticket, click the ticket subject in the support portal. On the ticket details attach a file as a new response. You can also add text to the response, if you'd like to add further details.
+To add a file to an existing ticket, click the ticket subject in the [support portal](https://support.lakefs.io/). On the ticket details attach a file as a new response. You can also add text to the response, if you'd like to add further details.
 
 ![existing ticket](../assets/img/flare_existing_ticket.png)

--- a/docs/howto/mirroring.md
+++ b/docs/howto/mirroring.md
@@ -9,6 +9,9 @@ description: Mirroring allows replicating commits between lakeFS installations i
 lakeFS Cloud
 {: .label .label-green }
 
+lakeFS Enterprise
+{: .label .label-purple }
+
 {: .note}
 > Mirroring is only available for [lakeFS Cloud]({% link cloud/index.md %}).
 

--- a/docs/howto/scim.md
+++ b/docs/howto/scim.md
@@ -11,6 +11,9 @@ redirect_from:
 lakeFS Cloud
 {: .label .label-green }
 
+lakeFS Enterprise
+{: .label .label-purple }
+
 lakeFS Cloud includes an [SCIM v2.0](https://datatracker.ietf.org/doc/html/rfc7644) compliant server, which can integrate with SCIM clients (IdPs) to automate provisioning/de-provisioning of users and groups.  
 
 {% include toc.html %}


### PR DESCRIPTION
Made following changes:
1. Changed 1st link in [this section](https://docs.lakefs.io/enterprise/#what-security-features-does-lakefs-enterprise-provide) to go to RBAC page instead of ACL page.
2. Added Enterprise tag for [Mirroring](https://docs.lakefs.io/howto/mirroring.html) and [SCIM](https://docs.lakefs.io/howto/scim.html) features.
3. Fixed typo in lakeFS in [this section](https://docs.lakefs.io/enterprise/getstarted/quickstart.html#lakefs-enterprise-sample): "MinIO container: used as the storage connected to lakFS"
4. Used [this link](https://github.com/treeverse/lakeFS-samples/blob/main/00_notebooks/00_index.ipynb)(index page has description for each notebook) for notebooks in [this section](https://docs.lakefs.io/enterprise/getstarted/quickstart.html#lakefs-enterprise-sample): Jupyter notebooks setup: Pre-populated with [notebooks](https://github.com/treeverse/lakeFS-samples/tree/main/00_notebooks) that demonstrate lakeFS Enterprise’ capabilities
5. Changed text from HubSpot Ticket to Support Ticket in [this section](https://docs.lakefs.io/enterprise/troubleshooting.html#step-4---zip-output-files-and-attach-to-hubspot-ticket) because most of the customers may not know what is HubSpot
6.  Included link to Support Portal: https://support.lakefs.io/ in [this section](https://docs.lakefs.io/enterprise/troubleshooting.html#step-4---zip-output-files-and-attach-to-hubspot-ticket)
7. Included link to Support Portal: https://support.lakefs.io/ in [this section also](https://docs.lakefs.io/enterprise/troubleshooting.html#existing-ticket)
