### PR TITLE
Truncated long value names in groups, users and policies

### DIFF
--- a/webui/src/lib/components/auth/nav.jsx
+++ b/webui/src/lib/components/auth/nav.jsx
@@ -9,6 +9,7 @@ import {Link, NavItem} from "../nav";
 import {useAPI} from "../../hooks/api";
 import {auth} from "../../api";
 
+const truncatedHeaderClass = "d-inline-block w-50 text-nowrap overflow-hidden text-truncate align-middle";
 
 export const UserNav = ({ userId, page = 'groups' }) => {
     const {RBAC: rbac} = useLoginConfigContext();
@@ -90,14 +91,7 @@ export const UserHeader = ({ userEmail, userId, page }) => {
                 <Link
                     component={BreadcrumbItem}
                     href={{pathname: '/auth/users/:userId', params: {userId}}}
-                    className="
-                        d-inline-block
-                        w-50
-                        text-nowrap
-                        overflow-hidden
-                        text-truncate
-                        align-middle
-                    "
+                    className={truncatedHeaderClass}
                     title={userEmail}
                 >
                     {userEmail}
@@ -119,14 +113,7 @@ export const GroupHeader = ({ groupId, page }) => {
                 <Link
                     component={BreadcrumbItem}
                     href={{pathname: '/auth/groups/:groupId', params: {groupId}}}
-                    className="
-                        d-inline-block
-                        w-50
-                        text-nowrap
-                        overflow-hidden
-                        text-truncate
-                        align-middle
-                    "
+                    className={truncatedHeaderClass}
                     title={groupId}
                 >
                     {groupId}
@@ -148,14 +135,7 @@ export const PolicyHeader = ({ policyId }) => {
                 <Link
                     component={BreadcrumbItem}
                     href={{pathname: '/auth/policies/:policyId', params: {policyId}}}
-                    className="
-                        d-inline-block
-                        w-50
-                        text-nowrap
-                        overflow-hidden
-                        text-truncate
-                        align-middle
-                    "
+                    className={truncatedHeaderClass}
                     title={policyId}
                 >
                     {policyId}

--- a/webui/src/lib/components/auth/nav.jsx
+++ b/webui/src/lib/components/auth/nav.jsx
@@ -19,14 +19,14 @@ export const UserNav = ({ userId, page = 'groups' }) => {
             </Link>
             {
                 rbac !== 'simplified' && (
-                <>
-                    <Link component={NavItem} active={page === 'policies'} href={{pathname: '/auth/users/:userId/policies', params: {userId}}}>
-                        Directly Attached Policies
-                    </Link>
-                    <Link component={NavItem} active={page === 'effectivePolicies'} href={{pathname: '/auth/users/:userId/policies/effective', params: {userId}}}>
-                        Effective Attached Policies
-                    </Link>
-                </>
+                    <>
+                        <Link component={NavItem} active={page === 'policies'} href={{pathname: '/auth/users/:userId/policies', params: {userId}}}>
+                            Directly Attached Policies
+                        </Link>
+                        <Link component={NavItem} active={page === 'effectivePolicies'} href={{pathname: '/auth/users/:userId/policies/effective', params: {userId}}}>
+                            Effective Attached Policies
+                        </Link>
+                    </>
                 )
 
             }
@@ -87,7 +87,19 @@ export const UserHeader = ({ userEmail, userId, page }) => {
                 <Link component={BreadcrumbItem} href='/auth/users'>
                     Users
                 </Link>
-                <Link component={BreadcrumbItem} href={{pathname: '/auth/users/:userId', params: {userId}}}>
+                <Link
+                    component={BreadcrumbItem}
+                    href={{pathname: '/auth/users/:userId', params: {userId}}}
+                    className="
+                        d-inline-block
+                        w-50
+                        text-nowrap
+                        overflow-hidden
+                        text-truncate
+                        align-middle
+                    "
+                    title={userEmail}
+                >
                     {userEmail}
                 </Link>
             </Breadcrumb>
@@ -104,7 +116,19 @@ export const GroupHeader = ({ groupId, page }) => {
                 <Link component={BreadcrumbItem} href='/auth/groups'>
                     Groups
                 </Link>
-                <Link component={BreadcrumbItem} href={{pathname: '/auth/groups/:groupId', params: {groupId}}}>
+                <Link
+                    component={BreadcrumbItem}
+                    href={{pathname: '/auth/groups/:groupId', params: {groupId}}}
+                    className="
+                        d-inline-block
+                        w-50
+                        text-nowrap
+                        overflow-hidden
+                        text-truncate
+                        align-middle
+                    "
+                    title={groupId}
+                >
                     {groupId}
                 </Link>
             </Breadcrumb>
@@ -121,7 +145,19 @@ export const PolicyHeader = ({ policyId }) => {
                 <Link component={BreadcrumbItem} href='/auth/policies'>
                     Policies
                 </Link>
-                <Link component={BreadcrumbItem} href={{pathname: '/auth/policies/:policyId', params: {policyId}}}>
+                <Link
+                    component={BreadcrumbItem}
+                    href={{pathname: '/auth/policies/:policyId', params: {policyId}}}
+                    className="
+                        d-inline-block
+                        w-50
+                        text-nowrap
+                        overflow-hidden
+                        text-truncate
+                        align-middle
+                    "
+                    title={policyId}
+                >
                     {policyId}
                 </Link>
             </Breadcrumb>

--- a/webui/src/lib/components/auth/nav.jsx
+++ b/webui/src/lib/components/auth/nav.jsx
@@ -19,14 +19,14 @@ export const UserNav = ({ userId, page = 'groups' }) => {
             </Link>
             {
                 rbac !== 'simplified' && (
-                    <>
-                        <Link component={NavItem} active={page === 'policies'} href={{pathname: '/auth/users/:userId/policies', params: {userId}}}>
-                            Directly Attached Policies
-                        </Link>
-                        <Link component={NavItem} active={page === 'effectivePolicies'} href={{pathname: '/auth/users/:userId/policies/effective', params: {userId}}}>
-                            Effective Attached Policies
-                        </Link>
-                    </>
+                <>
+                    <Link component={NavItem} active={page === 'policies'} href={{pathname: '/auth/users/:userId/policies', params: {userId}}}>
+                        Directly Attached Policies
+                    </Link>
+                    <Link component={NavItem} active={page === 'effectivePolicies'} href={{pathname: '/auth/users/:userId/policies/effective', params: {userId}}}>
+                        Effective Attached Policies
+                    </Link>
+                </>
                 )
 
             }


### PR DESCRIPTION
Closes #8665

## Issue
Long values names overflowed modal windows across Groups, Users and Policies pages in the "Administration" tab. 

## Fix
1. Applied truncation for long values in modals.
2. Users can hover to see full value and copy the truncated value.

## Changes Made

### In "Groups", "Users" and "Policies" Pages
Go to Administration -> "Groups", "Users" or "Policies" page -> click on the long name to enter to it's page

#### The issue screenshot:
![long_name_title_issue_1](https://github.com/user-attachments/assets/c8e2ae6d-3995-4daf-bd1f-c790f61a9869)

#### The fix screenshot:
![long_name_title_fix](https://github.com/user-attachments/assets/dd0d0aec-89f0-496c-96d1-37c4be1d8f4c)

#### Changed in file:
webui/src/lib/components/auth/nav.jsx (GroupHeader, PolicyHeader, UserHeader)
* Chaned in PolicyHeader since it has the same structure as GroupHeader and UserHeader

## Testing
Verified on lakeFS OSS using local DB & object store & ACL
