### PR TITLE
Document in OpenAPI spec replacements for old "internal" GC endpoints

### DIFF
--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -5551,6 +5551,7 @@ paths:
       tags:
         - internal
       operationId: internalGetGarbageCollectionRules
+      description: "Deprecated; use getGCRules."
       responses:
         200:
           description: gc rule list
@@ -5572,6 +5573,7 @@ paths:
       tags:
         - internal
       operationId: internalSetGarbageCollectionRules
+      description: "Deprecated; use setGCRules."
       requestBody:
         required: true
         content:
@@ -5594,6 +5596,7 @@ paths:
       tags:
         - internal
       operationId: internalDeleteGarbageCollectionRules
+      description: "Deprecated; use deleteGCRules."
       responses:
         204:
           description: deleted garbage collection rules successfully

--- a/clients/java/api/openapi.yaml
+++ b/clients/java/api/openapi.yaml
@@ -6427,6 +6427,7 @@ paths:
   /repositories/{repository}/gc/rules:
     delete:
       deprecated: true
+      description: Deprecated; use deleteGCRules.
       operationId: internalDeleteGarbageCollectionRules
       parameters:
       - explode: false
@@ -6464,6 +6465,7 @@ paths:
       x-accepts: application/json
     get:
       deprecated: true
+      description: Deprecated; use getGCRules.
       operationId: internalGetGarbageCollectionRules
       parameters:
       - explode: false
@@ -6505,6 +6507,7 @@ paths:
       x-accepts: application/json
     post:
       deprecated: true
+      description: Deprecated; use setGCRules.
       operationId: internalSetGarbageCollectionRules
       parameters:
       - explode: false

--- a/clients/java/docs/InternalApi.md
+++ b/clients/java/docs/InternalApi.md
@@ -1277,6 +1277,8 @@ null (empty response body)
 
 
 
+Deprecated; use deleteGCRules.
+
 ### Example
 ```java
 // Import classes:
@@ -1462,6 +1464,8 @@ public class Example {
 
 
 
+Deprecated; use getGCRules.
+
 ### Example
 ```java
 // Import classes:
