### PR TITLE
Docs: clarify auditing available on enterprise

### DIFF
--- a/docs/reference/auditing.md
+++ b/docs/reference/auditing.md
@@ -17,10 +17,7 @@ lakeFS Enterprise
 {: .label .label-purple }
 
 {: .note}
-> Auditing is only available for [lakeFS Cloud]({% link cloud/index.md %}).
-
-{: .warning }
-> Please note, as of Jan 2024, the queryable interface within the lakeFS Cloud UI has been removed in favor of direct access to lakeFS audit logs. This document now describes how to set up and query this information using [AWS Glue](https://aws.amazon.com/glue/) as a reference.
+> Auditing is only available for [lakeFS Cloud]({% link cloud/index.md %}) and [lakeFS Enterprise]({% link enterprise/index.md  %}).
 
 The lakeFS audit log allows you to view all relevant user action information in a clear and organized table, including when the action was performed, by whom, and what it was they did. 
 


### PR DESCRIPTION
clarify in the docs that the auditing log is available on both cloud and enterprise
