### PR TITLE
Simplify test setup by removing cleanup functions

### DIFF
--- a/cmd/lakectl/cmd/root_test.go
+++ b/cmd/lakectl/cmd/root_test.go
@@ -114,26 +114,23 @@ func TestInitConfig_LoadingScenarios(t *testing.T) {
 			name: "flag_and_env",
 			setup: func(t *testing.T) {
 				t.Helper()
+				tempDir := t.TempDir()
+
+				cfgFile = filepath.Join(tempDir, "flag.yaml")
+				envPath := filepath.Join(tempDir, "env.yaml")
+
 				const flagContent = "server:\n  endpoint_url: \"http://from-flag\"\n"
 				const envContent = "server:\n  endpoint_url: \"http://from-env\"\n"
-
-				cfgFile = filepath.Join(t.TempDir(), "flag.yaml")
-				envPath := filepath.Join(t.TempDir(), "env.yaml")
 
 				require.NoError(t, os.WriteFile(cfgFile, []byte(flagContent), 0644))
 				require.NoError(t, os.WriteFile(envPath, []byte(envContent), 0644))
 
 				t.Setenv("LAKECTL_CONFIG_FILE", envPath)
 			},
+
 			expectedURL: "http://from-flag",
 		},
 	}
-
-	originalCfgFile := cfgFile
-	defer func() {
-		cfgFile = originalCfgFile
-		initConfig()
-	}()
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {

--- a/cmd/lakectl/cmd/root_test.go
+++ b/cmd/lakectl/cmd/root_test.go
@@ -128,6 +128,10 @@ func TestInitConfig_LoadingScenarios(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			viper.Reset()
+
+			originalCfgFile := cfgFile
+			defer func() { cfgFile = originalCfgFile }()
+
 			cfgFile = ""
 
 			tt.setup(t)

--- a/cmd/lakectl/cmd/root_test.go
+++ b/cmd/lakectl/cmd/root_test.go
@@ -71,74 +71,84 @@ func TestLakectlUnixPerm(t *testing.T) {
 }
 
 func TestInitConfig_LoadingScenarios(t *testing.T) {
+	type setupFn func(t *testing.T)
+
 	tests := []struct {
 		name        string
-		setup       func(t *testing.T)
+		setup       setupFn
 		expectedURL string
 	}{
 		{
-			name: "using --config flag",
+			name: "flag",
 			setup: func(t *testing.T) {
-				tmpFile := filepath.Join(t.TempDir(), "config.yaml")
-				content := "server:\n  endpoint_url: \"http://flag-endpoint\"\n"
-				require.NoError(t, os.WriteFile(tmpFile, []byte(content), 0644))
-				cfgFile = tmpFile
+				t.Helper()
+				const content = "server:\n  endpoint_url: \"http://flag-endpoint\"\n"
+				path := filepath.Join(t.TempDir(), "config.yaml")
+				require.NoError(t, os.WriteFile(path, []byte(content), 0644))
+				cfgFile = path
 			},
 			expectedURL: "http://flag-endpoint",
 		},
 		{
-			name: "using LAKECTL_CONFIG_FILE env var",
+			name: "env",
 			setup: func(t *testing.T) {
-				tmpFile := filepath.Join(t.TempDir(), "env_config.yaml")
-				content := "server:\n  endpoint_url: \"http://env-endpoint\"\n"
-				require.NoError(t, os.WriteFile(tmpFile, []byte(content), 0644))
-				t.Setenv("LAKECTL_CONFIG_FILE", tmpFile)
+				t.Helper()
+				const content = "server:\n  endpoint_url: \"http://env-endpoint\"\n"
+				path := filepath.Join(t.TempDir(), "env_config.yaml")
+				require.NoError(t, os.WriteFile(path, []byte(content), 0644))
+				t.Setenv("LAKECTL_CONFIG_FILE", path)
 			},
 			expectedURL: "http://env-endpoint",
 		},
 		{
-			name: "using home directory default",
+			name: "home",
 			setup: func(t *testing.T) {
-				homeDir := t.TempDir()
-				tmpFile := filepath.Join(homeDir, ".lakectl.yaml")
-				content := "server:\n  endpoint_url: \"http://home-endpoint\"\n"
-				require.NoError(t, os.WriteFile(tmpFile, []byte(content), 0644))
-				t.Setenv("HOME", homeDir)
+				t.Helper()
+				const content = "server:\n  endpoint_url: \"http://home-endpoint\"\n"
+				home := t.TempDir()
+				require.NoError(t, os.WriteFile(filepath.Join(home, ".lakectl.yaml"), []byte(content), 0644))
+				t.Setenv("HOME", home)
 			},
 			expectedURL: "http://home-endpoint",
 		},
 		{
-			name: "both --config flag and env var are set, flag should win",
+			name: "flag_and_env",
 			setup: func(t *testing.T) {
-				tmpFileFlag := filepath.Join(t.TempDir(), "config_flag.yaml")
-				flagContent := "server:\n  endpoint_url: \"http://from-flag\"\n"
-				require.NoError(t, os.WriteFile(tmpFileFlag, []byte(flagContent), 0644))
+				t.Helper()
+				const flagContent = "server:\n  endpoint_url: \"http://from-flag\"\n"
+				const envContent = "server:\n  endpoint_url: \"http://from-env\"\n"
 
-				tmpFileEnv := filepath.Join(t.TempDir(), "config_env.yaml")
-				envContent := "server:\n  endpoint_url: \"http://from-env\"\n"
-				require.NoError(t, os.WriteFile(tmpFileEnv, []byte(envContent), 0644))
+				flagPath := filepath.Join(t.TempDir(), "flag.yaml")
+				envPath := filepath.Join(t.TempDir(), "env.yaml")
 
-				cfgFile = tmpFileFlag
-				t.Setenv("LAKECTL_CONFIG_FILE", tmpFileEnv)
+				require.NoError(t, os.WriteFile(flagPath, []byte(flagContent), 0644))
+				require.NoError(t, os.WriteFile(envPath, []byte(envContent), 0644))
+
+				cfgFile = flagPath
+				t.Setenv("LAKECTL_CONFIG_FILE", envPath)
 			},
 			expectedURL: "http://from-flag",
 		},
 	}
 
+	originalCfgFile := cfgFile
+	defer func() {
+		cfgFile = originalCfgFile
+		initConfig()
+	}()
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			viper.Reset()
-
-			originalCfgFile := cfgFile
-			defer func() { cfgFile = originalCfgFile }()
-
 			cfgFile = ""
 
 			tt.setup(t)
-
 			initConfig()
-			require.NoError(t, viper.Unmarshal(&cfg), "Failed to unmarshal config")
-			assert.Equal(t, tt.expectedURL, cfg.Server.EndpointURL.String(), "Unexpected endpoint URL")
+
+			var localCfg Configuration
+			require.NoError(t, viper.Unmarshal(&localCfg), "Failed to unmarshal config")
+
+			assert.Equal(t, tt.expectedURL, localCfg.Server.EndpointURL.String())
 		})
 	}
 }