@@ -1554,6 +1558,8 @@ public class Example {
 > internalSetGarbageCollectionRules(repository, garbageCollectionRules).execute();
 
 
+
+Deprecated; use setGCRules.
 
 ### Example
 ```java

--- a/clients/java/src/main/java/io/lakefs/clients/sdk/InternalApi.java
+++ b/clients/java/src/main/java/io/lakefs/clients/sdk/InternalApi.java
@@ -2691,7 +2691,7 @@ public class InternalApi {
 
     /**
      * 
-     * 
+     * Deprecated; use deleteGCRules.
      * @param repository  (required)
      * @return APIinternalDeleteGarbageCollectionRulesRequest
      * @http.response.details
@@ -3057,7 +3057,7 @@ public class InternalApi {
 
     /**
      * 
-     * 
+     * Deprecated; use getGCRules.
      * @param repository  (required)
      * @return APIinternalGetGarbageCollectionRulesRequest
      * @http.response.details
@@ -3244,7 +3244,7 @@ public class InternalApi {
 
     /**
      * 
-     * 
+     * Deprecated; use setGCRules.
      * @param repository  (required)
      * @param garbageCollectionRules  (required)
      * @return APIinternalSetGarbageCollectionRulesRequest

--- a/clients/java/src/test/java/io/lakefs/clients/sdk/InternalApiTest.java
+++ b/clients/java/src/test/java/io/lakefs/clients/sdk/InternalApiTest.java
@@ -240,6 +240,8 @@ public class InternalApiTest {
     }
 
     /**
+     * Deprecated; use deleteGCRules.
+     *
      * @throws ApiException if the Api call fails
      */
     @Test
@@ -264,6 +266,8 @@ public class InternalApiTest {
     }
 
     /**
+     * Deprecated; use getGCRules.
+     *
      * @throws ApiException if the Api call fails
      */
     @Test
@@ -275,6 +279,8 @@ public class InternalApiTest {
     }
 
     /**
+     * Deprecated; use setGCRules.
+     *
      * @throws ApiException if the Api call fails
      */
     @Test

--- a/clients/python/docs/InternalApi.md
+++ b/clients/python/docs/InternalApi.md
@@ -1479,6 +1479,8 @@ void (empty response body)
 
 
 
+Deprecated; use deleteGCRules.
+
 ### Example
 
 * Basic Authentication (basic_auth):
@@ -1695,6 +1697,8 @@ Name | Type | Description  | Notes
 
 
 
+Deprecated; use getGCRules.
+
 ### Example
 
 * Basic Authentication (basic_auth):
@@ -1803,6 +1807,8 @@ Name | Type | Description  | Notes
 > internal_set_garbage_collection_rules(repository, garbage_collection_rules)
 
 
+
+Deprecated; use setGCRules.
 
 ### Example
 

--- a/clients/python/lakefs_sdk/api/internal_api.py
+++ b/clients/python/lakefs_sdk/api/internal_api.py
@@ -2089,6 +2089,7 @@ class InternalApi:
     def internal_delete_garbage_collection_rules(self, repository : StrictStr, **kwargs) -> None:  # noqa: E501
         """(Deprecated) internal_delete_garbage_collection_rules  # noqa: E501
 
+        Deprecated; use deleteGCRules.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
@@ -2118,6 +2119,7 @@ class InternalApi:
     def internal_delete_garbage_collection_rules_with_http_info(self, repository : StrictStr, **kwargs) -> ApiResponse:  # noqa: E501
         """(Deprecated) internal_delete_garbage_collection_rules  # noqa: E501
 
+        Deprecated; use deleteGCRules.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
@@ -2370,6 +2372,7 @@ class InternalApi:
     def internal_get_garbage_collection_rules(self, repository : StrictStr, **kwargs) -> GarbageCollectionRules:  # noqa: E501
         """(Deprecated) internal_get_garbage_collection_rules  # noqa: E501
 
+        Deprecated; use getGCRules.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
@@ -2399,6 +2402,7 @@ class InternalApi:
     def internal_get_garbage_collection_rules_with_http_info(self, repository : StrictStr, **kwargs) -> ApiResponse:  # noqa: E501
         """(Deprecated) internal_get_garbage_collection_rules  # noqa: E501
 
+        Deprecated; use getGCRules.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
@@ -2513,6 +2517,7 @@ class InternalApi:
     def internal_set_garbage_collection_rules(self, repository : StrictStr, garbage_collection_rules : GarbageCollectionRules, **kwargs) -> None:  # noqa: E501
         """(Deprecated) internal_set_garbage_collection_rules  # noqa: E501
 
+        Deprecated; use setGCRules.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
@@ -2544,6 +2549,7 @@ class InternalApi:
     def internal_set_garbage_collection_rules_with_http_info(self, repository : StrictStr, garbage_collection_rules : GarbageCollectionRules, **kwargs) -> ApiResponse:  # noqa: E501
         """(Deprecated) internal_set_garbage_collection_rules  # noqa: E501
 
+        Deprecated; use setGCRules.  # noqa: E501
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 

--- a/clients/rust/docs/InternalApi.md
+++ b/clients/rust/docs/InternalApi.md
@@ -431,6 +431,8 @@ Name | Type | Description  | Required | Notes
 > internal_delete_garbage_collection_rules(repository)
 
 
+Deprecated; use deleteGCRules.
+
 ### Parameters
 
 
@@ -487,6 +489,8 @@ Name | Type | Description  | Required | Notes
 > models::GarbageCollectionRules internal_get_garbage_collection_rules(repository)
 
 
+Deprecated; use getGCRules.
+
 ### Parameters
 
 
@@ -514,6 +518,8 @@ Name | Type | Description  | Required | Notes
 
 > internal_set_garbage_collection_rules(repository, garbage_collection_rules)
 
+
+Deprecated; use setGCRules.
 
 ### Parameters
 

--- a/clients/rust/src/apis/internal_api.rs
+++ b/clients/rust/src/apis/internal_api.rs
@@ -786,6 +786,7 @@ pub async fn internal_delete_branch_protection_rule(configuration: &configuratio
     }
 }
 
+/// Deprecated; use deleteGCRules.
 pub async fn internal_delete_garbage_collection_rules(configuration: &configuration::Configuration, repository: &str) -> Result<(), Error<InternalDeleteGarbageCollectionRulesError>> {
     let local_var_configuration = configuration;
 
@@ -852,6 +853,7 @@ pub async fn internal_get_branch_protection_rules(configuration: &configuration:
     }
 }
 
+/// Deprecated; use getGCRules.
 pub async fn internal_get_garbage_collection_rules(configuration: &configuration::Configuration, repository: &str) -> Result<models::GarbageCollectionRules, Error<InternalGetGarbageCollectionRulesError>> {
     let local_var_configuration = configuration;
 
@@ -885,6 +887,7 @@ pub async fn internal_get_garbage_collection_rules(configuration: &configuration
     }
 }
 
+/// Deprecated; use setGCRules.
 pub async fn internal_set_garbage_collection_rules(configuration: &configuration::Configuration, repository: &str, garbage_collection_rules: models::GarbageCollectionRules) -> Result<(), Error<InternalSetGarbageCollectionRulesError>> {
     let local_var_configuration = configuration;
 

--- a/docs/assets/js/swagger.yml
+++ b/docs/assets/js/swagger.yml
@@ -5551,6 +5551,7 @@ paths:
       tags:
         - internal
       operationId: internalGetGarbageCollectionRules
+      description: "Deprecated; use getGCRules."
       responses:
         200:
           description: gc rule list
@@ -5572,6 +5573,7 @@ paths:
       tags:
         - internal
       operationId: internalSetGarbageCollectionRules
+      description: "Deprecated; use setGCRules."
       requestBody:
         required: true
         content:
@@ -5594,6 +5596,7 @@ paths:
       tags:
         - internal
       operationId: internalDeleteGarbageCollectionRules
+      description: "Deprecated; use deleteGCRules."
       responses:
         204:
           description: deleted garbage collection rules successfully


### PR DESCRIPTION
Users who find the old versions have difficulty finding new versions.
