### PR TITLE
WebUI: Sanitize user-input fields of PRs

### DIFF
--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -17,6 +17,7 @@
         "bootstrap": "^5.3.2",
         "csstype": "^3.1.3",
         "dayjs": "^1.11.10",
+        "dompurify": "^3.1.7",
         "lodash": "^4.17.21",
         "p-map": "^7.0.0",
         "prismjs": "^1.29.0",
@@ -8448,9 +8449,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.0.tgz",
-      "integrity": "sha512-yoU4rhgPKCo+p5UrWWWNKiIq+ToGqmVVhk0PmMYBK4kRsR3/qhemNFL8f6CFmBd4gMwm3F4T7HBoydP5uY07fA=="
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.7.tgz",
+      "integrity": "sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ=="
     },
     "node_modules/dotenv": {
       "version": "16.3.1",
@@ -29017,9 +29018,9 @@
       }
     },
     "dompurify": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.0.tgz",
-      "integrity": "sha512-yoU4rhgPKCo+p5UrWWWNKiIq+ToGqmVVhk0PmMYBK4kRsR3/qhemNFL8f6CFmBd4gMwm3F4T7HBoydP5uY07fA=="
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.1.7.tgz",
+      "integrity": "sha512-VaTstWtsneJY8xzy7DekmYWEOZcmzIe3Qb3zPd4STve1OBTa+e+WmS1ITQec1fZYXI3HCsOZZiSMpG6oxoWMWQ=="
     },
     "dotenv": {
       "version": "16.3.1",

--- a/webui/package.json
+++ b/webui/package.json
@@ -28,6 +28,7 @@
     "bootstrap": "^5.3.2",
     "csstype": "^3.1.3",
     "dayjs": "^1.11.10",
+    "dompurify": "^3.1.7",
     "lodash": "^4.17.21",
     "p-map": "^7.0.0",
     "prismjs": "^1.29.0",

--- a/webui/src/pages/repositories/repository/pulls/createPull.jsx
+++ b/webui/src/pages/repositories/repository/pulls/createPull.jsx
@@ -1,5 +1,6 @@
 import React, {useContext, useEffect, useState} from "react";
 import {useOutletContext} from "react-router-dom";
+import purify from "dompurify";
 
 import {ActionGroup, ActionsBar, AlertError, Loading} from "../../../../lib/components/controls";
 import {useRefs} from "../../../../lib/hooks/repo";
@@ -23,8 +24,8 @@ const CreatePullForm = ({repo, reference, compare}) => {
     const {state: {results: diffResults, loading: diffLoading, error: diffError}} = useContext(DiffContext);
     const isEmptyDiff = (!diffLoading && !diffError && !!diffResults && diffResults.length === 0);
 
-    const onTitleInput = ({target: {value}}) => setTitle(value);
-    const onDescriptionInput = ({target: {value}}) => setDescription(value);
+    const onTitleInput = ({target: {value}}) => setTitle(purify.sanitize(value));
+    const onDescriptionInput = ({target: {value}}) => setDescription(purify.sanitize(value));
 
     const submitForm = async () => {
         setLoading(true);


### PR DESCRIPTION
Closes #8203.

## Change Description

Adding sanitize for user-input fields of a PR, to prevent malicious attacks.
Currently it's only relevant for title + description when creating a PR.

Using the very popular [DOMPurify](https://github.com/cure53/DOMPurify) package.

### Testing Details

Verified manually that PR creation still works.
