### PR TITLE
Add CI wrapper tests against SDK changes

### DIFF
--- a/.github/workflows/esti.yaml
+++ b/.github/workflows/esti.yaml
@@ -1221,7 +1221,7 @@ jobs:
           job-summary: true
           custom-arguments: './clients/python-wrapper/tests/integration -rP -We'
           click-to-expand: true
-          report-title: 'Python Wrapper System Tests Report'
+          report-title: 'Python Wrapper System Tests SDK Changes Report'
 
   # e2e-<db type>-<block adapter type>
   e2e-ddb-local-local:

--- a/.github/workflows/esti.yaml
+++ b/.github/workflows/esti.yaml
@@ -15,6 +15,19 @@ permissions:
   pull-requests: write
 
 jobs:
+  paths-filter:
+    runs-on: ubuntu-22.04
+    outputs:
+      python-sdk-change: ${{ steps.filter.outputs.python-sdk == 'true' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            python-sdk: 
+              - 'clients/python/**'
+
   check-secrets:
     name: Check if secrets are available.
     outputs:
@@ -1123,6 +1136,73 @@ jobs:
       - name: Install dependencies
         working-directory: ./clients/python-wrapper
         run: pip install -r requirements.txt pytest pytest-md pytest-emoji
+
+      - name: Generate uniquifying value
+        id: unique
+        run: echo "value=$RANDOM" >> $GITHUB_OUTPUT
+
+      - name: Run Python Wrapper Tests
+        uses: pavelzw/pytest-action@v2
+        env:
+          LAKECTL_CREDENTIALS_ACCESS_KEY_ID: ${{ env.LAKEFS_INSTALLATION_ACCESS_KEY_ID }}
+          LAKECTL_CREDENTIALS_SECRET_ACCESS_KEY: ${{env.LAKEFS_INSTALLATION_SECRET_ACCESS_KEY }}
+          LAKECTL_SERVER_ENDPOINT_URL: http://localhost:8000
+          STORAGE_NAMESPACE: s3://esti-system-testing/${{ github.run_number }}-python-wrapper/${{ steps.unique.outputs.value }}
+        with:
+          verbose: true
+          emoji: true
+          job-summary: true
+          custom-arguments: './clients/python-wrapper/tests/integration -rP -We'
+          click-to-expand: true
+          report-title: 'Python Wrapper System Tests Report'
+
+  python-wrapper-new-sdk:
+    needs: [deploy-image, login-to-amazon-ecr, paths-filter]
+    if: ${{ needs.paths-filter.outputs.python-sdk-change == 'true' }}
+    name: Test changes in SDK against the python wrapper
+    runs-on: ubuntu-22.04
+    env:
+      TAG: ${{ needs.deploy-image.outputs.tag }}
+      REGISTRY: ${{ needs.login-to-amazon-ecr.outputs.registry }}
+      LAKEFS_INSTALLATION_ACCESS_KEY_ID: AKIAIOSFDNN7EXAMPLEQ
+      LAKEFS_INSTALLATION_SECRET_ACCESS_KEY: wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+
+    services:
+      lakefs:
+        image: ${{ needs.login-to-amazon-ecr.outputs.registry }}/lakefs:${{ needs.deploy-image.outputs.tag }}
+        credentials:
+          username: ${{ needs.login-to-amazon-ecr.outputs.docker_username }}
+          password: ${{ needs.login-to-amazon-ecr.outputs.docker_password }}
+        ports:
+          - '8000:8000'
+        env:
+          LAKEFS_DATABASE_TYPE: local
+          LAKEFS_BLOCKSTORE_TYPE: s3
+          LAKEFS_BLOCKSTORE_S3_CREDENTIALS_ACCESS_KEY_ID: ${{ secrets.ESTI_AWS_ACCESS_KEY_ID }}
+          LAKEFS_BLOCKSTORE_S3_CREDENTIALS_SECRET_ACCESS_KEY: ${{ secrets.ESTI_AWS_SECRET_ACCESS_KEY }}
+          LAKEFS_INSTALLATION_USER_NAME: admin
+          LAKEFS_INSTALLATION_ACCESS_KEY_ID: ${{ env.LAKEFS_INSTALLATION_ACCESS_KEY_ID }}
+          LAKEFS_INSTALLATION_SECRET_ACCESS_KEY: ${{env.LAKEFS_INSTALLATION_SECRET_ACCESS_KEY }}
+          LAKEFS_AUTH_ENCRYPT_SECRET_KEY: some random secret string
+          LAKEFS_STATS_ENABLED: false
+
+    steps:
+      - name: Check-out code
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+
+      - name: Install dependencies
+        working-directory: ./clients/python-wrapper
+        run: pip install -r requirements.txt pytest pytest-md pytest-emoji
+
+      - name: build and install lakeFS Python SDK
+        run: |
+          PACKAGE_VERSION=0.0.0-dev make sdk-python
+          pip install ./clients/python
 
       - name: Generate uniquifying value
         id: unique

--- a/.github/workflows/python-wrapper-unit-tests.yaml
+++ b/.github/workflows/python-wrapper-unit-tests.yaml
@@ -110,15 +110,6 @@ jobs:
           PACKAGE_VERSION=0.0.0-dev make sdk-python
           pip install ./clients/python
 
-      - name: Generate Documentation
-        run: make python-wrapper-gen-docs
-
-      - name: Validate Documentation
-        run: make validate-python-wrapper
-
-      - name: Run Pylint
-        run: make python-wrapper-lint
-
       - name: Run Unit Tests
         uses: pavelzw/pytest-action@v2
         with:
@@ -127,4 +118,4 @@ jobs:
           job-summary: true
           custom-arguments: './clients/python-wrapper/tests/utests -q -We'
           click-to-expand: true
-          report-title: 'Python Wrapper Unit Tests Report'
+          report-title: 'Python Wrapper Unit Tests SDK Changes Report'

--- a/.github/workflows/python-wrapper-unit-tests.yaml
+++ b/.github/workflows/python-wrapper-unit-tests.yaml
@@ -9,20 +9,23 @@ jobs:
   paths-filter:
     runs-on: ubuntu-22.04
     outputs:
-      client-change: ${{ steps.filter.outputs.client == 'true' }}
+      wrapper-change: ${{ steps.filter.outputs.wrapper == 'true' }}
+      sdk-change: ${{ steps.filter.outputs.sdk == 'true' }}
     steps:
-      - uses: actions/checkout@v3
-      - uses: dorny/paths-filter@v2
+      - uses: actions/checkout@v4
+      - uses: dorny/paths-filter@v3
         id: filter
         with:
           filters: |
-            client: 
+            wrapper: 
               - 'clients/python-wrapper/**'
               - '.github/workflows/python-wrapper-unit-tests.yaml'
+            sdk:
+              - 'clients/python/**'
 
   always-succeed:
     needs: paths-filter
-    if: ${{ needs.paths-filter.outputs.client-change != 'true' }}
+    if: ${{ needs.paths-filter.outputs.wrapper-change != 'true' }}
     name: Unit Test Python SDK Wrapper
     runs-on: ubuntu-22.04
     steps:
@@ -31,7 +34,7 @@ jobs:
 
   unit-tests:
     needs: paths-filter
-    if: ${{ needs.paths-filter.outputs.client-change == 'true' }}
+    if: ${{ needs.paths-filter.outputs.wrapper-change == 'true' }}
     strategy:
       fail-fast: false
       matrix:
@@ -66,6 +69,57 @@ jobs:
         run: make python-wrapper-lint
       
       - name: Run Unit Tests 
+        uses: pavelzw/pytest-action@v2
+        with:
+          verbose: true
+          emoji: true
+          job-summary: true
+          custom-arguments: './clients/python-wrapper/tests/utests -q -We'
+          click-to-expand: true
+          report-title: 'Python Wrapper Unit Tests Report'
+
+  unit-tests-new-sdk:
+    needs: paths-filter
+    if: ${{ needs.paths-filter.outputs.sdk-change == 'true' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        pydantic_v1: [ true, false ]
+    name: Unit Test Python SDK Wrapper - SDK Changes
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v4
+
+      - name: Set up Python 3.9
+        uses: actions/setup-python@v4
+        with:
+          python-version: 3.9
+      
+      # When installed it will skip the installation of pydantic in the next step which will install the latest > 2
+      - name: Install pydantic V1
+        if: matrix.pydantic_v1
+        run: pip install pydantic==1.10.6
+
+      - name: Install dependencies
+        working-directory: ./clients/python-wrapper
+        run: pip install -r requirements.txt pylint pytest pytest-md pytest-emoji
+
+      - name: build and install lakeFS Python SDK
+        run: |
+          PACKAGE_VERSION=0.0.0-dev make sdk-python
+          pip install ./clients/python
+
+      - name: Generate Documentation
+        run: make python-wrapper-gen-docs
+
+      - name: Validate Documentation
+        run: make validate-python-wrapper
+
+      - name: Run Pylint
+        run: make python-wrapper-lint
+
+      - name: Run Unit Tests
         uses: pavelzw/pytest-action@v2
         with:
           verbose: true


### PR DESCRIPTION
Adding non mandatory CI tests for the Python wrapper which trigger when the Python Client SDK is modified.
These jobs will then install the yet to be released SDK in the venv and run unit and integration tests.
This tests are non-mandatory to decouple changes in swagger and the python wrapper (allow us to introduce code changes in multiple PRs)