### PR TITLE
Fix: create pull request write header twice

### DIFF
--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -5430,7 +5430,6 @@ func (c *Controller) CreatePullRequest(w http.ResponseWriter, r *http.Request, b
 	if c.handleAPIError(ctx, w, r, err) {
 		return
 	}
-	w.WriteHeader(http.StatusCreated)
 	writeResponse(w, r, http.StatusCreated, response)
 }
 


### PR DESCRIPTION
Removed the `w.WriteHeader(http.StatusCreated)` from the `CreatePullRequest` function, it is called once by `writeResponse`.

Fix superfluous response.WriteHeader print outs.
