### PR TITLE
Default squash-merge behaviour must be OFF

### DIFF
--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -688,7 +688,7 @@ components:
           description: Allow merge when the branches have the same content
         squash_merge:
           type: boolean
-          default: true
+          default: false
           description: |
             If set, set only the destination branch as a parent, which "squashes" the merge to
             appear as a single commit on the destination branch.  The source commit is no longer

--- a/clients/java/api/openapi.yaml
+++ b/clients/java/api/openapi.yaml
@@ -8219,7 +8219,7 @@ components:
       example:
         metadata:
           key: metadata
-        squash_merge: true
+        squash_merge: false
         force: false
         message: message
         strategy: strategy
@@ -8247,7 +8247,7 @@ components:
           description: Allow merge when the branches have the same content
           type: boolean
         squash_merge:
-          default: true
+          default: false
           description: |
             If set, set only the destination branch as a parent, which "squashes" the merge to
             appear as a single commit on the destination branch.  The source commit is no longer

--- a/clients/java/src/main/java/io/lakefs/clients/sdk/model/Merge.java
+++ b/clients/java/src/main/java/io/lakefs/clients/sdk/model/Merge.java
@@ -76,7 +76,7 @@ public class Merge {
 
   public static final String SERIALIZED_NAME_SQUASH_MERGE = "squash_merge";
   @SerializedName(SERIALIZED_NAME_SQUASH_MERGE)
-  private Boolean squashMerge = true;
+  private Boolean squashMerge = false;
 
   public Merge() {
   }

--- a/clients/python/docs/Merge.md
+++ b/clients/python/docs/Merge.md
@@ -10,7 +10,7 @@ Name | Type | Description | Notes
 **strategy** | **str** | In case of a merge conflict, this option will force the merge process to automatically favor changes from the dest branch (&#39;dest-wins&#39;) or from the source branch(&#39;source-wins&#39;). In case no selection is made, the merge process will fail in case of a conflict | [optional] 
 **force** | **bool** | Allow merge into a read-only branch or into a branch with the same content | [optional] [default to False]
 **allow_empty** | **bool** | Allow merge when the branches have the same content | [optional] [default to False]
-**squash_merge** | **bool** | If set, set only the destination branch as a parent, which \&quot;squashes\&quot; the merge to appear as a single commit on the destination branch.  The source commit is no longer a part of the merge commit; consider adding it to the &#39;metadata&#39; or &#39;message&#39; fields.  This behaves like a GitHub or GitLab \&quot;squash merge\&quot;, or in Git terms &#39;git merge --squash; git commit ...&#39;.  | [optional] [default to True]
+**squash_merge** | **bool** | If set, set only the destination branch as a parent, which \&quot;squashes\&quot; the merge to appear as a single commit on the destination branch.  The source commit is no longer a part of the merge commit; consider adding it to the &#39;metadata&#39; or &#39;message&#39; fields.  This behaves like a GitHub or GitLab \&quot;squash merge\&quot;, or in Git terms &#39;git merge --squash; git commit ...&#39;.  | [optional] [default to False]
 
 ## Example
 

--- a/clients/python/lakefs_sdk/models/merge.py
+++ b/clients/python/lakefs_sdk/models/merge.py
@@ -34,7 +34,7 @@ class Merge(BaseModel):
     strategy: Optional[StrictStr] = Field(None, description="In case of a merge conflict, this option will force the merge process to automatically favor changes from the dest branch ('dest-wins') or from the source branch('source-wins'). In case no selection is made, the merge process will fail in case of a conflict")
     force: Optional[StrictBool] = Field(False, description="Allow merge into a read-only branch or into a branch with the same content")
     allow_empty: Optional[StrictBool] = Field(False, description="Allow merge when the branches have the same content")
-    squash_merge: Optional[StrictBool] = Field(True, description="If set, set only the destination branch as a parent, which \"squashes\" the merge to appear as a single commit on the destination branch.  The source commit is no longer a part of the merge commit; consider adding it to the 'metadata' or 'message' fields.  This behaves like a GitHub or GitLab \"squash merge\", or in Git terms 'git merge --squash; git commit ...'. ")
+    squash_merge: Optional[StrictBool] = Field(False, description="If set, set only the destination branch as a parent, which \"squashes\" the merge to appear as a single commit on the destination branch.  The source commit is no longer a part of the merge commit; consider adding it to the 'metadata' or 'message' fields.  This behaves like a GitHub or GitLab \"squash merge\", or in Git terms 'git merge --squash; git commit ...'. ")
     __properties = ["message", "metadata", "strategy", "force", "allow_empty", "squash_merge"]
 
     class Config:
@@ -78,7 +78,7 @@ class Merge(BaseModel):
             "strategy": obj.get("strategy"),
             "force": obj.get("force") if obj.get("force") is not None else False,
             "allow_empty": obj.get("allow_empty") if obj.get("allow_empty") is not None else False,
-            "squash_merge": obj.get("squash_merge") if obj.get("squash_merge") is not None else True
+            "squash_merge": obj.get("squash_merge") if obj.get("squash_merge") is not None else False
         })
         return _obj
 

