### PR TITLE
test: remove to stdout from test code

### DIFF
--- a/pkg/graveler/joined_diff_iterator_test.go
+++ b/pkg/graveler/joined_diff_iterator_test.go
@@ -456,12 +456,6 @@ func TestJoinedDiffIterator_NextValue(t *testing.T) {
 			}
 			require.NoError(t, it.Err())
 			// verify that what we produced is what we got from the iterator
-			for i := range got {
-				println("got", got[i].Key.String())
-			}
-			for i := range tt.wantValue {
-				println("want", tt.wantValue[i].Key.String())
-			}
 			if diff := deep.Equal(got, tt.wantValue); diff != nil {
 				t.Fatal("JoinedDiffIterator iterator found diff:", diff)
 			}

--- a/pkg/kv/cosmosdb/main_test.go
+++ b/pkg/kv/cosmosdb/main_test.go
@@ -47,8 +47,7 @@ func TestCosmosDB(t *testing.T) {
 			},
 		}, &azcosmos.CreateContainerOptions{ThroughputProperties: &throughput})
 		if err != nil {
-			print(resp2.RawResponse)
-			t.Fatalf("creating container: %v", err)
+			t.Fatalf("creating container: %v, raw response: %v", err, resp2.RawResponse)
 		}
 
 		store, err := kv.Open(ctx, kvparams.Config{CosmosDB: testParams, Type: cosmosdb.DriverName})
@@ -106,8 +105,7 @@ func TestMain(m *testing.M) {
 		&azcosmos.CreateDatabaseOptions{ThroughputProperties: &throughput},
 	)
 	if err != nil {
-		print(resp.RawResponse)
-		log.Fatalf("creating database: %v", err)
+		log.Fatalf("creating database: %v, raw response: %v", err, resp.RawResponse)
 	}
 
 	code := m.Run()


### PR DESCRIPTION
Removed print statements from test functions in `joined_diff_iterator_test.go` and `main_test.go` to improve code quality.

