### PR TITLE
Update description for `createPresignMultipartUpload` API

### DIFF
--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -4295,8 +4295,9 @@ paths:
       summary: Initiate a multipart upload
       description: |
         This operation is enabled only for the S3 blockstore.
-        Initiates a multipart upload and returns an upload ID with presigned URLs for each part (optional).
-        Part numbers begin at 1, and each part, except for the last one, must have a minimum size of 5 MB.
+        Part numbers start at 1.
+        Each part, except the last, must meet a minimum size requirement based on the underlying blockstore implementation.
+        For example, AWS S3 requires a minimum size of 5MB (excluding the last part).
       responses:
         201:
           description: Presign multipart upload initiated

--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -4343,7 +4343,9 @@ paths:
         - experimental
       operationId: completePresignMultipartUpload
       summary: Complete a presign multipart upload request
-      description: Completes a presign multipart upload by assembling the uploaded parts.
+      description: |
+        This operation is enabled only for the S3 blockstore.
+        Completes a presign multipart upload by assembling the uploaded parts.
       requestBody:
         content:
           application/json:
@@ -4378,7 +4380,9 @@ paths:
         - experimental
       operationId: abortPresignMultipartUpload
       summary: Abort a presign multipart upload
-      description: Aborts a presign multipart upload.
+      description: |
+        This operation is enabled only for the S3 blockstore.
+        Aborts a presign multipart upload.
       requestBody:
         content:
           application/json:

--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -4294,9 +4294,9 @@ paths:
       operationId: createPresignMultipartUpload
       summary: Initiate a multipart upload
       description: |
+        This operation is enabled only for the S3 blockstore.
         Initiates a multipart upload and returns an upload ID with presigned URLs for each part (optional).
-        Part numbers starts with 1. Each part except the last one has minimum size depends on the underlying blockstore implementation.
-        For example working with S3 blockstore, minimum size is 5MB (excluding the last part).
+        Part numbers begin at 1, and each part, except for the last one, must have a minimum size of 5 MB.
       responses:
         201:
           description: Presign multipart upload initiated

--- a/clients/java-legacy/api/openapi.yaml
+++ b/clients/java-legacy/api/openapi.yaml
@@ -4520,9 +4520,10 @@ paths:
   /repositories/{repository}/branches/{branch}/staging/pmpu:
     post:
       description: |
-        Initiates a multipart upload and returns an upload ID with presigned URLs for each part (optional).
-        Part numbers starts with 1. Each part except the last one has minimum size depends on the underlying blockstore implementation.
-        For example working with S3 blockstore, minimum size is 5MB (excluding the last part).
+        This operation is enabled only for the S3 blockstore.
+        Part numbers start at 1.
+        Each part, except the last, must meet a minimum size requirement based on the underlying blockstore implementation.
+        For example, AWS S3 requires a minimum size of 5MB (excluding the last part).
       operationId: createPresignMultipartUpload
       parameters:
       - explode: false
@@ -4594,7 +4595,9 @@ paths:
       x-accepts: application/json
   /repositories/{repository}/branches/{branch}/staging/pmpu/{uploadId}:
     delete:
-      description: Aborts a presign multipart upload.
+      description: |
+        This operation is enabled only for the S3 blockstore.
+        Aborts a presign multipart upload.
       operationId: abortPresignMultipartUpload
       parameters:
       - explode: false
@@ -4666,8 +4669,9 @@ paths:
       x-contentType: application/json
       x-accepts: application/json
     put:
-      description: Completes a presign multipart upload by assembling the uploaded
-        parts.
+      description: |
+        This operation is enabled only for the S3 blockstore.
+        Completes a presign multipart upload by assembling the uploaded parts.
       operationId: completePresignMultipartUpload
       parameters:
       - explode: false

--- a/clients/java-legacy/docs/ExperimentalApi.md
+++ b/clients/java-legacy/docs/ExperimentalApi.md
@@ -22,7 +22,7 @@ Method | HTTP request | Description
 
 Abort a presign multipart upload
 
