### PR TITLE
Updated protobuf to 1.5.4[Issue #8475]

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -18,7 +18,7 @@ require (
 	github.com/go-test/deep v1.1.0
 	github.com/gobwas/glob v0.2.3
 	github.com/golang/mock v1.6.0
-	github.com/golang/protobuf v1.5.3 // indirect
+	github.com/golang/protobuf v1.5.4 // indirect
 	github.com/google/uuid v1.6.0
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/hnlq715/golang-lru v0.3.0


### PR DESCRIPTION
Closes #(8475
## Change Description

### Background

protobuf package version was deprecated. I upgraded that.

### Contact Details

Contact me via git email.