--- a/cmd/lakectl/cmd/root_test.go
+++ b/cmd/lakectl/cmd/root_test.go
@@ -83,9 +83,8 @@ func TestInitConfig_LoadingScenarios(t *testing.T) {
 			setup: func(t *testing.T) {
 				t.Helper()
 				const content = "server:\n  endpoint_url: \"http://flag-endpoint\"\n"
-				path := filepath.Join(t.TempDir(), "config.yaml")
-				require.NoError(t, os.WriteFile(path, []byte(content), 0644))
-				cfgFile = path
+				cfgFile = filepath.Join(t.TempDir(), "config.yaml")
+				require.NoError(t, os.WriteFile(cfgFile, []byte(content), 0644))
 			},
 			expectedURL: "http://flag-endpoint",
 		},
@@ -118,13 +117,12 @@ func TestInitConfig_LoadingScenarios(t *testing.T) {
 				const flagContent = "server:\n  endpoint_url: \"http://from-flag\"\n"
 				const envContent = "server:\n  endpoint_url: \"http://from-env\"\n"
 
-				flagPath := filepath.Join(t.TempDir(), "flag.yaml")
+				cfgFile = filepath.Join(t.TempDir(), "flag.yaml")
 				envPath := filepath.Join(t.TempDir(), "env.yaml")
 
-				require.NoError(t, os.WriteFile(flagPath, []byte(flagContent), 0644))
+				require.NoError(t, os.WriteFile(cfgFile, []byte(flagContent), 0644))
 				require.NoError(t, os.WriteFile(envPath, []byte(envContent), 0644))
 
-				cfgFile = flagPath
 				t.Setenv("LAKECTL_CONFIG_FILE", envPath)
 			},
 			expectedURL: "http://from-flag",

