### PR TITLE
Added Group's and Policy's search functionality in webUI

### DIFF
--- a/webui/src/lib/components/controls.jsx
+++ b/webui/src/lib/components/controls.jsx
@@ -500,3 +500,19 @@ export const GrayOut = ({children}) =>
 
 export const WrapIf = ({enabled, Component, children}) => (
     enabled ? <Component>{children}</Component> : children);
+
+export const SearchInput = ({searchPrefix, setSearchPrefix, placeholder}) => {
+    return (
+        <InputGroup>
+            <Form.Control
+                autoFocus
+                placeholder={placeholder}
+                value={searchPrefix}
+                onChange={(e) => setSearchPrefix(e.target.value)}
+            />
+            <InputGroup.Text>
+                <SearchIcon />
+            </InputGroup.Text>
+        </InputGroup>
+    );
+};

--- a/webui/src/pages/auth/groups/index.tsx
+++ b/webui/src/pages/auth/groups/index.tsx
@@ -15,7 +15,8 @@ import {
     FormattedDate,
     Loading,
     RefreshButton,
-    useDebouncedState
+    useDebouncedState,
+    SearchInput
 } from "../../../lib/components/controls";
 import {useRouter} from "../../../lib/hooks/router";
 import {Link} from "../../../lib/components/nav";
@@ -23,9 +24,6 @@ import {EntityActionModal} from "../../../lib/components/auth/forms";
 import { disallowPercentSign, INVALID_GROUP_NAME_ERROR_MESSAGE } from "../validation";
 import {useLoginConfigContext} from "../../../lib/hooks/conf";
 import {useAuthOutletContext} from "../../../lib/components/auth/layout";
