### PR TITLE
Set object-store last-modified time as mtime in lakeFSFS direct access

### DIFF
--- a/clients/hadoopfs/pom.xml
+++ b/clients/hadoopfs/pom.xml
@@ -287,7 +287,7 @@ To export to S3:
         <dependency>
             <groupId>io.lakefs</groupId>
             <artifactId>sdk</artifactId>
-            <version>1.18.0</version>
+            <version>1.43.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/clients/hadoopfs/src/main/java/io/lakefs/LakeFSLinker.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/LakeFSLinker.java
@@ -1,6 +1,7 @@
 package io.lakefs;
 
 import java.io.IOException;
+import java.util.Date;
 import org.apache.hadoop.fs.Path;
 import io.lakefs.clients.sdk.ApiException;
 import io.lakefs.clients.sdk.StagingApi;
@@ -24,10 +25,16 @@ public class LakeFSLinker {
         this.overwrite = overwrite;
     }
 
-    public void link(String eTag, long byteSize) throws IOException {
+    public void link(String eTag, long byteSize, Date time) throws IOException {
         StagingApi staging = lakeFSClient.getStagingApi();
-        StagingMetadata stagingMetadata =
-                new StagingMetadata().checksum(eTag).sizeBytes(byteSize).staging(stagingLocation);
+        StagingMetadata stagingMetadata = new StagingMetadata()
+            .checksum(eTag)
+            .sizeBytes(byteSize)
+            .staging(stagingLocation);
+        if (time != null) {
+            long secs = (time.getTime() + 500) / 1000;
+            stagingMetadata.setMtime(secs);
+        }
         try {
             StagingApi.APIlinkPhysicalAddressRequest request = 
                     staging.linkPhysicalAddress(objectLoc.getRepository(), objectLoc.getRef(), objectLoc.getPath(), stagingMetadata);

--- a/clients/hadoopfs/src/main/java/io/lakefs/storage/LakeFSFileSystemOutputStream.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/storage/LakeFSFileSystemOutputStream.java
@@ -50,7 +50,7 @@ public class LakeFSFileSystemOutputStream extends OutputStream {
         if (eTag == null) {
             throw new IOException("Failed to finish writing to presigned link. No ETag found.");
         }
-        linker.link(eTag, buffer.size());
+        linker.link(eTag, buffer.size(), null);
         if (connection.getResponseCode() > 299) {
             throw new IOException("Failed to finish writing to presigned link. Response code: "
                     + connection.getResponseCode());

--- a/clients/hadoopfs/src/main/java/io/lakefs/storage/LinkOnCloseOutputStream.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/storage/LinkOnCloseOutputStream.java
@@ -58,7 +58,7 @@ class LinkOnCloseOutputStream extends OutputStream {
         // the underlying Hadoop FileSystem) so we can link it on lakeFS.
         if (!this.isLinked.getAndSet(true)) {
             ObjectMetadata objectMetadata = metadataClient.getObjectMetadata(physicalUri);
-            linker.link(objectMetadata.getETag(), objectMetadata.getContentLength());
+            linker.link(objectMetadata.getETag(), objectMetadata.getContentLength(), objectMetadata.getLastModified());
         }
     }
 }


### PR DESCRIPTION
(This is _not_ possible with presigned URLs, so obviously not done there.)

Closes #8339.
