### PR TITLE
clone #8420: adjusted dockerfile so that build args can be provided to switch the …

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,43 @@
 # syntax=docker/dockerfile:1
 ARG VERSION=dev
 
-FROM --platform=$BUILDPLATFORM golang:1.22.6-alpine3.20 AS build
+ARG BUILD_REPO=golang
+ARG BUILD_TAG=1.22.6-alpine3.20
+ARG BUILD_PACKAGES=build-base ca-certificates
+
+ARG IMAGE_REPO=alpine
+ARG IMAGE_TAG=3.18
+ARG IMAGE_PACKAGES=ca-certificates
+
+ARG ADD_PACKAGES=apk add -U --no-cache
+
+
+FROM --platform=$BUILDPLATFORM $BUILD_REPO:$BUILD_TAG AS build
 WORKDIR /build
-RUN apk add --no-cache build-base ca-certificates
+RUN $ADD_PACKAGES $BUILD_PACKAGES
 COPY go.mod go.sum ./
 RUN --mount=type=cache,target=/go/pkg go mod download
 COPY . ./
 
-FROM build as build-lakefs
+FROM build AS build-lakefs
 ARG VERSION TARGETOS TARGETARCH
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg \
     GOOS=$TARGETOS GOARCH=$TARGETARCH \
     go build -ldflags "-X github.com/treeverse/lakefs/pkg/version.Version=${VERSION}" -o lakefs ./cmd/lakefs
 
-FROM build as build-lakectl
+FROM build AS build-lakectl
 ARG VERSION TARGETOS TARGETARCH
 RUN --mount=type=cache,target=/root/.cache/go-build \
     --mount=type=cache,target=/go/pkg \
     GOOS=$TARGETOS GOARCH=$TARGETARCH \
     go build -ldflags "-X github.com/treeverse/lakefs/pkg/version.Version=${VERSION}" -o lakectl ./cmd/lakectl
 
-FROM alpine:3.18 AS lakectl
+FROM $IMAGE_REPO:$IMAGE_TAG AS lakectl
 WORKDIR /app
-ENV PATH /app:$PATH
+ENV PATH=/app:$PATH
 COPY --from=build-lakectl /build/lakectl /app/
-RUN apk add -U --no-cache ca-certificates
+RUN $ADD_PACKAGES $IMAGE_PACKAGES
 RUN addgroup -S lakefs && adduser -S lakefs -G lakefs
 USER lakefs
 WORKDIR /home/lakefs


### PR DESCRIPTION
…build from musl-amd64 to amd64

Clone of #8420, which I reviewed and will pull.

DO NOT PULL; this is only to get Esti to run.