### PR TITLE
Support Metrics Adapter label

### DIFF
--- a/modules/block/factory/build.go
+++ b/modules/block/factory/build.go
@@ -15,5 +15,5 @@ func BuildBlockAdapter(ctx context.Context, statsCollector stats.Collector, c co
 		return nil, err
 	}
 
-	return block.NewMetricsAdapter(adapter), nil
+	return block.NewMetricsAdapter(adapter, nil), nil
 }

--- a/pkg/block/metrics.go
+++ b/pkg/block/metrics.go
@@ -11,10 +11,11 @@ import (
 
 type MetricsAdapter struct {
 	adapter Adapter
+	label   *string
 }
 
-func NewMetricsAdapter(adapter Adapter) Adapter {
-	return &MetricsAdapter{adapter: adapter}
+func NewMetricsAdapter(adapter Adapter, label *string) Adapter {
+	return &MetricsAdapter{adapter: adapter, label: label}
 }
 
 func (m *MetricsAdapter) InnerAdapter() Adapter {
@@ -22,12 +23,12 @@ func (m *MetricsAdapter) InnerAdapter() Adapter {
 }
 
 func (m *MetricsAdapter) Put(ctx context.Context, obj ObjectPointer, sizeBytes int64, reader io.Reader, opts PutOpts) (*PutResponse, error) {
-	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType())
+	ctx = httputil.SetClientTraceWithLabel(ctx, m.adapter.BlockstoreType(), m.label)
 	return m.adapter.Put(ctx, obj, sizeBytes, reader, opts)
 }
 
 func (m *MetricsAdapter) Get(ctx context.Context, obj ObjectPointer) (io.ReadCloser, error) {
-	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType())
+	ctx = httputil.SetClientTraceWithLabel(ctx, m.adapter.BlockstoreType(), m.label)
 	return m.adapter.Get(ctx, obj)
 }
 
@@ -36,76 +37,76 @@ func (m *MetricsAdapter) GetWalker(storageID string, opts WalkerOptions) (Walker
 }
 
 func (m *MetricsAdapter) GetPreSignedURL(ctx context.Context, obj ObjectPointer, mode PreSignMode) (string, time.Time, error) {
-	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType())
+	ctx = httputil.SetClientTraceWithLabel(ctx, m.adapter.BlockstoreType(), m.label)
 	return m.adapter.GetPreSignedURL(ctx, obj, mode)
 }
 
 func (m *MetricsAdapter) GetPresignUploadPartURL(ctx context.Context, obj ObjectPointer, uploadID string, partNumber int) (string, error) {
-	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType())
+	ctx = httputil.SetClientTraceWithLabel(ctx, m.adapter.BlockstoreType(), m.label)
 	return m.adapter.GetPresignUploadPartURL(ctx, obj, uploadID, partNumber)
 }
 
 func (m *MetricsAdapter) Exists(ctx context.Context, obj ObjectPointer) (bool, error) {
-	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType())
+	ctx = httputil.SetClientTraceWithLabel(ctx, m.adapter.BlockstoreType(), m.label)
 	return m.adapter.Exists(ctx, obj)
 }
 
 func (m *MetricsAdapter) GetRange(ctx context.Context, obj ObjectPointer, startPosition int64, endPosition int64) (io.ReadCloser, error) {
-	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType())
+	ctx = httputil.SetClientTraceWithLabel(ctx, m.adapter.BlockstoreType(), m.label)
 	return m.adapter.GetRange(ctx, obj, startPosition, endPosition)
 }
 
 func (m *MetricsAdapter) GetProperties(ctx context.Context, obj ObjectPointer) (Properties, error) {
-	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType())
+	ctx = httputil.SetClientTraceWithLabel(ctx, m.adapter.BlockstoreType(), m.label)
 	return m.adapter.GetProperties(ctx, obj)
 }
 
 func (m *MetricsAdapter) Remove(ctx context.Context, obj ObjectPointer) error {
-	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType())
+	ctx = httputil.SetClientTraceWithLabel(ctx, m.adapter.BlockstoreType(), m.label)
 	return m.adapter.Remove(ctx, obj)
 }
 
 func (m *MetricsAdapter) Copy(ctx context.Context, sourceObj, destinationObj ObjectPointer) error {
-	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType())
+	ctx = httputil.SetClientTraceWithLabel(ctx, m.adapter.BlockstoreType(), m.label)
 	return m.adapter.Copy(ctx, sourceObj, destinationObj)
 }
 
 func (m *MetricsAdapter) CreateMultiPartUpload(ctx context.Context, obj ObjectPointer, r *http.Request, opts CreateMultiPartUploadOpts) (*CreateMultiPartUploadResponse, error) {
-	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType())
+	ctx = httputil.SetClientTraceWithLabel(ctx, m.adapter.BlockstoreType(), m.label)
 	return m.adapter.CreateMultiPartUpload(ctx, obj, r, opts)
 }
 
 func (m *MetricsAdapter) UploadPart(ctx context.Context, obj ObjectPointer, sizeBytes int64, reader io.Reader, uploadID string, partNumber int) (*UploadPartResponse, error) {
-	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType())
+	ctx = httputil.SetClientTraceWithLabel(ctx, m.adapter.BlockstoreType(), m.label)
 	return m.adapter.UploadPart(ctx, obj, sizeBytes, reader, uploadID, partNumber)
 }
 
 func (m *MetricsAdapter) ListParts(ctx context.Context, obj ObjectPointer, uploadID string, opts ListPartsOpts) (*ListPartsResponse, error) {
-	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType())
+	ctx = httputil.SetClientTraceWithLabel(ctx, m.adapter.BlockstoreType(), m.label)
 	return m.adapter.ListParts(ctx, obj, uploadID, opts)
 }
 func (m *MetricsAdapter) ListMultipartUploads(ctx context.Context, obj ObjectPointer, opts ListMultipartUploadsOpts) (*ListMultipartUploadsResponse, error) {
-	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType())
+	ctx = httputil.SetClientTraceWithLabel(ctx, m.adapter.BlockstoreType(), m.label)
 	return m.adapter.ListMultipartUploads(ctx, obj, opts)
 }
 
 func (m *MetricsAdapter) UploadCopyPart(ctx context.Context, sourceObj, destinationObj ObjectPointer, uploadID string, partNumber int) (*UploadPartResponse, error) {
-	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType())
+	ctx = httputil.SetClientTraceWithLabel(ctx, m.adapter.BlockstoreType(), m.label)
 	return m.adapter.UploadCopyPart(ctx, sourceObj, destinationObj, uploadID, partNumber)
 }
 
 func (m *MetricsAdapter) UploadCopyPartRange(ctx context.Context, sourceObj, destinationObj ObjectPointer, uploadID string, partNumber int, startPosition, endPosition int64) (*UploadPartResponse, error) {
-	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType())
+	ctx = httputil.SetClientTraceWithLabel(ctx, m.adapter.BlockstoreType(), m.label)
 	return m.adapter.UploadCopyPartRange(ctx, sourceObj, destinationObj, uploadID, partNumber, startPosition, endPosition)
 }
 
 func (m *MetricsAdapter) AbortMultiPartUpload(ctx context.Context, obj ObjectPointer, uploadID string) error {
-	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType())
+	ctx = httputil.SetClientTraceWithLabel(ctx, m.adapter.BlockstoreType(), m.label)
 	return m.adapter.AbortMultiPartUpload(ctx, obj, uploadID)
 }
 
 func (m *MetricsAdapter) CompleteMultiPartUpload(ctx context.Context, obj ObjectPointer, uploadID string, multipartList *MultipartUploadCompletion) (*CompleteMultiPartUploadResponse, error) {
-	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType())
+	ctx = httputil.SetClientTraceWithLabel(ctx, m.adapter.BlockstoreType(), m.label)
 	return m.adapter.CompleteMultiPartUpload(ctx, obj, uploadID, multipartList)
 }
 
@@ -114,7 +115,7 @@ func (m *MetricsAdapter) BlockstoreType() string {
 }
 
 func (m *MetricsAdapter) BlockstoreMetadata(ctx context.Context) (*BlockstoreMetadata, error) {
-	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType())
+	ctx = httputil.SetClientTraceWithLabel(ctx, m.adapter.BlockstoreType(), m.label)
 	return m.adapter.BlockstoreMetadata(ctx)
 }
 
@@ -127,7 +128,7 @@ func (m *MetricsAdapter) ResolveNamespace(storageID, storageNamespace, key strin
 }
 
 func (m *MetricsAdapter) GetRegion(ctx context.Context, storageID, storageNamespace string) (string, error) {
-	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType())
+	ctx = httputil.SetClientTraceWithLabel(ctx, m.adapter.BlockstoreType(), m.label)
 	return m.adapter.GetRegion(ctx, storageID, storageNamespace)
 }
 


### PR DESCRIPTION
Closes _#8672.

## Change Description

Currently, the Metrics Adapter has a `service` param -
Adding another `label` to it, to allow better tracing.
