### PR TITLE
Automate rbac documentation 8201 draft

### DIFF
--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -3467,23 +3467,11 @@ func (c *Controller) StageObject(w http.ResponseWriter, r *http.Request, body ap
 func (c *Controller) CopyObject(w http.ResponseWriter, r *http.Request, body apigen.CopyObjectJSONRequestBody, repository, branch string, params apigen.CopyObjectParams) {
 	srcPath := body.SrcPath
 	destPath := params.DestPath
-	if !c.authorize(w, r, permissions.Node{
-		Type: permissions.NodeTypeAnd,
-		Nodes: []permissions.Node{
-			{
-				Permission: permissions.Permission{
-					Action:   permissions.ReadObjectAction,
-					Resource: permissions.ObjectArn(repository, srcPath),
-				},
-			},
-			{
-				Permission: permissions.Permission{
-					Action:   permissions.WriteObjectAction,
-					Resource: permissions.ObjectArn(repository, destPath),
-				},
-			},
-		},
-	}) {
+	if !c.authorize(w, r, permissions.CreatePermission("copy_object", map[string]string{
+		permissions.RepoID:  repository,
+		permissions.SrcKey:  srcPath,
+		permissions.DestKey: destPath,
+	})) {
 		return
 	}
 

--- a/pkg/permissions/permission.go
+++ b/pkg/permissions/permission.go
@@ -1,5 +1,10 @@
 package permissions
 
+import (
+	"fmt"
+	"strings"
+)
+
 const (
 	fsArnPrefix   = "arn:lakefs:fs:::"
 	authArnPrefix = "arn:lakefs:auth:::"
@@ -60,4 +65,77 @@ func PolicyArn(policyID string) string {
 
 func ExternalPrincipalArn(principalID string) string {
 	return authArnPrefix + "externalPrincipal/" + principalID
+}
+
+func placeholder(key string) string {
+	return fmt.Sprintf("{%s}", key)
+}
+
+func RenamePlaceholder(template, oldKey, newKey string) string {
+	oldPlaceholder := fmt.Sprintf("{%s}", oldKey)
+	newPlaceholder := fmt.Sprintf("{%s}", newKey)
+	return strings.ReplaceAll(template, oldPlaceholder, newPlaceholder)
+}
+
+func FillTemplate(template string, values map[string]string) string {
+	for key, value := range values {
+		template = strings.ReplaceAll(template, placeholder(key), value)
+	}
+	return template
+}
+
+const (
+	RepoID    = "repoID"
+	BranchID  = "branchID"
+	ObjectKey = "key"
+	SrcKey    = "srcKey"
+	DestKey   = "destKey"
+)
+
+var (
+	RepoArnTemplate       = fsArnPrefix + "repository/" + placeholder(RepoID)
+	BranchArnTemplate     = fsArnPrefix + "repository/" + placeholder(RepoID) + "/branch/" + placeholder(BranchID)
+	ObjectArnTemplate     = fsArnPrefix + "repository/" + placeholder(RepoID) + "/object/" + placeholder(ObjectKey)
+	SrcObjectArnTemplate  = RenamePlaceholder(ObjectArnTemplate, ObjectKey, SrcKey)
+	DestObjectArnTemplate = RenamePlaceholder(ObjectArnTemplate, ObjectKey, DestKey)
+)
+
+func FillPermissionTemplate(node *Node, values map[string]string) {
+	node.Permission.Resource = FillTemplate(node.Permission.Resource, values)
+
+	for i := range node.Nodes {
+		FillPermissionTemplate(&node.Nodes[i], values)
+	}
+}
+
+type PermissionFactory func() Node
+
+var PermissionFactories = map[string]PermissionFactory{
+	"copy_object": CopyObjectPermissions,
+}
+
+func CreatePermission(action string, values map[string]string) Node {
+	permissionNode := PermissionFactories[action]()
+	FillPermissionTemplate(&permissionNode, values)
+	return permissionNode
+}
+
+func CopyObjectPermissions() Node {
+	return Node{
+		Type: NodeTypeAnd,
+		Nodes: []Node{
+			{
+				Permission: Permission{
+					Action:   ReadObjectAction,
+					Resource: SrcObjectArnTemplate,
+				},
+			},
+			{
+				Permission: Permission{
+					Action:   WriteObjectAction,
+					Resource: DestObjectArnTemplate,
+				},
+			},
+		},
+	}
 }

--- a/pkg/permissions/permission_test.go
+++ b/pkg/permissions/permission_test.go
@@ -1,0 +1,51 @@
+package permissions_test
+
+import (
+	"testing"
+	"github.com/stretchr/testify/assert"
+
+	"github.com/treeverse/lakefs/pkg/permissions"
+)
+
+func TestArnTemplate(t *testing.T) {
+	repoId := "someRepo"
+	branchId := "someBranch"
+
+	templateRes := permissions.FillTemplate(permissions.BranchArnTemplate, (map[string]string{
+		"repoID":   repoId,
+		"branchID": branchId,
+	}))
+	assert.Equal(t, templateRes, permissions.BranchArn(repoId, branchId))
+}
+
+func TestFillPermissionTemplate(t *testing.T) {
+	repoId := "someRepo"
+	srcPath := "obj1"
+	destPath := "obj2"
+
+	permission := permissions.CopyObjectPermissions()
+	permissions.FillPermissionTemplate(&permission, map[string]string{
+		permissions.RepoID:  repoId,
+		permissions.SrcKey:  srcPath,
+		permissions.DestKey: destPath,
+	})
+
+	compareTo := permissions.Node{
+		Type: permissions.NodeTypeAnd,
+		Nodes: []permissions.Node{
+			{
+				Permission: permissions.Permission{
+					Action:   permissions.ReadObjectAction,
+					Resource: permissions.ObjectArn(repoId, srcPath),
+				},
+			},
+			{
+				Permission: permissions.Permission{
+					Action:   permissions.WriteObjectAction,
+					Resource: permissions.ObjectArn(repoId, destPath),
+				},
+			},
+		},
+	}
+	assert.Equal(t, permission, compareTo)
+}


### PR DESCRIPTION
This is related to issue #8201 

This is a draft, to get feedback on this solution before doing the refactoring for the rest of the actions.
The idea is that every action will have a permissionFactory that returns a permission node (like the ones used in controller.go right now) but the "resource" string will be a template that can be
1. filled before calling authorize() [which creates the node as used now] or  
2. used as-is in the documentation.

I chose the copy objects action for the test here to show the need for RenamePlaceholder, which otherwise will both have the base placeholder from ObjectArnTemplate.

Actions names, like "copy_objects" here, will be extracted to a variable.
