### PR TITLE
Duplicate specification for apache commons-lang3 in HadoopFS client lib

### DIFF
--- a/clients/hadoopfs/pom.xml
+++ b/clients/hadoopfs/pom.xml
@@ -290,11 +290,6 @@ To export to S3:
             <version>1.18.0</version>
         </dependency>
         <dependency>
-            <groupId>org.apache.commons</groupId>
-            <artifactId>commons-lang3</artifactId>
-            <version>3.12.0</version>
-        </dependency>
-        <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
             <version>${hadoop.version}</version>


### PR DESCRIPTION
Removed the dependency on Apache Commons Lang (commons-lang3) from the pom.xml file.
Fixes the compile warning saying the package was specified more than one time.