### PR TITLE
serve open-api.yaml from API

### DIFF
--- a/pkg/api/serve.go
+++ b/pkg/api/serve.go
@@ -63,6 +63,8 @@ func Serve(cfg *config.Config, catalog *catalog.Catalog, middlewareAuthenticator
 	r.Mount("/metrics", promhttp.Handler())
 	r.Mount("/_pprof/", httputil.ServePPROF("/_pprof/"))
 	r.Mount("/openapi.json", http.HandlerFunc(swaggerSpecHandler))
+	// TODO: communicate with the team to check the design, it could be a breaking change
+	r.Mount("/resources/openapi.yaml", http.HandlerFunc(openAPISpecHandler)) // it seems that the above path could be also moved to under /resources as well
 	r.Mount(apiutil.BaseURL, http.HandlerFunc(InvalidAPIEndpointHandler))
 	r.Mount("/logout", NewLogoutHandler(sessionStore, logger, cfg.Auth.LogoutRedirectURL))
 
@@ -92,6 +94,10 @@ func swaggerSpecHandler(w http.ResponseWriter, _ *http.Request) {
 	}
 	w.Header().Set("Content-Type", "application/json")
 	_, _ = io.Copy(w, reader)
+}
+
+func openAPISpecHandler(w http.ResponseWriter, _ *http.Request) {
+	// TODO: implement me
 }
 
 // OapiRequestValidatorWithOptions Creates middleware to validate request by swagger spec.


### PR DESCRIPTION
Closes #8401 

## Change Description

### Background

it will introduce a new route for users to be able to download the open-api-spec in yaml format from raw path of git repo.

### Bug Fix

Not a bug.

### New Feature

users with pass the open-api-yaml version or main and the file will be returned from the Github raw path. (more details will be added later)

### Testing Details

TODO

### Breaking Change?

it can be a breaking change, since there is already a route called "/openapi.json", we cab move it to "resources/openapi.json" as well, then it can be a breaking change. I need to communicate with the team to either prevent it or introduce this breaking change. (and potentially propose a solution)

## Additional info

TODO

### Contact Details

my email: mahdikhashan1@gmail.com
