### PR TITLE
Truncated the display of overly long branch names in the dropdown.

### DIFF
--- a/webui/src/lib/components/repository/refDropdown.jsx
+++ b/webui/src/lib/components/repository/refDropdown.jsx
@@ -107,14 +107,14 @@ const RefSelector = ({ repo, selected, selectRef, withCommits, withWorkspace, wi
             <div className="ref-scroller">
                 {(results && results.length > 0) ? (
                     <>
-                        <ul className="list-group ref-list">
+                        <ListGroup as="ul" className="ref-list">
                             {results.map(namedRef => (
                                 <RefEntry key={namedRef.id} repo={repo} refType={refType} namedRef={namedRef.id} selectRef={selectRef} selected={selected} withCommits={refType !== RefTypeTag && withCommits} logCommits={async () => {
                                     const data = await commits.log(repo.id, namedRef.id)
                                     setCommitList({...commitList, branch: namedRef.id, commits: data.results});
                                 }}/>
                             ))}
-                        </ul>
+                        </ListGroup>
                         <Paginator results={refList.payload.results} pagination={refList.payload.pagination} from={pagination.after} onPaginate={(after) => {
                             setPagination({after})
                         }}/>
@@ -174,8 +174,8 @@ const CommitList = ({ commits, selectRef, reset, branch, withWorkspace }) => {
 
 const RefEntry = ({repo, namedRef, refType, selectRef, selected, logCommits, withCommits}) => {
     return (
-        <ListGroup.Item key={namedRef}>
-            <Container fluid>
+        <ListGroup.Item as="li" key={namedRef}>
+            <Container>
                 <Row className="align-items-center">
                     <Col
                         title={namedRef}

--- a/webui/src/lib/components/repository/refDropdown.jsx
+++ b/webui/src/lib/components/repository/refDropdown.jsx
@@ -181,16 +181,15 @@ const RefEntry = ({repo, namedRef, refType, selectRef, selected, logCommits, wit
                         title={namedRef}
                         className="text-nowrap overflow-hidden text-truncate"
                     >
-                        {!!selected && namedRef === selected.id ? (
-                            <strong>{namedRef}</strong>
-                        ) : (
+                        {!!selected && namedRef === selected.id ?
+                            <strong>{namedRef}</strong> :
                             <Button
                                 variant="link"
                                 onClick={() => selectRef({ id: namedRef, type: refType })}
                             >
                                 {namedRef}
                             </Button>
-                        )}
+                        }
                     </Col>
                     <Col xs="auto" className="actions d-flex align-items-center">
                         {refType === RefTypeBranch && namedRef === repo.default_branch && (

--- a/webui/src/lib/components/repository/refDropdown.jsx
+++ b/webui/src/lib/components/repository/refDropdown.jsx
@@ -6,7 +6,6 @@ import Button from "react-bootstrap/Button";
 import Badge from "react-bootstrap/Badge";
 import Overlay from "react-bootstrap/Overlay";
 import {Col, Nav, Row} from "react-bootstrap";
-import Container from "react-bootstrap/Container";
 import Popover from "react-bootstrap/Popover";
 import ListGroup from 'react-bootstrap/ListGroup';
 import {ChevronDownIcon, ChevronRightIcon, ChevronUpIcon, XIcon} from "@primer/octicons-react";
@@ -175,36 +174,34 @@ const CommitList = ({ commits, selectRef, reset, branch, withWorkspace }) => {
 const RefEntry = ({repo, namedRef, refType, selectRef, selected, logCommits, withCommits}) => {
     return (
         <ListGroup.Item as="li" key={namedRef}>
-            <Container>
-                <Row className="align-items-center">
-                    <Col
-                        title={namedRef}
-                        className="text-nowrap overflow-hidden text-truncate"
-                    >
-                        {!!selected && namedRef === selected.id ?
-                            <strong>{namedRef}</strong> :
-                            <Button
-                                variant="link"
-                                onClick={() => selectRef({ id: namedRef, type: refType })}
-                            >
-                                {namedRef}
-                            </Button>
-                        }
-                    </Col>
-                    <Col xs="auto" className="actions d-flex align-items-center">
-                        {refType === RefTypeBranch && namedRef === repo.default_branch && (
-                            <Badge variant="info" className="mr-2">
-                                Default
-                            </Badge>
-                        )}
-                        {withCommits && (
-                            <Button onClick={logCommits} size="sm" variant="link">
-                                <ChevronRightIcon />
-                            </Button>
-                        )}
-                    </Col>
-                </Row>
-            </Container>
+            <Row className="align-items-center">
+                <Col
+                    title={namedRef}
+                    className="text-nowrap overflow-hidden text-truncate"
+                >
+                    {!!selected && namedRef === selected.id ?
+                        <strong>{namedRef}</strong> :
+                        <Button
+                            variant="link"
+                            onClick={() => selectRef({ id: namedRef, type: refType })}
+                        >
+                            {namedRef}
+                        </Button>
+                    }
+                </Col>
+                <Col xs="auto" className="actions d-flex align-items-center">
+                    {refType === RefTypeBranch && namedRef === repo.default_branch && (
+                        <Badge variant="info" className="mr-2">
+                            Default
+                        </Badge>
+                    )}
+                    {withCommits && (
+                        <Button onClick={logCommits} size="sm" variant="link">
+                            <ChevronRightIcon />
+                        </Button>
+                    )}
+                </Col>
+            </Row>
         </ListGroup.Item>
     );
 };

--- a/webui/src/lib/components/repository/refDropdown.jsx
+++ b/webui/src/lib/components/repository/refDropdown.jsx
@@ -5,13 +5,14 @@ import Alert from "react-bootstrap/Alert";
 import Button from "react-bootstrap/Button";
 import Badge from "react-bootstrap/Badge";
 import Overlay from "react-bootstrap/Overlay";
-import {ChevronDownIcon, ChevronRightIcon, ChevronUpIcon, XIcon} from "@primer/octicons-react";
+import {Col, Nav, Row} from "react-bootstrap";
+import Container from "react-bootstrap/Container";
 import Popover from "react-bootstrap/Popover";
+import ListGroup from 'react-bootstrap/ListGroup';
+import {ChevronDownIcon, ChevronRightIcon, ChevronUpIcon, XIcon} from "@primer/octicons-react";
 
 import {tags, branches, commits} from '../../api';
-import {Nav} from "react-bootstrap";
 import {RefTypeBranch, RefTypeCommit, RefTypeTag} from "../../../constants";
-
 
 const RefSelector = ({ repo, selected, selectRef, withCommits, withWorkspace, withTags, amount = 300 }) => {
     // used for ref pagination
@@ -173,22 +174,39 @@ const CommitList = ({ commits, selectRef, reset, branch, withWorkspace }) => {
 
 const RefEntry = ({repo, namedRef, refType, selectRef, selected, logCommits, withCommits}) => {
     return (
-        <li className="list-group-item" key={namedRef}>
-            {(!!selected && namedRef === selected.id) ?
-                <strong>{namedRef}</strong> :
-                <Button variant="link" onClick={() => {
-                    selectRef({id: namedRef, type: refType});
-                }}>{namedRef}</Button>
-            }
-            <div className="actions">
-                {(refType === RefTypeBranch && namedRef === repo.default_branch) ? (<Badge variant="info">Default</Badge>) : <span/>}
-                {(withCommits) ? (
-                    <Button onClick={logCommits} size="sm" variant="link">
-                        <ChevronRightIcon/>
-                    </Button>
-                ) : (<span/>)}
-            </div>
-        </li>
+        <ListGroup.Item key={namedRef}>
+            <Container fluid>
+                <Row className="align-items-center">
+                    <Col
+                        title={namedRef}
+                        className="text-nowrap overflow-hidden text-truncate"
+                    >
+                        {!!selected && namedRef === selected.id ? (
+                            <strong>{namedRef}</strong>
+                        ) : (
+                            <Button
+                                variant="link"
+                                onClick={() => selectRef({ id: namedRef, type: refType })}
+                            >
+                                {namedRef}
+                            </Button>
+                        )}
+                    </Col>
+                    <Col xs="auto" className="actions d-flex align-items-center">
+                        {refType === RefTypeBranch && namedRef === repo.default_branch && (
+                            <Badge variant="info" className="mr-2">
+                                Default
+                            </Badge>
+                        )}
+                        {withCommits && (
+                            <Button onClick={logCommits} size="sm" variant="link">
+                                <ChevronRightIcon />
+                            </Button>
+                        )}
+                    </Col>
+                </Row>
+            </Container>
+        </ListGroup.Item>
     );
 };
 


### PR DESCRIPTION
Closes #8921

## Change Description

### Bug Fix

### Description

This PR addresses an issue where creating a very long branch name caused overflow in the dropdown modal on the **Objects** tab, as shown here:
![Screenshot 2025-04-01 at 14 48 32](https://github.com/user-attachments/assets/f5eadb72-67a2-40bb-b2aa-04a6e24baccf)

### Fix

I resolved this by applying Bootstrap utility classes and block components to:

- **Truncate** the long branch name to prevent overflow  
- **Display the full branch name on hover** using the `title` attribute

### Result

- Long branch names are now truncated properly and no longer break the modal layout  
- Hovering over the truncated branch name displays the full name  
- The modal no longer scrolls due to overly long branch name
![fix](https://github.com/user-attachments/assets/478e91ae-a75c-4646-9cf1-1eb93ffba684)



### Testing Details

On local lakeFS

