### PR TITLE
Switch to use openapi generator v7.0.1.2

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ UID_GID := $(shell id -u):$(shell id -g)
 CLIENT_JARS_BUCKET="s3://treeverse-clients-us-east/"
 
 # https://openapi-generator.tech
-OPENAPI_GENERATOR_IMAGE=treeverse/openapi-generator-cli:v7.0.1.1
+OPENAPI_GENERATOR_IMAGE=treeverse/openapi-generator-cli:v7.0.1.2
 OPENAPI_GENERATOR=$(DOCKER) run --user $(UID_GID) --rm -v $(shell pwd):/mnt $(OPENAPI_GENERATOR_IMAGE)
 OPENAPI_RUST_GENERATOR_IMAGE=openapitools/openapi-generator-cli:v7.5.0
 OPENAPI_RUST_GENERATOR=$(DOCKER) run --user $(UID_GID) --rm -v $(shell pwd):/mnt $(OPENAPI_RUST_GENERATOR_IMAGE)

--- a/clients/java/build.gradle
+++ b/clients/java/build.gradle
@@ -108,8 +108,8 @@ ext {
 dependencies {
     implementation 'io.swagger:swagger-annotations:1.6.8'
     implementation "com.google.code.findbugs:jsr305:3.0.2"
-    implementation 'com.squareup.okhttp3:okhttp:4.10.0'
-    implementation 'com.squareup.okhttp3:logging-interceptor:4.10.0'
+    implementation 'com.squareup.okhttp3:okhttp:4.12.0'
+    implementation 'com.squareup.okhttp3:logging-interceptor:4.12.0'
     implementation 'com.google.code.gson:gson:2.9.1'
     implementation 'io.gsonfire:gson-fire:1.8.5'
     implementation 'javax.ws.rs:jsr311-api:1.1.1'

--- a/clients/java/build.sbt
+++ b/clients/java/build.sbt
@@ -10,8 +10,8 @@ lazy val root = (project in file(".")).
     resolvers += Resolver.mavenLocal,
     libraryDependencies ++= Seq(
       "io.swagger" % "swagger-annotations" % "1.6.5",
-      "com.squareup.okhttp3" % "okhttp" % "4.10.0",
-      "com.squareup.okhttp3" % "logging-interceptor" % "4.10.0",
+      "com.squareup.okhttp3" % "okhttp" % "4.12.0",
+      "com.squareup.okhttp3" % "logging-interceptor" % "4.12.0",
       "com.google.code.gson" % "gson" % "2.9.1",
       "org.apache.commons" % "commons-lang3" % "3.12.0",
       "javax.ws.rs" % "jsr311-api" % "1.1.1",

--- a/clients/java/pom.xml
+++ b/clients/java/pom.xml
@@ -341,7 +341,7 @@
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
         <gson-fire-version>1.8.5</gson-fire-version>
-        <okhttp-version>4.10.0</okhttp-version>
+        <okhttp-version>4.12.0</okhttp-version>
         <gson-version>2.9.1</gson-version>
         <commons-lang3-version>3.12.0</commons-lang3-version>
         <jackson-databind-nullable-version>0.2.6</jackson-databind-nullable-version>


### PR DESCRIPTION
New generator patch updates the java client okhttp to v4.12.0

The generator change update can be found [here](https://github.com/treeverse/openapi-generator/compare/patch/v7.0.1.1...patch/v7.0.1.2)

Closes https://github.com/treeverse/lakeFS/issues/8709