### PR TITLE
Fix "deprecated" spelling in note on legacy Python SDK

### DIFF
--- a/docs/integrations/python.md
+++ b/docs/integrations/python.md
@@ -19,7 +19,7 @@ full story!
 Though our previous SDK client is still supported and maintained, we highly recommend using the new High Level SDK.
 **For previous Python SDKs follow these links:**
 [lakefs-sdk](https://pydocs-sdk.lakefs.io)
-[legacy-sdk](https://pydocs.lakefs.io) (Depracated)
+[legacy-sdk](https://pydocs.lakefs.io) (Deprecated)
 {: .note }
 
 There are three primary ways to work with lakeFS from Python:


### PR DESCRIPTION
To misquote a famous man,
> Is it not a strange fate that we should suffer so many comments and labels and process for so small a thing? So small a thing...
