### PR TITLE
lakectl log: add option to filter merge commits

### DIFF
--- a/cmd/lakectl/cmd/common_helpers.go
+++ b/cmd/lakectl/cmd/common_helpers.go
@@ -40,6 +40,7 @@ const (
 const (
 	internalPageSize           = 1000 // when retrieving all records, use this page size under the hood
 	defaultAmountArgumentValue = 100  // when no amount is specified, use this value for the argument
+	maxAmountNoMerges          = 333  // when using --no-merges & amount, this const is the upper limit use huristic
 
 	defaultPollInterval = 3 * time.Second // default interval while pulling tasks status
 	minimumPollInterval = time.Second     // minimum interval while pulling tasks status

--- a/cmd/lakectl/cmd/common_helpers.go
+++ b/cmd/lakectl/cmd/common_helpers.go
@@ -41,9 +41,10 @@ const (
 	internalPageSize           = 1000 // when retrieving all records, use this page size under the hood
 	defaultAmountArgumentValue = 100  // when no amount is specified, use this value for the argument
 
-	// when using --no-merges & amount, this const is the upper limit to use huristic.
+	// when using --no-merges & amount, this const is the upper limit to use heuristic.
 	// The heuristic asks for 3*amount results since some will filter out
 	maxAmountNoMerges = 333
+	noMergesHeuristic = 3
 
 	defaultPollInterval = 3 * time.Second // default interval while pulling tasks status
 	minimumPollInterval = time.Second     // minimum interval while pulling tasks status

--- a/cmd/lakectl/cmd/common_helpers.go
+++ b/cmd/lakectl/cmd/common_helpers.go
@@ -40,7 +40,10 @@ const (
 const (
 	internalPageSize           = 1000 // when retrieving all records, use this page size under the hood
 	defaultAmountArgumentValue = 100  // when no amount is specified, use this value for the argument
-	maxAmountNoMerges          = 333  // when using --no-merges & amount, this const is the upper limit use huristic
+
+	// when using --no-merges & amount, this const is the upper limit to use huristic.
+	// The heuristic asks for 3*amount results since some will filter out
+	maxAmountNoMerges = 333
 
 	defaultPollInterval = 3 * time.Second // default interval while pulling tasks status
 	minimumPollInterval = time.Second     // minimum interval while pulling tasks status

--- a/cmd/lakectl/cmd/log.go
+++ b/cmd/lakectl/cmd/log.go
@@ -116,7 +116,7 @@ var logCmd = &cobra.Command{
 		}
 		// case --no-merges & --amount, ask for more results since some will filter out
 		if noMerges && amountForPagination < maxAmountNoMerges {
-			amountForPagination *= 3
+			amountForPagination *= noMergesHeuristic
 		}
 		logCommitsParams := &apigen.LogCommitsParams{
 			After:       apiutil.Ptr(apigen.PaginationAfter(after)),
@@ -172,8 +172,8 @@ var logCmd = &cobra.Command{
 			// case --no-merges, filter commits and subtract that amount from amount desired
 			if noMerges {
 				data.Commits = filterMergeCommits(data.Commits)
-				amount -= len(data.Commits)
 			}
+			amount -= len(data.Commits)
 
 			if dot {
 				graph.Write(data.Commits)

--- a/cmd/lakectl/cmd/log.go
+++ b/cmd/lakectl/cmd/log.go
@@ -172,6 +172,7 @@ var logCmd = &cobra.Command{
 			// case --no-merges, filter commits and subtract that amount from amount desired
 			if noMerges {
 				data.Commits = filterMergeCommits(data.Commits)
+				data.Commits = data.Commits[:amount]
 			}
 			amount -= len(data.Commits)
 

--- a/cmd/lakectl/cmd/log.go
+++ b/cmd/lakectl/cmd/log.go
@@ -172,7 +172,7 @@ var logCmd = &cobra.Command{
 			// case --no-merges, filter commits and subtract that amount from amount desired
 			if noMerges {
 				data.Commits = filterMergeCommits(data.Commits)
-				amount = amount - (3 * len(data.Commits))
+				amount -= len(data.Commits)
 			}
 
 			if dot {

--- a/cmd/lakectl/cmd/log.go
+++ b/cmd/lakectl/cmd/log.go
@@ -172,7 +172,10 @@ var logCmd = &cobra.Command{
 			// case --no-merges, filter commits and subtract that amount from amount desired
 			if noMerges {
 				data.Commits = filterMergeCommits(data.Commits)
-				data.Commits = data.Commits[:amount]
+				// case user asked for a specified amount
+				if amount > 0 {
+					data.Commits = data.Commits[:amount]
+				}
 			}
 			amount -= len(data.Commits)
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2716,6 +2716,7 @@ lakectl log --dot lakefs://example-repository/main | dot -Tsvg > graph.svg
       --first-parent         follow only the first parent commit upon seeing a merge commit
   -h, --help                 help for log
       --limit                limit result just to amount. By default, returns whether more items are available.
+      --no-merges            skip merge commits
       --objects strings      show results that contains changes to at least one path in that list of objects. Use comma separator to pass all objects together
       --prefixes strings     show results that contains changes to at least one path in that list of prefixes. Use comma separator to pass all prefixes together
       --show-meta-range-id   also show meta range ID

--- a/esti/golden/lakectl_log_no_merges.golden
+++ b/esti/golden/lakectl_log_no_merges.golden
@@ -4,13 +4,13 @@ Author:        esti
 Date:          <DATE> <TIME> <TZ>
 
         ${SECOND_MESSAGE}
-    
+
 ID:            <COMMIT_ID>
 Author:        esti
 Date:          <DATE> <TIME> <TZ>
 
         ${MESSAGE}
-    
+
 ID:            <COMMIT_ID>
 Date:          <DATE> <TIME> <TZ>
 

--- a/esti/golden/lakectl_log_no_merges.golden
+++ b/esti/golden/lakectl_log_no_merges.golden
@@ -3,16 +3,16 @@ ID:            <COMMIT_ID>
 Author:        esti
 Date:          <DATE> <TIME> <TZ>
 
-        ${SECOND_MESSAGE}
+    ${SECOND_MESSAGE}
 
 ID:            <COMMIT_ID>
 Author:        esti
 Date:          <DATE> <TIME> <TZ>
 
-        ${MESSAGE}
+    ${MESSAGE}
 
 ID:            <COMMIT_ID>
 Date:          <DATE> <TIME> <TZ>
 
-        Repository created
+    Repository created
 

--- a/esti/golden/lakectl_log_no_merges.golden
+++ b/esti/golden/lakectl_log_no_merges.golden
@@ -1,11 +1,18 @@
+
 ID:            <COMMIT_ID>
 Author:        esti
 Date:          <DATE> <TIME> <TZ>
-    ${MESSAGE}
+
+    ${SECOND_MESSAGE}
+    
 ID:            <COMMIT_ID>
 Author:        esti
 Date:          <DATE> <TIME> <TZ>
+
     ${MESSAGE}
+    
 ID:            <COMMIT_ID>
 Date:          <DATE> <TIME> <TZ>
+
     Repository created
+

--- a/esti/golden/lakectl_log_no_merges.golden
+++ b/esti/golden/lakectl_log_no_merges.golden
@@ -1,0 +1,11 @@
+ID:            <COMMIT_ID>
+Author:        esti
+Date:          <DATE> <TIME> <TZ>
+    Initial commit
+ID:            <COMMIT_ID>
+Author:        esti
+Date:          <DATE> <TIME> <TZ>
+    Feature commit
+ID:            <COMMIT_ID>
+Date:          <DATE> <TIME> <TZ>
+    Repository created

--- a/esti/golden/lakectl_log_no_merges.golden
+++ b/esti/golden/lakectl_log_no_merges.golden
@@ -3,16 +3,16 @@ ID:            <COMMIT_ID>
 Author:        esti
 Date:          <DATE> <TIME> <TZ>
 
-     ${SECOND_MESSAGE}
+	${SECOND_MESSAGE}
 
 ID:            <COMMIT_ID>
 Author:        esti
 Date:          <DATE> <TIME> <TZ>
 
-     ${MESSAGE}
+	${MESSAGE}
 
 ID:            <COMMIT_ID>
 Date:          <DATE> <TIME> <TZ>
 
-     Repository created
+	Repository created
 

--- a/esti/golden/lakectl_log_no_merges.golden
+++ b/esti/golden/lakectl_log_no_merges.golden
@@ -3,16 +3,16 @@ ID:            <COMMIT_ID>
 Author:        esti
 Date:          <DATE> <TIME> <TZ>
 
-    ${SECOND_MESSAGE}
+     ${SECOND_MESSAGE}
 
 ID:            <COMMIT_ID>
 Author:        esti
 Date:          <DATE> <TIME> <TZ>
 
-    ${MESSAGE}
+     ${MESSAGE}
 
 ID:            <COMMIT_ID>
 Date:          <DATE> <TIME> <TZ>
 
-    Repository created
+     Repository created
 

--- a/esti/golden/lakectl_log_no_merges.golden
+++ b/esti/golden/lakectl_log_no_merges.golden
@@ -3,16 +3,16 @@ ID:            <COMMIT_ID>
 Author:        esti
 Date:          <DATE> <TIME> <TZ>
 
-    ${SECOND_MESSAGE}
+        ${SECOND_MESSAGE}
     
 ID:            <COMMIT_ID>
 Author:        esti
 Date:          <DATE> <TIME> <TZ>
 
-    ${MESSAGE}
+        ${MESSAGE}
     
 ID:            <COMMIT_ID>
 Date:          <DATE> <TIME> <TZ>
 
-    Repository created
+        Repository created
 

--- a/esti/golden/lakectl_log_no_merges.golden
+++ b/esti/golden/lakectl_log_no_merges.golden
@@ -1,11 +1,11 @@
 ID:            <COMMIT_ID>
 Author:        esti
 Date:          <DATE> <TIME> <TZ>
-    Initial commit
+    ${MESSAGE}
 ID:            <COMMIT_ID>
 Author:        esti
 Date:          <DATE> <TIME> <TZ>
-    Feature commit
+    ${MESSAGE}
 ID:            <COMMIT_ID>
 Date:          <DATE> <TIME> <TZ>
     Repository created

--- a/esti/golden/lakectl_log_no_merges_amount.golden
+++ b/esti/golden/lakectl_log_no_merges_amount.golden
@@ -11,4 +11,3 @@ Date:          <DATE> <TIME> <TZ>
 
 	${MESSAGE}
 
-for more results run with --amount 2 --after <COMMIT_ID>

--- a/esti/golden/lakectl_log_no_merges_amount.golden
+++ b/esti/golden/lakectl_log_no_merges_amount.golden
@@ -1,0 +1,14 @@
+
+ID:            <COMMIT_ID>
+Author:        esti
+Date:          <DATE> <TIME> <TZ>
+
+	${SECOND_MESSAGE}
+
+ID:            <COMMIT_ID>
+Author:        esti
+Date:          <DATE> <TIME> <TZ>
+
+	${MESSAGE}
+
+for more results run with --amount 2 --after <COMMIT_ID>

--- a/esti/lakectl_test.go
+++ b/esti/lakectl_test.go
@@ -354,6 +354,7 @@ func TestLakectlLogNoMergesWithCommitsAndMerges(t *testing.T) {
 		"STORAGE":       storage,
 		"SOURCE_BRANCH": mainBranch,
 		"DEST_BRANCH":   featureBranch,
+		"BRANCH":        featureBranch,
 	}
 
 	filePath1 := "file1"

--- a/esti/lakectl_test.go
+++ b/esti/lakectl_test.go
@@ -376,7 +376,7 @@ func TestLakectlLogNoMergesWithCommitsAndMerges(t *testing.T) {
 	branchVars["FILE_PATH"] = filePath2
 	RunCmdAndVerifySuccessWithFile(t, Lakectl()+" fs upload -s files/ro_1k lakefs://"+repoName+"/"+featureBranch+"/"+filePath2, false, "lakectl_fs_upload", branchVars)
 	commitMessage = "second commit to feature branch"
-	vars["MESSAGE"] = commitMessage
+	branchVars["MESSAGE"] = commitMessage
 	RunCmdAndVerifySuccessWithFile(t, Lakectl()+" commit lakefs://"+repoName+"/"+featureBranch+" -m \""+commitMessage+"\"", false, "lakectl_commit", branchVars)
 
 	// merge feature into main

--- a/esti/lakectl_test.go
+++ b/esti/lakectl_test.go
@@ -373,7 +373,7 @@ func TestLakectlLogNoMergesWithCommitsAndMerges(t *testing.T) {
 	RunCmdAndVerifySuccessWithFile(t, Lakectl()+" branch create lakefs://"+repoName+"/"+featureBranch+" --source lakefs://"+repoName+"/"+mainBranch, false, "lakectl_branch_create", branchVars)
 
 	// upload 'file2' to feature branch and commit
-	RunCmdAndVerifySuccessWithFile(t, Lakectl()+" fs upload -s files/ro_1k lakefs://"+repoName+"/"+featureBranch+"/"+filePath2, false, "lakectl_fs_upload", branchVars)
+	RunCmdAndVerifySuccessWithFile(t, Lakectl()+" fs upload -s files/ro_1k lakefs://"+repoName+"/"+featureBranch+"/"+filePath2, false, "lakectl_fs_upload", vars)
 	commitMessage = "second commit to feature branch"
 	vars["MESSAGE"] = commitMessage
 	RunCmdAndVerifySuccessWithFile(t, Lakectl()+" commit lakefs://"+repoName+"/"+featureBranch+" -m \""+commitMessage+"\"", false, "lakectl_commit", branchVars)

--- a/esti/lakectl_test.go
+++ b/esti/lakectl_test.go
@@ -339,48 +339,51 @@ func TestLakectlMergeAndStrategies(t *testing.T) {
 }
 
 func TestLakectlLogNoMergesWithCommitsAndMerges(t *testing.T) {
+
 	repoName := generateUniqueRepositoryName()
 	storage := generateUniqueStorageNamespace(repoName)
+	vars := map[string]string{
+		"REPO":    repoName,
+		"STORAGE": storage,
+		"BRANCH":  mainBranch,
+	}
+
+	featureBranch := "feature"
+	branchVars := map[string]string{
+		"REPO":          repoName,
+		"STORAGE":       storage,
+		"SOURCE_BRANCH": mainBranch,
+		"DEST_BRANCH":   featureBranch,
+	}
 
 	filePath1 := "file1"
 	filePath2 := "file2"
-	vars := map[string]string{
-		"REPO":        repoName,
-		"STORAGE":     storage,
-		"FILE_PATH_1": filePath1,
-		"FILE_PATH_2": filePath2,
-	}
 
-	// create repo
+	// create repo with 'main' branch
 	RunCmdAndVerifySuccessWithFile(t, Lakectl()+" repo create lakefs://"+repoName+" "+storage, false, "lakectl_repo_create", vars)
 
-	// create a branch
-	branchName := "main"
-	vars["BRANCH"] = branchName
-	RunCmdAndVerifySuccessWithFile(t, Lakectl()+" branch create lakefs://"+repoName+"/"+branchName, false, "lakectl_branch_create", vars)
-
-	// Upload a file and commit
-	RunCmdAndVerifySuccessWithFile(t, Lakectl()+" fs upload -s lakefs://"+repoName+"/"+branchName+"/"+filePath1, false, "lakectl_fs_upload", vars)
-	commitMessage := "Initial commit"
+	// upload 'file1' and commit
+	vars["FILE_PATH"] = filePath1
+	RunCmdAndVerifySuccessWithFile(t, Lakectl()+" fs upload -s files/ro_1k lakefs://"+repoName+"/"+mainBranch+"/"+filePath1, false, "lakectl_fs_upload", vars)
+	commitMessage := "first commit to main"
 	vars["MESSAGE"] = commitMessage
-	RunCmdAndVerifySuccessWithFile(t, Lakectl()+" commit lakefs://"+repoName+"/"+branchName+" -m \""+commitMessage+"\"", false, "lakectl_commit", vars)
+	RunCmdAndVerifySuccessWithFile(t, Lakectl()+" commit lakefs://"+repoName+"/"+mainBranch+" -m \""+commitMessage+"\"", false, "lakectl_commit", vars)
 
-	// create a new branch
-	newBranchName := "feature"
-	vars["NEW_BRANCH"] = newBranchName
-	RunCmdAndVerifySuccessWithFile(t, Lakectl()+" branch create lakefs://"+repoName+"/"+newBranchName+" lakefs://"+repoName+"/"+branchName, false, "lakectl_branch_create", vars)
-	// upload a file
-	RunCmdAndVerifySuccessWithFile(t, Lakectl()+" fs upload -s files/feature.txt lakefs://"+repoName+"/"+newBranchName+"/"+filePath2, false, "lakectl_fs_upload", vars)
-	newCommitMessage := "Feature commit"
-	vars["NEW_MESSAGE"] = newCommitMessage
-	// commit
-	RunCmdAndVerifySuccessWithFile(t, Lakectl()+" commit lakefs://"+repoName+"/"+newBranchName+" -m \""+newCommitMessage+"\"", false, "lakectl_commit", vars)
+	// create new branch 'feature'
+	RunCmdAndVerifySuccessWithFile(t, Lakectl()+" branch create lakefs://"+repoName+"/"+featureBranch+" --source lakefs://"+repoName+"/"+mainBranch, false, "lakectl_branch_create", branchVars)
 
-	// merge the feature branch into main
-	RunCmdAndVerifySuccessWithFile(t, Lakectl()+" merge lakefs://"+repoName+"/"+newBranchName+" lakefs://"+repoName+"/"+branchName, false, "lakectl_merge_success", vars)
+	// upload 'file2' to feature branch and commit
+	RunCmdAndVerifySuccessWithFile(t, Lakectl()+" fs upload -s files/ro_1k_other lakefs://"+repoName+"/"+featureBranch+"/"+filePath2, false, "lakectl_fs_upload", branchVars)
+	commitMessage = "second commit to feature branch"
+	vars["MESSAGE"] = commitMessage
+	RunCmdAndVerifySuccessWithFile(t, Lakectl()+" commit lakefs://"+repoName+"/"+featureBranch+" -m \""+commitMessage+"\"", false, "lakectl_commit", branchVars)
+
+	// merge feature into main
+	RunCmdAndVerifyFailureWithFile(t, Lakectl()+" merge lakefs://"+repoName+"/"+featureBranch+" lakefs://"+repoName+"/"+mainBranch, false, "lakectl_merge_success", branchVars)
 
 	// log the commits without merges
-	RunCmdAndVerifySuccessWithFile(t, Lakectl()+" log lakefs://"+repoName+"/"+branchName+" --no-merges", false, "lakectl_log_no_merges", vars)
+	RunCmdAndVerifySuccessWithFile(t, Lakectl()+" log lakefs://"+repoName+"/"+mainBranch+" --no-merges", false, "lakectl_log_no_merges", vars)
+
 }
 
 func TestLakectlAnnotate(t *testing.T) {

--- a/esti/lakectl_test.go
+++ b/esti/lakectl_test.go
@@ -390,6 +390,57 @@ func TestLakectlLogNoMergesWithCommitsAndMerges(t *testing.T) {
 
 }
 
+func TestLakectlLogNoMergesAndAmount(t *testing.T) {
+	repoName := generateUniqueRepositoryName()
+	storage := generateUniqueStorageNamespace(repoName)
+	vars := map[string]string{
+		"REPO":    repoName,
+		"STORAGE": storage,
+		"BRANCH":  mainBranch,
+	}
+
+	featureBranch := "feature"
+	branchVars := map[string]string{
+		"REPO":          repoName,
+		"STORAGE":       storage,
+		"SOURCE_BRANCH": mainBranch,
+		"DEST_BRANCH":   featureBranch,
+		"BRANCH":        featureBranch,
+	}
+
+	filePath1 := "file1"
+	filePath2 := "file2"
+
+	// create repo with 'main' branch
+	RunCmdAndVerifySuccessWithFile(t, Lakectl()+" repo create lakefs://"+repoName+" "+storage, false, "lakectl_repo_create", vars)
+
+	// upload 'file1' and commit
+	vars["FILE_PATH"] = filePath1
+	RunCmdAndVerifySuccessWithFile(t, Lakectl()+" fs upload -s files/ro_1k lakefs://"+repoName+"/"+mainBranch+"/"+filePath1, false, "lakectl_fs_upload", vars)
+	commitMessage := "first commit to main"
+	vars["MESSAGE"] = commitMessage
+	RunCmdAndVerifySuccessWithFile(t, Lakectl()+" commit lakefs://"+repoName+"/"+mainBranch+" -m \""+commitMessage+"\"", false, "lakectl_commit", vars)
+
+	// create new branch 'feature'
+	RunCmdAndVerifySuccessWithFile(t, Lakectl()+" branch create lakefs://"+repoName+"/"+featureBranch+" --source lakefs://"+repoName+"/"+mainBranch, false, "lakectl_branch_create", branchVars)
+
+	// upload 'file2' to feature branch and commit
+	branchVars["FILE_PATH"] = filePath2
+	RunCmdAndVerifySuccessWithFile(t, Lakectl()+" fs upload -s files/ro_1k lakefs://"+repoName+"/"+featureBranch+"/"+filePath2, false, "lakectl_fs_upload", branchVars)
+	commitMessage = "second commit to feature branch"
+	branchVars["MESSAGE"] = commitMessage
+	vars["SECOND_MESSAGE"] = commitMessage
+	RunCmdAndVerifySuccessWithFile(t, Lakectl()+" commit lakefs://"+repoName+"/"+featureBranch+" -m \""+commitMessage+"\"", false, "lakectl_commit", branchVars)
+
+	// merge feature into main
+	branchVars["SOURCE_BRANCH"] = featureBranch
+	branchVars["DEST_BRANCH"] = mainBranch
+	RunCmdAndVerifySuccessWithFile(t, Lakectl()+" merge lakefs://"+repoName+"/"+featureBranch+" lakefs://"+repoName+"/"+mainBranch, false, "lakectl_merge_success", branchVars)
+
+	// log the commits without merges
+	RunCmdAndVerifySuccessWithFile(t, Lakectl()+" log lakefs://"+repoName+"/"+mainBranch+" --no-merges --amount=2", false, "lakectl_log_no_merges_amount", vars)
+
+}
 func TestLakectlAnnotate(t *testing.T) {
 	repoName := generateUniqueRepositoryName()
 	storage := generateUniqueStorageNamespace(repoName)

--- a/esti/lakectl_test.go
+++ b/esti/lakectl_test.go
@@ -373,7 +373,8 @@ func TestLakectlLogNoMergesWithCommitsAndMerges(t *testing.T) {
 	RunCmdAndVerifySuccessWithFile(t, Lakectl()+" branch create lakefs://"+repoName+"/"+featureBranch+" --source lakefs://"+repoName+"/"+mainBranch, false, "lakectl_branch_create", branchVars)
 
 	// upload 'file2' to feature branch and commit
-	RunCmdAndVerifySuccessWithFile(t, Lakectl()+" fs upload -s files/ro_1k lakefs://"+repoName+"/"+featureBranch+"/"+filePath2, false, "lakectl_fs_upload", vars)
+	branchVars["FILE_PATH"] = filePath2
+	RunCmdAndVerifySuccessWithFile(t, Lakectl()+" fs upload -s files/ro_1k lakefs://"+repoName+"/"+featureBranch+"/"+filePath2, false, "lakectl_fs_upload", branchVars)
 	commitMessage = "second commit to feature branch"
 	vars["MESSAGE"] = commitMessage
 	RunCmdAndVerifySuccessWithFile(t, Lakectl()+" commit lakefs://"+repoName+"/"+featureBranch+" -m \""+commitMessage+"\"", false, "lakectl_commit", branchVars)

--- a/esti/lakectl_test.go
+++ b/esti/lakectl_test.go
@@ -373,7 +373,7 @@ func TestLakectlLogNoMergesWithCommitsAndMerges(t *testing.T) {
 	RunCmdAndVerifySuccessWithFile(t, Lakectl()+" branch create lakefs://"+repoName+"/"+featureBranch+" --source lakefs://"+repoName+"/"+mainBranch, false, "lakectl_branch_create", branchVars)
 
 	// upload 'file2' to feature branch and commit
-	RunCmdAndVerifySuccessWithFile(t, Lakectl()+" fs upload -s files/ro_1k_other lakefs://"+repoName+"/"+featureBranch+"/"+filePath2, false, "lakectl_fs_upload", branchVars)
+	RunCmdAndVerifySuccessWithFile(t, Lakectl()+" fs upload -s files/ro_1k lakefs://"+repoName+"/"+featureBranch+"/"+filePath2, false, "lakectl_fs_upload", branchVars)
 	commitMessage = "second commit to feature branch"
 	vars["MESSAGE"] = commitMessage
 	RunCmdAndVerifySuccessWithFile(t, Lakectl()+" commit lakefs://"+repoName+"/"+featureBranch+" -m \""+commitMessage+"\"", false, "lakectl_commit", branchVars)

--- a/esti/lakectl_test.go
+++ b/esti/lakectl_test.go
@@ -378,6 +378,7 @@ func TestLakectlLogNoMergesWithCommitsAndMerges(t *testing.T) {
 	RunCmdAndVerifySuccessWithFile(t, Lakectl()+" fs upload -s files/ro_1k lakefs://"+repoName+"/"+featureBranch+"/"+filePath2, false, "lakectl_fs_upload", branchVars)
 	commitMessage = "second commit to feature branch"
 	branchVars["MESSAGE"] = commitMessage
+	vars["SECOND_MESSAGE"] = commitMessage
 	RunCmdAndVerifySuccessWithFile(t, Lakectl()+" commit lakefs://"+repoName+"/"+featureBranch+" -m \""+commitMessage+"\"", false, "lakectl_commit", branchVars)
 
 	// merge feature into main

--- a/esti/lakectl_test.go
+++ b/esti/lakectl_test.go
@@ -339,7 +339,6 @@ func TestLakectlMergeAndStrategies(t *testing.T) {
 }
 
 func TestLakectlLogNoMergesWithCommitsAndMerges(t *testing.T) {
-
 	repoName := generateUniqueRepositoryName()
 	storage := generateUniqueStorageNamespace(repoName)
 	vars := map[string]string{

--- a/esti/lakectl_test.go
+++ b/esti/lakectl_test.go
@@ -381,7 +381,7 @@ func TestLakectlLogNoMergesWithCommitsAndMerges(t *testing.T) {
 	RunCmdAndVerifySuccessWithFile(t, Lakectl()+" commit lakefs://"+repoName+"/"+featureBranch+" -m \""+commitMessage+"\"", false, "lakectl_commit", branchVars)
 
 	// merge feature into main
-	RunCmdAndVerifyFailureWithFile(t, Lakectl()+" merge lakefs://"+repoName+"/"+featureBranch+" lakefs://"+repoName+"/"+mainBranch, false, "lakectl_merge_success", branchVars)
+	RunCmdAndVerifySuccessWithFile(t, Lakectl()+" merge lakefs://"+repoName+"/"+featureBranch+" lakefs://"+repoName+"/"+mainBranch, false, "lakectl_merge_success", branchVars)
 
 	// log the commits without merges
 	RunCmdAndVerifySuccessWithFile(t, Lakectl()+" log lakefs://"+repoName+"/"+mainBranch+" --no-merges", false, "lakectl_log_no_merges", vars)

--- a/esti/lakectl_test.go
+++ b/esti/lakectl_test.go
@@ -352,8 +352,8 @@ func TestLakectlLogNoMergesWithCommitsAndMerges(t *testing.T) {
 	branchVars := map[string]string{
 		"REPO":          repoName,
 		"STORAGE":       storage,
-		"SOURCE_BRANCH": mainBranch,
-		"DEST_BRANCH":   featureBranch,
+		"SOURCE_BRANCH": featureBranch,
+		"DEST_BRANCH":   mainBranch,
 		"BRANCH":        featureBranch,
 	}
 

--- a/esti/lakectl_test.go
+++ b/esti/lakectl_test.go
@@ -352,8 +352,8 @@ func TestLakectlLogNoMergesWithCommitsAndMerges(t *testing.T) {
 	branchVars := map[string]string{
 		"REPO":          repoName,
 		"STORAGE":       storage,
-		"SOURCE_BRANCH": featureBranch,
-		"DEST_BRANCH":   mainBranch,
+		"SOURCE_BRANCH": mainBranch,
+		"DEST_BRANCH":   featureBranch,
 		"BRANCH":        featureBranch,
 	}
 
@@ -381,6 +381,8 @@ func TestLakectlLogNoMergesWithCommitsAndMerges(t *testing.T) {
 	RunCmdAndVerifySuccessWithFile(t, Lakectl()+" commit lakefs://"+repoName+"/"+featureBranch+" -m \""+commitMessage+"\"", false, "lakectl_commit", branchVars)
 
 	// merge feature into main
+	branchVars["SOURCE_BRANCH"] = featureBranch
+	branchVars["DEST_BRANCH"] = mainBranch
 	RunCmdAndVerifySuccessWithFile(t, Lakectl()+" merge lakefs://"+repoName+"/"+featureBranch+" lakefs://"+repoName+"/"+mainBranch, false, "lakectl_merge_success", branchVars)
 
 	// log the commits without merges

--- a/esti/lakectl_util.go
+++ b/esti/lakectl_util.go
@@ -228,7 +228,7 @@ func runCmdAndVerifyResult(t *testing.T, cmd string, expectFail bool, isTerminal
 	t.Helper()
 	expanded, err := expandVariables(expected, vars)
 	if err != nil {
-		t.Fatal("Failed to extract variables for:", cmd)
+		t.Fatalf("Failed to extract variables for: \"%s\": %s", cmd, err)
 	}
 	sanitizedResult := runCmd(t, cmd, expectFail, isTerminal, vars)
 


### PR DESCRIPTION
Closes #7441

Added an option to filter merge commits in the log command. The flag `--no-merges` will filter every commit that has more than one parent and thus also import commits. The implementation concerns only lakectl at the moment. Filtering is done at The server's side similarly to `--first-parent` flag.

### Testing Details

Tested only manually, original test pass (after a slight modification) 



## Additional info

<img width="1274" alt="Screenshot 2024-09-08 at 10 36 14" src="https://github.com/user-attachments/assets/876aa62e-bb44-45ac-b4ba-12f519741904">

### Contact Details
itamar.yuran@treeverse.io
