### PR TITLE
Get installation ID from license manager

### DIFF
--- a/cmd/lakefs/cmd/run.go
+++ b/cmd/lakefs/cmd/run.go
@@ -110,7 +110,11 @@ var runCmd = &cobra.Command{
 		migrator := kv.NewDatabaseMigrator(kvParams)
 		multipartTracker := multipart.NewTracker(kvStore)
 		actionsStore := actions.NewActionsKVStore(kvStore)
-		authMetadataManager := auth.NewKVMetadataManager(version.Version, baseCfg.Installation.FixedID, baseCfg.Database.Type, kvStore)
+		installationID := licenseManager.InstallationID()
+		if installationID == "" {
+			installationID = baseCfg.Installation.FixedID
+		}
+		authMetadataManager := auth.NewKVMetadataManager(version.Version, installationID, baseCfg.Database.Type, kvStore)
 		idGen := &actions.DecreasingIDGenerator{}
 
 		authService := authfactory.NewAuthService(ctx, cfg, logger, kvStore, authMetadataManager)


### PR DESCRIPTION
Add option to get installation ID from license manager if exists.
The behavior will be changed so that installation ID will be determined by:
licenseManager (if exists) -> FixedID from config (if exists) -> Otherwise, create new installation ID

Where previous flow was:

FixedID from config (if exists) -> Otherwise, create new installation ID
