### PR TITLE
Fix "http: read on closed response body" error

### DIFF
--- a/cmd/lakectl/cmd/retry_client.go
+++ b/cmd/lakectl/cmd/retry_client.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"crypto/x509"
 	"errors"
-	"io"
 	"net/http"
 	"net/url"
 	"regexp"
@@ -17,10 +16,6 @@ var (
 	redirectsErrorRe  = regexp.MustCompile(`stopped after \d+ redirects\z`)
 	schemeErrorRe     = regexp.MustCompile(`unsupported protocol scheme`)
 	notTrustedErrorRe = regexp.MustCompile(`certificate is not trusted`)
-
-	// We need to consume response bodies to maintain http connections, but
-	// limit the size we consume to respReadLimit.
-	respReadLimit = int64(4096) //nolint:mnd
 )
 
 func NewRetryClient(retriesCfg RetriesCfg, transport *http.Transport) *http.Client {
@@ -33,7 +28,6 @@ func NewRetryClient(retriesCfg RetriesCfg, transport *http.Transport) *http.Clie
 	retryClient.RetryWaitMin = retriesCfg.MinWaitInterval
 	retryClient.RetryWaitMax = retriesCfg.MaxWaitInterval
 	retryClient.CheckRetry = lakectlRetryPolicy
-	retryClient.ErrorHandler = customErrorHandler
 	return retryClient.StandardClient()
 }
 
@@ -76,12 +70,4 @@ func lakectlRetryPolicy(ctx context.Context, resp *http.Response, err error) (bo
 		return true, nil
 	}
 	return false, nil
-}
-
-func customErrorHandler(resp *http.Response, err error, _ int) (*http.Response, error) {
-	if resp != nil {
-		defer resp.Body.Close()
-		io.Copy(io.Discard, io.LimitReader(resp.Body, respReadLimit)) //nolint:errcheck
-	}
-	return resp, err
 }

--- a/esti/golden/lakectl_doctor_wrong_uri_format_endpoint.golden
+++ b/esti/golden/lakectl_doctor_wrong_uri_format_endpoint.golden
@@ -1,3 +1,3 @@
 It looks like endpoint url is wrong.
-Get "/wrong_uri/repositories": unsupported protocol scheme ""
+Get "/wrong_uri/repositories": GET /wrong_uri/repositories giving up after 1 attempt(s): unsupported protocol scheme ""
 Suspicious URI format for server.endpoint_url: wrong_uri

--- a/esti/golden/lakectl_doctor_wrong_uri_format_endpoint_verbose.golden
+++ b/esti/golden/lakectl_doctor_wrong_uri_format_endpoint_verbose.golden
@@ -3,7 +3,7 @@ Trying to run a sanity command using current configuration.
 Got error while trying to run a sanity command.
 Trying to analyze error.
 It looks like endpoint url is wrong.
-Get "/wrong_uri/repositories": unsupported protocol scheme ""
+Get "/wrong_uri/repositories": GET /wrong_uri/repositories giving up after 1 attempt(s): unsupported protocol scheme ""
 Trying to validate access key format.
 Couldn't find a problem with access key format.
 Trying to validate secret access key format.


### PR DESCRIPTION
Closes #8331 

## Change Description

The current custom error handler is doing redundant work that eventually causes the `read on closed response body`.

### Current Flow

1. Using the retryable client, the **generated code** issues a request.
2. If the response is retryable, it is retried until the attempts are exhausted.
3. If none of the requests pass, and the error handler isn't nil (it's not), the error handler is called.
4. The custom error handler drains the response's body, closes it, and returns the response along with the passed error (which is nil).
5. The wrapping generated code will parse the response and then it will try to **read its body**. At this point, it will return the "read on closed response body" error.

Example for generated code from point 5:
```go
// ParsePostStatsEventsResponse parses an HTTP response from a PostStatsEventsWithResponse call
func ParsePostStatsEventsResponse(rsp *http.Response) (*PostStatsEventsResponse, error) {
	bodyBytes, err := ioutil.ReadAll(rsp.Body)
	defer rsp.Body.Close()
	if err != nil {
		return nil, err
	}
.....
```

Removing the custom error handler will not affect the current usage which will behave as we expect. This is because the behavior of the default retry client is to drain the body and return an error **without the response**. That way the generated code will not try to read the response, but will return an error...
