### PR TITLE
Request TTFB metric for GetObject API

### DIFF
--- a/pkg/api/stats.go
+++ b/pkg/api/stats.go
@@ -20,3 +20,11 @@ var requestHistograms = promauto.NewHistogramVec(
 		Buckets: []float64{0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10, 30, 60},
 	},
 	[]string{"operation", "code"})
+
+var requestTTFBHistograms = promauto.NewHistogramVec(
+	prometheus.HistogramOpts{
+		Name:    "api_request_ttfb_duration_seconds",
+		Help:    "request time-to-first-byte durations for lakeFS API",
+		Buckets: []float64{0.01, 0.02, 0.05, 0.1, 0.2, 0.5, 1, 2, 5, 10, 30, 60},
+	},
+	[]string{"operation"})


### PR DESCRIPTION
Closes #8503

## Change Description

### Background

Metric that will help us measure the GetObject API call's time during a request that does not involve the user's object content. This metric,  GetObject Time to First Byte (TTFB), is crucial for understanding the initial latency of fetching an object and differentiating it from subsequent data transfer times. 
      
### New Feature

This Pull Request introduces a new metric: **api_request_ttfb_duration_seconds**.  It measures the time elapsed from when a GetObject request is initiated until the first byte of data is sent back to the client. 

### Testing Details

The changes were tested by:

1. Making numerous GetObject requests
2. Analyzing /metrics to verify that the new TTFB metric is accurately recorded

### Breaking Change?

No, this change does not break any existing functionality (API, CLI, Clients). The new metric is added without modifying any existing endpoints or behaviors.
