### PR TITLE
adjusted dockerfile so that build args can be provided to switch the …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,16 +3,18 @@ ARG VERSION=dev
 
 ARG BUILD_REPO=golang
 ARG BUILD_TAG=1.22.6-alpine3.20
-ARG BUILD_PACKAGES=build-base ca-certificates
+ARG BUILD_PACKAGES="build-base ca-certificates"
 
 ARG IMAGE_REPO=alpine
 ARG IMAGE_TAG=3.18
 ARG IMAGE_PACKAGES=ca-certificates
 
-ARG ADD_PACKAGES=apk add -U --no-cache
+ARG ADD_PACKAGES="apk add -U --no-cache"
 
 
 FROM --platform=$BUILDPLATFORM $BUILD_REPO:$BUILD_TAG AS build
+ARG ADD_PACKAGES BUILD_PACKAGES
+
 WORKDIR /build
 RUN $ADD_PACKAGES $BUILD_PACKAGES
 COPY go.mod go.sum ./
@@ -20,20 +22,21 @@ RUN --mount=type=cache,target=/go/pkg go mod download
 COPY . ./
 
 FROM build AS build-lakefs
-ARG VERSION TARGETOS TARGETARCH
+ARG VERSION TARGETOS TARGETARCH ADD_PACKAGES BUILD_PACKAGES
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg \
     GOOS=$TARGETOS GOARCH=$TARGETARCH \
     go build -ldflags "-X github.com/treeverse/lakefs/pkg/version.Version=${VERSION}" -o lakefs ./cmd/lakefs
 
 FROM build AS build-lakectl
-ARG VERSION TARGETOS TARGETARCH
+ARG VERSION TARGETOS TARGETARCH ADD_PACKAGES BUILD_PACKAGES
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg \
     GOOS=$TARGETOS GOARCH=$TARGETARCH \
     go build -ldflags "-X github.com/treeverse/lakefs/pkg/version.Version=${VERSION}" -o lakectl ./cmd/lakectl
 
 FROM $IMAGE_REPO:$IMAGE_TAG AS lakectl
+ARG ADD_PACKAGES IMAGE_PACKAGES
 WORKDIR /app
 ENV PATH=/app:$PATH
 COPY --from=build-lakectl /build/lakectl /app/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,43 @@
 # syntax=docker/dockerfile:1
 ARG VERSION=dev
 
-FROM --platform=$BUILDPLATFORM golang:1.22.6-alpine3.20 AS build
+ARG BUILD_REPO=golang
+ARG BUILD_TAG=1.22.6-alpine3.20
+ARG BUILD_PACKAGES=build-base ca-certificates
+
+ARG IMAGE_REPO=alpine
+ARG IMAGE_TAG=3.18
+ARG IMAGE_PACKAGES=ca-certificates
+
+ARG ADD_PACKAGES=apk add -U --no-cache
+
+
+FROM --platform=$BUILDPLATFORM $BUILD_REPO:$BUILD_TAG AS build
 WORKDIR /build
-RUN apk add --no-cache build-base ca-certificates
+RUN $ADD_PACKAGES $BUILD_PACKAGES
 COPY go.mod go.sum ./
 RUN --mount=type=cache,target=/go/pkg go mod download
 COPY . ./
 
-FROM build as build-lakefs
+FROM build AS build-lakefs
 ARG VERSION TARGETOS TARGETARCH
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg \
     GOOS=$TARGETOS GOARCH=$TARGETARCH \
     go build -ldflags "-X github.com/treeverse/lakefs/pkg/version.Version=${VERSION}" -o lakefs ./cmd/lakefs
 
-FROM build as build-lakectl
+FROM build AS build-lakectl
 ARG VERSION TARGETOS TARGETARCH
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg \
     GOOS=$TARGETOS GOARCH=$TARGETARCH \
     go build -ldflags "-X github.com/treeverse/lakefs/pkg/version.Version=${VERSION}" -o lakectl ./cmd/lakectl
 
