### PR TITLE
Support MSB storage

### DIFF
--- a/clients/hadoopfs/pom.xml
+++ b/clients/hadoopfs/pom.xml
@@ -287,7 +287,7 @@ To export to S3:
         <dependency>
             <groupId>io.lakefs</groupId>
             <artifactId>sdk</artifactId>
-            <version>1.18.0</version>
+            <version>1.53.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.hadoop</groupId>

--- a/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileSystem.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/LakeFSFileSystem.java
@@ -80,7 +80,7 @@ public class LakeFSFileSystem extends FileSystem {
 
     private Configuration conf;
     private URI uri;
-    private Path workingDirectory = new Path(Constants.SEPARATOR);
+    private Path workingDirectory = new Path(SEPARATOR);
     private ClientFactory clientFactory;
     private LakeFSClient lfsClient;
     private int listAmount;
@@ -126,7 +126,7 @@ public class LakeFSFileSystem extends FileSystem {
                 .execute();
         String storageID = repository.getStorageId();
         Config cfg = lfsClient.getConfigApi().getConfig().execute();
-        StorageConfig storageConfig = new StorageConfig();
+        StorageConfig storageConfig = null;
         if (storageID == null || Objects.equals(storageID, "")) {
             storageConfig = cfg.getStorageConfig();
 
@@ -136,7 +136,7 @@ public class LakeFSFileSystem extends FileSystem {
                 storageConfig = storageConfigList.stream()
                         .filter(sc -> Objects.equals(sc.getBlockstoreId(), storageID))
                         .findFirst()
-                        .orElseThrow(() -> new IOException("Failed to get lakeFS blockstore type"));
+                        .orElseThrow(() -> new IOException("Failed to get lakeFS blockstore configuration"));
             }
         }
         return storageConfig;
@@ -208,7 +208,7 @@ public class LakeFSFileSystem extends FileSystem {
         if (getFSForConfig() != null) {
             return getFSForConfig().getDefaultBlockSize(path);
         }
-        return Constants.DEFAULT_BLOCK_SIZE;
+        return DEFAULT_BLOCK_SIZE;
     }
 
     @Override
@@ -216,7 +216,7 @@ public class LakeFSFileSystem extends FileSystem {
         if (getFSForConfig() != null) {
             return getFSForConfig().getDefaultBlockSize();
         }
-        return Constants.DEFAULT_BLOCK_SIZE;
+        return DEFAULT_BLOCK_SIZE;
     }
 
     @Override
@@ -762,7 +762,7 @@ public class LakeFSFileSystem extends FileSystem {
             ObjectLocation objectLoc = pathToObjectLocation(path).toDirectory();
             OutputStream out = storageAccessStrategy.createDataOutputStream(objectLoc, null);
             out.close();
-        } catch (io.lakefs.clients.sdk.ApiException e) {
+        } catch (ApiException e) {
             throw new IOException("createDirectoryMarker: " + e.getResponseBody(), e);
         }
     }
@@ -771,7 +771,7 @@ public class LakeFSFileSystem extends FileSystem {
      * Return a file status object that represents the path.
      * @param path to a file or directory
      * @return a LakeFSFileStatus object
-     * @throws java.io.FileNotFoundException when the path does not exist;
+     * @throws FileNotFoundException when the path does not exist;
      *         IOException API call or underlying filesystem exceptions
      */
     @Override

--- a/clients/hadoopfs/src/test/java/io/lakefs/FSTestBase.java
+++ b/clients/hadoopfs/src/test/java/io/lakefs/FSTestBase.java
@@ -144,22 +144,23 @@ public abstract class FSTestBase {
 
         System.setProperty("hadoop.home.dir", "/");
 
-        // lakeFSFS initialization requires a blockstore.
-        mockServerClient.when(request()
-                              .withMethod("GET")
-                              .withPath("/config/storage"),
-                              Times.once())
-            .respond(response()
-                     .withStatusCode(200)
-                     .withBody(gson.toJson(new StorageConfig()
-                                           .blockstoreType("s3")
-                                           .blockstoreNamespaceExample("/not/really")
-                                           .blockstoreNamespaceValidityRegex(".*")
-                                           // TODO(ariels): Change for presigned?
-                                           .preSignSupport(false)
-                                           .preSignSupportUi(false)
-                                           .importSupport(false)
-                                           .importValidityRegex(".*"))));
+        mockServerClient.when(
+                request()
+                        .withMethod("GET")
+                        .withPath("/config"),
+                Times.once()
+        ).respond(
+                response()
+                        .withStatusCode(200)
+                        .withBody(gson.toJson(new Config()
+                                .storageConfig(new StorageConfig()
+                                        .blockstoreType("s3")
+                                        .blockstoreNamespaceExample("unused-but-checked")
+                                        .preSignSupport(false)
+                                        .preSignSupportUi(false)
+                                        .importSupport(false)
+                                        .importValidityRegex(".*")
+                                        .blockstoreNamespaceValidityRegex(".*")))));
 
         // Always allow repo "repo" to be found, it's used in all tests.
         mockServerClient.when(request()


### PR DESCRIPTION
Closes treeverse/lakeFS-enterprise#48

## Change Description
This change provides the lakeFSFS to support storage config list case
This change:
- uses the config endpoint instead of the depricated internal getStorageConfig endpoint
- Uses getStorageConfigList in case it's provided, otherwise fallbacks to storageConfig

### How was this tested
This was tested by running the sonnets test locally with the following information:
1. Use lakeFSFS instead of gateway
2. Use on lakeFS running with MSB without a bc storage 

