### PR TITLE
feat: hook pre/post merge include merge source

### DIFF
--- a/docs/howto/hooks/webhooks.md
+++ b/docs/howto/hooks/webhooks.md
@@ -75,13 +75,13 @@ Upon execution, a webhook will send a request containing a JSON object with the 
 | commit_metadata[^2] | The metadata for the commit that is taking place                  | string |
 | commit_id[^2,^4]    | The ID of the commit that is being created                        | string |
 | tag_id[^3]          | The ID of the created/deleted tag                                 | string |
-| merge_source[^5]    | The ID of the created/deleted tag                                 | string |
+| merge_source[^5]    | The source branch/tag/ref on merge operation                      | string |
 
 [^1]: N\A for Tag events  
 [^2]: N\A for Tag and Create/Delete Branch events  
 [^3]: Applicable only for Tag events
 [^4]: Applicable to commit/merge events. For merges, this represents the merge commit ID to be created if the merge operation succeeds.
-[^5]: Applicable to merge events. This represents the merge source, if can be equal to the source_ref in case the source is a commit.
+[^5]: Applicable to merge events. This represents the merge source, it may be same as `source_ref` in case the source is a commit.
 
 Example:
 ```json

--- a/docs/howto/hooks/webhooks.md
+++ b/docs/howto/hooks/webhooks.md
@@ -61,27 +61,25 @@ hooks:
 ## Request body schema
 Upon execution, a webhook will send a request containing a JSON object with the following fields:
 
-| Field               | Description                                                       | Type   |
-|---------------------|-------------------------------------------------------------------|--------|
-| event_type          | Type of the event that triggered the _Action_                     | string |
-| event_time          | Time of the event that triggered the _Action_ (RFC3339 formatted) | string |
-| action_name         | Containing _Hook_ Action's Name                                   | string |
-| hook_id             | ID of the _Hook_                                                  | string |
-| repository_id       | ID of the Repository                                              | string |
-| branch_id[^1]       | ID of the Branch                                                  | string |
-| source_ref          | Reference to the source on which the event was triggered          | string |
-| commit_message[^2]  | The message for the commit (or merge) that is taking place        | string |
-| committer[^2]       | Name of the committer                                             | string |
-| commit_metadata[^2] | The metadata for the commit that is taking place                  | string |
-| commit_id[^2,^4]    | The ID of the commit that is being created                        | string |
-| tag_id[^3]          | The ID of the created/deleted tag                                 | string |
-| merge_source[^5]    | The source branch/tag/ref on merge operation                      | string |
+| Field               | Description                                                                | Type   |
+|---------------------|----------------------------------------------------------------------------|--------|
+| event_type          | Type of the event that triggered the _Action_                              | string |
+| event_time          | Time of the event that triggered the _Action_ (RFC3339 formatted)          | string |
+| action_name         | Containing _Hook_ Action's Name                                            | string |
+| hook_id             | ID of the _Hook_                                                           | string |
+| repository_id       | ID of the Repository                                                       | string |
+| branch_id[^1]       | ID of the Branch                                                           | string |
+| source_ref          | Reference to the source on which the event was triggered                   | string |
+| commit_message[^2]  | The message for the commit (or merge) that is taking place                 | string |
+| committer[^2]       | Name of the committer                                                      | string |
+| commit_metadata[^2] | The metadata for the commit that is taking place                           | string |
+| commit_id[^3]       | The ID of the commit that is being created                                 | string |
+| tag_id              | The ID of the created/deleted tag (available for Tag events)               | string |
+| merge_source        | The source branch/tag/ref on merge (available for Merge events)            | string |
 
-[^1]: N\A for Tag events  
-[^2]: N\A for Tag and Create/Delete Branch events  
-[^3]: Applicable only for Tag events
-[^4]: Applicable to commit/merge events. For merges, this represents the merge commit ID to be created if the merge operation succeeds.
-[^5]: Applicable to merge events. This represents the merge source, it may be same as `source_ref` in case the source is a commit.
+[^1]: N/A for Tag events 
+[^2]: N/A for Tag and Create/Delete Branch events  
+[^3]: Available for Commit/Merge events only. In Merge, this represents the merge commit ID to be created if the merge operation succeeds.
 
 Example:
 ```json

