### PR TITLE
lakectl: add --no-progress flag

### DIFF
--- a/cmd/lakectl/cmd/root.go
+++ b/cmd/lakectl/cmd/root.go
@@ -144,13 +144,15 @@ var (
 )
 
 const (
-	recursiveFlagName   = "recursive"
-	recursiveFlagShort  = "r"
-	presignFlagName     = "pre-sign"
-	parallelismFlagName = "parallelism"
+	recursiveFlagName     = "recursive"
+	recursiveFlagShort    = "r"
+	presignFlagName       = "pre-sign"
+	parallelismFlagName   = "parallelism"
+	noProgressBarFlagName = "no-progress"
 
 	defaultSyncParallelism = 25
 	defaultSyncPresign     = true
+	defaultNoProgress      = false
 
 	myRepoExample   = "lakefs://my-repo"
 	myBucketExample = "s3://my-bucket"
@@ -182,9 +184,15 @@ func withPresignFlag(cmd *cobra.Command) {
 		"Use pre-signed URLs when downloading/uploading data (recommended)")
 }
 
+func withNoProgress(cmd *cobra.Command) {
+	cmd.Flags().Bool(noProgressBarFlagName, defaultNoProgress,
+		"Disable progress bar animation for IO operations")
+}
+
 func withSyncFlags(cmd *cobra.Command) {
 	withParallelismFlag(cmd)
 	withPresignFlag(cmd)
+	withNoProgress(cmd)
 }
 
 type PresignMode struct {
@@ -232,6 +240,7 @@ func getSyncFlags(cmd *cobra.Command, client *apigen.ClientWithResponses) local.
 		Parallelism:      parallelism,
 		Presign:          presignMode.Enabled,
 		PresignMultipart: presignMode.Multipart,
+		NoProgress:       Must(cmd.Flags().GetBool(noProgressBarFlagName)),
 	}
 }
 

--- a/cmd/lakectl/cmd/root.go
+++ b/cmd/lakectl/cmd/root.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"golang.org/x/term"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -28,6 +27,7 @@ import (
 	"github.com/treeverse/lakefs/pkg/uri"
 	"github.com/treeverse/lakefs/pkg/version"
 	"golang.org/x/exp/slices"
+	"golang.org/x/term"
 )
 
 const (

--- a/cmd/lakectl/cmd/root.go
+++ b/cmd/lakectl/cmd/root.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"golang.org/x/term"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -229,6 +230,14 @@ func getPresignMode(cmd *cobra.Command, client *apigen.ClientWithResponses) Pres
 	return presignMode
 }
 
+func getNoProgressMode(cmd *cobra.Command) bool {
+	// Disable progress bar if stdout is not tty
+	if !term.IsTerminal(int(os.Stdout.Fd())) {
+		return true
+	}
+	return Must(cmd.Flags().GetBool(noProgressBarFlagName))
+}
+
 func getSyncFlags(cmd *cobra.Command, client *apigen.ClientWithResponses) local.SyncFlags {
 	parallelism := Must(cmd.Flags().GetInt(parallelismFlagName))
 	if parallelism < 1 {
@@ -240,7 +249,7 @@ func getSyncFlags(cmd *cobra.Command, client *apigen.ClientWithResponses) local.
 		Parallelism:      parallelism,
 		Presign:          presignMode.Enabled,
 		PresignMultipart: presignMode.Multipart,
-		NoProgress:       Must(cmd.Flags().GetBool(noProgressBarFlagName)),
+		NoProgress:       getNoProgressMode(cmd),
 	}
 }
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2156,6 +2156,7 @@ lakectl fs download <path URI> [<destination path>] [flags]
 
 ```
   -h, --help              help for download
+      --no-progress       Disable progress bar animation for IO operations
   -p, --parallelism int   Max concurrent operations to perform (default 25)
       --part-size int     part size in bytes for multipart download (default 8388608)
       --pre-sign          Use pre-signed URLs when downloading/uploading data (recommended) (default true)
@@ -2305,6 +2306,7 @@ lakectl fs upload <path URI> [flags]
 ```
       --content-type string   MIME type of contents
   -h, --help                  help for upload
+      --no-progress           Disable progress bar animation for IO operations
   -p, --parallelism int       Max concurrent operations to perform (default 25)
       --pre-sign              Use pre-signed URLs when downloading/uploading data (recommended) (default true)
   -r, --recursive             recursively copy all files under local source
