### PR TITLE
Validate config per repo on server start

### DIFF
--- a/cmd/lakefs/cmd/run.go
+++ b/cmd/lakefs/cmd/run.go
@@ -445,6 +445,10 @@ func checkRepos(ctx context.Context, logger logging.Logger, config config.Config
 
 			for _, repo := range repos {
 				adapterConfig := config.StorageConfig().GetStorageByID(repo.StorageID)
+				if adapterConfig == nil {
+					logger.Fatalf("No storage configuration found for repository '%s', StorageID='%s'", repo.Name, repo.StorageID)
+					continue
+				}
 				adapterStorageType := adapterConfig.BlockstoreType()
 				nsURL, err := url.Parse(repo.StorageNamespace)
 				if err != nil {


### PR DESCRIPTION
Validate (on server start) that each repository has a valid blockstore configured for its `StorageID`.

Utilizing the current repo validation in `run.checkRepos()`.

Note that this area has no unit-tests -
This was tested manually.
