### PR TITLE
Add a lakeFS / XID time slug decoder

### DIFF
--- a/contrib/decoder/decode_partition/main.go
+++ b/contrib/decoder/decode_partition/main.go
@@ -1,0 +1,34 @@
+// decode_partition decodes a lakeFS partition (the path component after
+// "data/" in an external location) and extracts its time.  It may be useful
+// for debugging.
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/rs/xid"
+)
+
+const (
+	unixYear4000 = 64060588800
+)
+
+func main() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stderr, "Usage: %s ID", os.Args[0])
+		os.Exit(1)
+	}
+
+	xid, err := xid.FromString(os.Args[1])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Not an XID: %s\n", err)
+		os.Exit(1)
+	}
+
+	createdAt := xid.Time().UTC()
+	fmt.Printf("%s (asc)\n", createdAt.UTC())
+	createdAt = time.Unix(unixYear4000-int64(createdAt.Unix()), 0)
+	fmt.Printf("%s (desc)\n", createdAt.UTC())
+}


### PR DESCRIPTION
# Add a lakeFS / XID time slug decoder

Decodes object names nicely, e.g.
```sh
❯ lakectl -c fs --pre-sign=false stat lakefs://repo/main/50m
Path: 50m
Modified Time: 2024-10-28 17:52:50 +0200 IST
Size: 52428800 bytes
Human Size: 52.4 MB
Physical Address: s3://treeverse-ariels-test-us/repos/s3-dev-repo/data/gcnl78vqmpl9eb7rqlr0/csfr6kfqmpl9eb7rqlt0,jMHnLFOwK2RtCVV_aE0iClDtfP7ehfORTH_siX9V5e8
Checksum: 4d98d5ac224a2a14a2b7efac5d100757-10
Content-Type: application/octet-stream

❯ go run ./contrib/decoder/decode_partition/ csfr6kfqmpl9eb7rqlt0
2024-10-28 15:52:49 +0000 UTC (asc)
3945-03-05 08:07:11 +0000 UTC (desc)
```

But does _not_ decode the partition name ("desc"); not sure why not.
```sh
❯ go run ./contrib/decoder/decode_partition/ gcnl78vqmpl9eb7rqlr0
2039-09-29 13:48:19 +0000 UTC (asc)
3930-04-04 10:11:41 +0000 UTC (desc)
```

(Happy to modify if reviewer can explain this!)
