### PR TITLE
Handle StorageID in S3 Gateway

### DIFF
--- a/pkg/block/adapter.go
+++ b/pkg/block/adapter.go
@@ -211,6 +211,7 @@ type Adapter interface {
 
 	BlockstoreType() string
 	BlockstoreMetadata(ctx context.Context) (*BlockstoreMetadata, error)
+	// GetStorageNamespaceInfo returns the StorageNamespaceInfo for storageID or nil if not found.
 	GetStorageNamespaceInfo(storageID string) *StorageNamespaceInfo
 	ResolveNamespace(storageID, storageNamespace, key string, identifierType IdentifierType) (QualifiedKey, error)
 

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -2740,7 +2740,7 @@ func (c *Catalog) CopyEntry(ctx context.Context, srcRepository, srcRef, srcPath,
 		}
 
 		if srcRepo.StorageID != destRepo.StorageID {
-			return nil, fmt.Errorf("copy between different blockstores is not allowed: %w", graveler.ErrInvalidValue)
+			return nil, fmt.Errorf("%w: cannot copy between repos with different StorageIDs", graveler.ErrInvalidStorageID)
 		}
 	}
 

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -2738,6 +2738,10 @@ func (c *Catalog) CopyEntry(ctx context.Context, srcRepository, srcRef, srcPath,
 		if err != nil {
 			return nil, err
 		}
+
+		if srcRepo.StorageID != destRepo.StorageID {
+			return nil, fmt.Errorf("copy between different blockstores is not allowed: %w", graveler.ErrInvalidValue)
+		}
 	}
 
 	// copy data to a new physical address

--- a/pkg/gateway/operations/listobjects.go
+++ b/pkg/gateway/operations/listobjects.go
@@ -442,6 +442,7 @@ func handleListMultipartUploads(w http.ResponseWriter, req *http.Request, o *Rep
 		opts.KeyMarker = &keyMarker
 	}
 	mpuResp, err := o.BlockStore.ListMultipartUploads(req.Context(), block.ObjectPointer{
+		StorageID:        o.Repository.StorageID,
 		StorageNamespace: o.Repository.StorageNamespace,
 		IdentifierType:   block.IdentifierTypeRelative,
 	}, opts)

--- a/pkg/gateway/operations/putobject.go
+++ b/pkg/gateway/operations/putobject.go
@@ -177,6 +177,12 @@ func handleUploadPart(w http.ResponseWriter, req *http.Request, o *PathOperation
 			}
 		}
 
+		if srcRepo.StorageID != o.Repository.StorageID {
+			o.Log(req).WithField("copy_source", copySource).WithError(err).Error("copy between different blockstores is not allowed")
+			_ = o.EncodeError(w, req, err, gatewayErrors.Codes.ToAPIErr(gatewayErrors.ErrInvalidCopySource))
+			return
+		}
+
 		src := block.ObjectPointer{
 			StorageID:        srcRepo.StorageID,
 			StorageNamespace: srcRepo.StorageNamespace,

--- a/pkg/gateway/operations/putobject.go
+++ b/pkg/gateway/operations/putobject.go
@@ -178,7 +178,7 @@ func handleUploadPart(w http.ResponseWriter, req *http.Request, o *PathOperation
 		}
 
 		if srcRepo.StorageID != o.Repository.StorageID {
-			o.Log(req).WithField("copy_source", copySource).WithError(err).Error("copy between different blockstores is not allowed")
+			o.Log(req).WithField("copy_source", copySource).Error("copy between repos with different StorageIDs is not allowed")
 			_ = o.EncodeError(w, req, err, gatewayErrors.Codes.ToAPIErr(gatewayErrors.ErrInvalidCopySource))
 			return
 		}

--- a/pkg/gateway/operations/putobject_test.go
+++ b/pkg/gateway/operations/putobject_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/treeverse/lakefs/pkg/api/apiutil"
 	"github.com/treeverse/lakefs/pkg/block"
+	"github.com/treeverse/lakefs/pkg/config"
 	"github.com/treeverse/lakefs/pkg/testutil"
 	"github.com/treeverse/lakefs/pkg/upload"
 )
@@ -46,7 +47,7 @@ func TestWriteBlob(t *testing.T) {
 			reader := bytes.NewReader(data)
 			adapter := testutil.NewMockAdapter()
 			objectPointer := block.ObjectPointer{
-				StorageID:        "",
+				StorageID:        config.SingleBlockstoreID,
 				StorageNamespace: storageNamespace,
 				IdentifierType:   block.IdentifierTypeRelative,
 				Identifier:       upload.DefaultPathProvider.NewPath(),

--- a/pkg/upload/write_blob_test.go
+++ b/pkg/upload/write_blob_test.go
@@ -1,4 +1,4 @@
-package operations_test
+package upload_test
 
 import (
 	"bytes"


### PR DESCRIPTION
Closes #8641.

## Change Description

### Background

Making sure S3 Gateway plays way with `StorageID`.

Note that `StorageID` was already added to most of the relevant `ObjectPointer` objects,
So it's mainly about not allowing copy ops between two different  `StorageIDs`.

### Testing Details

AFAIK there's no coverage for the copy part,
So this was tested manually.
