### PR TITLE
test: hooks success test compare time with grace

### DIFF
--- a/esti/hooks.go
+++ b/esti/hooks.go
@@ -84,7 +84,7 @@ func HooksSuccessTest(ctx context.Context, t *testing.T, repo string, lakeFSClie
 		if timeDiff < 0 {
 			timeDiff = -timeDiff // Get absolute value
 		}
-		const maxGraceTime = 3 * time.Second
+		const maxGraceTime = time.Second
 		require.LessOrEqual(t, timeDiff, maxGraceTime, "time difference too large. expected: %s actual: %s, diff: %s",
 			expectedTime.Format(time.RFC3339), run.StartTime.Format(time.RFC3339), timeDiff)
 	}


### PR DESCRIPTION
The issue:

https://github.com/treeverse/lakeFS/actions/runs/14167234427/job/39683161117?pr=8904

```
bad start time. expected: 2025-03-31 08:39:18 +0000 UTC actual: 2025-03-31 08:39:17 +0000 UTC
```

Comparing the hook start time with a grace period of 3 seconds should provide enough leeway for potential errors while still verifying that the expected time is accurate. 