### PR TITLE
ACLs: Modify superuser command and add migrate flow

### DIFF
--- a/.github/workflows/esti.yaml
+++ b/.github/workflows/esti.yaml
@@ -1353,7 +1353,7 @@ jobs:
           fi
 
   run-system-aws-s3-basic-auth:
-    name: Run latest lakeFS app on AWS S3
+    name: Run latest lakeFS app on AWS S3 + Basic Auth
     needs: [deploy-image, login-to-amazon-ecr]
     runs-on: ubuntu-22.04
     env:

--- a/contrib/auth/acl/service.go
+++ b/contrib/auth/acl/service.go
@@ -243,7 +243,7 @@ func (s *AuthService) ListUserCredentials(ctx context.Context, username string, 
 	if err != nil {
 		return nil, nil, err
 	}
-	creds, err := model.ConvertCredDataList(s.secretStore, msgs)
+	creds, err := model.ConvertCredDataList(s.secretStore, msgs, false)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/esti/golden/lakefs/help.golden
+++ b/esti/golden/lakefs/help.golden
@@ -1,0 +1,23 @@
+lakeFS is a data lake management platform
+
+Usage:
+  lakefs [command]
+
+Available Commands:
+  completion  Generate completion script
+  flare       collect configuration, environment variables, and logs for debugging and troubleshooting
+  help        Help about any command
+  migrate     Manage migrations
+  run         Run lakeFS
+  setup       Setup a new lakeFS instance with initial credentials
+  superuser   Create additional user with admin credentials
+
+Flags:
+  -c, --config string    config file (default is $HOME/.lakefs.yaml)
+  -h, --help             help for lakefs
+      --local-settings   Use lakeFS local default configuration
+      --quickstart       Use lakeFS quickstart configuration
+  -t, --toggle           Help message for toggle
+  -v, --version          version for lakefs
+
+Use "lakefs [command] --help" for more information about a command.

--- a/esti/lakectl_test.go
+++ b/esti/lakectl_test.go
@@ -423,7 +423,7 @@ func TestLakectlAuthUsers(t *testing.T) {
 	RunCmdAndVerifyFailure(t, Lakectl()+" auth users create --id "+userName, false, "Already exists\n409 Conflict\n", vars)
 
 	// Cleanup
-	expected := "Not implemented\n501 Not Implemented\n"
+	expected := "user not found\n404 Not Found\n"
 	if isSupported {
 		expected = "User deleted successfully\n"
 	}

--- a/esti/lakectl_test.go
+++ b/esti/lakectl_test.go
@@ -412,13 +412,9 @@ func TestLakectlAuthUsers(t *testing.T) {
 		"ID": userName,
 	}
 	isSupported := !isBasicAuth()
-	expected := "Not implemented\n501 Not Implemented\n"
-	if isSupported {
-		expected = "user not found\n404 Not Found\n"
-	}
 
 	// Not Found
-	RunCmdAndVerifyFailure(t, Lakectl()+" auth users delete --id "+userName, false, expected, vars)
+	RunCmdAndVerifyFailure(t, Lakectl()+" auth users delete --id "+userName, false, "user not found\n404 Not Found\n", vars)
 
 	// Check unique
 	if isSupported {
@@ -427,6 +423,7 @@ func TestLakectlAuthUsers(t *testing.T) {
 	RunCmdAndVerifyFailure(t, Lakectl()+" auth users create --id "+userName, false, "Already exists\n409 Conflict\n", vars)
 
 	// Cleanup
+	expected := "Not implemented\n501 Not Implemented\n"
 	if isSupported {
 		expected = "User deleted successfully\n"
 	}

--- a/esti/lakectl_util.go
+++ b/esti/lakectl_util.go
@@ -34,10 +34,12 @@ var (
 	rePhysicalAddress = regexp.MustCompile(`/data/[0-9a-v]{20}/(?:[0-9a-v]{20}(?:,.+)?)?`)
 	reVariable        = regexp.MustCompile(`\$\{([^${}]+)}`)
 	rePreSignURL      = regexp.MustCompile(`https://\S+\?\S+`)
+	reSecretAccessKey = regexp.MustCompile(`secret_access_key: \S{16,128}`)
+	reAccessKeyID     = regexp.MustCompile(`access_key_id: AKIA\S{12,124}`)
 )
 
 func lakectlLocation() string {
-	return viper.GetString("lakectl_dir") + "/lakectl"
+	return viper.GetString("binaries_dir") + "/lakectl"
 }
 
 func LakectlWithParams(accessKeyID, secretAccessKey, endPointURL string) string {
@@ -145,6 +147,8 @@ func sanitize(output string, vars map[string]string) string {
 	s = normalizeCommitID(s)
 	s = normalizeChecksum(s)
 	s = normalizeShortCommitID(s)
+	s = normalizeAccessKeyID(s)
+	s = normalizeSecretAccessKey(s)
 	return s
 }
 
@@ -266,4 +270,12 @@ func normalizeEndpoint(output string, endpoint string) string {
 
 func normalizePreSignURL(output string) string {
 	return rePreSignURL.ReplaceAllString(output, "<PRE_SIGN_URL>")
+}
+
+func normalizeAccessKeyID(output string) string {
+	return reAccessKeyID.ReplaceAllString(output, "access_key_id: <ACCESS_KEY_ID>")
+}
+
+func normalizeSecretAccessKey(output string) string {
+	return reSecretAccessKey.ReplaceAllString(output, "secret_access_key: <SECRET_ACCESS_KEY>")
 }

--- a/esti/lakefs_test.go
+++ b/esti/lakefs_test.go
@@ -10,12 +10,13 @@ func TestLakefsHelp(t *testing.T) {
 }
 
 func TestLakefsSuperuser_basic(t *testing.T) {
+	requirePostgresDB(t)
 	lakefsCmd := Lakefs()
 	outputString := "credentials:\n  access_key_id: <ACCESS_KEY_ID>\n  secret_access_key: <SECRET_ACCESS_KEY>\n"
 	username := t.Name()
 	expectFailure := false
 	if isBasicAuth() {
-		lakefsCmd = LakefsWithBasicAuth(t)
+		lakefsCmd = LakefsWithBasicAuth()
 		outputString = "already exists"
 		expectFailure = true
 	}
@@ -23,9 +24,10 @@ func TestLakefsSuperuser_basic(t *testing.T) {
 }
 
 func TestLakefsSuperuser_alreadyExists(t *testing.T) {
+	requirePostgresDB(t)
 	lakefsCmd := Lakefs()
 	if isBasicAuth() {
-		lakefsCmd = LakefsWithBasicAuth(t)
+		lakefsCmd = LakefsWithBasicAuth()
 	}
 	RunCmdAndVerifyFailureContainsText(t, lakefsCmd+" superuser --user-name "+AdminUsername, false, "already exists", nil)
 }

--- a/esti/lakefs_test.go
+++ b/esti/lakefs_test.go
@@ -1,0 +1,31 @@
+package esti
+
+import "testing"
+
+func TestLakefsHelp(t *testing.T) {
+	RunCmdAndVerifySuccessWithFile(t, Lakefs(), false, "lakefs/help", emptyVars)
+	RunCmdAndVerifySuccessWithFile(t, Lakefs()+" --help", false, "lakefs/help", emptyVars)
+	RunCmdAndVerifySuccessWithFile(t, Lakefs(), true, "lakefs/help", emptyVars)
+	RunCmdAndVerifySuccessWithFile(t, Lakefs()+" --help", true, "lakefs/help", emptyVars)
+}
+
+func TestLakefsSuperuser_basic(t *testing.T) {
+	lakefsCmd := Lakefs()
+	outputString := "credentials:\n  access_key_id: <ACCESS_KEY_ID>\n  secret_access_key: <SECRET_ACCESS_KEY>\n"
+	username := t.Name()
+	expectFailure := false
+	if isBasicAuth() {
+		lakefsCmd = LakefsWithBasicAuth(t)
+		outputString = "already exists"
+		expectFailure = true
+	}
+	runCmdAndVerifyContainsText(t, lakefsCmd+" superuser --user-name "+username, expectFailure, false, outputString, nil)
+}
+
+func TestLakefsSuperuser_alreadyExists(t *testing.T) {
+	lakefsCmd := Lakefs()
+	if isBasicAuth() {
+		lakefsCmd = LakefsWithBasicAuth(t)
+	}
+	RunCmdAndVerifyFailureContainsText(t, lakefsCmd+" superuser --user-name "+AdminUsername, false, "already exists", nil)
+}

--- a/esti/lakefs_test.go
+++ b/esti/lakefs_test.go
@@ -10,7 +10,7 @@ func TestLakefsHelp(t *testing.T) {
 }
 
 func TestLakefsSuperuser_basic(t *testing.T) {
-	requirePostgresDB(t)
+	RequirePostgresDB(t)
 	lakefsCmd := Lakefs()
 	outputString := "credentials:\n  access_key_id: <ACCESS_KEY_ID>\n  secret_access_key: <SECRET_ACCESS_KEY>\n"
 	username := t.Name()
@@ -24,7 +24,7 @@ func TestLakefsSuperuser_basic(t *testing.T) {
 }
 
 func TestLakefsSuperuser_alreadyExists(t *testing.T) {
-	requirePostgresDB(t)
+	RequirePostgresDB(t)
 	lakefsCmd := Lakefs()
 	if isBasicAuth() {
 		lakefsCmd = LakefsWithBasicAuth()

--- a/esti/lakefs_test.go
+++ b/esti/lakefs_test.go
@@ -29,5 +29,6 @@ func TestLakefsSuperuser_alreadyExists(t *testing.T) {
 	if isBasicAuth() {
 		lakefsCmd = LakefsWithBasicAuth()
 	}
+	// On init - the AdminUsername is already created and expected error should be "already exist" (also in basic auth mode)
 	RunCmdAndVerifyFailureContainsText(t, lakefsCmd+" superuser --user-name "+AdminUsername, false, "already exists", nil)
 }

--- a/esti/lakefs_util.go
+++ b/esti/lakefs_util.go
@@ -24,14 +24,17 @@ func lakefsLocation() string {
 	return viper.GetString("binaries_dir") + "/lakefs"
 }
 
-func LakefsWithBasicAuth(t *testing.T) string {
-	dbString := viper.GetString("database_connection_string")
-	if dbString == "" {
-		t.Skip("database connection string not set")
-	}
-	return LakefsWithParamsWithBasicAuth(dbString, true)
+func LakefsWithBasicAuth() string {
+	return LakefsWithParamsWithBasicAuth(viper.GetString("database_connection_string"), true)
 }
 
 func Lakefs() string {
 	return LakefsWithParams(viper.GetString("database_connection_string"))
+}
+
+func requirePostgresDB(t *testing.T) {
+	dbString := viper.GetString("database_connection_string")
+	if dbString == "" {
+		t.Skip("skip test - not postgres")
+	}
 }

--- a/esti/lakefs_util.go
+++ b/esti/lakefs_util.go
@@ -11,10 +11,10 @@ func LakefsWithParams(connectionString string) string {
 	return LakefsWithParamsWithBasicAuth(connectionString, false)
 }
 
-func LakefsWithParamsWithBasicAuth(connectionString string, BasicAuth bool) string {
+func LakefsWithParamsWithBasicAuth(connectionString string, basicAuth bool) string {
 	lakefsCmdline := "LAKEFS_DATABASE_TYPE=postgres" +
 		" LAKEFS_DATABASE_POSTGRES_CONNECTION_STRING=" + connectionString +
-		" LAKEFS_AUTH_INTERNAL_BASIC=" + strconv.FormatBool(BasicAuth) +
+		" LAKEFS_AUTH_INTERNAL_BASIC=" + strconv.FormatBool(basicAuth) +
 		" " + lakefsLocation()
 
 	return lakefsCmdline
@@ -32,7 +32,7 @@ func Lakefs() string {
 	return LakefsWithParams(viper.GetString("database_connection_string"))
 }
 
-func requirePostgresDB(t *testing.T) {
+func RequirePostgresDB(t *testing.T) {
 	dbString := viper.GetString("database_connection_string")
 	if dbString == "" {
 		t.Skip("skip test - not postgres")

--- a/esti/lakefs_util.go
+++ b/esti/lakefs_util.go
@@ -1,0 +1,37 @@
+package esti
+
+import (
+	"strconv"
+	"testing"
+
+	"github.com/spf13/viper"
+)
+
+func LakefsWithParams(connectionString string) string {
+	return LakefsWithParamsWithBasicAuth(connectionString, false)
+}
+
+func LakefsWithParamsWithBasicAuth(connectionString string, BasicAuth bool) string {
+	lakefsCmdline := "LAKEFS_DATABASE_TYPE=postgres" +
+		" LAKEFS_DATABASE_POSTGRES_CONNECTION_STRING=" + connectionString +
+		" LAKEFS_AUTH_INTERNAL_BASIC=" + strconv.FormatBool(BasicAuth) +
+		" " + lakefsLocation()
+
+	return lakefsCmdline
+}
+
+func lakefsLocation() string {
+	return viper.GetString("binaries_dir") + "/lakefs"
+}
+
+func LakefsWithBasicAuth(t *testing.T) string {
+	dbString := viper.GetString("database_connection_string")
+	if dbString == "" {
+		t.Skip("database connection string not set")
+	}
+	return LakefsWithParamsWithBasicAuth(dbString, true)
+}
+
+func Lakefs() string {
+	return LakefsWithParams(viper.GetString("database_connection_string"))
+}

--- a/esti/lakefs_util.go
+++ b/esti/lakefs_util.go
@@ -16,7 +16,7 @@ func LakefsWithParamsWithBasicAuth(connectionString string, basicAuth bool) stri
 		" LAKEFS_DATABASE_POSTGRES_CONNECTION_STRING=" + connectionString +
 		" LAKEFS_AUTH_INTERNAL_BASIC=" + strconv.FormatBool(basicAuth) +
 		" LAKEFS_BLOCKSTORE_TYPE=" + viper.GetString("blockstore_type") +
-		" LAKEFS_AUTH_ENCRYPT_SECRET_KEY='some random secret string'" + lakefsLocation()
+		" LAKEFS_AUTH_ENCRYPT_SECRET_KEY='some random secret string' " + lakefsLocation()
 
 	return lakefsCmdline
 }

--- a/esti/lakefs_util.go
+++ b/esti/lakefs_util.go
@@ -15,7 +15,8 @@ func LakefsWithParamsWithBasicAuth(connectionString string, basicAuth bool) stri
 	lakefsCmdline := "LAKEFS_DATABASE_TYPE=postgres" +
 		" LAKEFS_DATABASE_POSTGRES_CONNECTION_STRING=" + connectionString +
 		" LAKEFS_AUTH_INTERNAL_BASIC=" + strconv.FormatBool(basicAuth) +
-		" " + lakefsLocation()
+		" LAKEFS_BLOCKSTORE_TYPE=" + viper.GetString("blockstore_type") +
+		" LAKEFS_AUTH_ENCRYPT_SECRET_KEY='some random secret string'" + lakefsLocation()
 
 	return lakefsCmdline
 }

--- a/esti/main_test.go
+++ b/esti/main_test.go
@@ -23,6 +23,7 @@ import (
 const (
 	DefaultAdminAccessKeyID     = "AKIAIOSFDNN7EXAMPLEQ"
 	DefaultAdminSecretAccessKey = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+	AdminUsername               = "esti"
 )
 
 type (
@@ -234,7 +235,7 @@ func TestMain(m *testing.M) {
 	}
 
 	params := testutil.SetupTestingEnvParams{
-		Name:      "esti",
+		Name:      AdminUsername,
 		StorageNS: "esti-system-testing",
 	}
 

--- a/esti/ops/docker-compose-acl.yaml
+++ b/esti/ops/docker-compose-acl.yaml
@@ -69,7 +69,7 @@ services:
       - ESTI_SETUP_LAKEFS
       - ESTI_AWS_SECRET_ACCESS_KEY
       - ESTI_ENDPOINT_URL=http://lakefs:8000
-      - ESTI_LAKECTL_DIR=/app
+      - ESTI_BINARIES_DIR=/app
       - ESTI_DATABASE_CONNECTION_STRING=postgres://lakefs:lakefs@postgres/postgres?sslmode=disable
       - ESTI_GOTEST_FLAGS
       - ESTI_FLAGS

--- a/esti/ops/docker-compose-dynamodb.yaml
+++ b/esti/ops/docker-compose-dynamodb.yaml
@@ -52,7 +52,7 @@ services:
       - ESTI_SETUP_LAKEFS
       - ESTI_AWS_SECRET_ACCESS_KEY
       - ESTI_ENDPOINT_URL=http://lakefs:8000
-      - ESTI_LAKECTL_DIR=/app
+      - ESTI_BINARIES_DIR=/app
       - ESTI_DATABASE_KV_ENABLED
       - ESTI_KV_MIGRATION=${ESTI_KV_MIGRATION:-none}
       - ESTI_POST_MIGRATE

--- a/esti/ops/docker-compose-external-db.yaml
+++ b/esti/ops/docker-compose-external-db.yaml
@@ -47,7 +47,7 @@ services:
       - ESTI_SETUP_LAKEFS
       - ESTI_AWS_SECRET_ACCESS_KEY
       - ESTI_ENDPOINT_URL=http://lakefs:8000
-      - ESTI_LAKECTL_DIR=/app
+      - ESTI_BINARIES_DIR=/app
       - ESTI_GOTEST_FLAGS
       - ESTI_FLAGS
       - ESTI_LARGE_OBJECT_PATH

--- a/esti/ops/docker-compose.yaml
+++ b/esti/ops/docker-compose.yaml
@@ -55,7 +55,7 @@ services:
       - ESTI_SETUP_LAKEFS
       - ESTI_AWS_SECRET_ACCESS_KEY
       - ESTI_ENDPOINT_URL=http://lakefs:8000
-      - ESTI_LAKECTL_DIR=/app
+      - ESTI_BINARIES_DIR=/app
       - ESTI_DATABASE_CONNECTION_STRING=postgres://lakefs:lakefs@postgres/postgres?sslmode=disable
       - ESTI_GOTEST_FLAGS
       - ESTI_FLAGS

--- a/pkg/auth/basic_service_test.go
+++ b/pkg/auth/basic_service_test.go
@@ -50,6 +50,11 @@ func TestBasicAuthService_Users(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, username, createRes)
 
+	// Check get user
+	getRes, err := s.GetUser(ctx, user.Username)
+	require.NoError(t, err)
+	require.Equal(t, user.Username, getRes.Username)
+
 	// Check it is saved under the admin key
 	_, err = store.Get(ctx, []byte(auth.BasicPartitionKey), model.UserPath(auth.SuperAdminKey))
 	require.NoError(t, err)

--- a/pkg/auth/basic_service_test.go
+++ b/pkg/auth/basic_service_test.go
@@ -1,0 +1,188 @@
+package auth_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/treeverse/lakefs/pkg/auth"
+	"github.com/treeverse/lakefs/pkg/auth/crypt"
+	"github.com/treeverse/lakefs/pkg/auth/model"
+	authparams "github.com/treeverse/lakefs/pkg/auth/params"
+	"github.com/treeverse/lakefs/pkg/kv"
+	"github.com/treeverse/lakefs/pkg/kv/kvtest"
+	"github.com/treeverse/lakefs/pkg/logging"
+	"google.golang.org/protobuf/proto"
+)
+
+var secret string = "Secret"
+
+func SetupService(t *testing.T, secret string) (*auth.BasicAuthService, kv.Store) {
+	t.Helper()
+	kvStore := kvtest.GetStore(context.Background(), t)
+	return auth.NewBasicAuthService(kvStore, crypt.NewSecretStore([]byte(secret)), authparams.ServiceCache{
+		Enabled: false,
+	}, logging.ContextUnavailable()), kvStore
+}
+
+func TestBasicAuthService_Users(t *testing.T) {
+	ctx := context.Background()
+	s, store := SetupService(t, secret)
+	username := "testUser"
+
+	// Get user not exists
+	_, err := s.GetUser(ctx, username)
+	require.ErrorIs(t, err, auth.ErrNotFound)
+
+	// List users with no users
+	listRes, _, err := s.ListUsers(ctx, nil)
+	require.NoError(t, err)
+	require.Equal(t, 0, len(listRes))
+
+	// Delete no user
+	err = s.DeleteUser(ctx, username)
+	require.ErrorIs(t, err, auth.ErrNotFound)
+
+	user := &model.User{
+		Username: username,
+	}
+	createRes, err := s.CreateUser(ctx, user)
+	require.NoError(t, err)
+	require.Equal(t, username, createRes)
+
+	// Check it is saved under the admin key
+	_, err = store.Get(ctx, []byte(auth.BasicPartitionKey), model.UserPath(auth.SuperAdminKey))
+	require.NoError(t, err)
+
+	// List users
+	listRes, _, err = s.ListUsers(ctx, nil)
+	require.NoError(t, err)
+	require.Equal(t, 1, len(listRes))
+	require.Equal(t, username, listRes[0].Username)
+
+	// Delete user
+	err = s.DeleteUser(ctx, username)
+	require.NoError(t, err)
+
+	// Check admin key is deleted
+	_, err = store.Get(ctx, []byte(auth.BasicPartitionKey), model.UserPath(auth.SuperAdminKey))
+	require.ErrorIs(t, err, auth.ErrNotFound)
+}
+
+func TestBasicAuthService_Credentials(t *testing.T) {
+	ctx := context.Background()
+	s, _ := SetupService(t, secret)
+	username := "testUser"
+	accessKeyID := "SomeAccessKeyID"
+	secretAccessKey := "SomeSecretAccessKey"
+
+	// Get credentials no user
+	_, err := s.GetCredentials(ctx, username)
+	require.ErrorIs(t, err, auth.ErrNotFound)
+
+	// Create credentials no user
+	_, err = s.CreateCredentials(ctx, username)
+	require.ErrorIs(t, err, auth.ErrNotFound)
+
+	// Add credentials no user
+	_, err = s.AddCredentials(ctx, username, accessKeyID, secretAccessKey)
+	require.ErrorIs(t, err, auth.ErrNotFound)
+
+	user := &model.User{
+		Username: username,
+	}
+	createRes, err := s.CreateUser(ctx, user)
+	require.NoError(t, err)
+	require.Equal(t, username, createRes)
+
+	// Get credentials (no creds)
+	_, err = s.GetCredentials(ctx, accessKeyID)
+	require.ErrorIs(t, err, auth.ErrNotFound)
+
+	// Create credentials for user
+	creds, err := s.CreateCredentials(ctx, username)
+	require.NoError(t, err)
+
+	// Get credentials
+	_, err = s.GetCredentials(ctx, creds.AccessKeyID)
+	require.NoError(t, err)
+
+	// Add credentials already exists
+	_, err = s.AddCredentials(ctx, username, accessKeyID, secretAccessKey)
+	require.ErrorIs(t, err, auth.ErrInvalidRequest)
+}
+
+func TestBasicAuthService_CredentialsImport(t *testing.T) {
+	ctx := context.Background()
+	s, store := SetupService(t, secret)
+	username := "testUser"
+	accessKeyID := "SomeAccessKeyID"
+	secretAccessKey := "SomeSecretAccessKey"
+
+	// Import credentials no user
+	_, err := s.AddCredentials(ctx, username, accessKeyID, "")
+	require.ErrorIs(t, err, auth.ErrNotFound)
+
+	// Create users with creds under auth
+	user := &model.UserData{
+		Username: "user-old",
+	}
+	userData, err := proto.Marshal(user)
+	require.NoError(t, err)
+	require.NoError(t, store.Set(ctx, []byte(model.PartitionKey), model.UserPath(user.Username), userData))
+	encryptedKey, err := model.EncryptSecret(s.SecretStore(), secretAccessKey)
+	require.NoError(t, err)
+	creds := &model.CredentialData{
+		AccessKeyId:                   accessKeyID,
+		SecretAccessKeyEncryptedBytes: encryptedKey,
+		UserId:                        []byte(user.Username),
+	}
+	credsData, err := proto.Marshal(creds)
+	require.NoError(t, store.Set(ctx, []byte(model.PartitionKey), model.CredentialPath(user.Username, creds.AccessKeyId), credsData))
+
+	creds.AccessKeyId = "A" + secretAccessKey
+	encryptedKey, err = model.EncryptSecret(s.SecretStore(), "BadSecret")
+	require.NoError(t, err)
+
+	creds.SecretAccessKeyEncryptedBytes = encryptedKey
+	credsData, err = proto.Marshal(creds)
+	require.NoError(t, store.Set(ctx, []byte(model.PartitionKey), model.CredentialPath(user.Username, creds.AccessKeyId), credsData))
+
+	// Create a different user
+	createRes, err := s.CreateUser(ctx, &model.User{
+		Username: username,
+	})
+	require.NoError(t, err)
+	require.Equal(t, username, createRes)
+
+	// Try to import credentials of different user
+	_, err = s.AddCredentials(ctx, username, accessKeyID, "")
+	require.ErrorIs(t, err, auth.ErrNotFound)
+
+	// Delete user and create the right one this time
+	require.NoError(t, s.DeleteUser(ctx, username))
+	_, err = s.CreateUser(ctx, &model.User{
+		Username: user.Username,
+	})
+	require.NoError(t, err)
+
+	// Import credentials not exist
+	_, err = s.AddCredentials(ctx, user.Username, "NotExisting", "")
+	require.ErrorIs(t, err, auth.ErrNotFound)
+
+	// Import credentials
+	credsResp, err := s.AddCredentials(ctx, user.Username, accessKeyID, "")
+	require.NoError(t, err)
+	require.Equal(t, accessKeyID, credsResp.AccessKeyID)
+	require.Equal(t, secretAccessKey, credsResp.SecretAccessKey)
+
+	// Import after exists
+	_, err = s.AddCredentials(ctx, user.Username, accessKeyID, "")
+	require.ErrorIs(t, err, auth.ErrInvalidRequest)
+
+	// Get credentials and verify
+	getCred, err := s.GetCredentials(ctx, accessKeyID)
+	require.NoError(t, err)
+	require.Equal(t, accessKeyID, getCred.AccessKeyID)
+	require.Equal(t, secretAccessKey, getCred.SecretAccessKey)
+}

--- a/pkg/testutil/setup.go
+++ b/pkg/testutil/setup.go
@@ -56,7 +56,7 @@ func SetupTestingEnv(params *SetupTestingEnvParams) (logging.Logger, apigen.Clie
 	}
 	viper.SetDefault("glue_export_hooks_database", "export-hooks-esti")
 	viper.SetDefault("glue_export_region", "us-east-1")
-	viper.SetDefault("lakectl_dir", filepath.Join(currDir, ".."))
+	viper.SetDefault("binaries_dir", filepath.Join(currDir, ".."))
 	viper.SetDefault("azure_storage_account", "")
 	viper.SetDefault("azure_storage_access_key", "")
 	viper.SetDefault("large_object_path", "")
@@ -78,12 +78,12 @@ func SetupTestingEnv(params *SetupTestingEnvParams) (logging.Logger, apigen.Clie
 		logger.WithError(err).Fatal("could not initialize API client")
 	}
 
-	if err := waitUntilLakeFSRunning(ctx, logger, client); err != nil {
-		logger.WithError(err).Fatal("Waiting for lakeFS")
-	}
-
 	setupLakeFS := viper.GetBool("setup_lakefs")
 	if setupLakeFS {
+		if err := waitUntilLakeFSRunning(ctx, logger, client); err != nil {
+			logger.WithError(err).Fatal("Waiting for lakeFS")
+		}
+
 		// first setup of lakeFS
 		mockEmail := "test@acme.co"
 		commResp, err := client.SetupCommPrefsWithResponse(context.Background(), apigen.SetupCommPrefsJSONRequestBody{


### PR DESCRIPTION
Closes #8083

## Change Description

Updated superuser command to handle different types of auth services + added migration flow

About this change:

We can modify this PR in 2 vectors
1. We can separate the command itself for the migration flow if needed, I believe this will just create a redundant command that will be used a single time and by a limited number of users
2. We can move the migration logic from the AddCredentials flow. But this will probably require us to create a new endpoint for this matter