### PR TITLE
Clone of 8032 to run CI - fixed typo mount.md

### DIFF
--- a/docs/reference/mount.md
+++ b/docs/reference/mount.md
@@ -212,7 +212,7 @@ For read-only local data access. lakeFS Mount offers several benefits over lakec
 * **Reduced initial latency**: Start working on your data immediately without waiting for downloads.
 
 **Note**
-Note: Write support for lakeFS Mount is on our roadmap.
+Write support for lakeFS Mount is on our roadmap.
 {: .note }
 
 <!-- END EXCLUDE FROM TOC -->


### PR DESCRIPTION
Clone of #8032 pull that not this.

Integration tests for that PR failed for unrelated reasons.  GH deleted the log files a while back, it cannot re-run failed tests after 90 days.  So push this clone (only) to get that PR to pass CI!