--- a/clients/rust/docs/Merge.md
+++ b/clients/rust/docs/Merge.md
@@ -9,7 +9,7 @@ Name | Type | Description | Notes
 **strategy** | Option<**String**> | In case of a merge conflict, this option will force the merge process to automatically favor changes from the dest branch ('dest-wins') or from the source branch('source-wins'). In case no selection is made, the merge process will fail in case of a conflict | [optional]
 **force** | Option<**bool**> | Allow merge into a read-only branch or into a branch with the same content | [optional][default to false]
 **allow_empty** | Option<**bool**> | Allow merge when the branches have the same content | [optional][default to false]
-**squash_merge** | Option<**bool**> | If set, set only the destination branch as a parent, which \"squashes\" the merge to appear as a single commit on the destination branch.  The source commit is no longer a part of the merge commit; consider adding it to the 'metadata' or 'message' fields.  This behaves like a GitHub or GitLab \"squash merge\", or in Git terms 'git merge --squash; git commit ...'.  | [optional][default to true]
+**squash_merge** | Option<**bool**> | If set, set only the destination branch as a parent, which \"squashes\" the merge to appear as a single commit on the destination branch.  The source commit is no longer a part of the merge commit; consider adding it to the 'metadata' or 'message' fields.  This behaves like a GitHub or GitLab \"squash merge\", or in Git terms 'git merge --squash; git commit ...'.  | [optional][default to false]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/docs/assets/js/swagger.yml
+++ b/docs/assets/js/swagger.yml
@@ -688,7 +688,7 @@ components:
           description: Allow merge when the branches have the same content
         squash_merge:
           type: boolean
-          default: true
+          default: false
           description: |
             If set, set only the destination branch as a parent, which "squashes" the merge to
             appear as a single commit on the destination branch.  The source commit is no longer

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -3826,19 +3826,25 @@ func TestController_MergeSquashing(t *testing.T) {
 
 	cases := []struct {
 		Name               string
-		Squash             bool
+		Squash             *bool
 		ExpectedNumCommits int
 	}{{
 		Name:   "regular",
-		Squash: false,
+		Squash: swag.Bool(false),
 		// Commits: 1 "created repository", numCommits on branch, 1 merge.
 		ExpectedNumCommits: numCommits + 2,
 	}, {
 		Name:   "squash",
-		Squash: true,
+		Squash: swag.Bool(true),
 		// Commits: 1 "created repository", 1 merge.
 		ExpectedNumCommits: 2,
+	}, {
+		Name:   "default",
+		Squash: nil,
+		// Commits: 1 "created repository", 1 merge.
+		ExpectedNumCommits: numCommits + 2,
 	}}
+
 	for _, tc := range cases {
 		t.Run(tc.Name, func(t *testing.T) {
 			destinationBranch := "main-" + tc.Name
@@ -3846,7 +3852,7 @@ func TestController_MergeSquashing(t *testing.T) {
 			_, err := deps.catalog.CreateBranch(ctx, repo, destinationBranch, "main")
 			testutil.Must(t, err)
 
-			mergeResp, err := clt.MergeIntoBranchWithResponse(ctx, repo, "branch", destinationBranch, apigen.MergeIntoBranchJSONRequestBody{SquashMerge: &tc.Squash})
+			mergeResp, err := clt.MergeIntoBranchWithResponse(ctx, repo, "branch", destinationBranch, apigen.MergeIntoBranchJSONRequestBody{SquashMerge: tc.Squash})
 			testutil.MustDo(t, "perform merge into branch", err)
 			if !apiutil.IsStatusCodeOK(mergeResp.StatusCode()) {
 				t.Fatal("merge request failed", mergeResp.Status())


### PR DESCRIPTION
My original PR introduced an entirely wrong behaviour which is _also_ a breaking change.  Fix this bad default.

Closes #8482.
