### PR TITLE
Origin/origin/fix/tierfs storageid3

### DIFF
--- a/pkg/catalog/catalog_test.go
+++ b/pkg/catalog/catalog_test.go
@@ -889,7 +889,7 @@ func createPrepareUncommittedTestScenario(t *testing.T, repositoryID string, num
 			sort.Slice(diffs[i], func(ii, jj int) bool {
 				return bytes.Compare(diffs[i][ii].Key, diffs[i][jj].Key) < 0
 			})
-			test.CommittedManager.EXPECT().Diff(gomock.Any(), gomock.Any(), repository.StorageNamespace, gomock.Any(), branches[i].CompactedBaseMetaRangeID).MinTimes(1).Return(gUtils.NewDiffIter(diffs[i]), nil)
+			test.CommittedManager.EXPECT().Diff(gomock.Any(), graveler.StorageID(""), repository.StorageNamespace, gomock.Any(), branches[i].CompactedBaseMetaRangeID).MinTimes(1).Return(gUtils.NewDiffIter(diffs[i]), nil)
 		}
 	}
 

--- a/pkg/catalog/catalog_test.go
+++ b/pkg/catalog/catalog_test.go
@@ -747,7 +747,7 @@ func createPrepareUncommittedTestScenario(t *testing.T, repositoryID string, num
 	var expectedRecords []string
 	if numBranches > 0 {
 		test.RefManager.EXPECT().GetCommit(gomock.Any(), gomock.Any(), gomock.Any()).MinTimes(1).Return(&graveler.Commit{}, nil)
-		test.CommittedManager.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any()).MinTimes(1).Return(cUtils.NewFakeValueIterator([]*graveler.ValueRecord{}), nil)
+		test.CommittedManager.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).MinTimes(1).Return(cUtils.NewFakeValueIterator([]*graveler.ValueRecord{}), nil)
 	}
 	for i := 0; i < numBranches; i++ {
 		branchID := graveler.BranchID(fmt.Sprintf("branch%04d", i))
@@ -889,7 +889,7 @@ func createPrepareUncommittedTestScenario(t *testing.T, repositoryID string, num
 			sort.Slice(diffs[i], func(ii, jj int) bool {
 				return bytes.Compare(diffs[i][ii].Key, diffs[i][jj].Key) < 0
 			})
-			test.CommittedManager.EXPECT().Diff(gomock.Any(), repository.StorageNamespace, gomock.Any(), branches[i].CompactedBaseMetaRangeID).MinTimes(1).Return(gUtils.NewDiffIter(diffs[i]), nil)
+			test.CommittedManager.EXPECT().Diff(gomock.Any(), gomock.Any(), repository.StorageNamespace, gomock.Any(), branches[i].CompactedBaseMetaRangeID).MinTimes(1).Return(gUtils.NewDiffIter(diffs[i]), nil)
 		}
 	}
 

