### PR TITLE
Fix: Auth no endpoint error

### DIFF
--- a/cmd/lakefs/cmd/run.go
+++ b/cmd/lakefs/cmd/run.go
@@ -57,14 +57,20 @@ type Shutter interface {
 	Shutdown(context.Context) error
 }
 
-var errSimplifiedOrExternalAuth = errors.New(`cannot set auth.ui_config.rbac to non-simplified without setting an external auth service`)
+var (
+	errAuthNoEndpoint = errors.New("cannot set auth.ui_config.rbac to non-basic without setting an external auth service endpoint")
+	errInvalidAuth    = errors.New("invalid auth configuration")
+)
 
 func checkAuthModeSupport(cfg *config.Config) error {
 	if cfg.IsAuthBasic() { // Basic mode
 		return nil
 	}
-	if !cfg.IsAuthUISimplified() && !cfg.IsAuthTypeAPI() {
-		return errSimplifiedOrExternalAuth
+	if !cfg.IsAuthUISimplified() && !cfg.IsAdvancedAuth() {
+		return fmt.Errorf("%s: %w", cfg.Auth.UIConfig.RBAC, errInvalidAuth)
+	}
+	if !cfg.IsAuthTypeAPI() {
+		return errAuthNoEndpoint
 	}
 	return nil
 }

--- a/cmd/lakefs/cmd/run_test.go
+++ b/cmd/lakefs/cmd/run_test.go
@@ -14,6 +14,7 @@ import (
 func TestGetAuthService(t *testing.T) {
 	t.Run("maintain_inviter", func(t *testing.T) {
 		cfg := &config.Config{}
+		cfg.Auth.UIConfig.RBAC = config.AuthRBACInternal
 		cfg.Auth.API.Endpoint = "http://localhost:8000"
 		cfg.Auth.API.SkipHealthCheck = true
 		service := cmd.NewAuthService(context.Background(), cfg, logging.ContextUnavailable(), nil, nil)


### PR DESCRIPTION
Closes #8406

## Change Description

### Background

Add a check for auth endpoint configuration when using non basic authentication and present a proper error message instead failing on healthcheck

### Testing Details

Tested manually

### Breaking Change?

No
