### PR TITLE
Long policy name overflows error modal

### DIFF
--- a/webui/src/lib/api/index.js
+++ b/webui/src/lib/api/index.js
@@ -336,15 +336,7 @@ class Auth {
             body: JSON.stringify(policy)
         });
         if (response.status !== 201) {
-            const rawError = await extractError(response);
-            const idPatternInError = rawError.match(/"id":\s*"([^"]+)"/);
-            let truncatedError = rawError;
-            if (idPatternInError) {
-                const fullId = idPatternInError[1];
-                const truncatedId = (fullId.length > 40) ? fullId.slice(0,40) + "..." : fullId;
-                truncatedError = rawError.replace(fullId, truncatedId);
-            }
-            throw new Error(truncatedError)
+            throw new Error(await extractError(response));
         }
         return response.json();
     }

--- a/webui/src/lib/api/index.js
+++ b/webui/src/lib/api/index.js
@@ -336,7 +336,22 @@ class Auth {
             body: JSON.stringify(policy)
         });
         if (response.status !== 201) {
-            throw new Error(await extractError(response));
+            //throw new Error(await extractError(response));
+
+            const rawError = await extractError(response);
+            const idMatch = rawError.match(/"id":\s*"([^"]+)"/);
+            let truncatedError = rawError;
+            if (idMatch) {
+                const fullId = idMatch[1];
+                // truncate logic:
+                const displayId = (fullId.length > 40) ? fullId.slice(0,40) + "..." : fullId;
+                // replace the ID in the displayed error with a <span> that has a hover tooltip:
+                truncatedError = rawError.replace(
+                    fullId,
+                    displayId
+                );
+            }
+            throw new Error(truncatedError)
         }
         return response.json();
     }

--- a/webui/src/lib/api/index.js
+++ b/webui/src/lib/api/index.js
@@ -336,20 +336,13 @@ class Auth {
             body: JSON.stringify(policy)
         });
         if (response.status !== 201) {
-            //throw new Error(await extractError(response));
-
             const rawError = await extractError(response);
-            const idMatch = rawError.match(/"id":\s*"([^"]+)"/);
+            const idPatternInError = rawError.match(/"id":\s*"([^"]+)"/);
             let truncatedError = rawError;
-            if (idMatch) {
-                const fullId = idMatch[1];
-                // truncate logic:
-                const displayId = (fullId.length > 40) ? fullId.slice(0,40) + "..." : fullId;
-                // replace the ID in the displayed error with a <span> that has a hover tooltip:
-                truncatedError = rawError.replace(
-                    fullId,
-                    displayId
-                );
+            if (idPatternInError) {
+                const fullId = idPatternInError[1];
+                const truncatedId = (fullId.length > 40) ? fullId.slice(0,40) + "..." : fullId;
+                truncatedError = rawError.replace(fullId, truncatedId);
             }
             throw new Error(truncatedError)
         }

--- a/webui/src/lib/components/controls.jsx
+++ b/webui/src/lib/components/controls.jsx
@@ -81,12 +81,15 @@ export const AlertError = ({error, onDismiss = null, className = null}) => {
     let err = error;
     while (err.error) err = err.error;
     if (err.message) content = err.message;
+
+    const alertClassName = `${className} text-wrap text-break`.trim();
+
     if (onDismiss !== null) {
-        return <Alert className={className} variant="danger" dismissible onClose={onDismiss}>{content}</Alert>;
+        return <Alert className={alertClassName} variant="danger" dismissible onClose={onDismiss}>{content}</Alert>;
     }
     
     return (
-        <Alert className={className} variant="danger">{content}</Alert>
+        <Alert className={alertClassName} variant="danger">{content}</Alert>
     );
 };
 


### PR DESCRIPTION
Closes #8676

## Change Description

### Background

A long policy name overflows the error window, and this issue likely occurs in other error modals when the modal width is narrower than the text line.  

After discussing with Tal, we decided to **wrap long lines** to ensure they fit within the error modal, which adjusts dynamically based on screen size.  

**Error screenshots:**
![error_issue_1](https://github.com/user-attachments/assets/591865fa-0abe-4ddb-8351-a6e5c41fa527)

![error_issue_2](https://github.com/user-attachments/assets/df069bc9-95f8-45e1-9329-ba4eb3e9ed30)

### Steps to Reproduce  
1. Run fluffy
2. Run lakeFS locally with a connection to fluffy in configuration
3. Navigate to Administration → Policies → Create Policy 
4. Enter a **long policy ID (name)**  
5. Add an **empty policy JSON document**: `{}`  
6. Click **Save**  

### Bug Fix

Added React Bootstrap classes to the **AlertError** component to wrap long text onto a new line.  

**Fix screenshots:**
![error_fix_1](https://github.com/user-attachments/assets/288bfe52-bfd3-483a-be3a-dd164d771e59)

![error_fix_2](https://github.com/user-attachments/assets/e16219e6-0fff-4a0b-b3f8-e9ed72d7b717)

### Testing Details

Tested on **lakeFS OSS** with the **fluffy** configuration.

