### PR TITLE
Actions: Add pre-post revert hooks

### DIFF
--- a/docs/howto/hooks/index.md
+++ b/docs/howto/hooks/index.md
@@ -62,17 +62,17 @@ By default, when `if` is empty or omitted, the step will run only if no error oc
 
 #### Action File schema
 
-| Property             | Description                                               | Data Type  | Required | Default Value                                                           |
-|----------------------|-----------------------------------------------------------|------------|----------|-------------------------------------------------------------------------|
-| `name               `| Identifes the Action file                                 | String     | no       | Action filename                                    |
-| `on                 `| List of events that will trigger the hooks                | List       | yes      |                                                                         |
-| `on<event>.branches `| Glob pattern list of branches that triggers the hooks     | List       | no       | **Not applicable to Tag events.** If empty, Action runs on all branches |
-| `hooks              `| List of hooks to be executed                              | List       | yes      |                                                                         |
-| `hook.id            `| ID of the hook, must be unique within the action.         | String     | yes      |                                                                         |
-| `hook.type          `| Type of the hook ([types](#hook-types))                   | String     | yes      |                                                                         |
-| `hook.description   `| Description for the hook                                  | String     | no       |                                                                         |
-| `hook.if            `| Expression that will be evaluated before execute the hook | String     | no       | No value is the same as evaluate `success()`                            |
-| `hook.properties    `| Hook's specific configuration, see [Lua](./lua.md#action-file-lua-hook-properties), [WebHook](./webhooks.md#action-file-webhook-properties), and [Airflow](./airflow.md#action-file-airflow-hook-properties) for details                             | Dictionary | true     |                                                                         |
+| Property              | Description                                                                                                                                                                                                              | Data Type  | Required | Default Value                                                           |
+|-----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------|----------|-------------------------------------------------------------------------|
+| `name               ` | Identifes the Action file                                                                                                                                                                                                | String     | no       | Action filename                                                         |
+| `on                 ` | List of events that will trigger the hooks                                                                                                                                                                               | List       | yes      |                                                                         |
+| `on<event>.branches ` | Glob pattern list of branches that triggers the hooks                                                                                                                                                                    | List       | no       | **Not applicable to Tag events.** If empty, Action runs on all branches |
+| `hooks              ` | List of hooks to be executed                                                                                                                                                                                             | List       | yes      |                                                                         |
+| `hook.id            ` | ID of the hook, must be unique within the action.                                                                                                                                                                        | String     | yes      |                                                                         |
+| `hook.type          ` | Type of the hook ([types](#supported-events))                                                                                                                                                                            | String     | yes      |                                                                         |
+| `hook.description   ` | Description for the hook                                                                                                                                                                                                 | String     | no       |                                                                         |
+| `hook.if            ` | Expression that will be evaluated before execute the hook                                                                                                                                                                | String     | no       | No value is the same as evaluate `success()`                            |
+| `hook.properties    ` | Hook's specific configuration, see [Lua](./lua.md#action-file-lua-hook-properties), [WebHook](./webhooks.md#action-file-webhook-properties), and [Airflow](./airflow.md#action-file-airflow-hook-properties) for details | Dictionary | true     |                                                                         |
 
 #### Example Action File
 
@@ -142,6 +142,8 @@ For example, lakeFS will search and execute all the matching Action files with t
 | `post-create-branch` | Runs on the new branch after the branch was created                            |
 | `pre-delete-branch`  | Runs prior to deleting a branch                                                |
 | `post-delete-branch` | Runs after the branch was deleted                                              |
+| `pre-revert-branch`  | Runs prior to performing a revert operation on a branch                        |
+| `post-revert-branch` | Runs after performing a revert operation on a branch                           |
 | `pre-create-tag`     | Runs prior to creating a new tag                                               |
 | `post-create-tag`    | Runs after the tag was created                                                 |
 | `pre-delete-tag`     | Runs prior to deleting a tag                                                   |

--- a/esti/action_files/action_post_revert.yaml
+++ b/esti/action_files/action_post_revert.yaml
@@ -1,0 +1,12 @@
+name: Test Post Revert
+description: a test action description
+on:
+  post-revert:
+    branches:
+
+hooks:
+  - id: test_webhook
+    type: webhook
+    description: Check webhooks for post-revert works
+    properties:
+      url: "{{.URL}}/post-revert"

--- a/esti/action_files/action_pre_revert.yaml
+++ b/esti/action_files/action_pre_revert.yaml
@@ -1,0 +1,12 @@
+name: Test Pre Revert
+description: a test action description
+on:
+  pre-revert:
+    branches:
+
+hooks:
+  - id: test_webhook
+    type: webhook
+    description: Check webhooks for pre-revert works
+    properties:
+      url: "{{.URL}}/pre-revert"

--- a/esti/esti_utils.go
+++ b/esti/esti_utils.go
@@ -298,8 +298,7 @@ func tearDownTest(repoName string) {
 }
 
 func createRepositoryForTest(ctx context.Context, t testing.TB) string {
-	name := strings.ToLower(t.Name())
-	return createRepositoryByName(ctx, t, name)
+	return createRepositoryUnique(ctx, t)
 }
 
 func createRepositoryByName(ctx context.Context, t testing.TB, name string) string {
@@ -632,7 +631,7 @@ func WaitForListRepositoryRunsLen(ctx context.Context, t *testing.T, repo, ref s
 		if len(runs.Results) == l {
 			return nil
 		}
-		return fmt.Errorf("size: %d: %w", len(runs.Results), errRunResultsSize)
+		return fmt.Errorf("run result size: %d, expected: %d: %w", len(runs.Results), l, errRunResultsSize)
 	}
 	err := backoff.Retry(listFunc, bo)
 	require.NoError(t, err)

--- a/esti/esti_utils.go
+++ b/esti/esti_utils.go
@@ -632,7 +632,7 @@ func WaitForListRepositoryRunsLen(ctx context.Context, t *testing.T, repo, ref s
 		if len(runs.Results) == l {
 			return nil
 		}
-		return fmt.Errorf("size: %d: %w", len(runs.Results), errRunResultsSize)
+		return fmt.Errorf("size: %d: expected: %d, %w", len(runs.Results), l, errRunResultsSize)
 	}
 	err := backoff.Retry(listFunc, bo)
 	require.NoError(t, err)

--- a/esti/esti_utils.go
+++ b/esti/esti_utils.go
@@ -298,7 +298,8 @@ func tearDownTest(repoName string) {
 }
 
 func createRepositoryForTest(ctx context.Context, t testing.TB) string {
-	return createRepositoryUnique(ctx, t)
+	name := strings.ToLower(t.Name())
+	return createRepositoryByName(ctx, t, name)
 }
 
 func createRepositoryByName(ctx context.Context, t testing.TB, name string) string {
@@ -631,7 +632,7 @@ func WaitForListRepositoryRunsLen(ctx context.Context, t *testing.T, repo, ref s
 		if len(runs.Results) == l {
 			return nil
 		}
-		return fmt.Errorf("run result size: %d, expected: %d: %w", len(runs.Results), l, errRunResultsSize)
+		return fmt.Errorf("size: %d: %w", len(runs.Results), errRunResultsSize)
 	}
 	err := backoff.Retry(listFunc, bo)
 	require.NoError(t, err)

--- a/esti/hooks.go
+++ b/esti/hooks.go
@@ -426,7 +426,8 @@ func testRevertBranch(t *testing.T, ctx context.Context, repo string, hvd *hooks
 	ref := string(createBranchResp.Body)
 	t.Log("Branch created", ref)
 
-	logAmount := apigen.PaginationAmount(2)
+	const paginationAmount = 2
+	logAmount := apigen.PaginationAmount(paginationAmount)
 	logResp, err := client.LogCommitsWithResponse(ctx, repo, branch, &apigen.LogCommitsParams{
 		Amount: &logAmount,
 	})

--- a/esti/hooks_test.go
+++ b/esti/hooks_test.go
@@ -5,6 +5,7 @@ import (
 )
 
 func TestHooksSuccess(t *testing.T) {
+	t.Parallel()
 	ctx, _, repo := setupTest(t)
 	defer tearDownTest(repo)
 	HooksSuccessTest(ctx, t, repo, client)

--- a/esti/webhook_server_util.go
+++ b/esti/webhook_server_util.go
@@ -51,6 +51,8 @@ func StartWebhookServer(t testing.TB) *WebhookServer {
 	mux.HandleFunc("/post-create-tag", hookHandlerFunc(respCh))
 	mux.HandleFunc("/pre-delete-tag", hookHandlerFunc(respCh))
 	mux.HandleFunc("/post-delete-tag", hookHandlerFunc(respCh))
+	mux.HandleFunc("/pre-revert", hookHandlerFunc(respCh))
+	mux.HandleFunc("/post-revert", hookHandlerFunc(respCh))
 	mux.HandleFunc("/timeout", timeoutHandlerFunc(respCh))
 	mux.HandleFunc("/fail", failHandlerFunc(respCh))
 	listener, err := net.Listen("tcp", ":0") //nolint:gosec

--- a/pkg/actions/action.go
+++ b/pkg/actions/action.go
@@ -84,7 +84,9 @@ func isEventSupported(event graveler.EventType) bool {
 		graveler.EventTypePreCreateTag,
 		graveler.EventTypePostCreateTag,
 		graveler.EventTypePreDeleteTag,
-		graveler.EventTypePostDeleteTag:
+		graveler.EventTypePostDeleteTag,
+		graveler.EventTypePreRevert,
+		graveler.EventTypePostRevert:
 		return true
 	}
 	return false

--- a/pkg/actions/service.go
+++ b/pkg/actions/service.go
@@ -580,6 +580,21 @@ func (s *StoreService) PostDeleteBranchHook(ctx context.Context, record graveler
 	s.asyncRun(ctx, record)
 }
 
+func (s *StoreService) PreRevertHook(ctx context.Context, record graveler.HookRecord) error {
+	return s.Run(ctx, record)
+}
+
+func (s *StoreService) PostRevertHook(ctx context.Context, record graveler.HookRecord) error {
+	// update pre-commit with commit ID if needed
+	err := s.UpdateCommitID(ctx, record.Repository, record.PreRunID, record.CommitID.String())
+	if err != nil {
+		return err
+	}
+
+	s.asyncRun(ctx, record)
+	return nil
+}
+
 func (s *StoreService) NewRunID() string {
 	return s.idGen.NewRunID()
 }

--- a/pkg/graveler/graveler.go
+++ b/pkg/graveler/graveler.go
@@ -2093,12 +2093,13 @@ func (g *Graveler) List(ctx context.Context, repository *RepositoryRecord, ref R
 }
 
 func (g *Graveler) Commit(ctx context.Context, repository *RepositoryRecord, branchID BranchID, params CommitParams, opts ...SetOptionsFunc) (CommitID, error) {
-	var preRunID string
-	var commit Commit
-	var newCommitID CommitID
-	var storageNamespace StorageNamespace
-	var sealedToDrop []StagingToken
-
+	var (
+		preRunID         string
+		commit           Commit
+		newCommitID      CommitID
+		storageNamespace StorageNamespace
+		sealedToDrop     []StagingToken
+	)
 	isProtected, err := g.protectedBranchesManager.IsBlocked(ctx, repository, branchID, BranchProtectionBlockedAction_COMMIT)
 	if err != nil {
 		return "", err
@@ -2678,13 +2679,17 @@ func (g *Graveler) Revert(ctx context.Context, repository *RepositoryRecord, bra
 		parentNumber--
 	}
 
+	var (
+		preRunID     string
+		commit       Commit
+		newCommitID  CommitID
+		tokensToDrop []StagingToken
+	)
 	err = g.prepareForCommitIDUpdate(ctx, repository, branchID, "revert")
 	if err != nil {
 		return "", err
 	}
 
-	var commitID CommitID
-	var tokensToDrop []StagingToken
 	err = g.RefManager.BranchUpdate(ctx, repository, branchID, func(branch *Branch) (*Branch, error) {
 		if empty, err := g.isSealedEmpty(ctx, repository, branch); err != nil {
 			return nil, err
@@ -2715,7 +2720,7 @@ func (g *Graveler) Revert(ctx context.Context, repository *RepositoryRecord, bra
 		if (metaRangeID == branchCommit.MetaRangeID) && !commitParams.AllowEmpty {
 			return nil, ErrNoChanges
 		}
-		commit := NewCommit()
+		commit = NewCommit()
 		commit.Committer = commitParams.Committer
 		commit.Message = commitParams.Message
 		commit.MetaRangeID = metaRangeID
@@ -2724,14 +2729,34 @@ func (g *Graveler) Revert(ctx context.Context, repository *RepositoryRecord, bra
 		commit.Generation = branchCommit.Generation + 1
 
 		applyCommitOverrides(&commit, commitOverrides)
-		commitID, err = g.RefManager.AddCommit(ctx, repository, commit)
+
+		if !repository.ReadOnly {
+			preRunID = g.hooks.NewRunID()
+			err = g.hooks.PreRevertHook(ctx, HookRecord{
+				RunID:      preRunID,
+				EventType:  EventTypePreRevert,
+				SourceRef:  branchID.Ref(),
+				Repository: repository,
+				BranchID:   branchID,
+				Commit:     commit,
+			})
+			if err != nil {
+				return nil, &HookAbortError{
+					EventType: EventTypePreRevert,
+					RunID:     preRunID,
+					Err:       err,
+				}
+			}
+		}
+
+		newCommitID, err = g.RefManager.AddCommit(ctx, repository, commit)
 		if err != nil {
 			return nil, fmt.Errorf("add commit: %w", err)
 		}
 
 		tokensToDrop = branch.SealedTokens
 		branch.SealedTokens = []StagingToken{}
-		branch.CommitID = commitID
+		branch.CommitID = newCommitID
 		return branch, nil
 	})
 	if err != nil {
@@ -2739,7 +2764,28 @@ func (g *Graveler) Revert(ctx context.Context, repository *RepositoryRecord, bra
 	}
 
 	g.dropTokens(ctx, tokensToDrop...)
-	return commitID, nil
+
+	if !repository.ReadOnly {
+		postRunID := g.hooks.NewRunID()
+		err = g.hooks.PostRevertHook(ctx, HookRecord{
+			EventType:  EventTypePostRevert,
+			RunID:      postRunID,
+			Repository: repository,
+			SourceRef:  newCommitID.Ref(),
+			BranchID:   branchID,
+			Commit:     commit,
+			CommitID:   newCommitID,
+			PreRunID:   preRunID,
+		})
+		if err != nil {
+			g.log(ctx).WithError(err).
+				WithField("run_id", postRunID).
+				WithField("pre_run_id", preRunID).
+				Error("Post-revert hook failed")
+		}
+	}
+
+	return newCommitID, nil
 }
 
 // CherryPick creates a new commit on the given branch, with the changes from the given commit.

--- a/pkg/graveler/graveler_test.go
+++ b/pkg/graveler/graveler_test.go
@@ -138,6 +138,24 @@ func (h *Hooks) PostDeleteBranchHook(_ context.Context, record graveler.HookReco
 	h.BranchID = record.BranchID
 }
 
+func (h *Hooks) PreRevertHook(_ context.Context, record graveler.HookRecord) error {
+	h.Called = true
+	h.RepositoryID = record.Repository.RepositoryID
+	h.StorageNamespace = record.Repository.StorageNamespace
+	h.BranchID = record.BranchID
+	h.Commit = record.Commit
+	return h.Err
+}
+
+func (h *Hooks) PostRevertHook(_ context.Context, record graveler.HookRecord) error {
+	h.Called = true
+	h.RepositoryID = record.Repository.RepositoryID
+	h.BranchID = record.BranchID
+	h.CommitID = record.CommitID
+	h.Commit = record.Commit
+	return h.Err
+}
+
 func (h *Hooks) NewRunID() string {
 	return ""
 }

--- a/pkg/graveler/hooks_handler.go
+++ b/pkg/graveler/hooks_handler.go
@@ -22,6 +22,8 @@ const (
 	EventTypePostCreateBranch EventType = "post-create-branch"
 	EventTypePreDeleteBranch  EventType = "pre-delete-branch"
 	EventTypePostDeleteBranch EventType = "post-delete-branch"
+	EventTypePreRevert        EventType = "pre-revert"
+	EventTypePostRevert       EventType = "post-revert"
 
 	UnixYear3000 = 32500915200
 )
@@ -62,6 +64,8 @@ type HooksHandler interface {
 	PostCreateBranchHook(ctx context.Context, record HookRecord)
 	PreDeleteBranchHook(ctx context.Context, record HookRecord) error
 	PostDeleteBranchHook(ctx context.Context, record HookRecord)
+	PreRevertHook(ctx context.Context, record HookRecord) error
+	PostRevertHook(ctx context.Context, record HookRecord) error
 	// NewRunID TODO (niro): WA for now until KV feature complete
 	NewRunID() string
 }
@@ -110,6 +114,14 @@ func (h *HooksNoOp) PreDeleteBranchHook(context.Context, HookRecord) error {
 }
 
 func (h *HooksNoOp) PostDeleteBranchHook(context.Context, HookRecord) {
+}
+
+func (h *HooksNoOp) PreRevertHook(context.Context, HookRecord) error {
+	return nil
+}
+
+func (h *HooksNoOp) PostRevertHook(context.Context, HookRecord) error {
+	return nil
 }
 
 func (h *HooksNoOp) NewRunID() string {


### PR DESCRIPTION
Closes #8615

## Change Description

### Background

Add capability to trigger hooks on pre/post revert operations
Discovered https://github.com/treeverse/lakeFS/issues/8801 as part of this task

### New Feature

Introduced new action triggers `EventTypePreRevert` `EventTypePostRevert`
Which trigger during branch reset operation

### Testing Details

Added esti test and fixed current hook tests

### Breaking Change?

No
