### PR TITLE
Auto-release all clients when publishing with Maven

### DIFF
--- a/clients/pom.xml
+++ b/clients/pom.xml
@@ -86,6 +86,7 @@
         <configuration>
           <serverId>ossrh</serverId>
           <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
+          <autoReleaseAfterClose>true</autoReleaseAfterClose>
         </configuration>
       </plugin>
     </plugins>


### PR DESCRIPTION
Look what I found!  This property is covered in [the
docs](https://central.sonatype.org/publish/publish-maven/#nexus-staging-maven-plugin-for-deployment-and-release). It also allows for a manual review opportunity... but given that we don't do that, and that we test first, let's not go there.

Fixes #7974.

Tested by manually triggering [a release on this branch](https://github.com/treeverse/lakeFS/actions/runs/11879217904/job/33100855408).  It finished and I see no staging repository on https://s01.oss.sonatype.org/#stagingRepositories.  Naturally we will need to wait to see whether a release `test-auto-release` actually made it to Maven central.

But it's worth pulling even now, in the worst case we still need to do something extra.