### PR TITLE
Fixed - long branch name overflows selected branch button and path

### DIFF
--- a/webui/src/lib/components/repository/refDropdown.jsx
+++ b/webui/src/lib/components/repository/refDropdown.jsx
@@ -279,8 +279,20 @@ const RefDropdown = ({ repo, selected, selectRef, onCancel, variant="light", pre
     const title = prefix + (!!selected) ? `${prefix} ${selected.type}: ` : '';
     return (
         <>
-            <Button ref={target} variant={variant} onClick={()=> { setShow(!show) }}>
-                {title} <strong>{showId(selected)}</strong> {show ? <ChevronUpIcon/> : <ChevronDownIcon/>}
+            <Button ref={target}
+                    variant={variant}
+                    onClick={() => setShow(!show)}
+                    style={{ maxWidth: '250px' }}
+                    title={showId(selected)}
+                    className="d-inline-flex align-items-center"
+            >
+                <span className="text-truncate">
+                    {title}
+                    <strong>{showId(selected)}</strong>
+                </span>
+                <span className="ms-1">
+                    {show ? <ChevronUpIcon /> : <ChevronDownIcon />}
+                </span>
             </Button>
             {cancelButton}
             {popover}

--- a/webui/src/lib/components/repository/tree.jsx
+++ b/webui/src/lib/components/repository/tree.jsx
@@ -25,6 +25,8 @@ import Container from "react-bootstrap/Container";
 import Row from "react-bootstrap/Row";
 import Col from "react-bootstrap/Col";
 import Dropdown from "react-bootstrap/Dropdown";
+import Modal from "react-bootstrap/Modal";
+import {FaDownload} from "react-icons/fa";
 
 import { commits, linkToPath, objects } from "../../api";
 import { ConfirmationModal } from "../modals";
@@ -32,10 +34,8 @@ import { Paginator } from "../pagination";
 import { Link } from "../nav";
 import { RefTypeBranch, RefTypeCommit } from "../../../constants";
 import {ClipboardButton, copyTextToClipboard, AlertError, Loading} from "../controls";
-import Modal from "react-bootstrap/Modal";
 import { useAPI } from "../../hooks/api";
 import noop from "lodash/noop";
-import {FaDownload} from "react-icons/fa";
 import {CommitInfoCard} from "./commits";
 
 export const humanSize = (bytes) => {
@@ -650,30 +650,34 @@ export const URINavigator = ({
     <div className="d-flex">
       <div className="lakefs-uri flex-grow-1">
         {relativeTo === "" ? (
-          <>
-            <strong>{"lakefs://"}</strong>
-            <Link href={{ pathname: "/repositories/:repoId/objects", params }}>
-              {repo.id}
-            </Link>
-            <strong>{"/"}</strong>
-            <Link
-              href={{
-                pathname: "/repositories/:repoId/objects",
-                params,
-                query: { ref: reference.id },
-              }}
+            <div
+                title={reference.type === RefTypeCommit ? reference.id.substr(0, 12) : reference.id}
+                className="w-100 text-nowrap overflow-hidden text-truncate"
             >
-              {reference.type === RefTypeCommit
-                ? reference.id.substr(0, 12)
-                : reference.id}
-            </Link>
-            <strong>{"/"}</strong>
-          </>
+              <strong>lakefs://</strong>
+              <Link href={{ pathname: "/repositories/:repoId/objects", params }}>
+                {repo.id}
+              </Link>
+              <strong>/</strong>
+              <Link
+                  href={{
+                    pathname: "/repositories/:repoId/objects",
+                    params,
+                    query: { ref: reference.id },
+                  }}
+              >
+                {reference.type === RefTypeCommit ? reference.id.substr(0, 12) : reference.id}
+              </Link>
+              <strong>/</strong>
+            </div>
         ) : (
-          <>
-            <Link href={pathURLBuilder(params, { path: "" })}>{relativeTo}</Link>
-            <strong>{"/"}</strong>
-          </>
+            <div
+                title={reference.type === RefTypeCommit ? reference.id.substr(0, 12) : reference.id}
+                className="w-100 text-nowrap overflow-hidden text-truncate"
+            >
+              <Link href={pathURLBuilder(params, { path: "" })}>{relativeTo}</Link>
+              <strong>/</strong>
+            </div>
         )}
 
         {parts.map((part, i) => {

--- a/webui/src/lib/components/repository/tree.jsx
+++ b/webui/src/lib/components/repository/tree.jsx
@@ -645,40 +645,41 @@ export const URINavigator = ({
 }) => {
   const parts = pathParts(path, isPathToFile);
   const params = { repoId: repo.id };
+  const displayedReference =
+      reference.type === RefTypeCommit ? reference.id.substr(0, 12) : reference.id;
 
   return (
     <div className="d-flex">
       <div className="lakefs-uri flex-grow-1">
-        {relativeTo === "" ? (
-            <div
-                title={reference.type === RefTypeCommit ? reference.id.substr(0, 12) : reference.id}
-                className="w-100 text-nowrap overflow-hidden text-truncate"
-            >
-              <strong>lakefs://</strong>
-              <Link href={{ pathname: "/repositories/:repoId/objects", params }}>
-                {repo.id}
-              </Link>
-              <strong>/</strong>
-              <Link
-                  href={{
-                    pathname: "/repositories/:repoId/objects",
-                    params,
-                    query: { ref: reference.id },
-                  }}
-              >
-                {reference.type === RefTypeCommit ? reference.id.substr(0, 12) : reference.id}
-              </Link>
-              <strong>/</strong>
-            </div>
-        ) : (
-            <div
-                title={reference.type === RefTypeCommit ? reference.id.substr(0, 12) : reference.id}
-                className="w-100 text-nowrap overflow-hidden text-truncate"
-            >
-              <Link href={pathURLBuilder(params, { path: "" })}>{relativeTo}</Link>
-              <strong>/</strong>
-            </div>
-        )}
+        <div
+            title={displayedReference}
+            className="w-100 text-nowrap overflow-hidden text-truncate"
+        >
+          {relativeTo === "" ? (
+              <>
+                <strong>lakefs://</strong>
+                <Link href={{ pathname: "/repositories/:repoId/objects", params }}>
+                  {repo.id}
+                </Link>
+                <strong>/</strong>
+                <Link
+                    href={{
+                      pathname: "/repositories/:repoId/objects",
+                      params,
+                      query: { ref: reference.id },
+                    }}
+                >
+                  {displayedReference}
+                </Link>
+                <strong>/</strong>
+              </>
+          ) : (
+              <>
+                <Link href={pathURLBuilder(params, { path: "" })}>{relativeTo}</Link>
+                <strong>/</strong>
+              </>
+          )}
+        </div>
 
         {parts.map((part, i) => {
           const path =


### PR DESCRIPTION
Closes #8930 #8639

## Change Description

### Bug Fix

This PR fixes a UI issue where long branch names caused the "selected branch" button at the top-left corner of multiple pages to overflow, and also caused the branch name in the path to wrap onto multiple lines, as shown below:

![image](https://github.com/user-attachments/assets/3c36278a-44dc-44eb-8259-5025e78dae6c)
![image](https://github.com/user-attachments/assets/863fdd33-dafd-4197-8999-b53eb66c629b)


### Fix

- Applied React Bootstrap utility classes to **truncate** long branch names.
- Added a **max-width** to the branch button to prevent it from growing indefinitely.
- These changes were made in `refDropdown.jsx`.
- Applied React Bootstrap utility classes to **truncate** long branch names in the path in `tree.jsx`.

Fix:
![image](https://github.com/user-attachments/assets/1c3f5ead-48f4-477b-92db-bb831207e1fd)

### Testing Details

Tested locally on lakeFS with Fluffy.  
