### PR TITLE
Add StorageID to adapter metadata functions

### DIFF
--- a/cmd/lakefs/cmd/run.go
+++ b/cmd/lakefs/cmd/run.go
@@ -430,7 +430,8 @@ func checkRepos(ctx context.Context, logger logging.Logger, authMetadataManager 
 		logger.Debug("lakeFS isn't initialized, skipping mismatched adapter checks")
 	} else {
 		logger.
-			WithField("adapter_type", blockStore.BlockstoreType()).
+			// TODO (gilo): uncomment this?
+			//WithField("adapter_type", blockStore.BlockstoreType()).
 			Debug("lakeFS is initialized, checking repositories for mismatched adapter")
 		hasMore := true
 		next := ""
@@ -443,8 +444,8 @@ func checkRepos(ctx context.Context, logger logging.Logger, authMetadataManager 
 				logger.WithError(err).Fatal("Checking existing repositories failed")
 			}
 
-			adapterStorageType := blockStore.BlockstoreType()
 			for _, repo := range repos {
+				adapterStorageType := blockStore.BlockstoreType(repo.StorageID)
 				nsURL, err := url.Parse(repo.StorageNamespace)
 				if err != nil {
 					logger.WithError(err).Fatalf("Failed to parse repository %s namespace '%s'", repo.Name, repo.StorageNamespace)

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -167,15 +167,15 @@ func (c *Controller) CreatePresignMultipartUpload(w http.ResponseWriter, r *http
 	ctx := r.Context()
 	c.LogAction(ctx, "create_presign_multipart_upload", r, repository, branch, "")
 
-	// check if api is supported
-	storageConfig := c.getStorageConfig()
-	if !swag.BoolValue(storageConfig.PreSignMultipartUpload) {
-		writeError(w, r, http.StatusNotImplemented, "presign multipart upload API is not supported")
+	repo, err := c.Catalog.GetRepository(ctx, repository)
+	if c.handleAPIError(ctx, w, r, err) {
 		return
 	}
 
-	repo, err := c.Catalog.GetRepository(ctx, repository)
-	if c.handleAPIError(ctx, w, r, err) {
+	// check if api is supported
+	storageConfig := c.getStorageConfig(repo.StorageID)
+	if !swag.BoolValue(storageConfig.PreSignMultipartUpload) {
+		writeError(w, r, http.StatusNotImplemented, "presign multipart upload API is not supported")
 		return
 	}
 
@@ -211,7 +211,7 @@ func (c *Controller) CreatePresignMultipartUpload(w http.ResponseWriter, r *http
 		return
 	}
 
-	qk, err := c.BlockAdapter.ResolveNamespace(repo.StorageNamespace, address, block.IdentifierTypeRelative)
+	qk, err := c.BlockAdapter.ResolveNamespace(repo.StorageID, repo.StorageNamespace, address, block.IdentifierTypeRelative)
 	if err != nil {
 		writeError(w, r, http.StatusInternalServerError, err)
 		return
@@ -267,8 +267,13 @@ func (c *Controller) AbortPresignMultipartUpload(w http.ResponseWriter, r *http.
 	ctx := r.Context()
 	c.LogAction(ctx, "abort_presign_multipart_upload", r, repository, branch, "")
 
+	repo, err := c.Catalog.GetRepository(ctx, repository)
+	if c.handleAPIError(ctx, w, r, err) {
+		return
+	}
+
 	// check if api is supported
-	storageConfig := c.getStorageConfig()
+	storageConfig := c.getStorageConfig(repo.StorageID)
 	if !swag.BoolValue(storageConfig.PreSignMultipartUpload) {
 		writeError(w, r, http.StatusNotImplemented, "presign multipart upload API is not supported")
 		return
@@ -285,11 +290,6 @@ func (c *Controller) AbortPresignMultipartUpload(w http.ResponseWriter, r *http.
 	}
 	if body.PhysicalAddress == "" {
 		writeError(w, r, http.StatusBadRequest, "physical_address is required")
-		return
-	}
-
-	repo, err := c.Catalog.GetRepository(ctx, repository)
-	if c.handleAPIError(ctx, w, r, err) {
 		return
 	}
 
@@ -327,8 +327,14 @@ func (c *Controller) CompletePresignMultipartUpload(w http.ResponseWriter, r *ht
 	ctx := r.Context()
 	c.LogAction(ctx, "complete_presign_multipart_upload", r, repository, branch, "")
 
+	// verify physical address
+	repo, err := c.Catalog.GetRepository(ctx, repository)
+	if c.handleAPIError(ctx, w, r, err) {
+		return
+	}
+
 	// check if api is supported
-	storageConfig := c.getStorageConfig()
+	storageConfig := c.getStorageConfig(repo.StorageID)
 	if !swag.BoolValue(storageConfig.PreSignMultipartUpload) {
 		writeError(w, r, http.StatusNotImplemented, "presign multipart upload API is not supported")
 		return
@@ -349,12 +355,6 @@ func (c *Controller) CompletePresignMultipartUpload(w http.ResponseWriter, r *ht
 	}
 	if len(body.Parts) == 0 {
 		writeError(w, r, http.StatusBadRequest, "parts are required")
-		return
-	}
-
-	// verify physical address
-	repo, err := c.Catalog.GetRepository(ctx, repository)
-	if c.handleAPIError(ctx, w, r, err) {
 		return
 	}
 
@@ -696,7 +696,7 @@ func (c *Controller) GetPhysicalAddress(w http.ResponseWriter, r *http.Request, 
 		return
 	}
 
-	qk, err := c.BlockAdapter.ResolveNamespace(repo.StorageNamespace, address, block.IdentifierTypeRelative)
+	qk, err := c.BlockAdapter.ResolveNamespace(repo.StorageID, repo.StorageNamespace, address, block.IdentifierTypeRelative)
 	if err != nil {
 		writeError(w, r, http.StatusInternalServerError, err)
 		return
@@ -750,7 +750,7 @@ func (c *Controller) LinkPhysicalAddress(w http.ResponseWriter, r *http.Request,
 		return
 	}
 	// write metadata
-	qk, err := c.BlockAdapter.ResolveNamespace(repo.StorageNamespace, params.Path, block.IdentifierTypeRelative)
+	qk, err := c.BlockAdapter.ResolveNamespace(repo.StorageID, repo.StorageNamespace, params.Path, block.IdentifierTypeRelative)
 	if err != nil {
 		writeError(w, r, http.StatusInternalServerError, err)
 		return
@@ -765,7 +765,7 @@ func (c *Controller) LinkPhysicalAddress(w http.ResponseWriter, r *http.Request,
 		ifAbsent = true
 	}
 
-	blockStoreType := c.BlockAdapter.BlockstoreType()
+	blockStoreType := c.BlockAdapter.BlockstoreType(repo.StorageID)
 	expectedType := qk.GetStorageType().BlockstoreType()
 	if expectedType != blockStoreType {
 		c.Logger.WithContext(ctx).WithFields(logging.Fields{
@@ -1851,7 +1851,8 @@ func (c *Controller) GetConfig(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	storageCfg := c.getStorageConfig()
+	// TODO (gilo): is StorageID relevant here?
+	storageCfg := c.getStorageConfig("")
 	// TODO (niro): Needs to be populated
 	storageListCfg := apigen.StorageConfigList{}
 	versionConfig := c.getVersionConfig()
@@ -1868,11 +1869,12 @@ func (c *Controller) GetStorageConfig(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	writeResponse(w, r, http.StatusOK, c.getStorageConfig())
+	// TODO (gilo): is StorageID relevant here?
+	writeResponse(w, r, http.StatusOK, c.getStorageConfig(""))
 }
 
-func (c *Controller) getStorageConfig() apigen.StorageConfig {
-	info := c.BlockAdapter.GetStorageNamespaceInfo()
+func (c *Controller) getStorageConfig(storageID string) apigen.StorageConfig {
+	info := c.BlockAdapter.GetStorageNamespaceInfo(storageID)
 	defaultNamespacePrefix := swag.String(info.DefaultNamespacePrefix)
 	if c.Config.GetBaseConfig().Blockstore.DefaultNamespacePrefix != nil {
 		defaultNamespacePrefix = c.Config.GetBaseConfig().Blockstore.DefaultNamespacePrefix
@@ -1971,7 +1973,7 @@ func (c *Controller) CreateRepository(w http.ResponseWriter, r *http.Request, bo
 		c.LogAction(ctx, "repo_sample_data", r, body.Name, "", "")
 	}
 
-	if err := c.validateStorageNamespace(storageNamespace); err != nil {
+	if err := c.validateStorageNamespace(storageID, storageNamespace); err != nil {
 		writeError(w, r, http.StatusBadRequest, err)
 		return
 	}
@@ -2000,7 +2002,7 @@ func (c *Controller) CreateRepository(w http.ResponseWriter, r *http.Request, bo
 				retErr = err
 				reason = "bad_url"
 			case errors.Is(err, block.ErrInvalidAddress):
-				retErr = fmt.Errorf("%w, must match: %s", err, c.BlockAdapter.BlockstoreType())
+				retErr = fmt.Errorf("%w, must match: %s", err, c.BlockAdapter.BlockstoreType(storageID))
 				reason = "invalid_namespace"
 			case errors.Is(err, ErrStorageNamespaceInUse):
 				retErr = err
@@ -2075,8 +2077,8 @@ func (c *Controller) CreateRepository(w http.ResponseWriter, r *http.Request, bo
 	writeResponse(w, r, http.StatusCreated, response)
 }
 
-func (c *Controller) validateStorageNamespace(storageNamespace string) error {
-	validRegex := c.BlockAdapter.GetStorageNamespaceInfo().ValidityRegex
+func (c *Controller) validateStorageNamespace(storageID, storageNamespace string) error {
+	validRegex := c.BlockAdapter.GetStorageNamespaceInfo(storageID).ValidityRegex
 	storagePrefixRegex, err := regexp.Compile(validRegex)
 	if err != nil {
 		return fmt.Errorf("failed to compile validity regex %s: %w", validRegex, block.ErrInvalidNamespace)
@@ -3312,7 +3314,7 @@ func (c *Controller) UploadObject(w http.ResponseWriter, r *http.Request, reposi
 		identifierType = block.IdentifierTypeRelative
 	}
 
-	qk, err := c.BlockAdapter.ResolveNamespace(repo.StorageNamespace, blob.PhysicalAddress, identifierType)
+	qk, err := c.BlockAdapter.ResolveNamespace(repo.StorageID, repo.StorageNamespace, blob.PhysicalAddress, identifierType)
 	if err != nil {
 		writeError(w, r, http.StatusInternalServerError, err)
 		return
@@ -3348,16 +3350,16 @@ func (c *Controller) StageObject(w http.ResponseWriter, r *http.Request, body ap
 		return
 	}
 	// write metadata
-	qk, err := c.BlockAdapter.ResolveNamespace(repo.StorageNamespace, body.PhysicalAddress, block.IdentifierTypeFull)
+	qk, err := c.BlockAdapter.ResolveNamespace(repo.StorageID, repo.StorageNamespace, body.PhysicalAddress, block.IdentifierTypeFull)
 	if c.handleAPIError(ctx, w, r, err) {
 		return
 	}
 
 	// see what storage type this is and whether it fits our configuration
-	uriRegex := c.BlockAdapter.GetStorageNamespaceInfo().ValidityRegex
+	uriRegex := c.BlockAdapter.GetStorageNamespaceInfo(repo.StorageID).ValidityRegex
 	if match, err := regexp.MatchString(uriRegex, body.PhysicalAddress); err != nil || !match {
 		writeError(w, r, http.StatusBadRequest, fmt.Sprintf("physical address is not valid for block adapter: %s",
-			c.BlockAdapter.BlockstoreType(),
+			c.BlockAdapter.BlockstoreType(repo.StorageID),
 		))
 		return
 	}
@@ -3453,7 +3455,7 @@ func (c *Controller) CopyObject(w http.ResponseWriter, r *http.Request, body api
 		return
 	}
 
-	qk, err := c.BlockAdapter.ResolveNamespace(repo.StorageNamespace, entry.PhysicalAddress, block.IdentifierTypeRelative)
+	qk, err := c.BlockAdapter.ResolveNamespace(repo.StorageID, repo.StorageNamespace, entry.PhysicalAddress, block.IdentifierTypeRelative)
 	if err != nil {
 		writeError(w, r, http.StatusInternalServerError, err)
 		return
@@ -4177,7 +4179,7 @@ func (c *Controller) CreateSymlinkFile(w http.ResponseWriter, r *http.Request, r
 		}
 		// loop all entries enter to map[path] physicalAddress
 		for _, entry := range entries {
-			qk, err := c.BlockAdapter.ResolveNamespace(repo.StorageNamespace, entry.PhysicalAddress, entry.AddressType.ToIdentifierType())
+			qk, err := c.BlockAdapter.ResolveNamespace(repo.StorageID, repo.StorageNamespace, entry.PhysicalAddress, entry.AddressType.ToIdentifierType())
 			if err != nil {
 				writeError(w, r, http.StatusInternalServerError, fmt.Sprintf("error while resolving address: %s", err))
 				return
@@ -4610,7 +4612,7 @@ func (c *Controller) ListObjects(w http.ResponseWriter, r *http.Request, reposit
 
 	objList := make([]apigen.ObjectStats, 0, len(res))
 	for _, entry := range res {
-		qk, err := c.BlockAdapter.ResolveNamespace(repo.StorageNamespace, entry.PhysicalAddress, entry.AddressType.ToIdentifierType())
+		qk, err := c.BlockAdapter.ResolveNamespace(repo.StorageID, repo.StorageNamespace, entry.PhysicalAddress, entry.AddressType.ToIdentifierType())
 		if err != nil {
 			writeError(w, r, http.StatusInternalServerError, err)
 			return
@@ -4708,7 +4710,7 @@ func (c *Controller) StatObject(w http.ResponseWriter, r *http.Request, reposito
 		return
 	}
 
-	qk, err := c.BlockAdapter.ResolveNamespace(repo.StorageNamespace, entry.PhysicalAddress, entry.AddressType.ToIdentifierType())
+	qk, err := c.BlockAdapter.ResolveNamespace(repo.StorageID, repo.StorageNamespace, entry.PhysicalAddress, entry.AddressType.ToIdentifierType())
 	if c.handleAPIError(ctx, w, r, err) {
 		return
 	}
@@ -5091,7 +5093,8 @@ func (c *Controller) Setup(w http.ResponseWriter, r *http.Request, body apigen.S
 		return
 	}
 
-	meta := stats.NewMetadata(ctx, c.Logger, c.BlockAdapter.BlockstoreType(), c.MetadataManager, c.CloudMetadataProvider)
+	// TODO (gilo): which storageID should we use here?
+	meta := stats.NewMetadata(ctx, c.Logger, c.BlockAdapter.BlockstoreType(""), c.MetadataManager, c.CloudMetadataProvider)
 	c.Collector.SetInstallationID(meta.InstallationID)
 	c.Collector.CollectMetadata(meta)
 	c.Collector.CollectEvent(stats.Event{Class: "global", Name: "init", UserID: body.Username, Client: httputil.GetRequestLakeFSClient(r)})

--- a/pkg/block/adapter.go
+++ b/pkg/block/adapter.go
@@ -194,10 +194,10 @@ type Adapter interface {
 	AbortMultiPartUpload(ctx context.Context, obj ObjectPointer, uploadID string) error
 	CompleteMultiPartUpload(ctx context.Context, obj ObjectPointer, uploadID string, multipartList *MultipartUploadCompletion) (*CompleteMultiPartUploadResponse, error)
 
-	BlockstoreType() string
-	BlockstoreMetadata(ctx context.Context) (*BlockstoreMetadata, error)
-	GetStorageNamespaceInfo() StorageNamespaceInfo
-	ResolveNamespace(storageNamespace, key string, identifierType IdentifierType) (QualifiedKey, error)
+	BlockstoreType(storageID string) string
+	BlockstoreMetadata(ctx context.Context, storageID string) (*BlockstoreMetadata, error)
+	GetStorageNamespaceInfo(storageID string) StorageNamespaceInfo
+	ResolveNamespace(storageID, storageNamespace, key string, identifierType IdentifierType) (QualifiedKey, error)
 
 	// GetRegion storageID is not actively used, and it's here mainly for completeness
 	GetRegion(ctx context.Context, storageID, storageNamespace string) (string, error)

--- a/pkg/block/azure/adapter.go
+++ b/pkg/block/azure/adapter.go
@@ -583,11 +583,11 @@ func (a *Adapter) AbortMultiPartUpload(_ context.Context, _ block.ObjectPointer,
 	return nil
 }
 
-func (a *Adapter) BlockstoreType() string {
+func (a *Adapter) BlockstoreType(_ string) string {
 	return block.BlockstoreTypeAzure
 }
 
-func (a *Adapter) BlockstoreMetadata(_ context.Context) (*block.BlockstoreMetadata, error) {
+func (a *Adapter) BlockstoreMetadata(_ context.Context, _ string) (*block.BlockstoreMetadata, error) {
 	return nil, block.ErrOperationNotSupported
 }
 
@@ -606,7 +606,7 @@ func (a *Adapter) CompleteMultiPartUpload(ctx context.Context, obj block.ObjectP
 	return completeMultipart(ctx, multipartList.Part, *containerURL, qualifiedKey.BlobURL)
 }
 
-func (a *Adapter) GetStorageNamespaceInfo() block.StorageNamespaceInfo {
+func (a *Adapter) GetStorageNamespaceInfo(_ string) block.StorageNamespaceInfo {
 	info := block.DefaultStorageNamespaceInfo(block.BlockstoreTypeAzure)
 
 	info.ImportValidityRegex = fmt.Sprintf(`^https?://[a-z0-9_-]+\.%s`, a.clientCache.params.Domain)
@@ -622,7 +622,7 @@ func (a *Adapter) GetStorageNamespaceInfo() block.StorageNamespaceInfo {
 	return info
 }
 
-func (a *Adapter) ResolveNamespace(storageNamespace, key string, identifierType block.IdentifierType) (block.QualifiedKey, error) {
+func (a *Adapter) ResolveNamespace(storageID, storageNamespace, key string, identifierType block.IdentifierType) (block.QualifiedKey, error) {
 	return block.DefaultResolveNamespace(storageNamespace, key, identifierType)
 }
 

--- a/pkg/block/gs/adapter.go
+++ b/pkg/block/gs/adapter.go
@@ -650,15 +650,15 @@ func (a *Adapter) Close() error {
 	return a.client.Close()
 }
 
-func (a *Adapter) BlockstoreType() string {
+func (a *Adapter) BlockstoreType(_ string) string {
 	return block.BlockstoreTypeGS
 }
 
-func (a *Adapter) BlockstoreMetadata(_ context.Context) (*block.BlockstoreMetadata, error) {
+func (a *Adapter) BlockstoreMetadata(_ context.Context, _ string) (*block.BlockstoreMetadata, error) {
 	return nil, block.ErrOperationNotSupported
 }
 
-func (a *Adapter) GetStorageNamespaceInfo() block.StorageNamespaceInfo {
+func (a *Adapter) GetStorageNamespaceInfo(_ string) block.StorageNamespaceInfo {
 	info := block.DefaultStorageNamespaceInfo(block.BlockstoreTypeGS)
 	if a.disablePreSigned {
 		info.PreSignSupport = false
@@ -670,7 +670,7 @@ func (a *Adapter) GetStorageNamespaceInfo() block.StorageNamespaceInfo {
 }
 
 func (a *Adapter) extractParamsFromObj(obj block.ObjectPointer) (string, string, error) {
-	qk, err := a.ResolveNamespace(obj.StorageNamespace, obj.Identifier, obj.IdentifierType)
+	qk, err := a.ResolveNamespace(obj.StorageID, obj.StorageNamespace, obj.Identifier, obj.IdentifierType)
 	if err != nil {
 		return "", "", err
 	}
@@ -682,7 +682,7 @@ func (a *Adapter) extractParamsFromObj(obj block.ObjectPointer) (string, string,
 	return bucket, key, nil
 }
 
-func (a *Adapter) ResolveNamespace(storageNamespace, key string, identifierType block.IdentifierType) (block.QualifiedKey, error) {
+func (a *Adapter) ResolveNamespace(storageID, storageNamespace, key string, identifierType block.IdentifierType) (block.QualifiedKey, error) {
 	qualifiedKey, err := block.DefaultResolveNamespace(storageNamespace, key, identifierType)
 	if err != nil {
 		return qualifiedKey, err

--- a/pkg/block/local/adapter.go
+++ b/pkg/block/local/adapter.go
@@ -537,15 +537,15 @@ func (l *Adapter) getPartFiles(uploadID string, obj block.ObjectPointer) ([]stri
 	return names, nil
 }
 
-func (l *Adapter) BlockstoreType() string {
+func (l *Adapter) BlockstoreType(_ string) string {
 	return block.BlockstoreTypeLocal
 }
 
-func (l *Adapter) BlockstoreMetadata(_ context.Context) (*block.BlockstoreMetadata, error) {
+func (l *Adapter) BlockstoreMetadata(_ context.Context, _ string) (*block.BlockstoreMetadata, error) {
 	return nil, block.ErrOperationNotSupported
 }
 
-func (l *Adapter) GetStorageNamespaceInfo() block.StorageNamespaceInfo {
+func (l *Adapter) GetStorageNamespaceInfo(_ string) block.StorageNamespaceInfo {
 	info := block.DefaultStorageNamespaceInfo(block.BlockstoreTypeLocal)
 	info.PreSignSupport = false
 	info.DefaultNamespacePrefix = DefaultNamespacePrefix
@@ -553,7 +553,7 @@ func (l *Adapter) GetStorageNamespaceInfo() block.StorageNamespaceInfo {
 	return info
 }
 
-func (l *Adapter) ResolveNamespace(storageNamespace, key string, identifierType block.IdentifierType) (block.QualifiedKey, error) {
+func (l *Adapter) ResolveNamespace(storageID, storageNamespace, key string, identifierType block.IdentifierType) (block.QualifiedKey, error) {
 	qk, err := block.DefaultResolveNamespace(storageNamespace, key, identifierType)
 	if err != nil {
 		return nil, err

--- a/pkg/block/mem/adapter.go
+++ b/pkg/block/mem/adapter.go
@@ -335,22 +335,22 @@ func (a *Adapter) CompleteMultiPartUpload(_ context.Context, obj block.ObjectPoi
 	}, nil
 }
 
-func (a *Adapter) BlockstoreType() string {
+func (a *Adapter) BlockstoreType(_ string) string {
 	return block.BlockstoreTypeMem
 }
 
-func (a *Adapter) BlockstoreMetadata(_ context.Context) (*block.BlockstoreMetadata, error) {
+func (a *Adapter) BlockstoreMetadata(_ context.Context, _ string) (*block.BlockstoreMetadata, error) {
 	return nil, block.ErrOperationNotSupported
 }
 
-func (a *Adapter) GetStorageNamespaceInfo() block.StorageNamespaceInfo {
+func (a *Adapter) GetStorageNamespaceInfo(_ string) block.StorageNamespaceInfo {
 	info := block.DefaultStorageNamespaceInfo(block.BlockstoreTypeMem)
 	info.PreSignSupport = false
 	info.ImportSupport = false
 	return info
 }
 
-func (a *Adapter) ResolveNamespace(storageNamespace, key string, identifierType block.IdentifierType) (block.QualifiedKey, error) {
+func (a *Adapter) ResolveNamespace(storageID, storageNamespace, key string, identifierType block.IdentifierType) (block.QualifiedKey, error) {
 	return block.DefaultResolveNamespace(storageNamespace, key, identifierType)
 }
 

--- a/pkg/block/metrics.go
+++ b/pkg/block/metrics.go
@@ -23,12 +23,12 @@ func (m *MetricsAdapter) InnerAdapter() Adapter {
 }
 
 func (m *MetricsAdapter) Put(ctx context.Context, obj ObjectPointer, sizeBytes int64, reader io.Reader, opts PutOpts) (*PutResponse, error) {
-	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType())
+	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType(obj.StorageID))
 	return m.adapter.Put(ctx, obj, sizeBytes, reader, opts)
 }
 
 func (m *MetricsAdapter) Get(ctx context.Context, obj ObjectPointer) (io.ReadCloser, error) {
-	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType())
+	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType(obj.StorageID))
 	return m.adapter.Get(ctx, obj)
 }
 
@@ -37,94 +37,94 @@ func (m *MetricsAdapter) GetWalker(uri *url.URL) (Walker, error) {
 }
 
 func (m *MetricsAdapter) GetPreSignedURL(ctx context.Context, obj ObjectPointer, mode PreSignMode) (string, time.Time, error) {
-	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType())
+	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType(obj.StorageID))
 	return m.adapter.GetPreSignedURL(ctx, obj, mode)
 }
 
 func (m *MetricsAdapter) GetPresignUploadPartURL(ctx context.Context, obj ObjectPointer, uploadID string, partNumber int) (string, error) {
-	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType())
+	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType(obj.StorageID))
 	return m.adapter.GetPresignUploadPartURL(ctx, obj, uploadID, partNumber)
 }
 
 func (m *MetricsAdapter) Exists(ctx context.Context, obj ObjectPointer) (bool, error) {
-	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType())
+	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType(obj.StorageID))
 	return m.adapter.Exists(ctx, obj)
 }
 
 func (m *MetricsAdapter) GetRange(ctx context.Context, obj ObjectPointer, startPosition int64, endPosition int64) (io.ReadCloser, error) {
-	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType())
+	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType(obj.StorageID))
 	return m.adapter.GetRange(ctx, obj, startPosition, endPosition)
 }
 
 func (m *MetricsAdapter) GetProperties(ctx context.Context, obj ObjectPointer) (Properties, error) {
-	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType())
+	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType(obj.StorageID))
 	return m.adapter.GetProperties(ctx, obj)
 }
 
 func (m *MetricsAdapter) Remove(ctx context.Context, obj ObjectPointer) error {
-	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType())
+	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType(obj.StorageID))
 	return m.adapter.Remove(ctx, obj)
 }
 
 func (m *MetricsAdapter) Copy(ctx context.Context, sourceObj, destinationObj ObjectPointer) error {
-	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType())
+	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType(sourceObj.StorageID))
 	return m.adapter.Copy(ctx, sourceObj, destinationObj)
 }
 
 func (m *MetricsAdapter) CreateMultiPartUpload(ctx context.Context, obj ObjectPointer, r *http.Request, opts CreateMultiPartUploadOpts) (*CreateMultiPartUploadResponse, error) {
-	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType())
+	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType(obj.StorageID))
 	return m.adapter.CreateMultiPartUpload(ctx, obj, r, opts)
 }
 
 func (m *MetricsAdapter) UploadPart(ctx context.Context, obj ObjectPointer, sizeBytes int64, reader io.Reader, uploadID string, partNumber int) (*UploadPartResponse, error) {
-	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType())
+	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType(obj.StorageID))
 	return m.adapter.UploadPart(ctx, obj, sizeBytes, reader, uploadID, partNumber)
 }
 
 func (m *MetricsAdapter) ListParts(ctx context.Context, obj ObjectPointer, uploadID string, opts ListPartsOpts) (*ListPartsResponse, error) {
-	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType())
+	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType(obj.StorageID))
 	return m.adapter.ListParts(ctx, obj, uploadID, opts)
 }
 
 func (m *MetricsAdapter) UploadCopyPart(ctx context.Context, sourceObj, destinationObj ObjectPointer, uploadID string, partNumber int) (*UploadPartResponse, error) {
-	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType())
+	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType(sourceObj.StorageID))
 	return m.adapter.UploadCopyPart(ctx, sourceObj, destinationObj, uploadID, partNumber)
 }
 
 func (m *MetricsAdapter) UploadCopyPartRange(ctx context.Context, sourceObj, destinationObj ObjectPointer, uploadID string, partNumber int, startPosition, endPosition int64) (*UploadPartResponse, error) {
-	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType())
+	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType(sourceObj.StorageID))
 	return m.adapter.UploadCopyPartRange(ctx, sourceObj, destinationObj, uploadID, partNumber, startPosition, endPosition)
 }
 
 func (m *MetricsAdapter) AbortMultiPartUpload(ctx context.Context, obj ObjectPointer, uploadID string) error {
-	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType())
+	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType(obj.StorageID))
 	return m.adapter.AbortMultiPartUpload(ctx, obj, uploadID)
 }
 
 func (m *MetricsAdapter) CompleteMultiPartUpload(ctx context.Context, obj ObjectPointer, uploadID string, multipartList *MultipartUploadCompletion) (*CompleteMultiPartUploadResponse, error) {
-	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType())
+	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType(obj.StorageID))
 	return m.adapter.CompleteMultiPartUpload(ctx, obj, uploadID, multipartList)
 }
 
-func (m *MetricsAdapter) BlockstoreType() string {
-	return m.adapter.BlockstoreType()
+func (m *MetricsAdapter) BlockstoreType(storageID string) string {
+	return m.adapter.BlockstoreType(storageID)
 }
 
-func (m *MetricsAdapter) BlockstoreMetadata(ctx context.Context) (*BlockstoreMetadata, error) {
-	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType())
-	return m.adapter.BlockstoreMetadata(ctx)
+func (m *MetricsAdapter) BlockstoreMetadata(ctx context.Context, storageID string) (*BlockstoreMetadata, error) {
+	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType(storageID))
+	return m.adapter.BlockstoreMetadata(ctx, storageID)
 }
 
-func (m *MetricsAdapter) GetStorageNamespaceInfo() StorageNamespaceInfo {
-	return m.adapter.GetStorageNamespaceInfo()
+func (m *MetricsAdapter) GetStorageNamespaceInfo(storageID string) StorageNamespaceInfo {
+	return m.adapter.GetStorageNamespaceInfo(storageID)
 }
 
-func (m *MetricsAdapter) ResolveNamespace(storageNamespace, key string, identifierType IdentifierType) (QualifiedKey, error) {
-	return m.adapter.ResolveNamespace(storageNamespace, key, identifierType)
+func (m *MetricsAdapter) ResolveNamespace(storageID, storageNamespace, key string, identifierType IdentifierType) (QualifiedKey, error) {
+	return m.adapter.ResolveNamespace(storageID, storageNamespace, key, identifierType)
 }
 
 func (m *MetricsAdapter) GetRegion(ctx context.Context, storageID, storageNamespace string) (string, error) {
-	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType())
+	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType(storageID))
 	return m.adapter.GetRegion(ctx, storageID, storageNamespace)
 }
 

--- a/pkg/block/s3/adapter.go
+++ b/pkg/block/s3/adapter.go
@@ -851,11 +851,11 @@ func (a *Adapter) ListParts(ctx context.Context, obj block.ObjectPointer, upload
 	return &partsResp, nil
 }
 
-func (a *Adapter) BlockstoreType() string {
+func (a *Adapter) BlockstoreType(_ string) string {
 	return block.BlockstoreTypeS3
 }
 
-func (a *Adapter) BlockstoreMetadata(ctx context.Context) (*block.BlockstoreMetadata, error) {
+func (a *Adapter) BlockstoreMetadata(ctx context.Context, _ string) (*block.BlockstoreMetadata, error) {
 	region, err := a.clients.GetBucketRegionDefault(ctx, "")
 	if err != nil {
 		return nil, err
@@ -863,7 +863,7 @@ func (a *Adapter) BlockstoreMetadata(ctx context.Context) (*block.BlockstoreMeta
 	return &block.BlockstoreMetadata{Region: &region}, nil
 }
 
-func (a *Adapter) GetStorageNamespaceInfo() block.StorageNamespaceInfo {
+func (a *Adapter) GetStorageNamespaceInfo(_ string) block.StorageNamespaceInfo {
 	info := block.DefaultStorageNamespaceInfo(block.BlockstoreTypeS3)
 	if a.disablePreSigned {
 		info.PreSignSupport = false
@@ -888,7 +888,7 @@ func resolveNamespace(obj block.ObjectPointer) (block.CommonQualifiedKey, error)
 	return qualifiedKey, nil
 }
 
-func (a *Adapter) ResolveNamespace(storageNamespace, key string, identifierType block.IdentifierType) (block.QualifiedKey, error) {
+func (a *Adapter) ResolveNamespace(storageID, storageNamespace, key string, identifierType block.IdentifierType) (block.QualifiedKey, error) {
 	return block.DefaultResolveNamespace(storageNamespace, key, identifierType)
 }
 
@@ -945,7 +945,7 @@ func (a *Adapter) managerUpload(ctx context.Context, obj block.ObjectPointer, re
 }
 
 func (a *Adapter) extractParamsFromObj(obj block.ObjectPointer) (string, string, block.QualifiedKey, error) {
-	qk, err := a.ResolveNamespace(obj.StorageNamespace, obj.Identifier, obj.IdentifierType)
+	qk, err := a.ResolveNamespace(obj.StorageID, obj.StorageNamespace, obj.Identifier, obj.IdentifierType)
 	if err != nil {
 		return "", "", nil, err
 	}

--- a/pkg/block/transient/adapter.go
+++ b/pkg/block/transient/adapter.go
@@ -143,15 +143,15 @@ func (a *Adapter) CompleteMultiPartUpload(context.Context, block.ObjectPointer, 
 	}, nil
 }
 
-func (a *Adapter) BlockstoreType() string {
+func (a *Adapter) BlockstoreType(_ string) string {
 	return block.BlockstoreTypeTransient
 }
 
-func (a *Adapter) BlockstoreMetadata(_ context.Context) (*block.BlockstoreMetadata, error) {
+func (a *Adapter) BlockstoreMetadata(_ context.Context, _ string) (*block.BlockstoreMetadata, error) {
 	return nil, block.ErrOperationNotSupported
 }
 
-func (a *Adapter) GetStorageNamespaceInfo() block.StorageNamespaceInfo {
+func (a *Adapter) GetStorageNamespaceInfo(_ string) block.StorageNamespaceInfo {
 	info := block.DefaultStorageNamespaceInfo(block.BlockstoreTypeTransient)
 	info.PreSignSupport = false
 	info.PreSignSupportUI = false
@@ -159,7 +159,7 @@ func (a *Adapter) GetStorageNamespaceInfo() block.StorageNamespaceInfo {
 	return info
 }
 
-func (a *Adapter) ResolveNamespace(storageNamespace, key string, identifierType block.IdentifierType) (block.QualifiedKey, error) {
+func (a *Adapter) ResolveNamespace(storageID, storageNamespace, key string, identifierType block.IdentifierType) (block.QualifiedKey, error) {
 	return block.DefaultResolveNamespace(storageNamespace, key, identifierType)
 }
 

--- a/pkg/block/validations.go
+++ b/pkg/block/validations.go
@@ -7,7 +7,7 @@ import (
 )
 
 func ValidateInterRegionStorage(ctx context.Context, adapter Adapter, storageID, storageNamespace string) error {
-	blockstoreMetadata, err := adapter.BlockstoreMetadata(ctx)
+	blockstoreMetadata, err := adapter.BlockstoreMetadata(ctx, storageID)
 	if errors.Is(err, ErrOperationNotSupported) {
 		// region detection not supported for the server's blockstore, skip validation
 		return nil

--- a/pkg/graveler/retention/garbage_collection_manager.go
+++ b/pkg/graveler/retention/garbage_collection_manager.go
@@ -36,7 +36,8 @@ type GarbageCollectionManager struct {
 
 func (m *GarbageCollectionManager) GetCommitsCSVLocation(runID string, sn graveler.StorageNamespace) (string, error) {
 	key := fmt.Sprintf(commitsFileSuffixTemplate, m.committedBlockStoragePrefix, runID)
-	qk, err := m.blockAdapter.ResolveNamespace(sn.String(), key, block.IdentifierTypeRelative)
+	// TODO (gilo): replace StorageID with a real value
+	qk, err := m.blockAdapter.ResolveNamespace("", sn.String(), key, block.IdentifierTypeRelative)
 	if err != nil {
 		return "", err
 	}
@@ -45,7 +46,8 @@ func (m *GarbageCollectionManager) GetCommitsCSVLocation(runID string, sn gravel
 
 func (m *GarbageCollectionManager) GetAddressesLocation(sn graveler.StorageNamespace) (string, error) {
 	key := fmt.Sprintf(addressesFilePrefixTemplate, m.committedBlockStoragePrefix)
-	qk, err := m.blockAdapter.ResolveNamespace(sn.String(), key, block.IdentifierTypeRelative)
+	// TODO (gilo): replace StorageID with a real value
+	qk, err := m.blockAdapter.ResolveNamespace("", sn.String(), key, block.IdentifierTypeRelative)
 	if err != nil {
 		return "", err
 	}
@@ -55,7 +57,8 @@ func (m *GarbageCollectionManager) GetAddressesLocation(sn graveler.StorageNames
 // GetUncommittedLocation return full path to underlying storage path to store uncommitted information
 func (m *GarbageCollectionManager) GetUncommittedLocation(runID string, sn graveler.StorageNamespace) (string, error) {
 	key := fmt.Sprintf(uncommittedFilePrefixTemplate, m.committedBlockStoragePrefix, runID)
-	qk, err := m.blockAdapter.ResolveNamespace(sn.String(), key, block.IdentifierTypeRelative)
+	// TODO (gilo): replace StorageID with a real value
+	qk, err := m.blockAdapter.ResolveNamespace("", sn.String(), key, block.IdentifierTypeRelative)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/testutil/adapter.go
+++ b/pkg/testutil/adapter.go
@@ -129,11 +129,11 @@ func (a *MockAdapter) ListParts(_ context.Context, _ block.ObjectPointer, _ stri
 	panic("try to list parts in mock adapter")
 }
 
-func (a *MockAdapter) BlockstoreType() string {
+func (a *MockAdapter) BlockstoreType(_ string) string {
 	return "s3"
 }
 
-func (a *MockAdapter) BlockstoreMetadata(_ context.Context) (*block.BlockstoreMetadata, error) {
+func (a *MockAdapter) BlockstoreMetadata(_ context.Context, _ string) (*block.BlockstoreMetadata, error) {
 	if a.blockstoreMetadata != nil {
 		return a.blockstoreMetadata, nil
 	} else {
@@ -141,14 +141,14 @@ func (a *MockAdapter) BlockstoreMetadata(_ context.Context) (*block.BlockstoreMe
 	}
 }
 
-func (a *MockAdapter) GetStorageNamespaceInfo() block.StorageNamespaceInfo {
+func (a *MockAdapter) GetStorageNamespaceInfo(_ string) block.StorageNamespaceInfo {
 	info := block.DefaultStorageNamespaceInfo("s3")
 	info.PreSignSupport = false
 	info.ImportSupport = false
 	return info
 }
 
-func (a *MockAdapter) ResolveNamespace(storageNamespace, key string, identifierType block.IdentifierType) (block.QualifiedKey, error) {
+func (a *MockAdapter) ResolveNamespace(storageID, storageNamespace, key string, identifierType block.IdentifierType) (block.QualifiedKey, error) {
 	return block.DefaultResolveNamespace(storageNamespace, key, identifierType)
 }
 


### PR DESCRIPTION
Closes #8550.

### Notes
- `DefaultResolveNamespace` is still not using `StorageID`. This might be implemented later on.
- BlockstoreType() for the stats in server Setup still needs a decision.
