### PR TITLE
Use time of create MPU on backend storage as time of MPU

### DIFF
--- a/esti/multipart_test.go
+++ b/esti/multipart_test.go
@@ -26,8 +26,9 @@ const (
 func TestMultipartUpload(t *testing.T) {
 	// timeSlippage is a bound on the time difference between the local server and the S3
 	// server.  It is used to verify that the "Last-Modified" time is actually close to the
-	// CreateMultipartUpload time.
-	const timeSlippage = time.Millisecond * 150
+	// CreateMultipartUpload time.  BUT S3 provides this time only at a 1-second resolution.
+	// So a 1-second difference is possible.
+	const timeSlippage = time.Second
 
 	ctx, logger, repo := setupTest(t)
 	defer tearDownTest(repo)

--- a/esti/multipart_test.go
+++ b/esti/multipart_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/thanhpk/randstr"
 	"github.com/treeverse/lakefs/pkg/api/apigen"
+	"github.com/treeverse/lakefs/pkg/block"
 	"github.com/treeverse/lakefs/pkg/logging"
 )
 
@@ -53,9 +54,11 @@ func TestMultipartUpload(t *testing.T) {
 
 	completedParts := uploadMultipartParts(t, ctx, logger, resp, parts, 0)
 
-	// On S3 the object should have Last-Modified time at around time of MPU creation.
-	// Ensure lakeFS fails the test if it fakes it by using the current time.
-	time.Sleep(2 * timeResolution)
+	if isBlockstoreType(block.BlockstoreTypeS3) == nil {
+		// Object should have Last-Modified time at around time of MPU creation.  Ensure
+		// lakeFS fails the test if it fakes it by using the current time.
+		time.Sleep(2 * timeResolution)
+	}
 
 	completeResponse, err := uploadMultipartComplete(ctx, svc, resp, completedParts)
 	require.NoError(t, err, "failed to complete multipart upload")

--- a/esti/system_test.go
+++ b/esti/system_test.go
@@ -337,11 +337,20 @@ func listRepositories(t *testing.T, ctx context.Context) []apigen.Repository {
 	return listedRepos
 }
 
+// isBlockstoreType returns nil if the blockstore type is one of requiredTypes, or the actual
+// type of the blockstore.
+func isBlockstoreType(requiredTypes ...string) *string {
+	blockstoreType := viper.GetString(config.BlockstoreTypeKey)
+	if slices.Contains(requiredTypes, blockstoreType) {
+		return nil
+	}
+	return &blockstoreType
+}
+
 // requireBlockstoreType Skips test if blockstore type doesn't match the required type
 func requireBlockstoreType(t testing.TB, requiredTypes ...string) {
-	blockstoreType := viper.GetString(config.BlockstoreTypeKey)
-	if !slices.Contains(requiredTypes, blockstoreType) {
-		t.Skipf("Required blockstore types: %v, got: %s", requiredTypes, blockstoreType)
+	if blockstoreType := isBlockstoreType(requiredTypes...); blockstoreType != nil {
+		t.Skipf("Required blockstore types: %v, got: %s", requiredTypes, *blockstoreType)
 	}
 }
 

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -384,10 +384,10 @@ func (c *Controller) CompletePresignMultipartUpload(w http.ResponseWriter, r *ht
 
 	writeTime := time.Now()
 	checksum := httputil.StripQuotesAndSpaces(mpuResp.ETag)
+	// Anything else can be _really_ wrong when the storage layer assigns the time of MPU
+	// creation.  For instance, the S3 block adapter makes sure to return an MTime from
+	// headObject to ensure that we do have a time here.
 	if mpuResp.MTime != nil {
-		// Anything else can be _really_ wrong when the storage layer assigns the time
-		// of MPU creation.  For instance, the S3 block adapter takes sure to return an
-		// MTime from headObject to ensure that we do have a time here.
 		writeTime = *mpuResp.MTime
 	}
 	entryBuilder := catalog.NewDBEntryBuilder().

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -384,6 +384,14 @@ func (c *Controller) CompletePresignMultipartUpload(w http.ResponseWriter, r *ht
 
 	writeTime := time.Now()
 	checksum := httputil.StripQuotesAndSpaces(mpuResp.ETag)
+	if mpuResp.MTime == nil {
+		// This can be _really_ wrong when the storage layer assigns the time of MPU
+		// creation.  For instance, the S3 block adapter takes sure to return an MTime
+		// from headObject to ensure that we do have a time here.
+		writeTime = time.Now()
+	} else {
+		writeTime = *mpuResp.MTime
+	}
 	entryBuilder := catalog.NewDBEntryBuilder().
 		CommonLevel(false).
 		Path(params.Path).

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -384,12 +384,10 @@ func (c *Controller) CompletePresignMultipartUpload(w http.ResponseWriter, r *ht
 
 	writeTime := time.Now()
 	checksum := httputil.StripQuotesAndSpaces(mpuResp.ETag)
-	if mpuResp.MTime == nil {
-		// This can be _really_ wrong when the storage layer assigns the time of MPU
-		// creation.  For instance, the S3 block adapter takes sure to return an MTime
-		// from headObject to ensure that we do have a time here.
-		writeTime = time.Now()
-	} else {
+	if mpuResp.MTime != nil {
+		// Anything else can be _really_ wrong when the storage layer assigns the time
+		// of MPU creation.  For instance, the S3 block adapter takes sure to return an
+		// MTime from headObject to ensure that we do have a time here.
 		writeTime = *mpuResp.MTime
 	}
 	entryBuilder := catalog.NewDBEntryBuilder().

--- a/pkg/block/adapter.go
+++ b/pkg/block/adapter.go
@@ -96,10 +96,13 @@ type CreateMultiPartUploadResponse struct {
 	ServerSideHeader http.Header
 }
 
-// CompleteMultiPartUploadResponse complete multipart etag, content length and additional headers (implementation specific) currently it targets s3.
-// The ETag is a hex string value of the content checksum
+// CompleteMultiPartUploadResponse complete multipart etag, content length and additional headers (implementation specific).
 type CompleteMultiPartUploadResponse struct {
-	ETag             string
+	// ETag is a hex string value of the content checksum
+	ETag string
+	// MTime, if non-nil, is the creation time of the resulting object.  Typically the
+	// object store returns it on a Last-Modified header from some operations.
+	MTime            *time.Time
 	ContentLength    int64
 	ServerSideHeader http.Header
 }

--- a/pkg/block/azure/multipart_block_writer.go
+++ b/pkg/block/azure/multipart_block_writer.go
@@ -106,6 +106,7 @@ func completeMultipart(ctx context.Context, parts []block.MultipartPart, contain
 	etag := string(*res.ETag)
 	return &block.CompleteMultiPartUploadResponse{
 		ETag:          etag,
+		MTime:         res.LastModified,
 		ContentLength: size,
 	}, nil
 }

--- a/pkg/block/gs/adapter.go
+++ b/pkg/block/gs/adapter.go
@@ -524,6 +524,7 @@ func (a *Adapter) CompleteMultiPartUpload(ctx context.Context, obj block.ObjectP
 	lg.Debug("completed multipart upload")
 	return &block.CompleteMultiPartUploadResponse{
 		ETag:          targetAttrs.Etag,
+		MTime:         &targetAttrs.Created,
 		ContentLength: targetAttrs.Size,
 	}, nil
 }

--- a/pkg/block/s3/adapter.go
+++ b/pkg/block/s3/adapter.go
@@ -779,6 +779,7 @@ func (a *Adapter) CompleteMultiPartUpload(ctx context.Context, obj block.ObjectP
 	etag := strings.Trim(aws.ToString(resp.ETag), `"`)
 	return &block.CompleteMultiPartUploadResponse{
 		ETag:             etag,
+		MTime:            headResp.LastModified,
 		ContentLength:    aws.ToInt64(headResp.ContentLength),
 		ServerSideHeader: extractSSHeaderCompleteMultipartUpload(resp),
 	}, nil

--- a/pkg/gateway/operations/operation_utils.go
+++ b/pkg/gateway/operations/operation_utils.go
@@ -40,9 +40,14 @@ func shouldReplaceMetadata(req *http.Request) bool {
 	return req.Header.Get(amzMetadataDirectiveHeaderPrefix) == "REPLACE"
 }
 
-func (o *PathOperation) finishUpload(req *http.Request, checksum, physicalAddress string, size int64, relative bool, metadata map[string]string, contentType string) error {
+func (o *PathOperation) finishUpload(req *http.Request, mTime *time.Time, checksum, physicalAddress string, size int64, relative bool, metadata map[string]string, contentType string) error {
+	var writeTime time.Time
+	if mTime == nil {
+		writeTime = time.Now()
+	} else {
+		writeTime = *mTime
+	}
 	// write metadata
-	writeTime := time.Now()
 	entry := catalog.NewDBEntryBuilder().
 		Path(o.Path).
 		RelativeAddress(relative).

--- a/pkg/gateway/operations/postobject.go
+++ b/pkg/gateway/operations/postobject.go
@@ -124,7 +124,7 @@ func (controller *PostObject) HandleCompleteMultipartUpload(w http.ResponseWrite
 		return
 	}
 	checksum := strings.Split(resp.ETag, "-")[0]
-	err = o.finishUpload(req, checksum, objName, resp.ContentLength, true, multiPart.Metadata, multiPart.ContentType)
+	err = o.finishUpload(req, resp.MTime, checksum, objName, resp.ContentLength, true, multiPart.Metadata, multiPart.ContentType)
 	if errors.Is(err, graveler.ErrWriteToProtectedBranch) {
 		_ = o.EncodeError(w, req, err, gatewayErrors.Codes.ToAPIErr(gatewayErrors.ErrWriteToProtectedBranch))
 		return

--- a/pkg/gateway/operations/putobject.go
+++ b/pkg/gateway/operations/putobject.go
@@ -309,7 +309,6 @@ func handlePut(w http.ResponseWriter, req *http.Request, o *PathOperation) {
 	// write metadata
 	metadata := amzMetaAsMetadata(req)
 	contentType := req.Header.Get("Content-Type")
-	// BUG(ariels): Read MTime from upload!
 	err = o.finishUpload(req, nil, blob.Checksum, blob.PhysicalAddress, blob.Size, true, metadata, contentType)
 	if errors.Is(err, graveler.ErrWriteToProtectedBranch) {
 		_ = o.EncodeError(w, req, err, gatewayErrors.Codes.ToAPIErr(gatewayErrors.ErrWriteToProtectedBranch))

--- a/pkg/gateway/operations/putobject.go
+++ b/pkg/gateway/operations/putobject.go
@@ -309,7 +309,8 @@ func handlePut(w http.ResponseWriter, req *http.Request, o *PathOperation) {
 	// write metadata
 	metadata := amzMetaAsMetadata(req)
 	contentType := req.Header.Get("Content-Type")
-	err = o.finishUpload(req, blob.Checksum, blob.PhysicalAddress, blob.Size, true, metadata, contentType)
+	// BUG(ariels): Read MTime from upload!
+	err = o.finishUpload(req, nil, blob.Checksum, blob.PhysicalAddress, blob.Size, true, metadata, contentType)
 	if errors.Is(err, graveler.ErrWriteToProtectedBranch) {
 		_ = o.EncodeError(w, req, err, gatewayErrors.Codes.ToAPIErr(gatewayErrors.ErrWriteToProtectedBranch))
 		return


### PR DESCRIPTION
This time is either reported by the block adapter during completion, or it can be read by stat'ting the underlying object after complete-MPU.

Fixes #8303.
