### PR TITLE
add storageID to gc manager

### DIFF
--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -3729,8 +3729,12 @@ func (c *Controller) PrepareGarbageCollectionCommits(w http.ResponseWriter, r *h
 	if c.handleAPIError(ctx, w, r, err) {
 		return
 	}
-	// TODO (gilo): ObjectPointer init - add StorageID here
+	repo, err := c.Catalog.GetRepository(ctx, repository)
+	if c.handleAPIError(ctx, w, r, err) {
+		return
+	}
 	presignedURL, _, err := c.BlockAdapter.GetPreSignedURL(ctx, block.ObjectPointer{
+		StorageID:      repo.StorageID,
 		Identifier:     gcRunMetadata.CommitsCSVLocation,
 		IdentifierType: block.IdentifierTypeFull,
 	}, block.PreSignModeRead)

--- a/pkg/catalog/catalog_test.go
+++ b/pkg/catalog/catalog_test.go
@@ -895,7 +895,7 @@ func createPrepareUncommittedTestScenario(t *testing.T, repositoryID string, num
 
 	if numRecords > 0 {
 		test.GarbageCollectionManager.EXPECT().
-			GetUncommittedLocation(gomock.Any(), gomock.Any()).
+			GetUncommittedLocation(gomock.Any(), gomock.Any(), gomock.Any()).
 			MinTimes(1).
 			DoAndReturn(func(runID string, sn graveler.StorageNamespace) (string, error) {
 				return fmt.Sprintf("%s/retention/gc/uncommitted/%s/uncommitted/", "_lakefs", runID), nil

--- a/pkg/catalog/catalog_test.go
+++ b/pkg/catalog/catalog_test.go
@@ -897,7 +897,7 @@ func createPrepareUncommittedTestScenario(t *testing.T, repositoryID string, num
 		test.GarbageCollectionManager.EXPECT().
 			GetUncommittedLocation(gomock.Any(), gomock.Any(), gomock.Any()).
 			MinTimes(1).
-			DoAndReturn(func(runID string, sn graveler.StorageNamespace) (string, error) {
+			DoAndReturn(func(runID string, storageID graveler.StorageID, sn graveler.StorageNamespace) (string, error) {
 				return fmt.Sprintf("%s/retention/gc/uncommitted/%s/uncommitted/", "_lakefs", runID), nil
 			})
 	}

--- a/pkg/graveler/graveler.go
+++ b/pkg/graveler/graveler.go
@@ -1640,7 +1640,7 @@ func (g *Graveler) GetStagingToken(ctx context.Context, repository *RepositoryRe
 }
 
 func (g *Graveler) getGarbageCollectionRules(ctx context.Context, repository *RepositoryRecord) (*GarbageCollectionRules, error) {
-	return g.garbageCollectionManager.GetRules(ctx, repository.StorageNamespace)
+	return g.garbageCollectionManager.GetRules(ctx, repository.StorageID, repository.StorageNamespace)
 }
 
 func (g *Graveler) GetGarbageCollectionRules(ctx context.Context, repository *RepositoryRecord) (*GarbageCollectionRules, error) {
@@ -1648,7 +1648,7 @@ func (g *Graveler) GetGarbageCollectionRules(ctx context.Context, repository *Re
 }
 
 func (g *Graveler) SetGarbageCollectionRules(ctx context.Context, repository *RepositoryRecord, rules *GarbageCollectionRules) error {
-	return g.garbageCollectionManager.SaveRules(ctx, repository.StorageNamespace, rules)
+	return g.garbageCollectionManager.SaveRules(ctx, repository.StorageID, repository.StorageNamespace, rules)
 }
 
 func (g *Graveler) SaveGarbageCollectionCommits(ctx context.Context, repository *RepositoryRecord) (*GarbageCollectionRunMetadata, error) {
@@ -3725,8 +3725,8 @@ func (c *commitValueIterator) Close() {
 }
 
 type GarbageCollectionManager interface {
-	GetRules(ctx context.Context, storageNamespace StorageNamespace) (*GarbageCollectionRules, error)
-	SaveRules(ctx context.Context, storageNamespace StorageNamespace, rules *GarbageCollectionRules) error
+	GetRules(ctx context.Context, storageID StorageID, storageNamespace StorageNamespace) (*GarbageCollectionRules, error)
+	SaveRules(ctx context.Context, storageID StorageID, storageNamespace StorageNamespace, rules *GarbageCollectionRules) error
 
 	SaveGarbageCollectionCommits(ctx context.Context, repository *RepositoryRecord, rules *GarbageCollectionRules) (string, error)
 	GetCommitsCSVLocation(runID string, storageID StorageID, sn StorageNamespace) (string, error)

--- a/pkg/graveler/graveler.go
+++ b/pkg/graveler/graveler.go
@@ -1661,11 +1661,11 @@ func (g *Graveler) SaveGarbageCollectionCommits(ctx context.Context, repository 
 	if err != nil {
 		return nil, fmt.Errorf("save garbage collection commits: %w", err)
 	}
-	commitsLocation, err := g.garbageCollectionManager.GetCommitsCSVLocation(runID, repository.StorageNamespace)
+	commitsLocation, err := g.garbageCollectionManager.GetCommitsCSVLocation(runID, repository.StorageID, repository.StorageNamespace)
 	if err != nil {
 		return nil, err
 	}
-	addressLocation, err := g.garbageCollectionManager.GetAddressesLocation(repository.StorageNamespace)
+	addressLocation, err := g.garbageCollectionManager.GetAddressesLocation(repository.StorageID, repository.StorageNamespace)
 	if err != nil {
 		return nil, err
 	}
@@ -1678,7 +1678,7 @@ func (g *Graveler) SaveGarbageCollectionCommits(ctx context.Context, repository 
 }
 
 func (g *Graveler) GCGetUncommittedLocation(repository *RepositoryRecord, runID string) (string, error) {
-	return g.garbageCollectionManager.GetUncommittedLocation(runID, repository.StorageNamespace)
+	return g.garbageCollectionManager.GetUncommittedLocation(runID, repository.StorageID, repository.StorageNamespace)
 }
 
 func (g *Graveler) GCNewRunID() string {
@@ -3729,10 +3729,10 @@ type GarbageCollectionManager interface {
 	SaveRules(ctx context.Context, storageNamespace StorageNamespace, rules *GarbageCollectionRules) error
 
 	SaveGarbageCollectionCommits(ctx context.Context, repository *RepositoryRecord, rules *GarbageCollectionRules) (string, error)
-	GetCommitsCSVLocation(runID string, sn StorageNamespace) (string, error)
+	GetCommitsCSVLocation(runID string, storageID StorageID, sn StorageNamespace) (string, error)
 	SaveGarbageCollectionUncommitted(ctx context.Context, repository *RepositoryRecord, filename, runID string) error
-	GetUncommittedLocation(runID string, sn StorageNamespace) (string, error)
-	GetAddressesLocation(sn StorageNamespace) (string, error)
+	GetUncommittedLocation(runID string, storageID StorageID, sn StorageNamespace) (string, error)
+	GetAddressesLocation(storageID StorageID, sn StorageNamespace) (string, error)
 	NewID() string
 }
 

--- a/pkg/graveler/mock/graveler.go
+++ b/pkg/graveler/mock/graveler.go
@@ -3040,33 +3040,33 @@ func (m *MockGarbageCollectionManager) EXPECT() *MockGarbageCollectionManagerMoc
 }
 
 // GetAddressesLocation mocks base method.
-func (m *MockGarbageCollectionManager) GetAddressesLocation(sn graveler.StorageNamespace) (string, error) {
+func (m *MockGarbageCollectionManager) GetAddressesLocation(storageID graveler.StorageID, sn graveler.StorageNamespace) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetAddressesLocation", sn)
+	ret := m.ctrl.Call(m, "GetAddressesLocation", storageID, sn)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetAddressesLocation indicates an expected call of GetAddressesLocation.
-func (mr *MockGarbageCollectionManagerMockRecorder) GetAddressesLocation(sn interface{}) *gomock.Call {
+func (mr *MockGarbageCollectionManagerMockRecorder) GetAddressesLocation(storageID, sn interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAddressesLocation", reflect.TypeOf((*MockGarbageCollectionManager)(nil).GetAddressesLocation), sn)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetAddressesLocation", reflect.TypeOf((*MockGarbageCollectionManager)(nil).GetAddressesLocation), storageID, sn)
 }
 
 // GetCommitsCSVLocation mocks base method.
-func (m *MockGarbageCollectionManager) GetCommitsCSVLocation(runID string, sn graveler.StorageNamespace) (string, error) {
+func (m *MockGarbageCollectionManager) GetCommitsCSVLocation(runID string, storageID graveler.StorageID, sn graveler.StorageNamespace) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetCommitsCSVLocation", runID, sn)
+	ret := m.ctrl.Call(m, "GetCommitsCSVLocation", runID, storageID, sn)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetCommitsCSVLocation indicates an expected call of GetCommitsCSVLocation.
-func (mr *MockGarbageCollectionManagerMockRecorder) GetCommitsCSVLocation(runID, sn interface{}) *gomock.Call {
+func (mr *MockGarbageCollectionManagerMockRecorder) GetCommitsCSVLocation(runID, storageID, sn interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCommitsCSVLocation", reflect.TypeOf((*MockGarbageCollectionManager)(nil).GetCommitsCSVLocation), runID, sn)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetCommitsCSVLocation", reflect.TypeOf((*MockGarbageCollectionManager)(nil).GetCommitsCSVLocation), runID, storageID, sn)
 }
 
 // GetRules mocks base method.
@@ -3085,18 +3085,18 @@ func (mr *MockGarbageCollectionManagerMockRecorder) GetRules(ctx, storageNamespa
 }
 
 // GetUncommittedLocation mocks base method.
-func (m *MockGarbageCollectionManager) GetUncommittedLocation(runID string, sn graveler.StorageNamespace) (string, error) {
+func (m *MockGarbageCollectionManager) GetUncommittedLocation(runID string, storageID graveler.StorageID, sn graveler.StorageNamespace) (string, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetUncommittedLocation", runID, sn)
+	ret := m.ctrl.Call(m, "GetUncommittedLocation", runID, storageID, sn)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetUncommittedLocation indicates an expected call of GetUncommittedLocation.
-func (mr *MockGarbageCollectionManagerMockRecorder) GetUncommittedLocation(runID, sn interface{}) *gomock.Call {
+func (mr *MockGarbageCollectionManagerMockRecorder) GetUncommittedLocation(runID, storageID, sn interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUncommittedLocation", reflect.TypeOf((*MockGarbageCollectionManager)(nil).GetUncommittedLocation), runID, sn)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetUncommittedLocation", reflect.TypeOf((*MockGarbageCollectionManager)(nil).GetUncommittedLocation), runID, storageID, sn)
 }
 
 // NewID mocks base method.

--- a/pkg/graveler/mock/graveler.go
+++ b/pkg/graveler/mock/graveler.go
@@ -3070,18 +3070,18 @@ func (mr *MockGarbageCollectionManagerMockRecorder) GetCommitsCSVLocation(runID,
 }
 
 // GetRules mocks base method.
-func (m *MockGarbageCollectionManager) GetRules(ctx context.Context, storageNamespace graveler.StorageNamespace) (*graveler.GarbageCollectionRules, error) {
+func (m *MockGarbageCollectionManager) GetRules(ctx context.Context, storageID graveler.StorageID, storageNamespace graveler.StorageNamespace) (*graveler.GarbageCollectionRules, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetRules", ctx, storageNamespace)
+	ret := m.ctrl.Call(m, "GetRules", ctx, storageID, storageNamespace)
 	ret0, _ := ret[0].(*graveler.GarbageCollectionRules)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // GetRules indicates an expected call of GetRules.
-func (mr *MockGarbageCollectionManagerMockRecorder) GetRules(ctx, storageNamespace interface{}) *gomock.Call {
+func (mr *MockGarbageCollectionManagerMockRecorder) GetRules(ctx, storageID, storageNamespace interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRules", reflect.TypeOf((*MockGarbageCollectionManager)(nil).GetRules), ctx, storageNamespace)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetRules", reflect.TypeOf((*MockGarbageCollectionManager)(nil).GetRules), ctx, storageID, storageNamespace)
 }
 
 // GetUncommittedLocation mocks base method.
@@ -3143,17 +3143,17 @@ func (mr *MockGarbageCollectionManagerMockRecorder) SaveGarbageCollectionUncommi
 }
 
 // SaveRules mocks base method.
-func (m *MockGarbageCollectionManager) SaveRules(ctx context.Context, storageNamespace graveler.StorageNamespace, rules *graveler.GarbageCollectionRules) error {
+func (m *MockGarbageCollectionManager) SaveRules(ctx context.Context, storageID graveler.StorageID, storageNamespace graveler.StorageNamespace, rules *graveler.GarbageCollectionRules) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "SaveRules", ctx, storageNamespace, rules)
+	ret := m.ctrl.Call(m, "SaveRules", ctx, storageID, storageNamespace, rules)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // SaveRules indicates an expected call of SaveRules.
-func (mr *MockGarbageCollectionManagerMockRecorder) SaveRules(ctx, storageNamespace, rules interface{}) *gomock.Call {
+func (mr *MockGarbageCollectionManagerMockRecorder) SaveRules(ctx, storageID, storageNamespace, rules interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveRules", reflect.TypeOf((*MockGarbageCollectionManager)(nil).SaveRules), ctx, storageNamespace, rules)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "SaveRules", reflect.TypeOf((*MockGarbageCollectionManager)(nil).SaveRules), ctx, storageID, storageNamespace, rules)
 }
 
 // MockProtectedBranchesManager is a mock of ProtectedBranchesManager interface.

--- a/pkg/graveler/retention/garbage_collection_manager.go
+++ b/pkg/graveler/retention/garbage_collection_manager.go
@@ -34,20 +34,18 @@ type GarbageCollectionManager struct {
 	committedBlockStoragePrefix string
 }
 
-func (m *GarbageCollectionManager) GetCommitsCSVLocation(runID string, sn graveler.StorageNamespace) (string, error) {
+func (m *GarbageCollectionManager) GetCommitsCSVLocation(runID string, storageID graveler.StorageID, sn graveler.StorageNamespace) (string, error) {
 	key := fmt.Sprintf(commitsFileSuffixTemplate, m.committedBlockStoragePrefix, runID)
-	// TODO (gilo): replace StorageID with a real value
-	qk, err := m.blockAdapter.ResolveNamespace("", sn.String(), key, block.IdentifierTypeRelative)
+	qk, err := m.blockAdapter.ResolveNamespace(string(storageID), sn.String(), key, block.IdentifierTypeRelative)
 	if err != nil {
 		return "", err
 	}
 	return qk.Format(), nil
 }
 
-func (m *GarbageCollectionManager) GetAddressesLocation(sn graveler.StorageNamespace) (string, error) {
+func (m *GarbageCollectionManager) GetAddressesLocation(storageID graveler.StorageID, sn graveler.StorageNamespace) (string, error) {
 	key := fmt.Sprintf(addressesFilePrefixTemplate, m.committedBlockStoragePrefix)
-	// TODO (gilo): replace StorageID with a real value
-	qk, err := m.blockAdapter.ResolveNamespace("", sn.String(), key, block.IdentifierTypeRelative)
+	qk, err := m.blockAdapter.ResolveNamespace(string(storageID), sn.String(), key, block.IdentifierTypeRelative)
 	if err != nil {
 		return "", err
 	}
@@ -55,10 +53,9 @@ func (m *GarbageCollectionManager) GetAddressesLocation(sn graveler.StorageNames
 }
 
 // GetUncommittedLocation return full path to underlying storage path to store uncommitted information
-func (m *GarbageCollectionManager) GetUncommittedLocation(runID string, sn graveler.StorageNamespace) (string, error) {
+func (m *GarbageCollectionManager) GetUncommittedLocation(runID string, storageID graveler.StorageID, sn graveler.StorageNamespace) (string, error) {
 	key := fmt.Sprintf(uncommittedFilePrefixTemplate, m.committedBlockStoragePrefix, runID)
-	// TODO (gilo): replace StorageID with a real value
-	qk, err := m.blockAdapter.ResolveNamespace("", sn.String(), key, block.IdentifierTypeRelative)
+	qk, err := m.blockAdapter.ResolveNamespace(string(storageID), sn.String(), key, block.IdentifierTypeRelative)
 	if err != nil {
 		return "", err
 	}
@@ -66,7 +63,7 @@ func (m *GarbageCollectionManager) GetUncommittedLocation(runID string, sn grave
 }
 
 func (m *GarbageCollectionManager) SaveGarbageCollectionUncommitted(ctx context.Context, repository *graveler.RepositoryRecord, filename, runID string) error {
-	location, err := m.GetUncommittedLocation(runID, repository.StorageNamespace)
+	location, err := m.GetUncommittedLocation(runID, repository.StorageID, repository.StorageNamespace)
 	if err != nil {
 		return err
 	}
@@ -207,7 +204,7 @@ func (m *GarbageCollectionManager) SaveGarbageCollectionCommits(ctx context.Cont
 	}
 	commitsStr := b.String()
 	runID := m.NewID()
-	csvLocation, err := m.GetCommitsCSVLocation(runID, repository.StorageNamespace)
+	csvLocation, err := m.GetCommitsCSVLocation(runID, repository.StorageID, repository.StorageNamespace)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/graveler/retention/garbage_collection_manager.go
+++ b/pkg/graveler/retention/garbage_collection_manager.go
@@ -82,7 +82,7 @@ func (m *GarbageCollectionManager) SaveGarbageCollectionUncommitted(ctx context.
 	}
 	location += filename
 	_, err = m.blockAdapter.Put(ctx, block.ObjectPointer{
-		// TODO (gilo): ObjectPointer init - add StorageID here?
+		StorageID:      string(repository.StorageID),
 		Identifier:     location,
 		IdentifierType: block.IdentifierTypeFull,
 	}, stat.Size(), fd, block.PutOpts{})
@@ -115,9 +115,9 @@ func NewGarbageCollectionManager(blockAdapter block.Adapter, refManager graveler
 	}
 }
 
-func (m *GarbageCollectionManager) GetRules(ctx context.Context, storageNamespace graveler.StorageNamespace) (*graveler.GarbageCollectionRules, error) {
-	// TODO (gilo): ObjectPointer init - add StorageID here?
+func (m *GarbageCollectionManager) GetRules(ctx context.Context, storageID graveler.StorageID, storageNamespace graveler.StorageNamespace) (*graveler.GarbageCollectionRules, error) {
 	objectPointer := block.ObjectPointer{
+		StorageID:        string(storageID),
 		StorageNamespace: string(storageNamespace),
 		Identifier:       fmt.Sprintf(configFileSuffixTemplate, m.committedBlockStoragePrefix),
 		IdentifierType:   block.IdentifierTypeRelative,
@@ -148,13 +148,13 @@ func (m *GarbageCollectionManager) GetRules(ctx context.Context, storageNamespac
 	return &rules, nil
 }
 
-func (m *GarbageCollectionManager) SaveRules(ctx context.Context, storageNamespace graveler.StorageNamespace, rules *graveler.GarbageCollectionRules) error {
+func (m *GarbageCollectionManager) SaveRules(ctx context.Context, storageID graveler.StorageID, storageNamespace graveler.StorageNamespace, rules *graveler.GarbageCollectionRules) error {
 	rulesBytes, err := proto.Marshal(rules)
 	if err != nil {
 		return err
 	}
-	// TODO (gilo): ObjectPointer init - add StorageID here?
 	_, err = m.blockAdapter.Put(ctx, block.ObjectPointer{
+		StorageID:        string(storageID),
 		StorageNamespace: string(storageNamespace),
 		Identifier:       fmt.Sprintf(configFileSuffixTemplate, m.committedBlockStoragePrefix),
 		IdentifierType:   block.IdentifierTypeRelative,
@@ -209,7 +209,7 @@ func (m *GarbageCollectionManager) SaveGarbageCollectionCommits(ctx context.Cont
 		return "", err
 	}
 	_, err = m.blockAdapter.Put(ctx, block.ObjectPointer{
-		// TODO (gilo): ObjectPointer init - add StorageID here?
+		StorageID:      string(repository.StorageID),
 		Identifier:     csvLocation,
 		IdentifierType: block.IdentifierTypeFull,
 	}, int64(len(commitsStr)), strings.NewReader(commitsStr), block.PutOpts{})

--- a/pkg/graveler/retention/garbage_collection_manager_test.go
+++ b/pkg/graveler/retention/garbage_collection_manager_test.go
@@ -25,7 +25,7 @@ func TestGarbageCollectionManager_GetUncommittedLocation(t *testing.T) {
 	ns := graveler.StorageNamespace("mem://test-namespace/my-repo")
 	path := fmt.Sprintf("%s/%s/retention/gc/uncommitted/%s/uncommitted/", ns, prefix, runID)
 	gc := retention.NewGarbageCollectionManager(blockAdapter, refMgr, prefix)
-	location, err := gc.GetUncommittedLocation(runID, ns)
+	location, err := gc.GetUncommittedLocation(runID, "", ns)
 	require.NoError(t, err)
 	require.Equal(t, path, location)
 }
@@ -60,7 +60,7 @@ func TestGarbageCollectionManager_SaveGarbageCollectionUncommitted(t *testing.T)
 		},
 	}
 	gc := retention.NewGarbageCollectionManager(blockAdapter, refMgr, prefix)
-	location, err := gc.GetUncommittedLocation(runID, ns)
+	location, err := gc.GetUncommittedLocation(runID, "", ns)
 	require.NoError(t, err)
 	filename := "uncommitted_test_file"
 	testLine := "TestLine"

--- a/pkg/graveler/retention/garbage_collection_manager_test.go
+++ b/pkg/graveler/retention/garbage_collection_manager_test.go
@@ -12,10 +12,25 @@ import (
 	"github.com/stretchr/testify/require"
 	"github.com/treeverse/lakefs/pkg/block"
 	"github.com/treeverse/lakefs/pkg/block/mem"
+	"github.com/treeverse/lakefs/pkg/config"
 	"github.com/treeverse/lakefs/pkg/graveler"
 	"github.com/treeverse/lakefs/pkg/graveler/retention"
 	"github.com/treeverse/lakefs/pkg/graveler/testutil"
 )
+
+var cases = []struct {
+	Name      string
+	StorageID graveler.StorageID
+}{
+	{
+		Name:      "Default StorageID",
+		StorageID: config.SingleBlockstoreID,
+	},
+	{
+		Name:      "Another StorageID",
+		StorageID: "something-else",
+	},
+}
 
 func TestGarbageCollectionManager_GetUncommittedLocation(t *testing.T) {
 	blockAdapter := mem.New(context.Background())
@@ -24,10 +39,15 @@ func TestGarbageCollectionManager_GetUncommittedLocation(t *testing.T) {
 	const runID = "my_test_runID"
 	ns := graveler.StorageNamespace("mem://test-namespace/my-repo")
 	path := fmt.Sprintf("%s/%s/retention/gc/uncommitted/%s/uncommitted/", ns, prefix, runID)
-	gc := retention.NewGarbageCollectionManager(blockAdapter, refMgr, prefix)
-	location, err := gc.GetUncommittedLocation(runID, "", ns)
-	require.NoError(t, err)
-	require.Equal(t, path, location)
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			gc := retention.NewGarbageCollectionManager(blockAdapter, refMgr, prefix)
+			location, err := gc.GetUncommittedLocation(runID, tc.StorageID, ns)
+			require.NoError(t, err)
+			require.Equal(t, path, location)
+		})
+	}
 }
 
 func createTestFile(t *testing.T, filename, testLine string, count int) {
@@ -49,38 +69,44 @@ func TestGarbageCollectionManager_SaveGarbageCollectionUncommitted(t *testing.T)
 	const runID = "my_test_runID"
 	const repoID = "my-repo"
 	ns := graveler.StorageNamespace("mem://test-namespace/" + repoID)
-	repositoryRec := graveler.RepositoryRecord{
-		RepositoryID: repoID,
-		Repository: &graveler.Repository{
-			StorageNamespace: ns,
-			CreationDate:     time.Now(),
-			DefaultBranchID:  "",
-			State:            graveler.RepositoryState_ACTIVE,
-			InstanceUID:      uuid.New().String(),
-		},
+
+	for _, tc := range cases {
+		t.Run(tc.Name, func(t *testing.T) {
+			repositoryRec := graveler.RepositoryRecord{
+				RepositoryID: repoID,
+				Repository: &graveler.Repository{
+					StorageID:        tc.StorageID,
+					StorageNamespace: ns,
+					CreationDate:     time.Now(),
+					DefaultBranchID:  "",
+					State:            graveler.RepositoryState_ACTIVE,
+					InstanceUID:      uuid.New().String(),
+				},
+			}
+			gc := retention.NewGarbageCollectionManager(blockAdapter, refMgr, prefix)
+			location, err := gc.GetUncommittedLocation(runID, tc.StorageID, ns)
+			require.NoError(t, err)
+			filename := "uncommitted_test_file"
+			testLine := "TestLine"
+			lineCount := 5
+			createTestFile(t, filename, testLine, lineCount)
+			defer os.Remove(filename)
+			err = gc.SaveGarbageCollectionUncommitted(ctx, &repositoryRec, filename, runID)
+			require.NoError(t, err)
+			reader, err := blockAdapter.Get(ctx, block.ObjectPointer{
+				StorageID:        "",
+				StorageNamespace: "",
+				Identifier:       fmt.Sprintf("%s%s", location, filename),
+				IdentifierType:   block.IdentifierTypeFull,
+			})
+			require.NoError(t, err)
+			fileScanner := bufio.NewScanner(reader)
+			line := 0
+			for fileScanner.Scan() {
+				require.Equal(t, fmt.Sprintf("%s_%d", testLine, line), fileScanner.Text())
+				line += 1
+			}
+			require.Equal(t, lineCount, line)
+		})
 	}
-	gc := retention.NewGarbageCollectionManager(blockAdapter, refMgr, prefix)
-	location, err := gc.GetUncommittedLocation(runID, "", ns)
-	require.NoError(t, err)
-	filename := "uncommitted_test_file"
-	testLine := "TestLine"
-	lineCount := 5
-	createTestFile(t, filename, testLine, lineCount)
-	defer os.Remove(filename)
-	err = gc.SaveGarbageCollectionUncommitted(ctx, &repositoryRec, filename, runID)
-	require.NoError(t, err)
-	reader, err := blockAdapter.Get(ctx, block.ObjectPointer{
-		StorageID:        "",
-		StorageNamespace: "",
-		Identifier:       fmt.Sprintf("%s%s", location, filename),
-		IdentifierType:   block.IdentifierTypeFull,
-	})
-	require.NoError(t, err)
-	fileScanner := bufio.NewScanner(reader)
-	line := 0
-	for fileScanner.Scan() {
-		require.Equal(t, fmt.Sprintf("%s_%d", testLine, line), fileScanner.Text())
-		line += 1
-	}
-	require.Equal(t, lineCount, line)
 }


### PR DESCRIPTION
Closes #8685

## Change Description
Add StorageID to GarbageCollectionManager.

## Testing
Can test with local lakefs + S3
See SGC acceptance tests repo generation [here](https://github.com/treeverse/fluffy/tree/main/pkg/lakefsgc/acceptance)
Use the sparkless gc container- check that it identifies the correct commits
Run this flow for empty and non-empty storageID cases

lakefs:
  access_key_id:
  secret_access_key:
  endpoint_url: http://localhost:8000/
objects_min_age: 1m