### PR TITLE
Use StorageConfigList in lakectl when exists

### DIFF
--- a/cmd/lakectl/cmd/fs_cat.go
+++ b/cmd/lakectl/cmd/fs_cat.go
@@ -18,7 +18,7 @@ var fsCatCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		pathURI := MustParsePathURI("path URI", args[0])
 		client := getClient()
-		preSignMode := getPresignMode(cmd, client)
+		preSignMode := getPresignMode(cmd, client, pathURI.Repository)
 
 		var err error
 		var body io.ReadCloser

--- a/cmd/lakectl/cmd/fs_download.go
+++ b/cmd/lakectl/cmd/fs_download.go
@@ -31,7 +31,7 @@ var fsDownloadCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		remote, dest := getSyncArgs(args, true, false)
 		client := getClient()
-		syncFlags := getSyncFlags(cmd, client)
+		syncFlags := getSyncFlags(cmd, client, remote.Repository)
 		recursive := Must(cmd.Flags().GetBool(recursiveFlagName))
 		ctx := cmd.Context()
 		downloadPartSize := Must(cmd.Flags().GetInt64(partSizeFlagName))

--- a/cmd/lakectl/cmd/fs_presign.go
+++ b/cmd/lakectl/cmd/fs_presign.go
@@ -17,7 +17,7 @@ var fsPresignCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		pathURI := MustParsePathURI("path URI", args[0])
 		client := getClient()
-		preSignMode := getServerPreSignMode(cmd.Context(), client)
+		preSignMode := getServerPreSignMode(cmd.Context(), client, pathURI.Repository)
 		if !preSignMode.Enabled {
 			Die("Pre-signed URL support is currently disabled for this lakeFS server", 1)
 		}

--- a/cmd/lakectl/cmd/fs_stat.go
+++ b/cmd/lakectl/cmd/fs_stat.go
@@ -16,7 +16,7 @@ var fsStatCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		pathURI := MustParsePathURI("path URI", args[0])
 		client := getClient()
