### PR TITLE
branch now can't merge to itself

### DIFF
--- a/pkg/graveler/committed/manager.go
+++ b/pkg/graveler/committed/manager.go
@@ -207,7 +207,10 @@ func (c *committedManager) Merge(ctx context.Context, ns graveler.StorageNamespa
 		// no changes on source
 		return "", graveler.ErrNoChanges
 	}
-
+	if source == destination {
+		// merge branch to itself
+		return "", graveler.ErrNoChanges
+	}
 	if destination == base {
 		// changes introduced only on source
 		return source, nil


### PR DESCRIPTION
Closes #7824

## Change Description
Disabling the option of merging a branch to itself.

### Background
After introducing the new flags `--allow-empty` & `--force`, users had the option of merging a branch to itself.
This modification blocks this option by checking whether the branches source and destination are equal.

### Testing Details
Manually, did not create a dedicated test

## Additional info
For the error, I used the already exist `ErrNoChanges` error and did not create a new one.

### Contact Details
itamar.yuran@treeverse.io