--- a/docs/howto/hooks/webhooks.md
+++ b/docs/howto/hooks/webhooks.md
@@ -73,13 +73,15 @@ Upon execution, a webhook will send a request containing a JSON object with the 
 | commit_message[^2]  | The message for the commit (or merge) that is taking place        | string |
 | committer[^2]       | Name of the committer                                             | string |
 | commit_metadata[^2] | The metadata for the commit that is taking place                  | string |
-| commit_id[^2,^4]    | The ID of the commit that is being created              | string |
+| commit_id[^2,^4]    | The ID of the commit that is being created                        | string |
 | tag_id[^3]          | The ID of the created/deleted tag                                 | string |
+| merge_source[^5]    | The ID of the created/deleted tag                                 | string |
 
 [^1]: N\A for Tag events  
 [^2]: N\A for Tag and Create/Delete Branch events  
 [^3]: Applicable only for Tag events
 [^4]: Applicable to commit/merge events. For merges, this represents the merge commit ID to be created if the merge operation succeeds.
+[^5]: Applicable to merge events. This represents the merge source, if can be equal to the source_ref in case the source is a commit.
 
 Example:
 ```json

--- a/esti/hooks_test.go
+++ b/esti/hooks_test.go
@@ -191,6 +191,7 @@ func testCommitMerge(t *testing.T, ctx context.Context, repo string) {
 		ActionName:    "Test Pre Merge",
 		HookID:        "test_webhook",
 		RepositoryID:  repo,
+		MergeSource:   branch,
 		BranchID:      mainBranch,
 		Committer:     commitRecord.Committer,
 		CommitMessage: fmt.Sprintf("Merge '%s' into '%s'", branch, mainBranch),
@@ -212,6 +213,7 @@ func testCommitMerge(t *testing.T, ctx context.Context, repo string) {
 		ActionName:    "Test Post Merge",
 		HookID:        "test_webhook",
 		RepositoryID:  repo,
+		MergeSource:   branch,
 		BranchID:      mainBranch,
 		CommitID:      mergeRef,
 		Committer:     commitRecord.Committer,
@@ -473,6 +475,7 @@ type webhookEventInfo struct {
 	HookID        string            `json:"hook_id"`
 	RepositoryID  string            `json:"repository_id"`
 	BranchID      string            `json:"branch_id"`
+	MergeSource   string            `json:"merge_source"`
 	SourceRef     string            `json:"source_ref"`
 	TagID         string            `json:"tag_id"`
 	CommitID      string            `json:"commit_id"`

--- a/pkg/actions/event.go
+++ b/pkg/actions/event.go
@@ -20,6 +20,7 @@ type EventInfo struct {
 	CommitMessage  string            `json:"commit_message,omitempty"`
 	Committer      string            `json:"committer,omitempty"`
 	CommitMetadata map[string]string `json:"commit_metadata,omitempty"`
+	MergeSource    string            `json:"merge_source,omitempty"`
 }
 
 func marshalEventInformation(actionName, hookID string, record graveler.HookRecord) ([]byte, error) {
@@ -37,6 +38,7 @@ func marshalEventInformation(actionName, hookID string, record graveler.HookReco
 		CommitMessage:  record.Commit.Message,
 		Committer:      record.Commit.Committer,
 		CommitMetadata: record.Commit.Metadata,
+		MergeSource:    record.MergeSource.String(),
 	}
 	return json.Marshal(info)
 }

--- a/pkg/actions/lua.go
+++ b/pkg/actions/lua.go
@@ -54,6 +54,7 @@ func applyRecord(l *lua.State, actionName, hookID string, record graveler.HookRe
 		"branch_id":         record.BranchID.String(),
 		"source_ref":        record.SourceRef.String(),
 		"tag_id":            record.TagID.String(),
+		"merge_source":      record.MergeSource.String(),
 		"repository_id":     record.Repository.RepositoryID.String(),
 		"storage_namespace": record.Repository.StorageNamespace.String(),
 		"commit": map[string]interface{}{

--- a/pkg/actions/lua_test.go
+++ b/pkg/actions/lua_test.go
@@ -449,9 +449,10 @@ func TestLuaRunTable(t *testing.T) {
 				Commit: graveler.Commit{
 					Version: 1,
 				},
-				CommitID: "123456789",
-				PreRunID: "3498032432",
-				TagID:    "",
+				CommitID:    "123456789",
+				PreRunID:    "3498032432",
+				TagID:       "tag1",
+				MergeSource: "merge-source",
 			}, out)
 			if testCase.Error != "" {
 				if !strings.Contains(err.Error(), testCase.Error) {

--- a/pkg/actions/service_test.go
+++ b/pkg/actions/service_test.go
@@ -517,6 +517,9 @@ func checkEvent(t *testing.T, record graveler.HookRecord, event actions.EventInf
 	if event.SourceRef != record.SourceRef.String() {
 		t.Errorf("Webhook post SourceRef=%s, expected=%s", event.SourceRef, record.SourceRef)
 	}
+	if event.MergeSource != record.MergeSource.String() {
+		t.Errorf("Webhook post MergeSource=%s, expected=%s", event.MergeSource, record.MergeSource)
+	}
 	if event.CommitMessage != record.Commit.Message {
 		t.Errorf("Webhook post CommitMessage=%s, expected=%s", event.CommitMessage, record.Commit.Message)
 	}

--- a/pkg/actions/testdata/lua/json_marshal_action.output
+++ b/pkg/actions/testdata/lua/json_marshal_action.output
@@ -12,10 +12,11 @@
   "commit_id": "123456789",
   "event_type": "pre-create-branch",
   "hook_id": "myHook",
+  "merge_source": "merge-source",
   "pre_run_id": "3498032432",
   "repository_id": "example123",
   "run_id": "abc123",
   "source_ref": "abc123",
   "storage_namespace": "local://foo/bar",
-  "tag_id": ""
+  "tag_id": "tag1"
 }

--- a/pkg/graveler/graveler.go
+++ b/pkg/graveler/graveler.go
@@ -2953,9 +2953,9 @@ func (g *Graveler) Merge(ctx context.Context, repository *RepositoryRecord, dest
 				Repository:  repository,
 				BranchID:    destination,
 				SourceRef:   fromCommit.CommitID.Ref(), // comment id we merge from
+				MergeSource: source,                    // the requested source to merge from (branch/tag/ref)
 				Commit:      commit,
 				CommitID:    commitID,
-				MergeSource: source, // the requested source to merge from (branch/tag/ref)
 			})
 			if err != nil {
 				return nil, &HookAbortError{
@@ -2982,8 +2982,8 @@ func (g *Graveler) Merge(ctx context.Context, repository *RepositoryRecord, dest
 			RunID:       postRunID,
 			Repository:  repository,
 			BranchID:    destination,
-			MergeSource: source,         // the requested source to merge from (branch/tag/ref)
 			SourceRef:   commitID.Ref(), // commit id we merge from
+			MergeSource: source,         // the requested source to merge from (branch/tag/ref)
 			Commit:      commit,
 			CommitID:    commitID,
 			PreRunID:    preRunID,

--- a/pkg/graveler/graveler.go
+++ b/pkg/graveler/graveler.go
@@ -2948,13 +2948,14 @@ func (g *Graveler) Merge(ctx context.Context, repository *RepositoryRecord, dest
 		if !repository.ReadOnly {
 			preRunID = g.hooks.NewRunID()
 			err = g.hooks.PreMergeHook(ctx, HookRecord{
-				EventType:  EventTypePreMerge,
-				RunID:      preRunID,
-				Repository: repository,
-				BranchID:   destination,
-				SourceRef:  fromCommit.CommitID.Ref(),
-				Commit:     commit,
-				CommitID:   commitID,
+				EventType:   EventTypePreMerge,
+				RunID:       preRunID,
+				Repository:  repository,
+				BranchID:    destination,
+				SourceRef:   fromCommit.CommitID.Ref(),
+				Commit:      commit,
+				CommitID:    commitID,
+				MergeSource: source,
 			})
 			if err != nil {
 				return nil, &HookAbortError{
@@ -2977,15 +2978,15 @@ func (g *Graveler) Merge(ctx context.Context, repository *RepositoryRecord, dest
 	if !repository.ReadOnly {
 		postRunID := g.hooks.NewRunID()
 		err = g.hooks.PostMergeHook(ctx, HookRecord{
-			EventType:  EventTypePostMerge,
-			RunID:      postRunID,
-			Repository: repository,
-			BranchID:   destination,
-
-			SourceRef: commitID.Ref(),
-			Commit:    commit,
-			CommitID:  commitID,
-			PreRunID:  preRunID,
+			EventType:   EventTypePostMerge,
+			RunID:       postRunID,
+			Repository:  repository,
+			BranchID:    destination,
+			MergeSource: source,
+			SourceRef:   commitID.Ref(),
+			Commit:      commit,
+			CommitID:    commitID,
+			PreRunID:    preRunID,
 		})
 		if err != nil {
 			g.log(ctx).

--- a/pkg/graveler/graveler.go
+++ b/pkg/graveler/graveler.go
@@ -2952,10 +2952,10 @@ func (g *Graveler) Merge(ctx context.Context, repository *RepositoryRecord, dest
 				RunID:       preRunID,
 				Repository:  repository,
 				BranchID:    destination,
-				SourceRef:   fromCommit.CommitID.Ref(),
+				SourceRef:   fromCommit.CommitID.Ref(), // comment id we merge from
 				Commit:      commit,
 				CommitID:    commitID,
-				MergeSource: source,
+				MergeSource: source, // the requested source to merge from (branch/tag/ref)
 			})
 			if err != nil {
 				return nil, &HookAbortError{
@@ -2982,8 +2982,8 @@ func (g *Graveler) Merge(ctx context.Context, repository *RepositoryRecord, dest
 			RunID:       postRunID,
 			Repository:  repository,
 			BranchID:    destination,
-			MergeSource: source,
-			SourceRef:   commitID.Ref(),
+			MergeSource: source,         // the requested source to merge from (branch/tag/ref)
+			SourceRef:   commitID.Ref(), // commit id we merge from
 			Commit:      commit,
 			CommitID:    commitID,
 			PreRunID:    preRunID,

--- a/pkg/graveler/hooks_handler.go
+++ b/pkg/graveler/hooks_handler.go
@@ -45,7 +45,7 @@ type HookRecord struct {
 	PreRunID string
 	// Exists only in tag actions.
 	TagID TagID
-	// Exists only in merge actions.
+	// Exists only in merge actions. Contains the requested source to merge from (branch/tag/ref) as requested in the merge request
 	MergeSource Ref
 }
 

--- a/pkg/graveler/hooks_handler.go
+++ b/pkg/graveler/hooks_handler.go
@@ -45,6 +45,8 @@ type HookRecord struct {
 	PreRunID string
 	// Exists only in tag actions.
 	TagID TagID
+	// Exists only in merge actions.
+	MergeSource Ref
 }
 
 type HooksHandler interface {


### PR DESCRIPTION
The new field `merge_source` include source branch/tag/commit as requested.
The current event include `source_ref` which resolved to the specific commit the merge operation will merge.

Close https://github.com/treeverse/lakeFS/issues/8707