### PR TITLE
Add "squash merge" support to merge API

### DIFF
--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -690,10 +690,10 @@ components:
           type: boolean
           default: true
           description: |
-            If set, set only the destination branch as a parent, which
-            "squashes" the merge to appear as a single commit on the
-            destination branch.
-
+            If set, set only the destination branch as a parent, which "squashes" the merge to
+            appear as a single commit on the destination branch.  The source commit is no longer
+            a part of the merge commit; consider adding it to the 'metadata' or 'message'
+            fields.
     BranchCreation:
       type: object
       required:

--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -693,7 +693,8 @@ components:
             If set, set only the destination branch as a parent, which "squashes" the merge to
             appear as a single commit on the destination branch.  The source commit is no longer
             a part of the merge commit; consider adding it to the 'metadata' or 'message'
-            fields.
+            fields.  This behaves like a GitHub or GitLab "squash merge", or in Git terms 'git
+            merge --squash; git commit ...'.
     BranchCreation:
       type: object
       required:

--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -686,6 +686,13 @@ components:
           type: boolean
           default: false
           description: Allow merge when the branches have the same content
+        squash_merge:
+          type: boolean
+          default: true
+          description: |
+            If set, set only the destination branch as a parent, which
+            "squashes" the merge to appear as a single commit on the
+            destination branch.
 
     BranchCreation:
       type: object

--- a/clients/java/api/openapi.yaml
+++ b/clients/java/api/openapi.yaml
@@ -8249,9 +8249,10 @@ components:
         squash_merge:
           default: true
           description: |
-            If set, set only the destination branch as a parent, which
-            "squashes" the merge to appear as a single commit on the
-            destination branch.
+            If set, set only the destination branch as a parent, which "squashes" the merge to
+            appear as a single commit on the destination branch.  The source commit is no longer
+            a part of the merge commit; consider adding it to the 'metadata' or 'message'
+            fields.
           type: boolean
       type: object
     BranchCreation:

--- a/clients/java/api/openapi.yaml
+++ b/clients/java/api/openapi.yaml
@@ -8219,6 +8219,7 @@ components:
       example:
         metadata:
           key: metadata
+        squash_merge: true
         force: false
         message: message
         strategy: strategy
@@ -8244,6 +8245,13 @@ components:
         allow_empty:
           default: false
           description: Allow merge when the branches have the same content
+          type: boolean
+        squash_merge:
+          default: true
+          description: |
+            If set, set only the destination branch as a parent, which
+            "squashes" the merge to appear as a single commit on the
+            destination branch.
           type: boolean
       type: object
     BranchCreation:

--- a/clients/java/api/openapi.yaml
+++ b/clients/java/api/openapi.yaml
@@ -8252,7 +8252,8 @@ components:
             If set, set only the destination branch as a parent, which "squashes" the merge to
             appear as a single commit on the destination branch.  The source commit is no longer
             a part of the merge commit; consider adding it to the 'metadata' or 'message'
-            fields.
+            fields.  This behaves like a GitHub or GitLab "squash merge", or in Git terms 'git
+            merge --squash; git commit ...'.
           type: boolean
       type: object
     BranchCreation:

--- a/clients/java/docs/Merge.md
+++ b/clients/java/docs/Merge.md
@@ -12,6 +12,7 @@
 |**strategy** | **String** | In case of a merge conflict, this option will force the merge process to automatically favor changes from the dest branch (&#39;dest-wins&#39;) or from the source branch(&#39;source-wins&#39;). In case no selection is made, the merge process will fail in case of a conflict |  [optional] |
 |**force** | **Boolean** | Allow merge into a read-only branch or into a branch with the same content |  [optional] |
 |**allowEmpty** | **Boolean** | Allow merge when the branches have the same content |  [optional] |
+|**squashMerge** | **Boolean** | If set, set only the destination branch as a parent, which \&quot;squashes\&quot; the merge to appear as a single commit on the destination branch.  |  [optional] |
 
 
 

--- a/clients/java/docs/Merge.md
+++ b/clients/java/docs/Merge.md
@@ -12,7 +12,7 @@
 |**strategy** | **String** | In case of a merge conflict, this option will force the merge process to automatically favor changes from the dest branch (&#39;dest-wins&#39;) or from the source branch(&#39;source-wins&#39;). In case no selection is made, the merge process will fail in case of a conflict |  [optional] |
 |**force** | **Boolean** | Allow merge into a read-only branch or into a branch with the same content |  [optional] |
 |**allowEmpty** | **Boolean** | Allow merge when the branches have the same content |  [optional] |
-|**squashMerge** | **Boolean** | If set, set only the destination branch as a parent, which \&quot;squashes\&quot; the merge to appear as a single commit on the destination branch.  |  [optional] |
+|**squashMerge** | **Boolean** | If set, set only the destination branch as a parent, which \&quot;squashes\&quot; the merge to appear as a single commit on the destination branch.  The source commit is no longer a part of the merge commit; consider adding it to the &#39;metadata&#39; or &#39;message&#39; fields.  |  [optional] |
 
 
 

--- a/clients/java/docs/Merge.md
+++ b/clients/java/docs/Merge.md
@@ -12,7 +12,7 @@
 |**strategy** | **String** | In case of a merge conflict, this option will force the merge process to automatically favor changes from the dest branch (&#39;dest-wins&#39;) or from the source branch(&#39;source-wins&#39;). In case no selection is made, the merge process will fail in case of a conflict |  [optional] |
 |**force** | **Boolean** | Allow merge into a read-only branch or into a branch with the same content |  [optional] |
 |**allowEmpty** | **Boolean** | Allow merge when the branches have the same content |  [optional] |
-|**squashMerge** | **Boolean** | If set, set only the destination branch as a parent, which \&quot;squashes\&quot; the merge to appear as a single commit on the destination branch.  The source commit is no longer a part of the merge commit; consider adding it to the &#39;metadata&#39; or &#39;message&#39; fields.  |  [optional] |
+|**squashMerge** | **Boolean** | If set, set only the destination branch as a parent, which \&quot;squashes\&quot; the merge to appear as a single commit on the destination branch.  The source commit is no longer a part of the merge commit; consider adding it to the &#39;metadata&#39; or &#39;message&#39; fields.  This behaves like a GitHub or GitLab \&quot;squash merge\&quot;, or in Git terms &#39;git merge --squash; git commit ...&#39;.  |  [optional] |
 
 
 

--- a/clients/java/src/main/java/io/lakefs/clients/sdk/model/Merge.java
+++ b/clients/java/src/main/java/io/lakefs/clients/sdk/model/Merge.java
@@ -201,7 +201,7 @@ public class Merge {
   }
 
    /**
-   * If set, set only the destination branch as a parent, which \&quot;squashes\&quot; the merge to appear as a single commit on the destination branch. 
+   * If set, set only the destination branch as a parent, which \&quot;squashes\&quot; the merge to appear as a single commit on the destination branch.  The source commit is no longer a part of the merge commit; consider adding it to the &#39;metadata&#39; or &#39;message&#39; fields. 
    * @return squashMerge
   **/
   @javax.annotation.Nullable

--- a/clients/java/src/main/java/io/lakefs/clients/sdk/model/Merge.java
+++ b/clients/java/src/main/java/io/lakefs/clients/sdk/model/Merge.java
@@ -201,7 +201,7 @@ public class Merge {
   }
 
    /**
-   * If set, set only the destination branch as a parent, which \&quot;squashes\&quot; the merge to appear as a single commit on the destination branch.  The source commit is no longer a part of the merge commit; consider adding it to the &#39;metadata&#39; or &#39;message&#39; fields. 
+   * If set, set only the destination branch as a parent, which \&quot;squashes\&quot; the merge to appear as a single commit on the destination branch.  The source commit is no longer a part of the merge commit; consider adding it to the &#39;metadata&#39; or &#39;message&#39; fields.  This behaves like a GitHub or GitLab \&quot;squash merge\&quot;, or in Git terms &#39;git merge --squash; git commit ...&#39;. 
    * @return squashMerge
   **/
   @javax.annotation.Nullable

--- a/clients/java/src/main/java/io/lakefs/clients/sdk/model/Merge.java
+++ b/clients/java/src/main/java/io/lakefs/clients/sdk/model/Merge.java
@@ -74,6 +74,10 @@ public class Merge {
   @SerializedName(SERIALIZED_NAME_ALLOW_EMPTY)
   private Boolean allowEmpty = false;
 
+  public static final String SERIALIZED_NAME_SQUASH_MERGE = "squash_merge";
+  @SerializedName(SERIALIZED_NAME_SQUASH_MERGE)
+  private Boolean squashMerge = true;
+
   public Merge() {
   }
 
@@ -189,6 +193,27 @@ public class Merge {
     this.allowEmpty = allowEmpty;
   }
 
+
+  public Merge squashMerge(Boolean squashMerge) {
+    
+    this.squashMerge = squashMerge;
+    return this;
+  }
+
+   /**
+   * If set, set only the destination branch as a parent, which \&quot;squashes\&quot; the merge to appear as a single commit on the destination branch. 
+   * @return squashMerge
+  **/
+  @javax.annotation.Nullable
+  public Boolean getSquashMerge() {
+    return squashMerge;
+  }
+
+
+  public void setSquashMerge(Boolean squashMerge) {
+    this.squashMerge = squashMerge;
+  }
+
   /**
    * A container for additional, undeclared properties.
    * This is a holder for any undeclared properties as specified with
@@ -248,13 +273,14 @@ public class Merge {
         Objects.equals(this.metadata, merge.metadata) &&
         Objects.equals(this.strategy, merge.strategy) &&
         Objects.equals(this.force, merge.force) &&
-        Objects.equals(this.allowEmpty, merge.allowEmpty)&&
+        Objects.equals(this.allowEmpty, merge.allowEmpty) &&
+        Objects.equals(this.squashMerge, merge.squashMerge)&&
         Objects.equals(this.additionalProperties, merge.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(message, metadata, strategy, force, allowEmpty, additionalProperties);
+    return Objects.hash(message, metadata, strategy, force, allowEmpty, squashMerge, additionalProperties);
   }
 
   @Override
@@ -266,6 +292,7 @@ public class Merge {
     sb.append("    strategy: ").append(toIndentedString(strategy)).append("\n");
     sb.append("    force: ").append(toIndentedString(force)).append("\n");
     sb.append("    allowEmpty: ").append(toIndentedString(allowEmpty)).append("\n");
+    sb.append("    squashMerge: ").append(toIndentedString(squashMerge)).append("\n");
     sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
@@ -294,6 +321,7 @@ public class Merge {
     openapiFields.add("strategy");
     openapiFields.add("force");
     openapiFields.add("allow_empty");
+    openapiFields.add("squash_merge");
 
     // a set of required properties/fields (JSON key names)
     openapiRequiredFields = new HashSet<String>();

--- a/clients/java/src/test/java/io/lakefs/clients/sdk/model/MergeTest.java
+++ b/clients/java/src/test/java/io/lakefs/clients/sdk/model/MergeTest.java
@@ -79,4 +79,12 @@ public class MergeTest {
         // TODO: test allowEmpty
     }
 
+    /**
+     * Test the property 'squashMerge'
+     */
+    @Test
+    public void squashMergeTest() {
+        // TODO: test squashMerge
+    }
+
 }

--- a/clients/python/docs/Merge.md
+++ b/clients/python/docs/Merge.md
@@ -10,7 +10,7 @@ Name | Type | Description | Notes
 **strategy** | **str** | In case of a merge conflict, this option will force the merge process to automatically favor changes from the dest branch (&#39;dest-wins&#39;) or from the source branch(&#39;source-wins&#39;). In case no selection is made, the merge process will fail in case of a conflict | [optional] 
 **force** | **bool** | Allow merge into a read-only branch or into a branch with the same content | [optional] [default to False]
 **allow_empty** | **bool** | Allow merge when the branches have the same content | [optional] [default to False]
-**squash_merge** | **bool** | If set, set only the destination branch as a parent, which \&quot;squashes\&quot; the merge to appear as a single commit on the destination branch.  The source commit is no longer a part of the merge commit; consider adding it to the &#39;metadata&#39; or &#39;message&#39; fields.  | [optional] [default to True]
+**squash_merge** | **bool** | If set, set only the destination branch as a parent, which \&quot;squashes\&quot; the merge to appear as a single commit on the destination branch.  The source commit is no longer a part of the merge commit; consider adding it to the &#39;metadata&#39; or &#39;message&#39; fields.  This behaves like a GitHub or GitLab \&quot;squash merge\&quot;, or in Git terms &#39;git merge --squash; git commit ...&#39;.  | [optional] [default to True]
 
 ## Example
 

--- a/clients/python/docs/Merge.md
+++ b/clients/python/docs/Merge.md
@@ -10,6 +10,7 @@ Name | Type | Description | Notes
 **strategy** | **str** | In case of a merge conflict, this option will force the merge process to automatically favor changes from the dest branch (&#39;dest-wins&#39;) or from the source branch(&#39;source-wins&#39;). In case no selection is made, the merge process will fail in case of a conflict | [optional] 
 **force** | **bool** | Allow merge into a read-only branch or into a branch with the same content | [optional] [default to False]
 **allow_empty** | **bool** | Allow merge when the branches have the same content | [optional] [default to False]
+**squash_merge** | **bool** | If set, set only the destination branch as a parent, which \&quot;squashes\&quot; the merge to appear as a single commit on the destination branch.  | [optional] [default to True]
 
 ## Example
 

--- a/clients/python/docs/Merge.md
+++ b/clients/python/docs/Merge.md
@@ -10,7 +10,7 @@ Name | Type | Description | Notes
 **strategy** | **str** | In case of a merge conflict, this option will force the merge process to automatically favor changes from the dest branch (&#39;dest-wins&#39;) or from the source branch(&#39;source-wins&#39;). In case no selection is made, the merge process will fail in case of a conflict | [optional] 
 **force** | **bool** | Allow merge into a read-only branch or into a branch with the same content | [optional] [default to False]
 **allow_empty** | **bool** | Allow merge when the branches have the same content | [optional] [default to False]
-**squash_merge** | **bool** | If set, set only the destination branch as a parent, which \&quot;squashes\&quot; the merge to appear as a single commit on the destination branch.  | [optional] [default to True]
+**squash_merge** | **bool** | If set, set only the destination branch as a parent, which \&quot;squashes\&quot; the merge to appear as a single commit on the destination branch.  The source commit is no longer a part of the merge commit; consider adding it to the &#39;metadata&#39; or &#39;message&#39; fields.  | [optional] [default to True]
 
 ## Example
 

--- a/clients/python/lakefs_sdk/models/merge.py
+++ b/clients/python/lakefs_sdk/models/merge.py
@@ -34,7 +34,7 @@ class Merge(BaseModel):
     strategy: Optional[StrictStr] = Field(None, description="In case of a merge conflict, this option will force the merge process to automatically favor changes from the dest branch ('dest-wins') or from the source branch('source-wins'). In case no selection is made, the merge process will fail in case of a conflict")
     force: Optional[StrictBool] = Field(False, description="Allow merge into a read-only branch or into a branch with the same content")
     allow_empty: Optional[StrictBool] = Field(False, description="Allow merge when the branches have the same content")
-    squash_merge: Optional[StrictBool] = Field(True, description="If set, set only the destination branch as a parent, which \"squashes\" the merge to appear as a single commit on the destination branch. ")
+    squash_merge: Optional[StrictBool] = Field(True, description="If set, set only the destination branch as a parent, which \"squashes\" the merge to appear as a single commit on the destination branch.  The source commit is no longer a part of the merge commit; consider adding it to the 'metadata' or 'message' fields. ")
     __properties = ["message", "metadata", "strategy", "force", "allow_empty", "squash_merge"]
 
     class Config:

--- a/clients/python/lakefs_sdk/models/merge.py
+++ b/clients/python/lakefs_sdk/models/merge.py
@@ -34,7 +34,7 @@ class Merge(BaseModel):
     strategy: Optional[StrictStr] = Field(None, description="In case of a merge conflict, this option will force the merge process to automatically favor changes from the dest branch ('dest-wins') or from the source branch('source-wins'). In case no selection is made, the merge process will fail in case of a conflict")
     force: Optional[StrictBool] = Field(False, description="Allow merge into a read-only branch or into a branch with the same content")
     allow_empty: Optional[StrictBool] = Field(False, description="Allow merge when the branches have the same content")
-    squash_merge: Optional[StrictBool] = Field(True, description="If set, set only the destination branch as a parent, which \"squashes\" the merge to appear as a single commit on the destination branch.  The source commit is no longer a part of the merge commit; consider adding it to the 'metadata' or 'message' fields. ")
+    squash_merge: Optional[StrictBool] = Field(True, description="If set, set only the destination branch as a parent, which \"squashes\" the merge to appear as a single commit on the destination branch.  The source commit is no longer a part of the merge commit; consider adding it to the 'metadata' or 'message' fields.  This behaves like a GitHub or GitLab \"squash merge\", or in Git terms 'git merge --squash; git commit ...'. ")
     __properties = ["message", "metadata", "strategy", "force", "allow_empty", "squash_merge"]
 
     class Config:

--- a/clients/python/lakefs_sdk/models/merge.py
+++ b/clients/python/lakefs_sdk/models/merge.py
@@ -34,7 +34,8 @@ class Merge(BaseModel):
     strategy: Optional[StrictStr] = Field(None, description="In case of a merge conflict, this option will force the merge process to automatically favor changes from the dest branch ('dest-wins') or from the source branch('source-wins'). In case no selection is made, the merge process will fail in case of a conflict")
     force: Optional[StrictBool] = Field(False, description="Allow merge into a read-only branch or into a branch with the same content")
     allow_empty: Optional[StrictBool] = Field(False, description="Allow merge when the branches have the same content")
-    __properties = ["message", "metadata", "strategy", "force", "allow_empty"]
+    squash_merge: Optional[StrictBool] = Field(True, description="If set, set only the destination branch as a parent, which \"squashes\" the merge to appear as a single commit on the destination branch. ")
+    __properties = ["message", "metadata", "strategy", "force", "allow_empty", "squash_merge"]
 
     class Config:
         """Pydantic configuration"""
@@ -76,7 +77,8 @@ class Merge(BaseModel):
             "metadata": obj.get("metadata"),
             "strategy": obj.get("strategy"),
             "force": obj.get("force") if obj.get("force") is not None else False,
-            "allow_empty": obj.get("allow_empty") if obj.get("allow_empty") is not None else False
+            "allow_empty": obj.get("allow_empty") if obj.get("allow_empty") is not None else False,
+            "squash_merge": obj.get("squash_merge") if obj.get("squash_merge") is not None else True
         })
         return _obj
 

--- a/clients/python/test/test_merge.py
+++ b/clients/python/test/test_merge.py
@@ -45,7 +45,8 @@ class TestMerge(unittest.TestCase):
                     }, 
                 strategy = '', 
                 force = True, 
-                allow_empty = True
+                allow_empty = True, 
+                squash_merge = True
             )
         else :
             return Merge(

--- a/clients/rust/docs/Merge.md
+++ b/clients/rust/docs/Merge.md
@@ -9,6 +9,7 @@ Name | Type | Description | Notes
 **strategy** | Option<**String**> | In case of a merge conflict, this option will force the merge process to automatically favor changes from the dest branch ('dest-wins') or from the source branch('source-wins'). In case no selection is made, the merge process will fail in case of a conflict | [optional]
 **force** | Option<**bool**> | Allow merge into a read-only branch or into a branch with the same content | [optional][default to false]
 **allow_empty** | Option<**bool**> | Allow merge when the branches have the same content | [optional][default to false]
+**squash_merge** | Option<**bool**> | If set, set only the destination branch as a parent, which \"squashes\" the merge to appear as a single commit on the destination branch.  | [optional][default to true]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/clients/rust/docs/Merge.md
+++ b/clients/rust/docs/Merge.md
@@ -9,7 +9,7 @@ Name | Type | Description | Notes
 **strategy** | Option<**String**> | In case of a merge conflict, this option will force the merge process to automatically favor changes from the dest branch ('dest-wins') or from the source branch('source-wins'). In case no selection is made, the merge process will fail in case of a conflict | [optional]
 **force** | Option<**bool**> | Allow merge into a read-only branch or into a branch with the same content | [optional][default to false]
 **allow_empty** | Option<**bool**> | Allow merge when the branches have the same content | [optional][default to false]
-**squash_merge** | Option<**bool**> | If set, set only the destination branch as a parent, which \"squashes\" the merge to appear as a single commit on the destination branch.  The source commit is no longer a part of the merge commit; consider adding it to the 'metadata' or 'message' fields.  | [optional][default to true]
+**squash_merge** | Option<**bool**> | If set, set only the destination branch as a parent, which \"squashes\" the merge to appear as a single commit on the destination branch.  The source commit is no longer a part of the merge commit; consider adding it to the 'metadata' or 'message' fields.  This behaves like a GitHub or GitLab \"squash merge\", or in Git terms 'git merge --squash; git commit ...'.  | [optional][default to true]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/clients/rust/docs/Merge.md
+++ b/clients/rust/docs/Merge.md
@@ -9,7 +9,7 @@ Name | Type | Description | Notes
 **strategy** | Option<**String**> | In case of a merge conflict, this option will force the merge process to automatically favor changes from the dest branch ('dest-wins') or from the source branch('source-wins'). In case no selection is made, the merge process will fail in case of a conflict | [optional]
 **force** | Option<**bool**> | Allow merge into a read-only branch or into a branch with the same content | [optional][default to false]
 **allow_empty** | Option<**bool**> | Allow merge when the branches have the same content | [optional][default to false]
-**squash_merge** | Option<**bool**> | If set, set only the destination branch as a parent, which \"squashes\" the merge to appear as a single commit on the destination branch.  | [optional][default to true]
+**squash_merge** | Option<**bool**> | If set, set only the destination branch as a parent, which \"squashes\" the merge to appear as a single commit on the destination branch.  The source commit is no longer a part of the merge commit; consider adding it to the 'metadata' or 'message' fields.  | [optional][default to true]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/clients/rust/src/models/merge.rs
+++ b/clients/rust/src/models/merge.rs
@@ -25,6 +25,9 @@ pub struct Merge {
     /// Allow merge when the branches have the same content
     #[serde(rename = "allow_empty", skip_serializing_if = "Option::is_none")]
     pub allow_empty: Option<bool>,
+    /// If set, set only the destination branch as a parent, which \"squashes\" the merge to appear as a single commit on the destination branch. 
+    #[serde(rename = "squash_merge", skip_serializing_if = "Option::is_none")]
+    pub squash_merge: Option<bool>,
 }
 
 impl Merge {
@@ -35,6 +38,7 @@ impl Merge {
             strategy: None,
             force: None,
             allow_empty: None,
+            squash_merge: None,
         }
     }
 }

--- a/clients/rust/src/models/merge.rs
+++ b/clients/rust/src/models/merge.rs
@@ -25,7 +25,7 @@ pub struct Merge {
     /// Allow merge when the branches have the same content
     #[serde(rename = "allow_empty", skip_serializing_if = "Option::is_none")]
     pub allow_empty: Option<bool>,
-    /// If set, set only the destination branch as a parent, which \"squashes\" the merge to appear as a single commit on the destination branch. 
+    /// If set, set only the destination branch as a parent, which \"squashes\" the merge to appear as a single commit on the destination branch.  The source commit is no longer a part of the merge commit; consider adding it to the 'metadata' or 'message' fields. 
     #[serde(rename = "squash_merge", skip_serializing_if = "Option::is_none")]
     pub squash_merge: Option<bool>,
 }

--- a/clients/rust/src/models/merge.rs
+++ b/clients/rust/src/models/merge.rs
@@ -25,7 +25,7 @@ pub struct Merge {
     /// Allow merge when the branches have the same content
     #[serde(rename = "allow_empty", skip_serializing_if = "Option::is_none")]
     pub allow_empty: Option<bool>,
-    /// If set, set only the destination branch as a parent, which \"squashes\" the merge to appear as a single commit on the destination branch.  The source commit is no longer a part of the merge commit; consider adding it to the 'metadata' or 'message' fields. 
+    /// If set, set only the destination branch as a parent, which \"squashes\" the merge to appear as a single commit on the destination branch.  The source commit is no longer a part of the merge commit; consider adding it to the 'metadata' or 'message' fields.  This behaves like a GitHub or GitLab \"squash merge\", or in Git terms 'git merge --squash; git commit ...'. 
     #[serde(rename = "squash_merge", skip_serializing_if = "Option::is_none")]
     pub squash_merge: Option<bool>,
 }

--- a/cmd/lakectl/cmd/merge.go
+++ b/cmd/lakectl/cmd/merge.go
@@ -42,6 +42,7 @@ var mergeCmd = &cobra.Command{
 		strategy := Must(cmd.Flags().GetString("strategy"))
 		force := Must(cmd.Flags().GetBool("force"))
 		allowEmpty := Must(cmd.Flags().GetBool("allow-empty"))
+		squash := Must(cmd.Flags().GetBool("squash"))
 
 		fmt.Println("Source:", sourceRef)
 		fmt.Println("Destination:", destinationRef)
@@ -54,11 +55,12 @@ var mergeCmd = &cobra.Command{
 		}
 
 		body := apigen.MergeIntoBranchJSONRequestBody{
-			Message:    &message,
-			Metadata:   &apigen.Merge_Metadata{AdditionalProperties: kvPairs},
-			Strategy:   &strategy,
-			Force:      &force,
-			AllowEmpty: &allowEmpty,
+			Message:     &message,
+			Metadata:    &apigen.Merge_Metadata{AdditionalProperties: kvPairs},
+			Strategy:    &strategy,
+			Force:       &force,
+			AllowEmpty:  &allowEmpty,
+			SquashMerge: &squash,
 		}
 
 		resp, err := client.MergeIntoBranchWithResponse(cmd.Context(), destinationRef.Repository, sourceRef.Ref, destinationRef.Ref, body)
@@ -89,6 +91,7 @@ func init() {
 	flags.String("strategy", "", "In case of a merge conflict, this option will force the merge process to automatically favor changes from the dest branch (\"dest-wins\") or from the source branch(\"source-wins\"). In case no selection is made, the merge process will fail in case of a conflict")
 	flags.Bool("force", false, "Allow merge into a read-only branch or into a branch with the same content")
 	flags.Bool("allow-empty", false, "Allow merge when the branches have the same content")
+	flags.Bool("squash", false, "Squash all changes from source into a single commit on destination")
 	withCommitFlags(mergeCmd, true)
 	rootCmd.AddCommand(mergeCmd)
 }

--- a/docs/assets/js/swagger.yml
+++ b/docs/assets/js/swagger.yml
@@ -690,10 +690,10 @@ components:
           type: boolean
           default: true
           description: |
-            If set, set only the destination branch as a parent, which
-            "squashes" the merge to appear as a single commit on the
-            destination branch.
-
+            If set, set only the destination branch as a parent, which "squashes" the merge to
+            appear as a single commit on the destination branch.  The source commit is no longer
+            a part of the merge commit; consider adding it to the 'metadata' or 'message'
+            fields.
     BranchCreation:
       type: object
       required:

--- a/docs/assets/js/swagger.yml
+++ b/docs/assets/js/swagger.yml
@@ -693,7 +693,8 @@ components:
             If set, set only the destination branch as a parent, which "squashes" the merge to
             appear as a single commit on the destination branch.  The source commit is no longer
             a part of the merge commit; consider adding it to the 'metadata' or 'message'
-            fields.
+            fields.  This behaves like a GitHub or GitLab "squash merge", or in Git terms 'git
+            merge --squash; git commit ...'.
     BranchCreation:
       type: object
       required:

--- a/docs/assets/js/swagger.yml
+++ b/docs/assets/js/swagger.yml
@@ -686,6 +686,13 @@ components:
           type: boolean
           default: false
           description: Allow merge when the branches have the same content
+        squash_merge:
+          type: boolean
+          default: true
+          description: |
+            If set, set only the destination branch as a parent, which
+            "squashes" the merge to appear as a single commit on the
+            destination branch.
 
     BranchCreation:
       type: object

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -2384,6 +2384,7 @@ lakectl merge <source ref> <destination ref> [flags]
   -h, --help                  help for merge
   -m, --message string        commit message
       --meta strings          key value pair in the form of key=value
+      --squash                Squash all changes from source into a single commit on destination
       --strategy string       In case of a merge conflict, this option will force the merge process to automatically favor changes from the dest branch ("dest-wins") or from the source branch("source-wins"). In case no selection is made, the merge process will fail in case of a conflict
 ```
 

--- a/esti/golden/lakectl_merge_with_squashed_commit.golden
+++ b/esti/golden/lakectl_merge_with_squashed_commit.golden
@@ -1,0 +1,15 @@
+
+ID:            <COMMIT_ID>
+Author:        esti
+Date:          <DATE> <TIME> <TZ>
+
+	${MESSAGE}
+
+Metadata:
+	
+	.lakefs.merge.strategy = default
+	
+	key1               = value1
+	
+	key2               = value2
+	

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -4809,6 +4809,7 @@ func (c *Controller) MergeIntoBranch(w http.ResponseWriter, r *http.Request, bod
 		swag.StringValue(body.Strategy),
 		graveler.WithForce(swag.BoolValue(body.Force)),
 		graveler.WithAllowEmpty(swag.BoolValue(body.AllowEmpty)),
+		graveler.WithSquashMerge(swag.BoolValue(body.SquashMerge)),
 	)
 
 	if errors.Is(err, graveler.ErrConflictFound) {

--- a/pkg/graveler/graveler.go
+++ b/pkg/graveler/graveler.go
@@ -196,6 +196,9 @@ type SetOptions struct {
 	AllowEmpty bool
 	// Hidden Will create the branch with the hidden property
 	Hidden bool
+	// SquashMerge causes merge commits to be "squashed", losing parent
+	// information about the merged-from branch.
+	SquashMerge bool
 }
 
 type SetOptionsFunc func(opts *SetOptions)
@@ -229,6 +232,12 @@ func WithAllowEmpty(v bool) SetOptionsFunc {
 func WithHidden(v bool) SetOptionsFunc {
 	return func(opts *SetOptions) {
 		opts.Hidden = v
+	}
+}
+
+func WithSquashMerge(v bool) SetOptionsFunc {
+	return func(opts *SetOptions) {
+		opts.SquashMerge = v
 	}
 }
 
@@ -2926,7 +2935,11 @@ func (g *Graveler) Merge(ctx context.Context, repository *RepositoryRecord, dest
 		commit.Committer = commitParams.Committer
 		commit.Message = commitParams.Message
 		commit.MetaRangeID = metaRangeID
-		commit.Parents = []CommitID{toCommit.CommitID, fromCommit.CommitID}
+		if options.SquashMerge {
+			commit.Parents = []CommitID{toCommit.CommitID}
+		} else {
+			commit.Parents = []CommitID{toCommit.CommitID, fromCommit.CommitID}
+		}
 		if toCommit.Generation > fromCommit.Generation {
 			commit.Generation = toCommit.Generation + 1
 		} else {


### PR DESCRIPTION
Squashing really just means removing the source branch as a parent of the
resulting commit.

Fixes #7382.
