### PR TITLE
Fix: Truncate Long Path Values in Upload Object Modal

### DIFF
--- a/webui/src/pages/repositories/repository/objects.jsx
+++ b/webui/src/pages/repositories/repository/objects.jsx
@@ -287,10 +287,11 @@ const UploadCandidate = ({ repo, reference, path, file, state, onRemove = null }
   return (
     <Container>
       <Row className={`upload-item upload-item-${state ? state.status : "none"}`}>
-        <Col>
-          <span className="path">
-            lakefs://{repo.id}/{reference.id}/{fpath}
-          </span>
+          <Col
+              title={`lakefs://${repo.id}/${reference.id}/${fpath}`}
+              className="path text-nowrap overflow-hidden text-truncate align-middle"
+          >
+              lakefs://{repo.id}/{reference.id}/{fpath}
         </Col>
         <Col xs md="2">
           <span className="size">


### PR DESCRIPTION
Closes #8919

## Change Description

### Bug Fix

### Description

This PR addresses an issue where entering a very long path in the **Path** field  
(`Repositories → repo → Objects → Upload Object`) caused the input to overflow the modal window, as shown here:

![image](https://github.com/user-attachments/assets/c6315cff-113f-4b06-83b7-2d04f93f9fc5)

### Fix

I resolved this by applying Bootstrap utility classes to:

- **Truncate** the long path to prevent overflow  
- **Show the full path on hover** using the `title` attribute

### Result

- Long paths are now truncated properly and no longer break the modal layout  
- Hovering over the truncated path (at the bottom of the modal) displays the full path and file name

![Screenshot 2025-04-01 at 14 16 33](https://github.com/user-attachments/assets/95fbd75d-6b52-4bec-b742-e5717eb454b8)


### Testing Details

On local lakeFS

