### PR TITLE
Specified that Maven must run with Java 8 in docs

### DIFF
--- a/clients/hadoopfs/README.md
+++ b/clients/hadoopfs/README.md
@@ -9,4 +9,8 @@ Follow the [HadoopFS release checklist](https://github.com/treeverse/dev/blob/ma
 
 ## Building
 
+Maven must be run with Java 8.
+
+## Testing
+
 Maven tests must be run with Java 8.

--- a/clients/hadoopfs/README.md
+++ b/clients/hadoopfs/README.md
@@ -6,3 +6,7 @@ It uses the lakeFS server for metadata operations only.
 ## Publishing
 
 Follow the [HadoopFS release checklist](https://github.com/treeverse/dev/blob/main/pages/lakefs-clients-release.md#lakefs-hadoop-filesystem)
+
+## Building
+
+Maven tests must be run with Java 8.

--- a/clients/hadoopfs/README.md
+++ b/clients/hadoopfs/README.md
@@ -7,10 +7,7 @@ It uses the lakeFS server for metadata operations only.
 
 Follow the [HadoopFS release checklist](https://github.com/treeverse/dev/blob/main/pages/lakefs-clients-release.md#lakefs-hadoop-filesystem)
 
-## Building
+## Building and Testing
 
-Maven must be run with Java 8.
-
-## Testing
-
-Maven tests must be run with Java 8.
+The project uses Maven.  
+**Prerequisite:** Java 8 must be installed for building and testing.

--- a/docs/project/contributing.md
+++ b/docs/project/contributing.md
@@ -39,9 +39,10 @@ Our [Go release workflow](https://github.com/treeverse/lakeFS/blob/master/.githu
    1. [Docker](https://docs.docker.com/get-docker/)
    1. [Go](https://golang.org/doc/install)
    1. [Node.js & npm](https://www.npmjs.com/get-npm)
-   1. [Maven](https://maven.apache.org/) to build and test Spark client codes.
    1. Java 8
       * Apple M1 users can install this from [Azul Zulu Builds for Java JDK](https://www.azul.com/downloads/?package=jdk). Builds for Intel-based Macs are available from [java.com](https://www.java.com/en/download/help/mac_install.html).
+   1. [Maven](https://maven.apache.org/) with Java 8
+      * Java 8 is required for building and testing the hadoopfs client.
    1. *Optional* - [PostgreSQL 11](https://www.postgresql.org/docs/11/tutorial-install.html) (useful for running and debugging locally)
    1. *Optional* - [Rust & Cargo](https://www.rust-lang.org/tools/install) (useful for building the Rust SDK)
    1. *Optional* - [Buf CLI](https://buf.build/docs/installation) (only needed if you like to update Protocol Buffer files)

--- a/docs/project/contributing.md
+++ b/docs/project/contributing.md
@@ -41,8 +41,8 @@ Our [Go release workflow](https://github.com/treeverse/lakeFS/blob/master/.githu
    1. [Node.js & npm](https://www.npmjs.com/get-npm)
    1. Java 8
       * Apple M1 users can install this from [Azul Zulu Builds for Java JDK](https://www.azul.com/downloads/?package=jdk). Builds for Intel-based Macs are available from [java.com](https://www.java.com/en/download/help/mac_install.html).
-   1. [Maven](https://maven.apache.org/) with Java 8
-      * Java 8 is required for building and testing the hadoopfs client.
+   1. [Maven](https://maven.apache.org/) 
+      *  Required for building and testing Spark client code, as well as the hadoopfs client.
    1. *Optional* - [PostgreSQL 11](https://www.postgresql.org/docs/11/tutorial-install.html) (useful for running and debugging locally)
    1. *Optional* - [Rust & Cargo](https://www.rust-lang.org/tools/install) (useful for building the Rust SDK)
    1. *Optional* - [Buf CLI](https://buf.build/docs/installation) (only needed if you like to update Protocol Buffer files)


### PR DESCRIPTION
Closes #8581

## Change Description

### Background

When running make test with Maven using Java version greater than 8, the following error occurs:

```
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  1.770 s
[INFO] Finished at: 2025-01-28T17:43:16+02:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-compiler-plugin:3.8.1:testCompile (default-testCompile) on project hadoop-lakefs: Compilation failure: Compilation failure: 
[ERROR] /Users/annaseliverstov/work/lakeFS/clients/hadoopfs/src/test/java/io/lakefs/FSTestBase.java:[320,57] cannot find symbol
[ERROR]   symbol:   class ImmutablePagination
[ERROR]   location: class io.lakefs.FSTestBase
[ERROR] /Users/annaseliverstov/work/lakeFS/clients/hadoopfs/src/test/java/io/lakefs/FSTestBase.java:[324,68] cannot find symbol
[ERROR]   symbol:   class ImmutablePagination
[ERROR]   location: class io.lakefs.FSTestBase
```

### Fix And Updating Documentation

The failure happens in the hadoopfs client tests. However, when using Java 8, the tests pass successfully.

I updated the [Contributing to lakeFS](https://docs.lakefs.io/project/contributing.html) documentation and the clients/hadoopfs README by adding a building and testing section, specifying that Maven should be used with Java 8.

### Testing Details

I tested the appearance of the new document using Jekyll in Docker.
