### PR TITLE
Truncated long value names in selected in the AttachModal

### DIFF
--- a/webui/src/lib/components/auth/forms.jsx
+++ b/webui/src/lib/components/auth/forms.jsx
@@ -11,21 +11,21 @@ import {Checkbox, DataTable, DebouncedFormControl, AlertError, Loading} from "..
 
 
 export const AttachModal = ({
-                                show, searchFn, resolveEntityFn = (ent => ent.id), onAttach, onHide, addText = "Add",
-                                emptyState = 'No matches', modalTitle = 'Add', headers = ['Select', 'ID'],
-                                filterPlaceholder = 'Filter...'
+                              show, searchFn, resolveEntityFn = (ent => ent.id), onAttach, onHide, addText = "Add",
+                              emptyState = 'No matches', modalTitle = 'Add', headers = ['Select', 'ID'],
+                              filterPlaceholder = 'Filter...'
                             }) => {
   const search = useRef(null);
   const [searchPrefix, setSearchPrefix] = useState("");
   const [selected, setSelected] = useState([]);
 
   useEffect(() => {
-      if (!!search.current && search.current.value === "")
-          search.current.focus();
+    if (!!search.current && search.current.value === "")
+      search.current.focus();
   });
 
   const {response, error, loading} = useAPI(() => {
-      return searchFn(searchPrefix);
+    return searchFn(searchPrefix);
   }, [searchPrefix]);
 
   let content;
@@ -34,83 +34,83 @@ export const AttachModal = ({
   else content = (
       <>
         <DataTable
-            headers={headers}
-            keyFn={ent => ent.id}
-            emptyState={emptyState}
-            results={response}
-            rowFn={ent => [
-                <Checkbox
-                    defaultChecked={selected.some(selectedEnt => selectedEnt.id === ent.id)}
-                    onAdd={() => setSelected([...selected, ent])}
-                    onRemove={() => setSelected(selected.filter(selectedEnt => selectedEnt.id !== ent.id))}
-                    name={'selected'}/>,
-                <strong>{resolveEntityFn(ent)}</strong>
-            ]}/>
+          headers={headers}
+          keyFn={ent => ent.id}
+          emptyState={emptyState}
+          results={response}
+          rowFn={ent => [
+            <Checkbox
+              defaultChecked={selected.some(selectedEnt => selectedEnt.id === ent.id)}
+              onAdd={() => setSelected([...selected, ent])}
+              onRemove={() => setSelected(selected.filter(selectedEnt => selectedEnt.id !== ent.id))}
+              name={'selected'}/>,
+            <strong>{resolveEntityFn(ent)}</strong>
+        ]}/>
 
         <div className="mt-3">
-            {(selected.length > 0) &&
-                <p>
-                    <strong>Selected: </strong>
-                    {(selected.map(item => (
-                        <Badge
-                            key={item.id}
-                            pill
-                            variant="primary"
-                            className="
-                                me-1
-                                d-inline-block
-                                w-25
-                                text-nowrap
-                                overflow-hidden
-                                text-truncate
-                                align-middle
-                            "
-                            title={resolveEntityFn(item)}
-                        >
-                        {resolveEntityFn(item)}
-                        </Badge>
-                    )))}
-                </p>
-            }
+        {(selected.length > 0) &&
+          <p>
+            <strong>Selected: </strong>
+            {(selected.map(item => (
+              <Badge
+                key={item.id}
+                pill
+                variant="primary"
+                className="
+                    me-1
+                    d-inline-block
+                    w-25
+                    text-nowrap
+                    overflow-hidden
+                    text-truncate
+                    align-middle
+                "
+                title={resolveEntityFn(item)}
+              >
+                {resolveEntityFn(item)}
+              </Badge>
+            )))}
+          </p>
+        }
         </div>
-        </>
+      </>
     );
 
-    return (
-      <Modal show={show} onHide={onHide}>
-        <Modal.Header closeButton>
-          <Modal.Title>{modalTitle}</Modal.Title>
-        </Modal.Header>
-        <Modal.Body>
-          <Form onSubmit={e => {
-            e.preventDefault()
-          }}>
-            <InputGroup>
-                <InputGroup.Text>
-                    <SearchIcon/>
-                </InputGroup.Text>
-                <DebouncedFormControl
-                    ref={search}
-                    placeholder={filterPlaceholder}
-                    onChange={() => {
-                        setSearchPrefix(search.current.value)
-                    }}/>
-            </InputGroup>
-          </Form>
-          <div className="mt-2">
-            {content}
-          </div>
-        </Modal.Body>
-        <Modal.Footer>
-          <Button variant="success" disabled={selected.length === 0} onClick={() => {
-            onAttach(selected)
-          }}>
-            {addText}
-          </Button>
-          <Button variant="secondary" onClick={onHide}>Cancel</Button>
-        </Modal.Footer>
+  return (
+    <Modal show={show} onHide={onHide}>
+      <Modal.Header closeButton>
+        <Modal.Title>{modalTitle}</Modal.Title>
+      </Modal.Header>
+      <Modal.Body>
+        <Form onSubmit={e => {
+          e.preventDefault()
+        }}>
+          <InputGroup>
+            <InputGroup.Text>
+              <SearchIcon/>
+            </InputGroup.Text>
+            <DebouncedFormControl
+              ref={search}
+              placeholder={filterPlaceholder}
+              onChange={() => {
+                setSearchPrefix(search.current.value)
+              }}/>
+          </InputGroup>
+        </Form>
+        <div className="mt-2">
+          {content}
+        </div>
+      </Modal.Body>
+      <Modal.Footer>
+        <Button variant="success" disabled={selected.length === 0} onClick={() => {
+          onAttach(selected)
+        }}>
+          {addText}
+        </Button>
+        <Button variant="secondary" onClick={onHide}>Cancel</Button>
+      </Modal.Footer>
     </Modal>
-    );
+  );
 };
 
 export const EntityActionModal = ({
@@ -131,26 +131,26 @@ export const EntityActionModal = ({
 
   useEffect(() => {
     if (!!idField.current && idField.current.value === "") {
-        idField.current.focus();
+      idField.current.focus();
     }
   });
 
   const onSubmit = () => {
     if (validationFunction) {
-        const validationResult = validationFunction(idField.current.value);
+      const validationResult = validationFunction(idField.current.value);
+      if (!validationResult.isValid) {
+        setError(validationResult.errorMessage);
+        return;
+      }
+    }
+    if (showExtraField) {
+      if (extraValidationFunction) {
+        const validationResult = extraValidationFunction(extraField.current.value);
         if (!validationResult.isValid) {
           setError(validationResult.errorMessage);
           return;
         }
-    }
-    if (showExtraField) {
-        if (extraValidationFunction) {
-            const validationResult = extraValidationFunction(extraField.current.value);
-            if (!validationResult.isValid) {
-              setError(validationResult.errorMessage);
-              return;
-            }
-        }
+     }
       onAction(idField.current.value, extraField.current.value).catch(err => setError(err));
     } else {
       onAction(idField.current.value).catch(err => setError(err));
@@ -163,20 +163,20 @@ export const EntityActionModal = ({
         <Modal.Title>{title}</Modal.Title>
       </Modal.Header>
 
-    <Modal.Body>
-      <Form onSubmit={e => {
-        e.preventDefault()
-        onSubmit()
-      }}>
-        <FormControl ref={idField} autoFocus placeholder={placeholder} type="text"/>
-        {showExtraField &&
-          <FormControl ref={extraField} placeholder={extraPlaceholder} type="text" className="mt-3"/>
-        }
-    </Form>
+      <Modal.Body>
+        <Form onSubmit={e => {
+          e.preventDefault()
+          onSubmit()
+        }}>
+          <FormControl ref={idField} autoFocus placeholder={placeholder} type="text"/>
+          {showExtraField &&
+            <FormControl ref={extraField} placeholder={extraPlaceholder} type="text" className="mt-3"/>
+          }
+      </Form>
 
-      {(!!error) && <AlertError className="mt-3" error={error}/>}
+        {(!!error) && <AlertError className="mt-3" error={error}/>}
 
-    </Modal.Body>
+      </Modal.Body>
 
       <Modal.Footer>
         <Button onClick={onSubmit} variant="success">{actionName}</Button>

--- a/webui/src/lib/components/auth/forms.jsx
+++ b/webui/src/lib/components/auth/forms.jsx
@@ -15,173 +15,173 @@ export const AttachModal = ({
                                 emptyState = 'No matches', modalTitle = 'Add', headers = ['Select', 'ID'],
                                 filterPlaceholder = 'Filter...'
                             }) => {
-    const search = useRef(null);
-    const [searchPrefix, setSearchPrefix] = useState("");
-    const [selected, setSelected] = useState([]);
+  const search = useRef(null);
+  const [searchPrefix, setSearchPrefix] = useState("");
+  const [selected, setSelected] = useState([]);
 
-    useEffect(() => {
-        if (!!search.current && search.current.value === "")
-            search.current.focus();
-    });
+  useEffect(() => {
+      if (!!search.current && search.current.value === "")
+          search.current.focus();
+  });
 
-    const {response, error, loading} = useAPI(() => {
-        return searchFn(searchPrefix);
-    }, [searchPrefix]);
+  const {response, error, loading} = useAPI(() => {
+      return searchFn(searchPrefix);
+  }, [searchPrefix]);
 
-    let content;
-    if (loading) content = <Loading/>;
-    else if (error) content = <AlertError error={error}/>;
-    else content = (
-            <>
-                <DataTable
-                    headers={headers}
-                    keyFn={ent => ent.id}
-                    emptyState={emptyState}
-                    results={response}
-                    rowFn={ent => [
-                        <Checkbox
-                            defaultChecked={selected.some(selectedEnt => selectedEnt.id === ent.id)}
-                            onAdd={() => setSelected([...selected, ent])}
-                            onRemove={() => setSelected(selected.filter(selectedEnt => selectedEnt.id !== ent.id))}
-                            name={'selected'}/>,
-                        <strong>{resolveEntityFn(ent)}</strong>
-                    ]}/>
+  let content;
+  if (loading) content = <Loading/>;
+  else if (error) content = <AlertError error={error}/>;
+  else content = (
+      <>
+        <DataTable
+            headers={headers}
+            keyFn={ent => ent.id}
+            emptyState={emptyState}
+            results={response}
+            rowFn={ent => [
+                <Checkbox
+                    defaultChecked={selected.some(selectedEnt => selectedEnt.id === ent.id)}
+                    onAdd={() => setSelected([...selected, ent])}
+                    onRemove={() => setSelected(selected.filter(selectedEnt => selectedEnt.id !== ent.id))}
+                    name={'selected'}/>,
+                <strong>{resolveEntityFn(ent)}</strong>
+            ]}/>
 
-                <div className="mt-3">
-                    {(selected.length > 0) &&
-                        <p>
-                            <strong>Selected: </strong>
-                            {(selected.map(item => (
-                                <Badge
-                                    key={item.id}
-                                    pill
-                                    variant="primary"
-                                    className="
-                                        me-1
-                                        d-inline-block
-                                        w-25
-                                        text-nowrap
-                                        overflow-hidden
-                                        text-truncate
-                                        align-middle
-                                    "
-                                    title={resolveEntityFn(item)}
-                                >
-                                {resolveEntityFn(item)}
-                                </Badge>
-                            )))}
-                        </p>
-                    }
-                </div>
-            </>
-        );
+        <div className="mt-3">
+            {(selected.length > 0) &&
+                <p>
+                    <strong>Selected: </strong>
+                    {(selected.map(item => (
+                        <Badge
+                            key={item.id}
+                            pill
+                            variant="primary"
+                            className="
+                                me-1
+                                d-inline-block
+                                w-25
+                                text-nowrap
+                                overflow-hidden
+                                text-truncate
+                                align-middle
+                            "
+                            title={resolveEntityFn(item)}
+                        >
+                        {resolveEntityFn(item)}
+                        </Badge>
+                    )))}
+                </p>
+            }
+        </div>
+        </>
+    );
 
     return (
-        <Modal show={show} onHide={onHide}>
-            <Modal.Header closeButton>
-                <Modal.Title>{modalTitle}</Modal.Title>
-            </Modal.Header>
-            <Modal.Body>
-                <Form onSubmit={e => {
-                    e.preventDefault()
-                }}>
-                    <InputGroup>
-                        <InputGroup.Text>
-                            <SearchIcon/>
-                        </InputGroup.Text>
-                        <DebouncedFormControl
-                            ref={search}
-                            placeholder={filterPlaceholder}
-                            onChange={() => {
-                                setSearchPrefix(search.current.value)
-                            }}/>
-                    </InputGroup>
-                </Form>
-                <div className="mt-2">
-                    {content}
-                </div>
-            </Modal.Body>
-            <Modal.Footer>
-                <Button variant="success" disabled={selected.length === 0} onClick={() => {
-                    onAttach(selected)
-                }}>
-                    {addText}
-                </Button>
-                <Button variant="secondary" onClick={onHide}>Cancel</Button>
-            </Modal.Footer>
-        </Modal>
+      <Modal show={show} onHide={onHide}>
+        <Modal.Header closeButton>
+          <Modal.Title>{modalTitle}</Modal.Title>
+        </Modal.Header>
+        <Modal.Body>
+          <Form onSubmit={e => {
+            e.preventDefault()
+          }}>
+            <InputGroup>
+                <InputGroup.Text>
+                    <SearchIcon/>
+                </InputGroup.Text>
+                <DebouncedFormControl
+                    ref={search}
+                    placeholder={filterPlaceholder}
+                    onChange={() => {
+                        setSearchPrefix(search.current.value)
+                    }}/>
+            </InputGroup>
+          </Form>
+          <div className="mt-2">
+            {content}
+          </div>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button variant="success" disabled={selected.length === 0} onClick={() => {
+            onAttach(selected)
+          }}>
+            {addText}
+          </Button>
+          <Button variant="secondary" onClick={onHide}>Cancel</Button>
+        </Modal.Footer>
+    </Modal>
     );
 };
 
 export const EntityActionModal = ({
-                                      show,
-                                      onHide,
-                                      onAction,
-                                      title,
-                                      placeholder,
-                                      actionName,
-                                      validationFunction = null,
-                                      showExtraField = false,
-                                      extraPlaceholder = "",
-                                      extraValidationFunction = null
+                                    show,
+                                    onHide,
+                                    onAction,
+                                    title,
+                                    placeholder,
+                                    actionName,
+                                    validationFunction = null,
+                                    showExtraField = false,
+                                    extraPlaceholder = "",
+                                    extraValidationFunction = null
                                   }) => {
-    const [error, setError] = useState(null);
-    const idField = useRef(null);
-    const extraField = useRef(null);
+  const [error, setError] = useState(null);
+  const idField = useRef(null);
+  const extraField = useRef(null);
 
-    useEffect(() => {
-        if (!!idField.current && idField.current.value === "") {
-            idField.current.focus();
+  useEffect(() => {
+    if (!!idField.current && idField.current.value === "") {
+        idField.current.focus();
+    }
+  });
+
+  const onSubmit = () => {
+    if (validationFunction) {
+        const validationResult = validationFunction(idField.current.value);
+        if (!validationResult.isValid) {
+          setError(validationResult.errorMessage);
+          return;
         }
-    });
-
-    const onSubmit = () => {
-        if (validationFunction) {
-            const validationResult = validationFunction(idField.current.value);
+    }
+    if (showExtraField) {
+        if (extraValidationFunction) {
+            const validationResult = extraValidationFunction(extraField.current.value);
             if (!validationResult.isValid) {
-                setError(validationResult.errorMessage);
-                return;
+              setError(validationResult.errorMessage);
+              return;
             }
         }
-        if (showExtraField) {
-            if (extraValidationFunction) {
-                const validationResult = extraValidationFunction(extraField.current.value);
-                if (!validationResult.isValid) {
-                    setError(validationResult.errorMessage);
-                    return;
-                }
-            }
-            onAction(idField.current.value, extraField.current.value).catch(err => setError(err));
-        } else {
-            onAction(idField.current.value).catch(err => setError(err));
+      onAction(idField.current.value, extraField.current.value).catch(err => setError(err));
+    } else {
+      onAction(idField.current.value).catch(err => setError(err));
+    }
+  };
+
+  return (
+    <Modal show={show} onHide={onHide}>
+      <Modal.Header closeButton>
+        <Modal.Title>{title}</Modal.Title>
+      </Modal.Header>
+
+    <Modal.Body>
+      <Form onSubmit={e => {
+        e.preventDefault()
+        onSubmit()
+      }}>
+        <FormControl ref={idField} autoFocus placeholder={placeholder} type="text"/>
+        {showExtraField &&
+          <FormControl ref={extraField} placeholder={extraPlaceholder} type="text" className="mt-3"/>
         }
-    };
+    </Form>
 
-    return (
-        <Modal show={show} onHide={onHide}>
-            <Modal.Header closeButton>
-                <Modal.Title>{title}</Modal.Title>
-            </Modal.Header>
+      {(!!error) && <AlertError className="mt-3" error={error}/>}
 
-            <Modal.Body>
-                <Form onSubmit={e => {
-                    e.preventDefault()
-                    onSubmit()
-                }}>
-                    <FormControl ref={idField} autoFocus placeholder={placeholder} type="text"/>
-                    {showExtraField &&
-                        <FormControl ref={extraField} placeholder={extraPlaceholder} type="text" className="mt-3"/>
-                    }
-                </Form>
+    </Modal.Body>
 
-                {(!!error) && <AlertError className="mt-3" error={error}/>}
-
-            </Modal.Body>
-
-            <Modal.Footer>
-                <Button onClick={onSubmit} variant="success">{actionName}</Button>
-                <Button onClick={onHide} variant="secondary">Cancel</Button>
-            </Modal.Footer>
-        </Modal>
-    );
+      <Modal.Footer>
+        <Button onClick={onSubmit} variant="success">{actionName}</Button>
+        <Button onClick={onHide} variant="secondary">Cancel</Button>
+      </Modal.Footer>
+    </Modal>
+  );
 };

--- a/webui/src/lib/components/auth/forms.jsx
+++ b/webui/src/lib/components/auth/forms.jsx
@@ -67,7 +67,7 @@ export const AttachModal = ({
                                     "
                                     title={resolveEntityFn(item)}
                                 >
-                                    {resolveEntityFn(item)}
+                                {resolveEntityFn(item)}
                                 </Badge>
                             )))}
                         </p>

--- a/webui/src/lib/components/auth/forms.jsx
+++ b/webui/src/lib/components/auth/forms.jsx
@@ -45,36 +45,36 @@ export const AttachModal = ({
               onRemove={() => setSelected(selected.filter(selectedEnt => selectedEnt.id !== ent.id))}
               name={'selected'}/>,
             <strong>{resolveEntityFn(ent)}</strong>
-        ]}/>
+          ]}/>
 
         <div className="mt-3">
-        {(selected.length > 0) &&
-          <p>
-            <strong>Selected: </strong>
-            {(selected.map(item => (
-              <Badge
-                key={item.id}
-                pill
-                variant="primary"
-                className="
-                    me-1
-                    d-inline-block
-                    w-25
-                    text-nowrap
-                    overflow-hidden
-                    text-truncate
-                    align-middle
-                "
-                title={resolveEntityFn(item)}
-              >
-                {resolveEntityFn(item)}
-              </Badge>
+          {(selected.length > 0) &&
+            <p>
+              <strong>Selected: </strong>
+              {(selected.map(item => (
+                <Badge
+                  key={item.id}
+                  pill
+                  variant="primary"
+                  className="
+                      me-1
+                      d-inline-block
+                      w-25
+                      text-nowrap
+                      overflow-hidden
+                      text-truncate
+                      align-middle
+                  "
+                  title={resolveEntityFn(item)}
+                >
+                  {resolveEntityFn(item)}
+                </Badge>
             )))}
-          </p>
-        }
+            </p>
+          }
         </div>
       </>
-    );
+  );
 
   return (
     <Modal show={show} onHide={onHide}>
@@ -150,7 +150,7 @@ export const EntityActionModal = ({
           setError(validationResult.errorMessage);
           return;
         }
-     }
+      }
       onAction(idField.current.value, extraField.current.value).catch(err => setError(err));
     } else {
       onAction(idField.current.value).catch(err => setError(err));
@@ -172,7 +172,7 @@ export const EntityActionModal = ({
           {showExtraField &&
             <FormControl ref={extraField} placeholder={extraPlaceholder} type="text" className="mt-3"/>
           }
-      </Form>
+        </Form>
 
         {(!!error) && <AlertError className="mt-3" error={error}/>}
 

--- a/webui/src/lib/components/auth/forms.jsx
+++ b/webui/src/lib/components/auth/forms.jsx
@@ -69,12 +69,12 @@ export const AttachModal = ({
                 >
                   {resolveEntityFn(item)}
                 </Badge>
-            )))}
+              )))}
             </p>
           }
         </div>
       </>
-  );
+    );
 
   return (
     <Modal show={show} onHide={onHide}>

--- a/webui/src/lib/components/auth/forms.jsx
+++ b/webui/src/lib/components/auth/forms.jsx
@@ -11,163 +11,177 @@ import {Checkbox, DataTable, DebouncedFormControl, AlertError, Loading} from "..
 
 
 export const AttachModal = ({
-                              show, searchFn, resolveEntityFn = (ent => ent.id), onAttach, onHide, addText = "Add",
-                              emptyState = 'No matches', modalTitle = 'Add', headers = ['Select', 'ID'],
-                              filterPlaceholder = 'Filter...'
+                                show, searchFn, resolveEntityFn = (ent => ent.id), onAttach, onHide, addText = "Add",
+                                emptyState = 'No matches', modalTitle = 'Add', headers = ['Select', 'ID'],
+                                filterPlaceholder = 'Filter...'
                             }) => {
-  const search = useRef(null);
-  const [searchPrefix, setSearchPrefix] = useState("");
-  const [selected, setSelected] = useState([]);
+    const search = useRef(null);
+    const [searchPrefix, setSearchPrefix] = useState("");
+    const [selected, setSelected] = useState([]);
 
-  useEffect(() => {
-    if (!!search.current && search.current.value === "")
-      search.current.focus();
-  });
+    useEffect(() => {
+        if (!!search.current && search.current.value === "")
+            search.current.focus();
+    });
 
-  const {response, error, loading} = useAPI(() => {
-    return searchFn(searchPrefix);
-  }, [searchPrefix]);
+    const {response, error, loading} = useAPI(() => {
+        return searchFn(searchPrefix);
+    }, [searchPrefix]);
 
-  let content;
-  if (loading) content = <Loading/>;
-  else if (error) content = <AlertError error={error}/>;
-  else content = (
-      <>
-        <DataTable
-          headers={headers}
-          keyFn={ent => ent.id}
-          emptyState={emptyState}
-          results={response}
-          rowFn={ent => [
-            <Checkbox
-              defaultChecked={selected.some(selectedEnt => selectedEnt.id === ent.id)}
-              onAdd={() => setSelected([...selected, ent])}
-              onRemove={() => setSelected(selected.filter(selectedEnt => selectedEnt.id !== ent.id))}
-              name={'selected'}/>,
-            <strong>{resolveEntityFn(ent)}</strong>
-          ]}/>
+    let content;
+    if (loading) content = <Loading/>;
+    else if (error) content = <AlertError error={error}/>;
+    else content = (
+            <>
+                <DataTable
+                    headers={headers}
+                    keyFn={ent => ent.id}
+                    emptyState={emptyState}
+                    results={response}
+                    rowFn={ent => [
+                        <Checkbox
+                            defaultChecked={selected.some(selectedEnt => selectedEnt.id === ent.id)}
+                            onAdd={() => setSelected([...selected, ent])}
+                            onRemove={() => setSelected(selected.filter(selectedEnt => selectedEnt.id !== ent.id))}
+                            name={'selected'}/>,
+                        <strong>{resolveEntityFn(ent)}</strong>
+                    ]}/>
 
-        <div className="mt-3">
-          {(selected.length > 0) &&
-            <p>
-              <strong>Selected: </strong>
-              {(selected.map(item => (
-                <Badge key={item.id} pill variant="primary" className="me-1">
-                  {resolveEntityFn(item)}
-                </Badge>
-              )))}
-            </p>
-          }
-        </div>
-      </>
+                <div className="mt-3">
+                    {(selected.length > 0) &&
+                        <p>
+                            <strong>Selected: </strong>
+                            {(selected.map(item => (
+                                <Badge
+                                    key={item.id}
+                                    pill
+                                    variant="primary"
+                                    className="
+                                        me-1
+                                        d-inline-block
+                                        w-25
+                                        text-nowrap
+                                        overflow-hidden
+                                        text-truncate
+                                        align-middle
+                                    "
+                                    title={resolveEntityFn(item)}
+                                >
+                                    {resolveEntityFn(item)}
+                                </Badge>
+                            )))}
+                        </p>
+                    }
+                </div>
+            </>
+        );
+
+    return (
+        <Modal show={show} onHide={onHide}>
+            <Modal.Header closeButton>
+                <Modal.Title>{modalTitle}</Modal.Title>
+            </Modal.Header>
+            <Modal.Body>
+                <Form onSubmit={e => {
+                    e.preventDefault()
+                }}>
+                    <InputGroup>
+                        <InputGroup.Text>
+                            <SearchIcon/>
+                        </InputGroup.Text>
+                        <DebouncedFormControl
+                            ref={search}
+                            placeholder={filterPlaceholder}
+                            onChange={() => {
+                                setSearchPrefix(search.current.value)
+                            }}/>
+                    </InputGroup>
+                </Form>
+                <div className="mt-2">
+                    {content}
+                </div>
+            </Modal.Body>
+            <Modal.Footer>
+                <Button variant="success" disabled={selected.length === 0} onClick={() => {
+                    onAttach(selected)
+                }}>
+                    {addText}
+                </Button>
+                <Button variant="secondary" onClick={onHide}>Cancel</Button>
+            </Modal.Footer>
+        </Modal>
     );
-
-  return (
-    <Modal show={show} onHide={onHide}>
-      <Modal.Header closeButton>
-        <Modal.Title>{modalTitle}</Modal.Title>
-      </Modal.Header>
-      <Modal.Body>
-        <Form onSubmit={e => {
-          e.preventDefault()
-        }}>
-          <InputGroup>
-            <InputGroup.Text>
-              <SearchIcon/>
-            </InputGroup.Text>
-            <DebouncedFormControl
-              ref={search}
-              placeholder={filterPlaceholder}
-              onChange={() => {
-                setSearchPrefix(search.current.value)
-              }}/>
-          </InputGroup>
-        </Form>
-        <div className="mt-2">
-          {content}
-        </div>
-      </Modal.Body>
-      <Modal.Footer>
-        <Button variant="success" disabled={selected.length === 0} onClick={() => {
-          onAttach(selected)
-        }}>
-          {addText}
-        </Button>
-        <Button variant="secondary" onClick={onHide}>Cancel</Button>
-      </Modal.Footer>
-    </Modal>
-  );
 };
 
 export const EntityActionModal = ({
-                                    show,
-                                    onHide,
-                                    onAction,
-                                    title,
-                                    placeholder,
-                                    actionName,
-                                    validationFunction = null,
-                                    showExtraField = false,
-                                    extraPlaceholder = "",
-                                    extraValidationFunction = null
+                                      show,
+                                      onHide,
+                                      onAction,
+                                      title,
+                                      placeholder,
+                                      actionName,
+                                      validationFunction = null,
+                                      showExtraField = false,
+                                      extraPlaceholder = "",
+                                      extraValidationFunction = null
                                   }) => {
-  const [error, setError] = useState(null);
-  const idField = useRef(null);
-  const extraField = useRef(null);
+    const [error, setError] = useState(null);
+    const idField = useRef(null);
+    const extraField = useRef(null);
 
-  useEffect(() => {
-    if (!!idField.current && idField.current.value === "") {
-      idField.current.focus();
-    }
-  });
-
-  const onSubmit = () => {
-    if (validationFunction) {
-      const validationResult = validationFunction(idField.current.value);
-      if (!validationResult.isValid) {
-        setError(validationResult.errorMessage);
-        return;
-      }
-    }
-    if (showExtraField) {
-      if (extraValidationFunction) {
-        const validationResult = extraValidationFunction(extraField.current.value);
-        if (!validationResult.isValid) {
-          setError(validationResult.errorMessage);
-          return;
+    useEffect(() => {
+        if (!!idField.current && idField.current.value === "") {
+            idField.current.focus();
         }
-      }
-      onAction(idField.current.value, extraField.current.value).catch(err => setError(err));
-    } else {
-      onAction(idField.current.value).catch(err => setError(err));
-    }
-  };
+    });
 
-  return (
-    <Modal show={show} onHide={onHide}>
-      <Modal.Header closeButton>
-        <Modal.Title>{title}</Modal.Title>
-      </Modal.Header>
+    const onSubmit = () => {
+        if (validationFunction) {
+            const validationResult = validationFunction(idField.current.value);
+            if (!validationResult.isValid) {
+                setError(validationResult.errorMessage);
+                return;
+            }
+        }
+        if (showExtraField) {
+            if (extraValidationFunction) {
+                const validationResult = extraValidationFunction(extraField.current.value);
+                if (!validationResult.isValid) {
+                    setError(validationResult.errorMessage);
+                    return;
+                }
+            }
+            onAction(idField.current.value, extraField.current.value).catch(err => setError(err));
+        } else {
+            onAction(idField.current.value).catch(err => setError(err));
+        }
+    };
 
-      <Modal.Body>
-        <Form onSubmit={e => {
-          e.preventDefault()
-          onSubmit()
-        }}>
-          <FormControl ref={idField} autoFocus placeholder={placeholder} type="text"/>
-          {showExtraField &&
-            <FormControl ref={extraField} placeholder={extraPlaceholder} type="text" className="mt-3"/>
-          }
-        </Form>
+    return (
+        <Modal show={show} onHide={onHide}>
+            <Modal.Header closeButton>
+                <Modal.Title>{title}</Modal.Title>
+            </Modal.Header>
 
-        {(!!error) && <AlertError className="mt-3" error={error}/>}
+            <Modal.Body>
+                <Form onSubmit={e => {
+                    e.preventDefault()
+                    onSubmit()
+                }}>
+                    <FormControl ref={idField} autoFocus placeholder={placeholder} type="text"/>
+                    {showExtraField &&
+                        <FormControl ref={extraField} placeholder={extraPlaceholder} type="text" className="mt-3"/>
+                    }
+                </Form>
 
-      </Modal.Body>
+                {(!!error) && <AlertError className="mt-3" error={error}/>}
 
-      <Modal.Footer>
-        <Button onClick={onSubmit} variant="success">{actionName}</Button>
-        <Button onClick={onHide} variant="secondary">Cancel</Button>
-      </Modal.Footer>
-    </Modal>
-  );
+            </Modal.Body>
+
+            <Modal.Footer>
+                <Button onClick={onSubmit} variant="success">{actionName}</Button>
+                <Button onClick={onHide} variant="secondary">Cancel</Button>
+            </Modal.Footer>
+        </Modal>
+    );
 };


### PR DESCRIPTION
Closes #8667

## Issue
Long values names overflowed modal windows across Groups, Users and Policies pages in the "Administration" tab under the "Selected" section

## Fix
1. Applied truncation for long values in selected section modals.
2. Users can hover to see full value and copy the truncated value.

## Changes Made

### In "Groups" Page
1. create long user name under "Users"
2. Go to Administration -> "Groups" ->  click on some group name -> Add Members -> select a long user name

### In "Users" Page
1. create long group name under "Groups"
2. Go to Administration -> "Users" -> click on some user name -> Add User to group -> select the long group name (search for it)

#### The issue screenshot:
![selected_issue](https://github.com/user-attachments/assets/55beb5d6-a1ce-4ea9-8183-7427d9a36870)

#### The fix screenshot:
![selected_fix](https://github.com/user-attachments/assets/4c991a2d-11a8-443a-9f61-f6608ab2214c)

#### Changed in file:
webui/src/lib/components/auth/forms.jsx (AttachModal)

## Testing
Verified on lakeFS OSS using local DB & object store & ACL
