### PR TITLE
Lua Hooks: databricks alter table

### DIFF
--- a/docs/howto/hooks/lua.md
+++ b/docs/howto/hooks/lua.md
@@ -325,6 +325,24 @@ local client = databricks.client("https://my-host.cloud.databricks.com", "my-ser
 local schema_name = client.create_schema("main", "mycatalog", true)
 ```
 
+### `databricks/client.execute_statement(warehouse_id, catalog_name, schema_name, statement)`
+
+Parameters:
+
+- `warehouse_id(string)`: The SQL warehouse ID used in Databricks to run the `CREATE TABLE` query (fetched from the SQL warehouse
+- `catalog_name(string)`: The catalog name under which the schema will be created (or from which it will be fetched)
+- `schema_name(string)`: The required schema name
+- `statement(boolean)`: The SQL statement to execute on the databricks table
+  `status`, return the SQL status i.e. success or an error code/message
+
+Example:
+```lua
+local databricks = require("databricks")
+local client = databricks.client("https://my-host.cloud.databricks.com", "my-service-principal-token")
+local statement = "ALTER TABLE " .. table_descriptor.name .. " ALTER COLUMN ID SET MASK mask_num"
+databricks_client.execute_statement(args.warehouse_id,table_descriptor.catalog,table_descriptor.schema,statement)
+```
+
 ### `databricks/client.register_external_table(table_name, physical_path, warehouse_id, catalog_name, schema_name, metadata)`
 
 Registers an external table under the provided warehouse ID, catalog name, and schema name.

--- a/docs/howto/hooks/lua.md
+++ b/docs/howto/hooks/lua.md
@@ -325,14 +325,14 @@ local client = databricks.client("https://my-host.cloud.databricks.com", "my-ser
 local schema_name = client.create_schema("main", "mycatalog", true)
 ```
 
-### `databricks/client.execute_statement(warehouse_id, catalog_name, schema_name, statement)`
+### `databricks/client.execute_statement(statement, warehouse_id, catalog_name, schema_name)`
 
 Parameters:
 
+- `statement(boolean)`: The SQL statement to execute on the databricks table
 - `warehouse_id(string)`: The SQL warehouse ID used in Databricks to run the `CREATE TABLE` query (fetched from the SQL warehouse
 - `catalog_name(string)`: The catalog name under which the schema will be created (or from which it will be fetched)
 - `schema_name(string)`: The required schema name
-- `statement(boolean)`: The SQL statement to execute on the databricks table
   `status`, return the SQL status i.e. success or an error code/message
 
 Example:
@@ -340,7 +340,7 @@ Example:
 local databricks = require("databricks")
 local client = databricks.client("https://my-host.cloud.databricks.com", "my-service-principal-token")
 local statement = "ALTER TABLE " .. table_descriptor.name .. " ALTER COLUMN ID SET MASK mask_num"
-databricks_client.execute_statement(args.warehouse_id,table_descriptor.catalog,table_descriptor.schema,statement)
+databricks_client.execute_statement(statement, args.warehouse_id, table_descriptor.catalog, table_descriptor.schema)
 ```
 
 ### `databricks/client.register_external_table(table_name, physical_path, warehouse_id, catalog_name, schema_name, metadata)`

--- a/docs/howto/hooks/lua.md
+++ b/docs/howto/hooks/lua.md
@@ -333,7 +333,7 @@ Parameters:
 - `warehouse_id(string)`: The SQL warehouse ID used in Databricks to run the `CREATE TABLE` query (fetched from the SQL warehouse
 - `catalog_name(string)`: The catalog name under which the schema will be created (or from which it will be fetched)
 - `schema_name(string)`: The required schema name
-  `status`, return the SQL status i.e. success or an error code/message
+  `status`, return the SQL status i.e. SUCCEEDED or an error code/message
 
 Example:
 ```lua

--- a/pkg/actions/lua/databricks/client.go
+++ b/pkg/actions/lua/databricks/client.go
@@ -73,7 +73,7 @@ func (client *Client) createExternalTable(warehouseID, catalogName, schemaName, 
 }
 
 func (client *Client) alterTable(warehouseID, catalogName, schemaName, tableName, alterStatement string) (string, error) {
-	statement := fmt.Sprintf(`ALTER TABLE %s.%s.%s %s`, catalogName, schemaName, tableName, alterStatement)
+	statement := fmt.Sprintf(`ALTER TABLE %s %s`, tableName, alterStatement)
 	esr, err := client.workspaceClient.StatementExecution.ExecuteAndWait(client.ctx, sql.ExecuteStatementRequest{
 		WarehouseId: warehouseID,
 		Catalog:     catalogName,

--- a/pkg/actions/lua/databricks/client.go
+++ b/pkg/actions/lua/databricks/client.go
@@ -177,10 +177,10 @@ func (client *Client) CreateSchema(l *lua.State) int {
 }
 
 func (client *Client) ExecuteStatement(l *lua.State) int {
-	warehouseID := lua.CheckString(l, 1)
-	catalogName := lua.CheckString(l, 2)
-	schemaName := lua.CheckString(l, 3)
-	statement := lua.CheckString(l, 4)
+	statement := lua.CheckString(l, 1)
+	warehouseID := lua.CheckString(l, 2)
+	catalogName := lua.CheckString(l, 3)
+	schemaName := lua.CheckString(l, 4)
 	status, err := client.executeStatement(warehouseID, catalogName, schemaName, statement)
 	if err != nil {
 		lua.Errorf(l, "%s", err.Error())


### PR DESCRIPTION
Closes #8975 

## Change Description
      
### New Feature

We are extending our Lua Hooks runtime to support the following Databricks client method:
a general API similar to the databricks sql API
databricks/client.execute_statement(warehouse_id, catalog_name, schema_name, sql_statement)
returns status including SQL errors if any

### Testing Details

Manual tests

Test case 1: Test Alter
1. Create a table in databricks
2. Alter it via the lua hook

Test case 2: Test Alter
1. Create a table in databricks
2. Add a PII mask function to the catalog
3. Alter it via the lua hook thereby applying the PII mask function

Test case 3: SQL Error
Try different bad SQL cases-- make sure the Lua returns a nice understandable SQL error

Example:
Error: runtime error: [string "lua"]:94: execute statement failed: "8b45165ed9bb1013.nadav-catalog-test.default" statement: "ALTER TABLE test_table ALTER COLUMN ORG_NAME SET MASK pii_mask" FAILED: BAD_REQUEST [UNRESOLVED_COLUMN.WITH_SUGGESTION] A column, variable, or function parameter with name `ORG_NAME` cannot be resolved. Did you mean one of the following? []. SQLSTATE: 42703; line 1 pos 0

Esti-- this is a problem. We don't currently have infrastructure to test databricks integration in our ESTI tests. Maybe we should add this at some point