-Aborts a presign multipart upload.
+This operation is enabled only for the S3 blockstore. Aborts a presign multipart upload. 
 
 ### Example
 ```java
@@ -124,7 +124,7 @@ null (empty response body)
 
 Complete a presign multipart upload request
 
-Completes a presign multipart upload by assembling the uploaded parts.
+This operation is enabled only for the S3 blockstore. Completes a presign multipart upload by assembling the uploaded parts. 
 
 ### Example
 ```java
@@ -228,7 +228,7 @@ Name | Type | Description  | Notes
 
 Initiate a multipart upload
 
-Initiates a multipart upload and returns an upload ID with presigned URLs for each part (optional). Part numbers starts with 1. Each part except the last one has minimum size depends on the underlying blockstore implementation. For example working with S3 blockstore, minimum size is 5MB (excluding the last part). 
+This operation is enabled only for the S3 blockstore. Part numbers start at 1. Each part, except the last, must meet a minimum size requirement based on the underlying blockstore implementation. For example, AWS S3 requires a minimum size of 5MB (excluding the last part). 
 
 ### Example
 ```java

--- a/clients/java-legacy/src/main/java/io/lakefs/clients/api/ExperimentalApi.java
+++ b/clients/java-legacy/src/main/java/io/lakefs/clients/api/ExperimentalApi.java
@@ -154,7 +154,7 @@ public class ExperimentalApi {
 
     /**
      * Abort a presign multipart upload
-     * Aborts a presign multipart upload.
+     * This operation is enabled only for the S3 blockstore. Aborts a presign multipart upload. 
      * @param repository  (required)
      * @param branch  (required)
      * @param uploadId  (required)
@@ -178,7 +178,7 @@ public class ExperimentalApi {
 
     /**
      * Abort a presign multipart upload
-     * Aborts a presign multipart upload.
+     * This operation is enabled only for the S3 blockstore. Aborts a presign multipart upload. 
      * @param repository  (required)
      * @param branch  (required)
      * @param uploadId  (required)
@@ -204,7 +204,7 @@ public class ExperimentalApi {
 
     /**
      * Abort a presign multipart upload (asynchronously)
-     * Aborts a presign multipart upload.
+     * This operation is enabled only for the S3 blockstore. Aborts a presign multipart upload. 
      * @param repository  (required)
      * @param branch  (required)
      * @param uploadId  (required)
@@ -320,7 +320,7 @@ public class ExperimentalApi {
 
     /**
      * Complete a presign multipart upload request
-     * Completes a presign multipart upload by assembling the uploaded parts.
+     * This operation is enabled only for the S3 blockstore. Completes a presign multipart upload by assembling the uploaded parts. 
      * @param repository  (required)
      * @param branch  (required)
      * @param uploadId  (required)
@@ -347,7 +347,7 @@ public class ExperimentalApi {
 
     /**
      * Complete a presign multipart upload request
-     * Completes a presign multipart upload by assembling the uploaded parts.
+     * This operation is enabled only for the S3 blockstore. Completes a presign multipart upload by assembling the uploaded parts. 
      * @param repository  (required)
      * @param branch  (required)
      * @param uploadId  (required)
@@ -375,7 +375,7 @@ public class ExperimentalApi {
 
     /**
      * Complete a presign multipart upload request (asynchronously)
-     * Completes a presign multipart upload by assembling the uploaded parts.
+     * This operation is enabled only for the S3 blockstore. Completes a presign multipart upload by assembling the uploaded parts. 
      * @param repository  (required)
      * @param branch  (required)
      * @param uploadId  (required)
@@ -489,7 +489,7 @@ public class ExperimentalApi {
 
     /**
      * Initiate a multipart upload
-     * Initiates a multipart upload and returns an upload ID with presigned URLs for each part (optional). Part numbers starts with 1. Each part except the last one has minimum size depends on the underlying blockstore implementation. For example working with S3 blockstore, minimum size is 5MB (excluding the last part). 
+     * This operation is enabled only for the S3 blockstore. Part numbers start at 1. Each part, except the last, must meet a minimum size requirement based on the underlying blockstore implementation. For example, AWS S3 requires a minimum size of 5MB (excluding the last part). 
      * @param repository  (required)
      * @param branch  (required)
      * @param path relative to the branch (required)
@@ -514,7 +514,7 @@ public class ExperimentalApi {
 
     /**
      * Initiate a multipart upload
-     * Initiates a multipart upload and returns an upload ID with presigned URLs for each part (optional). Part numbers starts with 1. Each part except the last one has minimum size depends on the underlying blockstore implementation. For example working with S3 blockstore, minimum size is 5MB (excluding the last part). 
+     * This operation is enabled only for the S3 blockstore. Part numbers start at 1. Each part, except the last, must meet a minimum size requirement based on the underlying blockstore implementation. For example, AWS S3 requires a minimum size of 5MB (excluding the last part). 
      * @param repository  (required)
      * @param branch  (required)
      * @param path relative to the branch (required)
@@ -540,7 +540,7 @@ public class ExperimentalApi {
 
     /**
      * Initiate a multipart upload (asynchronously)
-     * Initiates a multipart upload and returns an upload ID with presigned URLs for each part (optional). Part numbers starts with 1. Each part except the last one has minimum size depends on the underlying blockstore implementation. For example working with S3 blockstore, minimum size is 5MB (excluding the last part). 
+     * This operation is enabled only for the S3 blockstore. Part numbers start at 1. Each part, except the last, must meet a minimum size requirement based on the underlying blockstore implementation. For example, AWS S3 requires a minimum size of 5MB (excluding the last part). 
      * @param repository  (required)
      * @param branch  (required)
      * @param path relative to the branch (required)

--- a/clients/java-legacy/src/test/java/io/lakefs/clients/api/ExperimentalApiTest.java
+++ b/clients/java-legacy/src/test/java/io/lakefs/clients/api/ExperimentalApiTest.java
@@ -46,7 +46,7 @@ public class ExperimentalApiTest {
     /**
      * Abort a presign multipart upload
      *
-     * Aborts a presign multipart upload.
+     * This operation is enabled only for the S3 blockstore. Aborts a presign multipart upload. 
      *
      * @throws ApiException
      *          if the Api call fails
@@ -65,7 +65,7 @@ public class ExperimentalApiTest {
     /**
      * Complete a presign multipart upload request
      *
-     * Completes a presign multipart upload by assembling the uploaded parts.
+     * This operation is enabled only for the S3 blockstore. Completes a presign multipart upload by assembling the uploaded parts. 
      *
      * @throws ApiException
      *          if the Api call fails
@@ -84,7 +84,7 @@ public class ExperimentalApiTest {
     /**
      * Initiate a multipart upload
      *
-     * Initiates a multipart upload and returns an upload ID with presigned URLs for each part (optional). Part numbers starts with 1. Each part except the last one has minimum size depends on the underlying blockstore implementation. For example working with S3 blockstore, minimum size is 5MB (excluding the last part). 
+     * This operation is enabled only for the S3 blockstore. Part numbers start at 1. Each part, except the last, must meet a minimum size requirement based on the underlying blockstore implementation. For example, AWS S3 requires a minimum size of 5MB (excluding the last part). 
      *
      * @throws ApiException
      *          if the Api call fails

--- a/clients/java/api/openapi.yaml
+++ b/clients/java/api/openapi.yaml
@@ -4520,9 +4520,10 @@ paths:
   /repositories/{repository}/branches/{branch}/staging/pmpu:
     post:
       description: |
-        Initiates a multipart upload and returns an upload ID with presigned URLs for each part (optional).
-        Part numbers starts with 1. Each part except the last one has minimum size depends on the underlying blockstore implementation.
-        For example working with S3 blockstore, minimum size is 5MB (excluding the last part).
+        This operation is enabled only for the S3 blockstore.
+        Part numbers start at 1.
+        Each part, except the last, must meet a minimum size requirement based on the underlying blockstore implementation.
+        For example, AWS S3 requires a minimum size of 5MB (excluding the last part).
       operationId: createPresignMultipartUpload
       parameters:
       - explode: false
@@ -4594,7 +4595,9 @@ paths:
       x-accepts: application/json
   /repositories/{repository}/branches/{branch}/staging/pmpu/{uploadId}:
     delete:
-      description: Aborts a presign multipart upload.
+      description: |
+        This operation is enabled only for the S3 blockstore.
+        Aborts a presign multipart upload.
       operationId: abortPresignMultipartUpload
       parameters:
       - explode: false
@@ -4666,8 +4669,9 @@ paths:
       x-content-type: application/json
       x-accepts: application/json
     put:
-      description: Completes a presign multipart upload by assembling the uploaded
-        parts.
+      description: |
+        This operation is enabled only for the S3 blockstore.
+        Completes a presign multipart upload by assembling the uploaded parts.
       operationId: completePresignMultipartUpload
       parameters:
       - explode: false

--- a/clients/java/docs/ExperimentalApi.md
+++ b/clients/java/docs/ExperimentalApi.md
@@ -22,7 +22,7 @@ All URIs are relative to */api/v1*
 
 Abort a presign multipart upload
 
-Aborts a presign multipart upload.
+This operation is enabled only for the S3 blockstore. Aborts a presign multipart upload. 
 
 ### Example
 ```java
