### PR TITLE
webui: add support for jsonl/ndjson file diffing as text files

### DIFF
--- a/webui/src/lib/components/repository/ObjectsDiff.jsx
+++ b/webui/src/lib/components/repository/ObjectsDiff.jsx
@@ -9,7 +9,7 @@ import {InfoIcon} from "@primer/octicons-react";
 import {useStorageConfig} from "../../hooks/storageConfig";
 
 const maxDiffSizeBytes = 120 << 10;
-const supportedReadableFormats = ["txt", "text", "csv", "tsv", "yaml", "yml", "json"];
+const supportedReadableFormats = ["txt", "text", "csv", "tsv", "yaml", "yml", "json", "jsonl", "ndjson"];
 
 export const ObjectsDiff = ({diffType, repoId, leftRef, rightRef, path}) => {
     const config = useStorageConfig();

--- a/webui/src/pages/repositories/repository/fileRenderers/index.tsx
+++ b/webui/src/pages/repositories/repository/fileRenderers/index.tsx
@@ -141,6 +141,8 @@ export function guessType(contentType: string | null, fileExtension: string | nu
         case 'yaml':
         case 'yml':
         case 'json':
+        case 'jsonl':
+        case 'ndjson':
             return FileType.TEXT
     }
     if (guessLanguage(fileExtension, contentType))


### PR DESCRIPTION
## Change Description
Closes https://github.com/treeverse/lakeFS/issues/8094

This change follows the approach taken for other similar formats, allowing newline-delimited JSON files to be viewed and diffed in the LakeFS UI.

### Background

Share context and relevant information for the PR: offline discussions, considerations, design decisions etc.

newline-delimited JSON is a useful format for human-readable representation of data. The goal of this change is to allow is to be viewed and diffed in the LakeFS UI.

First discussed in Slack here: https://lakefs.slack.com/archives/C016726JLJW/p1724354587851009

### New Feature

If this PR introduces a new feature, describe it here.

### Testing Details

How were the changes tested?

I ran `make build-docker` locally along with:

```
docker run --rm \
  --name lakefs \
  -e LAKEFS_DATABASE_TYPE="local" \
  -e LAKEFS_AUTH_ENCRYPT_SECRET_KEY="abc123" \
  -e LAKEFS_BLOCKSTORE_TYPE="local" \
  -p 8000:8000 \
  treeverse/lakefs:dev run
```

Then uploaded a basic JSONL file to a repo, as well as a modified version of it that adds a lineL

<img width="1358" alt="Screenshot 2024-09-06 at 18 26 03" src="https://github.com/user-attachments/assets/80bccb9c-e334-491e-86ab-065e21f74e1b">


### Breaking Change?

Does this change break any existing functionality? (API, CLI, Clients)

Nope!

## Additional info

Logs, outputs, screenshots of changes if applicable (CLI / GUI changes)

lmk if relevant.

### Contact Details

How can we get in touch with you if we need more info? (ex. email@example.com)

Happy to respond in this issue or the Slack thread!