### PR TITLE
Validate storage ID on repository creation

### DIFF
--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -16,6 +16,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"regexp"
+	"slices"
 	"strings"
 	"time"
 
@@ -2017,6 +2018,12 @@ func (c *Controller) CreateRepository(w http.ResponseWriter, r *http.Request, bo
 
 	if err := c.validateStorageNamespace(storageID, storageNamespace); err != nil {
 		writeError(w, r, http.StatusBadRequest, err)
+		return
+	}
+
+	// Validate storage ID exists
+	if !slices.Contains(c.Config.StorageConfig().GetStorageIDs(), storageID) {
+		c.handleAPIError(ctx, w, r, graveler.ErrInvalidStorageID)
 		return
 	}
 

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -451,10 +451,7 @@ func (c *Catalog) CreateRepository(ctx context.Context, repository string, stora
 	}); err != nil {
 		return nil, err
 	}
-	// TODO: this is a temporary validation. we should probably move this to the store level
-	if storageIdentifier != "" {
-		return nil, graveler.ErrInvalidStorageID
-	}
+
 	repo, err := c.Store.CreateRepository(ctx, repositoryID, storageIdentifier, storageNS, branchID, readOnly)
 	if err != nil {
 		return nil, err
@@ -483,10 +480,7 @@ func (c *Catalog) CreateBareRepository(ctx context.Context, repository string, s
 	}); err != nil {
 		return nil, err
 	}
-	// TODO: this is a temporary validation. we should probably move this to the store level
-	if storageIdentifier != "" {
-		return nil, graveler.ErrInvalidStorageID
-	}
+
 	repo, err := c.Store.CreateBareRepository(ctx, repositoryID, storageIdentifier, storageNS, branchID, readOnly)
 	if err != nil {
 		return nil, err

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -228,7 +228,7 @@ type Blockstore struct {
 }
 
 func (b *Blockstore) GetStorageIDs() []string {
-	return []string{""}
+	return []string{SingleBlockstoreID}
 }
 
 func (b *Blockstore) GetStorageByID(id string) AdapterConfig {

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -228,7 +228,7 @@ type Blockstore struct {
 }
 
 func (b *Blockstore) GetStorageIDs() []string {
-	return nil
+	return []string{""}
 }
 
 func (b *Blockstore) GetStorageByID(id string) AdapterConfig {


### PR DESCRIPTION
Closes #8618

## Change Description

### Background

This change completes the validation process of the storage ID while creating a repository

### Testing Details

Added controller tests to cover all the scenarios

### Breaking Change?

No
