### PR TITLE
Fix broken(!) example of basic authentication

### DIFF
--- a/docs/security/authentication.md
+++ b/docs/security/authentication.md
@@ -42,7 +42,7 @@ Authorization: Basic <base64 encoded access_key_id:secret_access_key>
 For example, assuming my access_key_id is `my_access_key_id` and my secret_access_key is `my_secret_access_key`, we'd send the following header with every request:
 
 ```text
-Authorization: Basic bXlfYWNjZXNzX2tleV9pZDpteV9hY2Nlc3Nfc2VjcmV0X2tleQ==
+Authorization: Basic bXlfYWNjZXNzX2tleV9pZDpteV9zZWNyZXRfYWNjZXNzX2tleQ==
 ```
 
 


### PR DESCRIPTION
The actual Authorization header to send was wrong, it switched the words "access" and "secret" before encoding via base64.

Some proofs that the new one is correct:
```sh
$ echo -n my_access_key_id:my_secret_access_key | base64
bXlfYWNjZXNzX2tleV9pZDpteV9zZWNyZXRfYWNjZXNzX2tleQ==
```

Or e.g. type in `my_access_key_id:my_secret_access_key` [here](https://mixedanalytics.com/tools/basic-authentication-generator/).  To get the previous versions you'd have to use the secret my_access_secret_key
