### PR TITLE
Use hive archive for CI test

### DIFF
--- a/test/lakectl_metastore/hive/Dockerfile
+++ b/test/lakectl_metastore/hive/Dockerfile
@@ -10,7 +10,6 @@ ENV HIVE_HOME=/opt/apache-hive-bin
 
 RUN mkdir ${HADOOP_HOME} ${HIVE_HOME}
 # Using the archive mirror instead of dist, see this Issue: https://github.com/treeverse/lakeFS/issues/8728
-# RUN curl -sSL https://www.apache.org/dist/hive/hive-${HIVE_VERSION}/apache-hive-${HIVE_VERSION}-bin.tar.gz | tar -zx --strip-components 1 -C ${HIVE_HOME} -f -
 RUN curl -sSL https://archive.apache.org/dist/hive/hive-${HIVE_VERSION}/apache-hive-${HIVE_VERSION}-bin.tar.gz | tar -zx --strip-components 1 -C ${HIVE_HOME} -f -
 RUN curl -sSL https://archive.apache.org/dist/hadoop/common/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}.tar.gz | tar -zx --strip-components 1 -C ${HADOOP_HOME} -f -
 RUN curl -sSL https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-8.0.19.tar.gz | tar -zx --strip-components 1 -C ${HIVE_HOME}/lib -f - mysql-connector-java-8.0.19/mysql-connector-java-8.0.19.jar

--- a/test/lakectl_metastore/hive/Dockerfile
+++ b/test/lakectl_metastore/hive/Dockerfile
@@ -9,7 +9,9 @@ ENV HADOOP_HOME=/opt/hadoop
 ENV HIVE_HOME=/opt/apache-hive-bin
 
 RUN mkdir ${HADOOP_HOME} ${HIVE_HOME}
-RUN curl -sSL https://www.apache.org/dist/hive/hive-${HIVE_VERSION}/apache-hive-${HIVE_VERSION}-bin.tar.gz | tar -zx --strip-components 1 -C ${HIVE_HOME} -f -
+# Using the archive mirror instead of dist, see this Issue: https://github.com/treeverse/lakeFS/issues/8728
+# RUN curl -sSL https://www.apache.org/dist/hive/hive-${HIVE_VERSION}/apache-hive-${HIVE_VERSION}-bin.tar.gz | tar -zx --strip-components 1 -C ${HIVE_HOME} -f -
+RUN curl -sSL https://archive.apache.org/dist/hive/hive-${HIVE_VERSION}/apache-hive-${HIVE_VERSION}-bin.tar.gz | tar -zx --strip-components 1 -C ${HIVE_HOME} -f -
 RUN curl -sSL https://archive.apache.org/dist/hadoop/common/hadoop-${HADOOP_VERSION}/hadoop-${HADOOP_VERSION}.tar.gz | tar -zx --strip-components 1 -C ${HADOOP_HOME} -f -
 RUN curl -sSL https://dev.mysql.com/get/Downloads/Connector-J/mysql-connector-java-8.0.19.tar.gz | tar -zx --strip-components 1 -C ${HIVE_HOME}/lib -f - mysql-connector-java-8.0.19/mysql-connector-java-8.0.19.jar
 RUN ln -s ${HADOOP_HOME}/share/hadoop/tools/lib/aws-java-sdk-bundle-${AWS_SDK_VERSION}.jar ${HIVE_HOME}/lib/


### PR DESCRIPTION
Closes #8728.

## Change Description

Since Hive 3.x is literally dead (see [Hive releases page](https://hive.apache.org/general/downloads/)),
Using meanwhile the archived version of it for the CI tests.
