### PR TITLE
prevent merging a branch to itself

### DIFF
--- a/pkg/graveler/graveler.go
+++ b/pkg/graveler/graveler.go
@@ -2897,6 +2897,9 @@ func (g *Graveler) Merge(ctx context.Context, repository *RepositoryRecord, dest
 		if err != nil {
 			return nil, err
 		}
+		if fromCommit.CommitID == toCommit.CommitID {
+			return nil, ErrNoChanges
+		}
 		lg.WithFields(logging.Fields{
 			"source_meta_range":      fromCommit.MetaRangeID,
 			"destination_meta_range": toCommit.MetaRangeID,


### PR DESCRIPTION
Closes #7824

## Change Description
### Background
Previously, it was possible to 
1. create `branch 1`
2. create `branch 2` from `branch 1`
3. merge `branch 2` into `branch 1` using `--force` or `--allow-empty`

### Bug Fix
The current code flow uses `findMergeBase `to dereference the source and destination branches to their underlying commits.
A validation check has been added to ensure that the source and destination commit IDs are different. If they are the same, the operation returns a "same branch" error.

In lakectl, this error displays as:
`update branch main: same branch validation error`

### Testing Details
* **Test Case 1**: Created a branch from an existing branch and attempted to merge one into the other.
**Result**: Merge failed as expected.
* **Test Case 2**: Created a branch from an existing branch, committed a change, and then merged it back into the first branch.
**Result**: Merge succeeded as expected.

### Contact Details
tkalir@gmail.com