### PR TITLE
Replace `golang.org/x/exp/slices` with stdlib `slices`

### DIFF
--- a/cmd/lakectl/cmd/branch_protect.go
+++ b/cmd/lakectl/cmd/branch_protect.go
@@ -2,11 +2,11 @@ package cmd
 
 import (
 	"net/http"
+	"slices"
 
 	"github.com/go-openapi/swag"
 	"github.com/spf13/cobra"
 	"github.com/treeverse/lakefs/pkg/api/apigen"
-	"golang.org/x/exp/slices"
 )
 
 const (

--- a/cmd/lakectl/cmd/log.go
+++ b/cmd/lakectl/cmd/log.go
@@ -7,13 +7,13 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"slices"
 	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/treeverse/lakefs/pkg/api/apigen"
 	"github.com/treeverse/lakefs/pkg/api/apiutil"
-	"golang.org/x/exp/slices"
 )
 
 const commitsTemplate = `{{ range $val := .Commits }}

--- a/cmd/lakectl/cmd/root.go
+++ b/cmd/lakectl/cmd/root.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"strings"
 	"time"
 
@@ -27,7 +28,6 @@ import (
 	"github.com/treeverse/lakefs/pkg/osinfo"
 	"github.com/treeverse/lakefs/pkg/uri"
 	"github.com/treeverse/lakefs/pkg/version"
-	"golang.org/x/exp/slices"
 	"golang.org/x/term"
 )
 

--- a/cmd/lakefs/cmd/root.go
+++ b/cmd/lakefs/cmd/root.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path"
+	"slices"
 	"strings"
 	"sync"
 
@@ -22,7 +23,6 @@ import (
 	"github.com/treeverse/lakefs/pkg/logging"
 	"github.com/treeverse/lakefs/pkg/stats"
 	"github.com/treeverse/lakefs/pkg/version"
-	"golang.org/x/exp/slices"
 )
 
 var cfgFile string

--- a/esti/catalog_export_test.go
+++ b/esti/catalog_export_test.go
@@ -10,6 +10,7 @@ import (
 	"io/fs"
 	"net/http"
 	"net/url"
+	"slices"
 	"strings"
 	"testing"
 	"text/template"
@@ -32,7 +33,6 @@ import (
 	lakefscfg "github.com/treeverse/lakefs/pkg/config"
 	"github.com/treeverse/lakefs/pkg/testutil"
 	"github.com/treeverse/lakefs/pkg/uri"
-	"golang.org/x/exp/slices"
 	"gopkg.in/yaml.v3"
 )
 

--- a/esti/lakectl_local_test.go
+++ b/esti/lakectl_local_test.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -16,7 +17,6 @@ import (
 	"github.com/treeverse/lakefs/pkg/fileutil"
 	"github.com/treeverse/lakefs/pkg/local"
 	"github.com/treeverse/lakefs/pkg/uri"
-	"golang.org/x/exp/slices"
 )
 
 func localCreateTestData(t *testing.T, vars map[string]string, objects []string) {

--- a/go.mod
+++ b/go.mod
@@ -244,7 +244,7 @@ require (
 	github.com/xeipuuv/gojsonschema v1.2.0 // indirect
 	go.opencensus.io v0.24.0 // indirect
 	go.uber.org/atomic v1.11.0
-	golang.org/x/exp v0.0.0-20231127185646-65229373498e
+	golang.org/x/exp v0.0.0-20231127185646-65229373498e // indirect
 	golang.org/x/mod v0.17.0 // indirect
 	golang.org/x/net v0.36.0
 	golang.org/x/sys v0.30.0 // indirect

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -15,6 +15,7 @@ import (
 	"net/http/httptest"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -44,7 +45,6 @@ import (
 	"github.com/treeverse/lakefs/pkg/stats"
 	"github.com/treeverse/lakefs/pkg/testutil"
 	"github.com/treeverse/lakefs/pkg/upload"
-	"golang.org/x/exp/slices"
 )
 
 const DefaultUserID = "example_user"

--- a/pkg/block/azure/client_cache.go
+++ b/pkg/block/azure/client_cache.go
@@ -3,6 +3,7 @@ package azure
 import (
 	"context"
 	"fmt"
+	"slices"
 	"time"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
@@ -15,7 +16,6 @@ import (
 	lru "github.com/hnlq715/golang-lru"
 	"github.com/puzpuzpuz/xsync"
 	"github.com/treeverse/lakefs/pkg/block/params"
-	"golang.org/x/exp/slices"
 )
 
 const UDCCacheExpiry = time.Hour

--- a/pkg/block/local/adapter.go
+++ b/pkg/block/local/adapter.go
@@ -12,7 +12,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -20,7 +20,6 @@ import (
 	"github.com/google/uuid"
 	"github.com/treeverse/lakefs/pkg/block"
 	"github.com/treeverse/lakefs/pkg/block/params"
-	"golang.org/x/exp/slices"
 )
 
 const DefaultNamespacePrefix = block.BlockstoreTypeLocal + "://"
@@ -534,7 +533,7 @@ func (l *Adapter) getPartFiles(uploadID string, obj block.ObjectPointer) ([]stri
 	if err != nil {
 		return nil, err
 	}
-	sort.Strings(names)
+	slices.Sort(names)
 	return names, nil
 }
 

--- a/pkg/gateway/handler.go
+++ b/pkg/gateway/handler.go
@@ -6,6 +6,7 @@ import (
 	gohttputil "net/http/httputil"
 	"net/url"
 	"regexp"
+	"slices"
 	"strings"
 
 	"github.com/treeverse/lakefs/pkg/auth"
@@ -20,7 +21,6 @@ import (
 	"github.com/treeverse/lakefs/pkg/permissions"
 	"github.com/treeverse/lakefs/pkg/stats"
 	"github.com/treeverse/lakefs/pkg/upload"
-	"golang.org/x/exp/slices"
 )
 
 type contextKey string

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -8,13 +8,13 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strings"
 	"text/template"
 
 	"github.com/treeverse/lakefs/pkg/fileutil"
 	giterror "github.com/treeverse/lakefs/pkg/git/errors"
 	"github.com/treeverse/lakefs/pkg/git/internal"
-	"golang.org/x/exp/slices"
 )
 
 const (

--- a/pkg/permissions/actions_test.go
+++ b/pkg/permissions/actions_test.go
@@ -1,7 +1,7 @@
 package permissions_test
 
 import (
-	"golang.org/x/exp/slices"
+	"slices"
 	"testing"
 
 	"github.com/treeverse/lakefs/pkg/permissions"


### PR DESCRIPTION
## Change Description

The experimental functions in `golang.org/x/exp/slices` are now available in the standard library in Go 1.21.

### Background

https://go.dev/doc/go1.21#slices

### Testing Details

```
make build
```

### Breaking Change?

No
