### PR TITLE
Change log level of stats failure warning 

### DIFF
--- a/cmd/lakectl/cmd/root.go
+++ b/cmd/lakectl/cmd/root.go
@@ -463,7 +463,7 @@ func sendStats(cmd *cobra.Command, cmdSuffix string) {
 			errStr = resp.Status()
 		}
 		if errStr != "" {
-			_, _ = fmt.Fprintf(os.Stderr, "Warning: failed sending statistics: %s\n", errStr)
+			logging.ContextUnavailable().Debugf("Warning: failed sending statistics: %s\n", errStr)
 		}
 	}
 }


### PR DESCRIPTION
Closes #8287

## Change Description
Changed the level of stats sending failure to debug

### Background
see https://github.com/treeverse/lakeFS/issues/8287

### Testing Details
Tested manually:
![Screenshot 2024-12-11 at 12 29 38](https://github.com/user-attachments/assets/5763f616-166d-4a57-a0b6-2d036edf40b1)
 
The way I reproduced the error:
 - write an error to to the request in the controller func `PostStatsEvents` - to make lakectl think stats sending failed
 - comment the first if statement in lakectl's root.go `sendStats` func - to hide the fact that lakefs is a dev version
