### PR TITLE
Delta Exporter action: Handle vacuumed objects correctly

### DIFF
--- a/pkg/actions/lua/lakefs/catalogexport/delta_exporter.lua
+++ b/pkg/actions/lua/lakefs/catalogexport/delta_exporter.lua
@@ -40,7 +40,7 @@ end
 
     delta_client:
         - get_table: function(repo, ref, prefix)
-    
+
     path_transformer: function(path) used for transforming path scheme (ex: Azure https to abfss)
 
 ]]
@@ -128,6 +128,9 @@ local function export_delta_log(action, table_def_names, write_object, delta_cli
                         elseif entry.remove ~= nil then
                             entry.remove.path = physical_path
                         end
+                    elseif code == 404 and entry.remove ~= nil then
+                        -- If the object is not found, and the entry is a remove entry, we can assume it was vacuumed
+                        print(string.format("REMOVE entry object `%s` wasn't found. Assuming vacuum.", unescaped_path))
                     else
                         error("failed stat_object with code: " .. tostring(code) .. ", and path: " .. unescaped_path)
                     end

--- a/pkg/actions/lua/lakefs/catalogexport/delta_exporter.lua
+++ b/pkg/actions/lua/lakefs/catalogexport/delta_exporter.lua
@@ -5,6 +5,11 @@ local utils = require("lakefs/catalogexport/internal")
 local extractor = require("lakefs/catalogexport/table_extractor")
 local strings = require("strings")
 local url = require("net/url")
+
+local function isTableNotEmpty(t)
+    return next(t) ~= nil
+end
+
 --[[
     delta_log_entry_key_generator returns a closure that returns a Delta Lake version key according to the Delta Lake
     protocol: https://github.com/delta-io/delta/blob/master/PROTOCOL.md#delta-log-entries
@@ -87,6 +92,7 @@ local function export_delta_log(action, table_def_names, write_object, delta_cli
         ]]
         local table_log = {}
         local keyGenerator = delta_log_entry_key_generator()
+        local unfound_paths = {}
         for _, key in ipairs(sortedKeys) do
             local content = t[key]
             local entry_log = {}
@@ -128,9 +134,14 @@ local function export_delta_log(action, table_def_names, write_object, delta_cli
                         elseif entry.remove ~= nil then
                             entry.remove.path = physical_path
                         end
-                    elseif code == 404 and entry.remove ~= nil then
-                        -- If the object is not found, and the entry is a remove entry, we can assume it was vacuumed
-                        print(string.format("REMOVE entry object `%s` wasn't found. Assuming vacuum.", unescaped_path))
+                    elseif code == 404 then
+                        if entry.remove ~= nil then
+                            -- If the object is not found, and the entry is a remove entry, we can assume it was vacuumed
+                            print(string.format("Object with path '%s' of a `remove` entry wasn't found. Assuming vacuum.", unescaped_path))
+                            unfound_paths[unescaped_path] = nil
+                        else
+                            unfound_paths[unescaped_path] = true
+                        end
                     else
                         error("failed stat_object with code: " .. tostring(code) .. ", and path: " .. unescaped_path)
                     end
@@ -139,6 +150,17 @@ local function export_delta_log(action, table_def_names, write_object, delta_cli
                 table.insert(entry_log, entry_m)
             end
             table_log[keyGenerator()] = entry_log
+        end
+
+        if isTableNotEmpty(unfound_paths) then
+            local unfound_paths_str = ""
+            for p, v in pairs(unfound_paths) do
+                if v ~= nil then
+                    unfound_paths_str = pathlib.join(" ", unfound_paths_str, p)
+                    print(p)
+                end
+            end
+            error("The following objects were not found: " .. unfound_paths)
         end
 
         local table_export_prefix = utils.get_storage_uri_prefix(ns, commit_id, action)


### PR DESCRIPTION
When traversing a delta lake log, we might come across entries of objects that were vacuumed. Prior to this change, we would stat all of the entry paths to get their physical address, even if those paths were vacuumed. This would cause a 404 "not found" status code to be returned, and the hook would error.
This fix handles such cases.
The resulting exported delta log will include **logical paths** of vacuumed objects but that doesn't matter for either reading a table, nor future vacuums.

## How was it tested?

Manually: created a table, added data, altered the table such that the delta log included a path under an `add` entry (in the `0000...0.json` file) and the same path under a `remove` entry (in the `0000...1.json` file). I've deleted the path manually, thus mimicking vacuum, and committed which made the hook run. 
Finally, verified that the resulting log is as expected, and read the table using Spark.