### PR TITLE
Add pagination support to attachment modal

### DIFF
--- a/webui/src/constants.ts
+++ b/webui/src/constants.ts
@@ -1,6 +1,7 @@
 export const RefTypeBranch = 'branch';
 export const RefTypeCommit = 'commit';
 export const RefTypeTag = 'tag';
+export const pageSize = 5;
 
 export enum TreeRowType {
     Object,

--- a/webui/src/constants.ts
+++ b/webui/src/constants.ts
@@ -1,7 +1,7 @@
 export const RefTypeBranch = 'branch';
 export const RefTypeCommit = 'commit';
 export const RefTypeTag = 'tag';
-export const pageSize = 5;
+export const PageSize = 5;
 
 export enum TreeRowType {
     Object,

--- a/webui/src/lib/components/auth/forms.jsx
+++ b/webui/src/lib/components/auth/forms.jsx
@@ -42,7 +42,7 @@ export const AttachModal = ({
   else if (error) content = <AlertError error={error}/>;
   else content = (
       <>
-            <DataTable
+          <DataTable
               headers={headers}
               keyFn={ent => ent.id}
               emptyState={emptyState}
@@ -56,7 +56,7 @@ export const AttachModal = ({
                 <strong>{resolveEntityFn(ent)}</strong>
               ]}
               firstFixedCol={true}
-            />
+          />
           <Paginator
               after={after}
               nextPage={response?.pagination?.next_offset && results.length > 0 ? response.pagination.next_offset : null}

--- a/webui/src/lib/components/auth/forms.jsx
+++ b/webui/src/lib/components/auth/forms.jsx
@@ -38,11 +38,11 @@ export const AttachModal = ({
   else content = (
       <>
         <DataTable
-            headers={headers}
-            keyFn={ent => ent.id}
-            emptyState={emptyState}
-            results={response.results}
-            rowFn={ent => [
+          headers={headers}
+          keyFn={ent => ent.id}
+          emptyState={emptyState}
+          results={response.results}
+          rowFn={ent => [
                 <Checkbox
                   defaultChecked={selected.some(selectedEnt => selectedEnt.id === ent.id)}
                   onAdd={() => setSelected([...selected, ent])}
@@ -50,13 +50,14 @@ export const AttachModal = ({
                   name={'selected'}/>,
                 <strong>{resolveEntityFn(ent)}</strong>
               ]}
-            firstFixedCol={true}
+          firstFixedCol={true}
         />
         <Paginator
             after={after}
             nextPage={nextPage}
             onPaginate={setAfter}
         />
+
         <div className="mt-3">
           {(selected.length > 0) &&
             <p>

--- a/webui/src/lib/components/auth/forms.jsx
+++ b/webui/src/lib/components/auth/forms.jsx
@@ -30,10 +30,7 @@ export const AttachModal = ({
           search.current.focus();
   });
 
-  const nextPage =
-      response?.pagination?.next_offset && response.results?.length > 0
-          ? response.pagination.next_offset
-          : null;
+  const nextPage = response?.pagination?.has_more ? response.pagination.next_offset : null;
 
   let content;
   if (loading) content = <Loading/>;

--- a/webui/src/lib/components/auth/forms.jsx
+++ b/webui/src/lib/components/auth/forms.jsx
@@ -42,7 +42,6 @@ export const AttachModal = ({
   else if (error) content = <AlertError error={error}/>;
   else content = (
       <>
-          <div style={{ height: '260px'}}>
             <DataTable
               headers={headers}
               keyFn={ent => ent.id}
@@ -58,7 +57,6 @@ export const AttachModal = ({
               ]}
               firstFixedCol={true}
             />
-          </div>
           <Paginator
               after={after}
               nextPage={response?.pagination?.next_offset && results.length > 0 ? response.pagination.next_offset : null}

--- a/webui/src/lib/components/auth/forms.jsx
+++ b/webui/src/lib/components/auth/forms.jsx
@@ -19,7 +19,6 @@ export const AttachModal = ({
   const search = useRef(null);
   const [searchPrefix, setSearchPrefix] = useState("");
   const [selected, setSelected] = useState([]);
-  const [results, setResults] = useState([]);
   const [after, setAfter] = useState("");
 
   const { response, error, loading } = useAPI(() => {
@@ -27,15 +26,14 @@ export const AttachModal = ({
   }, [searchPrefix, after]);
 
   useEffect(() => {
-      if (response) {
-          setResults(response.results);
-      }
-  }, [response]);
+      if (!!search.current && search.current.value === "")
+          search.current.focus();
+  });
 
-  useEffect(() => {
-      setAfter("");
-      search.current?.focus();
-  }, [searchPrefix]);
+  const nextPage =
+      response?.pagination?.next_offset && response.results?.length > 0
+          ? response.pagination.next_offset
+          : null;
 
   let content;
   if (loading) content = <Loading/>;
@@ -46,7 +44,7 @@ export const AttachModal = ({
               headers={headers}
               keyFn={ent => ent.id}
               emptyState={emptyState}
-              results={results}
+              results={response.results}
               rowFn={ent => [
                 <Checkbox
                   defaultChecked={selected.some(selectedEnt => selectedEnt.id === ent.id)}
@@ -59,7 +57,7 @@ export const AttachModal = ({
           />
           <Paginator
               after={after}
-              nextPage={response?.pagination?.next_offset && results.length > 0 ? response.pagination.next_offset : null}
+              nextPage={nextPage}
               onPaginate={setAfter}
           />
         <div className="mt-3">
@@ -91,6 +89,11 @@ export const AttachModal = ({
       </>
     );
 
+  const handleSearchChange = () => {
+      setSearchPrefix(search.current.value);
+      setAfter("");
+  };
+
   return (
     <Modal show={show} onHide={onHide}>
       <Modal.Header closeButton>
@@ -107,9 +110,7 @@ export const AttachModal = ({
             <DebouncedFormControl
               ref={search}
               placeholder={filterPlaceholder}
-              onChange={() => {
-                setSearchPrefix(search.current.value)
-              }}/>
+              onChange={handleSearchChange}/>
           </InputGroup>
         </Form>
         <div className="mt-2">

--- a/webui/src/lib/components/auth/forms.jsx
+++ b/webui/src/lib/components/auth/forms.jsx
@@ -17,13 +17,12 @@ export const AttachModal = ({
                               filterPlaceholder = 'Filter...'
                             }) => {
   const search = useRef(null);
-  const [searchPrefix, setSearchPrefix] = useState("");
+  const [paginationParams, setPaginationParams] = useState({ prefix: "", after: "" });
   const [selected, setSelected] = useState([]);
-  const [after, setAfter] = useState("");
 
   const { response, error, loading } = useAPI(() => {
-      return searchFn(searchPrefix, after);
-  }, [searchPrefix, after]);
+      return searchFn(paginationParams.prefix, paginationParams.after);
+  }, [paginationParams]);
 
   useEffect(() => {
     if (!!search.current && search.current.value === "")
@@ -53,11 +52,13 @@ export const AttachModal = ({
           firstFixedCol={true}
         />
         <Paginator
-            after={after}
+            after={paginationParams.after}
             nextPage={nextPage}
-            onPaginate={setAfter}
+            onPaginate={(newAfter) => setPaginationParams(prev => ({
+                ...prev,
+                after: newAfter
+            }))}
         />
-
         <div className="mt-3">
           {(selected.length > 0) &&
             <p>
@@ -88,8 +89,11 @@ export const AttachModal = ({
     );
 
   const handleSearchChange = () => {
-      setSearchPrefix(search.current.value);
-      setAfter("");
+      setPaginationParams(prev => ({
+          ...prev,
+          prefix: search.current.value,
+          after: ""
+      }));
   };
 
   return (

--- a/webui/src/lib/components/auth/forms.jsx
+++ b/webui/src/lib/components/auth/forms.jsx
@@ -26,8 +26,8 @@ export const AttachModal = ({
   }, [searchPrefix, after]);
 
   useEffect(() => {
-      if (!!search.current && search.current.value === "")
-          search.current.focus();
+    if (!!search.current && search.current.value === "")
+      search.current.focus();
   });
 
   const nextPage = response?.pagination?.has_more ? response.pagination.next_offset : null;

--- a/webui/src/lib/components/auth/forms.jsx
+++ b/webui/src/lib/components/auth/forms.jsx
@@ -43,13 +43,13 @@ export const AttachModal = ({
           emptyState={emptyState}
           results={response.results}
           rowFn={ent => [
-                <Checkbox
-                  defaultChecked={selected.some(selectedEnt => selectedEnt.id === ent.id)}
-                  onAdd={() => setSelected([...selected, ent])}
-                  onRemove={() => setSelected(selected.filter(selectedEnt => selectedEnt.id !== ent.id))}
-                  name={'selected'}/>,
-                <strong>{resolveEntityFn(ent)}</strong>
-              ]}
+            <Checkbox
+              defaultChecked={selected.some(selectedEnt => selectedEnt.id === ent.id)}
+              onAdd={() => setSelected([...selected, ent])}
+              onRemove={() => setSelected(selected.filter(selectedEnt => selectedEnt.id !== ent.id))}
+              name={'selected'}/>,
+            <strong>{resolveEntityFn(ent)}</strong>
+          ]}
           firstFixedCol={true}
         />
         <Paginator

--- a/webui/src/lib/components/auth/forms.jsx
+++ b/webui/src/lib/components/auth/forms.jsx
@@ -37,12 +37,12 @@ export const AttachModal = ({
   else if (error) content = <AlertError error={error}/>;
   else content = (
       <>
-          <DataTable
-              headers={headers}
-              keyFn={ent => ent.id}
-              emptyState={emptyState}
-              results={response.results}
-              rowFn={ent => [
+        <DataTable
+            headers={headers}
+            keyFn={ent => ent.id}
+            emptyState={emptyState}
+            results={response.results}
+            rowFn={ent => [
                 <Checkbox
                   defaultChecked={selected.some(selectedEnt => selectedEnt.id === ent.id)}
                   onAdd={() => setSelected([...selected, ent])}
@@ -50,13 +50,13 @@ export const AttachModal = ({
                   name={'selected'}/>,
                 <strong>{resolveEntityFn(ent)}</strong>
               ]}
-              firstFixedCol={true}
-          />
-          <Paginator
-              after={after}
-              nextPage={nextPage}
-              onPaginate={setAfter}
-          />
+            firstFixedCol={true}
+        />
+        <Paginator
+            after={after}
+            nextPage={nextPage}
+            onPaginate={setAfter}
+        />
         <div className="mt-3">
           {(selected.length > 0) &&
             <p>

--- a/webui/src/pages/auth/groups/group/members.jsx
+++ b/webui/src/pages/auth/groups/group/members.jsx
@@ -21,7 +21,7 @@ import {useRouter} from "../../../../lib/hooks/router";
 import {Link} from "../../../../lib/components/nav";
 import {resolveUserDisplayName} from "../../../../lib/utils";
 import {allUsersFromLakeFS} from "../../../../lib/components/auth/users";
-import {pageSize} from "../../../../constants";
+import {PageSize} from "../../../../constants";
 
 
 const GroupMemberList = ({ groupId, after, onPaginate }) => {
@@ -50,9 +50,9 @@ const GroupMemberList = ({ groupId, after, onPaginate }) => {
             resolveUserDisplayNameFN(user).toLowerCase().startsWith(prefix.toLowerCase())
         );
         const startIndex = after ? parseInt(after, 10) : 0;
-        const page = filteredUsers.slice(startIndex, startIndex + pageSize);
-        const nextOffset = (startIndex + pageSize < filteredUsers.length)
-            ? (startIndex + pageSize).toString()
+        const page = filteredUsers.slice(startIndex, startIndex + PageSize);
+        const nextOffset = (startIndex + PageSize < filteredUsers.length)
+            ? (startIndex + PageSize).toString()
             : null;
 
         return {

--- a/webui/src/pages/auth/groups/group/policies.jsx
+++ b/webui/src/pages/auth/groups/group/policies.jsx
@@ -74,14 +74,7 @@ const GroupPoliciesList = ({ groupId, after, onPaginate }) => {
                     filterPlaceholder={'Find Policy...'}
                     modalTitle={'Attach Policies'}
                     addText={'Attach Policies'}
-                    searchFn={(prefix, after) =>
-                        auth.listPolicies(prefix, after, 5).then(res => ({
-                            results: res.results,
-                            pagination: {
-                                next_offset: res.pagination?.next_offset
-                            }
-                        }))
-                    }
+                    searchFn={(prefix, after) => auth.listPolicies(prefix, after, 5)}
                     onHide={() => setShowAddModal(false)}
                     onAttach={(selected) => {
                         Promise.all(selected.map(policy => auth.attachPolicyToGroup(groupId, policy.id)))

--- a/webui/src/pages/auth/groups/group/policies.jsx
+++ b/webui/src/pages/auth/groups/group/policies.jsx
@@ -19,6 +19,7 @@ import {
 } from "../../../../lib/components/controls";
 import {Link} from "../../../../lib/components/nav";
 import {useRouter} from "../../../../lib/hooks/router";
+import {PageSize} from "../../../../constants";
 
 
 const GroupPoliciesList = ({ groupId, after, onPaginate }) => {
@@ -74,7 +75,7 @@ const GroupPoliciesList = ({ groupId, after, onPaginate }) => {
                     filterPlaceholder={'Find Policy...'}
                     modalTitle={'Attach Policies'}
                     addText={'Attach Policies'}
-                    searchFn={(prefix, after) => auth.listPolicies(prefix, after, 5)}
+                    searchFn={(prefix, after) => auth.listPolicies(prefix, after, PageSize)}
                     onHide={() => setShowAddModal(false)}
                     onAttach={(selected) => {
                         Promise.all(selected.map(policy => auth.attachPolicyToGroup(groupId, policy.id)))

--- a/webui/src/pages/auth/groups/group/policies.jsx
+++ b/webui/src/pages/auth/groups/group/policies.jsx
@@ -74,7 +74,14 @@ const GroupPoliciesList = ({ groupId, after, onPaginate }) => {
                     filterPlaceholder={'Find Policy...'}
                     modalTitle={'Attach Policies'}
                     addText={'Attach Policies'}
-                    searchFn={prefix => auth.listPolicies(prefix, "", 5).then(res => res.results)}
+                    searchFn={(prefix, after) =>
+                        auth.listPolicies(prefix, after, 5).then(res => ({
+                            results: res.results,
+                            pagination: {
+                                next_offset: res.pagination?.next_offset
+                            }
+                        }))
+                    }
                     onHide={() => setShowAddModal(false)}
                     onAttach={(selected) => {
                         Promise.all(selected.map(policy => auth.attachPolicyToGroup(groupId, policy.id)))

--- a/webui/src/pages/auth/users/user/groups.jsx
+++ b/webui/src/pages/auth/users/user/groups.jsx
@@ -20,6 +20,7 @@ import { AttachModal } from "../../../../lib/components/auth/forms";
 import { ConfirmationButton } from "../../../../lib/components/modals";
 import { useRouter } from "../../../../lib/hooks/router";
 import { Link } from "../../../../lib/components/nav";
+import {PageSize} from "../../../../constants";
 
 const resolveGroupDisplayName = (group) => {
     if(!group) return "";
@@ -100,7 +101,7 @@ const UserGroupsList = ({ userId, after, onPaginate }) => {
             modalTitle={"Add to Groups"}
             addText={"Add to Groups"}
             headers={["", "Group Name"]}
-            searchFn={(prefix, after) => auth.listGroups(prefix, after, 5)}
+            searchFn={(prefix, after) => auth.listGroups(prefix, after, PageSize)}
             resolveEntityFn={resolveGroupDisplayName}
             onHide={() => setShowAddModal(false)}
             onAttach={(selected) => {

--- a/webui/src/pages/auth/users/user/groups.jsx
+++ b/webui/src/pages/auth/users/user/groups.jsx
@@ -100,9 +100,7 @@ const UserGroupsList = ({ userId, after, onPaginate }) => {
             modalTitle={"Add to Groups"}
             addText={"Add to Groups"}
             headers={["", "Group Name"]}
-            searchFn={(prefix) =>
-              auth.listGroups(prefix, "", 5).then((res) => res.results)
-            }
+            searchFn={(prefix, after) => auth.listGroups(prefix, after, 5)}
             resolveEntityFn={resolveGroupDisplayName}
             onHide={() => setShowAddModal(false)}
             onAttach={(selected) => {

--- a/webui/src/pages/auth/users/user/policies.jsx
+++ b/webui/src/pages/auth/users/user/policies.jsx
@@ -19,6 +19,7 @@ import {AttachModal} from "../../../../lib/components/auth/forms";
 import {ConfirmationButton} from "../../../../lib/components/modals";
 import {Link} from "../../../../lib/components/nav";
 import {useRouter} from "../../../../lib/hooks/router";
+import {PageSize} from "../../../../constants";
 
 
 const UserPoliciesList = ({ userId, after, onPaginate }) => {
@@ -71,7 +72,7 @@ const UserPoliciesList = ({ userId, after, onPaginate }) => {
                     filterPlaceholder={'Find Policy...'}
                     modalTitle={'Attach Policies'}
                     addText={'Attach Policies'}
-                    searchFn={(prefix,after) => auth.listPolicies(prefix, after, 5)}
+                    searchFn={(prefix,after) => auth.listPolicies(prefix, after, PageSize)}
                     onHide={() => setShowAddModal(false)}
                     onAttach={(selected) => {
                         Promise.all(selected.map(policy => auth.attachPolicyToUser(userId, policy.id)))

--- a/webui/src/pages/auth/users/user/policies.jsx
+++ b/webui/src/pages/auth/users/user/policies.jsx
@@ -71,7 +71,7 @@ const UserPoliciesList = ({ userId, after, onPaginate }) => {
                     filterPlaceholder={'Find Policy...'}
                     modalTitle={'Attach Policies'}
                     addText={'Attach Policies'}
-                    searchFn={prefix => auth.listPolicies(prefix, "", 5).then(res => res.results)}
+                    searchFn={(prefix,after) => auth.listPolicies(prefix, after, 5)}
                     onHide={() => setShowAddModal(false)}
                     onAttach={(selected) => {
                         Promise.all(selected.map(policy => auth.attachPolicyToUser(userId, policy.id)))


### PR DESCRIPTION
Closes #8966 

## Change Description
Updated the attachment modal to include pagination for:
- Attach policy modal in users and groups sections (listing policies).
- Add user to group modal (listing groups).
- Add member to group modal (listing users/members).

Adjusted the search function and integrated a paginator for handling large datasets efficiently.
This enhances usability when browsing extensive policy/group/member lists.

### Testing Details

Was tested manually on local env, verified the pagination controls are showing, and added some more policies locally to increase the list size to see the pagination work appropriately.

<img width="497" alt="image" src="https://github.com/user-attachments/assets/0cc2dad0-967e-483e-b580-612e32d23336" />
<img width="491" alt="image" src="https://github.com/user-attachments/assets/073b57f5-d556-4e5d-98b4-0e9e35c5ac43" />
<img width="497" alt="image" src="https://github.com/user-attachments/assets/71de9727-ac09-4447-9f14-b51cebd85cdf" />
