### PR TITLE
Fix: lakectl local checkout src uri

### DIFF
--- a/cmd/lakectl/cmd/local_checkout.go
+++ b/cmd/lakectl/cmd/local_checkout.go
@@ -82,7 +82,7 @@ func localCheckout(cmd *cobra.Command, localPath string, specifiedRef string, co
 			newBase := newRemote.WithRef(newHead)
 
 			// write new index
-			_, err = local.WriteIndex(idx.LocalPath(), remote, newHead, "")
+			_, err = local.WriteIndex(idx.LocalPath(), newRemote, newHead, "")
 			if err != nil {
 				DieErr(err)
 			}


### PR DESCRIPTION
Closes #8138 

## Change Description

Fix bug where src is not update in `.lakefs_ref` file when providing ref flag for `lakectl local checkout` command

### Bug Fix

Use new remote uri when `-r` flag is provided
      
### Testing Details

Tested manually
