### PR TITLE
Fixed - A long branch name overflows the table view in the Branches tab

### DIFF
--- a/webui/src/pages/repositories/repository/branches.jsx
+++ b/webui/src/pages/repositories/repository/branches.jsx
@@ -58,7 +58,10 @@ const BranchWidget = ({ repo, branch, onDelete }) => {
     return (
         <ListGroup.Item>
             <Row className="d-flex align-items-center justify-content-between">
-                <Col className="flex-grow-1">
+                <Col
+                    title={branch.id}
+                    className="flex-grow-1 text-nowrap overflow-hidden text-truncate align-middle"
+                >
                     <h6 style={{marginBottom: 0}}>
                         <Link href={{
                             pathname: '/repositories/:repoId/objects',


### PR DESCRIPTION
Closes #8940

## Change Description

### Bug Fix

The issue was that a long branch name overflowed the table view in the Branches tab, causing the action buttons to shift out of place:
![image](https://github.com/user-attachments/assets/4d43e2a9-c6f7-4368-8f12-d3e54691112f)

To fix this, I added React Bootstrap utility classes to truncate the branch name and display the full name on hover.

Fix:
![image](https://github.com/user-attachments/assets/a5be8784-2a6b-4386-9ceb-c4b37ae1b3ac)

### Testing Details

On lakeFS local with fluffy
