### PR TITLE
Changed the error message for the repo name verify

### DIFF
--- a/webui/src/lib/components/repositoryCreateForm.jsx
+++ b/webui/src/lib/components/repositoryCreateForm.jsx
@@ -79,7 +79,8 @@ export const RepositoryCreateForm = ({ id, config, onSubmit, formValid, setFormV
               </FloatingLabel>
               {repoValid === false &&
                 <Form.Text className="text-danger">
-                    Min 3 characters. Only lowercase alphanumeric characters and {'\'-\''} allowed.
+                    Repository ID must be between 3 and 63 characters long. Only lowercase alphanumeric characters and
+                    {' \'-\''} are allowed. The first character must be alphanumeric and cannot be {'\'-\''}.
                 </Form.Text>
               }
           </Form.Group>

--- a/webui/src/lib/components/repositoryCreateForm.jsx
+++ b/webui/src/lib/components/repositoryCreateForm.jsx
@@ -79,8 +79,7 @@ export const RepositoryCreateForm = ({ id, config, onSubmit, formValid, setFormV
               </FloatingLabel>
               {repoValid === false &&
                 <Form.Text className="text-danger">
-                    Repository ID must be between 3 and 63 characters long. Only lowercase alphanumeric characters and
-                    {' \'-\''} are allowed. The first character must be alphanumeric and cannot be {'\'-\''}.
+                    The repository ID must be 3-63 lowercase alphanumeric characters or hyphens {'\'-\''}.
                 </Form.Text>
               }
           </Form.Group>


### PR DESCRIPTION
Closes #6949

## Change Description
Changed the error message for the repo name verification when inserting a long repository id (name) value.

Previous message: 
> Min 3 characters. Only lowercase alphanumeric characters and {'\'-\''} allowed.

New message:
> The repository ID must be 3-63 lowercase alphanumeric characters or hyphens {'\'-\''}.

### Screenshots
Old message:
![image](https://github.com/user-attachments/assets/75285594-cc87-4f89-9bed-100fc333dff5)

New message:
![image](https://github.com/user-attachments/assets/3fa18225-e4bd-4fa3-b4f3-6edd72db4007)


