### PR TITLE
lakectl: Add storage ID to repo list

### DIFF
--- a/cmd/lakectl/cmd/repo_list.go
+++ b/cmd/lakectl/cmd/repo_list.go
@@ -33,10 +33,10 @@ var repoListCmd = &cobra.Command{
 		rows := make([][]interface{}, len(repos))
 		for i, repo := range repos {
 			ts := time.Unix(repo.CreationDate, 0).String()
-			rows[i] = []interface{}{repo.Id, ts, repo.DefaultBranch, repo.StorageNamespace}
+			rows[i] = []interface{}{repo.Id, ts, repo.DefaultBranch, repo.Id, repo.StorageNamespace}
 		}
 		pagination := resp.JSON200.Pagination
-		PrintTable(rows, []interface{}{"Repository", "Creation Date", "Default Ref Name", "Storage Namespace"}, &pagination, amount)
+		PrintTable(rows, []interface{}{"Repository", "Creation Date", "Default Ref Name", "Storage ID", "Storage Namespace"}, &pagination, amount)
 	},
 }
 

--- a/esti/presign_test.go
+++ b/esti/presign_test.go
@@ -8,13 +8,12 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/treeverse/lakefs/pkg/graveler/committed"
-
 	"github.com/go-openapi/swag"
 	"github.com/stretchr/testify/require"
 	"github.com/thanhpk/randstr"
 	"github.com/treeverse/lakefs/pkg/api/apigen"
 	"github.com/treeverse/lakefs/pkg/block"
+	"github.com/treeverse/lakefs/pkg/graveler/committed"
 )
 
 func matchPreSignedURLContent(t *testing.T, preSignedURL, content string) {


### PR DESCRIPTION
Closes #8755

## Change Description

### Background

Display storage id as part of the repo list information

Tested manually
Example output:
```
lakectl repo list                                                              
+------------+-------------------------------+------------------+------------+-------------------+
| REPOSITORY | CREATION DATE                 | DEFAULT REF NAME | STORAGE ID | STORAGE NAMESPACE |
+------------+-------------------------------+------------------+------------+-------------------+
| test       | 2025-03-04 18:38:44 -0500 EST | main             |            | local://test      |
+------------+-------------------------------+------------------+------------+-------------------+

````