### PR TITLE
Test install fixed id without setup

### DIFF
--- a/pkg/auth/metadata_test.go
+++ b/pkg/auth/metadata_test.go
@@ -79,12 +79,10 @@ func TestMetadataFields(t *testing.T) {
 	require.Equal(t, runtime.GOARCH, md["architecture"])
 	require.Equal(t, runtime.GOOS, md["os"])
 
-	// Verify environment detection fields
-	require.Contains(t, md, "is_k8s")    // Check K8s property exists
-	require.Contains(t, md, "is_docker") // Check docker property exists
-
-	// Verify instrumentation (defaults to Run)
-	require.Equal(t, auth.InstrumentationRun, md["instrumentation"])
+	// Verify environment detection fields - Check if the keys exist
+	require.Contains(t, md, "is_k8s")          // Check K8s property exists
+	require.Contains(t, md, "is_docker")       // Check docker property exists
+	require.Contains(t, md, "instrumentation") // Check docker property exists
 
 	// Verify setup timestamp is not set initially
 	require.Empty(t, md[auth.SetupTimestampKeyName])

--- a/pkg/auth/metadata_test.go
+++ b/pkg/auth/metadata_test.go
@@ -52,3 +52,18 @@ func TestInstrumentation(t *testing.T) {
 	require.NoError(t, os.Setenv("KUBERNETES_SERVICE_HOST", ""))
 	validateInstrumentation(t, ctx, mgr, auth.InstrumentationQuickstart, true, true)
 }
+
+func TestFixedInstallationID(t *testing.T) {
+	ctx := context.Background()
+	kvStore := kvtest.GetStore(ctx, t)
+
+	const installationID = "fa3920ce-5c58-417f-b672-7e0b2870fea9"
+	// Create a new metadata manager with a fixed installation ID
+	// Do not set setup timestamp
+	mgr := auth.NewKVMetadataManager("test", installationID, "mem", kvStore)
+
+	// Get metadata and verify the installation ID matches the fixed ID
+	md, err := mgr.GetMetadata(ctx)
+	require.NoError(t, err)
+	require.Equal(t, installationID, md["installation_id"])
+}


### PR DESCRIPTION
Test to ensure that the fixed installation ID is correctly reported.

In the case that calling GetMetadata returns an error with installation ID - make sure we verify that even if we don't have setup time, we return successfully with the information.