### PR TITLE
added "read_only" parameter to repository creation in python-wrapper\…

### DIFF
--- a/clients/python-wrapper/lakefs/repository.py
+++ b/clients/python-wrapper/lakefs/repository.py
@@ -34,6 +34,7 @@ class Repository(_BaseLakeFSObject):
                default_branch: str = "main",
                include_samples: bool = False,
                exist_ok: bool = False,
+               read_only: bool = False,
                **kwargs) -> Repository:
         """
         Create a new repository in lakeFS from this object
@@ -43,6 +44,7 @@ class Repository(_BaseLakeFSObject):
         :param include_samples: Whether to include sample data in repository creation
         :param exist_ok: If False will throw an exception if a repository by this name already exists. Otherwise,
             return the existing repository without creating a new one
+        :param read_only: Whether the repository is a read-only repository - not relevant for bare repositories
         :param kwargs: Additional Keyword Arguments to send to the server
         :return: The lakeFS SDK object representing the repository
         :raise NotAuthorizedException: if user is not authorized to perform this operation
@@ -51,7 +53,8 @@ class Repository(_BaseLakeFSObject):
         repository_creation = lakefs_sdk.RepositoryCreation(name=self._id,
                                                             storage_namespace=storage_namespace,
                                                             default_branch=default_branch,
-                                                            sample_data=include_samples)
+                                                            sample_data=include_samples,
+                                                            read_only=read_only)
 
         def handle_conflict(e: LakeFSException):
             if isinstance(e, ConflictException) and exist_ok:


### PR DESCRIPTION
Closes #7848

### Background

Currently the following code raises an exception
 
```
import lakefs
from lakefs.client import Client

clt = Client(
    username="<username>",
    password="<password>",
    host="<host>",
)
repo = lakefs.Repository(repository_id="<repo id>", client=clt).create(
    storage_namespace="<namespace>",
    read_only=True,
)
```
the exception:
`lakefs_sdk.exceptions.ApiTypeError: Got an unexpected keyword argument 'read_only' to method create_repository
`
### Bug Fix
* Previously, `create()` received read_only as part of the kwargs object, which was passed to `sdk_client.repositories_api.create_repository(repository_creation, **kwargs)`. This raised an exception because `create_repository() `only accepts specific keyword arguments.

* Fix: I added the read_only parameter to `create()`, passing it to the `RepositoryCreation` constructor, which already supports this parameter. This way, read_only is passed to `create_repository()` through the `repository_creation ` object instead of via kwargs.

### Testing Details
I ran setup.py after the code change and created both a read-only and a regular repo using `Repository.create()`. 
![image](https://github.com/user-attachments/assets/92c75e14-896c-4a8f-ae61-e060265fe73f)

### Contact Details
tkalir@gmail.com \ Tamar Kalir in slack