### PR TITLE
Return single-store config

### DIFF
--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -1891,14 +1891,12 @@ func (c *Controller) GetStorageConfig(w http.ResponseWriter, r *http.Request) {
 }
 
 func (c *Controller) getStorageConfigs() (*apigen.StorageConfig, apigen.StorageConfigList) {
-	storageCfgList := c.getStorageConfigList()
-	if len(storageCfgList) > 1 {
-		// non-empty storage-config-list, return empty storage-config
-		return &apigen.StorageConfig{}, storageCfgList
-	} else {
-		storageCfg, _ := c.getStorageConfig(config.SingleBlockstoreID)
-		return storageCfg, storageCfgList
+	storageCfg, _ := c.getStorageConfig(config.SingleBlockstoreID)
+	if storageCfg == nil {
+		storageCfg = &apigen.StorageConfig{}
 	}
+	storageCfgList := c.getStorageConfigList()
+	return storageCfg, storageCfgList
 }
 
 func (c *Controller) getStorageConfig(storageID string) (*apigen.StorageConfig, error) {


### PR DESCRIPTION
## Change Description

Always populate StorageConfig (of `GET /config` and `GET /config/storage`) with the Single config.