-		preSignMode := getPresignMode(cmd, client)
+		preSignMode := getPresignMode(cmd, client, pathURI.Repository)
 
 		resp, err := client.StatObjectWithResponse(cmd.Context(), pathURI.Repository, pathURI.Ref, &apigen.StatObjectParams{
 			Path:         *pathURI.Path,

--- a/cmd/lakectl/cmd/fs_upload.go
+++ b/cmd/lakectl/cmd/fs_upload.go
@@ -23,7 +23,7 @@ var fsUploadCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getClient()
 		pathURI, _ := getSyncArgs(args, true, false)
-		syncFlags := getSyncFlags(cmd, client)
+		syncFlags := getSyncFlags(cmd, client, pathURI.Repository)
 		source := Must(cmd.Flags().GetString("source"))
 		contentType := Must(cmd.Flags().GetString("content-type"))
 		recursive := Must(cmd.Flags().GetBool(recursiveFlagName))

--- a/cmd/lakectl/cmd/import.go
+++ b/cmd/lakectl/cmd/import.go
@@ -167,10 +167,7 @@ func verifySourceMatchConfiguredStorage(ctx context.Context, client *apigen.Clie
 		Warning(fmt.Sprintf("'adls' hint is deprecated\n Using %s", source))
 	}
 
-	storageConfig, err := getStorageConfig(ctx, client, repositoryID)
-	if err != nil {
-		DieErr(err)
-	}
+	storageConfig := getStorageConfigOrDie(ctx, client, repositoryID)
 	if storageConfig.ImportValidityRegex == "" {
 		return
 	}

--- a/cmd/lakectl/cmd/import.go
+++ b/cmd/lakectl/cmd/import.go
@@ -38,7 +38,7 @@ var importCmd = &cobra.Command{
 
 		ctx := cmd.Context()
 		client := getClient()
-		verifySourceMatchConfiguredStorage(ctx, client, from)
+		verifySourceMatchConfiguredStorage(ctx, client, toURI.Repository, from)
 
 		// verify target branch exists before we try to create and import into the associated imported branch
 		if err, ok := branchExists(ctx, client, toURI.Repository, toURI.Ref); err != nil {
@@ -160,18 +160,16 @@ func newImportProgressBar(visible bool) *progressbar.ProgressBar {
 	return bar
 }
 
-func verifySourceMatchConfiguredStorage(ctx context.Context, client *apigen.ClientWithResponses, source string) {
+func verifySourceMatchConfiguredStorage(ctx context.Context, client *apigen.ClientWithResponses, repositoryID string, source string) {
 	// Adds backwards compatibility for ADLS Gen2 storage import `hint`
 	if strings.Contains(source, "adls.core.windows.net") {
 		source = strings.Replace(source, "adls.core.windows.net", "blob.core.windows.net", 1)
 		Warning(fmt.Sprintf("'adls' hint is deprecated\n Using %s", source))
 	}
 
-	confResp, err := client.GetConfigWithResponse(ctx)
-	DieOnErrorOrUnexpectedStatusCode(confResp, err, http.StatusOK)
-	storageConfig := confResp.JSON200.StorageConfig
-	if storageConfig == nil {
-		Die("Bad response from server", 1)
+	storageConfig, err := getStorageConfig(ctx, client, repositoryID)
+	if err != nil {
+		DieErr(err)
 	}
 	if storageConfig.ImportValidityRegex == "" {
 		return

--- a/cmd/lakectl/cmd/local_checkout.go
+++ b/cmd/lakectl/cmd/local_checkout.go
@@ -40,7 +40,6 @@ var localCheckoutCmd = &cobra.Command{
 
 func localCheckout(cmd *cobra.Command, localPath string, specifiedRef string, confirmByFlag bool) {
 	client := getClient()
-	syncFlags := getSyncFlags(cmd, client)
 	idx, err := local.ReadIndex(localPath)
 	if err != nil {
 		if errors.Is(err, fs.ErrNotExist) {
@@ -54,6 +53,7 @@ func localCheckout(cmd *cobra.Command, localPath string, specifiedRef string, co
 		DieErr(err)
 	}
 
+	syncFlags := getSyncFlags(cmd, client, remote.Repository)
 	currentBase := remote.WithRef(idx.AtHead)
 	diffs := local.Undo(localDiff(cmd.Context(), client, currentBase, idx.LocalPath()))
 	sigCtx := localHandleSyncInterrupt(cmd.Context(), idx, string(checkoutOperation))

--- a/cmd/lakectl/cmd/local_clone.go
+++ b/cmd/lakectl/cmd/local_clone.go
@@ -28,7 +28,7 @@ var localCloneCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getClient()
 		remote, localPath := getSyncArgs(args, true, false)
-		syncFlags := getSyncFlags(cmd, client)
+		syncFlags := getSyncFlags(cmd, client, remote.Repository)
 		updateIgnore := Must(cmd.Flags().GetBool(localGitIgnoreFlagName))
 		empty, err := fileutil.IsDirEmpty(localPath)
 		if err != nil {

--- a/cmd/lakectl/cmd/local_commit.go
+++ b/cmd/lakectl/cmd/local_commit.go
@@ -85,7 +85,6 @@ var localCommitCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		client := getClient()
 		_, localPath := getSyncArgs(args, false, false)
-		syncFlags := getSyncFlags(cmd, client)
 		message, kvPairs := getCommitFlags(cmd)
 		force := Must(cmd.Flags().GetBool(localForceFlagName))
 
@@ -98,6 +97,7 @@ var localCommitCmd = &cobra.Command{
 		if err != nil {
 			DieErr(err)
 		}
+		syncFlags := getSyncFlags(cmd, client, remote.Repository)
 
 		if idx.ActiveOperation != "" {
 			fmt.Printf("Latest 'local %s' operation was interrupted, running 'local commit' operation now might lead to data loss.\n", idx.ActiveOperation)

--- a/cmd/lakectl/cmd/local_pull.go
+++ b/cmd/lakectl/cmd/local_pull.go
@@ -20,7 +20,6 @@ var localPullCmd = &cobra.Command{
 		client := getClient()
 		_, localPath := getSyncArgs(args, false, false)
 		force := Must(cmd.Flags().GetBool(localForceFlagName))
-		syncFlags := getSyncFlags(cmd, client)
 		idx, err := local.ReadIndex(localPath)
 		if err != nil {
 			DieErr(err)
@@ -30,6 +29,7 @@ var localPullCmd = &cobra.Command{
 		if err != nil {
 			DieErr(err)
 		}
+		syncFlags := getSyncFlags(cmd, client, remote.Repository)
 
 		dieOnInterruptedOperation(LocalOperation(idx.ActiveOperation), force)
 

--- a/cmd/lakectl/cmd/root.go
+++ b/cmd/lakectl/cmd/root.go
@@ -221,7 +221,7 @@ func getStorageConfigOrDie(ctx context.Context, client *apigen.ClientWithRespons
 	DieOnErrorOrUnexpectedStatusCode(confResp, err, http.StatusOK)
 
 	storageConfigList := confResp.JSON200.StorageConfigList
-	if len(*storageConfigList) > 1 {
+	if storageConfigList != nil && len(*storageConfigList) > 1 {
 		repoResp, errRepo := client.GetRepositoryWithResponse(ctx, repositoryID)
 		DieOnErrorOrUnexpectedStatusCode(repoResp, errRepo, http.StatusOK)
 		if repoResp.JSON200 == nil {

--- a/cmd/lakectl/cmd/root.go
+++ b/cmd/lakectl/cmd/root.go
@@ -221,7 +221,7 @@ func getStorageConfigOrDie(ctx context.Context, client *apigen.ClientWithRespons
 	DieOnErrorOrUnexpectedStatusCode(confResp, err, http.StatusOK)
 
 	storageConfigList := confResp.JSON200.StorageConfigList
-	if storageConfigList != nil && len(*storageConfigList) > 1 {
+	if storageConfigList != nil && len(*storageConfigList) >= 1 {
 		repoResp, errRepo := client.GetRepositoryWithResponse(ctx, repositoryID)
 		DieOnErrorOrUnexpectedStatusCode(repoResp, errRepo, http.StatusOK)
 		if repoResp.JSON200 == nil {
@@ -239,6 +239,9 @@ func getStorageConfigOrDie(ctx context.Context, client *apigen.ClientWithRespons
 		Die("Storage config not found for repo "+repositoryID, 1)
 	}
 
+	if confResp.JSON200 == nil {
+		Die("Bad response from server for GetConfig", 1)
+	}
 	storageConfig := confResp.JSON200.StorageConfig
 	if storageConfig == nil {
 		Die("Bad response from server for GetConfig", 1)

--- a/cmd/lakectl/cmd/root.go
+++ b/cmd/lakectl/cmd/root.go
@@ -232,7 +232,7 @@ func getStorageConfig(ctx context.Context, client *apigen.ClientWithResponses, r
 			}
 		}
 		Die("Storage config not found for repo "+repositoryID, 1)
-		return nil, fmt.Errorf("storage config not found for repo %s", repositoryID)
+		return nil, nil // this is unreachable - just to make the go code happy
 	} else {
 		storageConfig := confResp.JSON200.StorageConfig
 		if storageConfig == nil {

--- a/cmd/lakectl/cmd/root.go
+++ b/cmd/lakectl/cmd/root.go
@@ -224,7 +224,7 @@ func getStorageConfigOrDie(ctx context.Context, client *apigen.ClientWithRespons
 	}
 
 	storageConfigList := confResp.JSON200.StorageConfigList
-	if storageConfigList != nil && len(*storageConfigList) >= 1 {
+	if storageConfigList != nil && len(*storageConfigList) > 1 {
 		repoResp, errRepo := client.GetRepositoryWithResponse(ctx, repositoryID)
 		DieOnErrorOrUnexpectedStatusCode(repoResp, errRepo, http.StatusOK)
 		if repoResp.JSON200 == nil {

--- a/cmd/lakectl/cmd/root.go
+++ b/cmd/lakectl/cmd/root.go
@@ -219,6 +219,9 @@ func withSyncFlags(cmd *cobra.Command) {
 func getStorageConfigOrDie(ctx context.Context, client *apigen.ClientWithResponses, repositoryID string) *apigen.StorageConfig {
 	confResp, err := client.GetConfigWithResponse(ctx)
 	DieOnErrorOrUnexpectedStatusCode(confResp, err, http.StatusOK)
+	if confResp.JSON200 == nil {
+		Die("Bad response from server for GetConfig", 1)
+	}
 
 	storageConfigList := confResp.JSON200.StorageConfigList
 	if storageConfigList != nil && len(*storageConfigList) >= 1 {
@@ -239,9 +242,6 @@ func getStorageConfigOrDie(ctx context.Context, client *apigen.ClientWithRespons
 		Die("Storage config not found for repo "+repositoryID, 1)
 	}
 
-	if confResp.JSON200 == nil {
-		Die("Bad response from server for GetConfig", 1)
-	}
 	storageConfig := confResp.JSON200.StorageConfig
 	if storageConfig == nil {
 		Die("Bad response from server for GetConfig", 1)


### PR DESCRIPTION
Closes #8708.

## Change Description

Now that `GET /config` might return a non-empty `StorageConfigList`, use it if present to get the config relevant for the repository.

