### PR TITLE
Add support for no-check flag in setup command

### DIFF
--- a/cmd/lakefs/cmd/run.go
+++ b/cmd/lakefs/cmd/run.go
@@ -241,7 +241,7 @@ var runCmd = &cobra.Command{
 		if (kvParams.Type == local.DriverName || kvParams.Type == mem.DriverName) &&
 			baseCfg.Installation.UserName != "" && baseCfg.Installation.AccessKeyID.SecureValue() != "" && baseCfg.Installation.SecretAccessKey.SecureValue() != "" {
 			setupCreds, err := setupLakeFS(ctx, baseCfg, authMetadataManager, authService, baseCfg.Installation.UserName,
-				baseCfg.Installation.AccessKeyID.SecureValue(), baseCfg.Installation.SecretAccessKey.SecureValue())
+				baseCfg.Installation.AccessKeyID.SecureValue(), baseCfg.Installation.SecretAccessKey.SecureValue(), false)
 			if err != nil {
 				logger.WithError(err).WithField("admin", baseCfg.Installation.UserName).Fatal("Failed to initial setup environment")
 			}
@@ -536,10 +536,10 @@ const localBanner = `
 
 var quickStartBanner = fmt.Sprintf(`
 │
-│ lakeFS running in quickstart mode. 
+│ lakeFS running in quickstart mode.
 │     Login at http://127.0.0.1:8000/
 │
-│     Access Key ID    : %s 
+│     Access Key ID    : %s
 │     Secret Access Key: %s
 │
 `, config.DefaultQuickstartKeyID, config.DefaultQuickstartSecretKey)

--- a/cmd/lakefs/cmd/setup.go
+++ b/cmd/lakefs/cmd/setup.go
@@ -138,7 +138,7 @@ func init() {
 	f.String("user-name", "", "an identifier for the user (e.g. \"jane.doe\")")
 	f.String("access-key-id", "", "AWS-format access key ID to create for that user (for integration)")
 	f.String("secret-access-key", "", "AWS-format secret access key to create for that user (for integration)")
-	f.Bool("no-check", false, "skip checking if setup is already complete")
+	f.Bool("no-check", false, "skip checking if setup is already complete and do anyway")
 	if err := f.MarkHidden("access-key-id"); err != nil {
 		// (internal error)
 		_, _ = fmt.Fprint(os.Stderr, err)

--- a/docs/enterprise/getstarted/migrate-from-oss.md
+++ b/docs/enterprise/getstarted/migrate-from-oss.md
@@ -26,7 +26,8 @@ To migrate from lakeFS Open Source to lakeFS Enterprise, follow the steps below:
    ```shell
    lakefs setup --user-name <admin> --access-key-id <key> --secret-access-key <secret> --no-check
    ```
-   Please note that the newly set up lakeFS instance remains inaccessible to users until full setup completion, due to the absence of established credentials within the system
+{: .warning }
+>Please note that the newly set up lakeFS instance remains inaccessible to users until full setup completion, due to the absence of established credentials within the system.
 
 [lakefs-enterprise-install]: {% link enterprise/getstarted/install.md %}
 [lakefs-enterprise-install-prerequisites]: {% link enterprise/getstarted/install.md %}#prerequisites

--- a/docs/enterprise/getstarted/migrate-from-oss.md
+++ b/docs/enterprise/getstarted/migrate-from-oss.md
@@ -22,6 +22,11 @@ To migrate from lakeFS Open Source to lakeFS Enterprise, follow the steps below:
    1. You should expect to see a log message saying Migration completed successfully.
    1. During this short db migration process please make sure not to make any policy / RBAC related changes.
 1. Once the migration completed - Upgrade your helm release with the modified `values.yaml` and the new version and run `helm ugprade`.
+1. Login to the new lakeFS pod: Execute the following command, make sure you have proper credentials, or discard to get new ones:
+   ```shell
+   lakefs setup --user-name <admin> --access-key-id <key> --secret-access-key <secret> --no-check
+   ```
+   Please note that the newly set up lakeFS instance remains inaccessible to users until full setup completion, due to the absence of established credentials within the system
 
 [lakefs-enterprise-install]: {% link enterprise/getstarted/install.md %}
 [lakefs-enterprise-install-prerequisites]: {% link enterprise/getstarted/install.md %}#prerequisites

--- a/pkg/auth/metadata.go
+++ b/pkg/auth/metadata.go
@@ -19,6 +19,7 @@ import (
 const (
 	InstallationIDKeyName  = "installation_id"
 	SetupTimestampKeyName  = "setup_timestamp"
+	SetupAuthTypeKeyPrefix = "setup_auth_"
 	CommPrefsSetKeyName    = "comm_prefs_set"
 	EmailKeyName           = "encoded_user_email"
 	FeatureUpdatesKeyName  = "feature_updates"
@@ -47,7 +48,7 @@ type MetadataManager interface {
 	GetSetupState(ctx context.Context) (SetupStateName, error)
 	UpdateCommPrefs(ctx context.Context, commPrefs *CommPrefs) (string, error)
 	IsCommPrefsSet(ctx context.Context) (bool, error)
-	UpdateSetupTimestamp(context.Context, time.Time) error
+	UpdateSetupTimestamp(ctx context.Context, setupTime time.Time, authType string) error
 	GetMetadata(context.Context) (map[string]string, error)
 }
 
@@ -170,10 +171,15 @@ func (m *KVMetadataManager) writeMetadata(ctx context.Context, items map[string]
 	return nil
 }
 
-func (m *KVMetadataManager) UpdateSetupTimestamp(ctx context.Context, ts time.Time) error {
-	return m.writeMetadata(ctx, map[string]string{
-		SetupTimestampKeyName: ts.UTC().Format(time.RFC3339),
-	})
+func (m *KVMetadataManager) UpdateSetupTimestamp(ctx context.Context, setupTime time.Time, authType string) error {
+	setupTimeStr := setupTime.UTC().Format(time.RFC3339)
+	items := map[string]string{
+		SetupTimestampKeyName: setupTimeStr,
+	}
+	if authType != "" {
+		items[SetupAuthTypeKeyPrefix+authType] = setupTimeStr
+	}
+	return m.writeMetadata(ctx, items)
 }
 
 // UpdateCommPrefs - updates the comm prefs metadata.

--- a/pkg/auth/metadata.go
+++ b/pkg/auth/metadata.go
@@ -176,9 +176,7 @@ func (m *KVMetadataManager) UpdateSetupTimestamp(ctx context.Context, setupTime 
 	items := map[string]string{
 		SetupTimestampKeyName: setupTimeStr,
 	}
-	if authType != "" {
-		items[SetupAuthTypeKeyPrefix+authType] = setupTimeStr
-	}
+	items[SetupAuthTypeKeyPrefix+authType] = setupTimeStr
 	return m.writeMetadata(ctx, items)
 }
 

--- a/pkg/auth/setup/setup.go
+++ b/pkg/auth/setup/setup.go
@@ -218,7 +218,7 @@ func CreateInitialAdminUser(ctx context.Context, authService auth.Service, cfg *
 	return CreateInitialAdminUserWithKeys(ctx, authService, cfg, metadataManger, username, nil, nil)
 }
 
-func CreateInitialAdminUserWithKeys(ctx context.Context, authService auth.Service, cfg *config.BaseConfig, metadataManger auth.MetadataManager, username string, accessKeyID *string, secretAccessKey *string) (*model.Credential, error) {
+func CreateInitialAdminUserWithKeys(ctx context.Context, authService auth.Service, cfg *config.BaseConfig, metadataManager auth.MetadataManager, username string, accessKeyID *string, secretAccessKey *string) (*model.Credential, error) {
 	adminUser := &model.SuperuserConfiguration{
 		User: model.User{
 			CreatedAt: time.Now(),
@@ -243,10 +243,11 @@ func CreateInitialAdminUserWithKeys(ctx context.Context, authService auth.Servic
 		return nil, err
 	}
 
-	// update setup timestamp
-	if err = metadataManger.UpdateSetupTimestamp(ctx, time.Now()); err != nil {
+	// update setup time with auth type used
+	if err = metadataManager.UpdateSetupTimestamp(ctx, time.Now(), cfg.Auth.UIConfig.RBAC); err != nil {
 		logging.FromContext(ctx).WithError(err).Error("Failed the update setup timestamp")
 	}
+
 	return cred, err
 }
 


### PR DESCRIPTION
- Added a new flag `--no-check` to the setup command to skip checking if setup is already complete.
- This flag is useful when the setup process is already known to be complete and skipping the check can handle migration from different auth type.

Close https://github.com/treeverse/lakeFS/issues/8605
Close https://github.com/treeverse/product/issues/678