### PR TITLE
test: client disconnect check metric with retry

### DIFF
--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -4763,9 +4763,11 @@ func TestController_ClientDisconnect(t *testing.T) {
 	}
 
 	// retry mechanism to identify if server updated metric on client disconnect
+	const tries = 3
+	const apiReqTotalMetricLabel = `api_requests_total{code="499",method="post"}`
 	const expectedCount = 1
 	var clientRequestClosedCount int
-	for try := 0; try < 3 && clientRequestClosedCount != expectedCount; try++ {
+	for try := 0; try < tries && clientRequestClosedCount != expectedCount; try++ {
 		// wait for the server to identify we left and update the counter
 		time.Sleep(time.Second)
 
@@ -4781,7 +4783,6 @@ func TestController_ClientDisconnect(t *testing.T) {
 		}
 
 		// process relevant metrics
-		const apiReqTotalMetricLabel = `api_requests_total{code="499",method="post"}`
 		for _, line := range strings.Split(string(body), "\n") {
 			if strings.HasPrefix(line, apiReqTotalMetricLabel) {
 				if count, err := strconv.Atoi(line[len(apiReqTotalMetricLabel)+1:]); err == nil {


### PR DESCRIPTION
This change introduces a retry mechanism for pulling metrics from the server when a client disconnection is detected. It attempts to retrieve the metric three times before giving up, ensuring data consistency even during brief interruptions.

