### PR TITLE
Add all missing Hadoop lakeFS client version to compatility tests

### DIFF
--- a/.github/workflows/compatibility-tests.yaml
+++ b/.github/workflows/compatibility-tests.yaml
@@ -259,7 +259,7 @@ jobs:
       matrix:
         # Removing a version from this list means the current lakeFS is no longer compatible with
         # that Hadoop lakeFS client version.
-        client_version: [0.1.10, 0.1.11, 0.1.12, 0.1.13, 0.1.14, 0.1.15, 0.2.1]
+        client_version: [0.1.10, 0.1.11, 0.1.12, 0.1.13, 0.1.14, 0.1.15, 0.2.1, 0.2.2, 0.2.3, 0.2.4, 0.2.5]
     runs-on: ubuntu-22.04
     env:
       CLIENT_VERSION: ${{ matrix.client_version }}


### PR DESCRIPTION
Added some missing Hadoop lakeFS client versions to the compatiblity tests
### note
I will not merge this in before Sunday