### PR TITLE
Remove StorageID from committed.iterator

### DIFF
--- a/pkg/graveler/committed/iterator.go
+++ b/pkg/graveler/committed/iterator.go
@@ -16,18 +16,16 @@ type iterator struct {
 	rng         *Range                 // Decoded value at which rangeIt point
 	it          graveler.ValueIterator // nil at start of range
 	err         error
-	storageID   StorageID
 	namespace   Namespace
 	beforeRange bool
 }
 
-func NewIterator(ctx context.Context, manager RangeManager, storageID StorageID, namespace Namespace, rangesIt ValueIterator) Iterator {
+func NewIterator(ctx context.Context, manager RangeManager, namespace Namespace, rangesIt ValueIterator) Iterator {
 	return &iterator{
 		ctx:       ctx,
 		manager:   manager,
 		namespace: namespace,
 		rangesIt:  rangesIt,
-		storageID: storageID,
 	}
 }
 

--- a/pkg/graveler/committed/iterator_test.go
+++ b/pkg/graveler/committed/iterator_test.go
@@ -176,7 +176,7 @@ func TestIterator(t *testing.T) {
 				lastKey = key
 			}
 			rangesIt := testutil.NewCommittedValueIteratorFake(makeRangeRecords(tt.PK))
-			pvi := committed.NewIterator(ctx, manager, "", namespace, rangesIt)
+			pvi := committed.NewIterator(ctx, manager, namespace, rangesIt)
 			defer pvi.Close()
 			assert.Equal(t, tt.PK, keysByRanges(t, pvi))
 			assert.False(t, pvi.NextRange())
@@ -201,7 +201,7 @@ func TestIterator(t *testing.T) {
 				lastKey = key
 			}
 			rangesIt := testutil.NewCommittedValueIteratorFake(makeRangeRecords(tt.PK))
-			pvi := committed.NewIterator(ctx, manager, "", namespace, rangesIt)
+			pvi := committed.NewIterator(ctx, manager, namespace, rangesIt)
 			defer pvi.Close()
 
 			if len(tt.PK) == 0 {

--- a/pkg/graveler/committed/meta_range_manager.go
+++ b/pkg/graveler/committed/meta_range_manager.go
@@ -110,7 +110,7 @@ func (m *metaRangeManager) NewMetaRangeIterator(ctx context.Context, ns graveler
 	if err != nil {
 		return nil, fmt.Errorf("manage metarange %s: %w", metaRangeID, err)
 	}
-	return NewIterator(ctx, m.rangeManager, StorageID(m.storageID), Namespace(ns), rangesIt), nil
+	return NewIterator(ctx, m.rangeManager, Namespace(ns), rangesIt), nil
 }
 
 func (m *metaRangeManager) GetMetaRangeURI(ctx context.Context, id graveler.MetaRangeID) (string, error) {


### PR DESCRIPTION
Cleanup:
The `storageID` of `committed.manager` isn't used,
Removing it.
