### PR TITLE
Accelerate large files download using concurent chunks for lakectl download recursive

### DIFF
--- a/cmd/lakectl/cmd/fs_download.go
+++ b/cmd/lakectl/cmd/fs_download.go
@@ -96,10 +96,11 @@ var fsDownloadCmd = &cobra.Command{
 			go func() {
 				defer wg.Done()
 				for relPath := range ch {
+					srcPath := remote.GetPath() + relPath
 					src := uri.URI{
 						Repository: remote.Repository,
 						Ref:        remote.Ref,
-						Path:       &relPath,
+						Path:       &srcPath,
 					}
 					destPath := filepath.Join(dest, relPath)
 					singleObjectDownloadHelper(ctx, downloader, src, destPath)

--- a/cmd/lakectl/cmd/fs_download.go
+++ b/cmd/lakectl/cmd/fs_download.go
@@ -42,25 +42,20 @@ var fsDownloadCmd = &cobra.Command{
 		downloader.PartSize = downloadPartSize
 
 		if !recursive {
-			src := uri.URI{
-				Repository: remote.Repository,
-				Ref:        remote.Ref,
-				Path:       remote.Path,
-			}
 			// if dest is a directory, add the file name
 			if s, _ := os.Stat(dest); s != nil && s.IsDir() {
 				dest += uri.PathSeparator
 			}
-			remotePath := src.GetPath()
+			remotePath := remote.GetPath()
 			if remotePath != "" && strings.HasSuffix(dest, uri.PathSeparator) {
 				dest += filepath.Base(remotePath)
 			}
 
-			err := downloader.Download(ctx, src, dest, nil)
+			err := downloader.Download(ctx, *remote, dest, nil)
 			if err != nil {
 				DieErr(err)
 			}
-			fmt.Printf("download: %s to %s\n", src.String(), dest)
+			fmt.Printf("download: %s to %s\n", remote.String(), dest)
 			return
 		}
 

--- a/esti/lakectl_test.go
+++ b/esti/lakectl_test.go
@@ -642,6 +642,10 @@ func TestLakectlFsDownload(t *testing.T) {
 		require.Contains(t, sanitizedResult, "download ro/ro_1k.2")
 		require.Contains(t, sanitizedResult, "download ro/ro_1k.3")
 		require.Contains(t, sanitizedResult, "download ro/ro_1k.4")
+		require.Contains(t, sanitizedResult, "Download Summary:")
+		require.Contains(t, sanitizedResult, "Downloaded: 5")
+		require.Contains(t, sanitizedResult, "Uploaded: 0")
+		require.Contains(t, sanitizedResult, "Removed: 0")
 	})
 
 	t.Run("directory_with_dest", func(t *testing.T) {
@@ -652,6 +656,10 @@ func TestLakectlFsDownload(t *testing.T) {
 		require.Contains(t, sanitizedResult, "download ro/ro_1k.2")
 		require.Contains(t, sanitizedResult, "download ro/ro_1k.3")
 		require.Contains(t, sanitizedResult, "download ro/ro_1k.4")
+		require.Contains(t, sanitizedResult, "Download Summary:")
+		require.Contains(t, sanitizedResult, "Downloaded: 5")
+		require.Contains(t, sanitizedResult, "Uploaded: 0")
+		require.Contains(t, sanitizedResult, "Removed: 0")
 	})
 
 	t.Run("directory_without_recursive", func(t *testing.T) {

--- a/esti/lakectl_test.go
+++ b/esti/lakectl_test.go
@@ -600,19 +600,17 @@ func TestLakectlFsDownload(t *testing.T) {
 		RunCmdAndVerifySuccessWithFile(t, Lakectl()+" fs upload -s files/ro_1k lakefs://"+repoName+"/"+mainBranch+"/"+vars["FILE_PATH"], false, "lakectl_fs_upload", vars)
 	}
 	t.Run("single", func(t *testing.T) {
-		const fn = "data/ro/ro_1k.0"
-		src := "lakefs://" + repoName + "/" + mainBranch + "/" + fn
+		src := "lakefs://" + repoName + "/" + mainBranch + "/data/ro/ro_1k.0"
 		sanitizedResult := runCmd(t, Lakectl()+" fs download "+src, false, false, map[string]string{})
-		require.Contains(t, sanitizedResult, "download "+fn)
+		require.Contains(t, sanitizedResult, "download: "+src)
 	})
 
 	t.Run("single_with_dest", func(t *testing.T) {
-		const fn = "data/ro/ro_1k.0"
-		src := "lakefs://" + repoName + "/" + mainBranch + "/" + fn
+		src := "lakefs://" + repoName + "/" + mainBranch + "/data/ro/ro_1k.0"
 		dest := t.TempDir()
 		sanitizedResult := runCmd(t, Lakectl()+" fs download "+src+" "+dest, false, false, map[string]string{})
-		require.Contains(t, sanitizedResult, "download "+fn)
-		require.Contains(t, sanitizedResult, fn)
+		require.Contains(t, sanitizedResult, "download: "+src)
+		require.Contains(t, sanitizedResult, dest+"/"+"ro_1k.0")
 	})
 
 	t.Run("single_with_rel_dest", func(t *testing.T) {
@@ -626,11 +624,10 @@ func TestLakectlFsDownload(t *testing.T) {
 			require.NoError(t, os.Chdir(currDir))
 		}()
 
-		const fn = "data/ro/ro_1k.0"
-		src := "lakefs://" + repoName + "/" + mainBranch + "/" + fn
+		src := "lakefs://" + repoName + "/" + mainBranch + "/data/ro/ro_1k.0"
 		sanitizedResult := runCmd(t, Lakectl()+" fs download "+src+" ./", false, false, map[string]string{})
-		require.Contains(t, sanitizedResult, "download "+fn)
-		require.Contains(t, sanitizedResult, fn)
+		require.Contains(t, sanitizedResult, "download: "+src)
+		require.Contains(t, sanitizedResult, dest+"/ro_1k.0")
 	})
 
 	t.Run("single_with_recursive_flag", func(t *testing.T) {
@@ -645,10 +642,6 @@ func TestLakectlFsDownload(t *testing.T) {
 		require.Contains(t, sanitizedResult, "download ro/ro_1k.2")
 		require.Contains(t, sanitizedResult, "download ro/ro_1k.3")
 		require.Contains(t, sanitizedResult, "download ro/ro_1k.4")
-		require.Contains(t, sanitizedResult, "Download Summary:")
-		require.Contains(t, sanitizedResult, "Downloaded: 5")
-		require.Contains(t, sanitizedResult, "Uploaded: 0")
-		require.Contains(t, sanitizedResult, "Removed: 0")
 	})
 
 	t.Run("directory_with_dest", func(t *testing.T) {
@@ -659,10 +652,6 @@ func TestLakectlFsDownload(t *testing.T) {
 		require.Contains(t, sanitizedResult, "download ro/ro_1k.2")
 		require.Contains(t, sanitizedResult, "download ro/ro_1k.3")
 		require.Contains(t, sanitizedResult, "download ro/ro_1k.4")
-		require.Contains(t, sanitizedResult, "Download Summary:")
-		require.Contains(t, sanitizedResult, "Downloaded: 5")
-		require.Contains(t, sanitizedResult, "Uploaded: 0")
-		require.Contains(t, sanitizedResult, "Removed: 0")
 	})
 
 	t.Run("directory_without_recursive", func(t *testing.T) {

--- a/esti/lakectl_test.go
+++ b/esti/lakectl_test.go
@@ -428,7 +428,6 @@ func TestLakectlLogNoMergesWithCommitsAndMerges(t *testing.T) {
 
 	// log the commits without merges
 	RunCmdAndVerifySuccessWithFile(t, Lakectl()+" log lakefs://"+repoName+"/"+mainBranch+" --no-merges", false, "lakectl_log_no_merges", vars)
-
 }
 
 func TestLakectlLogNoMergesAndAmount(t *testing.T) {
@@ -480,8 +479,8 @@ func TestLakectlLogNoMergesAndAmount(t *testing.T) {
 
 	// log the commits without merges
 	RunCmdAndVerifySuccessWithFile(t, Lakectl()+" log lakefs://"+repoName+"/"+mainBranch+" --no-merges --amount=2", false, "lakectl_log_no_merges_amount", vars)
-
 }
+
 func TestLakectlAnnotate(t *testing.T) {
 	repoName := generateUniqueRepositoryName()
 	storage := generateUniqueStorageNamespace(repoName)
@@ -577,7 +576,6 @@ func TestLakectlAuthUsers(t *testing.T) {
 
 // testing without user email for now, since it is a pain to config esti with a mail
 func TestLakectlIdentity(t *testing.T) {
-
 	userId := "mike"
 	vars := map[string]string{
 		"ID": userId,
@@ -602,16 +600,18 @@ func TestLakectlFsDownload(t *testing.T) {
 		RunCmdAndVerifySuccessWithFile(t, Lakectl()+" fs upload -s files/ro_1k lakefs://"+repoName+"/"+mainBranch+"/"+vars["FILE_PATH"], false, "lakectl_fs_upload", vars)
 	}
 	t.Run("single", func(t *testing.T) {
-		src := "lakefs://" + repoName + "/" + mainBranch + "/data/ro/ro_1k.0"
+		const fn = "data/ro/ro_1k.0"
+		src := "lakefs://" + repoName + "/" + mainBranch + "/" + fn
 		sanitizedResult := runCmd(t, Lakectl()+" fs download "+src, false, false, map[string]string{})
-		require.Contains(t, sanitizedResult, "download: "+src)
+		require.Contains(t, sanitizedResult, "download "+fn)
 	})
 
 	t.Run("single_with_dest", func(t *testing.T) {
-		src := "lakefs://" + repoName + "/" + mainBranch + "/data/ro/ro_1k.0"
+		const fn = "data/ro/ro_1k.0"
+		src := "lakefs://" + repoName + "/" + mainBranch + "/" + fn
 		dest := t.TempDir()
 		sanitizedResult := runCmd(t, Lakectl()+" fs download "+src+" "+dest, false, false, map[string]string{})
-		require.Contains(t, sanitizedResult, "download: "+src)
+		require.Contains(t, sanitizedResult, "download "+fn)
 		require.Contains(t, sanitizedResult, dest+"/"+"ro_1k.0")
 	})
 
@@ -626,9 +626,10 @@ func TestLakectlFsDownload(t *testing.T) {
 			require.NoError(t, os.Chdir(currDir))
 		}()
 
-		src := "lakefs://" + repoName + "/" + mainBranch + "/data/ro/ro_1k.0"
+		const fn = "data/ro/ro_1k.0"
+		src := "lakefs://" + repoName + "/" + mainBranch + "/" + fn
 		sanitizedResult := runCmd(t, Lakectl()+" fs download "+src+" ./", false, false, map[string]string{})
-		require.Contains(t, sanitizedResult, "download: "+src)
+		require.Contains(t, sanitizedResult, "download "+fn)
 		require.Contains(t, sanitizedResult, dest+"/ro_1k.0")
 	})
 
@@ -690,7 +691,6 @@ func TestLakectlFsUpload(t *testing.T) {
 	t.Run("single_file_with_recursive", func(t *testing.T) {
 		vars["FILE_PATH"] = "data/ro/ro_1k.0"
 		RunCmdAndVerifySuccessWithFile(t, Lakectl()+" fs upload --recursive -s files/ro_1k lakefs://"+repoName+"/"+mainBranch+"/"+vars["FILE_PATH"]+" -s files/ro_1k", false, "lakectl_fs_upload", vars)
-
 	})
 	t.Run("dir", func(t *testing.T) {
 		vars["FILE_PATH"] = "data/ro/"

--- a/esti/lakectl_test.go
+++ b/esti/lakectl_test.go
@@ -612,7 +612,7 @@ func TestLakectlFsDownload(t *testing.T) {
 		dest := t.TempDir()
 		sanitizedResult := runCmd(t, Lakectl()+" fs download "+src+" "+dest, false, false, map[string]string{})
 		require.Contains(t, sanitizedResult, "download "+fn)
-		require.Contains(t, sanitizedResult, dest+"/"+"ro_1k.0")
+		require.Contains(t, sanitizedResult, fn)
 	})
 
 	t.Run("single_with_rel_dest", func(t *testing.T) {
@@ -630,7 +630,7 @@ func TestLakectlFsDownload(t *testing.T) {
 		src := "lakefs://" + repoName + "/" + mainBranch + "/" + fn
 		sanitizedResult := runCmd(t, Lakectl()+" fs download "+src+" ./", false, false, map[string]string{})
 		require.Contains(t, sanitizedResult, "download "+fn)
-		require.Contains(t, sanitizedResult, dest+"/ro_1k.0")
+		require.Contains(t, sanitizedResult, fn)
 	})
 
 	t.Run("single_with_recursive_flag", func(t *testing.T) {

--- a/pkg/api/helpers/download.go
+++ b/pkg/api/helpers/download.go
@@ -72,7 +72,7 @@ func (d *Downloader) Download(ctx context.Context, src uri.URI, dst string) erro
 
 	// progress tracker
 	tracker := &progress.Tracker{
-		Message: "download " + dst,
+		Message: "download " + src.GetPath(),
 		Total:   -1,
 	}
 


### PR DESCRIPTION
The current `lakectl fs download` supports downloading large files by splitting the files and downloading the content in parallel.

This change add the same support to the recursive option with the support to run multiple downloads (of parallel chunks) in parallel.

Close #8383
