### PR TITLE
Enable parse config map properties from environment string value

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -597,7 +597,10 @@ func Unmarshal(c Config) error {
 	return viper.UnmarshalExact(&c,
 		viper.DecodeHook(
 			mapstructure.ComposeDecodeHookFunc(
-				DecodeStrings, mapstructure.StringToTimeDurationHookFunc())))
+				DecodeStrings,
+				mapstructure.StringToTimeDurationHookFunc(),
+				DecodeStringToMap(),
+			)))
 }
 
 func stringReverse(s string) string {

--- a/pkg/config/types.go
+++ b/pkg/config/types.go
@@ -17,6 +17,8 @@ var (
 	ourStringsType  = reflect.TypeOf(Strings{})
 	stringType      = reflect.TypeOf("")
 	stringSliceType = reflect.TypeOf([]string{})
+
+	ErrInvalidKeyValuePair = errors.New("invalid key-value pair")
 )
 
 // DecodeStrings is a mapstructure.HookFuncType that decodes a single string value or a slice
@@ -109,9 +111,9 @@ func DecodeStringToMap() mapstructure.DecodeHookFunc {
 		for _, pair := range pairs {
 			key, value, found := strings.Cut(pair, valueSep)
 			if !found {
-				return nil, fmt.Errorf("invalid key-value pair: %s", pair)
+				return nil, fmt.Errorf("%w: %s", ErrInvalidKeyValuePair, pair)
 			}
-			m[key] = value
+			m[strings.TrimSpace(key)] = strings.TrimSpace(value)
 		}
 
 		return m, nil


### PR DESCRIPTION
Closes #8658

Config populate from environment by DecodeStringToMap function for parsing string to map.

- Added a new function `DecodeStringToMap` to the `types.go` file.
- This function can be used to decode configuration values from a string to a map.
- This function is a `mapstructure.DecodeHookFunc` that converts a string to a map[string]string.
- The function parses a string that is expected to be a comma-separated list of key-value pairs, where the key and value are separated by an equal sign.
