### PR TITLE
support multiple resources PART1

### DIFF
--- a/pkg/auth/arn.go
+++ b/pkg/auth/arn.go
@@ -113,15 +113,13 @@ func ArnMatch(src, dst string) bool {
 }
 
 func ParsePolicyResourceAsList(resource string) ([]string, error) {
-	trimmed := strings.TrimSpace(resource)
-	if len(trimmed) == 0 {
+	var resources []string
+	if resource == "" {
 		return nil, ErrInvalidArn
 	}
-	if trimmed[0] != '[' || trimmed[len(trimmed)-1] != ']' {
+	if resource[0] != '[' || resource[len(resource)-1] != ']' {
 		return []string{resource}, nil
 	}
-
-	var resources []string
 	err := json.Unmarshal([]byte(resource), &resources)
 	if err != nil {
 		return nil, fmt.Errorf("unmarshal resource: %w", err)


### PR DESCRIPTION
Closes (https://github.com/treeverse/lakeFS/issues/8857) first part (see second part https://github.com/treeverse/lakeFS/pull/8907)

Following the [design](https://github.com/treeverse/dev/blob/647d64691e7ad02c64c824174bdec5afa91986e1/designs/open/multiple-resources-policy/resources-design.md), this PR is the first part of supporting multiple resources policies.
As lakeFS needs the functionality of an external auth server, this PR focuses on implementing the resource parser functionality, following PRs in lakefs will leverage this func to allow multiple resource policies.