### PR TITLE
UI: allow showing diffs for markdown

### DIFF
--- a/webui/src/lib/components/repository/ObjectsDiff.jsx
+++ b/webui/src/lib/components/repository/ObjectsDiff.jsx
@@ -12,7 +12,7 @@ import {useRefs} from "../../hooks/repo";
 import {getRepoStorageConfig} from "../../../pages/repositories/repository/utils";
 
 const maxDiffSizeBytes = 120 << 10;
-const supportedReadableFormats = ["txt", "text", "csv", "tsv", "yaml", "yml", "json", "jsonl", "ndjson"];
+const supportedReadableFormats = ["txt", "text", "md", "csv", "tsv", "yaml", "yml", "json", "jsonl", "ndjson"];
 
 export const ObjectsDiff = ({diffType, repoId, leftRef, rightRef, path}) => {
     const {repo, error: refsError, loading: refsLoading} = useRefs();


### PR DESCRIPTION
the lakeFS UI can show a diff for some textual file types. Notably missing (for me at least) is markdown: we can render markdown files in the UI but not diff them.

Before:

![Screenshot before](https://github.com/user-attachments/assets/b17b8aac-af3a-4086-8323-e2388243890a)

After:

![Screenshot after](https://github.com/user-attachments/assets/b045e273-f718-453c-a3bc-8e971b02595e)