--- a/cmd/lakectl/cmd/root_test.go
+++ b/cmd/lakectl/cmd/root_test.go
@@ -71,58 +71,45 @@ func TestLakectlUnixPerm(t *testing.T) {
 }
 
 func TestInitConfig_LoadingScenarios(t *testing.T) {
-	type setupFn func(t *testing.T) (cleanup func())
-
 	tests := []struct {
 		name        string
-		setup       setupFn
+		setup       func(t *testing.T)
 		expectedURL string
 	}{
 		{
 			name: "using --config flag",
-			setup: func(t *testing.T) func() {
+			setup: func(t *testing.T) {
 				tmpFile := filepath.Join(t.TempDir(), "config.yaml")
 				content := "server:\n  endpoint_url: \"http://flag-endpoint\"\n"
 				require.NoError(t, os.WriteFile(tmpFile, []byte(content), 0644))
 				cfgFile = tmpFile
-				return func() {
-					cfgFile = ""
-				}
 			},
 			expectedURL: "http://flag-endpoint",
 		},
 		{
 			name: "using LAKECTL_CONFIG_FILE env var",
-			setup: func(t *testing.T) func() {
+			setup: func(t *testing.T) {
 				tmpFile := filepath.Join(t.TempDir(), "env_config.yaml")
 				content := "server:\n  endpoint_url: \"http://env-endpoint\"\n"
 				require.NoError(t, os.WriteFile(tmpFile, []byte(content), 0644))
 				t.Setenv("LAKECTL_CONFIG_FILE", tmpFile)
-				cfgFile = ""
-				return func() {
-					os.Unsetenv("LAKECTL_CONFIG_FILE")
-				}
 			},
 			expectedURL: "http://env-endpoint",
 		},
 		{
 			name: "using home directory default",
-			setup: func(t *testing.T) func() {
+			setup: func(t *testing.T) {
 				homeDir := t.TempDir()
 				tmpFile := filepath.Join(homeDir, ".lakectl.yaml")
 				content := "server:\n  endpoint_url: \"http://home-endpoint\"\n"
 				require.NoError(t, os.WriteFile(tmpFile, []byte(content), 0644))
 				t.Setenv("HOME", homeDir)
-				cfgFile = ""
-				return func() {
-					os.Unsetenv("HOME")
-				}
 			},
 			expectedURL: "http://home-endpoint",
 		},
 		{
 			name: "both --config flag and env var are set, flag should win",
-			setup: func(t *testing.T) func() {
+			setup: func(t *testing.T) {
 				tmpFileFlag := filepath.Join(t.TempDir(), "config_flag.yaml")
 				flagContent := "server:\n  endpoint_url: \"http://from-flag\"\n"
 				require.NoError(t, os.WriteFile(tmpFileFlag, []byte(flagContent), 0644))
@@ -133,11 +120,6 @@ func TestInitConfig_LoadingScenarios(t *testing.T) {
 
 				cfgFile = tmpFileFlag
 				t.Setenv("LAKECTL_CONFIG_FILE", tmpFileEnv)
-
-				return func() {
-					cfgFile = ""
-					os.Unsetenv("LAKECTL_CONFIG_FILE")
-				}
 			},
 			expectedURL: "http://from-flag",
 		},
@@ -145,15 +127,13 @@ func TestInitConfig_LoadingScenarios(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			cfgFile = ""
 			viper.Reset()
+			cfgFile = ""
 
-			cleanup := tt.setup(t)
-			defer cleanup()
+			tt.setup(t)
 
 			initConfig()
 			require.NoError(t, viper.Unmarshal(&cfg), "Failed to unmarshal config")
-
 			assert.Equal(t, tt.expectedURL, cfg.Server.EndpointURL.String(), "Unexpected endpoint URL")
 		})
 	}

--- a/cmd/lakectl/cmd/root_test.go
+++ b/cmd/lakectl/cmd/root_test.go
@@ -132,6 +132,11 @@ func TestInitConfig_LoadingScenarios(t *testing.T) {
 		},
 	}
 
+	originalCfgFile := cfgFile
+	defer func() {
+		cfgFile = originalCfgFile
+	}()
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			viper.Reset()


### PR DESCRIPTION
## Change Description
lakectl support for env variable - simplify test setup by removing cleanup functions.

Removed unnecessary cleanup functions from test cases in `TestInitConfig_LoadingScenarios`. This refactor streamlines the code, as the test framework already handles environment and temporary file cleanup. It improves readability and reduces redundant logic.