### PR TITLE
replace lakefs_client with lakefs-sdk in Spark integration test harness

### DIFF
--- a/test/spark/requirements.txt
+++ b/test/spark/requirements.txt
@@ -1,3 +1,3 @@
-lakefs_client==0.104.0
+lakefs-sdk==1.43.0
 python-on-whales==0.62.0
 tenacity==8.2.2

--- a/test/spark/run-test.py
+++ b/test/spark/run-test.py
@@ -1,9 +1,9 @@
 import argparse
 import sys
 
-import lakefs_client
-from lakefs_client import models
-from lakefs_client.client import LakeFSClient
+import lakefs_sdk
+from lakefs_sdk import models
+from lakefs_sdk.client import LakeFSClient
 from python_on_whales import docker
 from tenacity import retry, stop_after_attempt, wait_fixed
 
@@ -48,7 +48,7 @@ def main():
         submit_flags = ["--jars", "/target/client.jar"]
 
     lfs_client = LakeFSClient(
-        lakefs_client.Configuration(username=lakefs_access_key,
+        lakefs_sdk.Configuration(username=lakefs_access_key,
                                     password=lakefs_secret_key,
                                     host='http://localhost:8000'))
     wait_for_setup(lfs_client)

--- a/test/spark/run-test.py
+++ b/test/spark/run-test.py
@@ -24,7 +24,7 @@ def get_spark_submit_cmd(submit_flags, spark_config, jar_name, jar_args):
 
 @retry(wait=wait_fixed(1), stop=stop_after_attempt(7))
 def wait_for_setup(lfs_client):
-    repositories = lfs_client.repositories.list_repositories()
+    repositories = lfs_client.repositories_api.list_repositories()
     assert len(repositories.results) >= 0
 
 def main():
@@ -52,7 +52,7 @@ def main():
                                     password=lakefs_secret_key,
                                     host='http://localhost:8000'))
     wait_for_setup(lfs_client)
-    lfs_client.repositories.create_repository(
+    lfs_client.repositories_api.create_repository(
         models.RepositoryCreation(name=args.repository,
                                   storage_namespace=args.storage_namespace,
                                   default_branch='main',))


### PR DESCRIPTION
Closes #8391 

## Change Description

### Background

Replace lakefs_client (deprecated python client) with the lakefs-sdk (1.43.0). 

### Bug Fix

Since in the Spark Integration tests the old deprecated client was used, this PR introduces the new python client (LakeFS_sdk). 
      
### New Feature

No new feature was added.

### Testing Details

Will be added later, right now I'm struggling with running the docker-compose which contains the testing environment on my local machine.

### Breaking Change?

No Breaking changes.

## Additional info

Logs, outputs, screenshots of changes if applicable (CLI / GUI changes)

### Contact Details

You can contact me here or by myemail: mahdikhashan1@gmail.com