### PR TITLE
support putifabsent

### DIFF
--- a/esti/multipart_test.go
+++ b/esti/multipart_test.go
@@ -52,7 +52,7 @@ func TestMultipartUpload(t *testing.T) {
 		partsConcat = append(partsConcat, parts[i]...)
 	}
 
-	completedParts := uploadMultipartParts(t, ctx, logger, resp, parts, 0)
+	completedParts := uploadMultipartParts(t, ctx, svc, logger, resp, parts, 0)
 
 	if isBlockstoreType(block.BlockstoreTypeS3) == nil {
 		// Object should have Last-Modified time at around time of MPU creation.  Ensure
@@ -166,7 +166,7 @@ func reverse(s string) string {
 	return string(runes)
 }
 
-func uploadMultipartParts(t *testing.T, ctx context.Context, logger logging.Logger, resp *s3.CreateMultipartUploadOutput, parts [][]byte, firstIndex int) []types.CompletedPart {
+func uploadMultipartParts(t *testing.T, ctx context.Context, client *s3.Client, logger logging.Logger, resp *s3.CreateMultipartUploadOutput, parts [][]byte, firstIndex int) []types.CompletedPart {
 	count := len(parts)
 	completedParts := make([]types.CompletedPart, count)
 	errs := make([]error, count)
@@ -176,7 +176,7 @@ func uploadMultipartParts(t *testing.T, ctx context.Context, logger logging.Logg
 		go func(i int) {
 			defer wg.Done()
 			partNumber := firstIndex + i + 1
-			completedParts[i], errs[i] = uploadMultipartPart(ctx, logger, svc, resp, parts[i], partNumber)
+			completedParts[i], errs[i] = uploadMultipartPart(ctx, logger, client, resp, parts[i], partNumber)
 		}(i)
 	}
 	wg.Wait()

--- a/esti/multipart_test.go
+++ b/esti/multipart_test.go
@@ -166,7 +166,7 @@ func reverse(s string) string {
 	return string(runes)
 }
 
-func uploadMultipartParts(t *testing.T, ctx context.Context, svc *s3.Client, logger logging.Logger, resp *s3.CreateMultipartUploadOutput, parts [][]byte, firstIndex int) []types.CompletedPart {
+func uploadMultipartParts(t *testing.T, ctx context.Context, client *s3.Client, logger logging.Logger, resp *s3.CreateMultipartUploadOutput, parts [][]byte, firstIndex int) []types.CompletedPart {
 	count := len(parts)
 	completedParts := make([]types.CompletedPart, count)
 	errs := make([]error, count)
@@ -176,7 +176,7 @@ func uploadMultipartParts(t *testing.T, ctx context.Context, svc *s3.Client, log
 		go func(i int) {
 			defer wg.Done()
 			partNumber := firstIndex + i + 1
-			completedParts[i], errs[i] = uploadMultipartPart(ctx, logger, svc, resp, parts[i], partNumber)
+			completedParts[i], errs[i] = uploadMultipartPart(ctx, logger, client, resp, parts[i], partNumber)
 		}(i)
 	}
 	wg.Wait()

--- a/esti/multipart_test.go
+++ b/esti/multipart_test.go
@@ -166,7 +166,7 @@ func reverse(s string) string {
 	return string(runes)
 }
 
-func uploadMultipartParts(t *testing.T, ctx context.Context, client *s3.Client, logger logging.Logger, resp *s3.CreateMultipartUploadOutput, parts [][]byte, firstIndex int) []types.CompletedPart {
+func uploadMultipartParts(t *testing.T, ctx context.Context, svc *s3.Client, logger logging.Logger, resp *s3.CreateMultipartUploadOutput, parts [][]byte, firstIndex int) []types.CompletedPart {
 	count := len(parts)
 	completedParts := make([]types.CompletedPart, count)
 	errs := make([]error, count)
@@ -176,7 +176,7 @@ func uploadMultipartParts(t *testing.T, ctx context.Context, client *s3.Client, 
 		go func(i int) {
 			defer wg.Done()
 			partNumber := firstIndex + i + 1
-			completedParts[i], errs[i] = uploadMultipartPart(ctx, logger, client, resp, parts[i], partNumber)
+			completedParts[i], errs[i] = uploadMultipartPart(ctx, logger, svc, resp, parts[i], partNumber)
 		}(i)
 	}
 	wg.Wait()

--- a/esti/s3_gateway_test.go
+++ b/esti/s3_gateway_test.go
@@ -198,11 +198,11 @@ func TestS3IfNoneMatch(t *testing.T) {
 	}
 
 	testCases := []TestCase{
-		{Path: "object1", Content: "data1", IfNoneMatch: "", ExpectError: false},
-		{Path: "object1", Content: "data2", IfNoneMatch: "*", ExpectError: false},
-		{Path: "object2", Content: "data3", IfNoneMatch: "*", ExpectError: false},
-		{Path: "object2", Content: "data3", IfNoneMatch: "*", ExpectError: false},
-		{Path: "object3", Content: "data4", IfNoneMatch: "hi", ExpectError: false},
+		{Path: "object1", Content: "data", IfNoneMatch: "", ExpectError: false},
+		{Path: "object1", Content: "data", IfNoneMatch: "*", ExpectError: true},
+		{Path: "object2", Content: "data", IfNoneMatch: "*", ExpectError: false},
+		{Path: "object2", Content: "data", IfNoneMatch: "", ExpectError: false},
+		{Path: "object3", Content: "data", IfNoneMatch: "hi", ExpectError: true},
 	}
 
 	objects := make(chan TestCase, parallelism*2)

--- a/esti/s3_gateway_test.go
+++ b/esti/s3_gateway_test.go
@@ -231,8 +231,9 @@ func TestMultipartUploadIfNoneMatch(t *testing.T) {
 			},
 		}
 		_, err = s3Client.CompleteMultipartUpload(ctx, completeInput, s3.WithAPIOptions(setHTTPHeaders(tc.IfNoneMatch)))
-		require.ErrorContains(t, err, tc.ExpectedError)
-
+		if tc.ExpectedError != "" {
+			require.ErrorContains(t, err, tc.ExpectedError)
+		}
 	}
 }
 
@@ -278,8 +279,9 @@ func TestS3IfNoneMatch(t *testing.T) {
 			Key:    aws.String(tc.Path),
 		}
 		_, err := s3Client.PutObject(ctx, input, s3.WithAPIOptions(setHTTPHeaders(tc.IfNoneMatch)))
-		require.ErrorContains(t, err, tc.ExpectedError)
-
+		if tc.ExpectedError != "" {
+			require.ErrorContains(t, err, tc.ExpectedError)
+		}
 	}
 }
 

--- a/esti/s3_gateway_test.go
+++ b/esti/s3_gateway_test.go
@@ -239,9 +239,8 @@ func TestS3IfNoneMatch(t *testing.T) {
 					Key:    aws.String(tc.Path),
 					Body:   strings.NewReader(tc.Content),
 				}
-				_, err := s3Client.PutObject(ctx, input, func(o *s3.Options) {
-					o.APIOptions = append(o.APIOptions, setHTTPHeaders(tc.IfNoneMatch))
-				})
+				_, err := s3Client.PutObject(ctx, input, s3.WithAPIOptions(setHTTPHeaders(tc.IfNoneMatch)))
+
 				if tc.ExpectError {
 					require.Error(t, err, "was expecting an error")
 				} else {

--- a/esti/s3_gateway_test.go
+++ b/esti/s3_gateway_test.go
@@ -233,6 +233,8 @@ func TestMultipartUploadIfNoneMatch(t *testing.T) {
 		_, err = s3Client.CompleteMultipartUpload(ctx, completeInput, s3.WithAPIOptions(setHTTPHeaders(tc.IfNoneMatch)))
 		if tc.ExpectedError != "" {
 			require.ErrorContains(t, err, tc.ExpectedError)
+		} else {
+			require.NoError(t, err, "expected no error but got %w")
 		}
 	}
 }
@@ -281,6 +283,8 @@ func TestS3IfNoneMatch(t *testing.T) {
 		_, err := s3Client.PutObject(ctx, input, s3.WithAPIOptions(setHTTPHeaders(tc.IfNoneMatch)))
 		if tc.ExpectedError != "" {
 			require.ErrorContains(t, err, tc.ExpectedError)
+		} else {
+			require.NoError(t, err, "expected no error but got %w")
 		}
 	}
 }

--- a/esti/s3_gateway_test.go
+++ b/esti/s3_gateway_test.go
@@ -188,8 +188,8 @@ func TestS3IfNoneMatch(t *testing.T) {
 
 	ctx, _, repo := setupTest(t)
 	defer tearDownTest(repo)
-
-	client := createS3Client(endpointURL, t)
+	endpoint := "http://localhost:8000"
+	client := createS3Client(endpoint, t)
 	bucketName := "test-bucket"
 	_, err := client.CreateBucket(ctx, &s3.CreateBucketInput{
 		Bucket: aws.String(bucketName),

--- a/esti/s3_gateway_test.go
+++ b/esti/s3_gateway_test.go
@@ -223,7 +223,7 @@ func TestS3IfNoneMatch(t *testing.T) {
 		{Path: "main/object1", Content: "data", IfNoneMatch: "*", ExpectError: true},
 		{Path: "main/object2", Content: "data", IfNoneMatch: "*", ExpectError: false},
 		{Path: "main/object2", Content: "data", IfNoneMatch: "", ExpectError: false},
-		{Path: "main/object3", Content: "data", IfNoneMatch: "hi", ExpectError: true},
+		{Path: "main/object2", Content: "data", IfNoneMatch: "*", ExpectError: true},
 	}
 
 	objects := make(chan TestCase, parallelism*2)

--- a/esti/s3_gateway_test.go
+++ b/esti/s3_gateway_test.go
@@ -218,8 +218,7 @@ func TestS3IfNoneMatch(t *testing.T) {
 				}
 
 				if tc.IfNoneMatch != "" {
-					opts.UserMetadata["If-None-Match"] = tc.IfNoneMatch
-					opts.Header()
+					opts.UserMetadata["X-Amz-If-None-Match"] = tc.IfNoneMatch
 				}
 
 				_, err := client.PutObject(ctx, repo, tc.Path, strings.NewReader(tc.Content), int64(len(tc.Content)), opts)
@@ -229,7 +228,6 @@ func TestS3IfNoneMatch(t *testing.T) {
 			}
 		}()
 	}
-
 	// Enqueue test cases
 	for _, tc := range testCases {
 		objects <- tc

--- a/esti/s3_gateway_test.go
+++ b/esti/s3_gateway_test.go
@@ -218,7 +218,7 @@ func TestS3IfNoneMatch(t *testing.T) {
 				}
 
 				if tc.IfNoneMatch != "" {
-					opts.UserMetadata["X-Amz-If-None-Match"] = tc.IfNoneMatch
+					opts.Header().Add("If-None-Match", tc.IfNoneMatch)
 				}
 
 				_, err := client.PutObject(ctx, repo, tc.Path, strings.NewReader(tc.Content), int64(len(tc.Content)), opts)

--- a/esti/s3_gateway_test.go
+++ b/esti/s3_gateway_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/aws/smithy-go/middleware"
 	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/go-openapi/swag"
+	"github.com/thanhpk/randstr"
 
 	"github.com/minio/minio-go/v7"
 	"github.com/minio/minio-go/v7/pkg/credentials"
@@ -208,6 +209,7 @@ func TestMultipartUploadIfNoneMatch(t *testing.T) {
 	defer tearDownTest(repo)
 	s3Endpoint := viper.GetString("s3_endpoint")
 	s3Client := createS3Client(s3Endpoint, t)
+	multipartNumberOfParts := 7
 	type TestCase struct {
 		Path        string
 		Content     string
@@ -230,6 +232,9 @@ func TestMultipartUploadIfNoneMatch(t *testing.T) {
 		logger.Info("Created multipart upload request")
 
 		parts := make([][]byte, multipartNumberOfParts)
+		for i := 0; i < multipartNumberOfParts; i++ {
+			parts[i] = randstr.Bytes(multipartPartSize + i)
+		}
 
 		completedParts := uploadMultipartParts(t, ctx, s3Client, logger, resp, parts, 0)
 

--- a/esti/s3_gateway_test.go
+++ b/esti/s3_gateway_test.go
@@ -216,11 +216,11 @@ func TestS3IfNoneMatch(t *testing.T) {
 	}
 
 	testCases := []TestCase{
-		{Path: "object1", Content: "data", IfNoneMatch: "", ExpectError: false},
-		{Path: "object1", Content: "data", IfNoneMatch: "*", ExpectError: true},
-		{Path: "object2", Content: "data", IfNoneMatch: "*", ExpectError: false},
-		{Path: "object2", Content: "data", IfNoneMatch: "", ExpectError: false},
-		{Path: "object3", Content: "data", IfNoneMatch: "hi", ExpectError: true},
+		{Path: "main/object1", Content: "data", IfNoneMatch: "", ExpectError: false},
+		{Path: "main/object1", Content: "data", IfNoneMatch: "*", ExpectError: true},
+		{Path: "main/object2", Content: "data", IfNoneMatch: "*", ExpectError: false},
+		{Path: "main/object2", Content: "data", IfNoneMatch: "", ExpectError: false},
+		{Path: "main/object3", Content: "data", IfNoneMatch: "hi", ExpectError: true},
 	}
 
 	objects := make(chan TestCase, parallelism*2)

--- a/esti/s3_gateway_test.go
+++ b/esti/s3_gateway_test.go
@@ -202,9 +202,9 @@ func TestMultipartUploadIfNoneMatch(t *testing.T) {
 	}
 
 	testCases := []TestCase{
-		{Path: "main/object1", IfNoneMatch: "", ExpectedError: ""},
+		{Path: "main/object1"},
 		{Path: "main/object1", IfNoneMatch: "*", ExpectedError: errorPreconditionFailed},
-		{Path: "main/object2", IfNoneMatch: "*", ExpectedError: ""},
+		{Path: "main/object2", IfNoneMatch: "*"},
 	}
 	for _, tc := range testCases {
 		input := &s3.CreateMultipartUploadInput{
@@ -269,10 +269,10 @@ func TestS3IfNoneMatch(t *testing.T) {
 	}
 
 	testCases := []TestCase{
-		{Path: "main/object1", IfNoneMatch: "", ExpectedError: ""},
+		{Path: "main/object1"},
 		{Path: "main/object1", IfNoneMatch: "*", ExpectedError: errorPreconditionFailed},
-		{Path: "main/object2", IfNoneMatch: "*", ExpectedError: ""},
-		{Path: "main/object2", IfNoneMatch: "", ExpectedError: ""},
+		{Path: "main/object2", IfNoneMatch: "*"},
+		{Path: "main/object2"},
 		{Path: "main/object3", IfNoneMatch: "unsupported string", ExpectedError: errorNotImplemented},
 	}
 	for _, tc := range testCases {

--- a/esti/s3_gateway_test.go
+++ b/esti/s3_gateway_test.go
@@ -186,18 +186,6 @@ func TestS3UploadAndDownload(t *testing.T) {
 		})
 	}
 }
-func uploadMultipartCompleteIfNoneMatch(ctx context.Context, svc *s3.Client, resp *s3.CreateMultipartUploadOutput, completedParts []types.CompletedPart) (*s3.CompleteMultipartUploadOutput, error) {
-	completeInput := &s3.CompleteMultipartUploadInput{
-		Bucket:   resp.Bucket,
-		Key:      resp.Key,
-		UploadId: resp.UploadId,
-		MultipartUpload: &types.CompletedMultipartUpload{
-			Parts: completedParts,
-		},
-	}
-	return svc.CompleteMultipartUpload(ctx, completeInput)
-}
-
 func TestMultipartUploadIfNoneMatch(t *testing.T) {
 	// timeResolution is a duration greater than the timestamp resolution of the backing
 	// store.  Multipart object on S3 is the time of create-MPU, waiting before completion
@@ -272,9 +260,7 @@ func setHTTPHeaders(ifNoneMatch string) func(*middleware.Stack) error {
 			if req, ok := in.Request.(*smithyhttp.Request); ok {
 				// Add the If-None-Match header
 				req.Header.Set("If-None-Match", ifNoneMatch)
-				fmt.Printf("Set If-None-Match header: %s\n", ifNoneMatch) // Debug logging
 			}
-			// Continue with the next middleware handler
 			return next.HandleBuild(ctx, in)
 		}), middleware.Before)
 	}

--- a/esti/s3_gateway_test.go
+++ b/esti/s3_gateway_test.go
@@ -193,14 +193,14 @@ func setHTTPHeaders(ifNoneMatch string) func(*middleware.Stack) error {
 		) {
 			if req, ok := in.Request.(*http.Request); ok {
 				// Add the If-None-Match header
-				req.Header.Add("If-None-Match", ifNoneMatch)
+				req.Header.Set("If-None-Match", ifNoneMatch)
+				fmt.Printf("Set If-None-Match header: %s\n", ifNoneMatch) // Debug logging
 			}
 			// Continue with the next middleware handler
 			return next.HandleBuild(ctx, in)
 		}), middleware.Before)
 	}
 }
