### PR TITLE
Align lakectl config map parse from env support

### DIFF
--- a/cmd/lakectl/cmd/root.go
+++ b/cmd/lakectl/cmd/root.go
@@ -436,9 +436,12 @@ func preRunCmd(cmd *cobra.Command) {
 	logging.ContextUnavailable().
 		WithField("file", viper.ConfigFileUsed()).
 		Debug("loaded configuration from file")
-	err = viper.UnmarshalExact(&cfg, viper.DecodeHook(mapstructure.ComposeDecodeHookFunc(
-		lakefsconfig.DecodeOnlyString,
-		mapstructure.StringToTimeDurationHookFunc())))
+	err = viper.UnmarshalExact(&cfg, viper.DecodeHook(
+		mapstructure.ComposeDecodeHookFunc(
+			lakefsconfig.DecodeOnlyString,
+			mapstructure.StringToTimeDurationHookFunc(),
+			lakefsconfig.DecodeStringToMap(),
+		)))
 	if err != nil {
 		DieFmt("error unmarshal configuration: %v", err)
 	}


### PR DESCRIPTION
Part of #8658