-import InputGroup from "react-bootstrap/InputGroup";
-import { Form } from "react-bootstrap";
-import {SearchIcon} from "@primer/octicons-react";
 
 interface PermissionTypes {
     Read: string;
@@ -106,8 +104,8 @@ const GroupsContainer = () => {
     const [refresh, setRefresh] = useState(false);
 
     const router = useRouter();
-    const after = (router.query.after) ? router.query.after : "";
     const prefix = (router.query.prefix) ? router.query.prefix : "";
+    const after = (router.query.after) ? router.query.after : "";
 
     const lc = useLoginConfigContext();
     const simplified = lc.RBAC === 'simplified';
@@ -158,18 +156,11 @@ const GroupsContainer = () => {
                     </ConfirmationButton>
                 </ActionGroup>
                 <ActionGroup orientation="right">
-                    <InputGroup>
-                        <Form.Control
-                            placeholder="Find a Group..."
-                            autoFocus
-                            value={searchPrefix}
-                            onChange={e => setSearchPrefix(e.target.value)}
-                        />
-                        <InputGroup.Text>
-                            <SearchIcon/>
-                        </InputGroup.Text>
-                    </InputGroup>
-
+                    <SearchInput
+                        searchPrefix={searchPrefix}
+                        setSearchPrefix={setSearchPrefix}
+                        placeholder="Find a Group..."
+                    />
                     <RefreshButton onClick={() => setRefresh(!refresh)}/>
                 </ActionGroup>
             </ActionsBar>
@@ -227,11 +218,7 @@ const GroupsContainer = () => {
             <Paginator
                 nextPage={nextPage}
                 after={after}
-                onPaginate={after => {
-                    const query = {after};
-                    if (router.query.prefix) query.prefix = router.query.prefix;
-                    router.push({pathname: '/auth/groups', query})
-                }}
+                onPaginate={(after) => router.push({pathname: "/auth/groups", query: {prefix, after}})}
             />
         </>
     );

--- a/webui/src/pages/auth/policies/index.jsx
+++ b/webui/src/pages/auth/policies/index.jsx
@@ -18,14 +18,12 @@ import {
     RefreshButton,
     Warning,
     useDebouncedState,
+    SearchInput
 } from "../../../lib/components/controls";
 import {useRouter} from "../../../lib/hooks/router";
 import {useLoginConfigContext} from "../../../lib/hooks/conf";
 import {Link} from "../../../lib/components/nav";
 import { disallowPercentSign, INVALID_POLICY_ID_ERROR_MESSAGE } from "../validation";
-import InputGroup from "react-bootstrap/InputGroup";
-import { Form } from "react-bootstrap";
-import {SearchIcon} from "@primer/octicons-react";
 
 
 const PoliciesContainer = () => {
@@ -36,8 +34,8 @@ const PoliciesContainer = () => {
     const [createModalError, setCreateModalError] = useState(null);
 
     const router = useRouter();
-    const after = (router.query.after) ? router.query.after : "";
     const prefix = (router.query.prefix) ? router.query.prefix : "";
+    const after = (router.query.after) ? router.query.after : "";
 
     const [searchPrefix, setSearchPrefix] = useDebouncedState(
         prefix,
@@ -81,18 +79,11 @@ const PoliciesContainer = () => {
                     </ConfirmationButton>
                 </ActionGroup>
                 <ActionGroup orientation="right">
-                    <InputGroup>
-                        <Form.Control
-                            placeholder="Find a Policy..."
-                            autoFocus
-                            value={searchPrefix}
-                            onChange={e => setSearchPrefix(e.target.value)}
-                        />
-                        <InputGroup.Text>
-                            <SearchIcon/>
-                        </InputGroup.Text>
-                    </InputGroup>
-
+                    <SearchInput
+                        searchPrefix={searchPrefix}
+                        setSearchPrefix={setSearchPrefix}
+                        placeholder="Find a Policy..."
+                    />
                     <RefreshButton onClick={() => setRefresh(!refresh)}/>
                 </ActionGroup>
             </ActionsBar>
@@ -149,11 +140,7 @@ const PoliciesContainer = () => {
             <Paginator
                 nextPage={nextPage}
                 after={after}
-                onPaginate={after => {
-                    const query = {after};
-                    if (router.query.prefix) query.prefix = router.query.prefix;
-                    router.push({pathname: '/auth/policies', query})
-                }}
+                onPaginate={(after) => router.push({pathname: "/auth/policies", query: {prefix, after}})}
             />
         </>
     );


### PR DESCRIPTION
## Change Description

### Background

Previously, there was no way to search for Groups and Policies in the Administration tab of the web UI.

### New Feature

This PR introduces a search box in the Groups and Policies tabs in the Administration section of the web UI.

**Functionality:**

1. Prefix Search – The search box performs a prefix search on the user’s input, returning all groups and policies whose names start with the given prefix.
2. API Prefix Search – The search utilizes the prefix parameter in the API call to retrieve only the filtered results.
3. Case-Sensitive – The search is case-sensitive, meaning it distinguishes between uppercase and lowercase letters.
4. Real-Time Search – The user does not need to press "Enter" to submit the input; results appear immediately as they type.
5. Debounced API Calls – To optimize performance, API requests are debounced by 300ms, reducing unnecessary calls.
6. Supports Pagination – If the search results exceed the default page size, they are displayed in pages, maintaining the prefix filter.
7. Search Persistence After Refresh – After a page refresh, the previous search prefix remains applied, with an indicator showing the last input.

**Limitations:**
If no results match the search, an empty window is displayed, similar to the Repository search behavior.

**Screenshots:**
![image](https://github.com/user-attachments/assets/ee0ac24f-cdcb-4110-819a-c1842c809118)
![image](https://github.com/user-attachments/assets/913b039b-92d8-4004-994b-1dc99d7f65d0)
![image](https://github.com/user-attachments/assets/c87ff95d-847b-4dd7-9bf9-dc8229a4c1c4)
![image](https://github.com/user-attachments/assets/445a3fc9-edd0-40d5-a087-a1566b368e1e)


### Testing Details

Tested with Fluffy and lakeFS OSS locally.

