### PR TITLE
Fix - enhance repository tree layout and link behavior

### DIFF
--- a/webui/src/lib/components/repository/layout.jsx
+++ b/webui/src/lib/components/repository/layout.jsx
@@ -12,7 +12,7 @@ import { RefContextProvider } from "../../hooks/repo";
 import { ReadOnlyBadge } from "../badges";
 
 const RepoNav = () => {
-    const { repo } = useRefs();
+    const { repo, reference } = useRefs();
     const [repoId, setRepoId] = useState("");
     useEffect(() => {
         if (repo) {
@@ -20,13 +20,21 @@ const RepoNav = () => {
         }
     }, [repo]);
 
+    const repoLink = {
+        pathname: '/repositories/:repoId/objects',
+        params: { repoId },
+    };
+    if (reference?.id) {
+        repoLink.query = { ref: reference.id };
+    }
+
     return (
         <Stack direction="horizontal" gap={2}>
             <Breadcrumb>
                 <Link href={{pathname: '/repositories'}} component={Breadcrumb.Item}>
                     Repositories
                 </Link>
-                <Link href={{pathname: '/repositories/:repoId/objects', params: {repoId}}} component={Breadcrumb.Item}>
+                <Link href={repoLink} component={Breadcrumb.Item}>
                     {repoId}
                 </Link>
             </Breadcrumb>

--- a/webui/src/lib/components/repository/tree.jsx
+++ b/webui/src/lib/components/repository/tree.jsx
@@ -650,7 +650,7 @@ export const URINavigator = ({
 
   return (
     <div className="d-flex">
-      <div className="lakefs-uri flex-grow-1" style={{ minWidth: 0 }}>
+      <div className="lakefs-uri flex-grow-1">
         <div
             title={displayedReference}
             className="w-100 text-nowrap overflow-hidden text-truncate"

--- a/webui/src/lib/components/repository/tree.jsx
+++ b/webui/src/lib/components/repository/tree.jsx
@@ -650,7 +650,7 @@ export const URINavigator = ({
 
   return (
     <div className="d-flex">
-      <div className="lakefs-uri flex-grow-1">
+      <div className="lakefs-uri flex-grow-1" style={{ minWidth: 0 }}>
         <div
             title={displayedReference}
             className="w-100 text-nowrap overflow-hidden text-truncate"
@@ -658,7 +658,13 @@ export const URINavigator = ({
           {relativeTo === "" ? (
               <>
                 <strong>lakefs://</strong>
-                <Link href={{ pathname: "/repositories/:repoId/objects", params }}>
+                <Link
+                    href={{
+                      pathname: "/repositories/:repoId/objects",
+                      params,
+                      query: { ref: reference.id },
+                    }}
+                >
                   {repo.id}
                 </Link>
                 <strong>/</strong>
@@ -679,28 +685,28 @@ export const URINavigator = ({
                 <strong>/</strong>
               </>
           )}
-        </div>
 
-        {parts.map((part, i) => {
-          const path =
-            parts
-              .slice(0, i + 1)
-              .map((p) => p.name)
-              .join("/") + "/";
-          const query = { path, ref: reference.id };
-          const edgeElement =
-            isPathToFile && i === parts.length - 1 ? (
-              <span>{part.name}</span>
-            ) : (
-              <>
-                <Link href={pathURLBuilder(params, query)}>{part.name}</Link>
-                <strong>{"/"}</strong>
-              </>
-            );
-          return <span key={part.name}>{edgeElement}</span>;
-        })}
+          {parts.map((part, i) => {
+            const path =
+              parts
+                .slice(0, i + 1)
+                .map((p) => p.name)
+                .join("/") + "/";
+            const query = { path, ref: reference.id };
+            const edgeElement =
+              isPathToFile && i === parts.length - 1 ? (
+                <span>{part.name}</span>
+              ) : (
+                <>
+                  <Link href={pathURLBuilder(params, query)}>{part.name}</Link>
+                  <strong>{"/"}</strong>
+                </>
+              );
+            return <span key={part.name}>{edgeElement}</span>;
+          })}
         </div>
-      <div className="object-viewer-buttons">
+      </div>
+      <div className="object-viewer-buttons" style={{ flexShrink: 0 }}>
         {hasCopyButton &&
         <ClipboardButton
             text={`lakefs://${repo.id}/${reference.id}/${path}`}

--- a/webui/src/styles/globals.css
+++ b/webui/src/styles/globals.css
@@ -143,6 +143,7 @@
   font-size: .9rem;
   color: var(--bs-body-color);
   width: 95%;
+  min-width: 0;
 }
 
 .lakefs-uri strong {


### PR DESCRIPTION
Closes #8995 

## Change Description

### Bug Fix

### Problem

* The URI navigator wrapped into two lines instead of staying on one.
![image](https://github.com/user-attachments/assets/fa8cc43f-6076-4460-b78d-13a68784a6c5)

* Clicking the repository name in the URI navigator caused the branch to reset to main, even when viewing a different branch.

### Root cause
* Although the inner div had the proper truncation classes (`text-truncate`, `overflow-hidden`, etc.), the actual path. 
  segments rendered by `parts.map(...)` were not inside that div, so they were not affected by truncation. Additionally, the container layout (a flex row) required two layout tweaks that were missing - 
    (A) `min-width: 0` on the container holding the URI to allow shrinking.
    (B) `flex-shrink: 0` on the container holding the buttons, to prevent them from shrinking and pushing the URI down.

* The link for the repository name did not include the current ref in its query parameters, so clicking it navigated back to. 
   the default branch (main).

### Solution
* Moved the `parts.map(...)` output into the same div that applies truncation, added `style={{ minWidth: 0 }}` to the URI. 
   container, and `style={{ flexShrink: 0 }}` to the buttons container to ensure proper flex behavior.
![image](https://github.com/user-attachments/assets/44a5f9db-f223-46ed-ad39-aac7f73a81aa)

* Updated the repository name link to include the current ref in the query string to preserve the branch context on. 
   navigation.

### Testing Details

Was tested locally on lakeFS.