### PR TITLE
Remove cookieconsent js from Docs

### DIFF
--- a/docs/_includes/head_custom.html
+++ b/docs/_includes/head_custom.html
@@ -14,12 +14,12 @@
 <link rel="preload" href="/assets/fonts/Rene Bieder - Galano Grotesque Medium.otf" as="font" type="font/otf" crossorigin>
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.2.1/css/fontawesome.min.css" integrity="sha512-giQeaPns4lQTBMRpOOHsYnGw1tGVzbAIHUyHRgn7+6FmiEgGGjaG0T2LZJmAPMzRCl+Cug0ItQ2xDZpTmEc+CQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.2.1/css/all.min.css" integrity="sha512-MV7K8+y+gLIBoVD59lQIYicR65iaqukzvf/nwasF0nqhPay5w/9lJmVM2hMDcnK1OnMGCdVK+iQrJ7lzPJQd1w==" crossorigin="anonymous" referrerpolicy="no-referrer" />
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orestbida/cookieconsent@v3.0.0/dist/cookieconsent.css">
-<link rel="stylesheet" href="{{ site.baseurl }}/assets/css/cookieconsent.css" />
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.1/jquery.min.js" crossorigin="anonymous"></script>
 <link rel="stylesheet" href="https://ajax.googleapis.com/ajax/libs/jqueryui/1.13.2/themes/smoothness/jquery-ui.css">
 <script src="https://ajax.googleapis.com/ajax/libs/jqueryui/1.13.2/jquery-ui.min.js"></script>
-<script type="module" src="{{ site.baseurl }}/assets/js/cookieconsent-init.js"></script>
+<!--<link rel="stylesheet" href="https://cdn.jsdelivr.net/gh/orestbida/cookieconsent@v3.0.0/dist/cookieconsent.css">-->
+<!--<link rel="stylesheet" href="{{ site.baseurl }}/assets/css/cookieconsent.css" />-->
+<!--<script type="module" src="{{ site.baseurl }}/assets/js/cookieconsent-init.js"></script>-->
 <script src="{{ site.baseurl }}/assets/js/copy-code.js"></script>
 <script>
     $(function () {


### PR DESCRIPTION
Closes #8440.

## Change Description

### Background

The [API page](https://docs.lakefs.io/reference/api.html) of the lakeFS Docs loads for the first time,
But after accepting the cookies consent ("Hello fellow axolotl, it's cookie time!"), the Swagger part of the page fails to load.

This happens due to the "cookieconsent-init.js". Once it's removed, the page loads fine.

### Bug Fix

Since we already have a cookies-consent popup provided by HubSpot, the fix is to simply remove the "cookieconsent-init.js" from the docs.

### Testing Details

Tested in the CI.
