### PR TITLE
Bump webrick from 1.8.1 to 1.8.2 in /docs

### DIFF
--- a/docs/Gemfile.lock
+++ b/docs/Gemfile.lock
@@ -254,7 +254,7 @@ GEM
       unf_ext
     unf_ext (0.0.8.2)
     unicode-display_width (1.8.0)
-    webrick (1.8.1)
+    webrick (1.8.2)
 
 PLATFORMS
   ruby


### PR DESCRIPTION
Copy of dependabot #8233 to see if it needs a _user_ to run Esti in CI.