--- a/pkg/graveler/committed/import_test.go
+++ b/pkg/graveler/committed/import_test.go
@@ -362,9 +362,9 @@ func Test_import(t *testing.T) {
 				metaRangeManager.EXPECT().NewWriter(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(writer)
 				sourceMetaRangeID := tst.sourceRange.GetMetaRangeID()
 				destMetaRangeID := tst.destRange.GetMetaRangeID()
-				metaRangeManager.EXPECT().NewMetaRangeIterator(gomock.Any(), gomock.Any(), graveler.MetaRangeID("")).AnyTimes().Return(committed.NewEmptyIterator(), nil) // empty base
-				metaRangeManager.EXPECT().NewMetaRangeIterator(gomock.Any(), gomock.Any(), sourceMetaRangeID).AnyTimes().Return(createIter(tst.sourceRange), nil)
-				metaRangeManager.EXPECT().NewMetaRangeIterator(gomock.Any(), gomock.Any(), destMetaRangeID).AnyTimes().Return(createIter(tst.destRange), nil)
+				metaRangeManager.EXPECT().NewMetaRangeIterator(gomock.Any(), gomock.Any(), gomock.Any(), graveler.MetaRangeID("")).AnyTimes().Return(committed.NewEmptyIterator(), nil) // empty base
+				metaRangeManager.EXPECT().NewMetaRangeIterator(gomock.Any(), gomock.Any(), gomock.Any(), sourceMetaRangeID).AnyTimes().Return(createIter(tst.sourceRange), nil)
+				metaRangeManager.EXPECT().NewMetaRangeIterator(gomock.Any(), gomock.Any(), gomock.Any(), destMetaRangeID).AnyTimes().Return(createIter(tst.destRange), nil)
 
 				rangeManager := mock.NewMockRangeManager(ctrl)
 
@@ -372,7 +372,7 @@ func Test_import(t *testing.T) {
 				metaRangeId := graveler.MetaRangeID("import")
 				writer.EXPECT().Close(gomock.Any()).Return(&metaRangeId, nil).AnyTimes()
 				committedManager := committed.NewCommittedManager(metaRangeManager, rangeManager, params)
-				_, err := committedManager.Import(ctx, "ns", destMetaRangeID, sourceMetaRangeID, tst.prefixes)
+				_, err := committedManager.Import(ctx, "", "ns", destMetaRangeID, sourceMetaRangeID, tst.prefixes)
 				if !errors.Is(err, expectedResult.expectedErr) {
 					t.Fatalf("Import error = '%v', expected '%v'", err, expectedResult.expectedErr)
 				}

--- a/pkg/graveler/committed/import_test.go
+++ b/pkg/graveler/committed/import_test.go
@@ -359,7 +359,7 @@ func Test_import(t *testing.T) {
 					}
 				}
 				metaRangeManager := mock.NewMockMetaRangeManager(ctrl)
-				metaRangeManager.EXPECT().NewWriter(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(writer)
+				metaRangeManager.EXPECT().NewWriter(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(writer)
 				sourceMetaRangeID := tst.sourceRange.GetMetaRangeID()
 				destMetaRangeID := tst.destRange.GetMetaRangeID()
 				metaRangeManager.EXPECT().NewMetaRangeIterator(gomock.Any(), gomock.Any(), gomock.Any(), graveler.MetaRangeID("")).AnyTimes().Return(committed.NewEmptyIterator(), nil) // empty base

--- a/pkg/graveler/committed/iterator.go
+++ b/pkg/graveler/committed/iterator.go
@@ -16,6 +16,7 @@ type iterator struct {
 	rng         *Range                 // Decoded value at which rangeIt point
 	it          graveler.ValueIterator // nil at start of range
 	err         error
+	storageID   StorageID
 	namespace   Namespace
 	beforeRange bool
 }
@@ -32,7 +33,7 @@ func NewIterator(ctx context.Context, manager RangeManager, namespace Namespace,
 // loadIt loads rvi.it to start iterating over a new range.  It returns false and sets rvi.err
 // if it fails to open the new range.
 func (rvi *iterator) loadIt() bool {
-	it, err := rvi.manager.NewRangeIterator(rvi.ctx, rvi.namespace, rvi.rng.ID)
+	it, err := rvi.manager.NewRangeIterator(rvi.ctx, rvi.storageID, rvi.namespace, rvi.rng.ID)
 	if err != nil {
 		rvi.err = fmt.Errorf("open range %s: %w", rvi.rng.ID, err)
 		return false

--- a/pkg/graveler/committed/iterator.go
+++ b/pkg/graveler/committed/iterator.go
@@ -33,7 +33,7 @@ func NewIterator(ctx context.Context, manager RangeManager, namespace Namespace,
 // loadIt loads rvi.it to start iterating over a new range.  It returns false and sets rvi.err
 // if it fails to open the new range.
 func (rvi *iterator) loadIt() bool {
-	it, err := rvi.manager.NewRangeIterator(rvi.ctx, rvi.storageID, rvi.namespace, rvi.rng.ID)
+	it, err := rvi.manager.NewRangeIterator(rvi.ctx, rvi.namespace, rvi.rng.ID)
 	if err != nil {
 		rvi.err = fmt.Errorf("open range %s: %w", rvi.rng.ID, err)
 		return false

--- a/pkg/graveler/committed/iterator_test.go
+++ b/pkg/graveler/committed/iterator_test.go
@@ -171,7 +171,7 @@ func TestIterator(t *testing.T) {
 					key = committed.Key(p.Keys[len(p.Keys)-1])
 				}
 				manager.EXPECT().
-					NewRangeIterator(gomock.Any(), gomock.Eq(namespace), committed.ID(key)).
+					NewRangeIterator(gomock.Any(), gomock.Any(), gomock.Eq(namespace), committed.ID(key)).
 					Return(makeRangeIterator(p.Keys), nil)
 				lastKey = key
 			}
@@ -195,7 +195,7 @@ func TestIterator(t *testing.T) {
 					key = committed.Key(p.Keys[len(p.Keys)-1])
 				}
 				manager.EXPECT().
-					NewRangeIterator(gomock.Any(), gomock.Eq(namespace), committed.ID(key)).
+					NewRangeIterator(gomock.Any(), gomock.Any(), gomock.Eq(namespace), committed.ID(key)).
 					Return(makeRangeIterator(p.Keys), nil).
 					AnyTimes()
 				lastKey = key

--- a/pkg/graveler/committed/iterator_test.go
+++ b/pkg/graveler/committed/iterator_test.go
@@ -117,6 +117,7 @@ func keysByRanges(t testing.TB, it committed.Iterator) []rangeKeys {
 }
 
 func TestIterator(t *testing.T) {
+	storageID := committed.StorageID("")
 	namespace := committed.Namespace("ns")
 	tests := []struct {
 		Name string
@@ -171,7 +172,7 @@ func TestIterator(t *testing.T) {
 					key = committed.Key(p.Keys[len(p.Keys)-1])
 				}
 				manager.EXPECT().
-					NewRangeIterator(gomock.Any(), gomock.Eq(""), gomock.Eq(namespace), committed.ID(key)).
+					NewRangeIterator(gomock.Any(), gomock.Eq(storageID), gomock.Eq(namespace), committed.ID(key)).
 					Return(makeRangeIterator(p.Keys), nil)
 				lastKey = key
 			}
@@ -195,7 +196,7 @@ func TestIterator(t *testing.T) {
 					key = committed.Key(p.Keys[len(p.Keys)-1])
 				}
 				manager.EXPECT().
-					NewRangeIterator(gomock.Any(), gomock.Eq(""), gomock.Eq(namespace), committed.ID(key)).
+					NewRangeIterator(gomock.Any(), gomock.Eq(storageID), gomock.Eq(namespace), committed.ID(key)).
 					Return(makeRangeIterator(p.Keys), nil).
 					AnyTimes()
 				lastKey = key

--- a/pkg/graveler/committed/iterator_test.go
+++ b/pkg/graveler/committed/iterator_test.go
@@ -171,7 +171,7 @@ func TestIterator(t *testing.T) {
 					key = committed.Key(p.Keys[len(p.Keys)-1])
 				}
 				manager.EXPECT().
-					NewRangeIterator(gomock.Any(), gomock.Any(), gomock.Eq(namespace), committed.ID(key)).
+					NewRangeIterator(gomock.Any(), gomock.Eq(""), gomock.Eq(namespace), committed.ID(key)).
 					Return(makeRangeIterator(p.Keys), nil)
 				lastKey = key
 			}
@@ -195,7 +195,7 @@ func TestIterator(t *testing.T) {
 					key = committed.Key(p.Keys[len(p.Keys)-1])
 				}
 				manager.EXPECT().
-					NewRangeIterator(gomock.Any(), gomock.Any(), gomock.Eq(namespace), committed.ID(key)).
+					NewRangeIterator(gomock.Any(), gomock.Eq(""), gomock.Eq(namespace), committed.ID(key)).
 					Return(makeRangeIterator(p.Keys), nil).
 					AnyTimes()
 				lastKey = key

--- a/pkg/graveler/committed/manager.go
+++ b/pkg/graveler/committed/manager.go
@@ -330,12 +330,12 @@ func (c *committedManager) Compare(ctx context.Context, storageID graveler.Stora
 }
 
 func (c *committedManager) GetMetaRange(ctx context.Context, ns graveler.StorageNamespace, id graveler.MetaRangeID) (graveler.MetaRangeAddress, error) {
-	uri, err := c.metaRangeManager.GetMetaRangeURI(ctx, id)
+	uri, err := c.metaRangeManager.GetMetaRangeURI(ctx, ns, id)
 	return graveler.MetaRangeAddress(uri), err
 }
 
 func (c *committedManager) GetRange(ctx context.Context, ns graveler.StorageNamespace, id graveler.RangeID) (graveler.RangeAddress, error) {
-	uri, err := c.metaRangeManager.GetRangeURI(ctx, id)
+	uri, err := c.metaRangeManager.GetRangeURI(ctx, ns, id)
 	return graveler.RangeAddress(uri), err
 }
 

--- a/pkg/graveler/committed/manager.go
+++ b/pkg/graveler/committed/manager.go
@@ -110,8 +110,8 @@ func (c *committedManager) WriteRange(ctx context.Context, storageID graveler.St
 	}, nil
 }
 
-func (c *committedManager) WriteMetaRange(ctx context.Context, ns graveler.StorageNamespace, ranges []*graveler.RangeInfo) (*graveler.MetaRangeInfo, error) {
-	writer := c.metaRangeManager.NewWriter(ctx, ns, nil)
+func (c *committedManager) WriteMetaRange(ctx context.Context, storageID graveler.StorageID, ns graveler.StorageNamespace, ranges []*graveler.RangeInfo) (*graveler.MetaRangeInfo, error) {
+	writer := c.metaRangeManager.NewWriter(ctx, storageID, ns, nil)
 	defer func() {
 		if err := writer.Abort(); err != nil {
 			logging.FromContext(ctx).WithError(err).Error("Aborting write to meta range")
@@ -146,8 +146,8 @@ func (c *committedManager) WriteMetaRange(ctx context.Context, ns graveler.Stora
 	}, nil
 }
 
-func (c *committedManager) WriteMetaRangeByIterator(ctx context.Context, ns graveler.StorageNamespace, it graveler.ValueIterator, metadata graveler.Metadata) (*graveler.MetaRangeID, error) {
-	writer := c.metaRangeManager.NewWriter(ctx, ns, metadata)
+func (c *committedManager) WriteMetaRangeByIterator(ctx context.Context, storageID graveler.StorageID, ns graveler.StorageNamespace, it graveler.ValueIterator, metadata graveler.Metadata) (*graveler.MetaRangeID, error) {
+	writer := c.metaRangeManager.NewWriter(ctx, storageID, ns, metadata)
 	defer func() {
 		if err := writer.Abort(); err != nil {
 			logging.FromContext(ctx).WithError(err).Error("Aborting write to meta range")
@@ -264,7 +264,7 @@ func (c *committedManager) merge(ctx context.Context, mctx mergeContext) (gravel
 		defer srcIt.Close()
 	}
 
-	mwWriter := c.metaRangeManager.NewWriter(ctx, mctx.ns, nil)
+	mwWriter := c.metaRangeManager.NewWriter(ctx, mctx.storageID, mctx.ns, nil)
 	defer func() {
 		err = mwWriter.Abort()
 		if err != nil {
@@ -287,7 +287,7 @@ func (c *committedManager) merge(ctx context.Context, mctx mergeContext) (gravel
 }
 
 func (c *committedManager) Commit(ctx context.Context, storageID graveler.StorageID, ns graveler.StorageNamespace, baseMetaRangeID graveler.MetaRangeID, changes graveler.ValueIterator, allowEmpty bool, _ ...graveler.SetOptionsFunc) (graveler.MetaRangeID, graveler.DiffSummary, error) {
-	mwWriter := c.metaRangeManager.NewWriter(ctx, ns, nil)
+	mwWriter := c.metaRangeManager.NewWriter(ctx, storageID, ns, nil)
 	defer func() {
 		err := mwWriter.Abort()
 		if err != nil {

--- a/pkg/graveler/committed/manager.go
+++ b/pkg/graveler/committed/manager.go
@@ -330,12 +330,12 @@ func (c *committedManager) Compare(ctx context.Context, storageID graveler.Stora
 }
 
 func (c *committedManager) GetMetaRange(ctx context.Context, ns graveler.StorageNamespace, id graveler.MetaRangeID) (graveler.MetaRangeAddress, error) {
-	uri, err := c.metaRangeManager.GetMetaRangeURI(ctx, ns, id)
+	uri, err := c.metaRangeManager.GetMetaRangeURI(ctx, id)
 	return graveler.MetaRangeAddress(uri), err
 }
 
 func (c *committedManager) GetRange(ctx context.Context, ns graveler.StorageNamespace, id graveler.RangeID) (graveler.RangeAddress, error) {
-	uri, err := c.metaRangeManager.GetRangeURI(ctx, ns, id)
+	uri, err := c.metaRangeManager.GetRangeURI(ctx, id)
 	return graveler.RangeAddress(uri), err
 }
 

--- a/pkg/graveler/committed/manager.go
+++ b/pkg/graveler/committed/manager.go
@@ -25,12 +25,12 @@ func NewCommittedManager(m MetaRangeManager, r RangeManager, p Params) graveler.
 	}
 }
 
-func (c *committedManager) Exists(ctx context.Context, ns graveler.StorageNamespace, id graveler.MetaRangeID) (bool, error) {
-	return c.metaRangeManager.Exists(ctx, ns, id)
+func (c *committedManager) Exists(ctx context.Context, storageID graveler.StorageID, ns graveler.StorageNamespace, id graveler.MetaRangeID) (bool, error) {
+	return c.metaRangeManager.Exists(ctx, storageID, ns, id)
 }
 
-func (c *committedManager) Get(ctx context.Context, ns graveler.StorageNamespace, rangeID graveler.MetaRangeID, key graveler.Key) (*graveler.Value, error) {
-	it, err := c.metaRangeManager.NewMetaRangeIterator(ctx, ns, rangeID)
+func (c *committedManager) Get(ctx context.Context, storageID graveler.StorageID, ns graveler.StorageNamespace, rangeID graveler.MetaRangeID, key graveler.Key) (*graveler.Value, error) {
+	it, err := c.metaRangeManager.NewMetaRangeIterator(ctx, storageID, ns, rangeID)
 	if err != nil {
 		return nil, err
 	}
@@ -53,8 +53,8 @@ func (c *committedManager) Get(ctx context.Context, ns graveler.StorageNamespace
 	return rec.Value, nil
 }
 
-func (c *committedManager) List(ctx context.Context, ns graveler.StorageNamespace, rangeID graveler.MetaRangeID) (graveler.ValueIterator, error) {
-	it, err := c.metaRangeManager.NewMetaRangeIterator(ctx, ns, rangeID)
+func (c *committedManager) List(ctx context.Context, storageID graveler.StorageID, ns graveler.StorageNamespace, rangeID graveler.MetaRangeID) (graveler.ValueIterator, error) {
+	it, err := c.metaRangeManager.NewMetaRangeIterator(ctx, storageID, ns, rangeID)
 	if err != nil {
 		return nil, err
 	}
@@ -170,20 +170,20 @@ func (c *committedManager) WriteMetaRangeByIterator(ctx context.Context, ns grav
 	return id, nil
 }
 
-func (c *committedManager) Diff(ctx context.Context, ns graveler.StorageNamespace, left, right graveler.MetaRangeID) (graveler.DiffIterator, error) {
-	leftIt, err := c.metaRangeManager.NewMetaRangeIterator(ctx, ns, left)
+func (c *committedManager) Diff(ctx context.Context, storageID graveler.StorageID, ns graveler.StorageNamespace, left, right graveler.MetaRangeID) (graveler.DiffIterator, error) {
+	leftIt, err := c.metaRangeManager.NewMetaRangeIterator(ctx, storageID, ns, left)
 	if err != nil {
 		return nil, err
 	}
-	rightIt, err := c.metaRangeManager.NewMetaRangeIterator(ctx, ns, right)
+	rightIt, err := c.metaRangeManager.NewMetaRangeIterator(ctx, storageID, ns, right)
 	if err != nil {
 		return nil, err
 	}
 	return NewDiffValueIterator(ctx, leftIt, rightIt), nil
 }
 
-func (c *committedManager) Import(ctx context.Context, ns graveler.StorageNamespace, destination, source graveler.MetaRangeID, prefixes []graveler.Prefix, _ ...graveler.SetOptionsFunc) (graveler.MetaRangeID, error) {
-	destIt, err := c.metaRangeManager.NewMetaRangeIterator(ctx, ns, destination)
+func (c *committedManager) Import(ctx context.Context, storageID graveler.StorageID, ns graveler.StorageNamespace, destination, source graveler.MetaRangeID, prefixes []graveler.Prefix, _ ...graveler.SetOptionsFunc) (graveler.MetaRangeID, error) {
+	destIt, err := c.metaRangeManager.NewMetaRangeIterator(ctx, storageID, ns, destination)
 	if err != nil {
 		return "", fmt.Errorf("get destination iterator: %w", err)
 	}
@@ -228,6 +228,7 @@ type mergeContext struct {
 	srcIt         Iterator
 	baseIt        Iterator
 	strategy      graveler.MergeStrategy
+	storageID     graveler.StorageID
 	ns            graveler.StorageNamespace
 	destinationID graveler.MetaRangeID
 	sourceID      graveler.MetaRangeID
@@ -238,7 +239,7 @@ func (c *committedManager) merge(ctx context.Context, mctx mergeContext) (gravel
 	var err error = nil
 	baseIt := mctx.baseIt
 	if baseIt == nil {
-		baseIt, err = c.metaRangeManager.NewMetaRangeIterator(ctx, mctx.ns, mctx.baseID)
+		baseIt, err = c.metaRangeManager.NewMetaRangeIterator(ctx, mctx.storageID, mctx.ns, mctx.baseID)
 		if err != nil {
 			return "", fmt.Errorf("get base iterator: %w", err)
 		}
@@ -247,7 +248,7 @@ func (c *committedManager) merge(ctx context.Context, mctx mergeContext) (gravel
 
 	destIt := mctx.destIt
 	if destIt == nil {
-		destIt, err = c.metaRangeManager.NewMetaRangeIterator(ctx, mctx.ns, mctx.destinationID)
+		destIt, err = c.metaRangeManager.NewMetaRangeIterator(ctx, mctx.storageID, mctx.ns, mctx.destinationID)
 		if err != nil {
 			return "", fmt.Errorf("get destination iterator: %w", err)
 		}
@@ -256,7 +257,7 @@ func (c *committedManager) merge(ctx context.Context, mctx mergeContext) (gravel
 
 	srcIt := mctx.srcIt
 	if srcIt == nil {
-		srcIt, err = c.metaRangeManager.NewMetaRangeIterator(ctx, mctx.ns, mctx.sourceID)
+		srcIt, err = c.metaRangeManager.NewMetaRangeIterator(ctx, mctx.storageID, mctx.ns, mctx.sourceID)
 		if err != nil {
 			return "", fmt.Errorf("get source iterator: %w", err)
 		}
@@ -285,7 +286,7 @@ func (c *committedManager) merge(ctx context.Context, mctx mergeContext) (gravel
 	return *newID, err
 }
 
-func (c *committedManager) Commit(ctx context.Context, ns graveler.StorageNamespace, baseMetaRangeID graveler.MetaRangeID, changes graveler.ValueIterator, allowEmpty bool, _ ...graveler.SetOptionsFunc) (graveler.MetaRangeID, graveler.DiffSummary, error) {
+func (c *committedManager) Commit(ctx context.Context, storageID graveler.StorageID, ns graveler.StorageNamespace, baseMetaRangeID graveler.MetaRangeID, changes graveler.ValueIterator, allowEmpty bool, _ ...graveler.SetOptionsFunc) (graveler.MetaRangeID, graveler.DiffSummary, error) {
 	mwWriter := c.metaRangeManager.NewWriter(ctx, ns, nil)
 	defer func() {
 		err := mwWriter.Abort()
@@ -293,7 +294,7 @@ func (c *committedManager) Commit(ctx context.Context, ns graveler.StorageNamesp
 			logging.FromContext(ctx).WithError(err).Error("Abort failed after Commit")
 		}
 	}()
-	metaRangeIterator, err := c.metaRangeManager.NewMetaRangeIterator(ctx, ns, baseMetaRangeID)
+	metaRangeIterator, err := c.metaRangeManager.NewMetaRangeIterator(ctx, storageID, ns, baseMetaRangeID)
 	summary := graveler.DiffSummary{
 		Count: map[graveler.DiffType]int{},
 	}
@@ -315,12 +316,12 @@ func (c *committedManager) Commit(ctx context.Context, ns graveler.StorageNamesp
 	return *newID, summary, err
 }
 
-func (c *committedManager) Compare(ctx context.Context, ns graveler.StorageNamespace, destination, source, base graveler.MetaRangeID) (graveler.DiffIterator, error) {
-	diffIt, err := c.Diff(ctx, ns, destination, source)
+func (c *committedManager) Compare(ctx context.Context, storageID graveler.StorageID, ns graveler.StorageNamespace, destination, source, base graveler.MetaRangeID) (graveler.DiffIterator, error) {
+	diffIt, err := c.Diff(ctx, storageID, ns, destination, source)
 	if err != nil {
 		return nil, fmt.Errorf("diff: %w", err)
 	}
-	baseIt, err := c.metaRangeManager.NewMetaRangeIterator(ctx, ns, base)
+	baseIt, err := c.metaRangeManager.NewMetaRangeIterator(ctx, storageID, ns, base)
 	if err != nil {
 		diffIt.Close()
 		return nil, fmt.Errorf("get base iterator: %w", err)
@@ -338,11 +339,11 @@ func (c *committedManager) GetRange(ctx context.Context, ns graveler.StorageName
 	return graveler.RangeAddress(uri), err
 }
 
-func (c *committedManager) GetRangeIDByKey(ctx context.Context, ns graveler.StorageNamespace, id graveler.MetaRangeID, key graveler.Key) (graveler.RangeID, error) {
+func (c *committedManager) GetRangeIDByKey(ctx context.Context, storageID graveler.StorageID, ns graveler.StorageNamespace, id graveler.MetaRangeID, key graveler.Key) (graveler.RangeID, error) {
 	if id == "" {
 		return "", graveler.ErrNotFound
 	}
-	r, err := c.metaRangeManager.GetRangeByKey(ctx, ns, id, key)
+	r, err := c.metaRangeManager.GetRangeByKey(ctx, storageID, ns, id, key)
 	if err != nil {
 		return "", fmt.Errorf("get range for key: %w", err)
 	}

--- a/pkg/graveler/committed/manager.go
+++ b/pkg/graveler/committed/manager.go
@@ -61,8 +61,8 @@ func (c *committedManager) List(ctx context.Context, storageID graveler.StorageI
 	return NewValueIterator(it), nil
 }
 
-func (c *committedManager) WriteRange(ctx context.Context, ns graveler.StorageNamespace, it graveler.ValueIterator) (*graveler.RangeInfo, error) {
-	writer, err := c.RangeManager.GetWriter(ctx, Namespace(ns), nil)
+func (c *committedManager) WriteRange(ctx context.Context, storageID graveler.StorageID, ns graveler.StorageNamespace, it graveler.ValueIterator) (*graveler.RangeInfo, error) {
+	writer, err := c.RangeManager.GetWriter(ctx, StorageID(storageID), Namespace(ns), nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed creating range writer: %w", err)
 	}

--- a/pkg/graveler/committed/manager_test.go
+++ b/pkg/graveler/committed/manager_test.go
@@ -56,7 +56,7 @@ func TestManager_WriteRange(t *testing.T) {
 			rangeWriter := mock.NewMockRangeWriter(ctrl)
 
 			rangeWriter.EXPECT().Abort().Return(nil)
-			rangeManager.EXPECT().GetWriter(context.Background(), committed.StorageID(ns), committed.Namespace(ns), nil).Return(rangeWriter, nil)
+			rangeManager.EXPECT().GetWriter(context.Background(), committed.StorageID(""), committed.Namespace(ns), nil).Return(rangeWriter, nil)
 
 			sut := committed.NewCommittedManager(metarangeManager, rangeManager, params)
 

--- a/pkg/graveler/committed/manager_test.go
+++ b/pkg/graveler/committed/manager_test.go
@@ -56,7 +56,7 @@ func TestManager_WriteRange(t *testing.T) {
 			rangeWriter := mock.NewMockRangeWriter(ctrl)
 
 			rangeWriter.EXPECT().Abort().Return(nil)
-			rangeManager.EXPECT().GetWriter(context.Background(), committed.Namespace(ns), nil).Return(rangeWriter, nil)
+			rangeManager.EXPECT().GetWriter(context.Background(), committed.StorageID(ns), committed.Namespace(ns), nil).Return(rangeWriter, nil)
 
 			sut := committed.NewCommittedManager(metarangeManager, rangeManager, params)
 
@@ -69,7 +69,7 @@ func TestManager_WriteRange(t *testing.T) {
 			rangeWriter.EXPECT().SetMetadata(committed.MetadataTypeKey, committed.MetadataRangesType)
 
 			it := testutils.NewFakeValueIterator(tt.records)
-			rangeInfo, err := sut.WriteRange(context.Background(), ns, it)
+			rangeInfo, err := sut.WriteRange(context.Background(), "", ns, it)
 			require.NoError(t, err)
 			require.Equal(t, &graveler.RangeInfo{
 				ID:                      graveler.RangeID(writeResult.RangeID),

--- a/pkg/graveler/committed/manager_test.go
+++ b/pkg/graveler/committed/manager_test.go
@@ -84,7 +84,8 @@ func TestManager_WriteRange(t *testing.T) {
 
 func TestManager_WriteMetaRange(t *testing.T) {
 	const (
-		ns = "some-ns"
+		storageID = ""
+		ns        = "some-ns"
 	)
 
 	expectedMetarangeID := graveler.MetaRangeID("some-id")
@@ -117,7 +118,7 @@ func TestManager_WriteMetaRange(t *testing.T) {
 			metarangeWriter := mock.NewMockMetaRangeWriter(ctrl)
 
 			minKey := ""
-			metarangeManager.EXPECT().NewWriter(context.Background(), graveler.StorageNamespace(ns), nil).Return(metarangeWriter)
+			metarangeManager.EXPECT().NewWriter(context.Background(), graveler.StorageID(storageID), graveler.StorageNamespace(ns), nil).Return(metarangeWriter)
 			metarangeWriter.EXPECT().WriteRange(gomock.Any()).Return(nil).
 				DoAndReturn(func(info committed.Range) error {
 					if string(info.MinKey) < minKey {
@@ -130,7 +131,7 @@ func TestManager_WriteMetaRange(t *testing.T) {
 			metarangeWriter.EXPECT().Abort().Return(nil)
 			sut := committed.NewCommittedManager(metarangeManager, rangeManager, params)
 
-			actualMetarangeID, err := sut.WriteMetaRange(context.Background(), ns, tt.records)
+			actualMetarangeID, err := sut.WriteMetaRange(context.Background(), storageID, ns, tt.records)
 			require.NoError(t, err)
 			require.Equal(t, &graveler.MetaRangeInfo{ID: expectedMetarangeID}, actualMetarangeID)
 		})

--- a/pkg/graveler/committed/merge.go
+++ b/pkg/graveler/committed/merge.go
@@ -490,7 +490,7 @@ func (m *merger) validWritingRange(it Iterator) bool {
 	}
 }
 
-func Merge(ctx context.Context, writer MetaRangeWriter, base Iterator, source Iterator, destination Iterator, strategy graveler.MergeStrategy) error {
+func Merge(ctx context.Context, writer MetaRangeWriter, base graveler.Iterator, source graveler.Iterator, destination graveler.Iterator, strategy graveler.MergeStrategy) error {
 	m := merger{
 		ctx:      ctx,
 		logger:   logging.FromContext(ctx),

--- a/pkg/graveler/committed/merge_test.go
+++ b/pkg/graveler/committed/merge_test.go
@@ -1715,7 +1715,7 @@ func runMergeTests(tests testCases, t *testing.T) {
 						}
 					}
 					metaRangeManager := mock.NewMockMetaRangeManager(ctrl)
-					metaRangeManager.EXPECT().NewWriter(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(writer)
+					metaRangeManager.EXPECT().NewWriter(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(writer)
 					sourceMetaRangeID := tst.sourceRange.GetMetaRangeID()
 					destMetaRangeID := tst.destRange.GetMetaRangeID()
 					baseMetaRangeID := tst.baseRange.GetMetaRangeID()

--- a/pkg/graveler/committed/merge_test.go
+++ b/pkg/graveler/committed/merge_test.go
@@ -1719,9 +1719,9 @@ func runMergeTests(tests testCases, t *testing.T) {
 					sourceMetaRangeID := tst.sourceRange.GetMetaRangeID()
 					destMetaRangeID := tst.destRange.GetMetaRangeID()
 					baseMetaRangeID := tst.baseRange.GetMetaRangeID()
-					metaRangeManager.EXPECT().NewMetaRangeIterator(gomock.Any(), gomock.Any(), baseMetaRangeID).AnyTimes().Return(createIter(tst.baseRange), nil)
-					metaRangeManager.EXPECT().NewMetaRangeIterator(gomock.Any(), gomock.Any(), sourceMetaRangeID).AnyTimes().Return(createIter(tst.sourceRange), nil)
-					metaRangeManager.EXPECT().NewMetaRangeIterator(gomock.Any(), gomock.Any(), destMetaRangeID).AnyTimes().Return(createIter(tst.destRange), nil)
+					metaRangeManager.EXPECT().NewMetaRangeIterator(gomock.Any(), gomock.Any(), gomock.Any(), baseMetaRangeID).AnyTimes().Return(createIter(tst.baseRange), nil)
+					metaRangeManager.EXPECT().NewMetaRangeIterator(gomock.Any(), gomock.Any(), gomock.Any(), sourceMetaRangeID).AnyTimes().Return(createIter(tst.sourceRange), nil)
+					metaRangeManager.EXPECT().NewMetaRangeIterator(gomock.Any(), gomock.Any(), gomock.Any(), destMetaRangeID).AnyTimes().Return(createIter(tst.destRange), nil)
 
 					rangeManager := mock.NewMockRangeManager(ctrl)
 

--- a/pkg/graveler/committed/meta_range.go
+++ b/pkg/graveler/committed/meta_range.go
@@ -73,17 +73,17 @@ func (r RangeDiff) Copy() *RangeDiff {
 
 // MetaRangeManager is an abstraction for a repository of MetaRanges that exposes operations on them
 type MetaRangeManager interface {
-	Exists(ctx context.Context, storageID graveler.StorageID, ns graveler.StorageNamespace, id graveler.MetaRangeID) (bool, error)
+	Exists(ctx context.Context, ns graveler.StorageNamespace, id graveler.MetaRangeID) (bool, error)
 
 	// GetValue returns the matching in-range graveler.ValueRecord for key in the
 	// MetaRange with id.
-	GetValue(ctx context.Context, storageID graveler.StorageID, ns graveler.StorageNamespace, id graveler.MetaRangeID, key graveler.Key) (*graveler.ValueRecord, error)
+	GetValue(ctx context.Context, ns graveler.StorageNamespace, id graveler.MetaRangeID, key graveler.Key) (*graveler.ValueRecord, error)
 
 	// NewWriter returns a writer that is used for creating new MetaRanges
-	NewWriter(ctx context.Context, storageID graveler.StorageID, ns graveler.StorageNamespace, metadata graveler.Metadata) MetaRangeWriter
+	NewWriter(ctx context.Context, ns graveler.StorageNamespace, metadata graveler.Metadata) MetaRangeWriter
 
 	// NewMetaRangeIterator returns an Iterator over the MetaRange with id.
-	NewMetaRangeIterator(ctx context.Context, storageID graveler.StorageID, ns graveler.StorageNamespace, metaRangeID graveler.MetaRangeID) (Iterator, error)
+	NewMetaRangeIterator(ctx context.Context, ns graveler.StorageNamespace, metaRangeID graveler.MetaRangeID) (Iterator, error)
 
 	// GetMetaRangeURI returns a URI with an object representing metarange ID.  It may
 	// return a URI that does not resolve (rather than an error) if ID does not exist.
@@ -94,7 +94,7 @@ type MetaRangeManager interface {
 	GetRangeURI(ctx context.Context, ns graveler.StorageNamespace, rangeID graveler.RangeID) (string, error)
 
 	// GetRangeByKey returns the Range that contains key in the MetaRange with id.
-	GetRangeByKey(ctx context.Context, storageID graveler.StorageID, ns graveler.StorageNamespace, id graveler.MetaRangeID, key graveler.Key) (*Range, error)
+	GetRangeByKey(ctx context.Context, ns graveler.StorageNamespace, id graveler.MetaRangeID, key graveler.Key) (*Range, error)
 }
 
 // MetaRangeWriter is an abstraction for creating new MetaRanges

--- a/pkg/graveler/committed/meta_range.go
+++ b/pkg/graveler/committed/meta_range.go
@@ -87,11 +87,11 @@ type MetaRangeManager interface {
 
 	// GetMetaRangeURI returns a URI with an object representing metarange ID.  It may
 	// return a URI that does not resolve (rather than an error) if ID does not exist.
-	GetMetaRangeURI(ctx context.Context, metaRangeID graveler.MetaRangeID) (string, error)
+	GetMetaRangeURI(ctx context.Context, ns graveler.StorageNamespace, metaRangeID graveler.MetaRangeID) (string, error)
 
 	// GetRangeURI returns a URI with an object representing range ID.  It may
 	// return a URI that does not resolve (rather than an error) if ID does not exist.
-	GetRangeURI(ctx context.Context, rangeID graveler.RangeID) (string, error)
+	GetRangeURI(ctx context.Context, ns graveler.StorageNamespace, rangeID graveler.RangeID) (string, error)
 
 	// GetRangeByKey returns the Range that contains key in the MetaRange with id.
 	GetRangeByKey(ctx context.Context, storageID graveler.StorageID, ns graveler.StorageNamespace, id graveler.MetaRangeID, key graveler.Key) (*Range, error)

--- a/pkg/graveler/committed/meta_range.go
+++ b/pkg/graveler/committed/meta_range.go
@@ -87,11 +87,11 @@ type MetaRangeManager interface {
 
 	// GetMetaRangeURI returns a URI with an object representing metarange ID.  It may
 	// return a URI that does not resolve (rather than an error) if ID does not exist.
-	GetMetaRangeURI(ctx context.Context, ns graveler.StorageNamespace, metaRangeID graveler.MetaRangeID) (string, error)
+	GetMetaRangeURI(ctx context.Context, metaRangeID graveler.MetaRangeID) (string, error)
 
 	// GetRangeURI returns a URI with an object representing range ID.  It may
 	// return a URI that does not resolve (rather than an error) if ID does not exist.
-	GetRangeURI(ctx context.Context, ns graveler.StorageNamespace, rangeID graveler.RangeID) (string, error)
+	GetRangeURI(ctx context.Context, rangeID graveler.RangeID) (string, error)
 
 	// GetRangeByKey returns the Range that contains key in the MetaRange with id.
 	GetRangeByKey(ctx context.Context, storageID graveler.StorageID, ns graveler.StorageNamespace, id graveler.MetaRangeID, key graveler.Key) (*Range, error)

--- a/pkg/graveler/committed/meta_range.go
+++ b/pkg/graveler/committed/meta_range.go
@@ -73,17 +73,17 @@ func (r RangeDiff) Copy() *RangeDiff {
 
 // MetaRangeManager is an abstraction for a repository of MetaRanges that exposes operations on them
 type MetaRangeManager interface {
-	Exists(ctx context.Context, ns graveler.StorageNamespace, id graveler.MetaRangeID) (bool, error)
+	Exists(ctx context.Context, storageID graveler.StorageID, ns graveler.StorageNamespace, id graveler.MetaRangeID) (bool, error)
 
 	// GetValue returns the matching in-range graveler.ValueRecord for key in the
 	// MetaRange with id.
-	GetValue(ctx context.Context, ns graveler.StorageNamespace, id graveler.MetaRangeID, key graveler.Key) (*graveler.ValueRecord, error)
+	GetValue(ctx context.Context, storageID graveler.StorageID, ns graveler.StorageNamespace, id graveler.MetaRangeID, key graveler.Key) (*graveler.ValueRecord, error)
 
 	// NewWriter returns a writer that is used for creating new MetaRanges
 	NewWriter(ctx context.Context, ns graveler.StorageNamespace, metadata graveler.Metadata) MetaRangeWriter
 
 	// NewMetaRangeIterator returns an Iterator over the MetaRange with id.
-	NewMetaRangeIterator(ctx context.Context, ns graveler.StorageNamespace, metaRangeID graveler.MetaRangeID) (Iterator, error)
+	NewMetaRangeIterator(ctx context.Context, storageID graveler.StorageID, ns graveler.StorageNamespace, metaRangeID graveler.MetaRangeID) (Iterator, error)
 
 	// GetMetaRangeURI returns a URI with an object representing metarange ID.  It may
 	// return a URI that does not resolve (rather than an error) if ID does not exist.
@@ -94,7 +94,7 @@ type MetaRangeManager interface {
 	GetRangeURI(ctx context.Context, ns graveler.StorageNamespace, rangeID graveler.RangeID) (string, error)
 
 	// GetRangeByKey returns the Range that contains key in the MetaRange with id.
-	GetRangeByKey(ctx context.Context, ns graveler.StorageNamespace, id graveler.MetaRangeID, key graveler.Key) (*Range, error)
+	GetRangeByKey(ctx context.Context, storageID graveler.StorageID, ns graveler.StorageNamespace, id graveler.MetaRangeID, key graveler.Key) (*Range, error)
 }
 
 // MetaRangeWriter is an abstraction for creating new MetaRanges

--- a/pkg/graveler/committed/meta_range.go
+++ b/pkg/graveler/committed/meta_range.go
@@ -80,7 +80,7 @@ type MetaRangeManager interface {
 	GetValue(ctx context.Context, storageID graveler.StorageID, ns graveler.StorageNamespace, id graveler.MetaRangeID, key graveler.Key) (*graveler.ValueRecord, error)
 
 	// NewWriter returns a writer that is used for creating new MetaRanges
-	NewWriter(ctx context.Context, ns graveler.StorageNamespace, metadata graveler.Metadata) MetaRangeWriter
+	NewWriter(ctx context.Context, storageID graveler.StorageID, ns graveler.StorageNamespace, metadata graveler.Metadata) MetaRangeWriter
 
 	// NewMetaRangeIterator returns an Iterator over the MetaRange with id.
 	NewMetaRangeIterator(ctx context.Context, storageID graveler.StorageID, ns graveler.StorageNamespace, metaRangeID graveler.MetaRangeID) (Iterator, error)

--- a/pkg/graveler/committed/meta_range_manager.go
+++ b/pkg/graveler/committed/meta_range_manager.go
@@ -111,10 +111,10 @@ func (m *metaRangeManager) NewMetaRangeIterator(ctx context.Context, storageID g
 	return NewIterator(ctx, m.rangeManager, Namespace(ns), rangesIt), nil
 }
 
-func (m *metaRangeManager) GetMetaRangeURI(ctx context.Context, ns graveler.StorageNamespace, id graveler.MetaRangeID) (string, error) {
-	return m.metaManager.GetURI(ctx, Namespace(ns), ID(id))
+func (m *metaRangeManager) GetMetaRangeURI(ctx context.Context, id graveler.MetaRangeID) (string, error) {
+	return m.metaManager.GetURI(ctx, ID(id))
 }
 
-func (m *metaRangeManager) GetRangeURI(ctx context.Context, ns graveler.StorageNamespace, id graveler.RangeID) (string, error) {
-	return m.rangeManager.GetURI(ctx, Namespace(ns), ID(id))
+func (m *metaRangeManager) GetRangeURI(ctx context.Context, id graveler.RangeID) (string, error) {
+	return m.rangeManager.GetURI(ctx, ID(id))
 }

--- a/pkg/graveler/committed/meta_range_manager.go
+++ b/pkg/graveler/committed/meta_range_manager.go
@@ -28,11 +28,12 @@ type metaRangeManager struct {
 	params       Params
 	metaManager  RangeManager // For metaranges
 	rangeManager RangeManager // For ranges
+	storageID    graveler.StorageID
 }
 
 var ErrNeedBatchClosers = errors.New("need at least 1 batch uploaded")
 
-func NewMetaRangeManager(params Params, metaManager, rangeManager RangeManager) (MetaRangeManager, error) {
+func NewMetaRangeManager(params Params, metaManager, rangeManager RangeManager, storageID graveler.StorageID) (MetaRangeManager, error) {
 	if params.MaxUploaders < 1 {
 		return nil, fmt.Errorf("only %d async closers: %w", params.MaxUploaders, ErrNeedBatchClosers)
 	}
@@ -40,24 +41,25 @@ func NewMetaRangeManager(params Params, metaManager, rangeManager RangeManager) 
 		params:       params,
 		metaManager:  metaManager,
 		rangeManager: rangeManager,
+		storageID:    storageID,
 	}, nil
 }
 
-func (m *metaRangeManager) Exists(ctx context.Context, storageID graveler.StorageID, ns graveler.StorageNamespace, id graveler.MetaRangeID) (bool, error) {
-	return m.metaManager.Exists(ctx, StorageID(storageID), Namespace(ns), ID(id))
+func (m *metaRangeManager) Exists(ctx context.Context, ns graveler.StorageNamespace, id graveler.MetaRangeID) (bool, error) {
+	return m.metaManager.Exists(ctx, Namespace(ns), ID(id))
 }
 
 // GetValue finds the matching graveler.ValueRecord in the MetaRange with the rangeID
-func (m *metaRangeManager) GetValue(ctx context.Context, storageID graveler.StorageID, ns graveler.StorageNamespace, id graveler.MetaRangeID, key graveler.Key) (*graveler.ValueRecord, error) {
+func (m *metaRangeManager) GetValue(ctx context.Context, ns graveler.StorageNamespace, id graveler.MetaRangeID, key graveler.Key) (*graveler.ValueRecord, error) {
 	// Fetch range containing key.
-	rng, err := m.GetRangeByKey(ctx, storageID, ns, id, key)
+	rng, err := m.GetRangeByKey(ctx, ns, id, key)
 	if err != nil {
 		return nil, err
 	}
 
-	r, err := m.rangeManager.GetValue(ctx, StorageID(storageID), Namespace(ns), rng.ID, Key(key))
+	r, err := m.rangeManager.GetValue(ctx, Namespace(ns), rng.ID, Key(key))
 	if err != nil {
-		return nil, fmt.Errorf("get value in range %s of %s for %s: %w", rng.ID, id, key, err)
+		return nil, fmt.Errorf("get value in range %s of %s for %s: %w", rng.GetID(), id, key, err)
 	}
 	value, err := UnmarshalValue(r.Value)
 	if err != nil {
@@ -69,8 +71,8 @@ func (m *metaRangeManager) GetValue(ctx context.Context, storageID graveler.Stor
 	}, nil
 }
 
-func (m *metaRangeManager) GetRangeByKey(ctx context.Context, storageID graveler.StorageID, ns graveler.StorageNamespace, id graveler.MetaRangeID, key graveler.Key) (*Range, error) {
-	v, err := m.metaManager.GetValueGE(ctx, StorageID(storageID), Namespace(ns), ID(id), Key(key))
+func (m *metaRangeManager) GetRangeByKey(ctx context.Context, ns graveler.StorageNamespace, id graveler.MetaRangeID, key graveler.Key) (*Range, error) {
+	v, err := m.metaManager.GetValueGE(ctx, Namespace(ns), ID(id), Key(key))
 	if errors.Is(err, ErrNotFound) {
 		return nil, err
 	}
@@ -96,15 +98,15 @@ func (m *metaRangeManager) GetRangeByKey(ctx context.Context, storageID graveler
 	return &rng, nil
 }
 
-func (m *metaRangeManager) NewWriter(ctx context.Context, storageID graveler.StorageID, ns graveler.StorageNamespace, metadata graveler.Metadata) MetaRangeWriter {
-	return NewGeneralMetaRangeWriter(ctx, m.rangeManager, m.metaManager, &m.params, StorageID(storageID), Namespace(ns), metadata)
+func (m *metaRangeManager) NewWriter(ctx context.Context, ns graveler.StorageNamespace, metadata graveler.Metadata) MetaRangeWriter {
+	return NewGeneralMetaRangeWriter(ctx, m.rangeManager, m.metaManager, &m.params, StorageID(m.storageID), Namespace(ns), metadata)
 }
 
-func (m *metaRangeManager) NewMetaRangeIterator(ctx context.Context, storageID graveler.StorageID, ns graveler.StorageNamespace, id graveler.MetaRangeID) (Iterator, error) {
+func (m *metaRangeManager) NewMetaRangeIterator(ctx context.Context, ns graveler.StorageNamespace, id graveler.MetaRangeID) (Iterator, error) {
 	if id == "" {
 		return NewEmptyIterator(), nil
 	}
-	rangesIt, err := m.metaManager.NewRangeIterator(ctx, StorageID(storageID), Namespace(ns), ID(id))
+	rangesIt, err := m.metaManager.NewRangeIterator(ctx, Namespace(ns), ID(id))
 	if err != nil {
 		return nil, fmt.Errorf("manage metarange %s: %w", id, err)
 	}
@@ -117,4 +119,8 @@ func (m *metaRangeManager) GetMetaRangeURI(ctx context.Context, ns graveler.Stor
 
 func (m *metaRangeManager) GetRangeURI(ctx context.Context, ns graveler.StorageNamespace, id graveler.RangeID) (string, error) {
 	return m.rangeManager.GetURI(ctx, Namespace(ns), ID(id))
+}
+
+func (m *metaRangeManager) GetStorageID() graveler.StorageID {
+	return m.storageID
 }

--- a/pkg/graveler/committed/meta_range_manager.go
+++ b/pkg/graveler/committed/meta_range_manager.go
@@ -96,8 +96,8 @@ func (m *metaRangeManager) GetRangeByKey(ctx context.Context, storageID graveler
 	return &rng, nil
 }
 
-func (m *metaRangeManager) NewWriter(ctx context.Context, ns graveler.StorageNamespace, metadata graveler.Metadata) MetaRangeWriter {
-	return NewGeneralMetaRangeWriter(ctx, m.rangeManager, m.metaManager, &m.params, Namespace(ns), metadata)
+func (m *metaRangeManager) NewWriter(ctx context.Context, storageID graveler.StorageID, ns graveler.StorageNamespace, metadata graveler.Metadata) MetaRangeWriter {
+	return NewGeneralMetaRangeWriter(ctx, m.rangeManager, m.metaManager, &m.params, StorageID(storageID), Namespace(ns), metadata)
 }
 
 func (m *metaRangeManager) NewMetaRangeIterator(ctx context.Context, storageID graveler.StorageID, ns graveler.StorageNamespace, id graveler.MetaRangeID) (Iterator, error) {

--- a/pkg/graveler/committed/meta_range_manager.go
+++ b/pkg/graveler/committed/meta_range_manager.go
@@ -111,10 +111,10 @@ func (m *metaRangeManager) NewMetaRangeIterator(ctx context.Context, storageID g
 	return NewIterator(ctx, m.rangeManager, Namespace(ns), rangesIt), nil
 }
 
-func (m *metaRangeManager) GetMetaRangeURI(ctx context.Context, id graveler.MetaRangeID) (string, error) {
-	return m.metaManager.GetURI(ctx, ID(id))
+func (m *metaRangeManager) GetMetaRangeURI(ctx context.Context, ns graveler.StorageNamespace, id graveler.MetaRangeID) (string, error) {
+	return m.metaManager.GetURI(ctx, Namespace(ns), ID(id))
 }
 
-func (m *metaRangeManager) GetRangeURI(ctx context.Context, id graveler.RangeID) (string, error) {
-	return m.rangeManager.GetURI(ctx, ID(id))
+func (m *metaRangeManager) GetRangeURI(ctx context.Context, ns graveler.StorageNamespace, id graveler.RangeID) (string, error) {
+	return m.rangeManager.GetURI(ctx, Namespace(ns), ID(id))
 }

--- a/pkg/graveler/committed/meta_range_manager.go
+++ b/pkg/graveler/committed/meta_range_manager.go
@@ -43,19 +43,19 @@ func NewMetaRangeManager(params Params, metaManager, rangeManager RangeManager) 
 	}, nil
 }
 
-func (m *metaRangeManager) Exists(ctx context.Context, ns graveler.StorageNamespace, id graveler.MetaRangeID) (bool, error) {
-	return m.metaManager.Exists(ctx, Namespace(ns), ID(id))
+func (m *metaRangeManager) Exists(ctx context.Context, storageID graveler.StorageID, ns graveler.StorageNamespace, id graveler.MetaRangeID) (bool, error) {
+	return m.metaManager.Exists(ctx, StorageID(storageID), Namespace(ns), ID(id))
 }
 
 // GetValue finds the matching graveler.ValueRecord in the MetaRange with the rangeID
-func (m *metaRangeManager) GetValue(ctx context.Context, ns graveler.StorageNamespace, id graveler.MetaRangeID, key graveler.Key) (*graveler.ValueRecord, error) {
+func (m *metaRangeManager) GetValue(ctx context.Context, storageID graveler.StorageID, ns graveler.StorageNamespace, id graveler.MetaRangeID, key graveler.Key) (*graveler.ValueRecord, error) {
 	// Fetch range containing key.
-	rng, err := m.GetRangeByKey(ctx, ns, id, key)
+	rng, err := m.GetRangeByKey(ctx, storageID, ns, id, key)
 	if err != nil {
 		return nil, err
 	}
 
-	r, err := m.rangeManager.GetValue(ctx, Namespace(ns), rng.ID, Key(key))
+	r, err := m.rangeManager.GetValue(ctx, StorageID(storageID), Namespace(ns), rng.ID, Key(key))
 	if err != nil {
 		return nil, fmt.Errorf("get value in range %s of %s for %s: %w", rng.ID, id, key, err)
 	}
@@ -69,8 +69,8 @@ func (m *metaRangeManager) GetValue(ctx context.Context, ns graveler.StorageName
 	}, nil
 }
 
-func (m *metaRangeManager) GetRangeByKey(ctx context.Context, ns graveler.StorageNamespace, id graveler.MetaRangeID, key graveler.Key) (*Range, error) {
-	v, err := m.metaManager.GetValueGE(ctx, Namespace(ns), ID(id), Key(key))
+func (m *metaRangeManager) GetRangeByKey(ctx context.Context, storageID graveler.StorageID, ns graveler.StorageNamespace, id graveler.MetaRangeID, key graveler.Key) (*Range, error) {
+	v, err := m.metaManager.GetValueGE(ctx, StorageID(storageID), Namespace(ns), ID(id), Key(key))
 	if errors.Is(err, ErrNotFound) {
 		return nil, err
 	}
@@ -100,11 +100,11 @@ func (m *metaRangeManager) NewWriter(ctx context.Context, ns graveler.StorageNam
 	return NewGeneralMetaRangeWriter(ctx, m.rangeManager, m.metaManager, &m.params, Namespace(ns), metadata)
 }
 
-func (m *metaRangeManager) NewMetaRangeIterator(ctx context.Context, ns graveler.StorageNamespace, id graveler.MetaRangeID) (Iterator, error) {
+func (m *metaRangeManager) NewMetaRangeIterator(ctx context.Context, storageID graveler.StorageID, ns graveler.StorageNamespace, id graveler.MetaRangeID) (Iterator, error) {
 	if id == "" {
 		return NewEmptyIterator(), nil
 	}
-	rangesIt, err := m.metaManager.NewRangeIterator(ctx, Namespace(ns), ID(id))
+	rangesIt, err := m.metaManager.NewRangeIterator(ctx, StorageID(storageID), Namespace(ns), ID(id))
 	if err != nil {
 		return nil, fmt.Errorf("manage metarange %s: %w", id, err)
 	}

--- a/pkg/graveler/committed/meta_range_writer.go
+++ b/pkg/graveler/committed/meta_range_writer.go
@@ -60,7 +60,7 @@ func (w *GeneralMetaRangeWriter) WriteRecord(record graveler.ValueRecord) error 
 
 	var err error
 	if w.rangeWriter == nil {
-		w.rangeWriter, err = w.rangeManager.GetWriter(w.ctx, w.storageID, w.namespace, w.metadata)
+		w.rangeWriter, err = w.rangeManager.GetWriter(w.ctx, w.namespace, w.metadata)
 		if err != nil {
 			return fmt.Errorf("get range writer: %w", err)
 		}
@@ -147,7 +147,7 @@ func (w *GeneralMetaRangeWriter) shouldBreakAtKey(key graveler.Key) bool {
 
 // writeRangesToMetaRange writes all ranges to a MetaRange and returns the MetaRangeID
 func (w *GeneralMetaRangeWriter) writeRangesToMetaRange(ctx context.Context) (*graveler.MetaRangeID, error) {
-	metaRangeWriter, err := w.metaRangeManager.GetWriter(w.ctx, w.storageID, w.namespace, w.metadata)
+	metaRangeWriter, err := w.metaRangeManager.GetWriter(w.ctx, w.namespace, w.metadata)
 	if err != nil {
 		return nil, fmt.Errorf("failed creating metarange writer: %w", err)
 	}

--- a/pkg/graveler/committed/meta_range_writer.go
+++ b/pkg/graveler/committed/meta_range_writer.go
@@ -36,7 +36,7 @@ var (
 	ErrNilValue     = errors.New("record value should not be nil")
 )
 
-func NewGeneralMetaRangeWriter(ctx context.Context, rangeManager, metaRangeManager RangeManager, params *Params, namespace Namespace, md graveler.Metadata) *GeneralMetaRangeWriter {
+func NewGeneralMetaRangeWriter(ctx context.Context, rangeManager, metaRangeManager RangeManager, params *Params, storageID StorageID, namespace Namespace, md graveler.Metadata) *GeneralMetaRangeWriter {
 	return &GeneralMetaRangeWriter{
 		ctx:              ctx,
 		metadata:         md,
@@ -44,6 +44,7 @@ func NewGeneralMetaRangeWriter(ctx context.Context, rangeManager, metaRangeManag
 		metaRangeManager: metaRangeManager,
 		batchWriteCloser: NewBatchCloser(params.MaxUploaders),
 		params:           params,
+		storageID:        storageID,
 		namespace:        namespace,
 	}
 }

--- a/pkg/graveler/committed/meta_range_writer.go
+++ b/pkg/graveler/committed/meta_range_writer.go
@@ -15,6 +15,7 @@ type GeneralMetaRangeWriter struct {
 	ctx              context.Context
 	metadata         graveler.Metadata
 	params           *Params // for breaking ranges
+	storageID        StorageID
 	namespace        Namespace
 	metaRangeManager RangeManager
 	rangeManager     RangeManager
@@ -58,7 +59,7 @@ func (w *GeneralMetaRangeWriter) WriteRecord(record graveler.ValueRecord) error 
 
 	var err error
 	if w.rangeWriter == nil {
-		w.rangeWriter, err = w.rangeManager.GetWriter(w.ctx, w.namespace, w.metadata)
+		w.rangeWriter, err = w.rangeManager.GetWriter(w.ctx, w.storageID, w.namespace, w.metadata)
 		if err != nil {
 			return fmt.Errorf("get range writer: %w", err)
 		}
@@ -145,7 +146,7 @@ func (w *GeneralMetaRangeWriter) shouldBreakAtKey(key graveler.Key) bool {
 
 // writeRangesToMetaRange writes all ranges to a MetaRange and returns the MetaRangeID
 func (w *GeneralMetaRangeWriter) writeRangesToMetaRange(ctx context.Context) (*graveler.MetaRangeID, error) {
-	metaRangeWriter, err := w.metaRangeManager.GetWriter(w.ctx, w.namespace, w.metadata)
+	metaRangeWriter, err := w.metaRangeManager.GetWriter(w.ctx, w.storageID, w.namespace, w.metadata)
 	if err != nil {
 		return nil, fmt.Errorf("failed creating metarange writer: %w", err)
 	}

--- a/pkg/graveler/committed/meta_range_writer_test.go
+++ b/pkg/graveler/committed/meta_range_writer_test.go
@@ -39,7 +39,7 @@ func TestWriter_WriteRecords(t *testing.T) {
 	fakeWriter := NewFakeRangeWriter(&writeResult, nil)
 
 	rangeManager := mock.NewMockRangeManager(ctrl)
-	rangeManager.EXPECT().GetWriter(gomock.Any(), gomock.Any(), gomock.Any()).Return(fakeWriter, nil)
+	rangeManager.EXPECT().GetWriter(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(fakeWriter, nil)
 
 	metaWriteResult := committed.WriteResult{
 		RangeID: committed.ID("meta-range-id"),
@@ -51,7 +51,7 @@ func TestWriter_WriteRecords(t *testing.T) {
 	fakeMetaWriter.ExpectAnyRecord()
 
 	rangeManagerMeta := mock.NewMockRangeManager(ctrl)
-	rangeManagerMeta.EXPECT().GetWriter(gomock.Any(), gomock.Any(), gomock.Any()).Return(fakeMetaWriter, nil)
+	rangeManagerMeta.EXPECT().GetWriter(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(fakeMetaWriter, nil)
 	namespace := committed.Namespace("ns")
 	w := committed.NewGeneralMetaRangeWriter(ctx, rangeManager, rangeManagerMeta, &params, namespace, nil)
 
@@ -136,8 +136,8 @@ func TestWriter_RecordRangeAndClose(t *testing.T) {
 	rng := committed.Range{ID: "rng2-id", MinKey: committed.Key("a"), MaxKey: committed.Key("g"), Count: 4}
 
 	// get writer - once for record writer, once for range writer
-	rangeManager.EXPECT().GetWriter(gomock.Any(), gomock.Any(), gomock.Any()).Return(fakeWriter, nil)
-	rangeManagerMeta.EXPECT().GetWriter(gomock.Any(), gomock.Any(), gomock.Any()).Return(fakeMetaWriter, nil)
+	rangeManager.EXPECT().GetWriter(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(fakeWriter, nil)
+	rangeManagerMeta.EXPECT().GetWriter(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(fakeMetaWriter, nil)
 
 	// Never attempt to split files: fake writers return size 0.
 

--- a/pkg/graveler/committed/meta_range_writer_test.go
+++ b/pkg/graveler/committed/meta_range_writer_test.go
@@ -52,8 +52,9 @@ func TestWriter_WriteRecords(t *testing.T) {
 
 	rangeManagerMeta := mock.NewMockRangeManager(ctrl)
 	rangeManagerMeta.EXPECT().GetWriter(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return(fakeMetaWriter, nil)
+	storageID := committed.StorageID("")
 	namespace := committed.Namespace("ns")
-	w := committed.NewGeneralMetaRangeWriter(ctx, rangeManager, rangeManagerMeta, &params, namespace, nil)
+	w := committed.NewGeneralMetaRangeWriter(ctx, rangeManager, rangeManagerMeta, &params, storageID, namespace, nil)
 
 	// Add first record
 	firstRecord := graveler.ValueRecord{
@@ -101,10 +102,11 @@ func TestWriter_OverlappingRanges(t *testing.T) {
 	defer ctrl.Finish()
 
 	rangeManager := mock.NewMockRangeManager(ctrl)
+	storageID := committed.StorageID("")
 	namespace := committed.Namespace("ns")
 	rng := committed.Range{MinKey: committed.Key("a"), MaxKey: committed.Key("g")}
 	rng2 := committed.Range{MinKey: committed.Key("c"), MaxKey: committed.Key("l")}
-	w := committed.NewGeneralMetaRangeWriter(ctx, rangeManager, rangeManager, &params, namespace, nil)
+	w := committed.NewGeneralMetaRangeWriter(ctx, rangeManager, rangeManager, &params, storageID, namespace, nil)
 	err := w.WriteRange(rng)
 	if err != nil {
 		t.Fatalf("unexpected error %s", err)
@@ -131,6 +133,7 @@ func TestWriter_RecordRangeAndClose(t *testing.T) {
 	rangeManagerMeta := mock.NewMockRangeManager(ctrl)
 	fakeMetaWriter := NewFakeRangeWriter(&committed.WriteResult{}, nil)
 
+	storageID := committed.StorageID("")
 	namespace := committed.Namespace("ns")
 	record := graveler.ValueRecord{Key: nil, Value: &graveler.Value{}}
 	rng := committed.Range{ID: "rng2-id", MinKey: committed.Key("a"), MaxKey: committed.Key("g"), Count: 4}
@@ -164,7 +167,7 @@ func TestWriter_RecordRangeAndClose(t *testing.T) {
 		},
 	}))
 
-	w := committed.NewGeneralMetaRangeWriter(ctx, rangeManager, rangeManagerMeta, &params, namespace, nil)
+	w := committed.NewGeneralMetaRangeWriter(ctx, rangeManager, rangeManagerMeta, &params, storageID, namespace, nil)
 	err := w.WriteRecord(record)
 	if err != nil {
 		t.Fatalf("unexpected error %s", err)

--- a/pkg/graveler/committed/mock/meta_range.go
+++ b/pkg/graveler/committed/mock/meta_range.go
@@ -335,17 +335,17 @@ func (mr *MockMetaRangeManagerMockRecorder) NewMetaRangeIterator(ctx, storageID,
 }
 
 // NewWriter mocks base method.
-func (m *MockMetaRangeManager) NewWriter(ctx context.Context, ns graveler.StorageNamespace, metadata graveler.Metadata) committed.MetaRangeWriter {
+func (m *MockMetaRangeManager) NewWriter(ctx context.Context, storageID graveler.StorageID, ns graveler.StorageNamespace, metadata graveler.Metadata) committed.MetaRangeWriter {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewWriter", ctx, ns, metadata)
+	ret := m.ctrl.Call(m, "NewWriter", ctx, storageID, ns, metadata)
 	ret0, _ := ret[0].(committed.MetaRangeWriter)
 	return ret0
 }
 
 // NewWriter indicates an expected call of NewWriter.
-func (mr *MockMetaRangeManagerMockRecorder) NewWriter(ctx, ns, metadata interface{}) *gomock.Call {
+func (mr *MockMetaRangeManagerMockRecorder) NewWriter(ctx, storageID, ns, metadata interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewWriter", reflect.TypeOf((*MockMetaRangeManager)(nil).NewWriter), ctx, ns, metadata)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewWriter", reflect.TypeOf((*MockMetaRangeManager)(nil).NewWriter), ctx, storageID, ns, metadata)
 }
 
 // MockMetaRangeWriter is a mock of MetaRangeWriter interface.

--- a/pkg/graveler/committed/mock/meta_range.go
+++ b/pkg/graveler/committed/mock/meta_range.go
@@ -245,18 +245,18 @@ func (m *MockMetaRangeManager) EXPECT() *MockMetaRangeManagerMockRecorder {
 }
 
 // Exists mocks base method.
-func (m *MockMetaRangeManager) Exists(ctx context.Context, ns graveler.StorageNamespace, id graveler.MetaRangeID) (bool, error) {
+func (m *MockMetaRangeManager) Exists(ctx context.Context, storageID graveler.StorageID, ns graveler.StorageNamespace, id graveler.MetaRangeID) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Exists", ctx, ns, id)
+	ret := m.ctrl.Call(m, "Exists", ctx, storageID, ns, id)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Exists indicates an expected call of Exists.
-func (mr *MockMetaRangeManagerMockRecorder) Exists(ctx, ns, id interface{}) *gomock.Call {
+func (mr *MockMetaRangeManagerMockRecorder) Exists(ctx, storageID, ns, id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exists", reflect.TypeOf((*MockMetaRangeManager)(nil).Exists), ctx, ns, id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exists", reflect.TypeOf((*MockMetaRangeManager)(nil).Exists), ctx, storageID, ns, id)
 }
 
 // GetMetaRangeURI mocks base method.
@@ -275,18 +275,18 @@ func (mr *MockMetaRangeManagerMockRecorder) GetMetaRangeURI(ctx, ns, metaRangeID
 }
 
 // GetRangeByKey mocks base method.
-func (m *MockMetaRangeManager) GetRangeByKey(ctx context.Context, ns graveler.StorageNamespace, id graveler.MetaRangeID, key graveler.Key) (*committed.Range, error) {
+func (m *MockMetaRangeManager) GetRangeByKey(ctx context.Context, storageID graveler.StorageID, ns graveler.StorageNamespace, id graveler.MetaRangeID, key graveler.Key) (*committed.Range, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRangeByKey", ctx, ns, id, key)
+	ret := m.ctrl.Call(m, "GetRangeByKey", ctx, storageID, ns, id, key)
 	ret0, _ := ret[0].(*committed.Range)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetRangeByKey indicates an expected call of GetRangeByKey.
-func (mr *MockMetaRangeManagerMockRecorder) GetRangeByKey(ctx, ns, id, key interface{}) *gomock.Call {
+func (mr *MockMetaRangeManagerMockRecorder) GetRangeByKey(ctx, storageID, ns, id, key interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRangeByKey", reflect.TypeOf((*MockMetaRangeManager)(nil).GetRangeByKey), ctx, ns, id, key)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRangeByKey", reflect.TypeOf((*MockMetaRangeManager)(nil).GetRangeByKey), ctx, storageID, ns, id, key)
 }
 
 // GetRangeURI mocks base method.
@@ -305,33 +305,33 @@ func (mr *MockMetaRangeManagerMockRecorder) GetRangeURI(ctx, ns, rangeID interfa
 }
 
 // GetValue mocks base method.
-func (m *MockMetaRangeManager) GetValue(ctx context.Context, ns graveler.StorageNamespace, id graveler.MetaRangeID, key graveler.Key) (*graveler.ValueRecord, error) {
+func (m *MockMetaRangeManager) GetValue(ctx context.Context, storageID graveler.StorageID, ns graveler.StorageNamespace, id graveler.MetaRangeID, key graveler.Key) (*graveler.ValueRecord, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetValue", ctx, ns, id, key)
+	ret := m.ctrl.Call(m, "GetValue", ctx, storageID, ns, id, key)
 	ret0, _ := ret[0].(*graveler.ValueRecord)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetValue indicates an expected call of GetValue.
-func (mr *MockMetaRangeManagerMockRecorder) GetValue(ctx, ns, id, key interface{}) *gomock.Call {
+func (mr *MockMetaRangeManagerMockRecorder) GetValue(ctx, storageID, ns, id, key interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetValue", reflect.TypeOf((*MockMetaRangeManager)(nil).GetValue), ctx, ns, id, key)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetValue", reflect.TypeOf((*MockMetaRangeManager)(nil).GetValue), ctx, storageID, ns, id, key)
 }
 
 // NewMetaRangeIterator mocks base method.
-func (m *MockMetaRangeManager) NewMetaRangeIterator(ctx context.Context, ns graveler.StorageNamespace, metaRangeID graveler.MetaRangeID) (committed.Iterator, error) {
+func (m *MockMetaRangeManager) NewMetaRangeIterator(ctx context.Context, storageID graveler.StorageID, ns graveler.StorageNamespace, metaRangeID graveler.MetaRangeID) (committed.Iterator, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewMetaRangeIterator", ctx, ns, metaRangeID)
+	ret := m.ctrl.Call(m, "NewMetaRangeIterator", ctx, storageID, ns, metaRangeID)
 	ret0, _ := ret[0].(committed.Iterator)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // NewMetaRangeIterator indicates an expected call of NewMetaRangeIterator.
-func (mr *MockMetaRangeManagerMockRecorder) NewMetaRangeIterator(ctx, ns, metaRangeID interface{}) *gomock.Call {
+func (mr *MockMetaRangeManagerMockRecorder) NewMetaRangeIterator(ctx, storageID, ns, metaRangeID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewMetaRangeIterator", reflect.TypeOf((*MockMetaRangeManager)(nil).NewMetaRangeIterator), ctx, ns, metaRangeID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewMetaRangeIterator", reflect.TypeOf((*MockMetaRangeManager)(nil).NewMetaRangeIterator), ctx, storageID, ns, metaRangeID)
 }
 
 // NewWriter mocks base method.

--- a/pkg/graveler/committed/mock/meta_range.go
+++ b/pkg/graveler/committed/mock/meta_range.go
@@ -260,18 +260,18 @@ func (mr *MockMetaRangeManagerMockRecorder) Exists(ctx, storageID, ns, id interf
 }
 
 // GetMetaRangeURI mocks base method.
-func (m *MockMetaRangeManager) GetMetaRangeURI(ctx context.Context, ns graveler.StorageNamespace, metaRangeID graveler.MetaRangeID) (string, error) {
+func (m *MockMetaRangeManager) GetMetaRangeURI(ctx context.Context, metaRangeID graveler.MetaRangeID) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMetaRangeURI", ctx, ns, metaRangeID)
+	ret := m.ctrl.Call(m, "GetMetaRangeURI", ctx, metaRangeID)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetMetaRangeURI indicates an expected call of GetMetaRangeURI.
-func (mr *MockMetaRangeManagerMockRecorder) GetMetaRangeURI(ctx, ns, metaRangeID interface{}) *gomock.Call {
+func (mr *MockMetaRangeManagerMockRecorder) GetMetaRangeURI(ctx, metaRangeID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMetaRangeURI", reflect.TypeOf((*MockMetaRangeManager)(nil).GetMetaRangeURI), ctx, ns, metaRangeID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMetaRangeURI", reflect.TypeOf((*MockMetaRangeManager)(nil).GetMetaRangeURI), ctx, metaRangeID)
 }
 
 // GetRangeByKey mocks base method.
@@ -290,18 +290,18 @@ func (mr *MockMetaRangeManagerMockRecorder) GetRangeByKey(ctx, storageID, ns, id
 }
 
 // GetRangeURI mocks base method.
-func (m *MockMetaRangeManager) GetRangeURI(ctx context.Context, ns graveler.StorageNamespace, rangeID graveler.RangeID) (string, error) {
+func (m *MockMetaRangeManager) GetRangeURI(ctx context.Context, rangeID graveler.RangeID) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRangeURI", ctx, ns, rangeID)
+	ret := m.ctrl.Call(m, "GetRangeURI", ctx, rangeID)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetRangeURI indicates an expected call of GetRangeURI.
-func (mr *MockMetaRangeManagerMockRecorder) GetRangeURI(ctx, ns, rangeID interface{}) *gomock.Call {
+func (mr *MockMetaRangeManagerMockRecorder) GetRangeURI(ctx, rangeID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRangeURI", reflect.TypeOf((*MockMetaRangeManager)(nil).GetRangeURI), ctx, ns, rangeID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRangeURI", reflect.TypeOf((*MockMetaRangeManager)(nil).GetRangeURI), ctx, rangeID)
 }
 
 // GetValue mocks base method.

--- a/pkg/graveler/committed/mock/meta_range.go
+++ b/pkg/graveler/committed/mock/meta_range.go
@@ -260,18 +260,18 @@ func (mr *MockMetaRangeManagerMockRecorder) Exists(ctx, storageID, ns, id interf
 }
 
 // GetMetaRangeURI mocks base method.
-func (m *MockMetaRangeManager) GetMetaRangeURI(ctx context.Context, metaRangeID graveler.MetaRangeID) (string, error) {
+func (m *MockMetaRangeManager) GetMetaRangeURI(ctx context.Context, ns graveler.StorageNamespace, metaRangeID graveler.MetaRangeID) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMetaRangeURI", ctx, metaRangeID)
+	ret := m.ctrl.Call(m, "GetMetaRangeURI", ctx, ns, metaRangeID)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetMetaRangeURI indicates an expected call of GetMetaRangeURI.
-func (mr *MockMetaRangeManagerMockRecorder) GetMetaRangeURI(ctx, metaRangeID interface{}) *gomock.Call {
+func (mr *MockMetaRangeManagerMockRecorder) GetMetaRangeURI(ctx, ns, metaRangeID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMetaRangeURI", reflect.TypeOf((*MockMetaRangeManager)(nil).GetMetaRangeURI), ctx, metaRangeID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMetaRangeURI", reflect.TypeOf((*MockMetaRangeManager)(nil).GetMetaRangeURI), ctx, ns, metaRangeID)
 }
 
 // GetRangeByKey mocks base method.
@@ -290,18 +290,18 @@ func (mr *MockMetaRangeManagerMockRecorder) GetRangeByKey(ctx, storageID, ns, id
 }
 
 // GetRangeURI mocks base method.
-func (m *MockMetaRangeManager) GetRangeURI(ctx context.Context, rangeID graveler.RangeID) (string, error) {
+func (m *MockMetaRangeManager) GetRangeURI(ctx context.Context, ns graveler.StorageNamespace, rangeID graveler.RangeID) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRangeURI", ctx, rangeID)
+	ret := m.ctrl.Call(m, "GetRangeURI", ctx, ns, rangeID)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetRangeURI indicates an expected call of GetRangeURI.
-func (mr *MockMetaRangeManagerMockRecorder) GetRangeURI(ctx, rangeID interface{}) *gomock.Call {
+func (mr *MockMetaRangeManagerMockRecorder) GetRangeURI(ctx, ns, rangeID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRangeURI", reflect.TypeOf((*MockMetaRangeManager)(nil).GetRangeURI), ctx, rangeID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRangeURI", reflect.TypeOf((*MockMetaRangeManager)(nil).GetRangeURI), ctx, ns, rangeID)
 }
 
 // GetValue mocks base method.

--- a/pkg/graveler/committed/mock/range_manager.go
+++ b/pkg/graveler/committed/mock/range_manager.go
@@ -141,18 +141,18 @@ func (mr *MockRangeManagerMockRecorder) Exists(ctx, storageID, ns, id interface{
 }
 
 // GetURI mocks base method.
-func (m *MockRangeManager) GetURI(ctx context.Context, ns committed.Namespace, id committed.ID) (string, error) {
+func (m *MockRangeManager) GetURI(ctx context.Context, id committed.ID) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetURI", ctx, ns, id)
+	ret := m.ctrl.Call(m, "GetURI", ctx, id)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetURI indicates an expected call of GetURI.
-func (mr *MockRangeManagerMockRecorder) GetURI(ctx, ns, id interface{}) *gomock.Call {
+func (mr *MockRangeManagerMockRecorder) GetURI(ctx, id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetURI", reflect.TypeOf((*MockRangeManager)(nil).GetURI), ctx, ns, id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetURI", reflect.TypeOf((*MockRangeManager)(nil).GetURI), ctx, id)
 }
 
 // GetValue mocks base method.

--- a/pkg/graveler/committed/mock/range_manager.go
+++ b/pkg/graveler/committed/mock/range_manager.go
@@ -141,18 +141,18 @@ func (mr *MockRangeManagerMockRecorder) Exists(ctx, storageID, ns, id interface{
 }
 
 // GetURI mocks base method.
-func (m *MockRangeManager) GetURI(ctx context.Context, id committed.ID) (string, error) {
+func (m *MockRangeManager) GetURI(ctx context.Context, ns committed.Namespace, id committed.ID) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetURI", ctx, id)
+	ret := m.ctrl.Call(m, "GetURI", ctx, ns, id)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetURI indicates an expected call of GetURI.
-func (mr *MockRangeManagerMockRecorder) GetURI(ctx, id interface{}) *gomock.Call {
+func (mr *MockRangeManagerMockRecorder) GetURI(ctx, ns, id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetURI", reflect.TypeOf((*MockRangeManager)(nil).GetURI), ctx, id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetURI", reflect.TypeOf((*MockRangeManager)(nil).GetURI), ctx, ns, id)
 }
 
 // GetValue mocks base method.

--- a/pkg/graveler/committed/mock/range_manager.go
+++ b/pkg/graveler/committed/mock/range_manager.go
@@ -126,18 +126,18 @@ func (m *MockRangeManager) EXPECT() *MockRangeManagerMockRecorder {
 }
 
 // Exists mocks base method.
-func (m *MockRangeManager) Exists(ctx context.Context, ns committed.Namespace, id committed.ID) (bool, error) {
+func (m *MockRangeManager) Exists(ctx context.Context, storageID committed.StorageID, ns committed.Namespace, id committed.ID) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Exists", ctx, ns, id)
+	ret := m.ctrl.Call(m, "Exists", ctx, storageID, ns, id)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Exists indicates an expected call of Exists.
-func (mr *MockRangeManagerMockRecorder) Exists(ctx, ns, id interface{}) *gomock.Call {
+func (mr *MockRangeManagerMockRecorder) Exists(ctx, storageID, ns, id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exists", reflect.TypeOf((*MockRangeManager)(nil).Exists), ctx, ns, id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exists", reflect.TypeOf((*MockRangeManager)(nil).Exists), ctx, storageID, ns, id)
 }
 
 // GetURI mocks base method.
@@ -156,33 +156,33 @@ func (mr *MockRangeManagerMockRecorder) GetURI(ctx, ns, id interface{}) *gomock.
 }
 
 // GetValue mocks base method.
-func (m *MockRangeManager) GetValue(ctx context.Context, ns committed.Namespace, id committed.ID, key committed.Key) (*committed.Record, error) {
+func (m *MockRangeManager) GetValue(ctx context.Context, storageID committed.StorageID, ns committed.Namespace, id committed.ID, key committed.Key) (*committed.Record, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetValue", ctx, ns, id, key)
+	ret := m.ctrl.Call(m, "GetValue", ctx, storageID, ns, id, key)
 	ret0, _ := ret[0].(*committed.Record)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetValue indicates an expected call of GetValue.
-func (mr *MockRangeManagerMockRecorder) GetValue(ctx, ns, id, key interface{}) *gomock.Call {
+func (mr *MockRangeManagerMockRecorder) GetValue(ctx, storageID, ns, id, key interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetValue", reflect.TypeOf((*MockRangeManager)(nil).GetValue), ctx, ns, id, key)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetValue", reflect.TypeOf((*MockRangeManager)(nil).GetValue), ctx, storageID, ns, id, key)
 }
 
 // GetValueGE mocks base method.
-func (m *MockRangeManager) GetValueGE(ctx context.Context, ns committed.Namespace, id committed.ID, key committed.Key) (*committed.Record, error) {
+func (m *MockRangeManager) GetValueGE(ctx context.Context, storageID committed.StorageID, ns committed.Namespace, id committed.ID, key committed.Key) (*committed.Record, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetValueGE", ctx, ns, id, key)
+	ret := m.ctrl.Call(m, "GetValueGE", ctx, storageID, ns, id, key)
 	ret0, _ := ret[0].(*committed.Record)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetValueGE indicates an expected call of GetValueGE.
-func (mr *MockRangeManagerMockRecorder) GetValueGE(ctx, ns, id, key interface{}) *gomock.Call {
+func (mr *MockRangeManagerMockRecorder) GetValueGE(ctx, storageID, ns, id, key interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetValueGE", reflect.TypeOf((*MockRangeManager)(nil).GetValueGE), ctx, ns, id, key)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetValueGE", reflect.TypeOf((*MockRangeManager)(nil).GetValueGE), ctx, storageID, ns, id, key)
 }
 
 // GetWriter mocks base method.
@@ -201,18 +201,18 @@ func (mr *MockRangeManagerMockRecorder) GetWriter(ctx, ns, metadata interface{})
 }
 
 // NewRangeIterator mocks base method.
-func (m *MockRangeManager) NewRangeIterator(ctx context.Context, ns committed.Namespace, pid committed.ID) (committed.ValueIterator, error) {
+func (m *MockRangeManager) NewRangeIterator(ctx context.Context, storageID committed.StorageID, ns committed.Namespace, pid committed.ID) (committed.ValueIterator, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewRangeIterator", ctx, ns, pid)
+	ret := m.ctrl.Call(m, "NewRangeIterator", ctx, storageID, ns, pid)
 	ret0, _ := ret[0].(committed.ValueIterator)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // NewRangeIterator indicates an expected call of NewRangeIterator.
-func (mr *MockRangeManagerMockRecorder) NewRangeIterator(ctx, ns, pid interface{}) *gomock.Call {
+func (mr *MockRangeManagerMockRecorder) NewRangeIterator(ctx, storageID, ns, pid interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewRangeIterator", reflect.TypeOf((*MockRangeManager)(nil).NewRangeIterator), ctx, ns, pid)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewRangeIterator", reflect.TypeOf((*MockRangeManager)(nil).NewRangeIterator), ctx, storageID, ns, pid)
 }
 
 // MockRangeWriter is a mock of RangeWriter interface.

--- a/pkg/graveler/committed/mock/range_manager.go
+++ b/pkg/graveler/committed/mock/range_manager.go
@@ -126,18 +126,18 @@ func (m *MockRangeManager) EXPECT() *MockRangeManagerMockRecorder {
 }
 
 // Exists mocks base method.
-func (m *MockRangeManager) Exists(ctx context.Context, storageID committed.StorageID, ns committed.Namespace, id committed.ID) (bool, error) {
+func (m *MockRangeManager) Exists(ctx context.Context, ns committed.Namespace, id committed.ID) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Exists", ctx, storageID, ns, id)
+	ret := m.ctrl.Call(m, "Exists", ctx, ns, id)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Exists indicates an expected call of Exists.
-func (mr *MockRangeManagerMockRecorder) Exists(ctx, storageID, ns, id interface{}) *gomock.Call {
+func (mr *MockRangeManagerMockRecorder) Exists(ctx, ns, id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exists", reflect.TypeOf((*MockRangeManager)(nil).Exists), ctx, storageID, ns, id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exists", reflect.TypeOf((*MockRangeManager)(nil).Exists), ctx, ns, id)
 }
 
 // GetURI mocks base method.
@@ -156,63 +156,63 @@ func (mr *MockRangeManagerMockRecorder) GetURI(ctx, ns, id interface{}) *gomock.
 }
 
 // GetValue mocks base method.
-func (m *MockRangeManager) GetValue(ctx context.Context, storageID committed.StorageID, ns committed.Namespace, id committed.ID, key committed.Key) (*committed.Record, error) {
+func (m *MockRangeManager) GetValue(ctx context.Context, ns committed.Namespace, id committed.ID, key committed.Key) (*committed.Record, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetValue", ctx, storageID, ns, id, key)
+	ret := m.ctrl.Call(m, "GetValue", ctx, ns, id, key)
 	ret0, _ := ret[0].(*committed.Record)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetValue indicates an expected call of GetValue.
-func (mr *MockRangeManagerMockRecorder) GetValue(ctx, storageID, ns, id, key interface{}) *gomock.Call {
+func (mr *MockRangeManagerMockRecorder) GetValue(ctx, ns, id, key interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetValue", reflect.TypeOf((*MockRangeManager)(nil).GetValue), ctx, storageID, ns, id, key)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetValue", reflect.TypeOf((*MockRangeManager)(nil).GetValue), ctx, ns, id, key)
 }
 
 // GetValueGE mocks base method.
-func (m *MockRangeManager) GetValueGE(ctx context.Context, storageID committed.StorageID, ns committed.Namespace, id committed.ID, key committed.Key) (*committed.Record, error) {
+func (m *MockRangeManager) GetValueGE(ctx context.Context, ns committed.Namespace, id committed.ID, key committed.Key) (*committed.Record, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetValueGE", ctx, storageID, ns, id, key)
+	ret := m.ctrl.Call(m, "GetValueGE", ctx, ns, id, key)
 	ret0, _ := ret[0].(*committed.Record)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetValueGE indicates an expected call of GetValueGE.
-func (mr *MockRangeManagerMockRecorder) GetValueGE(ctx, storageID, ns, id, key interface{}) *gomock.Call {
+func (mr *MockRangeManagerMockRecorder) GetValueGE(ctx, ns, id, key interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetValueGE", reflect.TypeOf((*MockRangeManager)(nil).GetValueGE), ctx, storageID, ns, id, key)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetValueGE", reflect.TypeOf((*MockRangeManager)(nil).GetValueGE), ctx, ns, id, key)
 }
 
 // GetWriter mocks base method.
-func (m *MockRangeManager) GetWriter(ctx context.Context, storageID committed.StorageID, ns committed.Namespace, metadata graveler.Metadata) (committed.RangeWriter, error) {
+func (m *MockRangeManager) GetWriter(ctx context.Context, ns committed.Namespace, metadata graveler.Metadata) (committed.RangeWriter, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetWriter", ctx, storageID, ns, metadata)
+	ret := m.ctrl.Call(m, "GetWriter", ctx, ns, metadata)
 	ret0, _ := ret[0].(committed.RangeWriter)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetWriter indicates an expected call of GetWriter.
-func (mr *MockRangeManagerMockRecorder) GetWriter(ctx, storageID, ns, metadata interface{}) *gomock.Call {
+func (mr *MockRangeManagerMockRecorder) GetWriter(ctx, ns, metadata interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWriter", reflect.TypeOf((*MockRangeManager)(nil).GetWriter), ctx, storageID, ns, metadata)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWriter", reflect.TypeOf((*MockRangeManager)(nil).GetWriter), ctx, ns, metadata)
 }
 
 // NewRangeIterator mocks base method.
-func (m *MockRangeManager) NewRangeIterator(ctx context.Context, storageID committed.StorageID, ns committed.Namespace, pid committed.ID) (committed.ValueIterator, error) {
+func (m *MockRangeManager) NewRangeIterator(ctx context.Context, ns committed.Namespace, pid committed.ID) (committed.ValueIterator, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "NewRangeIterator", ctx, storageID, ns, pid)
+	ret := m.ctrl.Call(m, "NewRangeIterator", ctx, ns, pid)
 	ret0, _ := ret[0].(committed.ValueIterator)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // NewRangeIterator indicates an expected call of NewRangeIterator.
-func (mr *MockRangeManagerMockRecorder) NewRangeIterator(ctx, storageID, ns, pid interface{}) *gomock.Call {
+func (mr *MockRangeManagerMockRecorder) NewRangeIterator(ctx, ns, pid interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewRangeIterator", reflect.TypeOf((*MockRangeManager)(nil).NewRangeIterator), ctx, storageID, ns, pid)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewRangeIterator", reflect.TypeOf((*MockRangeManager)(nil).NewRangeIterator), ctx, ns, pid)
 }
 
 // MockRangeWriter is a mock of RangeWriter interface.

--- a/pkg/graveler/committed/mock/range_manager.go
+++ b/pkg/graveler/committed/mock/range_manager.go
@@ -186,18 +186,18 @@ func (mr *MockRangeManagerMockRecorder) GetValueGE(ctx, storageID, ns, id, key i
 }
 
 // GetWriter mocks base method.
-func (m *MockRangeManager) GetWriter(ctx context.Context, ns committed.Namespace, metadata graveler.Metadata) (committed.RangeWriter, error) {
+func (m *MockRangeManager) GetWriter(ctx context.Context, storageID committed.StorageID, ns committed.Namespace, metadata graveler.Metadata) (committed.RangeWriter, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetWriter", ctx, ns, metadata)
+	ret := m.ctrl.Call(m, "GetWriter", ctx, storageID, ns, metadata)
 	ret0, _ := ret[0].(committed.RangeWriter)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetWriter indicates an expected call of GetWriter.
-func (mr *MockRangeManagerMockRecorder) GetWriter(ctx, ns, metadata interface{}) *gomock.Call {
+func (mr *MockRangeManagerMockRecorder) GetWriter(ctx, storageID, ns, metadata interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWriter", reflect.TypeOf((*MockRangeManager)(nil).GetWriter), ctx, ns, metadata)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWriter", reflect.TypeOf((*MockRangeManager)(nil).GetWriter), ctx, storageID, ns, metadata)
 }
 
 // NewRangeIterator mocks base method.

--- a/pkg/graveler/committed/range.go
+++ b/pkg/graveler/committed/range.go
@@ -3,6 +3,7 @@ package committed
 import (
 	"bytes"
 
+	"github.com/treeverse/lakefs/pkg/graveler"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -33,6 +34,10 @@ func (r Range) EqualBounds(o *Range) bool {
 
 func (r Range) BeforeRange(o *Range) bool {
 	return bytes.Compare(r.MaxKey, o.MinKey) < 0
+}
+
+func (r Range) GetID() graveler.RangeID {
+	return graveler.RangeID(r.ID)
 }
 
 func MarshalRange(r Range) ([]byte, error) {

--- a/pkg/graveler/committed/range_manager.go
+++ b/pkg/graveler/committed/range_manager.go
@@ -60,7 +60,7 @@ type RangeManager interface {
 	NewRangeIterator(ctx context.Context, storageID StorageID, ns Namespace, pid ID) (ValueIterator, error)
 
 	// GetWriter returns a new Range writer instance
-	GetWriter(ctx context.Context, ns Namespace, metadata graveler.Metadata) (RangeWriter, error)
+	GetWriter(ctx context.Context, storageID StorageID, ns Namespace, metadata graveler.Metadata) (RangeWriter, error)
 
 	// GetURI returns a URI from which to read the contents of id.  If id does not exist
 	// it may return a URI that resolves nowhere rather than an error.

--- a/pkg/graveler/committed/range_manager.go
+++ b/pkg/graveler/committed/range_manager.go
@@ -46,21 +46,21 @@ var ErrNotFound = graveler.ErrNotFound
 
 type RangeManager interface {
 	// Exists returns true if id references a Range.
-	Exists(ctx context.Context, storageID StorageID, ns Namespace, id ID) (bool, error)
+	Exists(ctx context.Context, ns Namespace, id ID) (bool, error)
 
 	// GetValue returns the value matching key in the Range referenced by id. If id not
 	// found, it return (nil, ErrNotFound).
-	GetValue(ctx context.Context, storageID StorageID, ns Namespace, id ID, key Key) (*Record, error)
+	GetValue(ctx context.Context, ns Namespace, id ID, key Key) (*Record, error)
 
 	// GetValueGE returns the first value keyed at or after key in the Range referenced by
 	// id.  If all values are keyed before key, it returns (nil, ErrNotFound).
-	GetValueGE(ctx context.Context, storageID StorageID, ns Namespace, id ID, key Key) (*Record, error)
+	GetValueGE(ctx context.Context, ns Namespace, id ID, key Key) (*Record, error)
 
 	// NewRangeIterator returns an iterator over values in the Range with ID.
-	NewRangeIterator(ctx context.Context, storageID StorageID, ns Namespace, pid ID) (ValueIterator, error)
+	NewRangeIterator(ctx context.Context, ns Namespace, pid ID) (ValueIterator, error)
 
 	// GetWriter returns a new Range writer instance
-	GetWriter(ctx context.Context, storageID StorageID, ns Namespace, metadata graveler.Metadata) (RangeWriter, error)
+	GetWriter(ctx context.Context, ns Namespace, metadata graveler.Metadata) (RangeWriter, error)
 
 	// GetURI returns a URI from which to read the contents of id.  If id does not exist
 	// it may return a URI that resolves nowhere rather than an error.

--- a/pkg/graveler/committed/range_manager.go
+++ b/pkg/graveler/committed/range_manager.go
@@ -64,7 +64,7 @@ type RangeManager interface {
 
 	// GetURI returns a URI from which to read the contents of id.  If id does not exist
 	// it may return a URI that resolves nowhere rather than an error.
-	GetURI(ctx context.Context, id ID) (string, error)
+	GetURI(ctx context.Context, ns Namespace, id ID) (string, error)
 }
 
 // WriteResult is the result of a completed write of a Range

--- a/pkg/graveler/committed/range_manager.go
+++ b/pkg/graveler/committed/range_manager.go
@@ -11,11 +11,11 @@ import (
 // ID is an identifier for a Range
 type ID string
 
-// Namespace is namespace for ID ranges
-type Namespace string
-
 // StorageID is id for object storage
 type StorageID string
+
+// Namespace is namespace for ID ranges
+type Namespace string
 
 // Key and Value types for to be stored in any Range of the MetaRange
 type Key []byte

--- a/pkg/graveler/committed/range_manager.go
+++ b/pkg/graveler/committed/range_manager.go
@@ -14,6 +14,9 @@ type ID string
 // Namespace is namespace for ID ranges
 type Namespace string
 
+// StorageID is id for object storage
+type StorageID string
+
 // Key and Value types for to be stored in any Range of the MetaRange
 type Key []byte
 
@@ -43,18 +46,18 @@ var ErrNotFound = graveler.ErrNotFound
 
 type RangeManager interface {
 	// Exists returns true if id references a Range.
-	Exists(ctx context.Context, ns Namespace, id ID) (bool, error)
+	Exists(ctx context.Context, storageID StorageID, ns Namespace, id ID) (bool, error)
 
 	// GetValue returns the value matching key in the Range referenced by id. If id not
 	// found, it return (nil, ErrNotFound).
-	GetValue(ctx context.Context, ns Namespace, id ID, key Key) (*Record, error)
+	GetValue(ctx context.Context, storageID StorageID, ns Namespace, id ID, key Key) (*Record, error)
 
 	// GetValueGE returns the first value keyed at or after key in the Range referenced by
 	// id.  If all values are keyed before key, it returns (nil, ErrNotFound).
-	GetValueGE(ctx context.Context, ns Namespace, id ID, key Key) (*Record, error)
+	GetValueGE(ctx context.Context, storageID StorageID, ns Namespace, id ID, key Key) (*Record, error)
 
 	// NewRangeIterator returns an iterator over values in the Range with ID.
-	NewRangeIterator(ctx context.Context, ns Namespace, pid ID) (ValueIterator, error)
+	NewRangeIterator(ctx context.Context, storageID StorageID, ns Namespace, pid ID) (ValueIterator, error)
 
 	// GetWriter returns a new Range writer instance
 	GetWriter(ctx context.Context, ns Namespace, metadata graveler.Metadata) (RangeWriter, error)

--- a/pkg/graveler/committed/range_manager.go
+++ b/pkg/graveler/committed/range_manager.go
@@ -64,7 +64,7 @@ type RangeManager interface {
 
 	// GetURI returns a URI from which to read the contents of id.  If id does not exist
 	// it may return a URI that resolves nowhere rather than an error.
-	GetURI(ctx context.Context, ns Namespace, id ID) (string, error)
+	GetURI(ctx context.Context, id ID) (string, error)
 }
 
 // WriteResult is the result of a completed write of a Range

--- a/pkg/graveler/graveler.go
+++ b/pkg/graveler/graveler.go
@@ -1014,14 +1014,14 @@ type CommittedManager interface {
 	Exists(ctx context.Context, storageID StorageID, ns StorageNamespace, id MetaRangeID) (bool, error)
 
 	// WriteMetaRangeByIterator flushes the iterator to a new MetaRange and returns the created ID.
-	WriteMetaRangeByIterator(ctx context.Context, ns StorageNamespace, it ValueIterator, metadata Metadata) (*MetaRangeID, error)
+	WriteMetaRangeByIterator(ctx context.Context, storageID StorageID, ns StorageNamespace, it ValueIterator, metadata Metadata) (*MetaRangeID, error)
 
 	// WriteRange creates a new Range from the iterator values.
 	// Keeps Range closing logic, so might not exhaust the iterator.
 	WriteRange(ctx context.Context, storageID StorageID, ns StorageNamespace, it ValueIterator) (*RangeInfo, error)
 
 	// WriteMetaRange creates a new MetaRange from the given Ranges.
-	WriteMetaRange(ctx context.Context, ns StorageNamespace, ranges []*RangeInfo) (*MetaRangeInfo, error)
+	WriteMetaRange(ctx context.Context, storageID StorageID, ns StorageNamespace, ranges []*RangeInfo) (*MetaRangeInfo, error)
 
 	// List takes a given tree and returns an ValueIterator
 	List(ctx context.Context, storageID StorageID, ns StorageNamespace, rangeID MetaRangeID) (ValueIterator, error)
@@ -1251,7 +1251,7 @@ func (g *Graveler) WriteMetaRange(ctx context.Context, repository *RepositoryRec
 	if repository.ReadOnly && !options.Force {
 		return nil, ErrReadOnlyRepository
 	}
-	return g.CommittedManager.WriteMetaRange(ctx, repository.StorageNamespace, ranges)
+	return g.CommittedManager.WriteMetaRange(ctx, repository.StorageID, repository.StorageNamespace, ranges)
 }
 
 func (g *Graveler) StageObject(ctx context.Context, stagingToken string, object ValueRecord) error {
@@ -1263,7 +1263,7 @@ func (g *Graveler) WriteMetaRangeByIterator(ctx context.Context, repository *Rep
 	if repository.ReadOnly && !options.Force {
 		return nil, ErrReadOnlyRepository
 	}
-	return g.CommittedManager.WriteMetaRangeByIterator(ctx, repository.StorageNamespace, it, nil)
+	return g.CommittedManager.WriteMetaRangeByIterator(ctx, repository.StorageID, repository.StorageNamespace, it, nil)
 }
 
 func (g *Graveler) GetCommit(ctx context.Context, repository *RepositoryRecord, commitID CommitID) (*Commit, error) {
@@ -3436,7 +3436,7 @@ func (g *Graveler) DumpCommits(ctx context.Context, repository *RepositoryRecord
 	if err != nil {
 		return nil, err
 	}
-	return g.CommittedManager.WriteMetaRangeByIterator(ctx, repository.StorageNamespace,
+	return g.CommittedManager.WriteMetaRangeByIterator(ctx, repository.StorageID, repository.StorageNamespace,
 		commitsToValueIterator(iter),
 		Metadata{
 			EntityTypeKey:             EntityTypeCommit,
@@ -3456,7 +3456,7 @@ func (g *Graveler) DumpBranches(ctx context.Context, repository *RepositoryRecor
 	if err != nil {
 		return nil, err
 	}
-	return g.CommittedManager.WriteMetaRangeByIterator(ctx, repository.StorageNamespace,
+	return g.CommittedManager.WriteMetaRangeByIterator(ctx, repository.StorageID, repository.StorageNamespace,
 		branchesToValueIterator(iter),
 		Metadata{
 			EntityTypeKey:             EntityTypeBranch,
@@ -3476,7 +3476,7 @@ func (g *Graveler) DumpTags(ctx context.Context, repository *RepositoryRecord) (
 	if err != nil {
 		return nil, err
 	}
-	return g.CommittedManager.WriteMetaRangeByIterator(ctx, repository.StorageNamespace,
+	return g.CommittedManager.WriteMetaRangeByIterator(ctx, repository.StorageID, repository.StorageNamespace,
 		tagsToValueIterator(iter),
 		Metadata{
 			EntityTypeKey:             EntityTypeTag,

--- a/pkg/graveler/graveler.go
+++ b/pkg/graveler/graveler.go
@@ -1018,7 +1018,7 @@ type CommittedManager interface {
 
 	// WriteRange creates a new Range from the iterator values.
 	// Keeps Range closing logic, so might not exhaust the iterator.
-	WriteRange(ctx context.Context, ns StorageNamespace, it ValueIterator) (*RangeInfo, error)
+	WriteRange(ctx context.Context, storageID StorageID, ns StorageNamespace, it ValueIterator) (*RangeInfo, error)
 
 	// WriteMetaRange creates a new MetaRange from the given Ranges.
 	WriteMetaRange(ctx context.Context, ns StorageNamespace, ranges []*RangeInfo) (*MetaRangeInfo, error)
@@ -1243,7 +1243,7 @@ func (g *Graveler) WriteRange(ctx context.Context, repository *RepositoryRecord,
 	if repository.ReadOnly && !options.Force {
 		return nil, ErrReadOnlyRepository
 	}
-	return g.CommittedManager.WriteRange(ctx, repository.StorageNamespace, it)
+	return g.CommittedManager.WriteRange(ctx, repository.StorageID, repository.StorageNamespace, it)
 }
 
 func (g *Graveler) WriteMetaRange(ctx context.Context, repository *RepositoryRecord, ranges []*RangeInfo, opts ...SetOptionsFunc) (*MetaRangeInfo, error) {

--- a/pkg/graveler/graveler.go
+++ b/pkg/graveler/graveler.go
@@ -1008,10 +1008,10 @@ type RefManager interface {
 // it is responsible for de-duping them, persisting them and providing basic diff, merge and list capabilities
 type CommittedManager interface {
 	// Get returns the provided key, if exists, from the provided MetaRangeID
-	Get(ctx context.Context, ns StorageNamespace, rangeID MetaRangeID, key Key) (*Value, error)
+	Get(ctx context.Context, storageID StorageID, ns StorageNamespace, rangeID MetaRangeID, key Key) (*Value, error)
 
 	// Exists returns true if a MetaRange matching ID exists in namespace ns.
-	Exists(ctx context.Context, ns StorageNamespace, id MetaRangeID) (bool, error)
+	Exists(ctx context.Context, storageID StorageID, ns StorageNamespace, id MetaRangeID) (bool, error)
 
 	// WriteMetaRangeByIterator flushes the iterator to a new MetaRange and returns the created ID.
 	WriteMetaRangeByIterator(ctx context.Context, ns StorageNamespace, it ValueIterator, metadata Metadata) (*MetaRangeID, error)
@@ -1024,15 +1024,15 @@ type CommittedManager interface {
 	WriteMetaRange(ctx context.Context, ns StorageNamespace, ranges []*RangeInfo) (*MetaRangeInfo, error)
 
 	// List takes a given tree and returns an ValueIterator
-	List(ctx context.Context, ns StorageNamespace, rangeID MetaRangeID) (ValueIterator, error)
+	List(ctx context.Context, storageID StorageID, ns StorageNamespace, rangeID MetaRangeID) (ValueIterator, error)
 
 	// Diff receives two metaRanges and returns a DiffIterator describing all differences between them.
 	// This is similar to a two-dot diff in git (left..right)
-	Diff(ctx context.Context, ns StorageNamespace, left, right MetaRangeID) (DiffIterator, error)
+	Diff(ctx context.Context, storageID StorageID, ns StorageNamespace, left, right MetaRangeID) (DiffIterator, error)
 
 	// Compare returns the difference between 'source' and 'destination', relative to a merge base 'base'.
 	// This is similar to a three-dot diff in git.
-	Compare(ctx context.Context, ns StorageNamespace, destination, source, base MetaRangeID) (DiffIterator, error)
+	Compare(ctx context.Context, storageID StorageID, ns StorageNamespace, destination, source, base MetaRangeID) (DiffIterator, error)
 
 	// Merge applies changes from 'source' to 'destination', relative to a merge base 'base' and
 	// returns the ID of the new metarange. This is similar to a git merge operation.
@@ -1041,12 +1041,12 @@ type CommittedManager interface {
 
 	// Import sync changes from 'source' to 'destination'. All the given prefixes are completely overridden on the resulting metarange. Returns the ID of the new
 	// metarange.
-	Import(ctx context.Context, ns StorageNamespace, destination, source MetaRangeID, prefixes []Prefix, opts ...SetOptionsFunc) (MetaRangeID, error)
+	Import(ctx context.Context, storageID StorageID, ns StorageNamespace, destination, source MetaRangeID, prefixes []Prefix, opts ...SetOptionsFunc) (MetaRangeID, error)
 
 	// Commit is the act of taking an existing metaRange (snapshot) and applying a set of changes to it.
 	// A change is either an entity to write/overwrite, or a tombstone to mark a deletion
 	// it returns a new MetaRangeID that is expected to be immediately addressable
-	Commit(ctx context.Context, ns StorageNamespace, baseMetaRangeID MetaRangeID, changes ValueIterator, allowEmpty bool, opts ...SetOptionsFunc) (MetaRangeID, DiffSummary, error)
+	Commit(ctx context.Context, storageID StorageID, ns StorageNamespace, baseMetaRangeID MetaRangeID, changes ValueIterator, allowEmpty bool, opts ...SetOptionsFunc) (MetaRangeID, DiffSummary, error)
 
 	// GetMetaRange returns information where metarangeID is stored.
 	GetMetaRange(ctx context.Context, ns StorageNamespace, metaRangeID MetaRangeID) (MetaRangeAddress, error)
@@ -1054,7 +1054,7 @@ type CommittedManager interface {
 	GetRange(ctx context.Context, ns StorageNamespace, rangeID RangeID) (RangeAddress, error)
 
 	// GetRangeIDByKey returns the RangeID that contains the given key.
-	GetRangeIDByKey(ctx context.Context, ns StorageNamespace, id MetaRangeID, key Key) (RangeID, error)
+	GetRangeIDByKey(ctx context.Context, storageID StorageID, ns StorageNamespace, id MetaRangeID, key Key) (RangeID, error)
 }
 
 // StagingManager manages entries in a staging area, denoted by a staging token
@@ -1748,7 +1748,7 @@ func (g *Graveler) Get(ctx context.Context, repository *RepositoryRecord, ref Re
 	}
 
 	if updatedValue == nil && reference.CompactedBaseMetaRangeID != "" {
-		updatedValue, err = g.CommittedManager.Get(ctx, repository.StorageNamespace, reference.CompactedBaseMetaRangeID, key)
+		updatedValue, err = g.CommittedManager.Get(ctx, repository.StorageID, repository.StorageNamespace, reference.CompactedBaseMetaRangeID, key)
 		// no need to check for ErrNotFound, since if the key is not found in the compacted base, it will not be found in the committed, and we already checked the staging area
 		if err != nil {
 			return nil, err
@@ -1770,7 +1770,7 @@ func (g *Graveler) Get(ctx context.Context, repository *RepositoryRecord, ref Re
 		if err != nil {
 			return nil, err
 		}
-		committedVal, err := g.CommittedManager.Get(ctx, repository.StorageNamespace, commit.MetaRangeID, key)
+		committedVal, err := g.CommittedManager.Get(ctx, repository.StorageID, repository.StorageNamespace, commit.MetaRangeID, key)
 		if err != nil && !errors.Is(err, ErrNotFound) {
 			return nil, err
 		}
@@ -1787,7 +1787,7 @@ func (g *Graveler) Get(ctx context.Context, repository *RepositoryRecord, ref Re
 	if err != nil {
 		return nil, err
 	}
-	return g.CommittedManager.Get(ctx, repository.StorageNamespace, commit.MetaRangeID, key)
+	return g.CommittedManager.Get(ctx, repository.StorageID, repository.StorageNamespace, commit.MetaRangeID, key)
 }
 
 func (g *Graveler) GetByCommitID(ctx context.Context, repository *RepositoryRecord, commitID CommitID, key Key) (*Value, error) {
@@ -1796,7 +1796,7 @@ func (g *Graveler) GetByCommitID(ctx context.Context, repository *RepositoryReco
 	if err != nil {
 		return nil, err
 	}
-	return g.CommittedManager.Get(ctx, repository.StorageNamespace, commit.MetaRangeID, key)
+	return g.CommittedManager.Get(ctx, repository.StorageID, repository.StorageNamespace, commit.MetaRangeID, key)
 }
 
 func (g *Graveler) GetRangeIDByKey(ctx context.Context, repository *RepositoryRecord, commitID CommitID, key Key) (RangeID, error) {
@@ -1804,7 +1804,7 @@ func (g *Graveler) GetRangeIDByKey(ctx context.Context, repository *RepositoryRe
 	if err != nil {
 		return "", err
 	}
-	return g.CommittedManager.GetRangeIDByKey(ctx, repository.StorageNamespace, commit.MetaRangeID, key)
+	return g.CommittedManager.GetRangeIDByKey(ctx, repository.StorageID, repository.StorageNamespace, commit.MetaRangeID, key)
 }
 
 func (g *Graveler) Set(ctx context.Context, repository *RepositoryRecord, branchID BranchID, key Key, value Value, opts ...SetOptionsFunc) error {
@@ -2011,7 +2011,7 @@ func (g *Graveler) deleteUnsafe(ctx context.Context, repository *RepositoryRecor
 		metaRangeID = commit.MetaRangeID
 	}
 
-	_, err = g.CommittedManager.Get(ctx, repository.StorageNamespace, metaRangeID, key)
+	_, err = g.CommittedManager.Get(ctx, repository.StorageID, repository.StorageNamespace, metaRangeID, key)
 	if err == nil {
 		// found in committed, set tombstone
 		return g.deleteAndNotify(ctx, repository.RepositoryID, branchRecord, key, false)
@@ -2089,7 +2089,7 @@ func (g *Graveler) List(ctx context.Context, repository *RepositoryRecord, ref R
 		metaRangeID = commit.MetaRangeID
 	}
 
-	listing, err := g.CommittedManager.List(ctx, repository.StorageNamespace, metaRangeID)
+	listing, err := g.CommittedManager.List(ctx, repository.StorageID, repository.StorageNamespace, metaRangeID)
 	if err != nil {
 		return nil, err
 	}
@@ -2205,7 +2205,7 @@ func (g *Graveler) Commit(ctx context.Context, repository *RepositoryRecord, bra
 			}
 			defer changes.Close()
 			// returns err if the commit is empty (no changes)
-			commit.MetaRangeID, _, err = g.CommittedManager.Commit(ctx, storageNamespace, branchMetaRangeID, changes, params.AllowEmpty)
+			commit.MetaRangeID, _, err = g.CommittedManager.Commit(ctx, repository.StorageID, storageNamespace, branchMetaRangeID, changes, params.AllowEmpty)
 			if err != nil {
 				return nil, fmt.Errorf("commit: %w", err)
 			}
@@ -2353,7 +2353,7 @@ func (g *Graveler) AddCommit(ctx context.Context, repository *RepositoryRecord, 
 // addCommitNoLock lower API used to add commit into a repository. It will verify that the commit meta-range is accessible but will not lock any metadata update.
 func (g *Graveler) addCommitNoLock(ctx context.Context, repository *RepositoryRecord, commit Commit) (CommitID, error) {
 	// verify access to meta range
-	ok, err := g.CommittedManager.Exists(ctx, repository.StorageNamespace, commit.MetaRangeID)
+	ok, err := g.CommittedManager.Exists(ctx, repository.StorageID, repository.StorageNamespace, commit.MetaRangeID)
 	if err != nil {
 		return "", fmt.Errorf("checking for meta range %s: %w", commit.MetaRangeID, err)
 	}
@@ -2386,7 +2386,7 @@ func (g *Graveler) checkEmpty(ctx context.Context, repository *RepositoryRecord,
 	if err != nil {
 		return false, err
 	}
-	committedList, err := g.CommittedManager.List(ctx, repository.StorageNamespace, commit.MetaRangeID)
+	committedList, err := g.CommittedManager.List(ctx, repository.StorageID, repository.StorageNamespace, commit.MetaRangeID)
 	if err != nil {
 		return false, err
 	}
@@ -2577,7 +2577,7 @@ func (g *Graveler) ResetKey(ctx context.Context, repository *RepositoryRecord, b
 			return err
 		}
 		if branch.CompactedBaseMetaRangeID != "" {
-			uncommittedValue, err = g.CommittedManager.Get(ctx, repository.StorageNamespace, branch.CompactedBaseMetaRangeID, key)
+			uncommittedValue, err = g.CommittedManager.Get(ctx, repository.StorageID, repository.StorageNamespace, branch.CompactedBaseMetaRangeID, key)
 			if err != nil && !errors.Is(err, ErrNotFound) {
 				return err
 			}
@@ -3084,7 +3084,7 @@ func (g *Graveler) Import(ctx context.Context, repository *RepositoryRecord, des
 			"destination_meta_range": toCommit.MetaRangeID,
 		}).Trace("Import")
 
-		metaRangeID, err := g.CommittedManager.Import(ctx, storageNamespace, toCommit.MetaRangeID, source, prefixes)
+		metaRangeID, err := g.CommittedManager.Import(ctx, repository.StorageID, storageNamespace, toCommit.MetaRangeID, source, prefixes)
 		if err != nil {
 			if !errors.Is(err, ErrUserVisible) {
 				err = fmt.Errorf("merge in CommitManager: %w", err)
@@ -3188,7 +3188,7 @@ func (g *Graveler) diffUncommitted(ctx context.Context, repository *RepositoryRe
 	if err != nil {
 		return nil, err
 	}
-	committedValueIterator, err := g.CommittedManager.List(ctx, repository.StorageNamespace, metaRangeID)
+	committedValueIterator, err := g.CommittedManager.List(ctx, repository.StorageID, repository.StorageNamespace, metaRangeID)
 	if err != nil {
 		valueIterator.Close()
 		return nil, err
@@ -3197,7 +3197,7 @@ func (g *Graveler) diffUncommitted(ctx context.Context, repository *RepositoryRe
 		return NewUncommittedDiffIterator(ctx, committedValueIterator, valueIterator), nil
 	}
 	// return the diff of staging + sealed from committed on top of the diff of compacted from committed
-	diffCommitAndCompacted, err := g.CommittedManager.Diff(ctx, repository.StorageNamespace, metaRangeID, branch.CompactedBaseMetaRangeID)
+	diffCommitAndCompacted, err := g.CommittedManager.Diff(ctx, repository.StorageID, repository.StorageNamespace, metaRangeID, branch.CompactedBaseMetaRangeID)
 	if err != nil {
 		valueIterator.Close()
 		committedValueIterator.Close()
@@ -3240,14 +3240,14 @@ func (g *Graveler) Diff(ctx context.Context, repository *RepositoryRecord, left,
 	if err != nil {
 		return nil, err
 	}
-	diff, err := g.CommittedManager.Diff(ctx, repository.StorageNamespace, leftCommit.MetaRangeID, rightCommit.MetaRangeID)
+	diff, err := g.CommittedManager.Diff(ctx, repository.StorageID, repository.StorageNamespace, leftCommit.MetaRangeID, rightCommit.MetaRangeID)
 	if err != nil {
 		return nil, err
 	}
 	if rightRawRef.ResolvedBranchModifier != ResolvedBranchModifierStaging {
 		return diff, nil
 	}
-	leftValueIterator, err := g.CommittedManager.List(ctx, repository.StorageNamespace, leftCommit.MetaRangeID)
+	leftValueIterator, err := g.CommittedManager.List(ctx, repository.StorageID, repository.StorageNamespace, leftCommit.MetaRangeID)
 	if err != nil {
 		return nil, err
 	}
@@ -3266,7 +3266,7 @@ func (g *Graveler) Diff(ctx context.Context, repository *RepositoryRecord, left,
 		return NewCombinedDiffIterator(diff, leftValueIterator, stagingIterator), nil
 	}
 	diff.Close()
-	compactedDiffIterator, err := g.CommittedManager.Diff(ctx, repository.StorageNamespace, leftCommit.MetaRangeID, rightBranch.CompactedBaseMetaRangeID)
+	compactedDiffIterator, err := g.CommittedManager.Diff(ctx, repository.StorageID, repository.StorageNamespace, leftCommit.MetaRangeID, rightBranch.CompactedBaseMetaRangeID)
 	if err != nil {
 		leftValueIterator.Close()
 		stagingIterator.Close()
@@ -3299,7 +3299,7 @@ func (g *Graveler) Compare(ctx context.Context, repository *RepositoryRecord, le
 	if err != nil {
 		return nil, err
 	}
-	return g.CommittedManager.Compare(ctx, repository.StorageNamespace, toCommit.MetaRangeID, fromCommit.MetaRangeID, baseCommit.MetaRangeID)
+	return g.CommittedManager.Compare(ctx, repository.StorageID, repository.StorageNamespace, toCommit.MetaRangeID, fromCommit.MetaRangeID, baseCommit.MetaRangeID)
 }
 
 func (g *Graveler) SetHooksHandler(handler HooksHandler) {
@@ -3316,7 +3316,7 @@ func (g *Graveler) LoadCommits(ctx context.Context, repository *RepositoryRecord
 		return ErrReadOnlyRepository
 	}
 
-	iter, err := g.CommittedManager.List(ctx, repository.StorageNamespace, metaRangeID)
+	iter, err := g.CommittedManager.List(ctx, repository.StorageID, repository.StorageNamespace, metaRangeID)
 	if err != nil {
 		return err
 	}
@@ -3364,7 +3364,7 @@ func (g *Graveler) LoadBranches(ctx context.Context, repository *RepositoryRecor
 	if repository.ReadOnly && !options.Force {
 		return ErrReadOnlyRepository
 	}
-	iter, err := g.CommittedManager.List(ctx, repository.StorageNamespace, metaRangeID)
+	iter, err := g.CommittedManager.List(ctx, repository.StorageID, repository.StorageNamespace, metaRangeID)
 	if err != nil {
 		return err
 	}
@@ -3397,7 +3397,7 @@ func (g *Graveler) LoadTags(ctx context.Context, repository *RepositoryRecord, m
 	if repository.ReadOnly && !options.Force {
 		return ErrReadOnlyRepository
 	}
-	iter, err := g.CommittedManager.List(ctx, repository.StorageNamespace, metaRangeID)
+	iter, err := g.CommittedManager.List(ctx, repository.StorageID, repository.StorageNamespace, metaRangeID)
 	if err != nil {
 		return err
 	}

--- a/pkg/graveler/graveler.go
+++ b/pkg/graveler/graveler.go
@@ -15,6 +15,7 @@ import (
 	"github.com/prometheus/client_golang/prometheus"
 	"github.com/prometheus/client_golang/prometheus/promauto"
 	"github.com/rs/xid"
+	"github.com/treeverse/lakefs/pkg/graveler/committed"
 	"github.com/treeverse/lakefs/pkg/ident"
 	"github.com/treeverse/lakefs/pkg/kv"
 	"github.com/treeverse/lakefs/pkg/logging"
@@ -1049,12 +1050,14 @@ type CommittedManager interface {
 	Commit(ctx context.Context, storageID StorageID, ns StorageNamespace, baseMetaRangeID MetaRangeID, changes ValueIterator, allowEmpty bool, opts ...SetOptionsFunc) (MetaRangeID, DiffSummary, error)
 
 	// GetMetaRange returns information where metarangeID is stored.
-	GetMetaRange(ctx context.Context, ns StorageNamespace, metaRangeID MetaRangeID) (MetaRangeAddress, error)
+	GetMetaRange(ctx context.Context, storageID StorageID, ns StorageNamespace, metaRangeID MetaRangeID) (MetaRangeAddress, error)
 	// GetRange returns information where rangeID is stored.
-	GetRange(ctx context.Context, ns StorageNamespace, rangeID RangeID) (RangeAddress, error)
+	GetRange(ctx context.Context, storageID StorageID, ns StorageNamespace, rangeID RangeID) (RangeAddress, error)
 
 	// GetRangeIDByKey returns the RangeID that contains the given key.
 	GetRangeIDByKey(ctx context.Context, storageID StorageID, ns StorageNamespace, id MetaRangeID, key Key) (RangeID, error)
+
+	AddMetadataManager(storageID StorageID, metadataManager committed.MetaRangeManager)
 }
 
 // StagingManager manages entries in a staging area, denoted by a staging token
@@ -3419,11 +3422,11 @@ func (g *Graveler) LoadTags(ctx context.Context, repository *RepositoryRecord, m
 }
 
 func (g *Graveler) GetMetaRange(ctx context.Context, repository *RepositoryRecord, metaRangeID MetaRangeID) (MetaRangeAddress, error) {
-	return g.CommittedManager.GetMetaRange(ctx, repository.StorageNamespace, metaRangeID)
+	return g.CommittedManager.GetMetaRange(ctx, repository.StorageID, repository.StorageNamespace, metaRangeID)
 }
 
 func (g *Graveler) GetRange(ctx context.Context, repository *RepositoryRecord, rangeID RangeID) (RangeAddress, error) {
-	return g.CommittedManager.GetRange(ctx, repository.StorageNamespace, rangeID)
+	return g.CommittedManager.GetRange(ctx, repository.StorageID, repository.StorageNamespace, rangeID)
 }
 
 func (g *Graveler) DumpCommits(ctx context.Context, repository *RepositoryRecord) (*MetaRangeID, error) {

--- a/pkg/graveler/graveler_v2_test.go
+++ b/pkg/graveler/graveler_v2_test.go
@@ -3,7 +3,6 @@ package graveler_test
 import (
 	"context"
 	"errors"
-	"github.com/treeverse/lakefs/pkg/graveler/committed"
 	"slices"
 	"testing"
 	"time"
@@ -114,7 +113,7 @@ func TestGravelerGet(t *testing.T) {
 		test.StagingManager.EXPECT().Get(ctx, stagingToken3, key1).Times(1).Return(nil, graveler.ErrNotFound)
 
 		test.RefManager.EXPECT().GetCommit(ctx, repository, commit1ID).Times(1).Return(&commit1, nil)
-		test.CommittedManager.EXPECT().Get(ctx, committed.StorageID(""), repository.StorageNamespace, commit1.MetaRangeID, key1).Times(1).Return(value1, nil)
+		test.CommittedManager.EXPECT().Get(ctx, graveler.StorageID(""), repository.StorageNamespace, commit1.MetaRangeID, key1).Times(1).Return(value1, nil)
 
 		val, err := test.Sut.Get(ctx, repository, graveler.Ref(branch1ID), key1)
 
@@ -160,7 +159,7 @@ func TestGravelerGet(t *testing.T) {
 		test.StagingManager.EXPECT().Get(ctx, stagingToken1, key1).Times(1).Return(value1, nil)
 
 		test.RefManager.EXPECT().GetCommit(ctx, repository, commit1ID).Times(1).Return(&commit1, nil)
-		test.CommittedManager.EXPECT().Get(ctx, "", repository.StorageNamespace, commit1.MetaRangeID, key1).Times(1).Return(value1, nil)
+		test.CommittedManager.EXPECT().Get(ctx, graveler.StorageID(""), repository.StorageNamespace, commit1.MetaRangeID, key1).Times(1).Return(value1, nil)
 
 		val, err := test.Sut.Get(ctx, repository, graveler.Ref(branch1ID), key1, graveler.WithStageOnly(true))
 
@@ -177,7 +176,7 @@ func TestGravelerGet(t *testing.T) {
 		test.StagingManager.EXPECT().Get(ctx, stagingToken2, key1).Times(1).Return(nil, graveler.ErrNotFound)
 		test.StagingManager.EXPECT().Get(ctx, stagingToken3, key1).Times(1).Return(nil, graveler.ErrNotFound)
 
-		test.CommittedManager.EXPECT().Get(ctx, "", repository.StorageNamespace, mr2ID, key1).Times(1).Return(value1, nil)
+		test.CommittedManager.EXPECT().Get(ctx, graveler.StorageID(""), repository.StorageNamespace, mr2ID, key1).Times(1).Return(value1, nil)
 
 		val, err := test.Sut.Get(ctx, repository, graveler.Ref(branch3ID), key1)
 
@@ -195,10 +194,10 @@ func TestGravelerGet(t *testing.T) {
 		test.StagingManager.EXPECT().Get(ctx, stagingToken2, key1).Times(1).Return(nil, graveler.ErrNotFound)
 		test.StagingManager.EXPECT().Get(ctx, stagingToken3, key1).Times(1).Return(nil, graveler.ErrNotFound)
 
-		test.CommittedManager.EXPECT().Get(ctx, "", repository.StorageNamespace, mr2ID, key1).Times(1).Return(value1, nil)
+		test.CommittedManager.EXPECT().Get(ctx, graveler.StorageID(""), repository.StorageNamespace, mr2ID, key1).Times(1).Return(value1, nil)
 
 		test.RefManager.EXPECT().GetCommit(ctx, repository, commit1ID).Times(1).Return(&commit1, nil)
-		test.CommittedManager.EXPECT().Get(ctx, "", repository.StorageNamespace, commit1.MetaRangeID, key1).Times(1).Return(value1, nil)
+		test.CommittedManager.EXPECT().Get(ctx, graveler.StorageID(""), repository.StorageNamespace, commit1.MetaRangeID, key1).Times(1).Return(value1, nil)
 
 		val, err := test.Sut.Get(ctx, repository, graveler.Ref(branch3ID), key1, graveler.WithStageOnly(true))
 

--- a/pkg/graveler/graveler_v2_test.go
+++ b/pkg/graveler/graveler_v2_test.go
@@ -214,10 +214,10 @@ func TestGravelerGet(t *testing.T) {
 		test.StagingManager.EXPECT().Get(ctx, stagingToken2, key1).Times(1).Return(nil, graveler.ErrNotFound)
 		test.StagingManager.EXPECT().Get(ctx, stagingToken3, key1).Times(1).Return(nil, graveler.ErrNotFound)
 
-		test.CommittedManager.EXPECT().Get(ctx, "", repository.StorageNamespace, mr2ID, key1).Times(1).Return(value1, nil)
+		test.CommittedManager.EXPECT().Get(ctx, graveler.StorageID(""), repository.StorageNamespace, mr2ID, key1).Times(1).Return(value1, nil)
 		test.RefManager.EXPECT().GetCommit(ctx, repository, commit1ID).Times(1).Return(&commit1, nil)
 
-		test.CommittedManager.EXPECT().Get(ctx, "", repository.StorageNamespace, commit1.MetaRangeID, key1).Times(1).Return(value2, nil)
+		test.CommittedManager.EXPECT().Get(ctx, graveler.StorageID(""), repository.StorageNamespace, commit1.MetaRangeID, key1).Times(1).Return(value2, nil)
 		val, err := test.Sut.Get(ctx, repository, graveler.Ref(branch3ID), key1, graveler.WithStageOnly(true))
 
 		require.NoError(t, err)
@@ -234,10 +234,10 @@ func TestGravelerGet(t *testing.T) {
 		test.StagingManager.EXPECT().Get(ctx, stagingToken2, key1).Times(1).Return(nil, graveler.ErrNotFound)
 		test.StagingManager.EXPECT().Get(ctx, stagingToken3, key1).Times(1).Return(nil, graveler.ErrNotFound)
 
-		test.CommittedManager.EXPECT().Get(ctx, "", repository.StorageNamespace, mr2ID, key1).Times(1).Return(value1, nil)
+		test.CommittedManager.EXPECT().Get(ctx, graveler.StorageID(""), repository.StorageNamespace, mr2ID, key1).Times(1).Return(value1, nil)
 		test.RefManager.EXPECT().GetCommit(ctx, repository, commit1ID).Times(1).Return(&commit1, nil)
 
-		test.CommittedManager.EXPECT().Get(ctx, "", repository.StorageNamespace, commit1.MetaRangeID, key1).Times(1).Return(nil, graveler.ErrNotFound)
+		test.CommittedManager.EXPECT().Get(ctx, graveler.StorageID(""), repository.StorageNamespace, commit1.MetaRangeID, key1).Times(1).Return(nil, graveler.ErrNotFound)
 		val, err := test.Sut.Get(ctx, repository, graveler.Ref(branch3ID), key1, graveler.WithStageOnly(true))
 
 		require.NoError(t, err)
@@ -267,7 +267,7 @@ func TestGravelerGet(t *testing.T) {
 		test.StagingManager.EXPECT().Get(ctx, stagingToken2, key1).Times(1).Return(nil, graveler.ErrNotFound)
 		test.StagingManager.EXPECT().Get(ctx, stagingToken3, key1).Times(1).Return(nil, graveler.ErrNotFound)
 
-		test.CommittedManager.EXPECT().Get(ctx, "", repository.StorageNamespace, mr2ID, key1).Times(1).Return(nil, graveler.ErrNotFound)
+		test.CommittedManager.EXPECT().Get(ctx, graveler.StorageID(""), repository.StorageNamespace, mr2ID, key1).Times(1).Return(nil, graveler.ErrNotFound)
 
 		val, err := test.Sut.Get(ctx, repository, graveler.Ref(branch3ID), key1)
 
@@ -284,7 +284,7 @@ func TestGravelerGet(t *testing.T) {
 		test.StagingManager.EXPECT().Get(ctx, stagingToken3, key1).Times(1).Return(nil, graveler.ErrNotFound)
 
 		test.RefManager.EXPECT().GetCommit(ctx, repository, commit1ID).Times(1).Return(&commit1, nil)
-		test.CommittedManager.EXPECT().Get(ctx, "", repository.StorageNamespace, commit1.MetaRangeID, key1).Times(1).Return(nil, graveler.ErrNotFound)
+		test.CommittedManager.EXPECT().Get(ctx, graveler.StorageID(""), repository.StorageNamespace, commit1.MetaRangeID, key1).Times(1).Return(nil, graveler.ErrNotFound)
 
 		val, err := test.Sut.Get(ctx, repository, graveler.Ref(branch1ID), key1)
 
@@ -297,7 +297,7 @@ func TestGravelerGet(t *testing.T) {
 		setupGetFromCommit(test)
 
 		test.RefManager.EXPECT().GetCommit(ctx, repository, commit1ID).Times(1).Return(&commit1, nil)
-		test.CommittedManager.EXPECT().Get(ctx, "", repository.StorageNamespace, commit1.MetaRangeID, key1).Times(1).Return(value1, nil)
+		test.CommittedManager.EXPECT().Get(ctx, graveler.StorageID(""), repository.StorageNamespace, commit1.MetaRangeID, key1).Times(1).Return(value1, nil)
 
 		val, err := test.Sut.Get(ctx, repository, graveler.Ref(commit1ID), key1)
 
@@ -311,7 +311,7 @@ func TestGravelerGet(t *testing.T) {
 		setupGetFromCommit(test)
 
 		test.RefManager.EXPECT().GetCommit(ctx, repository, commit1ID).Times(1).Return(&commit1, nil)
-		test.CommittedManager.EXPECT().Get(ctx, "", repository.StorageNamespace, commit1.MetaRangeID, key1).Times(1).Return(nil, graveler.ErrNotFound)
+		test.CommittedManager.EXPECT().Get(ctx, graveler.StorageID(""), repository.StorageNamespace, commit1.MetaRangeID, key1).Times(1).Return(nil, graveler.ErrNotFound)
 
 		val, err := test.Sut.Get(ctx, repository, graveler.Ref(commit1ID), key1)
 
@@ -351,7 +351,7 @@ func TestGravelerMerge(t *testing.T) {
 		firstUpdateBranch(test)
 		emptyStagingTokenCombo(test, 2)
 		test.RefManager.EXPECT().GetCommit(ctx, repository, commit1ID).Times(3).Return(&commit1, nil)
-		test.CommittedManager.EXPECT().List(ctx, "", repository.StorageNamespace, mr1ID).Times(2).Return(testutils.NewFakeValueIterator(nil), nil)
+		test.CommittedManager.EXPECT().List(ctx, graveler.StorageID(""), repository.StorageNamespace, mr1ID).Times(2).Return(testutils.NewFakeValueIterator(nil), nil)
 		test.RefManager.EXPECT().ParseRef(graveler.Ref(branch2ID)).Times(1).Return(rawRefCommit2, nil)
 		test.RefManager.EXPECT().ParseRef(graveler.Ref(branch1ID)).Times(1).Return(rawRefCommit1, nil)
 		test.RefManager.EXPECT().ResolveRawRef(ctx, repository, rawRefCommit2).Times(1).Return(&graveler.ResolvedRef{Type: graveler.ReferenceTypeCommit, BranchRecord: graveler.BranchRecord{Branch: &graveler.Branch{CommitID: commit2ID}}}, nil)
@@ -408,7 +408,7 @@ func TestGravelerMerge(t *testing.T) {
 			Value: value1,
 		}}))
 		test.RefManager.EXPECT().GetCommit(ctx, repository, commit1ID).Times(1).Return(&commit1, nil)
-		test.CommittedManager.EXPECT().List(ctx, "", repository.StorageNamespace, mr1ID).Times(1).Return(testutils.NewFakeValueIterator(nil), nil)
+		test.CommittedManager.EXPECT().List(ctx, graveler.StorageID(""), repository.StorageNamespace, mr1ID).Times(1).Return(testutils.NewFakeValueIterator(nil), nil)
 
 		val, err := test.Sut.Merge(ctx, repository, branch1ID, graveler.Ref(branch2ID), graveler.CommitParams{Metadata: graveler.Metadata{}}, "")
 		require.Equal(t, graveler.ErrDirtyBranch, err)
@@ -427,8 +427,8 @@ func TestGravelerMerge(t *testing.T) {
 				return err
 			}).Times(1)
 		test.RefManager.EXPECT().GetCommit(ctx, repository, commit1ID).Times(1).Return(&commit1, nil)
-		test.CommittedManager.EXPECT().List(ctx, "", repository.StorageNamespace, mr1ID).Times(1).Return(testutils.NewFakeValueIterator(nil), nil)
-		test.CommittedManager.EXPECT().Diff(ctx, "", repository.StorageNamespace, mr1ID, mr2ID).Times(1).Return(testutil.NewDiffIter([]graveler.Diff{{Key: key1, Type: graveler.DiffTypeRemoved}}), nil)
+		test.CommittedManager.EXPECT().List(ctx, graveler.StorageID(""), repository.StorageNamespace, mr1ID).Times(1).Return(testutils.NewFakeValueIterator(nil), nil)
+		test.CommittedManager.EXPECT().Diff(ctx, graveler.StorageID(""), repository.StorageNamespace, mr1ID, mr2ID).Times(1).Return(testutil.NewDiffIter([]graveler.Diff{{Key: key1, Type: graveler.DiffTypeRemoved}}), nil)
 
 		test.StagingManager.EXPECT().List(ctx, stagingToken1, gomock.Any()).Times(1).Return(testutils.NewFakeValueIterator(nil))
 		test.StagingManager.EXPECT().List(ctx, stagingToken2, gomock.Any()).Times(1).Return(testutils.NewFakeValueIterator(nil))
@@ -450,7 +450,7 @@ func TestGravelerMerge(t *testing.T) {
 		firstUpdateBranch(test)
 		emptyStagingTokenCombo(test, 2)
 		test.RefManager.EXPECT().GetCommit(ctx, repository, commit1ID).Times(3).Return(&commit1, nil)
-		test.CommittedManager.EXPECT().List(ctx, "", repository.StorageNamespace, mr1ID).Times(2).Return(testutils.NewFakeValueIterator(nil), nil)
+		test.CommittedManager.EXPECT().List(ctx, graveler.StorageID(""), repository.StorageNamespace, mr1ID).Times(2).Return(testutils.NewFakeValueIterator(nil), nil)
 		test.RefManager.EXPECT().ParseRef(graveler.Ref(branch2ID)).Times(1).Return(rawRefCommit2, nil)
 		test.RefManager.EXPECT().ParseRef(graveler.Ref(branch1ID)).Times(1).Return(rawRefCommit1, nil)
 		test.RefManager.EXPECT().ResolveRawRef(ctx, repository, rawRefCommit2).Times(1).Return(&graveler.ResolvedRef{Type: graveler.ReferenceTypeCommit, BranchRecord: graveler.BranchRecord{Branch: &graveler.Branch{CommitID: commit2ID}}}, nil)
@@ -492,7 +492,7 @@ func TestGravelerMerge(t *testing.T) {
 		firstUpdateBranch(test)
 		emptyStagingTokenCombo(test, 1)
 		test.RefManager.EXPECT().GetCommit(ctx, repository, commit1ID).Times(1).Return(&commit1, nil)
-		test.CommittedManager.EXPECT().List(ctx, "", repository.StorageNamespace, mr1ID).Times(1).Return(testutils.NewFakeValueIterator(nil), nil)
+		test.CommittedManager.EXPECT().List(ctx, graveler.StorageID(""), repository.StorageNamespace, mr1ID).Times(1).Return(testutils.NewFakeValueIterator(nil), nil)
 		test.RefManager.EXPECT().BranchUpdate(ctx, repository, branch1ID, gomock.Any()).
 			DoAndReturn(func(_ context.Context, _ *graveler.RepositoryRecord, _ graveler.BranchID, f graveler.BranchUpdateFunc) error {
 				return kv.ErrPredicateFailed
@@ -542,7 +542,7 @@ func TestGravelerRevert(t *testing.T) {
 
 	setupSuccessfulRevertExpectations := func(test *testutil.GravelerTest) {
 		test.RefManager.EXPECT().GetCommit(ctx, repository, commit1ID).Times(3).Return(&commit1, nil)
-		test.CommittedManager.EXPECT().List(ctx, "", repository.StorageNamespace, mr1ID).Times(2).Return(testutils.NewFakeValueIterator(nil), nil)
+		test.CommittedManager.EXPECT().List(ctx, graveler.StorageID(""), repository.StorageNamespace, mr1ID).Times(2).Return(testutils.NewFakeValueIterator(nil), nil)
 		test.RefManager.EXPECT().ParseRef(graveler.Ref(commit2ID)).Times(1).Return(rawRefCommit2, nil)
 		test.RefManager.EXPECT().ParseRef(graveler.Ref(commit1ID)).Times(1).Return(rawRefCommit1, nil)
 		test.RefManager.EXPECT().ParseRef(graveler.Ref(commit4ID)).Times(1).Return(rawRefCommit4, nil)
@@ -686,7 +686,7 @@ func TestGravelerRevert(t *testing.T) {
 		dirtyStagingTokenCombo(test)
 
 		test.RefManager.EXPECT().GetCommit(ctx, repository, commit1ID).Times(2).Return(&commit1, nil)
-		test.CommittedManager.EXPECT().List(ctx, "", repository.StorageNamespace, mr1ID).Times(2).Return(testutils.NewFakeValueIterator(nil), nil)
+		test.CommittedManager.EXPECT().List(ctx, graveler.StorageID(""), repository.StorageNamespace, mr1ID).Times(2).Return(testutils.NewFakeValueIterator(nil), nil)
 		test.RefManager.EXPECT().ParseRef(graveler.Ref(commit2ID)).Times(1).Return(rawRefCommit2, nil)
 		test.RefManager.EXPECT().ResolveRawRef(ctx, repository, rawRefCommit2).Times(1).Return(&graveler.ResolvedRef{Type: graveler.ReferenceTypeCommit, BranchRecord: graveler.BranchRecord{Branch: &graveler.Branch{CommitID: commit2ID}}}, nil)
 		test.RefManager.EXPECT().GetCommit(ctx, repository, commit2ID).Times(1).Return(&commit2, nil)
@@ -735,7 +735,7 @@ func TestGravelerCherryPick(t *testing.T) {
 
 	setupCherryPickExpectations := func(test *testutil.GravelerTest) {
 		test.RefManager.EXPECT().GetCommit(ctx, repository, commit1ID).Times(3).Return(&commit1, nil)
-		test.CommittedManager.EXPECT().List(ctx, "", repository.StorageNamespace, mr1ID).Times(2).Return(testutils.NewFakeValueIterator(nil), nil)
+		test.CommittedManager.EXPECT().List(ctx, graveler.StorageID(""), repository.StorageNamespace, mr1ID).Times(2).Return(testutils.NewFakeValueIterator(nil), nil)
 		test.RefManager.EXPECT().ParseRef(graveler.Ref(commit2ID)).Times(1).Return(rawRefCommit2, nil)
 		test.RefManager.EXPECT().ParseRef(graveler.Ref(commit1ID)).Times(1).Return(rawRefCommit1, nil)
 		test.RefManager.EXPECT().ParseRef(graveler.Ref(commit4ID)).Times(1).Return(rawRefCommit4, nil)
@@ -883,7 +883,7 @@ func TestGravelerCommit_v2(t *testing.T) {
 		test.StagingManager.EXPECT().List(ctx, stagingToken1, gomock.Any()).Times(1).Return(testutils.NewFakeValueIterator([]*graveler.ValueRecord{}))
 		test.StagingManager.EXPECT().List(ctx, stagingToken2, gomock.Any()).Times(1).Return(testutils.NewFakeValueIterator([]*graveler.ValueRecord{}))
 		test.StagingManager.EXPECT().List(ctx, stagingToken3, gomock.Any()).Times(1).Return(testutils.NewFakeValueIterator([]*graveler.ValueRecord{}))
-		test.CommittedManager.EXPECT().Commit(ctx, repository.StorageNamespace, mr1ID, gomock.Any(), false, []graveler.SetOptionsFunc{}).Times(1).Return(graveler.MetaRangeID(""), graveler.DiffSummary{}, nil)
+		test.CommittedManager.EXPECT().Commit(ctx, graveler.StorageID(""), repository.StorageNamespace, mr1ID, gomock.Any(), false, []graveler.SetOptionsFunc{}).Times(1).Return(graveler.MetaRangeID(""), graveler.DiffSummary{}, nil)
 		test.RefManager.EXPECT().AddCommit(ctx, repository, gomock.Any()).Return(graveler.CommitID(""), nil)
 		test.StagingManager.EXPECT().DropAsync(ctx, stagingToken1).Return(nil)
 		test.StagingManager.EXPECT().DropAsync(ctx, stagingToken2).Return(nil)
@@ -925,7 +925,7 @@ func TestGravelerCommit_v2(t *testing.T) {
 		test.StagingManager.EXPECT().List(ctx, stagingToken1, gomock.Any()).Times(1).Return(testutils.NewFakeValueIterator([]*graveler.ValueRecord{}))
 		test.StagingManager.EXPECT().List(ctx, stagingToken2, gomock.Any()).Times(1).Return(testutils.NewFakeValueIterator([]*graveler.ValueRecord{}))
 		test.StagingManager.EXPECT().List(ctx, stagingToken3, gomock.Any()).Times(1).Return(testutils.NewFakeValueIterator([]*graveler.ValueRecord{}))
-		test.CommittedManager.EXPECT().Commit(ctx, repository.StorageNamespace, mr1ID, gomock.Any(), false, []graveler.SetOptionsFunc{}).Times(1).Return(graveler.MetaRangeID(""), graveler.DiffSummary{}, graveler.ErrNoChanges)
+		test.CommittedManager.EXPECT().Commit(ctx, graveler.StorageID(""), repository.StorageNamespace, mr1ID, gomock.Any(), false, []graveler.SetOptionsFunc{}).Times(1).Return(graveler.MetaRangeID(""), graveler.DiffSummary{}, graveler.ErrNoChanges)
 
 		val, err := test.Sut.Commit(ctx, repository, branch1ID, graveler.CommitParams{})
 
@@ -1011,10 +1011,10 @@ func TestGravelerImport(t *testing.T) {
 		firstUpdateBranch(test)
 		emptyStagingTokenCombo(test, 2)
 		test.RefManager.EXPECT().GetCommit(ctx, repository, commit1ID).Times(3).Return(&commit1, nil)
-		test.CommittedManager.EXPECT().List(ctx, "", repository.StorageNamespace, mr1ID).Times(2).Return(testutils.NewFakeValueIterator(nil), nil)
+		test.CommittedManager.EXPECT().List(ctx, graveler.StorageID(""), repository.StorageNamespace, mr1ID).Times(2).Return(testutils.NewFakeValueIterator(nil), nil)
 		test.RefManager.EXPECT().ParseRef(graveler.Ref(branch1ID)).Times(1).Return(rawRefCommit1, nil)
 		test.RefManager.EXPECT().ResolveRawRef(ctx, repository, rawRefCommit1).Times(1).Return(&graveler.ResolvedRef{Type: graveler.ReferenceTypeCommit, BranchRecord: graveler.BranchRecord{Branch: &graveler.Branch{CommitID: commit1ID}}}, nil)
-		test.CommittedManager.EXPECT().Import(ctx, repository.StorageNamespace, mr1ID, mr2ID, nil, []graveler.SetOptionsFunc{}).Times(1).Return(mr4ID, nil)
+		test.CommittedManager.EXPECT().Import(ctx, graveler.StorageID(""), repository.StorageNamespace, mr1ID, mr2ID, nil, []graveler.SetOptionsFunc{}).Times(1).Return(mr4ID, nil)
 		test.RefManager.EXPECT().AddCommit(ctx, repository, gomock.Any()).DoAndReturn(func(ctx context.Context, repository *graveler.RepositoryRecord, commit graveler.Commit) (graveler.CommitID, error) {
 			require.Equal(t, mr4ID, commit.MetaRangeID)
 			return commit4ID, nil

--- a/pkg/graveler/graveler_v2_test.go
+++ b/pkg/graveler/graveler_v2_test.go
@@ -3,6 +3,7 @@ package graveler_test
 import (
 	"context"
 	"errors"
+	"github.com/treeverse/lakefs/pkg/graveler/committed"
 	"slices"
 	"testing"
 	"time"
@@ -113,7 +114,7 @@ func TestGravelerGet(t *testing.T) {
 		test.StagingManager.EXPECT().Get(ctx, stagingToken3, key1).Times(1).Return(nil, graveler.ErrNotFound)
 
 		test.RefManager.EXPECT().GetCommit(ctx, repository, commit1ID).Times(1).Return(&commit1, nil)
-		test.CommittedManager.EXPECT().Get(ctx, repository.StorageNamespace, commit1.MetaRangeID, key1).Times(1).Return(value1, nil)
+		test.CommittedManager.EXPECT().Get(ctx, committed.StorageID(""), repository.StorageNamespace, commit1.MetaRangeID, key1).Times(1).Return(value1, nil)
 
 		val, err := test.Sut.Get(ctx, repository, graveler.Ref(branch1ID), key1)
 
@@ -143,7 +144,7 @@ func TestGravelerGet(t *testing.T) {
 		test.StagingManager.EXPECT().Get(ctx, stagingToken1, key1).Times(1).Return(value1, nil)
 
 		test.RefManager.EXPECT().GetCommit(ctx, repository, commit1ID).Times(1).Return(&commit1, nil)
-		test.CommittedManager.EXPECT().Get(ctx, repository.StorageNamespace, commit1.MetaRangeID, key1).Times(1).Return(value2, nil)
+		test.CommittedManager.EXPECT().Get(ctx, graveler.StorageID(""), repository.StorageNamespace, commit1.MetaRangeID, key1).Times(1).Return(value2, nil)
 
 		val, err := test.Sut.Get(ctx, repository, graveler.Ref(branch1ID), key1, graveler.WithStageOnly(true))
 
@@ -159,7 +160,7 @@ func TestGravelerGet(t *testing.T) {
 		test.StagingManager.EXPECT().Get(ctx, stagingToken1, key1).Times(1).Return(value1, nil)
 
 		test.RefManager.EXPECT().GetCommit(ctx, repository, commit1ID).Times(1).Return(&commit1, nil)
-		test.CommittedManager.EXPECT().Get(ctx, repository.StorageNamespace, commit1.MetaRangeID, key1).Times(1).Return(value1, nil)
+		test.CommittedManager.EXPECT().Get(ctx, "", repository.StorageNamespace, commit1.MetaRangeID, key1).Times(1).Return(value1, nil)
 
 		val, err := test.Sut.Get(ctx, repository, graveler.Ref(branch1ID), key1, graveler.WithStageOnly(true))
 
@@ -176,7 +177,7 @@ func TestGravelerGet(t *testing.T) {
 		test.StagingManager.EXPECT().Get(ctx, stagingToken2, key1).Times(1).Return(nil, graveler.ErrNotFound)
 		test.StagingManager.EXPECT().Get(ctx, stagingToken3, key1).Times(1).Return(nil, graveler.ErrNotFound)
 
-		test.CommittedManager.EXPECT().Get(ctx, repository.StorageNamespace, mr2ID, key1).Times(1).Return(value1, nil)
+		test.CommittedManager.EXPECT().Get(ctx, "", repository.StorageNamespace, mr2ID, key1).Times(1).Return(value1, nil)
 
 		val, err := test.Sut.Get(ctx, repository, graveler.Ref(branch3ID), key1)
 
@@ -194,10 +195,10 @@ func TestGravelerGet(t *testing.T) {
 		test.StagingManager.EXPECT().Get(ctx, stagingToken2, key1).Times(1).Return(nil, graveler.ErrNotFound)
 		test.StagingManager.EXPECT().Get(ctx, stagingToken3, key1).Times(1).Return(nil, graveler.ErrNotFound)
 
-		test.CommittedManager.EXPECT().Get(ctx, repository.StorageNamespace, mr2ID, key1).Times(1).Return(value1, nil)
+		test.CommittedManager.EXPECT().Get(ctx, "", repository.StorageNamespace, mr2ID, key1).Times(1).Return(value1, nil)
 
 		test.RefManager.EXPECT().GetCommit(ctx, repository, commit1ID).Times(1).Return(&commit1, nil)
-		test.CommittedManager.EXPECT().Get(ctx, repository.StorageNamespace, commit1.MetaRangeID, key1).Times(1).Return(value1, nil)
+		test.CommittedManager.EXPECT().Get(ctx, "", repository.StorageNamespace, commit1.MetaRangeID, key1).Times(1).Return(value1, nil)
 
 		val, err := test.Sut.Get(ctx, repository, graveler.Ref(branch3ID), key1, graveler.WithStageOnly(true))
 
@@ -214,10 +215,10 @@ func TestGravelerGet(t *testing.T) {
 		test.StagingManager.EXPECT().Get(ctx, stagingToken2, key1).Times(1).Return(nil, graveler.ErrNotFound)
 		test.StagingManager.EXPECT().Get(ctx, stagingToken3, key1).Times(1).Return(nil, graveler.ErrNotFound)
 
-		test.CommittedManager.EXPECT().Get(ctx, repository.StorageNamespace, mr2ID, key1).Times(1).Return(value1, nil)
+		test.CommittedManager.EXPECT().Get(ctx, "", repository.StorageNamespace, mr2ID, key1).Times(1).Return(value1, nil)
 		test.RefManager.EXPECT().GetCommit(ctx, repository, commit1ID).Times(1).Return(&commit1, nil)
 
-		test.CommittedManager.EXPECT().Get(ctx, repository.StorageNamespace, commit1.MetaRangeID, key1).Times(1).Return(value2, nil)
+		test.CommittedManager.EXPECT().Get(ctx, "", repository.StorageNamespace, commit1.MetaRangeID, key1).Times(1).Return(value2, nil)
 		val, err := test.Sut.Get(ctx, repository, graveler.Ref(branch3ID), key1, graveler.WithStageOnly(true))
 
 		require.NoError(t, err)
@@ -234,10 +235,10 @@ func TestGravelerGet(t *testing.T) {
 		test.StagingManager.EXPECT().Get(ctx, stagingToken2, key1).Times(1).Return(nil, graveler.ErrNotFound)
 		test.StagingManager.EXPECT().Get(ctx, stagingToken3, key1).Times(1).Return(nil, graveler.ErrNotFound)
 
-		test.CommittedManager.EXPECT().Get(ctx, repository.StorageNamespace, mr2ID, key1).Times(1).Return(value1, nil)
+		test.CommittedManager.EXPECT().Get(ctx, "", repository.StorageNamespace, mr2ID, key1).Times(1).Return(value1, nil)
 		test.RefManager.EXPECT().GetCommit(ctx, repository, commit1ID).Times(1).Return(&commit1, nil)
 
-		test.CommittedManager.EXPECT().Get(ctx, repository.StorageNamespace, commit1.MetaRangeID, key1).Times(1).Return(nil, graveler.ErrNotFound)
+		test.CommittedManager.EXPECT().Get(ctx, "", repository.StorageNamespace, commit1.MetaRangeID, key1).Times(1).Return(nil, graveler.ErrNotFound)
 		val, err := test.Sut.Get(ctx, repository, graveler.Ref(branch3ID), key1, graveler.WithStageOnly(true))
 
 		require.NoError(t, err)
@@ -267,7 +268,7 @@ func TestGravelerGet(t *testing.T) {
 		test.StagingManager.EXPECT().Get(ctx, stagingToken2, key1).Times(1).Return(nil, graveler.ErrNotFound)
 		test.StagingManager.EXPECT().Get(ctx, stagingToken3, key1).Times(1).Return(nil, graveler.ErrNotFound)
 
-		test.CommittedManager.EXPECT().Get(ctx, repository.StorageNamespace, mr2ID, key1).Times(1).Return(nil, graveler.ErrNotFound)
+		test.CommittedManager.EXPECT().Get(ctx, "", repository.StorageNamespace, mr2ID, key1).Times(1).Return(nil, graveler.ErrNotFound)
 
 		val, err := test.Sut.Get(ctx, repository, graveler.Ref(branch3ID), key1)
 
@@ -284,7 +285,7 @@ func TestGravelerGet(t *testing.T) {
 		test.StagingManager.EXPECT().Get(ctx, stagingToken3, key1).Times(1).Return(nil, graveler.ErrNotFound)
 
 		test.RefManager.EXPECT().GetCommit(ctx, repository, commit1ID).Times(1).Return(&commit1, nil)
-		test.CommittedManager.EXPECT().Get(ctx, repository.StorageNamespace, commit1.MetaRangeID, key1).Times(1).Return(nil, graveler.ErrNotFound)
+		test.CommittedManager.EXPECT().Get(ctx, "", repository.StorageNamespace, commit1.MetaRangeID, key1).Times(1).Return(nil, graveler.ErrNotFound)
 
 		val, err := test.Sut.Get(ctx, repository, graveler.Ref(branch1ID), key1)
 
@@ -297,7 +298,7 @@ func TestGravelerGet(t *testing.T) {
 		setupGetFromCommit(test)
 
 		test.RefManager.EXPECT().GetCommit(ctx, repository, commit1ID).Times(1).Return(&commit1, nil)
-		test.CommittedManager.EXPECT().Get(ctx, repository.StorageNamespace, commit1.MetaRangeID, key1).Times(1).Return(value1, nil)
+		test.CommittedManager.EXPECT().Get(ctx, "", repository.StorageNamespace, commit1.MetaRangeID, key1).Times(1).Return(value1, nil)
 
 		val, err := test.Sut.Get(ctx, repository, graveler.Ref(commit1ID), key1)
 
@@ -311,7 +312,7 @@ func TestGravelerGet(t *testing.T) {
 		setupGetFromCommit(test)
 
 		test.RefManager.EXPECT().GetCommit(ctx, repository, commit1ID).Times(1).Return(&commit1, nil)
-		test.CommittedManager.EXPECT().Get(ctx, repository.StorageNamespace, commit1.MetaRangeID, key1).Times(1).Return(nil, graveler.ErrNotFound)
+		test.CommittedManager.EXPECT().Get(ctx, "", repository.StorageNamespace, commit1.MetaRangeID, key1).Times(1).Return(nil, graveler.ErrNotFound)
 
 		val, err := test.Sut.Get(ctx, repository, graveler.Ref(commit1ID), key1)
 
@@ -351,7 +352,7 @@ func TestGravelerMerge(t *testing.T) {
 		firstUpdateBranch(test)
 		emptyStagingTokenCombo(test, 2)
 		test.RefManager.EXPECT().GetCommit(ctx, repository, commit1ID).Times(3).Return(&commit1, nil)
-		test.CommittedManager.EXPECT().List(ctx, repository.StorageNamespace, mr1ID).Times(2).Return(testutils.NewFakeValueIterator(nil), nil)
+		test.CommittedManager.EXPECT().List(ctx, "", repository.StorageNamespace, mr1ID).Times(2).Return(testutils.NewFakeValueIterator(nil), nil)
 		test.RefManager.EXPECT().ParseRef(graveler.Ref(branch2ID)).Times(1).Return(rawRefCommit2, nil)
 		test.RefManager.EXPECT().ParseRef(graveler.Ref(branch1ID)).Times(1).Return(rawRefCommit1, nil)
 		test.RefManager.EXPECT().ResolveRawRef(ctx, repository, rawRefCommit2).Times(1).Return(&graveler.ResolvedRef{Type: graveler.ReferenceTypeCommit, BranchRecord: graveler.BranchRecord{Branch: &graveler.Branch{CommitID: commit2ID}}}, nil)
@@ -408,7 +409,7 @@ func TestGravelerMerge(t *testing.T) {
 			Value: value1,
 		}}))
 		test.RefManager.EXPECT().GetCommit(ctx, repository, commit1ID).Times(1).Return(&commit1, nil)
-		test.CommittedManager.EXPECT().List(ctx, repository.StorageNamespace, mr1ID).Times(1).Return(testutils.NewFakeValueIterator(nil), nil)
+		test.CommittedManager.EXPECT().List(ctx, "", repository.StorageNamespace, mr1ID).Times(1).Return(testutils.NewFakeValueIterator(nil), nil)
 
 		val, err := test.Sut.Merge(ctx, repository, branch1ID, graveler.Ref(branch2ID), graveler.CommitParams{Metadata: graveler.Metadata{}}, "")
 		require.Equal(t, graveler.ErrDirtyBranch, err)
@@ -427,8 +428,8 @@ func TestGravelerMerge(t *testing.T) {
 				return err
 			}).Times(1)
 		test.RefManager.EXPECT().GetCommit(ctx, repository, commit1ID).Times(1).Return(&commit1, nil)
-		test.CommittedManager.EXPECT().List(ctx, repository.StorageNamespace, mr1ID).Times(1).Return(testutils.NewFakeValueIterator(nil), nil)
-		test.CommittedManager.EXPECT().Diff(ctx, repository.StorageNamespace, mr1ID, mr2ID).Times(1).Return(testutil.NewDiffIter([]graveler.Diff{{Key: key1, Type: graveler.DiffTypeRemoved}}), nil)
+		test.CommittedManager.EXPECT().List(ctx, "", repository.StorageNamespace, mr1ID).Times(1).Return(testutils.NewFakeValueIterator(nil), nil)
+		test.CommittedManager.EXPECT().Diff(ctx, "", repository.StorageNamespace, mr1ID, mr2ID).Times(1).Return(testutil.NewDiffIter([]graveler.Diff{{Key: key1, Type: graveler.DiffTypeRemoved}}), nil)
 
 		test.StagingManager.EXPECT().List(ctx, stagingToken1, gomock.Any()).Times(1).Return(testutils.NewFakeValueIterator(nil))
 		test.StagingManager.EXPECT().List(ctx, stagingToken2, gomock.Any()).Times(1).Return(testutils.NewFakeValueIterator(nil))
@@ -450,7 +451,7 @@ func TestGravelerMerge(t *testing.T) {
 		firstUpdateBranch(test)
 		emptyStagingTokenCombo(test, 2)
 		test.RefManager.EXPECT().GetCommit(ctx, repository, commit1ID).Times(3).Return(&commit1, nil)
-		test.CommittedManager.EXPECT().List(ctx, repository.StorageNamespace, mr1ID).Times(2).Return(testutils.NewFakeValueIterator(nil), nil)
+		test.CommittedManager.EXPECT().List(ctx, "", repository.StorageNamespace, mr1ID).Times(2).Return(testutils.NewFakeValueIterator(nil), nil)
 		test.RefManager.EXPECT().ParseRef(graveler.Ref(branch2ID)).Times(1).Return(rawRefCommit2, nil)
 		test.RefManager.EXPECT().ParseRef(graveler.Ref(branch1ID)).Times(1).Return(rawRefCommit1, nil)
 		test.RefManager.EXPECT().ResolveRawRef(ctx, repository, rawRefCommit2).Times(1).Return(&graveler.ResolvedRef{Type: graveler.ReferenceTypeCommit, BranchRecord: graveler.BranchRecord{Branch: &graveler.Branch{CommitID: commit2ID}}}, nil)
@@ -492,7 +493,7 @@ func TestGravelerMerge(t *testing.T) {
 		firstUpdateBranch(test)
 		emptyStagingTokenCombo(test, 1)
 		test.RefManager.EXPECT().GetCommit(ctx, repository, commit1ID).Times(1).Return(&commit1, nil)
-		test.CommittedManager.EXPECT().List(ctx, repository.StorageNamespace, mr1ID).Times(1).Return(testutils.NewFakeValueIterator(nil), nil)
+		test.CommittedManager.EXPECT().List(ctx, "", repository.StorageNamespace, mr1ID).Times(1).Return(testutils.NewFakeValueIterator(nil), nil)
 		test.RefManager.EXPECT().BranchUpdate(ctx, repository, branch1ID, gomock.Any()).
 			DoAndReturn(func(_ context.Context, _ *graveler.RepositoryRecord, _ graveler.BranchID, f graveler.BranchUpdateFunc) error {
 				return kv.ErrPredicateFailed
@@ -542,7 +543,7 @@ func TestGravelerRevert(t *testing.T) {
 
 	setupSuccessfulRevertExpectations := func(test *testutil.GravelerTest) {
 		test.RefManager.EXPECT().GetCommit(ctx, repository, commit1ID).Times(3).Return(&commit1, nil)
-		test.CommittedManager.EXPECT().List(ctx, repository.StorageNamespace, mr1ID).Times(2).Return(testutils.NewFakeValueIterator(nil), nil)
+		test.CommittedManager.EXPECT().List(ctx, "", repository.StorageNamespace, mr1ID).Times(2).Return(testutils.NewFakeValueIterator(nil), nil)
 		test.RefManager.EXPECT().ParseRef(graveler.Ref(commit2ID)).Times(1).Return(rawRefCommit2, nil)
 		test.RefManager.EXPECT().ParseRef(graveler.Ref(commit1ID)).Times(1).Return(rawRefCommit1, nil)
 		test.RefManager.EXPECT().ParseRef(graveler.Ref(commit4ID)).Times(1).Return(rawRefCommit4, nil)
@@ -686,7 +687,7 @@ func TestGravelerRevert(t *testing.T) {
 		dirtyStagingTokenCombo(test)
 
 		test.RefManager.EXPECT().GetCommit(ctx, repository, commit1ID).Times(2).Return(&commit1, nil)
-		test.CommittedManager.EXPECT().List(ctx, repository.StorageNamespace, mr1ID).Times(2).Return(testutils.NewFakeValueIterator(nil), nil)
+		test.CommittedManager.EXPECT().List(ctx, "", repository.StorageNamespace, mr1ID).Times(2).Return(testutils.NewFakeValueIterator(nil), nil)
 		test.RefManager.EXPECT().ParseRef(graveler.Ref(commit2ID)).Times(1).Return(rawRefCommit2, nil)
 		test.RefManager.EXPECT().ResolveRawRef(ctx, repository, rawRefCommit2).Times(1).Return(&graveler.ResolvedRef{Type: graveler.ReferenceTypeCommit, BranchRecord: graveler.BranchRecord{Branch: &graveler.Branch{CommitID: commit2ID}}}, nil)
 		test.RefManager.EXPECT().GetCommit(ctx, repository, commit2ID).Times(1).Return(&commit2, nil)
@@ -735,7 +736,7 @@ func TestGravelerCherryPick(t *testing.T) {
 
 	setupCherryPickExpectations := func(test *testutil.GravelerTest) {
 		test.RefManager.EXPECT().GetCommit(ctx, repository, commit1ID).Times(3).Return(&commit1, nil)
-		test.CommittedManager.EXPECT().List(ctx, repository.StorageNamespace, mr1ID).Times(2).Return(testutils.NewFakeValueIterator(nil), nil)
+		test.CommittedManager.EXPECT().List(ctx, "", repository.StorageNamespace, mr1ID).Times(2).Return(testutils.NewFakeValueIterator(nil), nil)
 		test.RefManager.EXPECT().ParseRef(graveler.Ref(commit2ID)).Times(1).Return(rawRefCommit2, nil)
 		test.RefManager.EXPECT().ParseRef(graveler.Ref(commit1ID)).Times(1).Return(rawRefCommit1, nil)
 		test.RefManager.EXPECT().ParseRef(graveler.Ref(commit4ID)).Times(1).Return(rawRefCommit4, nil)
@@ -1011,7 +1012,7 @@ func TestGravelerImport(t *testing.T) {
 		firstUpdateBranch(test)
 		emptyStagingTokenCombo(test, 2)
 		test.RefManager.EXPECT().GetCommit(ctx, repository, commit1ID).Times(3).Return(&commit1, nil)
-		test.CommittedManager.EXPECT().List(ctx, repository.StorageNamespace, mr1ID).Times(2).Return(testutils.NewFakeValueIterator(nil), nil)
+		test.CommittedManager.EXPECT().List(ctx, "", repository.StorageNamespace, mr1ID).Times(2).Return(testutils.NewFakeValueIterator(nil), nil)
 		test.RefManager.EXPECT().ParseRef(graveler.Ref(branch1ID)).Times(1).Return(rawRefCommit1, nil)
 		test.RefManager.EXPECT().ResolveRawRef(ctx, repository, rawRefCommit1).Times(1).Return(&graveler.ResolvedRef{Type: graveler.ReferenceTypeCommit, BranchRecord: graveler.BranchRecord{Branch: &graveler.Branch{CommitID: commit1ID}}}, nil)
 		test.CommittedManager.EXPECT().Import(ctx, repository.StorageNamespace, mr1ID, mr2ID, nil, []graveler.SetOptionsFunc{}).Times(1).Return(mr4ID, nil)

--- a/pkg/graveler/mock/graveler.go
+++ b/pkg/graveler/mock/graveler.go
@@ -2813,18 +2813,18 @@ func (mr *MockCommittedManagerMockRecorder) WriteMetaRangeByIterator(ctx, ns, it
 }
 
 // WriteRange mocks base method.
-func (m *MockCommittedManager) WriteRange(ctx context.Context, ns graveler.StorageNamespace, it graveler.ValueIterator) (*graveler.RangeInfo, error) {
+func (m *MockCommittedManager) WriteRange(ctx context.Context, storageID graveler.StorageID, ns graveler.StorageNamespace, it graveler.ValueIterator) (*graveler.RangeInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WriteRange", ctx, ns, it)
+	ret := m.ctrl.Call(m, "WriteRange", ctx, storageID, ns, it)
 	ret0, _ := ret[0].(*graveler.RangeInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // WriteRange indicates an expected call of WriteRange.
-func (mr *MockCommittedManagerMockRecorder) WriteRange(ctx, ns, it interface{}) *gomock.Call {
+func (mr *MockCommittedManagerMockRecorder) WriteRange(ctx, storageID, ns, it interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteRange", reflect.TypeOf((*MockCommittedManager)(nil).WriteRange), ctx, ns, it)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteRange", reflect.TypeOf((*MockCommittedManager)(nil).WriteRange), ctx, storageID, ns, it)
 }
 
 // MockStagingManager is a mock of StagingManager interface.

--- a/pkg/graveler/mock/graveler.go
+++ b/pkg/graveler/mock/graveler.go
@@ -2601,6 +2601,18 @@ func (m *MockCommittedManager) EXPECT() *MockCommittedManagerMockRecorder {
 	return m.recorder
 }
 
+// AddMetadataManager mocks base method.
+func (m *MockCommittedManager) AddMetadataManager(storageID graveler.StorageID, metadataManager graveler.MetaRangeManager) {
+	m.ctrl.T.Helper()
+	m.ctrl.Call(m, "AddMetadataManager", storageID, metadataManager)
+}
+
+// AddMetadataManager indicates an expected call of AddMetadataManager.
+func (mr *MockCommittedManagerMockRecorder) AddMetadataManager(storageID, metadataManager interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "AddMetadataManager", reflect.TypeOf((*MockCommittedManager)(nil).AddMetadataManager), storageID, metadataManager)
+}
+
 // Commit mocks base method.
 func (m *MockCommittedManager) Commit(ctx context.Context, storageID graveler.StorageID, ns graveler.StorageNamespace, baseMetaRangeID graveler.MetaRangeID, changes graveler.ValueIterator, allowEmpty bool, opts ...graveler.SetOptionsFunc) (graveler.MetaRangeID, graveler.DiffSummary, error) {
 	m.ctrl.T.Helper()
@@ -2683,33 +2695,33 @@ func (mr *MockCommittedManagerMockRecorder) Get(ctx, storageID, ns, rangeID, key
 }
 
 // GetMetaRange mocks base method.
-func (m *MockCommittedManager) GetMetaRange(ctx context.Context, ns graveler.StorageNamespace, metaRangeID graveler.MetaRangeID) (graveler.MetaRangeAddress, error) {
+func (m *MockCommittedManager) GetMetaRange(ctx context.Context, storageID graveler.StorageID, ns graveler.StorageNamespace, metaRangeID graveler.MetaRangeID) (graveler.MetaRangeAddress, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetMetaRange", ctx, ns, metaRangeID)
+	ret := m.ctrl.Call(m, "GetMetaRange", ctx, storageID, ns, metaRangeID)
 	ret0, _ := ret[0].(graveler.MetaRangeAddress)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetMetaRange indicates an expected call of GetMetaRange.
-func (mr *MockCommittedManagerMockRecorder) GetMetaRange(ctx, ns, metaRangeID interface{}) *gomock.Call {
+func (mr *MockCommittedManagerMockRecorder) GetMetaRange(ctx, storageID, ns, metaRangeID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMetaRange", reflect.TypeOf((*MockCommittedManager)(nil).GetMetaRange), ctx, ns, metaRangeID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetMetaRange", reflect.TypeOf((*MockCommittedManager)(nil).GetMetaRange), ctx, storageID, ns, metaRangeID)
 }
 
 // GetRange mocks base method.
-func (m *MockCommittedManager) GetRange(ctx context.Context, ns graveler.StorageNamespace, rangeID graveler.RangeID) (graveler.RangeAddress, error) {
+func (m *MockCommittedManager) GetRange(ctx context.Context, storageID graveler.StorageID, ns graveler.StorageNamespace, rangeID graveler.RangeID) (graveler.RangeAddress, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRange", ctx, ns, rangeID)
+	ret := m.ctrl.Call(m, "GetRange", ctx, storageID, ns, rangeID)
 	ret0, _ := ret[0].(graveler.RangeAddress)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetRange indicates an expected call of GetRange.
-func (mr *MockCommittedManagerMockRecorder) GetRange(ctx, ns, rangeID interface{}) *gomock.Call {
+func (mr *MockCommittedManagerMockRecorder) GetRange(ctx, storageID, ns, rangeID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRange", reflect.TypeOf((*MockCommittedManager)(nil).GetRange), ctx, ns, rangeID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRange", reflect.TypeOf((*MockCommittedManager)(nil).GetRange), ctx, storageID, ns, rangeID)
 }
 
 // GetRangeIDByKey mocks base method.

--- a/pkg/graveler/mock/graveler.go
+++ b/pkg/graveler/mock/graveler.go
@@ -2783,33 +2783,33 @@ func (mr *MockCommittedManagerMockRecorder) Merge(ctx, ns, destination, source, 
 }
 
 // WriteMetaRange mocks base method.
-func (m *MockCommittedManager) WriteMetaRange(ctx context.Context, ns graveler.StorageNamespace, ranges []*graveler.RangeInfo) (*graveler.MetaRangeInfo, error) {
+func (m *MockCommittedManager) WriteMetaRange(ctx context.Context, storageID graveler.StorageID, ns graveler.StorageNamespace, ranges []*graveler.RangeInfo) (*graveler.MetaRangeInfo, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WriteMetaRange", ctx, ns, ranges)
+	ret := m.ctrl.Call(m, "WriteMetaRange", ctx, storageID, ns, ranges)
 	ret0, _ := ret[0].(*graveler.MetaRangeInfo)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // WriteMetaRange indicates an expected call of WriteMetaRange.
-func (mr *MockCommittedManagerMockRecorder) WriteMetaRange(ctx, ns, ranges interface{}) *gomock.Call {
+func (mr *MockCommittedManagerMockRecorder) WriteMetaRange(ctx, storageID, ns, ranges interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteMetaRange", reflect.TypeOf((*MockCommittedManager)(nil).WriteMetaRange), ctx, ns, ranges)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteMetaRange", reflect.TypeOf((*MockCommittedManager)(nil).WriteMetaRange), ctx, storageID, ns, ranges)
 }
 
 // WriteMetaRangeByIterator mocks base method.
-func (m *MockCommittedManager) WriteMetaRangeByIterator(ctx context.Context, ns graveler.StorageNamespace, it graveler.ValueIterator, metadata graveler.Metadata) (*graveler.MetaRangeID, error) {
+func (m *MockCommittedManager) WriteMetaRangeByIterator(ctx context.Context, storageID graveler.StorageID, ns graveler.StorageNamespace, it graveler.ValueIterator, metadata graveler.Metadata) (*graveler.MetaRangeID, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "WriteMetaRangeByIterator", ctx, ns, it, metadata)
+	ret := m.ctrl.Call(m, "WriteMetaRangeByIterator", ctx, storageID, ns, it, metadata)
 	ret0, _ := ret[0].(*graveler.MetaRangeID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // WriteMetaRangeByIterator indicates an expected call of WriteMetaRangeByIterator.
-func (mr *MockCommittedManagerMockRecorder) WriteMetaRangeByIterator(ctx, ns, it, metadata interface{}) *gomock.Call {
+func (mr *MockCommittedManagerMockRecorder) WriteMetaRangeByIterator(ctx, storageID, ns, it, metadata interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteMetaRangeByIterator", reflect.TypeOf((*MockCommittedManager)(nil).WriteMetaRangeByIterator), ctx, ns, it, metadata)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "WriteMetaRangeByIterator", reflect.TypeOf((*MockCommittedManager)(nil).WriteMetaRangeByIterator), ctx, storageID, ns, it, metadata)
 }
 
 // WriteRange mocks base method.

--- a/pkg/graveler/mock/graveler.go
+++ b/pkg/graveler/mock/graveler.go
@@ -2602,9 +2602,9 @@ func (m *MockCommittedManager) EXPECT() *MockCommittedManagerMockRecorder {
 }
 
 // Commit mocks base method.
-func (m *MockCommittedManager) Commit(ctx context.Context, ns graveler.StorageNamespace, baseMetaRangeID graveler.MetaRangeID, changes graveler.ValueIterator, allowEmpty bool, opts ...graveler.SetOptionsFunc) (graveler.MetaRangeID, graveler.DiffSummary, error) {
+func (m *MockCommittedManager) Commit(ctx context.Context, storageID graveler.StorageID, ns graveler.StorageNamespace, baseMetaRangeID graveler.MetaRangeID, changes graveler.ValueIterator, allowEmpty bool, opts ...graveler.SetOptionsFunc) (graveler.MetaRangeID, graveler.DiffSummary, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{ctx, ns, baseMetaRangeID, changes, allowEmpty}
+	varargs := []interface{}{ctx, storageID, ns, baseMetaRangeID, changes, allowEmpty}
 	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
@@ -2616,70 +2616,70 @@ func (m *MockCommittedManager) Commit(ctx context.Context, ns graveler.StorageNa
 }
 
 // Commit indicates an expected call of Commit.
-func (mr *MockCommittedManagerMockRecorder) Commit(ctx, ns, baseMetaRangeID, changes, allowEmpty interface{}, opts ...interface{}) *gomock.Call {
+func (mr *MockCommittedManagerMockRecorder) Commit(ctx, storageID, ns, baseMetaRangeID, changes, allowEmpty interface{}, opts ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{ctx, ns, baseMetaRangeID, changes, allowEmpty}, opts...)
+	varargs := append([]interface{}{ctx, storageID, ns, baseMetaRangeID, changes, allowEmpty}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Commit", reflect.TypeOf((*MockCommittedManager)(nil).Commit), varargs...)
 }
 
 // Compare mocks base method.
-func (m *MockCommittedManager) Compare(ctx context.Context, ns graveler.StorageNamespace, destination, source, base graveler.MetaRangeID) (graveler.DiffIterator, error) {
+func (m *MockCommittedManager) Compare(ctx context.Context, storageID graveler.StorageID, ns graveler.StorageNamespace, destination, source, base graveler.MetaRangeID) (graveler.DiffIterator, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Compare", ctx, ns, destination, source, base)
+	ret := m.ctrl.Call(m, "Compare", ctx, storageID, ns, destination, source, base)
 	ret0, _ := ret[0].(graveler.DiffIterator)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Compare indicates an expected call of Compare.
-func (mr *MockCommittedManagerMockRecorder) Compare(ctx, ns, destination, source, base interface{}) *gomock.Call {
+func (mr *MockCommittedManagerMockRecorder) Compare(ctx, storageID, ns, destination, source, base interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Compare", reflect.TypeOf((*MockCommittedManager)(nil).Compare), ctx, ns, destination, source, base)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Compare", reflect.TypeOf((*MockCommittedManager)(nil).Compare), ctx, storageID, ns, destination, source, base)
 }
 
 // Diff mocks base method.
-func (m *MockCommittedManager) Diff(ctx context.Context, ns graveler.StorageNamespace, left, right graveler.MetaRangeID) (graveler.DiffIterator, error) {
+func (m *MockCommittedManager) Diff(ctx context.Context, storageID graveler.StorageID, ns graveler.StorageNamespace, left, right graveler.MetaRangeID) (graveler.DiffIterator, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Diff", ctx, ns, left, right)
+	ret := m.ctrl.Call(m, "Diff", ctx, storageID, ns, left, right)
 	ret0, _ := ret[0].(graveler.DiffIterator)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Diff indicates an expected call of Diff.
-func (mr *MockCommittedManagerMockRecorder) Diff(ctx, ns, left, right interface{}) *gomock.Call {
+func (mr *MockCommittedManagerMockRecorder) Diff(ctx, storageID, ns, left, right interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Diff", reflect.TypeOf((*MockCommittedManager)(nil).Diff), ctx, ns, left, right)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Diff", reflect.TypeOf((*MockCommittedManager)(nil).Diff), ctx, storageID, ns, left, right)
 }
 
 // Exists mocks base method.
-func (m *MockCommittedManager) Exists(ctx context.Context, ns graveler.StorageNamespace, id graveler.MetaRangeID) (bool, error) {
+func (m *MockCommittedManager) Exists(ctx context.Context, storageID graveler.StorageID, ns graveler.StorageNamespace, id graveler.MetaRangeID) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Exists", ctx, ns, id)
+	ret := m.ctrl.Call(m, "Exists", ctx, storageID, ns, id)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Exists indicates an expected call of Exists.
-func (mr *MockCommittedManagerMockRecorder) Exists(ctx, ns, id interface{}) *gomock.Call {
+func (mr *MockCommittedManagerMockRecorder) Exists(ctx, storageID, ns, id interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exists", reflect.TypeOf((*MockCommittedManager)(nil).Exists), ctx, ns, id)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exists", reflect.TypeOf((*MockCommittedManager)(nil).Exists), ctx, storageID, ns, id)
 }
 
 // Get mocks base method.
-func (m *MockCommittedManager) Get(ctx context.Context, ns graveler.StorageNamespace, rangeID graveler.MetaRangeID, key graveler.Key) (*graveler.Value, error) {
+func (m *MockCommittedManager) Get(ctx context.Context, storageID graveler.StorageID, ns graveler.StorageNamespace, rangeID graveler.MetaRangeID, key graveler.Key) (*graveler.Value, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Get", ctx, ns, rangeID, key)
+	ret := m.ctrl.Call(m, "Get", ctx, storageID, ns, rangeID, key)
 	ret0, _ := ret[0].(*graveler.Value)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Get indicates an expected call of Get.
-func (mr *MockCommittedManagerMockRecorder) Get(ctx, ns, rangeID, key interface{}) *gomock.Call {
+func (mr *MockCommittedManagerMockRecorder) Get(ctx, storageID, ns, rangeID, key interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockCommittedManager)(nil).Get), ctx, ns, rangeID, key)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockCommittedManager)(nil).Get), ctx, storageID, ns, rangeID, key)
 }
 
 // GetMetaRange mocks base method.
@@ -2713,24 +2713,24 @@ func (mr *MockCommittedManagerMockRecorder) GetRange(ctx, ns, rangeID interface{
 }
 
 // GetRangeIDByKey mocks base method.
-func (m *MockCommittedManager) GetRangeIDByKey(ctx context.Context, ns graveler.StorageNamespace, id graveler.MetaRangeID, key graveler.Key) (graveler.RangeID, error) {
+func (m *MockCommittedManager) GetRangeIDByKey(ctx context.Context, storageID graveler.StorageID, ns graveler.StorageNamespace, id graveler.MetaRangeID, key graveler.Key) (graveler.RangeID, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRangeIDByKey", ctx, ns, id, key)
+	ret := m.ctrl.Call(m, "GetRangeIDByKey", ctx, storageID, ns, id, key)
 	ret0, _ := ret[0].(graveler.RangeID)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetRangeIDByKey indicates an expected call of GetRangeIDByKey.
-func (mr *MockCommittedManagerMockRecorder) GetRangeIDByKey(ctx, ns, id, key interface{}) *gomock.Call {
+func (mr *MockCommittedManagerMockRecorder) GetRangeIDByKey(ctx, storageID, ns, id, key interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRangeIDByKey", reflect.TypeOf((*MockCommittedManager)(nil).GetRangeIDByKey), ctx, ns, id, key)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRangeIDByKey", reflect.TypeOf((*MockCommittedManager)(nil).GetRangeIDByKey), ctx, storageID, ns, id, key)
 }
 
 // Import mocks base method.
-func (m *MockCommittedManager) Import(ctx context.Context, ns graveler.StorageNamespace, destination, source graveler.MetaRangeID, prefixes []graveler.Prefix, opts ...graveler.SetOptionsFunc) (graveler.MetaRangeID, error) {
+func (m *MockCommittedManager) Import(ctx context.Context, storageID graveler.StorageID, ns graveler.StorageNamespace, destination, source graveler.MetaRangeID, prefixes []graveler.Prefix, opts ...graveler.SetOptionsFunc) (graveler.MetaRangeID, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{ctx, ns, destination, source, prefixes}
+	varargs := []interface{}{ctx, storageID, ns, destination, source, prefixes}
 	for _, a := range opts {
 		varargs = append(varargs, a)
 	}
@@ -2741,25 +2741,25 @@ func (m *MockCommittedManager) Import(ctx context.Context, ns graveler.StorageNa
 }
 
 // Import indicates an expected call of Import.
-func (mr *MockCommittedManagerMockRecorder) Import(ctx, ns, destination, source, prefixes interface{}, opts ...interface{}) *gomock.Call {
+func (mr *MockCommittedManagerMockRecorder) Import(ctx, storageID, ns, destination, source, prefixes interface{}, opts ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{ctx, ns, destination, source, prefixes}, opts...)
+	varargs := append([]interface{}{ctx, storageID, ns, destination, source, prefixes}, opts...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Import", reflect.TypeOf((*MockCommittedManager)(nil).Import), varargs...)
 }
 
 // List mocks base method.
-func (m *MockCommittedManager) List(ctx context.Context, ns graveler.StorageNamespace, rangeID graveler.MetaRangeID) (graveler.ValueIterator, error) {
+func (m *MockCommittedManager) List(ctx context.Context, storageID graveler.StorageID, ns graveler.StorageNamespace, rangeID graveler.MetaRangeID) (graveler.ValueIterator, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "List", ctx, ns, rangeID)
+	ret := m.ctrl.Call(m, "List", ctx, storageID, ns, rangeID)
 	ret0, _ := ret[0].(graveler.ValueIterator)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // List indicates an expected call of List.
-func (mr *MockCommittedManagerMockRecorder) List(ctx, ns, rangeID interface{}) *gomock.Call {
+func (mr *MockCommittedManagerMockRecorder) List(ctx, storageID, ns, rangeID interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockCommittedManager)(nil).List), ctx, ns, rangeID)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "List", reflect.TypeOf((*MockCommittedManager)(nil).List), ctx, storageID, ns, rangeID)
 }
 
 // Merge mocks base method.

--- a/pkg/graveler/sstable/range_manager.go
+++ b/pkg/graveler/sstable/range_manager.go
@@ -164,8 +164,8 @@ func (m *RangeManager) NewRangeIterator(ctx context.Context, storageID committed
 }
 
 // GetWriter returns a new SSTable writer instance
-func (m *RangeManager) GetWriter(ctx context.Context, ns committed.Namespace, metadata graveler.Metadata) (committed.RangeWriter, error) {
-	return NewDiskWriter(ctx, m.fs, ns, m.hash.New(), metadata)
+func (m *RangeManager) GetWriter(ctx context.Context, storageID committed.StorageID, ns committed.Namespace, metadata graveler.Metadata) (committed.RangeWriter, error) {
+	return NewDiskWriter(ctx, m.fs, storageID, ns, m.hash.New(), metadata)
 }
 
 func (m *RangeManager) GetURI(ctx context.Context, ns committed.Namespace, id committed.ID) (string, error) {

--- a/pkg/graveler/sstable/range_manager.go
+++ b/pkg/graveler/sstable/range_manager.go
@@ -168,8 +168,8 @@ func (m *RangeManager) GetWriter(ctx context.Context, storageID committed.Storag
 	return NewDiskWriter(ctx, m.fs, storageID, ns, m.hash.New(), metadata)
 }
 
-func (m *RangeManager) GetURI(ctx context.Context, id committed.ID) (string, error) {
-	return m.fs.GetRemoteURI(ctx, string(id))
+func (m *RangeManager) GetURI(ctx context.Context, ns committed.Namespace, id committed.ID) (string, error) {
+	return m.fs.GetRemoteURI(ctx, string(ns), string(id))
 }
 
 func (m *RangeManager) execAndLog(ctx context.Context, f func() error, msg string) {

--- a/pkg/graveler/sstable/range_manager.go
+++ b/pkg/graveler/sstable/range_manager.go
@@ -25,9 +25,10 @@ type RangeManager struct {
 	fs        pyramid.FS
 	hash      crypto.Hash
 	cache     Unrefer
+	storageID committed.StorageID
 }
 
-func NewPebbleSSTableRangeManager(cache *pebble.Cache, fs pyramid.FS, hash crypto.Hash) *RangeManager {
+func NewPebbleSSTableRangeManager(cache *pebble.Cache, fs pyramid.FS, hash crypto.Hash, storageID committed.StorageID) *RangeManager {
 	if cache != nil { // nil cache allowed (size=0), see sstable.ReaderOptions
 		cache.Ref()
 	}
@@ -35,7 +36,7 @@ func NewPebbleSSTableRangeManager(cache *pebble.Cache, fs pyramid.FS, hash crypt
 	newReader := func(ctx context.Context, storageID committed.StorageID, ns committed.Namespace, id committed.ID) (*sstable.Reader, error) {
 		return newReader(ctx, fs, storageID, ns, id, opts)
 	}
-	return NewPebbleSSTableRangeManagerWithNewReader(newReader, opts.Cache, fs, hash)
+	return NewPebbleSSTableRangeManagerWithNewReader(newReader, opts.Cache, fs, hash, storageID)
 }
 
 func newReader(ctx context.Context, fs pyramid.FS, storageID committed.StorageID, ns committed.Namespace, id committed.ID, opts sstable.ReaderOptions) (*sstable.Reader, error) {
@@ -50,12 +51,13 @@ func newReader(ctx context.Context, fs pyramid.FS, storageID committed.StorageID
 	return r, nil
 }
 
-func NewPebbleSSTableRangeManagerWithNewReader(newReader NewSSTableReaderFn, cache Unrefer, fs pyramid.FS, hash crypto.Hash) *RangeManager {
+func NewPebbleSSTableRangeManagerWithNewReader(newReader NewSSTableReaderFn, cache Unrefer, fs pyramid.FS, hash crypto.Hash, storageID committed.StorageID) *RangeManager {
 	return &RangeManager{
 		fs:        fs,
 		hash:      hash,
 		newReader: newReader,
 		cache:     cache,
+		storageID: storageID,
 	}
 }
 
@@ -66,12 +68,12 @@ var (
 	_ committed.RangeManager = &RangeManager{}
 )
 
-func (m *RangeManager) Exists(ctx context.Context, storageID committed.StorageID, ns committed.Namespace, id committed.ID) (bool, error) {
-	return m.fs.Exists(ctx, string(storageID), string(ns), string(id))
+func (m *RangeManager) Exists(ctx context.Context, ns committed.Namespace, id committed.ID) (bool, error) {
+	return m.fs.Exists(ctx, string(m.storageID), string(ns), string(id))
 }
 
-func (m *RangeManager) GetValueGE(ctx context.Context, storageID committed.StorageID, ns committed.Namespace, id committed.ID, lookup committed.Key) (*committed.Record, error) {
-	reader, err := m.newReader(ctx, storageID, ns, id)
+func (m *RangeManager) GetValueGE(ctx context.Context, ns committed.Namespace, id committed.ID, lookup committed.Key) (*committed.Record, error) {
+	reader, err := m.newReader(ctx, m.storageID, ns, id)
 	if err != nil {
 		return nil, err
 	}
@@ -105,8 +107,8 @@ func (m *RangeManager) GetValueGE(ctx context.Context, storageID committed.Stora
 
 // GetValue returns the Record matching the key in the SSTable referenced by the id.
 // If key is not found, (nil, ErrKeyNotFound) is returned.
-func (m *RangeManager) GetValue(ctx context.Context, storageID committed.StorageID, ns committed.Namespace, id committed.ID, lookup committed.Key) (*committed.Record, error) {
-	reader, err := m.newReader(ctx, storageID, ns, id)
+func (m *RangeManager) GetValue(ctx context.Context, ns committed.Namespace, id committed.ID, lookup committed.Key) (*committed.Record, error) {
+	reader, err := m.newReader(ctx, m.storageID, ns, id)
 	if err != nil {
 		return nil, err
 	}
@@ -146,8 +148,8 @@ func (m *RangeManager) GetValue(ctx context.Context, storageID committed.Storage
 }
 
 // NewRangeIterator takes a given SSTable and returns an EntryIterator seeked to >= "from" path
-func (m *RangeManager) NewRangeIterator(ctx context.Context, storageID committed.StorageID, ns committed.Namespace, tid committed.ID) (committed.ValueIterator, error) {
-	reader, err := m.newReader(ctx, storageID, ns, tid)
+func (m *RangeManager) NewRangeIterator(ctx context.Context, ns committed.Namespace, tid committed.ID) (committed.ValueIterator, error) {
+	reader, err := m.newReader(ctx, m.storageID, ns, tid)
 	if err != nil {
 		return nil, err
 	}
@@ -164,8 +166,8 @@ func (m *RangeManager) NewRangeIterator(ctx context.Context, storageID committed
 }
 
 // GetWriter returns a new SSTable writer instance
-func (m *RangeManager) GetWriter(ctx context.Context, storageID committed.StorageID, ns committed.Namespace, metadata graveler.Metadata) (committed.RangeWriter, error) {
-	return NewDiskWriter(ctx, m.fs, storageID, ns, m.hash.New(), metadata)
+func (m *RangeManager) GetWriter(ctx context.Context, ns committed.Namespace, metadata graveler.Metadata) (committed.RangeWriter, error) {
+	return NewDiskWriter(ctx, m.fs, m.storageID, ns, m.hash.New(), metadata)
 }
 
 func (m *RangeManager) GetURI(ctx context.Context, ns committed.Namespace, id committed.ID) (string, error) {

--- a/pkg/graveler/sstable/range_manager.go
+++ b/pkg/graveler/sstable/range_manager.go
@@ -168,8 +168,8 @@ func (m *RangeManager) GetWriter(ctx context.Context, storageID committed.Storag
 	return NewDiskWriter(ctx, m.fs, storageID, ns, m.hash.New(), metadata)
 }
 
-func (m *RangeManager) GetURI(ctx context.Context, ns committed.Namespace, id committed.ID) (string, error) {
-	return m.fs.GetRemoteURI(ctx, string(ns), string(id))
+func (m *RangeManager) GetURI(ctx context.Context, id committed.ID) (string, error) {
+	return m.fs.GetRemoteURI(ctx, string(id))
 }
 
 func (m *RangeManager) execAndLog(ctx context.Context, f func() error, msg string) {

--- a/pkg/graveler/sstable/range_manager.go
+++ b/pkg/graveler/sstable/range_manager.go
@@ -14,7 +14,7 @@ import (
 	"github.com/treeverse/lakefs/pkg/pyramid"
 )
 
-type NewSSTableReaderFn func(ctx context.Context, ns committed.Namespace, id committed.ID) (*sstable.Reader, error)
+type NewSSTableReaderFn func(ctx context.Context, storageID committed.StorageID, ns committed.Namespace, id committed.ID) (*sstable.Reader, error)
 
 type Unrefer interface {
 	Unref()
@@ -32,14 +32,14 @@ func NewPebbleSSTableRangeManager(cache *pebble.Cache, fs pyramid.FS, hash crypt
 		cache.Ref()
 	}
 	opts := sstable.ReaderOptions{Cache: cache}
-	newReader := func(ctx context.Context, ns committed.Namespace, id committed.ID) (*sstable.Reader, error) {
-		return newReader(ctx, fs, ns, id, opts)
+	newReader := func(ctx context.Context, storageID committed.StorageID, ns committed.Namespace, id committed.ID) (*sstable.Reader, error) {
+		return newReader(ctx, fs, storageID, ns, id, opts)
 	}
 	return NewPebbleSSTableRangeManagerWithNewReader(newReader, opts.Cache, fs, hash)
 }
 
-func newReader(ctx context.Context, fs pyramid.FS, ns committed.Namespace, id committed.ID, opts sstable.ReaderOptions) (*sstable.Reader, error) {
-	file, err := fs.Open(ctx, string(ns), string(id))
+func newReader(ctx context.Context, fs pyramid.FS, storageID committed.StorageID, ns committed.Namespace, id committed.ID, opts sstable.ReaderOptions) (*sstable.Reader, error) {
+	file, err := fs.Open(ctx, string(storageID), string(ns), string(id))
 	if err != nil {
 		return nil, fmt.Errorf("open sstable file %s %s: %w", ns, id, err)
 	}
@@ -66,12 +66,12 @@ var (
 	_ committed.RangeManager = &RangeManager{}
 )
 
-func (m *RangeManager) Exists(ctx context.Context, ns committed.Namespace, id committed.ID) (bool, error) {
-	return m.fs.Exists(ctx, string(ns), string(id))
+func (m *RangeManager) Exists(ctx context.Context, storageID committed.StorageID, ns committed.Namespace, id committed.ID) (bool, error) {
+	return m.fs.Exists(ctx, string(storageID), string(ns), string(id))
 }
 
-func (m *RangeManager) GetValueGE(ctx context.Context, ns committed.Namespace, id committed.ID, lookup committed.Key) (*committed.Record, error) {
-	reader, err := m.newReader(ctx, ns, id)
+func (m *RangeManager) GetValueGE(ctx context.Context, storageID committed.StorageID, ns committed.Namespace, id committed.ID, lookup committed.Key) (*committed.Record, error) {
+	reader, err := m.newReader(ctx, storageID, ns, id)
 	if err != nil {
 		return nil, err
 	}
@@ -105,8 +105,8 @@ func (m *RangeManager) GetValueGE(ctx context.Context, ns committed.Namespace, i
 
 // GetValue returns the Record matching the key in the SSTable referenced by the id.
 // If key is not found, (nil, ErrKeyNotFound) is returned.
-func (m *RangeManager) GetValue(ctx context.Context, ns committed.Namespace, id committed.ID, lookup committed.Key) (*committed.Record, error) {
-	reader, err := m.newReader(ctx, ns, id)
+func (m *RangeManager) GetValue(ctx context.Context, storageID committed.StorageID, ns committed.Namespace, id committed.ID, lookup committed.Key) (*committed.Record, error) {
+	reader, err := m.newReader(ctx, storageID, ns, id)
 	if err != nil {
 		return nil, err
 	}
@@ -146,8 +146,8 @@ func (m *RangeManager) GetValue(ctx context.Context, ns committed.Namespace, id 
 }
 
 // NewRangeIterator takes a given SSTable and returns an EntryIterator seeked to >= "from" path
-func (m *RangeManager) NewRangeIterator(ctx context.Context, ns committed.Namespace, tid committed.ID) (committed.ValueIterator, error) {
-	reader, err := m.newReader(ctx, ns, tid)
+func (m *RangeManager) NewRangeIterator(ctx context.Context, storageID committed.StorageID, ns committed.Namespace, tid committed.ID) (committed.ValueIterator, error) {
+	reader, err := m.newReader(ctx, storageID, ns, tid)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/graveler/sstable/range_manager_test.go
+++ b/pkg/graveler/sstable/range_manager_test.go
@@ -38,12 +38,12 @@ func TestGetEntrySuccess(t *testing.T) {
 
 	reader := createSStableReader(t, keys, vals)
 
-	sut := sstable.NewPebbleSSTableRangeManagerWithNewReader(makeNewReader(reader), &NoCache{}, mockFS, crypto.SHA256)
+	sut := sstable.NewPebbleSSTableRangeManagerWithNewReader(makeNewReader(reader), &NoCache{}, mockFS, crypto.SHA256, "")
 
 	ns := "some-ns"
 	sstableID := "some-id"
 
-	val, err := sut.GetValue(ctx, "", committed.Namespace(ns), committed.ID(sstableID), committed.Key(keys[len(keys)/3]))
+	val, err := sut.GetValue(ctx, committed.Namespace(ns), committed.ID(sstableID), committed.Key(keys[len(keys)/3]))
 	require.NoError(t, err)
 	require.NotNil(t, val)
 
@@ -60,12 +60,12 @@ func TestGetEntryCacheFailure(t *testing.T) {
 
 	sut := sstable.NewPebbleSSTableRangeManagerWithNewReader(func(context.Context, committed.StorageID, committed.Namespace, committed.ID) (*pebblesst.Reader, error) {
 		return nil, expectedErr
-	}, &NoCache{}, mockFS, crypto.SHA256)
+	}, &NoCache{}, mockFS, crypto.SHA256, "")
 
 	ns := "some-ns"
 	sstableID := committed.ID("some-id")
 
-	val, err := sut.GetValue(ctx, "", committed.Namespace(ns), sstableID, committed.Key("some-key"))
+	val, err := sut.GetValue(ctx, committed.Namespace(ns), sstableID, committed.Key("some-key"))
 	require.Error(t, expectedErr, err)
 	require.Nil(t, val)
 }
@@ -82,12 +82,12 @@ func TestGetEntryNotFound(t *testing.T) {
 
 	reader := createSStableReader(t, keys, vals)
 
-	sut := sstable.NewPebbleSSTableRangeManagerWithNewReader(makeNewReader(reader), &NoCache{}, mockFS, crypto.SHA256)
+	sut := sstable.NewPebbleSSTableRangeManagerWithNewReader(makeNewReader(reader), &NoCache{}, mockFS, crypto.SHA256, "")
 
 	ns := "some-ns"
 	sstableID := committed.ID("some-id")
 
-	val, err := sut.GetValue(ctx, "", committed.Namespace(ns), sstableID, committed.Key("does-not-exist"))
+	val, err := sut.GetValue(ctx, committed.Namespace(ns), sstableID, committed.Key("does-not-exist"))
 	require.Error(t, err)
 	require.Nil(t, val)
 
@@ -100,13 +100,13 @@ func TestGetWriterSuccess(t *testing.T) {
 
 	mockFS := fsMock.NewMockFS(ctrl)
 
-	sut := sstable.NewPebbleSSTableRangeManagerWithNewReader(nil, &NoCache{}, mockFS, crypto.SHA256)
+	sut := sstable.NewPebbleSSTableRangeManagerWithNewReader(nil, &NoCache{}, mockFS, crypto.SHA256, "")
 
 	ns := "some-ns"
 	mockFile := fsMock.NewMockStoredFile(ctrl)
 	mockFS.EXPECT().Create(ctx, "", ns).Return(mockFile, nil).Times(1)
 
-	writer, err := sut.GetWriter(ctx, "", committed.Namespace(ns), nil)
+	writer, err := sut.GetWriter(ctx, committed.Namespace(ns), nil)
 	require.NoError(t, err)
 	require.NotNil(t, writer)
 
@@ -128,12 +128,12 @@ func TestNewPartIteratorSuccess(t *testing.T) {
 	vals := randomStrings(len(keys))
 	reader := createSStableReader(t, keys, vals)
 
-	sut := sstable.NewPebbleSSTableRangeManagerWithNewReader(makeNewReader(reader), &NoCache{}, mockFS, crypto.SHA256)
+	sut := sstable.NewPebbleSSTableRangeManagerWithNewReader(makeNewReader(reader), &NoCache{}, mockFS, crypto.SHA256, "")
 
 	ns := "some-ns"
 	sstableID := committed.ID("some-id")
 
-	iter, err := sut.NewRangeIterator(ctx, "", committed.Namespace(ns), sstableID)
+	iter, err := sut.NewRangeIterator(ctx, committed.Namespace(ns), sstableID)
 	require.NoError(t, err)
 	require.NotNil(t, iter)
 
@@ -152,7 +152,7 @@ func TestGetWriterRangeID(t *testing.T) {
 
 	mockFS := fsMock.NewMockFS(ctrl)
 
-	sut := sstable.NewPebbleSSTableRangeManagerWithNewReader(nil, &NoCache{}, mockFS, crypto.SHA256)
+	sut := sstable.NewPebbleSSTableRangeManagerWithNewReader(nil, &NoCache{}, mockFS, crypto.SHA256, "")
 
 	for times := 0; times < 2; times++ {
 		const ns = "some-ns"
@@ -165,7 +165,7 @@ func TestGetWriterRangeID(t *testing.T) {
 		mockFile.EXPECT().Store(gomock.Any(), gomock.Any()).Return(nil).Times(1)
 		mockFS.EXPECT().Create(ctx, "", ns).Return(mockFile, nil).Times(1)
 
-		writer, err := sut.GetWriter(ctx, "", ns, nil)
+		writer, err := sut.GetWriter(ctx, ns, nil)
 		require.NoError(t, err)
 		require.NotNil(t, writer)
 		err = writer.WriteRecord(committed.Record{

--- a/pkg/graveler/sstable/writer.go
+++ b/pkg/graveler/sstable/writer.go
@@ -35,8 +35,8 @@ type DiskWriter struct {
 	closed bool
 }
 
-func NewDiskWriter(ctx context.Context, tierFS pyramid.FS, ns committed.Namespace, hash hash.Hash, metadata graveler.Metadata) (*DiskWriter, error) {
-	fh, err := tierFS.Create(ctx, string(ns))
+func NewDiskWriter(ctx context.Context, tierFS pyramid.FS, storageID committed.StorageID, ns committed.Namespace, hash hash.Hash, metadata graveler.Metadata) (*DiskWriter, error) {
+	fh, err := tierFS.Create(ctx, string(storageID), string(ns))
 	if err != nil {
 		return nil, fmt.Errorf("opening file: %w", err)
 	}

--- a/pkg/graveler/sstable/writer_test.go
+++ b/pkg/graveler/sstable/writer_test.go
@@ -24,10 +24,10 @@ func TestWriter(t *testing.T) {
 	// create the mock file with the matching file-system
 	mockFile := mock.NewMockStoredFile(ctrl)
 	mockFile.EXPECT().Close().Return(nil).Times(1)
-	mockFS.EXPECT().Create(gomock.Any(), string(ns)).Return(mockFile, nil)
+	mockFS.EXPECT().Create(gomock.Any(), "", string(ns)).Return(mockFile, nil)
 
 	writes := 500
-	dw, err := sstable.NewDiskWriter(ctx, mockFS, ns, sha256.New(), nil)
+	dw, err := sstable.NewDiskWriter(ctx, mockFS, "", ns, sha256.New(), nil)
 	require.NoError(t, err)
 	require.NotNil(t, dw)
 
@@ -77,9 +77,9 @@ func TestWriterAbort(t *testing.T) {
 	mockFile := mock.NewMockStoredFile(ctrl)
 	mockFile.EXPECT().Abort(gomock.Any()).Return(nil).Times(1)
 	mockFile.EXPECT().Close().Return(nil).Times(1)
-	mockFS.EXPECT().Create(gomock.Any(), string(ns)).Return(mockFile, nil)
+	mockFS.EXPECT().Create(gomock.Any(), "", string(ns)).Return(mockFile, nil)
 
-	dw, err := sstable.NewDiskWriter(ctx, mockFS, ns, sha256.New(), nil)
+	dw, err := sstable.NewDiskWriter(ctx, mockFS, "", ns, sha256.New(), nil)
 	require.NoError(t, err)
 	require.NotNil(t, dw)
 
@@ -111,14 +111,14 @@ func TestWriterAbortAfterClose(t *testing.T) {
 	// create the mock file with the matching file-system
 	mockFile := mock.NewMockStoredFile(ctrl)
 	mockFile.EXPECT().Close().Return(nil).Times(1)
-	mockFS.EXPECT().Create(gomock.Any(), string(ns)).Return(mockFile, nil)
+	mockFS.EXPECT().Create(gomock.Any(), "", string(ns)).Return(mockFile, nil)
 	// expect any write file actions
 	mockFile.EXPECT().Write(gomock.Any()).DoAndReturn(func(b []byte) (int, error) { return len(b), nil }).Times(1)
 	mockFile.EXPECT().Sync().Return(nil).Times(1)
 	mockFile.EXPECT().Store(gomock.Any(), gomock.Any()).DoAndReturn(func(_ context.Context, filename string) error { return nil }).Times(1)
 
 	// Create writer
-	dw, err := sstable.NewDiskWriter(ctx, mockFS, ns, sha256.New(), nil)
+	dw, err := sstable.NewDiskWriter(ctx, mockFS, "", ns, sha256.New(), nil)
 	require.NoError(t, err)
 	require.NotNil(t, dw)
 

--- a/pkg/graveler/testutil/fakes.go
+++ b/pkg/graveler/testutil/fakes.go
@@ -103,7 +103,7 @@ func (c *CommittedFake) Commit(_ context.Context, _ graveler.StorageID, _ gravel
 	return c.MetaRangeID, c.DiffSummary, nil
 }
 
-func (c *CommittedFake) WriteMetaRangeByIterator(context.Context, graveler.StorageNamespace, graveler.ValueIterator, graveler.Metadata) (*graveler.MetaRangeID, error) {
+func (c *CommittedFake) WriteMetaRangeByIterator(context.Context, graveler.StorageID, graveler.StorageNamespace, graveler.ValueIterator, graveler.Metadata) (*graveler.MetaRangeID, error) {
 	if c.Err != nil {
 		return nil, c.Err
 	}

--- a/pkg/graveler/testutil/fakes.go
+++ b/pkg/graveler/testutil/fakes.go
@@ -114,7 +114,7 @@ func (c *CommittedFake) WriteRange(context.Context, graveler.StorageID, graveler
 	return &c.RangeInfo, nil
 }
 
-func (c *CommittedFake) WriteMetaRange(context.Context, graveler.StorageNamespace, []*graveler.RangeInfo) (*graveler.MetaRangeInfo, error) {
+func (c *CommittedFake) WriteMetaRange(context.Context, graveler.StorageID, graveler.StorageNamespace, []*graveler.RangeInfo) (*graveler.MetaRangeInfo, error) {
 	return &graveler.MetaRangeInfo{ID: c.MetaRangeID}, nil
 }
 

--- a/pkg/graveler/testutil/fakes.go
+++ b/pkg/graveler/testutil/fakes.go
@@ -30,7 +30,7 @@ type CommittedFake struct {
 	AppliedData   AppliedData
 }
 
-func (c *CommittedFake) GetRangeIDByKey(_ context.Context, _ graveler.StorageNamespace, _ graveler.MetaRangeID, _ graveler.Key) (graveler.RangeID, error) {
+func (c *CommittedFake) GetRangeIDByKey(_ context.Context, _ graveler.StorageID, _ graveler.StorageNamespace, _ graveler.MetaRangeID, _ graveler.Key) (graveler.RangeID, error) {
 	panic("implement me")
 }
 
@@ -42,21 +42,21 @@ func (t *MetaRangeFake) ID() graveler.MetaRangeID {
 	return t.id
 }
 
-func (c *CommittedFake) Exists(context.Context, graveler.StorageNamespace, graveler.MetaRangeID) (bool, error) {
+func (c *CommittedFake) Exists(context.Context, graveler.StorageID, graveler.StorageNamespace, graveler.MetaRangeID) (bool, error) {
 	if c.Err != nil {
 		return false, c.Err
 	}
 	return true, nil
 }
 
-func (c *CommittedFake) Get(_ context.Context, _ graveler.StorageNamespace, _ graveler.MetaRangeID, key graveler.Key) (*graveler.Value, error) {
+func (c *CommittedFake) Get(_ context.Context, _ graveler.StorageID, _ graveler.StorageNamespace, _ graveler.MetaRangeID, key graveler.Key) (*graveler.Value, error) {
 	if c.Err != nil {
 		return nil, c.Err
 	}
 	return c.ValuesByKey[string(key)], nil
 }
 
-func (c *CommittedFake) List(_ context.Context, _ graveler.StorageNamespace, mr graveler.MetaRangeID) (graveler.ValueIterator, error) {
+func (c *CommittedFake) List(_ context.Context, _ graveler.StorageID, _ graveler.StorageNamespace, mr graveler.MetaRangeID) (graveler.ValueIterator, error) {
 	if c.Err != nil {
 		return nil, c.Err
 	}
@@ -66,14 +66,14 @@ func (c *CommittedFake) List(_ context.Context, _ graveler.StorageNamespace, mr 
 	return c.ValueIterator, nil
 }
 
-func (c *CommittedFake) Diff(context.Context, graveler.StorageNamespace, graveler.MetaRangeID, graveler.MetaRangeID) (graveler.DiffIterator, error) {
+func (c *CommittedFake) Diff(context.Context, graveler.StorageID, graveler.StorageNamespace, graveler.MetaRangeID, graveler.MetaRangeID) (graveler.DiffIterator, error) {
 	if c.Err != nil {
 		return nil, c.Err
 	}
 	return c.DiffIterator, nil
 }
 
-func (c *CommittedFake) Compare(context.Context, graveler.StorageNamespace, graveler.MetaRangeID, graveler.MetaRangeID, graveler.MetaRangeID) (graveler.DiffIterator, error) {
+func (c *CommittedFake) Compare(context.Context, graveler.StorageID, graveler.StorageNamespace, graveler.MetaRangeID, graveler.MetaRangeID, graveler.MetaRangeID) (graveler.DiffIterator, error) {
 	if c.Err != nil {
 		return nil, c.Err
 	}
@@ -87,14 +87,14 @@ func (c *CommittedFake) Merge(_ context.Context, _ graveler.StorageNamespace, _,
 	return c.MetaRangeID, nil
 }
 
-func (c *CommittedFake) Import(_ context.Context, _ graveler.StorageNamespace, _, _ graveler.MetaRangeID, _ []graveler.Prefix, _ ...graveler.SetOptionsFunc) (graveler.MetaRangeID, error) {
+func (c *CommittedFake) Import(_ context.Context, _ graveler.StorageID, _ graveler.StorageNamespace, _, _ graveler.MetaRangeID, _ []graveler.Prefix, _ ...graveler.SetOptionsFunc) (graveler.MetaRangeID, error) {
 	if c.Err != nil {
 		return "", c.Err
 	}
 	return c.MetaRangeID, nil
 }
 
-func (c *CommittedFake) Commit(_ context.Context, _ graveler.StorageNamespace, baseMetaRangeID graveler.MetaRangeID, changes graveler.ValueIterator, _ bool, _ ...graveler.SetOptionsFunc) (graveler.MetaRangeID, graveler.DiffSummary, error) {
+func (c *CommittedFake) Commit(_ context.Context, _ graveler.StorageID, _ graveler.StorageNamespace, baseMetaRangeID graveler.MetaRangeID, changes graveler.ValueIterator, _ bool, _ ...graveler.SetOptionsFunc) (graveler.MetaRangeID, graveler.DiffSummary, error) {
 	if c.Err != nil {
 		return "", graveler.DiffSummary{}, c.Err
 	}
@@ -110,7 +110,7 @@ func (c *CommittedFake) WriteMetaRangeByIterator(context.Context, graveler.Stora
 	return &c.MetaRangeID, nil
 }
 
-func (c *CommittedFake) WriteRange(context.Context, graveler.StorageNamespace, graveler.ValueIterator) (*graveler.RangeInfo, error) {
+func (c *CommittedFake) WriteRange(context.Context, graveler.StorageID, graveler.StorageNamespace, graveler.ValueIterator) (*graveler.RangeInfo, error) {
 	return &c.RangeInfo, nil
 }
 

--- a/pkg/pyramid/mock/pyramid.go
+++ b/pkg/pyramid/mock/pyramid.go
@@ -67,18 +67,18 @@ func (mr *MockFSMockRecorder) Exists(ctx, storageID, namespace, filename interfa
 }
 
 // GetRemoteURI mocks base method.
-func (m *MockFS) GetRemoteURI(ctx context.Context, namespace, filename string) (string, error) {
+func (m *MockFS) GetRemoteURI(ctx context.Context, filename string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRemoteURI", ctx, namespace, filename)
+	ret := m.ctrl.Call(m, "GetRemoteURI", ctx, filename)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetRemoteURI indicates an expected call of GetRemoteURI.
-func (mr *MockFSMockRecorder) GetRemoteURI(ctx, namespace, filename interface{}) *gomock.Call {
+func (mr *MockFSMockRecorder) GetRemoteURI(ctx, filename interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRemoteURI", reflect.TypeOf((*MockFS)(nil).GetRemoteURI), ctx, namespace, filename)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRemoteURI", reflect.TypeOf((*MockFS)(nil).GetRemoteURI), ctx, filename)
 }
 
 // Open mocks base method.

--- a/pkg/pyramid/mock/pyramid.go
+++ b/pkg/pyramid/mock/pyramid.go
@@ -67,18 +67,18 @@ func (mr *MockFSMockRecorder) Exists(ctx, storageID, namespace, filename interfa
 }
 
 // GetRemoteURI mocks base method.
-func (m *MockFS) GetRemoteURI(ctx context.Context, filename string) (string, error) {
+func (m *MockFS) GetRemoteURI(ctx context.Context, namespace, filename string) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRemoteURI", ctx, filename)
+	ret := m.ctrl.Call(m, "GetRemoteURI", ctx, namespace, filename)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetRemoteURI indicates an expected call of GetRemoteURI.
-func (mr *MockFSMockRecorder) GetRemoteURI(ctx, filename interface{}) *gomock.Call {
+func (mr *MockFSMockRecorder) GetRemoteURI(ctx, namespace, filename interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRemoteURI", reflect.TypeOf((*MockFS)(nil).GetRemoteURI), ctx, filename)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRemoteURI", reflect.TypeOf((*MockFS)(nil).GetRemoteURI), ctx, namespace, filename)
 }
 
 // Open mocks base method.

--- a/pkg/pyramid/mock/pyramid.go
+++ b/pkg/pyramid/mock/pyramid.go
@@ -37,33 +37,33 @@ func (m *MockFS) EXPECT() *MockFSMockRecorder {
 }
 
 // Create mocks base method.
-func (m *MockFS) Create(ctx context.Context, namespace string) (pyramid.StoredFile, error) {
+func (m *MockFS) Create(ctx context.Context, storageID, namespace string) (pyramid.StoredFile, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Create", ctx, namespace)
+	ret := m.ctrl.Call(m, "Create", ctx, storageID, namespace)
 	ret0, _ := ret[0].(pyramid.StoredFile)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Create indicates an expected call of Create.
-func (mr *MockFSMockRecorder) Create(ctx, namespace interface{}) *gomock.Call {
+func (mr *MockFSMockRecorder) Create(ctx, storageID, namespace interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockFS)(nil).Create), ctx, namespace)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockFS)(nil).Create), ctx, storageID, namespace)
 }
 
 // Exists mocks base method.
-func (m *MockFS) Exists(ctx context.Context, namespace, filename string) (bool, error) {
+func (m *MockFS) Exists(ctx context.Context, storageID, namespace, filename string) (bool, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Exists", ctx, namespace, filename)
+	ret := m.ctrl.Call(m, "Exists", ctx, storageID, namespace, filename)
 	ret0, _ := ret[0].(bool)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Exists indicates an expected call of Exists.
-func (mr *MockFSMockRecorder) Exists(ctx, namespace, filename interface{}) *gomock.Call {
+func (mr *MockFSMockRecorder) Exists(ctx, storageID, namespace, filename interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exists", reflect.TypeOf((*MockFS)(nil).Exists), ctx, namespace, filename)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Exists", reflect.TypeOf((*MockFS)(nil).Exists), ctx, storageID, namespace, filename)
 }
 
 // GetRemoteURI mocks base method.
@@ -82,18 +82,18 @@ func (mr *MockFSMockRecorder) GetRemoteURI(ctx, namespace, filename interface{})
 }
 
 // Open mocks base method.
-func (m *MockFS) Open(ctx context.Context, namespace, filename string) (pyramid.File, error) {
+func (m *MockFS) Open(ctx context.Context, storageID, namespace, filename string) (pyramid.File, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Open", ctx, namespace, filename)
+	ret := m.ctrl.Call(m, "Open", ctx, storageID, namespace, filename)
 	ret0, _ := ret[0].(pyramid.File)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Open indicates an expected call of Open.
-func (mr *MockFSMockRecorder) Open(ctx, namespace, filename interface{}) *gomock.Call {
+func (mr *MockFSMockRecorder) Open(ctx, storageID, namespace, filename interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Open", reflect.TypeOf((*MockFS)(nil).Open), ctx, namespace, filename)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Open", reflect.TypeOf((*MockFS)(nil).Open), ctx, storageID, namespace, filename)
 }
 
 // MockFile is a mock of File interface.

--- a/pkg/pyramid/pyramid.go
+++ b/pkg/pyramid/pyramid.go
@@ -14,14 +14,14 @@ import (
 type FS interface {
 	// Create creates a new file in the FS.
 	// It will only be persistent after the returned file is stored.
-	Create(ctx context.Context, namespace string) (StoredFile, error)
+	Create(ctx context.Context, storageID string, namespace string) (StoredFile, error)
 
 	// Open finds the referenced file and returns its read-only File.
 	// If file isn't in the local disk, it is fetched from the block storage.
-	Open(ctx context.Context, namespace, filename string) (File, error)
+	Open(ctx context.Context, storageID string, namespace, filename string) (File, error)
 
 	// Exists returns true if filename currently exists on block storage.
-	Exists(ctx context.Context, namespace, filename string) (bool, error)
+	Exists(ctx context.Context, storageID string, namespace, filename string) (bool, error)
 
 	// GetRemoteURI returns the URI for filename on block storage.  That URI might not
 	// resolve if filename does not exist.

--- a/pkg/pyramid/pyramid.go
+++ b/pkg/pyramid/pyramid.go
@@ -25,7 +25,7 @@ type FS interface {
 
 	// GetRemoteURI returns the URI for filename on block storage.  That URI might not
 	// resolve if filename does not exist.
-	GetRemoteURI(ctx context.Context, namespace, filename string) (string, error)
+	GetRemoteURI(ctx context.Context, filename string) (string, error)
 }
 
 // File is pyramid abstraction for an os.File

--- a/pkg/pyramid/pyramid.go
+++ b/pkg/pyramid/pyramid.go
@@ -14,14 +14,14 @@ import (
 type FS interface {
 	// Create creates a new file in the FS.
 	// It will only be persistent after the returned file is stored.
-	Create(ctx context.Context, storageID string, namespace string) (StoredFile, error)
+	Create(ctx context.Context, storageID, namespace string) (StoredFile, error)
 
 	// Open finds the referenced file and returns its read-only File.
 	// If file isn't in the local disk, it is fetched from the block storage.
-	Open(ctx context.Context, storageID string, namespace, filename string) (File, error)
+	Open(ctx context.Context, storageID, namespace, filename string) (File, error)
 
 	// Exists returns true if filename currently exists on block storage.
-	Exists(ctx context.Context, storageID string, namespace, filename string) (bool, error)
+	Exists(ctx context.Context, storageID, namespace, filename string) (bool, error)
 
 	// GetRemoteURI returns the URI for filename on block storage.  That URI might not
 	// resolve if filename does not exist.

--- a/pkg/pyramid/pyramid.go
+++ b/pkg/pyramid/pyramid.go
@@ -25,7 +25,7 @@ type FS interface {
 
 	// GetRemoteURI returns the URI for filename on block storage.  That URI might not
 	// resolve if filename does not exist.
-	GetRemoteURI(ctx context.Context, filename string) (string, error)
+	GetRemoteURI(ctx context.Context, namespace, filename string) (string, error)
 }
 
 // File is pyramid abstraction for an os.File

--- a/pkg/pyramid/tier_fs.go
+++ b/pkg/pyramid/tier_fs.go
@@ -178,7 +178,7 @@ func (tfs *TierFS) store(ctx context.Context, storageID, namespace, originalPath
 	}
 }
 
-func (tfs *TierFS) GetRemoteURI(_ context.Context, filename string) (string, error) {
+func (tfs *TierFS) GetRemoteURI(_ context.Context, _, filename string) (string, error) {
 	return tfs.blockStoragePath(filename), nil
 }
 

--- a/pkg/pyramid/tier_fs.go
+++ b/pkg/pyramid/tier_fs.go
@@ -178,7 +178,7 @@ func (tfs *TierFS) store(ctx context.Context, storageID, namespace, originalPath
 	}
 }
 
-func (tfs *TierFS) GetRemoteURI(_ context.Context, _, filename string) (string, error) {
+func (tfs *TierFS) GetRemoteURI(_ context.Context, filename string) (string, error) {
 	return tfs.blockStoragePath(filename), nil
 }
 

--- a/pkg/pyramid/tier_fs.go
+++ b/pkg/pyramid/tier_fs.go
@@ -140,9 +140,10 @@ func (tfs *TierFS) removeFromLocalInternal(rPath params.RelativePath) {
 	}()
 }
 
-func (tfs *TierFS) store(ctx context.Context, namespace, originalPath, nsPath, filename string) error {
+func (tfs *TierFS) store(ctx context.Context, storageID string, namespace, originalPath, nsPath, filename string) error {
 	if tfs.logger.IsTracing() {
 		tfs.log(ctx).WithFields(logging.Fields{
+			"storageID":     storageID,
 			"namespace":     namespace,
 			"original_path": originalPath,
 			"ns_path":       nsPath,
@@ -160,7 +161,7 @@ func (tfs *TierFS) store(ctx context.Context, namespace, originalPath, nsPath, f
 		return fmt.Errorf("file stat %s: %w", originalPath, err)
 	}
 
-	if _, err = tfs.adapter.Put(ctx, tfs.objPointer(namespace, filename), stat.Size(), f, block.PutOpts{}); err != nil {
+	if _, err = tfs.adapter.Put(ctx, tfs.objPointer(storageID, namespace, filename), stat.Size(), f, block.PutOpts{}); err != nil {
 		return fmt.Errorf("adapter put %s %s: %w", namespace, filename, err)
 	}
 
@@ -168,7 +169,7 @@ func (tfs *TierFS) store(ctx context.Context, namespace, originalPath, nsPath, f
 		return fmt.Errorf("closing file %s: %w", filename, err)
 	}
 
-	fileRef := tfs.newLocalFileRef(namespace, nsPath, filename)
+	fileRef := tfs.newLocalFileRef(storageID, namespace, nsPath, filename)
 	if tfs.eviction.Store(fileRef.fsRelativePath, stat.Size()) {
 		// file was stored by the policy
 		return tfs.syncDir.renameFile(originalPath, fileRef.fullPath)
@@ -184,7 +185,7 @@ func (tfs *TierFS) GetRemoteURI(_ context.Context, _, filename string) (string, 
 // Create creates a new file in TierFS.  File isn't stored in TierFS until a successful close
 // operation.  Open(namespace, filename) calls will return an error before the close was
 // called.  Create only performs local operations so it ignores the context.
-func (tfs *TierFS) Create(_ context.Context, namespace string) (StoredFile, error) {
+func (tfs *TierFS) Create(_ context.Context, storageID string, namespace string) (StoredFile, error) {
 	nsPath, err := parseNamespacePath(namespace)
 	if err != nil {
 		return nil, err
@@ -203,7 +204,7 @@ func (tfs *TierFS) Create(_ context.Context, namespace string) (StoredFile, erro
 		File:   fh,
 		logger: tfs.logger,
 		store: func(ctx context.Context, filename string) error {
-			return tfs.store(ctx, namespace, tempPath, nsPath, filename)
+			return tfs.store(ctx, storageID, namespace, tempPath, nsPath, filename)
 		},
 		abort: func(context.Context) error {
 			return os.Remove(tempPath)
@@ -213,7 +214,7 @@ func (tfs *TierFS) Create(_ context.Context, namespace string) (StoredFile, erro
 
 // Open returns a file descriptor to the local file.
 // If the file is missing from the local disk, it will try to fetch it from the block storage.
-func (tfs *TierFS) Open(ctx context.Context, namespace, filename string) (File, error) {
+func (tfs *TierFS) Open(ctx context.Context, storageID, namespace, filename string) (File, error) {
 	nsPath, err := parseNamespacePath(namespace)
 	if err != nil {
 		return nil, err
@@ -223,7 +224,7 @@ func (tfs *TierFS) Open(ctx context.Context, namespace, filename string) (File, 
 	}
 
 	// check if file is there - without taking the lock
-	fileRef := tfs.newLocalFileRef(namespace, nsPath, filename)
+	fileRef := tfs.newLocalFileRef(storageID, namespace, nsPath, filename)
 	fh, err := os.Open(fileRef.fullPath)
 	if err == nil {
 		if tfs.logger.IsTracing() {
@@ -249,9 +250,9 @@ func (tfs *TierFS) Open(ctx context.Context, namespace, filename string) (File, 
 	return tfs.openFile(ctx, fileRef, fh)
 }
 
-func (tfs *TierFS) Exists(ctx context.Context, namespace, filename string) (bool, error) {
+func (tfs *TierFS) Exists(ctx context.Context, storageID, namespace, filename string) (bool, error) {
 	cacheAccess.WithLabelValues(tfs.fsName, "Exists").Inc()
-	return tfs.adapter.Exists(ctx, tfs.objPointer(namespace, filename))
+	return tfs.adapter.Exists(ctx, tfs.objPointer(storageID, namespace, filename))
 }
 
 // openFile converts an os.File to pyramid.ROFile and updates the eviction control.
@@ -283,6 +284,7 @@ func (tfs *TierFS) openWithLock(ctx context.Context, fileRef localFileRef) (*os.
 	log := tfs.log(ctx)
 	if tfs.logger.IsTracing() {
 		log.WithFields(logging.Fields{
+			"storageID": fileRef.storageID,
 			"namespace": fileRef.namespace,
 			"file":      fileRef.filename,
 			"fullpath":  fileRef.fullPath,
@@ -297,6 +299,7 @@ func (tfs *TierFS) openWithLock(ctx context.Context, fileRef localFileRef) (*os.
 		if err == nil {
 			if log.IsTracing() {
 				log.WithFields(logging.Fields{
+					"storageID": fileRef.storageID,
 					"namespace": fileRef.namespace,
 					"file":      fileRef.filename,
 					"fullpath":  fileRef.fullPath,
@@ -312,12 +315,13 @@ func (tfs *TierFS) openWithLock(ctx context.Context, fileRef localFileRef) (*os.
 
 		if log.IsTracing() {
 			log.WithFields(logging.Fields{
+				"storageID": fileRef.storageID,
 				"namespace": fileRef.namespace,
 				"file":      fileRef.filename,
 				"fullpath":  fileRef.fullPath,
 			}).Trace("get file from block storage")
 		}
-		reader, err := tfs.adapter.Get(ctx, tfs.objPointer(fileRef.namespace, fileRef.filename))
+		reader, err := tfs.adapter.Get(ctx, tfs.objPointer(fileRef.storageID, fileRef.namespace, fileRef.filename))
 		if err != nil {
 			return nil, fmt.Errorf("read from block storage: %w", err)
 		}
@@ -379,6 +383,7 @@ func validateFilename(filename string) error {
 
 // localFileRef consists of all possible local file references
 type localFileRef struct {
+	storageID      string
 	namespace      string
 	filename       string
 	fullPath       string
@@ -408,9 +413,10 @@ func (tfs *TierFS) storeLocalFile(rPath params.RelativePath, size int64) {
 	}
 }
 
-func (tfs *TierFS) newLocalFileRef(namespace, nsPath, filename string) localFileRef {
+func (tfs *TierFS) newLocalFileRef(storageID, namespace, nsPath, filename string) localFileRef {
 	rPath := path.Join(nsPath, filename)
 	return localFileRef{
+		storageID:      storageID,
 		namespace:      namespace,
 		filename:       filename,
 		fsRelativePath: params.RelativePath(rPath),
@@ -418,9 +424,9 @@ func (tfs *TierFS) newLocalFileRef(namespace, nsPath, filename string) localFile
 	}
 }
 
-func (tfs *TierFS) objPointer(namespace, filename string) block.ObjectPointer {
-	// TODO (gilo): ObjectPointer init - add StorageID here
+func (tfs *TierFS) objPointer(storageID, namespace, filename string) block.ObjectPointer {
 	return block.ObjectPointer{
+		StorageID:        storageID,
 		StorageNamespace: namespace,
 		IdentifierType:   block.IdentifierTypeRelative,
 		Identifier:       tfs.blockStoragePath(filepath.ToSlash(filename)),

--- a/pkg/pyramid/tier_fs.go
+++ b/pkg/pyramid/tier_fs.go
@@ -140,7 +140,7 @@ func (tfs *TierFS) removeFromLocalInternal(rPath params.RelativePath) {
 	}()
 }
 
-func (tfs *TierFS) store(ctx context.Context, storageID string, namespace, originalPath, nsPath, filename string) error {
+func (tfs *TierFS) store(ctx context.Context, storageID, namespace, originalPath, nsPath, filename string) error {
 	if tfs.logger.IsTracing() {
 		tfs.log(ctx).WithFields(logging.Fields{
 			"storageID":     storageID,
@@ -185,7 +185,7 @@ func (tfs *TierFS) GetRemoteURI(_ context.Context, _, filename string) (string, 
 // Create creates a new file in TierFS.  File isn't stored in TierFS until a successful close
 // operation.  Open(namespace, filename) calls will return an error before the close was
 // called.  Create only performs local operations so it ignores the context.
-func (tfs *TierFS) Create(_ context.Context, storageID string, namespace string) (StoredFile, error) {
+func (tfs *TierFS) Create(_ context.Context, storageID, namespace string) (StoredFile, error) {
 	nsPath, err := parseNamespacePath(namespace)
 	if err != nil {
 		return nil, err

--- a/pkg/pyramid/tier_fs_test.go
+++ b/pkg/pyramid/tier_fs_test.go
@@ -40,7 +40,7 @@ func TestReadFailDuringWrite(t *testing.T) {
 	ctx := context.Background()
 	namespace := uniqueNamespace()
 	filename := "file1"
-	f, err := fs.Create(ctx, namespace)
+	f, err := fs.Create(ctx, "", namespace)
 	require.NoError(t, err)
 
 	content := []byte("some content")
@@ -48,7 +48,7 @@ func TestReadFailDuringWrite(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, len(content), n)
 
-	readF, err := fs.Open(ctx, namespace, filename)
+	readF, err := fs.Open(ctx, "", namespace, filename)
 	require.Nil(t, readF)
 	require.Error(t, err)
 	require.NoError(t, f.Close())
@@ -127,7 +127,7 @@ func TestStartup(t *testing.T) {
 	// package os this does not matter.
 	assert.Error(t, err, os.ErrNotExist, "expected %s not to exist", workspacePath)
 
-	f, err := localFS.Open(ctx, "mem://"+namespaceID, filename)
+	f, err := localFS.Open(ctx, "", "mem://"+namespaceID, filename)
 	defer func() { _ = f.Close() }()
 	assert.NoError(t, err)
 
@@ -156,7 +156,7 @@ func testEviction(t *testing.T, namespaces ...string) {
 	for i := 0; i < numFiles; i++ {
 		filename := "file_" + strconv.Itoa(i)
 
-		f, err := fs.Open(ctx, namespaces[i%len(namespaces)], filename)
+		f, err := fs.Open(ctx, "", namespaces[i%len(namespaces)], filename)
 		require.NoError(t, err)
 
 		_, err = io.ReadAll(f)
@@ -206,7 +206,7 @@ func TestMultipleConcurrentReads(t *testing.T) {
 
 func writeToFile(t *testing.T, ctx context.Context, namespace, filename string, content []byte) {
 	t.Helper()
-	f, err := fs.Create(ctx, namespace)
+	f, err := fs.Create(ctx, "", namespace)
 	require.NoError(t, err)
 
 	n, err := f.Write(content)
@@ -219,7 +219,7 @@ func writeToFile(t *testing.T, ctx context.Context, namespace, filename string, 
 
 func checkContent(t *testing.T, ctx context.Context, namespace string, filename string, content []byte) {
 	t.Helper()
-	f, err := fs.Open(ctx, namespace, filename)
+	f, err := fs.Open(ctx, "", namespace, filename)
 	if err != nil {
 		t.Errorf("Failed to open namespace:%s filename:%s - %s", namespace, filename, err)
 		return


### PR DESCRIPTION
Working on Ariel's request from https://github.com/treeverse/lakeFS/pull/8549

The changes here and in range_manager.go seem odd. AFAICT, a metarange from a storage backend will manage ranges from that same backend. So why not hold storage ID on the metarange and range managers? Everything on them is either externally owned (like TierFS) or reference-counted (like the pebble read cache, which we manage as "cache Unrefer"). So committedManager might hold a map from StorageID to their metarange and range managers. This would allow us to limit the spread of StorageIDs throughout the code.