-
 func TestS3IfNoneMatch(t *testing.T) {
 	const parallelism = 10
 
@@ -239,6 +239,7 @@ func TestS3IfNoneMatch(t *testing.T) {
 					Key:    aws.String(tc.Path),
 					Body:   strings.NewReader(tc.Content),
 				}
+				fmt.Printf("Sending PutObject request for Path: %s with If-None-Match: %s\n", tc.Path, tc.IfNoneMatch) // Debug logging
 				_, err := s3Client.PutObject(ctx, input, s3.WithAPIOptions(setHTTPHeaders(tc.IfNoneMatch)))
 
 				if tc.ExpectError {

--- a/esti/s3_gateway_test.go
+++ b/esti/s3_gateway_test.go
@@ -235,9 +235,9 @@ func TestS3IfNoneMatch(t *testing.T) {
 		_, err := s3Client.PutObject(ctx, input, s3.WithAPIOptions(setHTTPHeaders(tc.IfNoneMatch)))
 
 		if tc.ExpectError {
-			require.Error(t, err, "was expecting an error")
+			require.Error(t, err, "was expecting an error with path %s and header %s", tc.Path, tc.IfNoneMatch)
 		} else {
-			require.NoError(t, err, "wasn't expecting error")
+			require.NoError(t, err, "wasn't expecting error with path %s and header %s", tc.Path, tc.IfNoneMatch)
 		}
 	}
 }

--- a/esti/s3_gateway_test.go
+++ b/esti/s3_gateway_test.go
@@ -183,12 +183,29 @@ func TestS3UploadAndDownload(t *testing.T) {
 		})
 	}
 }
