### PR TITLE
Improve WebUI users sort

### DIFF
--- a/webui/src/pages/auth/groups/group/members.jsx
+++ b/webui/src/pages/auth/groups/group/members.jsx
@@ -63,7 +63,7 @@ const GroupMemberList = ({ groupId, after, onPaginate }) => {
                             Remove
                         </ConfirmationButton>
                     }]}
-                    results={results}
+                    results={results.sort((a,b) => resolveDisplayName(a).localeCompare(resolveDisplayName(b)))}
                     emptyState={'No users found'}
                 />
 


### PR DESCRIPTION
## Change Description

### Background

Currently, the WebUI Users page displays the list of users, as fetched from the server.
The issue is that the server sorts the users by their `id`, while the UI is displaying the User ID for each user using a more complex logic (`email` => `friendly_name` => `id`).
This creates a confusing situation: where some users has emails while others don't have, the sorting might be messed up.

For example:

List of users:
```
[
  {id: 'ccc`},
  {id: 'zzz', email: 'a@a.com'} 
]
```

Actual display:
```
User ID
-------
ccc
a@a.com
```


### Change

This PR aligns the display order to be sorted according to the displayed `User ID`.

### Testing Details

Tested manually on my local env.

## Additional info

Note that this is not a complete solution, since the UI uses pagination.
But it should at least improve the current state, and make it easier to find users on the current results page.

A complete solution will require a bigger change to support it, which will probably involve both changing the UI and change the default sorting of the API.
