### PR TITLE
Import: prohibit import from storage namespace

### DIFF
--- a/esti/import_test.go
+++ b/esti/import_test.go
@@ -376,7 +376,7 @@ func TestImportToStorageNamespace(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, repoResp.JSON200)
 
-	branch := fmt.Sprintf("%s-%s", importBranchBase, "from-namespace")
+	const branch = importBranchBase + "-from-namespace"
 	createResp, err := client.CreateBranchWithResponse(ctx, repoName, apigen.CreateBranchJSONRequestBody{
 		Name:   branch,
 		Source: "main",

--- a/esti/import_test.go
+++ b/esti/import_test.go
@@ -138,10 +138,12 @@ func verifyImportObjects(t testing.TB, ctx context.Context, repoName, prefix, im
 }
 
 func TestImport(t *testing.T) {
+	t.Parallel()
 	blockstoreType, importPath, expectedContentLength := setupImportByBlockstoreType(t)
 	metadata := map[string]string{"created_by": "import"}
 
 	t.Run("default", func(t *testing.T) {
+		t.Parallel()
 		ctx, _, repoName := setupTest(t)
 		defer tearDownTest(repoName)
 		branch := fmt.Sprintf("%s-%s", importBranchBase, "default")
@@ -180,6 +182,7 @@ func TestImport(t *testing.T) {
 	})
 
 	t.Run("parent", func(t *testing.T) {
+		t.Parallel()
 		ctx, _, repoName := setupTest(t)
 		defer tearDownTest(repoName)
 		branch := fmt.Sprintf("%s-%s", importBranchBase, "parent")
@@ -198,6 +201,7 @@ func TestImport(t *testing.T) {
 	})
 
 	t.Run("several_paths", func(t *testing.T) {
+		t.Parallel()
 		ctx, _, repoName := setupTest(t)
 		defer tearDownTest(repoName)
 		branch := fmt.Sprintf("%s-%s", importBranchBase, "several-paths")
@@ -221,6 +225,7 @@ func TestImport(t *testing.T) {
 	})
 
 	t.Run("prefixes_and_objects", func(t *testing.T) {
+		t.Parallel()
 		ctx, _, repoName := setupTest(t)
 		defer tearDownTest(repoName)
 		branch := fmt.Sprintf("%s-%s", importBranchBase, "prefixes-and-objects")
@@ -300,6 +305,7 @@ func testImportNew(t testing.TB, ctx context.Context, repoName, importBranch str
 }
 
 func TestImportCancel(t *testing.T) {
+	t.Parallel()
 	_, importPath, _ := setupImportByBlockstoreType(t)
 	ctx, _, repoName := setupTest(t)
 	defer tearDownTest(repoName)
@@ -333,6 +339,13 @@ func TestImportCancel(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, http.StatusNoContent, cancelResp.StatusCode())
 
+	// Try cancel twice
+	cancelResp, err = client.ImportCancelWithResponse(ctx, repoName, branch, &apigen.ImportCancelParams{
+		Id: importResp.JSON202.Id,
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusNoContent, cancelResp.StatusCode())
+
 	// Check status is canceled
 	var updateTime time.Time
 	timer := time.NewTimer(0)
@@ -351,5 +364,55 @@ func TestImportCancel(t *testing.T) {
 			break
 		}
 		timer.Reset(3 * time.Second) // Server updates status every 1 second - unless operation was canceled successfully
+	}
+}
+
+func TestImportToStorageNamespace(t *testing.T) {
+	t.Parallel()
+	ctx, _, repoName := setupTest(t)
+	defer tearDownTest(repoName)
+
+	repoResp, err := client.GetRepositoryWithResponse(ctx, repoName)
+	require.NoError(t, err)
+	require.NotNil(t, repoResp.JSON200)
+
+	branch := fmt.Sprintf("%s-%s", importBranchBase, "from-namespace")
+	createResp, err := client.CreateBranchWithResponse(ctx, repoName, apigen.CreateBranchJSONRequestBody{
+		Name:   branch,
+		Source: "main",
+	})
+	require.NoError(t, err, "failed to create branch", branch)
+	require.Equal(t, http.StatusCreated, createResp.StatusCode(), "failed to create branch", branch)
+
+	testCases := []struct {
+		Name       string
+		ImportPath string
+	}{
+		{
+			Name:       "exact namespace",
+			ImportPath: repoResp.JSON200.StorageNamespace,
+		},
+		{
+			Name:       "path in namespace",
+			ImportPath: repoResp.JSON200.StorageNamespace + "/some_path/in/namespace",
+		},
+	}
+	for _, tt := range testCases {
+		t.Run(tt.Name, func(t *testing.T) {
+			importResp, err := client.ImportStartWithResponse(ctx, repoName, branch, apigen.ImportStartJSONRequestBody{
+				Commit: apigen.CommitCreation{
+					Message:  "created by import",
+					Metadata: &apigen.CommitCreation_Metadata{AdditionalProperties: map[string]string{"created_by": "import"}},
+				},
+				Paths: []apigen.ImportLocation{{
+					Destination: importTargetPrefix,
+					Path:        tt.ImportPath,
+					Type:        catalog.ImportPathTypePrefix,
+				}},
+			})
+			require.NoError(t, err)
+			require.NotNil(t, importResp.JSON400)
+			require.Contains(t, importResp.JSON400.Message, "invalid import source")
+		})
 	}
 }

--- a/esti/s3_gateway_test.go
+++ b/esti/s3_gateway_test.go
@@ -38,8 +38,7 @@ type GetCredentials = func(id, secret, token string) *credentials.Credentials
 const (
 	numUploads           = 100
 	randomDataPathLength = 1020
-	branch               = "main"
-	gatewayTestPrefix    = branch + "/data/"
+	gatewayTestPrefix    = mainBranch + "/data/"
 )
 
 func newMinioClient(t *testing.T, getCredentials GetCredentials) *minio.Client {
@@ -702,7 +701,7 @@ func TestS3CopyObjectMultipart(t *testing.T) {
 
 	s3lakefsClient := newMinioClient(t, credentials.NewStaticV4)
 
-	srcPath, objectLength := getOrCreatePathToLargeObject(t, ctx, s3lakefsClient, repo, branch)
+	srcPath, objectLength := getOrCreatePathToLargeObject(t, ctx, s3lakefsClient, repo, mainBranch)
 	destPath := gatewayTestPrefix + "dest-file"
 
 	dest := minio.CopyDestOptions{

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -2822,7 +2822,8 @@ func (c *Controller) handleAPIErrorCallback(ctx context.Context, w http.Response
 		errors.Is(err, block.ErrOperationNotSupported),
 		errors.Is(err, authentication.ErrInvalidRequest),
 		errors.Is(err, graveler.ErrSameBranch),
-		errors.Is(err, graveler.ErrInvalidPullRequestStatus):
+		errors.Is(err, graveler.ErrInvalidPullRequestStatus),
+		errors.Is(err, catalog.ErrInvalidImportSource):
 		log.Debug("Bad request")
 		cb(w, r, http.StatusBadRequest, err)
 

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -2446,6 +2446,19 @@ func (c *Catalog) importAsync(ctx context.Context, repository *graveler.Reposito
 	return nil
 }
 
+// verifyImportPaths - Verify that import paths will not cause an import of objects from the repository namespace itself
+func verifyImportPaths(storageNamespace string, params ImportRequest) error {
+	for _, p := range params.Paths {
+		if strings.HasPrefix(p.Path, storageNamespace) {
+			return fmt.Errorf("import path (%s) in repository namespace (%s) is prohibited: %w", p.Path, storageNamespace, ErrInvalidImportSource)
+		}
+		if p.Type == ImportPathTypePrefix && strings.HasPrefix(storageNamespace, p.Path) {
+			return fmt.Errorf("prefix (%s) contains repository namespace: (%s), %w", p.Path, storageNamespace, ErrInvalidImportSource)
+		}
+	}
+	return nil
+}
+
 func (c *Catalog) Import(ctx context.Context, repositoryID, branchID string, params ImportRequest) (string, error) {
 	repository, err := c.getRepository(ctx, repositoryID)
 	if err != nil {
@@ -2457,10 +2470,8 @@ func (c *Catalog) Import(ctx context.Context, repositoryID, branchID string, par
 		return "", err
 	}
 
-	for _, p := range params.Paths {
-		if strings.HasPrefix(p.Path, repository.StorageNamespace.String()) {
-			return "", fmt.Errorf("import from repository storage namespace is prohibited: %s, %w", p.Path, ErrInvalidImportSource)
-		}
+	if err = verifyImportPaths(repository.StorageNamespace.String(), params); err != nil {
+		return "", err
 	}
 
 	id := xid.New().String()

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -2457,6 +2457,12 @@ func (c *Catalog) Import(ctx context.Context, repositoryID, branchID string, par
 		return "", err
 	}
 
+	for _, p := range params.Paths {
+		if strings.HasPrefix(p.Path, repository.StorageNamespace.String()) {
+			return "", fmt.Errorf("import from repository storage namespace is prohibited: %s, %w", p.Path, ErrInvalidImportSource)
+		}
+	}
+
 	id := xid.New().String()
 	// Run import
 	go func() {

--- a/pkg/catalog/import.go
+++ b/pkg/catalog/import.go
@@ -17,7 +17,10 @@ import (
 
 const ImportCanceled = "Canceled"
 
-var ErrImportClosed = errors.New("import closed")
+var (
+	ErrImportClosed        = errors.New("import closed")
+	ErrInvalidImportSource = errors.New("invalid import source")
+)
 
 type Import struct {
 	db            *pebble.DB


### PR DESCRIPTION
Closes #8735

## Change Description

### Background

Prevent imports from repository namespace as this might cause unexpected behavior

### Bug Fix

Go over import path and return an error in case any of them are in the destination repo namespace
      
### Testing Details

Added esti tests

