### PR TITLE
Truncated long value names in confirmation window

### DIFF
--- a/webui/src/pages/auth/users/user/credentials.jsx
+++ b/webui/src/pages/auth/users/user/credentials.jsx
@@ -41,7 +41,7 @@ const UserCredentialsList = ({ userId, after, onPaginate }) => {
                     onPaginate={onPaginate}
                 />
             </>
-    );
+        );
 
     const getMsg = (email) => (
         <span>
@@ -60,7 +60,6 @@ const UserCredentialsList = ({ userId, after, onPaginate }) => {
             >
                 {email}
                 </strong>
-            <br/>
             {" "}?
             </span>
     );

--- a/webui/src/pages/auth/users/user/credentials.jsx
+++ b/webui/src/pages/auth/users/user/credentials.jsx
@@ -31,16 +31,16 @@ const UserCredentialsList = ({ userId, after, onPaginate }) => {
             });
     };
     const content = (
-        <>
-            {createError && <AlertError error={createError}/>}
-            <CredentialsTable
-                userId={userId}
-                currentAccessKey={(user) ? user.accessKeyId : ""}
-                refresh={refresh}
-                after={after}
-                onPaginate={onPaginate}
-            />
-        </>
+            <>
+                {createError && <AlertError error={createError}/>}
+                <CredentialsTable
+                    userId={userId}
+                    currentAccessKey={(user) ? user.accessKeyId : ""}
+                    refresh={refresh}
+                    after={after}
+                    onPaginate={onPaginate}
+                />
+            </>
     );
 
     const getMsg = (email) => (

--- a/webui/src/pages/auth/users/user/credentials.jsx
+++ b/webui/src/pages/auth/users/user/credentials.jsx
@@ -60,7 +60,7 @@ const UserCredentialsList = ({ userId, after, onPaginate }) => {
             >
                 {email}
             </strong>
-            {" "}?
+            ?
         </span>
     );
     return (

--- a/webui/src/pages/auth/users/user/credentials.jsx
+++ b/webui/src/pages/auth/users/user/credentials.jsx
@@ -48,20 +48,18 @@ const UserCredentialsList = ({ userId, after, onPaginate }) => {
                 Create new credentials for user{" "}
             <br/>
             <strong
-                className="
-                        d-inline-block
-                        w-50
-                        text-nowrap
-                        overflow-hidden
-                        text-truncate
-                        align-middle
-                    "
+                className={`d-inline-block
+                            text-nowrap
+                            overflow-hidden
+                            text-truncate
+                            align-bottom
+                            ${email.length > 40 ? "w-75" : ""}`}
                 title={email}
             >
                 {email}
-                </strong>
+            </strong>
             {" "}?
-            </span>
+        </span>
     );
     return (
         <>

--- a/webui/src/pages/auth/users/user/credentials.jsx
+++ b/webui/src/pages/auth/users/user/credentials.jsx
@@ -13,6 +13,8 @@ import {
 } from "../../../../lib/components/controls";
 import {useRouter} from "../../../../lib/hooks/router";
 
+const EMAIL_TRUNCATION_THRESHOLD_LENGTH = 40;
+
 
 const UserCredentialsList = ({ userId, after, onPaginate }) => {
     const {user} = useUser();
@@ -53,7 +55,7 @@ const UserCredentialsList = ({ userId, after, onPaginate }) => {
                             overflow-hidden
                             text-truncate
                             align-bottom
-                            ${email.length > 40 ? "w-75" : ""}`}
+                            ${email.length > EMAIL_TRUNCATION_THRESHOLD_LENGTH ? "w-75" : ""}`}
                 title={email}
             >
                 {email}

--- a/webui/src/pages/auth/users/user/credentials.jsx
+++ b/webui/src/pages/auth/users/user/credentials.jsx
@@ -31,19 +31,39 @@ const UserCredentialsList = ({ userId, after, onPaginate }) => {
             });
     };
     const content = (
-            <>
-                {createError && <AlertError error={createError}/>}
-                <CredentialsTable
-                    userId={userId}
-                    currentAccessKey={(user) ? user.accessKeyId : ""}
-                    refresh={refresh}
-                    after={after}
-                    onPaginate={onPaginate}
-                />
-            </>
-        );
+        <>
+            {createError && <AlertError error={createError}/>}
+            <CredentialsTable
+                userId={userId}
+                currentAccessKey={(user) ? user.accessKeyId : ""}
+                refresh={refresh}
+                after={after}
+                onPaginate={onPaginate}
+            />
+        </>
+    );
 
-        const getMsg = (email) => <span>Create new credentials for user <strong>{email}</strong>?</span>;
+    const getMsg = (email) => (
+        <span>
+                Create new credentials for user{" "}
+            <br/>
+            <strong
+                className="
+                        d-inline-block
+                        w-50
+                        text-nowrap
+                        overflow-hidden
+                        text-truncate
+                        align-middle
+                    "
+                title={email}
+            >
+                {email}
+                </strong>
+            <br/>
+            {" "}?
+            </span>
+    );
     return (
         <>
             <UserHeaderWithContext userId={userId} page={'credentials'}/>


### PR DESCRIPTION
Closes #8669

## Issue
Long user names overflowed "Confirmation" window 

## Fix
1. Applied truncation for long values in selected section modals.
2. Users can hover to see full value and copy the truncated value.

## Changes Made

### In "Users" Page
1. create long user name under "Users"
2. Go to Administration -> Users -> click on the long user name -> Access Credentials tab -> Create Access Key

#### The issue screenshot:
![long_user_name_in_confirm_issue](https://github.com/user-attachments/assets/2fff675f-d28b-4533-9881-1dfebcdc69f3)

#### The fix screenshot:
![long_user_name_in_confirm_fix](https://github.com/user-attachments/assets/c37401d6-6faf-4033-abeb-763b51b45d0e)

#### Changed in file:
webui/src/pages/auth/users/user/credentials.jsx (getMsg function)

## Testing
Verified on lakeFS OSS using local DB & object store & ACL