+
+//	func setHTTPHeaders() func(*middleware.Stack) error {
+//		return func(stack *middleware.Stack) error {
+//			return stack.Build.Add(middleware.BuildMiddlewareFunc("AddIfNoneMatchHeader", func(
+//				ctx context.Context, in middleware.BuildInput, next middleware.BuildHandler,
+//			) (
+//				middleware.BuildOutput, middleware.Metadata, error,
+//			) {
+//				if req, ok := in.Request.(*smithyhttp.Request); ok {
+//					// Add the If-None-Match header
+//					req.Header.Add("If-None-Match",req.)
+//				}
+//				// Continue with the next middleware handler
+//				return next.HandleBuild(ctx, in)
+//			}), middleware.Before)
+//		}
+//	}
 func TestS3IfNoneMatch(t *testing.T) {
 	const parallelism = 10
 
 	ctx, _, repo := setupTest(t)
 	defer tearDownTest(repo)
-	endpoint := "http://localhost:8000"
+	endpoint := "http://lakefs:8000"
 	client := createS3Client(endpoint, t)
 	bucketName := "test-bucket"
 	_, err := client.CreateBucket(ctx, &s3.CreateBucketInput{

--- a/esti/s3_gateway_test.go
+++ b/esti/s3_gateway_test.go
@@ -15,7 +15,6 @@ import (
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
-	"github.com/aws/aws-sdk-go-v2/service/s3/types"
 	"github.com/go-openapi/swag"
 
 	"github.com/minio/minio-go/v7"
@@ -205,17 +204,9 @@ func TestS3IfNoneMatch(t *testing.T) {
 
 	ctx, _, repo := setupTest(t)
 	defer tearDownTest(repo)
-	endpoint := "http://lakefs:8000"
-	client := createS3Client(endpoint, t)
-	bucketName := "test-bucket"
-	_, err := client.CreateBucket(ctx, &s3.CreateBucketInput{
-		Bucket: aws.String(bucketName),
-		CreateBucketConfiguration: &types.CreateBucketConfiguration{
-			LocationConstraint: types.BucketLocationConstraint("us-east-1"),
-		},
-	})
 
-	require.NoError(t, err, "Error creating bucket")
+	s3Endpoint := viper.GetString("s3_endpoint")
+	s3Client := createS3Client(s3Endpoint, t)
 
 	type TestCase struct {
 		Path        string
@@ -241,8 +232,8 @@ func TestS3IfNoneMatch(t *testing.T) {
 			defer wg.Done()
 			for tc := range objects {
 				// Create the PutObject request
-				_, err := client.PutObject(ctx, &s3.PutObjectInput{
-					Bucket: aws.String(bucketName),
+				_, err := s3Client.PutObject(ctx, &s3.PutObjectInput{
+					Bucket: aws.String(repo),
 					Key:    aws.String(tc.Path),
 					Body:   strings.NewReader(tc.Content),
 				})

--- a/esti/s3_gateway_test.go
+++ b/esti/s3_gateway_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/aws/smithy-go/middleware"
+	smithyhttp "github.com/aws/smithy-go/transport/http"
 	"github.com/go-openapi/swag"
 
 	"github.com/minio/minio-go/v7"
@@ -191,7 +192,7 @@ func setHTTPHeaders(ifNoneMatch string) func(*middleware.Stack) error {
 		) (
 			middleware.BuildOutput, middleware.Metadata, error,
 		) {
-			if req, ok := in.Request.(*http.Request); ok {
+			if req, ok := in.Request.(*smithyhttp.Request); ok {
 				// Add the If-None-Match header
 				req.Header.Set("If-None-Match", ifNoneMatch)
 				fmt.Printf("Set If-None-Match header: %s\n", ifNoneMatch) // Debug logging

--- a/esti/s3_gateway_test.go
+++ b/esti/s3_gateway_test.go
@@ -187,12 +187,6 @@ func TestS3UploadAndDownload(t *testing.T) {
 	}
 }
 func TestMultipartUploadIfNoneMatch(t *testing.T) {
-	// timeResolution is a duration greater than the timestamp resolution of the backing
-	// store.  Multipart object on S3 is the time of create-MPU, waiting before completion
-	// ensures that lakeFS did not use the current time.  For other blockstores MPU
-	// completion time is used, meaning it will be hard to detect if the underlying and
-	// lakeFS objects share the same time.
-	const timeResolution = time.Second
 	ctx, logger, repo := setupTest(t)
 	defer tearDownTest(repo)
 	s3Endpoint := viper.GetString("s3_endpoint")
@@ -210,8 +204,10 @@ func TestMultipartUploadIfNoneMatch(t *testing.T) {
 		{Path: "main/object1", Content: "data", IfNoneMatch: "", ExpectError: false},
 		{Path: "main/object1", Content: "data", IfNoneMatch: "*", ExpectError: true},
 		{Path: "main/object1", Content: "data", IfNoneMatch: "", ExpectError: false},
+		{Path: "main/object1", Content: "data", IfNoneMatch: "", ExpectError: false},
+		{Path: "main/object2", Content: "data", IfNoneMatch: "*", ExpectError: false},
 	}
-	for _, tc := range testCases {
+	for i, tc := range testCases {
 		input := &s3.CreateMultipartUploadInput{
 			Bucket: aws.String(repo),
 			Key:    aws.String(tc.Path),
@@ -228,11 +224,6 @@ func TestMultipartUploadIfNoneMatch(t *testing.T) {
 
 		completedParts := uploadMultipartParts(t, ctx, s3Client, logger, resp, parts, 0)
 
-		if isBlockstoreType(block.BlockstoreTypeS3) == nil {
-			// Object should have Last-Modified time at around time of MPU creation.  Ensure
-			// lakeFS fails the test if it fakes it by using the current time.
-			time.Sleep(2 * timeResolution)
-		}
 		completeInput := &s3.CompleteMultipartUploadInput{
 			Bucket:   resp.Bucket,
 			Key:      resp.Key,
@@ -243,9 +234,9 @@ func TestMultipartUploadIfNoneMatch(t *testing.T) {
 		}
 		_, err = s3Client.CompleteMultipartUpload(ctx, completeInput, s3.WithAPIOptions(setHTTPHeaders(tc.IfNoneMatch)))
 		if tc.ExpectError {
-			require.Error(t, err, "was expecting an error with path %s and header %s in test case # %s", tc.Path, tc.IfNoneMatch)
+			require.Error(t, err, "was expecting an error with path %s and header %s in test case # %d", tc.Path, tc.IfNoneMatch, i+1)
 		} else {
-			require.NoError(t, err, "wasn't expecting error with path %s and header %s in test case # %s", tc.Path, tc.IfNoneMatch)
+			require.NoError(t, err, "wasn't expecting error with path %s and header %s in test case # %d", tc.Path, tc.IfNoneMatch, i+1)
 		}
 	}
 }
@@ -267,7 +258,7 @@ func setHTTPHeaders(ifNoneMatch string) func(*middleware.Stack) error {
 }
 func TestS3IfNoneMatch(t *testing.T) {
 
-	ctx, _, repo := setupTest(t)
+	ctx, logger, repo := setupTest(t)
 	defer tearDownTest(repo)
 
 	s3Endpoint := viper.GetString("s3_endpoint")
@@ -286,7 +277,7 @@ func TestS3IfNoneMatch(t *testing.T) {
 		{Path: "main/object2", Content: "data", IfNoneMatch: "*", ExpectError: false},
 		{Path: "main/object2", Content: "data", IfNoneMatch: "", ExpectError: false},
 		{Path: "main/object2", Content: "data", IfNoneMatch: "*", ExpectError: true},
-		{Path: "main/object3", Content: "data", IfNoneMatch: "hi", ExpectError: true},
+		{Path: "main/object3", Content: "data", IfNoneMatch: "unsupported string", ExpectError: true},
 	}
 	for i, tc := range testCases {
 		input := &s3.PutObjectInput{
@@ -294,13 +285,13 @@ func TestS3IfNoneMatch(t *testing.T) {
 			Key:    aws.String(tc.Path),
 			Body:   strings.NewReader(tc.Content),
 		}
-		fmt.Printf("Sending PutObject request for Path: %s with If-None-Match: %s\n", tc.Path, tc.IfNoneMatch) // Debug logging
+		logger.Info("Sending PutObject request for Path: %s with If-None-Match: %s\n", tc.Path, tc.IfNoneMatch)
 		_, err := s3Client.PutObject(ctx, input, s3.WithAPIOptions(setHTTPHeaders(tc.IfNoneMatch)))
 
 		if tc.ExpectError {
-			require.Error(t, err, "was expecting an error with path %s and header %s in test case # %s", tc.Path, tc.IfNoneMatch, i+1)
+			require.Error(t, err, "was expecting an error with path %s and header %s in test case # %d", tc.Path, tc.IfNoneMatch, i+1)
 		} else {
-			require.NoError(t, err, "wasn't expecting error with path %s and header %s in test case # %s", tc.Path, tc.IfNoneMatch, i+1)
+			require.NoError(t, err, "wasn't expecting error with path %s and header %s in test case # %d", tc.Path, tc.IfNoneMatch, i+1)
 		}
 	}
 }

--- a/esti/s3_gateway_test.go
+++ b/esti/s3_gateway_test.go
@@ -201,7 +201,7 @@ func TestS3IfNoneMatch(t *testing.T) {
 		{Path: "object1", Content: "data", IfNoneMatch: "", ExpectError: false},
 		{Path: "object1", Content: "data", IfNoneMatch: "*", ExpectError: true},
 		{Path: "object2", Content: "data", IfNoneMatch: "*", ExpectError: false},
-		{Path: "object2", Content: "data", IfNoneMatch: "", ExpectError: false},
+		{Path: "object2", Content: "data", IfNoneMatch: "", ExpectError: true},
 		{Path: "object3", Content: "data", IfNoneMatch: "hi", ExpectError: true},
 	}
 
@@ -213,13 +213,8 @@ func TestS3IfNoneMatch(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for tc := range objects {
-				opts := minio.PutObjectOptions{
-					UserMetadata: make(map[string]string),
-				}
-				if tc.IfNoneMatch != "" {
-					opts.UserMetadata["If-None-Match"] = tc.IfNoneMatch
-				}
-
+				opts := minio.PutObjectOptions{}
+				opts.SetMatchETagExcept(tc.IfNoneMatch)
 				_, err := client.PutObject(ctx, repo, tc.Path, strings.NewReader(tc.Content), int64(len(tc.Content)), opts)
 				if (err != nil) != tc.ExpectError {
 					t.Errorf("unexpected error for Path %s with If-None-Match %q: %v", tc.Path, tc.IfNoneMatch, err)

--- a/esti/s3_gateway_test.go
+++ b/esti/s3_gateway_test.go
@@ -231,7 +231,7 @@ func TestMultipartUploadIfNoneMatch(t *testing.T) {
 
 		parts := make([][]byte, multipartNumberOfParts)
 
-		completedParts := uploadMultipartParts(t, ctx, logger, resp, parts, 0)
+		completedParts := uploadMultipartParts(t, ctx, s3Client, logger, resp, parts, 0)
 
 		if isBlockstoreType(block.BlockstoreTypeS3) == nil {
 			// Object should have Last-Modified time at around time of MPU creation.  Ensure

--- a/esti/s3_gateway_test.go
+++ b/esti/s3_gateway_test.go
@@ -218,7 +218,7 @@ func TestS3IfNoneMatch(t *testing.T) {
 				}
 
 				if tc.IfNoneMatch != "" {
-					opts.Header().Add("If-None-Match", tc.IfNoneMatch)
+					opts.UserMetadata["If-None-Match"] = tc.IfNoneMatch
 				}
 
 				_, err := client.PutObject(ctx, repo, tc.Path, strings.NewReader(tc.Content), int64(len(tc.Content)), opts)

--- a/esti/s3_gateway_test.go
+++ b/esti/s3_gateway_test.go
@@ -40,8 +40,8 @@ const (
 	randomDataPathLength    = 1020
 	branch                  = "main"
 	gatewayTestPrefix       = branch + "/data/"
-	errorPreconditionFailed = "An error occurred (PreconditionFailed) when calling the PutObject operation: At least one of the pre-conditions you specified did not hold"
-	errorNotImplemented     = "An error occurred (NotImplemented) when calling the PutObject operation: A header you provided implies functionality that is not implemented"
+	errorPreconditionFailed = "At least one of the pre-conditions you specified did not hold"
+	errorNotImplemented     = "A header you provided implies functionality that is not implemented"
 )
 
 func newMinioClient(t *testing.T, getCredentials GetCredentials) *minio.Client {

--- a/esti/s3_gateway_test.go
+++ b/esti/s3_gateway_test.go
@@ -201,7 +201,7 @@ func TestS3IfNoneMatch(t *testing.T) {
 		{Path: "object1", Content: "data", IfNoneMatch: "", ExpectError: false},
 		{Path: "object1", Content: "data", IfNoneMatch: "*", ExpectError: true},
 		{Path: "object2", Content: "data", IfNoneMatch: "*", ExpectError: false},
-		{Path: "object2", Content: "data", IfNoneMatch: "", ExpectError: true},
+		{Path: "object2", Content: "data", IfNoneMatch: "", ExpectError: false},
 		{Path: "object3", Content: "data", IfNoneMatch: "hi", ExpectError: true},
 	}
 
@@ -213,8 +213,15 @@ func TestS3IfNoneMatch(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			for tc := range objects {
-				opts := minio.PutObjectOptions{}
-				opts.SetMatchETagExcept(tc.IfNoneMatch)
+				opts := minio.PutObjectOptions{
+					UserMetadata: map[string]string{},
+				}
+
+				if tc.IfNoneMatch != "" {
+					opts.UserMetadata["If-None-Match"] = tc.IfNoneMatch
+					opts.Header()
+				}
+
 				_, err := client.PutObject(ctx, repo, tc.Path, strings.NewReader(tc.Content), int64(len(tc.Content)), opts)
 				if (err != nil) != tc.ExpectError {
 					t.Errorf("unexpected error for Path %s with If-None-Match %q: %v", tc.Path, tc.IfNoneMatch, err)

--- a/esti/s3_gateway_test.go
+++ b/esti/s3_gateway_test.go
@@ -225,7 +225,7 @@ func TestS3IfNoneMatch(t *testing.T) {
 		{Path: "main/object2", Content: "data", IfNoneMatch: "*", ExpectError: true},
 		{Path: "main/object3", Content: "data", IfNoneMatch: "hi", ExpectError: true},
 	}
-	for _, tc := range testCases {
+	for i, tc := range testCases {
 		input := &s3.PutObjectInput{
 			Bucket: aws.String(repo),
 			Key:    aws.String(tc.Path),
@@ -235,9 +235,9 @@ func TestS3IfNoneMatch(t *testing.T) {
 		_, err := s3Client.PutObject(ctx, input, s3.WithAPIOptions(setHTTPHeaders(tc.IfNoneMatch)))
 
 		if tc.ExpectError {
-			require.Error(t, err, "was expecting an error with path %s and header %s", tc.Path, tc.IfNoneMatch)
+			require.Error(t, err, "was expecting an error with path %s and header %s in test case # %s", tc.Path, tc.IfNoneMatch, i+1)
 		} else {
-			require.NoError(t, err, "wasn't expecting error with path %s and header %s", tc.Path, tc.IfNoneMatch)
+			require.NoError(t, err, "wasn't expecting error with path %s and header %s in test case # %s", tc.Path, tc.IfNoneMatch, i+1)
 		}
 	}
 }

--- a/pkg/gateway/errors/errors.go
+++ b/pkg/gateway/errors/errors.go
@@ -169,7 +169,6 @@ const (
 
 	// S3 extended errors.
 	ErrContentSHA256Mismatch
-	ErrObjectExists
 
 	// Lakefs errors
 	ERRLakeFSNotSupported
@@ -756,11 +755,6 @@ var Codes = errorCodeMap{
 		Code:           "ErrInvalidAPIVersion",
 		Description:    "Invalid version found in the request",
 		HTTPStatusCode: http.StatusNotFound,
-	},
-	ErrObjectExists: {
-		Code:           "ErrObjectExists",
-		Description:    "Object path already exists in DB",
-		HTTPStatusCode: http.StatusNotModified,
 	},
 	// LakeFS errors
 	ERRLakeFSNotSupported: {

--- a/pkg/gateway/errors/errors.go
+++ b/pkg/gateway/errors/errors.go
@@ -756,6 +756,7 @@ var Codes = errorCodeMap{
 		Description:    "Invalid version found in the request",
 		HTTPStatusCode: http.StatusNotFound,
 	},
+
 	// LakeFS errors
 	ERRLakeFSNotSupported: {
 		Code:           "ERRLakeFSNotSupported",

--- a/pkg/gateway/errors/errors.go
+++ b/pkg/gateway/errors/errors.go
@@ -169,6 +169,7 @@ const (
 
 	// S3 extended errors.
 	ErrContentSHA256Mismatch
+	ErrObjectExists
 
 	// Lakefs errors
 	ERRLakeFSNotSupported
@@ -756,7 +757,11 @@ var Codes = errorCodeMap{
 		Description:    "Invalid version found in the request",
 		HTTPStatusCode: http.StatusNotFound,
 	},
-
+	ErrObjectExists: {
+		Code:           "ErrObjectExists",
+		Description:    "Object path already exists in DB",
+		HTTPStatusCode: http.StatusNotModified,
+	},
 	// LakeFS errors
 	ERRLakeFSNotSupported: {
 		Code:           "ERRLakeFSNotSupported",

--- a/pkg/gateway/operations/operation_utils.go
+++ b/pkg/gateway/operations/operation_utils.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/treeverse/lakefs/pkg/catalog"
+	"github.com/treeverse/lakefs/pkg/graveler"
 	"github.com/treeverse/lakefs/pkg/logging"
 )
 
@@ -40,7 +41,7 @@ func shouldReplaceMetadata(req *http.Request) bool {
 	return req.Header.Get(amzMetadataDirectiveHeaderPrefix) == "REPLACE"
 }
 
-func (o *PathOperation) finishUpload(req *http.Request, mTime *time.Time, checksum, physicalAddress string, size int64, relative bool, metadata map[string]string, contentType string) error {
+func (o *PathOperation) finishUpload(req *http.Request, mTime *time.Time, checksum, physicalAddress string, size int64, relative bool, metadata map[string]string, contentType string, allowOverWrite bool) error {
 	var writeTime time.Time
 	if mTime == nil {
 		writeTime = time.Now()
@@ -59,7 +60,7 @@ func (o *PathOperation) finishUpload(req *http.Request, mTime *time.Time, checks
 		ContentType(contentType).
 		Build()
 
-	err := o.Catalog.CreateEntry(req.Context(), o.Repository.Name, o.Reference, entry)
+	err := o.Catalog.CreateEntry(req.Context(), o.Repository.Name, o.Reference, entry, graveler.WithIfAbsent(!allowOverWrite))
 	if err != nil {
 		o.Log(req).WithError(err).Error("could not update metadata")
 		return err

--- a/pkg/gateway/operations/operation_utils.go
+++ b/pkg/gateway/operations/operation_utils.go
@@ -41,7 +41,7 @@ func shouldReplaceMetadata(req *http.Request) bool {
 	return req.Header.Get(amzMetadataDirectiveHeaderPrefix) == "REPLACE"
 }
 
-func (o *PathOperation) finishUpload(req *http.Request, mTime *time.Time, checksum, physicalAddress string, size int64, relative bool, metadata map[string]string, contentType string, allowOverWrite bool) error {
+func (o *PathOperation) finishUpload(req *http.Request, mTime *time.Time, checksum, physicalAddress string, size int64, relative bool, metadata map[string]string, contentType string, allowOverwrite bool) error {
 	var writeTime time.Time
 	if mTime == nil {
 		writeTime = time.Now()
@@ -60,7 +60,7 @@ func (o *PathOperation) finishUpload(req *http.Request, mTime *time.Time, checks
 		ContentType(contentType).
 		Build()
 
-	err := o.Catalog.CreateEntry(req.Context(), o.Repository.Name, o.Reference, entry, graveler.WithIfAbsent(!allowOverWrite))
+	err := o.Catalog.CreateEntry(req.Context(), o.Repository.Name, o.Reference, entry, graveler.WithIfAbsent(!allowOverwrite))
 	if err != nil {
 		o.Log(req).WithError(err).Error("could not update metadata")
 		return err

--- a/pkg/gateway/operations/postobject.go
+++ b/pkg/gateway/operations/postobject.go
@@ -94,6 +94,11 @@ func (controller *PostObject) HandleCompleteMultipartUpload(w http.ResponseWrite
 		_ = o.EncodeError(w, req, err, gatewayErrors.Codes.ToAPIErr(gatewayErrors.ErrInternalError))
 		return
 	}
+	err = o.checkIfAbsent(req)
+	if err != nil {
+		_ = o.EncodeError(w, req, err, gatewayErrors.Codes.ToAPIErr(gatewayErrors.ErrObjectExists))
+		return
+	}
 	objName := multiPart.PhysicalAddress
 	req = req.WithContext(logging.AddFields(req.Context(), logging.Fields{logging.PhysicalAddressFieldKey: objName}))
 	xmlMultipartComplete, err := io.ReadAll(req.Body)

--- a/pkg/gateway/operations/postobject.go
+++ b/pkg/gateway/operations/postobject.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/treeverse/lakefs/pkg/block"
+	"github.com/treeverse/lakefs/pkg/catalog"
 	gatewayErrors "github.com/treeverse/lakefs/pkg/gateway/errors"
 	"github.com/treeverse/lakefs/pkg/gateway/multipart"
 	"github.com/treeverse/lakefs/pkg/gateway/path"
@@ -94,14 +95,20 @@ func (controller *PostObject) HandleCompleteMultipartUpload(w http.ResponseWrite
 		_ = o.EncodeError(w, req, err, gatewayErrors.Codes.ToAPIErr(gatewayErrors.ErrInternalError))
 		return
 	}
-	allowOverWrite, err := o.checkIfAbsent(req)
-	if errors.Is(err, gatewayErrors.ErrPreconditionFailed) {
-		_ = o.EncodeError(w, req, err, gatewayErrors.Codes.ToAPIErr(gatewayErrors.ErrPreconditionFailed))
-		return
-	}
-	if errors.Is(err, gatewayErrors.ErrNotImplemented) {
+	// before completing multipart upload, check whether if-none-match header is added,
+	// in order to not overwrite object
+	allowOverwrite, err := o.checkIfAbsent(req)
+	if err != nil {
 		_ = o.EncodeError(w, req, err, gatewayErrors.Codes.ToAPIErr(gatewayErrors.ErrNotImplemented))
 		return
+	}
+	if !allowOverwrite {
+		_, err := o.Catalog.GetEntry(req.Context(), o.Repository.Name, o.Reference, o.Path, catalog.GetEntryParams{})
+		if err == nil {
+			// In case object exists in catalog, no error returns
+			_ = o.EncodeError(w, req, err, gatewayErrors.Codes.ToAPIErr(gatewayErrors.ErrPreconditionFailed))
+			return
+		}
 	}
 	objName := multiPart.PhysicalAddress
 	req = req.WithContext(logging.AddFields(req.Context(), logging.Fields{logging.PhysicalAddressFieldKey: objName}))
@@ -133,7 +140,7 @@ func (controller *PostObject) HandleCompleteMultipartUpload(w http.ResponseWrite
 		return
 	}
 	checksum := strings.Split(resp.ETag, "-")[0]
-	err = o.finishUpload(req, resp.MTime, checksum, objName, resp.ContentLength, true, multiPart.Metadata, multiPart.ContentType, allowOverWrite)
+	err = o.finishUpload(req, resp.MTime, checksum, objName, resp.ContentLength, true, multiPart.Metadata, multiPart.ContentType, allowOverwrite)
 	if errors.Is(err, graveler.ErrPreconditionFailed) {
 		_ = o.EncodeError(w, req, err, gatewayErrors.Codes.ToAPIErr(gatewayErrors.ErrPreconditionFailed))
 		return

--- a/pkg/gateway/operations/putobject.go
+++ b/pkg/gateway/operations/putobject.go
@@ -339,12 +339,12 @@ func (o *PathOperation) checkIfAbsent(req *http.Request) error {
 	case "*":
 		_, err := o.Catalog.GetEntry(req.Context(), o.Repository.Name, o.Reference, o.Path, catalog.GetEntryParams{})
 		if err == nil {
-			return errors.New("path exists in storage")
+			return gatewayErrors.ErrObjectExists
 		}
 	default:
 		_, err := o.Catalog.GetEntry(req.Context(), o.Repository.Name, o.Reference, Header, catalog.GetEntryParams{})
 		if err == nil {
-			return errors.New("path exists in storage")
+			return gatewayErrors.ErrObjectExists
 		}
 	}
 	return nil

--- a/pkg/gateway/operations/putobject.go
+++ b/pkg/gateway/operations/putobject.go
@@ -2,6 +2,7 @@ package operations
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -353,5 +354,6 @@ func (o *PathOperation) checkIfAbsent(req *http.Request) (bool, error) {
 			return false, gatewayErrors.ErrInternalError
 		}
 	}
+	fmt.Printf("got here with header %s", Header)
 	return false, gatewayErrors.ErrNotImplemented
 }

--- a/pkg/gateway/operations/putobject.go
+++ b/pkg/gateway/operations/putobject.go
@@ -341,6 +341,11 @@ func handlePut(w http.ResponseWriter, req *http.Request, o *PathOperation) {
 }
 
 func (o *PathOperation) checkIfAbsent(req *http.Request) (bool, error) {
+	for key, values := range req.Header {
+		for _, value := range values {
+			fmt.Printf("HEADER: %s = %s\n", key, value)
+		}
+	}
 	Header := req.Header.Get(IfNoneMatchHeader)
 	fmt.Println("HEADER: ", Header)
 	if Header == "" {

--- a/pkg/gateway/operations/putobject.go
+++ b/pkg/gateway/operations/putobject.go
@@ -2,7 +2,6 @@ package operations
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -32,8 +31,6 @@ type PutObject struct{}
 
 func (controller *PutObject) RequiredPermissions(req *http.Request, repoID, _, destPath string) (permissions.Node, error) {
 	copySource := req.Header.Get(CopySourceHeader)
-	noneMatch := req.Header.Get(CopySourceHeader)
-	fmt.Println(copySource, noneMatch)
 	if len(copySource) == 0 {
 		return permissions.Node{
 			Permission: permissions.Permission{
@@ -336,8 +333,6 @@ func handlePut(w http.ResponseWriter, req *http.Request, o *PathOperation) {
 
 func (o *PathOperation) checkIfAbsent(req *http.Request) error {
 	Header := req.Header.Get(IfNoneMatchHeader)
-	fmt.Println("o.path", o.Path)
-	fmt.Println("Header ", Header)
 	switch Header {
 	case "":
 		return nil

--- a/pkg/gateway/operations/putobject.go
+++ b/pkg/gateway/operations/putobject.go
@@ -2,6 +2,7 @@ package operations
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -341,6 +342,7 @@ func handlePut(w http.ResponseWriter, req *http.Request, o *PathOperation) {
 
 func (o *PathOperation) checkIfAbsent(req *http.Request) (bool, error) {
 	Header := req.Header.Get(IfNoneMatchHeader)
+	fmt.Println("HEADER: ", Header)
 	if Header == "" {
 		return true, nil
 	}

--- a/pkg/gateway/operations/putobject.go
+++ b/pkg/gateway/operations/putobject.go
@@ -2,7 +2,6 @@ package operations
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -341,13 +340,7 @@ func handlePut(w http.ResponseWriter, req *http.Request, o *PathOperation) {
 }
 
 func (o *PathOperation) checkIfAbsent(req *http.Request) (bool, error) {
-	for key, values := range req.Header {
-		for _, value := range values {
-			fmt.Printf("HEADER: %s = %s\n", key, value)
-		}
-	}
 	Header := req.Header.Get(IfNoneMatchHeader)
-	fmt.Println("HEADER: ", Header)
 	if Header == "" {
 		return true, nil
 	}

--- a/pkg/gateway/operations/putobject.go
+++ b/pkg/gateway/operations/putobject.go
@@ -2,7 +2,6 @@ package operations
 
 import (
 	"errors"
-	"fmt"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -356,6 +355,5 @@ func (o *PathOperation) checkIfAbsent(req *http.Request) (bool, error) {
 			return true, nil
 		}
 	}
-	fmt.Printf("got here with header %s", Header)
 	return false, gatewayErrors.ErrNotImplemented
 }

--- a/pkg/gateway/operations/putobject.go
+++ b/pkg/gateway/operations/putobject.go
@@ -352,6 +352,8 @@ func (o *PathOperation) checkIfAbsent(req *http.Request) (bool, error) {
 		}
 		if !errors.Is(err, graveler.ErrNotFound) {
 			return false, gatewayErrors.ErrInternalError
+		} else {
+			return true, nil
 		}
 	}
 	fmt.Printf("got here with header %s", Header)

--- a/pkg/gateway/operations/putobject.go
+++ b/pkg/gateway/operations/putobject.go
@@ -349,7 +349,9 @@ func (o *PathOperation) checkIfAbsent(req *http.Request) (bool, error) {
 		if err == nil {
 			return false, gatewayErrors.ErrPreconditionFailed
 		}
-		return false, nil
+		if !errors.Is(err, graveler.ErrNotFound) {
+			return false, gatewayErrors.ErrInternalError
+		}
 	}
 	return false, gatewayErrors.ErrNotImplemented
 }


### PR DESCRIPTION
Closes #8380

## Change Description
Added support for if-none-match header.
The header can be used for putObject or complete-multipart-upload operations.


changes were tested manually. In case of a collision an error with http status 304 will return, as in aws cli.