### PR TITLE
test: server timeout set to a minute

### DIFF
--- a/pkg/api/serve_test.go
+++ b/pkg/api/serve_test.go
@@ -40,7 +40,7 @@ import (
 )
 
 const (
-	ServerTimeout = 30 * time.Second
+	ServerTimeout = time.Minute
 )
 
 type dependencies struct {

--- a/pkg/api/serve_test.go
+++ b/pkg/api/serve_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/treeverse/lakefs/pkg/block"
 	"github.com/treeverse/lakefs/pkg/cache"
 	"github.com/treeverse/lakefs/pkg/catalog"
+	"github.com/treeverse/lakefs/pkg/cloud"
 	"github.com/treeverse/lakefs/pkg/config"
 	"github.com/treeverse/lakefs/pkg/graveler/settings"
 	"github.com/treeverse/lakefs/pkg/kv"
@@ -40,7 +41,7 @@ import (
 )
 
 const (
-	ServerTimeout = time.Minute
+	ServerTimeout = 30 * time.Second
 )
 
 type dependencies struct {
@@ -162,6 +163,9 @@ func setupHandler(t testing.TB) (http.Handler, *dependencies) {
 
 	authenticationService := authentication.NewDummyService()
 	handler := api.Serve(cfg, c, authenticator, authService, authenticationService, c.BlockAdapter, meta, migrator, collector, actionsService, auditChecker, logging.ContextUnavailable(), nil, nil, upload.DefaultPathProvider, stats.DefaultUsageReporter)
+
+	// reset cloud metadata - faster setup, the cloud metadata maintain its own tests
+	cloud.Reset()
 
 	return handler, &dependencies{
 		blocks:      c.BlockAdapter,

--- a/pkg/cloud/metadata.go
+++ b/pkg/cloud/metadata.go
@@ -45,10 +45,12 @@ type DetectorFunc func() (string, error)
 
 // RegisterDetector registers a new cloud detector with the given name
 func RegisterDetector(name string, detector DetectorFunc) {
-	// Only add to order list if it's not already there
-	if _, exists := detectorsRegistry[name]; !exists {
-		detectorOrder = append(detectorOrder, name)
+	_, exists := detectorsRegistry[name]
+	if exists {
+		// detector already registered, do nothing
+		return
 	}
+	detectorOrder = append(detectorOrder, name)
 	detectorsRegistry[name] = detector
 }
 
@@ -130,10 +132,16 @@ func checkAzureMetadata() bool {
 }
 
 // init registers the built-in cloud detectors
-// maintained the original order: GCP first, then AWS, then Azure
 //
 //nolint:gochecknoinits
 func init() {
+	RegisterDefaultDetectors()
+}
+
+// RegisterDefaultDetectors registers the built-in cloud detectors
+//
+// maintained the order: GCP first, then AWS, then Azure
+func RegisterDefaultDetectors() {
 	RegisterDetector(GCPCloud, GetGCPProjectID)
 	RegisterDetector(AWSCloud, GetAWSAccountID)
 	RegisterDetector(AzureCloud, GetAzureSubscriptionID)

--- a/pkg/cloud/metadata_test.go
+++ b/pkg/cloud/metadata_test.go
@@ -87,3 +87,32 @@ func TestGetHashedInformation(t *testing.T) {
 		t.Fatalf("Expected hashed ID to still be '%s', got '%s'", expectedHash, cloudID)
 	}
 }
+
+// TestDetectWithDefaultDetectors verifies that only known clouds can be detected
+func TestDetectWithDefaultDetectors(t *testing.T) {
+	// Reset all detectors before the test
+	Reset()
+
+	// Register the default cloud detectors (AWS, GCP, Azure)
+	RegisterDefaultDetectors()
+
+	// Run detection
+	Detect()
+
+	// If a cloud was detected, verify it's one of the known types
+	if cloudDetected {
+		switch cloudType {
+		case AWSCloud, GCPCloud, AzureCloud:
+			// Known cloud type detected - test passes
+		default:
+			t.Errorf("Detected unknown cloud type: %s", cloudType)
+		}
+
+		// Verify we got a non-empty cloud ID
+		if cloudID == "" {
+			t.Error("Cloud was detected but cloud ID is empty")
+		}
+	}
+	// Note: if no cloud was detected, that's also a valid state
+	// since the test might run in a non-cloud environment
+}


### PR DESCRIPTION
Fix issues related to tests running API calls that got timed our after 30 seconds:

```
--- FAIL: TestAuthMiddleware (30.34s)
    auth_middleware_test.go:24: Failed run setup env 503 503 Service Unavailable
FAIL
```