### PR TITLE
Make update object metadata API atomic

### DIFF
--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -4701,16 +4701,8 @@ func (c *Controller) UpdateObjectUserMetadata(w http.ResponseWriter, r *http.Req
 	ctx := r.Context()
 	c.LogAction(ctx, "update_object_user_metadata", r, repository, branch, "")
 
-	// read all the _other_ metadata.  Does not require checking read
-	// permissions, as the caller will never see this.
-	entry, err := c.Catalog.GetEntry(ctx, repository, branch, params.Path, catalog.GetEntryParams{})
-	if c.handleAPIError(ctx, w, r, err) {
-		return
-	}
-
-	entry.Metadata = catalog.Metadata(body.Set.AdditionalProperties)
-
-	err = c.Catalog.CreateEntry(ctx, repository, branch, *entry)
+	newUserMetadata := body.Set.AdditionalProperties
+	err := c.Catalog.UpdateEntryUserMetadata(ctx, repository, branch, params.Path, newUserMetadata)
 	if c.handleAPIError(ctx, w, r, err) {
 		return
 	}

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -1000,6 +1000,40 @@ func (c *Catalog) GetEntry(ctx context.Context, repositoryID string, reference s
 	return &catalogEntry, nil
 }
 
+// UpdateEntryUserMetadata updates user metadata for the current entry for a
+// path in repository branch reference.
+func (c *Catalog) UpdateEntryUserMetadata(ctx context.Context, repositoryID, branch, path string, newUserMetadata map[string]string) error {
+	branchID := graveler.BranchID(branch)
+	if err := validator.Validate([]validator.ValidateArg{
+		{Name: "repository", Value: repositoryID, Fn: graveler.ValidateRepositoryID},
+		{Name: "branch", Value: branchID, Fn: graveler.ValidateBranchID},
+		{Name: "path", Value: Path(path), Fn: ValidatePath},
+	}); err != nil {
+		return fmt.Errorf("%w: %s %s %s", err, repositoryID, branchID, path)
+	}
+
+	repository, err := c.getRepository(ctx, repositoryID)
+	if err != nil {
+		return nil
+	}
+
+	key := graveler.Key(path)
+	updater := graveler.ValueUpdateFunc(func(value *graveler.Value) (*graveler.Value, error) {
+		if value == nil {
+			return nil, fmt.Errorf("update user metadata on %s/%s/%s: %w",
+				repositoryID, branchID, path, graveler.ErrNotFound)
+		}
+		entry, err := ValueToEntry(value)
+		if err != nil {
+			return nil, err
+		}
+		entry.Metadata = newUserMetadata
+		return EntryToValue(entry)
+	})
+	err = c.Store.UpdateObjectMetadata(ctx, repository, branchID, key, updater)
+	return err
+}
+
 func newEntryFromCatalogEntry(entry DBEntry) *Entry {
 	ent := &Entry{
 		Address:      entry.PhysicalAddress,

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -1009,7 +1009,7 @@ func (c *Catalog) UpdateEntryUserMetadata(ctx context.Context, repositoryID, bra
 		{Name: "branch", Value: branchID, Fn: graveler.ValidateBranchID},
 		{Name: "path", Value: Path(path), Fn: ValidatePath},
 	}); err != nil {
-		return fmt.Errorf("%w: %s %s %s", err, repositoryID, branchID, path)
+		return err
 	}
 
 	repository, err := c.getRepository(ctx, repositoryID)
@@ -1030,8 +1030,7 @@ func (c *Catalog) UpdateEntryUserMetadata(ctx context.Context, repositoryID, bra
 		entry.Metadata = newUserMetadata
 		return EntryToValue(entry)
 	})
-	err = c.Store.UpdateObjectMetadata(ctx, repository, branchID, key, updater)
-	return err
+	return c.Store.Update(ctx, repository, branchID, key, updater)
 }
 
 func newEntryFromCatalogEntry(entry DBEntry) *Entry {

--- a/pkg/catalog/fake_graveler_test.go
+++ b/pkg/catalog/fake_graveler_test.go
@@ -116,7 +116,7 @@ func (g *FakeGraveler) Set(_ context.Context, repository *graveler.RepositoryRec
 	return nil
 }
 
-func (g *FakeGraveler) UpdateObjectMetadata(ctx context.Context, repository *graveler.RepositoryRecord, branchID graveler.BranchID, key graveler.Key, update graveler.ValueUpdateFunc, opts ...graveler.SetOptionsFunc) error {
+func (g *FakeGraveler) Update(ctx context.Context, repository *graveler.RepositoryRecord, branchID graveler.BranchID, key graveler.Key, update graveler.ValueUpdateFunc, opts ...graveler.SetOptionsFunc) error {
 	if g.Err != nil {
 		return g.Err
 	}

--- a/pkg/catalog/fake_graveler_test.go
+++ b/pkg/catalog/fake_graveler_test.go
@@ -116,6 +116,19 @@ func (g *FakeGraveler) Set(_ context.Context, repository *graveler.RepositoryRec
 	return nil
 }
 
+func (g *FakeGraveler) UpdateObjectMetadata(ctx context.Context, repository *graveler.RepositoryRecord, branchID graveler.BranchID, key graveler.Key, update graveler.ValueUpdateFunc, opts ...graveler.SetOptionsFunc) error {
+	if g.Err != nil {
+		return g.Err
+	}
+	k := fakeGravelerBuildKey(repository.RepositoryID, graveler.Ref(branchID.String()), key)
+	value, err := update(g.KeyValue[k])
+	if err != nil {
+		return err
+	}
+	g.KeyValue[k] = value
+	return nil
+}
+
 func (g *FakeGraveler) Delete(ctx context.Context, repository *graveler.RepositoryRecord, branchID graveler.BranchID, key graveler.Key, _ ...graveler.SetOptionsFunc) error {
 	return nil
 }

--- a/pkg/graveler/graveler.go
+++ b/pkg/graveler/graveler.go
@@ -541,10 +541,9 @@ type KeyValueStore interface {
 	// Set stores value on repository / branch by key. nil value is a valid value for tombstone
 	Set(ctx context.Context, repository *RepositoryRecord, branchID BranchID, key Key, value Value, opts ...SetOptionsFunc) error
 
-	// UpdateObjectMetadata atomically runs update on repository /
-	// branch by key.  (Of course, if entry is only on committed, the
-	// updated entry will still be created (atomically) on staging.)
-	UpdateObjectMetadata(ctx context.Context, repository *RepositoryRecord, branchID BranchID, key Key, update ValueUpdateFunc, opts ...SetOptionsFunc) error
+	// Update atomically runs update on repository / branch by key.  (Of course, if entry
+	// is only on committed, the updated entry will still be created (atomically) on staging.)
+	Update(ctx context.Context, repository *RepositoryRecord, branchID BranchID, key Key, update ValueUpdateFunc, opts ...SetOptionsFunc) error
 
 	// Delete value from repository / branch by key
 	Delete(ctx context.Context, repository *RepositoryRecord, branchID BranchID, key Key, opts ...SetOptionsFunc) error
@@ -1845,7 +1844,7 @@ func (g *Graveler) safeBranchWrite(ctx context.Context, log logging.Logger, repo
 	return nil
 }
 
-func (g *Graveler) UpdateObjectMetadata(ctx context.Context, repository *RepositoryRecord, branchID BranchID, key Key, update ValueUpdateFunc, opts ...SetOptionsFunc) error {
+func (g *Graveler) Update(ctx context.Context, repository *RepositoryRecord, branchID BranchID, key Key, update ValueUpdateFunc, opts ...SetOptionsFunc) error {
 	isProtected, err := g.protectedBranchesManager.IsBlocked(ctx, repository, branchID, BranchProtectionBlockedAction_STAGING_WRITE)
 	if err != nil {
 		return err
@@ -1874,7 +1873,7 @@ func (g *Graveler) UpdateObjectMetadata(ctx context.Context, repository *Reposit
 					committedValue, err = g.Get(ctx, repository, Ref(branchID), key)
 					if err != nil {
 						// (Includes ErrNotFound)
-						return nil, fmt.Errorf("read %s/%s/%s from committed: %w", repository.RepositoryID, branchID, key, err)
+						return nil, fmt.Errorf("read from committed: %w", err)
 					}
 				}
 				// Get always returns a non-nil value or an error.

--- a/pkg/graveler/graveler.go
+++ b/pkg/graveler/graveler.go
@@ -1861,8 +1861,8 @@ func (g *Graveler) Update(ctx context.Context, repository *RepositoryRecord, bra
 	log := g.log(ctx).WithFields(logging.Fields{"key": key, "operation": "update_user_metadata"})
 
 	// committedValue, if non-nil is a value read from either uncommitted or committed.  Usually
-	// it it is read from committed.  If there is a value on staging, that entry will be
-	// modified and committedValue will never be read.
+	// it is read from committed.  If there is a value on staging, that entry will be modified
+	// and committedValue will never be read.
 	var committedValue *Value
 
 	err = g.safeBranchWrite(ctx, log, repository, branchID, safeBranchWriteOptions{MaxTries: options.MaxTries}, func(branch *Branch) error {

--- a/pkg/graveler/mock/graveler.go
+++ b/pkg/graveler/mock/graveler.go
@@ -158,6 +158,25 @@ func (mr *MockKeyValueStoreMockRecorder) Set(ctx, repository, branchID, key, val
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Set", reflect.TypeOf((*MockKeyValueStore)(nil).Set), varargs...)
 }
 
+// UpdateObjectMetadata mocks base method.
+func (m *MockKeyValueStore) UpdateObjectMetadata(ctx context.Context, repository *graveler.RepositoryRecord, branchID graveler.BranchID, key graveler.Key, update graveler.ValueUpdateFunc, opts ...graveler.SetOptionsFunc) error {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{ctx, repository, branchID, key, update}
+	for _, a := range opts {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "UpdateObjectMetadata", varargs...)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// UpdateObjectMetadata indicates an expected call of UpdateObjectMetadata.
+func (mr *MockKeyValueStoreMockRecorder) UpdateObjectMetadata(ctx, repository, branchID, key, update interface{}, opts ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{ctx, repository, branchID, key, update}, opts...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateObjectMetadata", reflect.TypeOf((*MockKeyValueStore)(nil).UpdateObjectMetadata), varargs...)
+}
+
 // MockVersionController is a mock of VersionController interface.
 type MockVersionController struct {
 	ctrl     *gomock.Controller

--- a/pkg/graveler/mock/graveler.go
+++ b/pkg/graveler/mock/graveler.go
@@ -158,23 +158,23 @@ func (mr *MockKeyValueStoreMockRecorder) Set(ctx, repository, branchID, key, val
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Set", reflect.TypeOf((*MockKeyValueStore)(nil).Set), varargs...)
 }
 
-// UpdateObjectMetadata mocks base method.
-func (m *MockKeyValueStore) UpdateObjectMetadata(ctx context.Context, repository *graveler.RepositoryRecord, branchID graveler.BranchID, key graveler.Key, update graveler.ValueUpdateFunc, opts ...graveler.SetOptionsFunc) error {
+// Update mocks base method.
+func (m *MockKeyValueStore) Update(ctx context.Context, repository *graveler.RepositoryRecord, branchID graveler.BranchID, key graveler.Key, update graveler.ValueUpdateFunc, opts ...graveler.SetOptionsFunc) error {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{ctx, repository, branchID, key, update}
 	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
-	ret := m.ctrl.Call(m, "UpdateObjectMetadata", varargs...)
+	ret := m.ctrl.Call(m, "Update", varargs...)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
-// UpdateObjectMetadata indicates an expected call of UpdateObjectMetadata.
-func (mr *MockKeyValueStoreMockRecorder) UpdateObjectMetadata(ctx, repository, branchID, key, update interface{}, opts ...interface{}) *gomock.Call {
+// Update indicates an expected call of Update.
+func (mr *MockKeyValueStoreMockRecorder) Update(ctx, repository, branchID, key, update interface{}, opts ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{ctx, repository, branchID, key, update}, opts...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateObjectMetadata", reflect.TypeOf((*MockKeyValueStore)(nil).UpdateObjectMetadata), varargs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Update", reflect.TypeOf((*MockKeyValueStore)(nil).Update), varargs...)
 }
 
 // MockVersionController is a mock of VersionController interface.


### PR DESCRIPTION
Protect updating object metadata on an existing entry to be safe against concurrent modifications, deletions, and commits and merges to the branch. This is a bit tricky because it needs to work for both committed and staged objects.

Fixes #8262 - a race that would give an odd result if update object metadata managed to lose against concurrent delete and uncommitted GC, or potentially merges into the branch.
