### PR TITLE
can't merge branch to itself

### DIFF
--- a/cmd/lakectl/cmd/merge.go
+++ b/cmd/lakectl/cmd/merge.go
@@ -46,6 +46,9 @@ var mergeCmd = &cobra.Command{
 		fmt.Println("Source:", sourceRef)
 		fmt.Println("Destination:", destinationRef)
 
+		if destinationRef.Ref == sourceRef.Ref {
+			Die("branch can not be merged to itself", 1)
+		}
 		if destinationRef.Repository != sourceRef.Repository {
 			Die("both references must belong to the same repository", 1)
 		}


### PR DESCRIPTION
Closes #7824

blocking the option of merging a branch to itself, by checking source and dest ref. currently only in lakectl.