-FROM alpine:3.18 AS lakectl
+FROM $IMAGE_REPO:$IMAGE_TAG AS lakectl
 WORKDIR /app
-ENV PATH /app:$PATH
+ENV PATH=/app:$PATH
 COPY --from=build-lakectl /build/lakectl /app/
-RUN apk add -U --no-cache ca-certificates
+RUN $ADD_PACKAGES $IMAGE_PACKAGES
 RUN addgroup -S lakefs && adduser -S lakefs -G lakefs
 USER lakefs
 WORKDIR /home/lakefs


### PR DESCRIPTION

Closes #8419 

## Change Description

 I added the following build args to generalize the `Dockerfile` to `debian::bookworm`. 
 
  - `BUILD_REPO`
  - `BUILD_TAG`
  - `BUILD_PACKAGES`
  - `IMAGE_REPO`
  - `IMAGE_TAG`
  - `IMAGE_PACKAGES`
  - `ADD_PACKAGES`



### Background

I mentioned this in LakeFS' help channel in slack, and was recommended to create this issue and make a PR.  This is no problem, and I went ahead and generalized the `Dockerfile` so that we can toggle our base repo, architecture, and so on via our CI/CD build variables. 



### Bug Fix

If this PR is a bug fix, please let us know about:

1. Problem - The reason for opening the bug
2. Root cause - Discovered root cause after investigation
3. Solution - How the bug was fixed
      
### New Feature

The base docker image can now be built with an arbitrary linux base image, e.g. `debian:bookworm`:

```
docker build --build-arg BUILD_REPO=golang --build-arg BUILD_TAG=1.22.6-bookworm --build-arg IMAGE_REPO=debian --build-arg IMAGE_TAG=bookworm --build-arg BUILD_PACKAGES="build-essential ca-certificates" --build-arg IMAGE_PACKAGES=ca-certificates --build-arg ADD_PACKAGES="apt-get update && apt-get install -y" .
```

### Testing Details

I built the image. 

### Breaking Change?

It doesn't break anything, per say. However, I ran into a bug that I saw on both the unchanged `master` branch and my updated branch. Namely, I saw the following go error when building on an `arm64` mac w/ `colima` in `x86_64` emulation mode via `qemu`:

```
 => [build 6/6] COPY . ./                                                                                                                                                                                                                                                                                                                                            1.3s 
 => ERROR [build-lakefs 1/1] RUN --mount=type=cache,target=/root/.cache/go-build     --mount=type=cache,target=/go/pkg     GOOS=linux GOARCH=amd64     go build -ldflags "-X github.com/treeverse/lakefs/pkg/version.Version=dev" -o lakefs ./cmd/lakefs                                                                                                             2.6s 
 => CANCELED [build-lakectl 1/1] RUN --mount=type=cache,target=/root/.cache/go-build     --mount=type=cache,target=/go/pkg     GOOS=linux GOARCH=amd64     go build -ldflags "-X github.com/treeverse/lakefs/pkg/version.Version=dev" -o lakectl ./cmd/lakectl                                                                                                       2.8s 
------                                                                                                                                                                                                                                                                                                                                                                    
 > [build-lakefs 1/1] RUN --mount=type=cache,target=/root/.cache/go-build     --mount=type=cache,target=/go/pkg     GOOS=linux GOARCH=amd64     go build -ldflags "-X github.com/treeverse/lakefs/pkg/version.Version=dev" -o lakefs ./cmd/lakefs:                                                                                                                        
2.397 pkg/authentication/service.go:12:2: no required module provides package github.com/treeverse/lakefs/pkg/authentication/apiclient; to add it:                                                                                                                                                                                                                        
2.397   go get github.com/treeverse/lakefs/pkg/authentication/apiclient
2.397 webui/content.go:7:12: pattern dist: no matching files found
```

I assume this is because of my setup, and I hope that we'll still be able to build the image in our CI/CD. 

## Additional info


### Contact Details

christopher.j.donlan@gmail.com
