### PR TITLE
Add a deprecation and upgrade warning to python-legacy client

### DIFF
--- a/clients/python-legacy/setup.py
+++ b/clients/python-legacy/setup.py
@@ -25,18 +25,32 @@ REQUIRES = [
   "python-dateutil",
 ]
 
+long_prefix = '''
+[EOL] Do NOT use: lakeFS OpenAPI Python client legacy SDK
+
+The lakeFS OpenAPI Python client legacy SDK has reached end of life.  Please
+use lakefs-sdk or lakefs-wrapper instead.
+
+* lakefs-sdk code maintains backwards compatibility.
+* lakefs-wrapper uses lakefs-sdk to provide support at a much higher level.
+
+lakefs-client will shortly stop being published.  For help migrating, refer
+to
+https://docs.lakefs.io/project/code-migrate-1.0-sdk.html#migrating-sdk-code-for-python.
+'''
+
 with open('README.md') as f:
     import re
     # replace relative links with links to the docs:
     doc_version = '.'.join(f'v{VERSION}'.split('.')[:2])
-    long_description = re.sub(r'(\[[*a-zA-Z_]*]\()docs/([A-Za-z0-9]*)\.md',
+    long_description = long_prefix + re.sub(r'(\[[*a-zA-Z_]*]\()docs/([A-Za-z0-9]*)\.md',
                               rf'\1https://pydocs.lakefs.io/{doc_version}/docs/\2.html',
                               f.read())
 
 setup(
     name=NAME,
     version=VERSION,
-    description="lakeFS API",
+    description="[legacy] lakeFS API",
     author="Treeverse",
     author_email="services@treeverse.io",
     url="https://github.com/treeverse/lakeFS/tree/master/clients/python-legacy",

--- a/clients/python-legacy/templates/setup.mustache
+++ b/clients/python-legacy/templates/setup.mustache
@@ -54,7 +54,7 @@ with open('README.md') as f:
 setup(
     name=NAME,
     version=VERSION,
-    description="{{appName}}",
+    description="[legacy] {{appName}}",
     author="{{infoName}}{{^infoName}}OpenAPI Generator community{{/infoName}}",
     author_email="{{infoEmail}}{{^infoEmail}}team@openapitools.org{{/infoEmail}}",
     url="{{packageUrl}}",

--- a/clients/python-legacy/templates/setup.mustache
+++ b/clients/python-legacy/templates/setup.mustache
@@ -29,11 +29,25 @@ REQUIRES = [
 {{/hasHttpSignatureMethods}}
 ]
 
+long_prefix = '''
+[EOL] Do NOT use: lakeFS OpenAPI Python client legacy SDK
+
+The lakeFS OpenAPI Python client legacy SDK has reached end of life.  Please
+use lakefs-sdk or lakefs-wrapper instead.
+
+* lakefs-sdk code maintains backwards compatibility.
+* lakefs-wrapper uses lakefs-sdk to provide support at a much higher level.
+
+lakefs-client will shortly stop being published.  For help migrating, refer
+to
+https://docs.lakefs.io/project/code-migrate-1.0-sdk.html#migrating-sdk-code-for-python.
+'''
+
 with open('README.md') as f:
     import re
     # replace relative links with links to the docs:
     doc_version = '.'.join(f'v{VERSION}'.split('.')[:2])
-    long_description = re.sub(r'(\[[*a-zA-Z_]*]\()docs/([A-Za-z0-9]*)\.md',
+    long_description = long_prefix + re.sub(r'(\[[*a-zA-Z_]*]\()docs/([A-Za-z0-9]*)\.md',
                               rf'\1https://pydocs.lakefs.io/{doc_version}/docs/\2.html',
                               f.read())
 


### PR DESCRIPTION
~Part of #8194 - do not pull until we decide we're doing that!~

We're good to go. Next python legacy client will be marked. We can drop it shortly afterwards.
