### PR TITLE
chore: Define types for inner configuration structure

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -166,66 +166,75 @@ type AdapterConfig interface {
 	ID() string
 }
 
+type BlockstoreLocal struct {
+	Path                    string   `mapstructure:"path"`
+	ImportEnabled           bool     `mapstructure:"import_enabled"`
+	ImportHidden            bool     `mapstructure:"import_hidden"`
+	AllowedExternalPrefixes []string `mapstructure:"allowed_external_prefixes"`
+}
+
+type BlockstoreS3WebIdentity struct {
+	SessionDuration     time.Duration `mapstructure:"session_duration"`
+	SessionExpiryWindow time.Duration `mapstructure:"session_expiry_window"`
+}
+
+type BlockstoreS3 struct {
+	S3AuthInfo                    `mapstructure:",squash"`
+	Region                        string        `mapstructure:"region"`
+	Endpoint                      string        `mapstructure:"endpoint"`
+	MaxRetries                    int           `mapstructure:"max_retries"`
+	ForcePathStyle                bool          `mapstructure:"force_path_style"`
+	DiscoverBucketRegion          bool          `mapstructure:"discover_bucket_region"`
+	SkipVerifyCertificateTestOnly bool          `mapstructure:"skip_verify_certificate_test_only"`
+	ServerSideEncryption          string        `mapstructure:"server_side_encryption"`
+	ServerSideEncryptionKmsKeyID  string        `mapstructure:"server_side_encryption_kms_key_id"`
+	PreSignedExpiry               time.Duration `mapstructure:"pre_signed_expiry"`
+	// Endpoint for pre-signed URLs, if set, will override the default pre-signed URL S3 endpoint (only for pre-sign URL generation)
+	PreSignedEndpoint         string                   `mapstructure:"pre_signed_endpoint"`
+	DisablePreSigned          bool                     `mapstructure:"disable_pre_signed"`
+	DisablePreSignedUI        bool                     `mapstructure:"disable_pre_signed_ui"`
+	DisablePreSignedMultipart bool                     `mapstructure:"disable_pre_signed_multipart"`
+	ClientLogRetries          bool                     `mapstructure:"client_log_retries"`
+	ClientLogRequest          bool                     `mapstructure:"client_log_request"`
+	WebIdentity               *BlockstoreS3WebIdentity `mapstructure:"web_identity"`
+}
+
+type BlockstoreAzure struct {
+	TryTimeout       time.Duration `mapstructure:"try_timeout"`
+	StorageAccount   string        `mapstructure:"storage_account"`
+	StorageAccessKey string        `mapstructure:"storage_access_key"`
+	// Deprecated: Value ignored
+	AuthMethod         string        `mapstructure:"auth_method"`
+	PreSignedExpiry    time.Duration `mapstructure:"pre_signed_expiry"`
+	DisablePreSigned   bool          `mapstructure:"disable_pre_signed"`
+	DisablePreSignedUI bool          `mapstructure:"disable_pre_signed_ui"`
+	// Deprecated: Value ignored
+	ChinaCloudDeprecated bool   `mapstructure:"china_cloud"`
+	TestEndpointURL      string `mapstructure:"test_endpoint_url"`
+	// Domain by default points to Azure default domain blob.core.windows.net, can be set to other Azure domains (China/Gov)
+	Domain string `mapstructure:"domain"`
+}
+type BlockstoreGS struct {
+	S3Endpoint                           string        `mapstructure:"s3_endpoint"`
+	CredentialsFile                      string        `mapstructure:"credentials_file"`
+	CredentialsJSON                      string        `mapstructure:"credentials_json"`
+	PreSignedExpiry                      time.Duration `mapstructure:"pre_signed_expiry"`
+	DisablePreSigned                     bool          `mapstructure:"disable_pre_signed"`
+	DisablePreSignedUI                   bool          `mapstructure:"disable_pre_signed_ui"`
+	ServerSideEncryptionCustomerSupplied string        `mapstructure:"server_side_encryption_customer_supplied"`
+	ServerSideEncryptionKmsKeyID         string        `mapstructure:"server_side_encryption_kms_key_id"`
+}
+
 type Blockstore struct {
 	Signing struct {
 		SecretKey SecureString `mapstructure:"secret_key"`
 	} `mapstructure:"signing"`
-	Type                   string  `mapstructure:"type"`
-	DefaultNamespacePrefix *string `mapstructure:"default_namespace_prefix"`
-	Local                  *struct {
-		Path                    string   `mapstructure:"path"`
-		ImportEnabled           bool     `mapstructure:"import_enabled"`
-		ImportHidden            bool     `mapstructure:"import_hidden"`
-		AllowedExternalPrefixes []string `mapstructure:"allowed_external_prefixes"`
-	} `mapstructure:"local"`
-	S3 *struct {
-		S3AuthInfo                    `mapstructure:",squash"`
-		Region                        string        `mapstructure:"region"`
-		Endpoint                      string        `mapstructure:"endpoint"`
-		MaxRetries                    int           `mapstructure:"max_retries"`
-		ForcePathStyle                bool          `mapstructure:"force_path_style"`
-		DiscoverBucketRegion          bool          `mapstructure:"discover_bucket_region"`
-		SkipVerifyCertificateTestOnly bool          `mapstructure:"skip_verify_certificate_test_only"`
-		ServerSideEncryption          string        `mapstructure:"server_side_encryption"`
-		ServerSideEncryptionKmsKeyID  string        `mapstructure:"server_side_encryption_kms_key_id"`
-		PreSignedExpiry               time.Duration `mapstructure:"pre_signed_expiry"`
-		// Endpoint for pre-signed URLs, if set, will override the default pre-signed URL S3 endpoint (only for pre-sign URL generation)
-		PreSignedEndpoint         string `mapstructure:"pre_signed_endpoint"`
-		DisablePreSigned          bool   `mapstructure:"disable_pre_signed"`
-		DisablePreSignedUI        bool   `mapstructure:"disable_pre_signed_ui"`
-		DisablePreSignedMultipart bool   `mapstructure:"disable_pre_signed_multipart"`
-		ClientLogRetries          bool   `mapstructure:"client_log_retries"`
-		ClientLogRequest          bool   `mapstructure:"client_log_request"`
-		WebIdentity               *struct {
-			SessionDuration     time.Duration `mapstructure:"session_duration"`
-			SessionExpiryWindow time.Duration `mapstructure:"session_expiry_window"`
-		} `mapstructure:"web_identity"`
-	} `mapstructure:"s3"`
-	Azure *struct {
-		TryTimeout       time.Duration `mapstructure:"try_timeout"`
-		StorageAccount   string        `mapstructure:"storage_account"`
-		StorageAccessKey string        `mapstructure:"storage_access_key"`
-		// Deprecated: Value ignored
-		AuthMethod         string        `mapstructure:"auth_method"`
-		PreSignedExpiry    time.Duration `mapstructure:"pre_signed_expiry"`
-		DisablePreSigned   bool          `mapstructure:"disable_pre_signed"`
-		DisablePreSignedUI bool          `mapstructure:"disable_pre_signed_ui"`
-		// Deprecated: Value ignored
-		ChinaCloudDeprecated bool   `mapstructure:"china_cloud"`
-		TestEndpointURL      string `mapstructure:"test_endpoint_url"`
-		// Domain by default points to Azure default domain blob.core.windows.net, can be set to other Azure domains (China/Gov)
-		Domain string `mapstructure:"domain"`
-	} `mapstructure:"azure"`
-	GS *struct {
-		S3Endpoint                           string        `mapstructure:"s3_endpoint"`
-		CredentialsFile                      string        `mapstructure:"credentials_file"`
-		CredentialsJSON                      string        `mapstructure:"credentials_json"`
-		PreSignedExpiry                      time.Duration `mapstructure:"pre_signed_expiry"`
-		DisablePreSigned                     bool          `mapstructure:"disable_pre_signed"`
-		DisablePreSignedUI                   bool          `mapstructure:"disable_pre_signed_ui"`
-		ServerSideEncryptionCustomerSupplied string        `mapstructure:"server_side_encryption_customer_supplied"`
-		ServerSideEncryptionKmsKeyID         string        `mapstructure:"server_side_encryption_kms_key_id"`
-	} `mapstructure:"gs"`
+	Type                   string           `mapstructure:"type"`
+	DefaultNamespacePrefix *string          `mapstructure:"default_namespace_prefix"`
+	Local                  *BlockstoreLocal `mapstructure:"local"`
+	S3                     *BlockstoreS3    `mapstructure:"s3"`
+	Azure                  *BlockstoreAzure `mapstructure:"azure"`
+	GS                     *BlockstoreGS    `mapstructure:"gs"`
 }
 
 func (b *Blockstore) GetStorageIDs() []string {
@@ -609,13 +618,21 @@ func SetDefaults(cfgType string, c Config) {
 }
 
 func Unmarshal(c Config) error {
-	return viper.UnmarshalExact(&c,
-		viper.DecodeHook(
-			mapstructure.ComposeDecodeHookFunc(
-				DecodeStrings,
-				mapstructure.StringToTimeDurationHookFunc(),
-				DecodeStringToMap(),
-			)))
+	return viper.UnmarshalExact(&c, decoderConfig())
+}
+
+func UnmarshalKey(key string, rawVal any) error {
+	return viper.UnmarshalKey(key, rawVal, decoderConfig())
+}
+
+func decoderConfig() viper.DecoderConfigOption {
+	hook := viper.DecodeHook(
+		mapstructure.ComposeDecodeHookFunc(
+			DecodeStrings,
+			mapstructure.StringToTimeDurationHookFunc(),
+			DecodeStringToMap(),
+		))
+	return hook
 }
 
 func stringReverse(s string) string {


### PR DESCRIPTION
- Name anonymous structs used in blockstore configuration
- Enable configuration unmarshal for specific key