@@ -2538,6 +2540,7 @@ lakectl local checkout [directory] [flags]
 ```
       --all               Checkout given source branch or reference for all linked directories
   -h, --help              help for checkout
+      --no-progress       Disable progress bar animation for IO operations
   -p, --parallelism int   Max concurrent operations to perform (default 25)
       --pre-sign          Use pre-signed URLs when downloading/uploading data (recommended) (default true)
   -r, --ref string        Checkout the given reference
@@ -2560,6 +2563,7 @@ lakectl local clone <path URI> [directory] [flags]
 ```
       --gitignore         Update .gitignore file when working in a git repository context (default true)
   -h, --help              help for clone
+      --no-progress       Disable progress bar animation for IO operations
   -p, --parallelism int   Max concurrent operations to perform (default 25)
       --pre-sign          Use pre-signed URLs when downloading/uploading data (recommended) (default true)
 ```
@@ -2583,6 +2587,7 @@ lakectl local commit [directory] [flags]
   -h, --help                  help for commit
   -m, --message string        commit message
       --meta strings          key value pair in the form of key=value
+      --no-progress           Disable progress bar animation for IO operations
   -p, --parallelism int       Max concurrent operations to perform (default 25)
       --pre-sign              Use pre-signed URLs when downloading/uploading data (recommended) (default true)
 ```
@@ -2662,6 +2667,7 @@ lakectl local pull [directory] [flags]
 ```
       --force             Reset any uncommitted local change
   -h, --help              help for pull
+      --no-progress       Disable progress bar animation for IO operations
   -p, --parallelism int   Max concurrent operations to perform (default 25)
       --pre-sign          Use pre-signed URLs when downloading/uploading data (recommended) (default true)
 ```

--- a/pkg/fileutil/fs_case.go
+++ b/pkg/fileutil/fs_case.go
@@ -24,6 +24,13 @@ func IsCaseInsensitiveLocation(fs FS, dirPath string, warnFunc func(string)) (bo
 	if err != nil {
 		return false, fmt.Errorf("generate random name: %w", err)
 	}
+	exists, err := fs.Exists(dirPath)
+	if err != nil {
+		return false, fmt.Errorf("check path exists: %w", err)
+	}
+	if !exists { // Folder can be created by the command itself - go back one dir
+		dirPath = filepath.Dir(dirPath)
+	}
 	path := filepath.Join(dirPath, caseSensitiveNamePrefix+id)
 	err = fs.Touch(path)
 	if err != nil {

--- a/pkg/local/config.go
+++ b/pkg/local/config.go
@@ -12,6 +12,7 @@ type SyncFlags struct {
 	Parallelism      int
 	Presign          bool
 	PresignMultipart bool
+	NoProgress       bool
 }
 
 type Config struct {

--- a/pkg/local/sync.go
+++ b/pkg/local/sync.go
@@ -17,6 +17,7 @@ import (
 	"time"
 
 	"github.com/go-openapi/swag"
+	"github.com/jedib0t/go-pretty/v6/progress"
 	"github.com/treeverse/lakefs/pkg/api/apigen"
 	"github.com/treeverse/lakefs/pkg/api/helpers"
 	"github.com/treeverse/lakefs/pkg/fileutil"
@@ -52,13 +53,17 @@ type SyncManager struct {
 }
 
 func NewSyncManager(ctx context.Context, client *apigen.ClientWithResponses, httpClient *http.Client, cfg Config) *SyncManager {
-	return &SyncManager{
+	sm := &SyncManager{
 		ctx:         ctx,
 		client:      client,
 		httpClient:  httpClient,
 		progressBar: NewProgressPool(),
 		cfg:         cfg,
 	}
+	if cfg.NoProgress {
+		sm.progressBar.pw.Style().Visibility = progress.StyleVisibility{}
+	}
+	return sm
 }
 
 // Sync - sync changes between remote and local directory given the Changes channel.


### PR DESCRIPTION
Closes #7732

## Change Description

Add a new flag to lakectl to disable progress bar animation.

### Background

Share context and relevant information for the PR: offline discussions, considerations, design decisions etc.

### Bug Fix

Fix check for case insensitive FS when folder has not been created yet
      
### New Feature

Default behavior was maintained, passing --no-progress bar to relevant commands will disable the progress bar animation

### Testing Details

Tested manually

### Breaking Change?

No

