### PR TITLE
Update documentation for standalone garbage collector

### DIFF
--- a/docs/howto/garbage-collection/standalone-gc.md
+++ b/docs/howto/garbage-collection/standalone-gc.md
@@ -39,7 +39,7 @@ the sweep stage to delete them. It functions similarly to the GC's [mark-only mo
 
 ## Installation 
 
-### Step 1: Obtain Dockerhub token
+### Step 1: Obtain DockerHub token
 
 #### lakeFS Enterprise customers 
 
@@ -50,7 +50,7 @@ the `externallakefs` user.
 
 Please [contact us](https://lakefs.io/contact-sales/) to get trial access to Standalone GC.
 
-### Step 2: Login to Dockerhub with this token
+### Step 2: Login to DockerHub with this token
 
 ```bash
 docker login -u <token>
@@ -58,7 +58,8 @@ docker login -u <token>
 
 ### Step 3: Download the docker image
 
-Download the image from the [lakefs-sgc](https://hub.docker.com/repository/docker/treeverse/lakefs-sgc/general) repository:
+Download the `treeverse/lakefs-sgc` image from Docker Hub:
+
 ```bash
 docker pull treeverse/lakefs-sgc:<tag>
 ```
@@ -72,6 +73,7 @@ To run `lakefs-sgc`, you need both AWS (or S3-compatible) storage and lakeFS use
 #### Storage permissions
 
 The minimum required permissions for AWS or S3-compatible storage are:
+
 ```json
 {
   "Version": "2012-10-17",

--- a/docs/security/sso.md
+++ b/docs/security/sso.md
@@ -301,7 +301,7 @@ The authentication works by querying the LDAP server for user information and au
 
 See [Fluffy configuration][fluffy-configuration] reference.
 
-1. Repalce `auth.ldap.remote_authenticator.server_endpoint` with your LDAP server endpoint  (e.g `ldaps://ldap.ldap-address.com:636`)
+1. Replace `auth.ldap.remote_authenticator.server_endpoint` with your LDAP server endpoint  (e.g `ldaps://ldap.ldap-address.com:636`)
 2. Replace `auth.ldap.remote_authenticator.bind_dn` with the LDAP bind user/permissions to query your LDAP server.
 3. Replace `auth.ldap.remote_authenticator.user_base_dn` with the user base to search users in.
 
@@ -356,7 +356,7 @@ If you encounter LDAP connection errors, you should inspect the **fluffy contain
 
 ### Authentication issues
 
-Auth issues (e.g. user not found, invalid credentials) can be debugged with the [ldapwhoami](https://www.unix.com/man-page/osx/1/ldapwhoami) CLI tool. 
+Auth issues (e.g. user not found, invalid credentials) can be debugged with the `ldapwhoami` CLI tool. 
 
 The Examples are based on the fluffy config above:
 


### PR DESCRIPTION
- Remove the missing link to ldapwhoami man page
- Remove the link to private repository in ducker hub registry
- Fix spelling mistake