@@ -126,7 +126,7 @@ null (empty response body)
 
 Complete a presign multipart upload request
 
-Completes a presign multipart upload by assembling the uploaded parts.
+This operation is enabled only for the S3 blockstore. Completes a presign multipart upload by assembling the uploaded parts. 
 
 ### Example
 ```java
@@ -232,7 +232,7 @@ public class Example {
 
 Initiate a multipart upload
 
-Initiates a multipart upload and returns an upload ID with presigned URLs for each part (optional). Part numbers starts with 1. Each part except the last one has minimum size depends on the underlying blockstore implementation. For example working with S3 blockstore, minimum size is 5MB (excluding the last part). 
+This operation is enabled only for the S3 blockstore. Part numbers start at 1. Each part, except the last, must meet a minimum size requirement based on the underlying blockstore implementation. For example, AWS S3 requires a minimum size of 5MB (excluding the last part). 
 
 ### Example
 ```java

--- a/clients/java/src/main/java/io/lakefs/clients/sdk/ExperimentalApi.java
+++ b/clients/java/src/main/java/io/lakefs/clients/sdk/ExperimentalApi.java
@@ -278,7 +278,7 @@ public class ExperimentalApi {
 
     /**
      * Abort a presign multipart upload
-     * Aborts a presign multipart upload.
+     * This operation is enabled only for the S3 blockstore. Aborts a presign multipart upload. 
      * @param repository  (required)
      * @param branch  (required)
      * @param uploadId  (required)
@@ -501,7 +501,7 @@ public class ExperimentalApi {
 
     /**
      * Complete a presign multipart upload request
-     * Completes a presign multipart upload by assembling the uploaded parts.
+     * This operation is enabled only for the S3 blockstore. Completes a presign multipart upload by assembling the uploaded parts. 
      * @param repository  (required)
      * @param branch  (required)
      * @param uploadId  (required)
@@ -716,7 +716,7 @@ public class ExperimentalApi {
 
     /**
      * Initiate a multipart upload
-     * Initiates a multipart upload and returns an upload ID with presigned URLs for each part (optional). Part numbers starts with 1. Each part except the last one has minimum size depends on the underlying blockstore implementation. For example working with S3 blockstore, minimum size is 5MB (excluding the last part). 
+     * This operation is enabled only for the S3 blockstore. Part numbers start at 1. Each part, except the last, must meet a minimum size requirement based on the underlying blockstore implementation. For example, AWS S3 requires a minimum size of 5MB (excluding the last part). 
      * @param repository  (required)
      * @param branch  (required)
      * @param path relative to the branch (required)

--- a/clients/java/src/test/java/io/lakefs/clients/sdk/ExperimentalApiTest.java
+++ b/clients/java/src/test/java/io/lakefs/clients/sdk/ExperimentalApiTest.java
@@ -45,7 +45,7 @@ public class ExperimentalApiTest {
     /**
      * Abort a presign multipart upload
      *
-     * Aborts a presign multipart upload.
+     * This operation is enabled only for the S3 blockstore. Aborts a presign multipart upload. 
      *
      * @throws ApiException if the Api call fails
      */
@@ -65,7 +65,7 @@ public class ExperimentalApiTest {
     /**
      * Complete a presign multipart upload request
      *
-     * Completes a presign multipart upload by assembling the uploaded parts.
+     * This operation is enabled only for the S3 blockstore. Completes a presign multipart upload by assembling the uploaded parts. 
      *
      * @throws ApiException if the Api call fails
      */
@@ -85,7 +85,7 @@ public class ExperimentalApiTest {
     /**
      * Initiate a multipart upload
      *
-     * Initiates a multipart upload and returns an upload ID with presigned URLs for each part (optional). Part numbers starts with 1. Each part except the last one has minimum size depends on the underlying blockstore implementation. For example working with S3 blockstore, minimum size is 5MB (excluding the last part). 
+     * This operation is enabled only for the S3 blockstore. Part numbers start at 1. Each part, except the last, must meet a minimum size requirement based on the underlying blockstore implementation. For example, AWS S3 requires a minimum size of 5MB (excluding the last part). 
      *
      * @throws ApiException if the Api call fails
      */

--- a/clients/python-legacy/docs/ExperimentalApi.md
+++ b/clients/python-legacy/docs/ExperimentalApi.md
@@ -21,7 +21,7 @@ Method | HTTP request | Description
 
 Abort a presign multipart upload
 
-Aborts a presign multipart upload.
+This operation is enabled only for the S3 blockstore. Aborts a presign multipart upload. 
 
 ### Example
 
@@ -149,7 +149,7 @@ void (empty response body)
 
 Complete a presign multipart upload request
 
-Completes a presign multipart upload by assembling the uploaded parts.
+This operation is enabled only for the S3 blockstore. Completes a presign multipart upload by assembling the uploaded parts. 
 
 ### Example
 
@@ -292,7 +292,7 @@ Name | Type | Description  | Notes
 
 Initiate a multipart upload
 
-Initiates a multipart upload and returns an upload ID with presigned URLs for each part (optional). Part numbers starts with 1. Each part except the last one has minimum size depends on the underlying blockstore implementation. For example working with S3 blockstore, minimum size is 5MB (excluding the last part). 
+This operation is enabled only for the S3 blockstore. Part numbers start at 1. Each part, except the last, must meet a minimum size requirement based on the underlying blockstore implementation. For example, AWS S3 requires a minimum size of 5MB (excluding the last part). 
 
 ### Example
 

--- a/clients/python-legacy/lakefs_client/api/experimental_api.py
+++ b/clients/python-legacy/lakefs_client/api/experimental_api.py
@@ -717,7 +717,7 @@ class ExperimentalApi(object):
     ):
         """Abort a presign multipart upload  # noqa: E501
 
-        Aborts a presign multipart upload.  # noqa: E501
+        This operation is enabled only for the S3 blockstore. Aborts a presign multipart upload.   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
@@ -796,7 +796,7 @@ class ExperimentalApi(object):
     ):
         """Complete a presign multipart upload request  # noqa: E501
 
-        Completes a presign multipart upload by assembling the uploaded parts.  # noqa: E501
+        This operation is enabled only for the S3 blockstore. Completes a presign multipart upload by assembling the uploaded parts.   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
@@ -874,7 +874,7 @@ class ExperimentalApi(object):
     ):
         """Initiate a multipart upload  # noqa: E501
 
-        Initiates a multipart upload and returns an upload ID with presigned URLs for each part (optional). Part numbers starts with 1. Each part except the last one has minimum size depends on the underlying blockstore implementation. For example working with S3 blockstore, minimum size is 5MB (excluding the last part).   # noqa: E501
+        This operation is enabled only for the S3 blockstore. Part numbers start at 1. Each part, except the last, must meet a minimum size requirement based on the underlying blockstore implementation. For example, AWS S3 requires a minimum size of 5MB (excluding the last part).   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 

--- a/clients/python/docs/ExperimentalApi.md
+++ b/clients/python/docs/ExperimentalApi.md
@@ -21,7 +21,7 @@ Method | HTTP request | Description
 
 Abort a presign multipart upload
 
-Aborts a presign multipart upload.
+This operation is enabled only for the S3 blockstore. Aborts a presign multipart upload. 
 
 ### Example
 
@@ -140,7 +140,7 @@ void (empty response body)
 
 Complete a presign multipart upload request
 
-Completes a presign multipart upload by assembling the uploaded parts.
+This operation is enabled only for the S3 blockstore. Completes a presign multipart upload by assembling the uploaded parts. 
 
 ### Example
 
@@ -263,7 +263,7 @@ Name | Type | Description  | Notes
 
 Initiate a multipart upload
 
-Initiates a multipart upload and returns an upload ID with presigned URLs for each part (optional). Part numbers starts with 1. Each part except the last one has minimum size depends on the underlying blockstore implementation. For example working with S3 blockstore, minimum size is 5MB (excluding the last part). 
+This operation is enabled only for the S3 blockstore. Part numbers start at 1. Each part, except the last, must meet a minimum size requirement based on the underlying blockstore implementation. For example, AWS S3 requires a minimum size of 5MB (excluding the last part). 
 
 ### Example
 

--- a/clients/python/lakefs_sdk/api/experimental_api.py
+++ b/clients/python/lakefs_sdk/api/experimental_api.py
@@ -65,7 +65,7 @@ class ExperimentalApi(object):
     def abort_presign_multipart_upload(self, repository : StrictStr, branch : StrictStr, upload_id : StrictStr, path : Annotated[StrictStr, Field(..., description="relative to the branch")], abort_presign_multipart_upload : Optional[AbortPresignMultipartUpload] = None, **kwargs) -> None:  # noqa: E501
         """Abort a presign multipart upload  # noqa: E501
 
-        Aborts a presign multipart upload.  # noqa: E501
+        This operation is enabled only for the S3 blockstore. Aborts a presign multipart upload.   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
@@ -102,7 +102,7 @@ class ExperimentalApi(object):
     def abort_presign_multipart_upload_with_http_info(self, repository : StrictStr, branch : StrictStr, upload_id : StrictStr, path : Annotated[StrictStr, Field(..., description="relative to the branch")], abort_presign_multipart_upload : Optional[AbortPresignMultipartUpload] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """Abort a presign multipart upload  # noqa: E501
 
-        Aborts a presign multipart upload.  # noqa: E501
+        This operation is enabled only for the S3 blockstore. Aborts a presign multipart upload.   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
@@ -241,7 +241,7 @@ class ExperimentalApi(object):
     def complete_presign_multipart_upload(self, repository : StrictStr, branch : StrictStr, upload_id : StrictStr, path : Annotated[StrictStr, Field(..., description="relative to the branch")], complete_presign_multipart_upload : Optional[CompletePresignMultipartUpload] = None, **kwargs) -> ObjectStats:  # noqa: E501
         """Complete a presign multipart upload request  # noqa: E501
 
-        Completes a presign multipart upload by assembling the uploaded parts.  # noqa: E501
+        This operation is enabled only for the S3 blockstore. Completes a presign multipart upload by assembling the uploaded parts.   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
@@ -278,7 +278,7 @@ class ExperimentalApi(object):
     def complete_presign_multipart_upload_with_http_info(self, repository : StrictStr, branch : StrictStr, upload_id : StrictStr, path : Annotated[StrictStr, Field(..., description="relative to the branch")], complete_presign_multipart_upload : Optional[CompletePresignMultipartUpload] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """Complete a presign multipart upload request  # noqa: E501
 
-        Completes a presign multipart upload by assembling the uploaded parts.  # noqa: E501
+        This operation is enabled only for the S3 blockstore. Completes a presign multipart upload by assembling the uploaded parts.   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
@@ -424,7 +424,7 @@ class ExperimentalApi(object):
     def create_presign_multipart_upload(self, repository : StrictStr, branch : StrictStr, path : Annotated[StrictStr, Field(..., description="relative to the branch")], parts : Annotated[Optional[StrictInt], Field(description="number of presigned URL parts required to upload")] = None, **kwargs) -> PresignMultipartUpload:  # noqa: E501
         """Initiate a multipart upload  # noqa: E501
 
-        Initiates a multipart upload and returns an upload ID with presigned URLs for each part (optional). Part numbers starts with 1. Each part except the last one has minimum size depends on the underlying blockstore implementation. For example working with S3 blockstore, minimum size is 5MB (excluding the last part).   # noqa: E501
+        This operation is enabled only for the S3 blockstore. Part numbers start at 1. Each part, except the last, must meet a minimum size requirement based on the underlying blockstore implementation. For example, AWS S3 requires a minimum size of 5MB (excluding the last part).   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
@@ -459,7 +459,7 @@ class ExperimentalApi(object):
     def create_presign_multipart_upload_with_http_info(self, repository : StrictStr, branch : StrictStr, path : Annotated[StrictStr, Field(..., description="relative to the branch")], parts : Annotated[Optional[StrictInt], Field(description="number of presigned URL parts required to upload")] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """Initiate a multipart upload  # noqa: E501
 
-        Initiates a multipart upload and returns an upload ID with presigned URLs for each part (optional). Part numbers starts with 1. Each part except the last one has minimum size depends on the underlying blockstore implementation. For example working with S3 blockstore, minimum size is 5MB (excluding the last part).   # noqa: E501
+        This operation is enabled only for the S3 blockstore. Part numbers start at 1. Each part, except the last, must meet a minimum size requirement based on the underlying blockstore implementation. For example, AWS S3 requires a minimum size of 5MB (excluding the last part).   # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 

--- a/clients/rust/docs/ExperimentalApi.md
+++ b/clients/rust/docs/ExperimentalApi.md
@@ -22,7 +22,7 @@ Method | HTTP request | Description
 > abort_presign_multipart_upload(repository, branch, upload_id, path, abort_presign_multipart_upload)
 Abort a presign multipart upload
 
-Aborts a presign multipart upload.
+This operation is enabled only for the S3 blockstore. Aborts a presign multipart upload. 
 
 ### Parameters
 
@@ -56,7 +56,7 @@ Name | Type | Description  | Required | Notes
 > models::ObjectStats complete_presign_multipart_upload(repository, branch, upload_id, path, complete_presign_multipart_upload)
 Complete a presign multipart upload request
 
-Completes a presign multipart upload by assembling the uploaded parts.
+This operation is enabled only for the S3 blockstore. Completes a presign multipart upload by assembling the uploaded parts. 
 
 ### Parameters
 
@@ -90,7 +90,7 @@ Name | Type | Description  | Required | Notes
 > models::PresignMultipartUpload create_presign_multipart_upload(repository, branch, path, parts)
 Initiate a multipart upload
 
-Initiates a multipart upload and returns an upload ID with presigned URLs for each part (optional). Part numbers starts with 1. Each part except the last one has minimum size depends on the underlying blockstore implementation. For example working with S3 blockstore, minimum size is 5MB (excluding the last part). 
+This operation is enabled only for the S3 blockstore. Part numbers start at 1. Each part, except the last, must meet a minimum size requirement based on the underlying blockstore implementation. For example, AWS S3 requires a minimum size of 5MB (excluding the last part). 
 
 ### Parameters
 

--- a/clients/rust/src/apis/experimental_api.rs
+++ b/clients/rust/src/apis/experimental_api.rs
@@ -134,7 +134,7 @@ pub enum StsLoginError {
 }
 
 
-/// Aborts a presign multipart upload.
+/// This operation is enabled only for the S3 blockstore. Aborts a presign multipart upload. 
 pub async fn abort_presign_multipart_upload(configuration: &configuration::Configuration, repository: &str, branch: &str, upload_id: &str, path: &str, abort_presign_multipart_upload: Option<models::AbortPresignMultipartUpload>) -> Result<(), Error<AbortPresignMultipartUploadError>> {
     let local_var_configuration = configuration;
 
@@ -170,7 +170,7 @@ pub async fn abort_presign_multipart_upload(configuration: &configuration::Confi
     }
 }
 
-/// Completes a presign multipart upload by assembling the uploaded parts.
+/// This operation is enabled only for the S3 blockstore. Completes a presign multipart upload by assembling the uploaded parts. 
 pub async fn complete_presign_multipart_upload(configuration: &configuration::Configuration, repository: &str, branch: &str, upload_id: &str, path: &str, complete_presign_multipart_upload: Option<models::CompletePresignMultipartUpload>) -> Result<models::ObjectStats, Error<CompletePresignMultipartUploadError>> {
     let local_var_configuration = configuration;
 
@@ -206,7 +206,7 @@ pub async fn complete_presign_multipart_upload(configuration: &configuration::Co
     }
 }
 
-/// Initiates a multipart upload and returns an upload ID with presigned URLs for each part (optional). Part numbers starts with 1. Each part except the last one has minimum size depends on the underlying blockstore implementation. For example working with S3 blockstore, minimum size is 5MB (excluding the last part). 
+/// This operation is enabled only for the S3 blockstore. Part numbers start at 1. Each part, except the last, must meet a minimum size requirement based on the underlying blockstore implementation. For example, AWS S3 requires a minimum size of 5MB (excluding the last part). 
 pub async fn create_presign_multipart_upload(configuration: &configuration::Configuration, repository: &str, branch: &str, path: &str, parts: Option<i32>) -> Result<models::PresignMultipartUpload, Error<CreatePresignMultipartUploadError>> {
     let local_var_configuration = configuration;
 

--- a/docs/assets/js/swagger.yml
+++ b/docs/assets/js/swagger.yml
@@ -4294,9 +4294,9 @@ paths:
       operationId: createPresignMultipartUpload
       summary: Initiate a multipart upload
       description: |
+        This operation is enabled only for the S3 blockstore.
         Initiates a multipart upload and returns an upload ID with presigned URLs for each part (optional).
-        Part numbers starts with 1. Each part except the last one has minimum size depends on the underlying blockstore implementation.
-        For example working with S3 blockstore, minimum size is 5MB (excluding the last part).
+        Part numbers begin at 1, and each part, except for the last one, must have a minimum size of 5 MB.
       responses:
         201:
           description: Presign multipart upload initiated
@@ -4343,7 +4343,9 @@ paths:
         - experimental
       operationId: completePresignMultipartUpload
       summary: Complete a presign multipart upload request
-      description: Completes a presign multipart upload by assembling the uploaded parts.
+      description: |
+        This operation is enabled only for the S3 blockstore.
+        Completes a presign multipart upload by assembling the uploaded parts.
       requestBody:
         content:
           application/json:
@@ -4378,7 +4380,9 @@ paths:
         - experimental
       operationId: abortPresignMultipartUpload
       summary: Abort a presign multipart upload
-      description: Aborts a presign multipart upload.
+      description: |
+        This operation is enabled only for the S3 blockstore.
+        Aborts a presign multipart upload.
       requestBody:
         content:
           application/json:

--- a/docs/assets/js/swagger.yml
+++ b/docs/assets/js/swagger.yml
@@ -4295,8 +4295,9 @@ paths:
       summary: Initiate a multipart upload
       description: |
         This operation is enabled only for the S3 blockstore.
-        Initiates a multipart upload and returns an upload ID with presigned URLs for each part (optional).
-        Part numbers begin at 1, and each part, except for the last one, must have a minimum size of 5 MB.
+        Part numbers start at 1.
+        Each part, except the last, must meet a minimum size requirement based on the underlying blockstore implementation.
+        For example, AWS S3 requires a minimum size of 5MB (excluding the last part).
       responses:
         201:
           description: Presign multipart upload initiated


### PR DESCRIPTION
Closes #8103

## Change Description
As stated in the issue, this operation is only relevant to S3.
This PR changes the description of this operation to reflect that fact.