### PR TITLE
Make UploadFileRandomDataAndReport public for Esti

### DIFF
--- a/esti/commit_test.go
+++ b/esti/commit_test.go
@@ -56,7 +56,7 @@ type Upload struct {
 // upload uploads random file data for uploads.
 func upload(ctx context.Context, uploads chan Upload) error {
 	for u := range uploads {
-		_, _, err := uploadFileRandomDataAndReport(ctx, u.Repo, u.Branch, u.Path, false, nil)
+		_, _, err := UploadFileRandomDataAndReport(ctx, u.Repo, u.Branch, u.Path, false, nil)
 		if err != nil {
 			return err
 		}

--- a/esti/esti_utils.go
+++ b/esti/esti_utils.go
@@ -381,7 +381,7 @@ const (
 	largeDataContentLength = 6 << 20
 )
 
-func uploadFileRandomDataAndReport(ctx context.Context, repo, branch, objPath string, direct bool, clt apigen.ClientWithResponsesInterface) (checksum, content string, err error) {
+func UploadFileRandomDataAndReport(ctx context.Context, repo, branch, objPath string, direct bool, clt apigen.ClientWithResponsesInterface) (checksum, content string, err error) {
 	objContent := randstr.String(randomDataContentLength)
 	checksum, err = UploadFileAndReport(ctx, repo, branch, objPath, objContent, direct, clt)
 	if err != nil {
@@ -495,7 +495,7 @@ func UploadContent(ctx context.Context, repo, branch, objPath, objContent string
 }
 
 func UploadFileRandomData(ctx context.Context, t *testing.T, repo, branch, objPath string, clt apigen.ClientWithResponsesInterface) (checksum, content string) {
-	checksum, content, err := uploadFileRandomDataAndReport(ctx, repo, branch, objPath, false, clt)
+	checksum, content, err := UploadFileRandomDataAndReport(ctx, repo, branch, objPath, false, clt)
 	require.NoError(t, err, "failed to upload file", repo, branch, objPath)
 	return checksum, content
 }

--- a/esti/identity_test.go
+++ b/esti/identity_test.go
@@ -20,7 +20,7 @@ func TestIdentity(t *testing.T) {
 	})
 	require.NoError(t, err, "failed creating branch1")
 
-	checksum, objContent, err := uploadFileRandomDataAndReport(ctx, repo, branch1, objPath, false, nil)
+	checksum, objContent, err := UploadFileRandomDataAndReport(ctx, repo, branch1, objPath, false, nil)
 	require.NoError(t, err, "failed uploading file")
 	commitResp, err := client.CommitWithResponse(ctx, repo, branch1, &apigen.CommitParams{}, apigen.CommitJSONRequestBody{
 		Message: "commit on branch1",


### PR DESCRIPTION
Enable using `UploadFileRandomDataAndReport` for Esti in other places.