### PR TITLE
Support Unsigned Payload Trailers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -180,7 +180,9 @@ gen-code: gen-api ## Run the generator for inline commands
 		./tools/wrapgen/testcode
 
 LD_FLAGS := "-X github.com/treeverse/lakefs/pkg/version.Version=$(VERSION)-$(REVISION)"
-build: gen docs ## Download dependencies and build the default binary
+build: gen docs build-binaries ## Download dependencies and build the default binary
+
+build-binaries:
 	$(GOBUILD) -o $(LAKEFS_BINARY_NAME) -ldflags $(LD_FLAGS) -v ./cmd/$(LAKEFS_BINARY_NAME)
 	$(GOBUILD) -o $(LAKECTL_BINARY_NAME) -ldflags $(LD_FLAGS) -v ./cmd/$(LAKECTL_BINARY_NAME)
 

--- a/go.mod
+++ b/go.mod
@@ -98,6 +98,7 @@ require (
 	github.com/hashicorp/go-version v1.6.0
 	github.com/jackc/pgx/v5 v5.6.0
 	github.com/matoous/go-nanoid v1.5.0
+	github.com/minio/crc64nvme v1.0.1
 	github.com/puzpuzpuz/xsync v1.5.2
 	go.uber.org/ratelimit v0.3.0
 	gocloud.dev v0.34.1-0.20231122211418-53ccd8db26a1
@@ -148,7 +149,7 @@ require (
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/inhies/go-bytesize v0.0.0-20220417184213-4913239db9cf // indirect
 	github.com/jackc/puddle/v2 v2.2.1 // indirect
-	github.com/klauspost/cpuid/v2 v2.2.5 // indirect
+	github.com/klauspost/cpuid/v2 v2.2.9 // indirect
 	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/labstack/echo/v4 v4.11.4 // indirect
 	github.com/mattn/go-shellwords v1.0.12 // indirect

--- a/go.sum
+++ b/go.sum
@@ -778,8 +778,8 @@ github.com/klauspost/cpuid v1.2.1/go.mod h1:Pj4uuM528wm8OyEC2QMXAi2YiTZ96dNQPGgo
 github.com/klauspost/cpuid/v2 v2.0.1/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.0.4/go.mod h1:FInQzS24/EEf25PyTYn52gqo7WaD8xa0213Md/qVLRg=
 github.com/klauspost/cpuid/v2 v2.1.0/go.mod h1:RVVoqg1df56z8g3pUjL/3lE5UfnlrJX8tyFgg4nqhuY=
-github.com/klauspost/cpuid/v2 v2.2.5 h1:0E5MSMDEoAulmXNFquVs//DdoomxaoTY1kUhbc/qbZg=
-github.com/klauspost/cpuid/v2 v2.2.5/go.mod h1:Lcz8mBdAVJIBVzewtcLocK12l3Y+JytZYpaMropDUws=
+github.com/klauspost/cpuid/v2 v2.2.9 h1:66ze0taIn2H33fBvCkXuv9BmCwDfafmiIVpKV9kKGuY=
+github.com/klauspost/cpuid/v2 v2.2.9/go.mod h1:rqkxqrZ1EhYM9G+hXH7YdowN5R5RGN6NK4QwQ3WMXF8=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/fs v0.1.0/go.mod h1:FFnZGqtBN9Gxj7eW1uZ42v5BccTP0vu6NEaFoC2HwRg=
@@ -859,6 +859,8 @@ github.com/mediocregopher/mediocre-go-lib v0.0.0-20181029021733-cb65787f37ed/go.
 github.com/mediocregopher/radix/v3 v3.3.0/go.mod h1:EmfVyvspXz1uZEyPBMyGK+kjWiKQGvsUt6O3Pj+LDCQ=
 github.com/mediocregopher/radix/v3 v3.4.2/go.mod h1:8FL3F6UQRXHXIBSPUs5h0RybMF8i4n7wVopoX3x7Bv8=
 github.com/microcosm-cc/bluemonday v1.0.2/go.mod h1:iVP4YcDBq+n/5fb23BhYFvIMq/leAFZyRl6bYmGDlGc=
+github.com/minio/crc64nvme v1.0.1 h1:DHQPrYPdqK7jQG/Ls5CTBZWeex/2FMS3G5XGkycuFrY=
+github.com/minio/crc64nvme v1.0.1/go.mod h1:eVfm2fAzLlxMdUGc0EEBGSMmPwmXD5XiNRpnu9J3bvg=
 github.com/minio/md5-simd v1.1.2 h1:Gdi1DZK69+ZVMoNHRXJyNcxrMA4dSxoYHZSQbirFg34=
 github.com/minio/md5-simd v1.1.2/go.mod h1:MzdKDxYpY2BT9XQFocsiZf/NKVtR7nkE4RoEpN+20RM=
 github.com/minio/minio-go/v7 v7.0.34/go.mod h1:nCrRzjoSUQh8hgKKtu3Y708OLvRLtuASMg2/nvmbarw=
@@ -1415,7 +1417,6 @@ golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f/go.mod h1:oPkhp1MJrh7nUepCBc
 golang.org/x/sys v0.0.0-20220811171246-fbc7d0a398ab/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.2.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
-golang.org/x/sys v0.5.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.30.0 h1:QjkSwP/36a20jFYWkSue1YwXzLmsV5Gfq7Eiy72C1uc=
 golang.org/x/sys v0.30.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=

--- a/pkg/gateway/sig/v4_streaming_reader.go
+++ b/pkg/gateway/sig/v4_streaming_reader.go
@@ -49,7 +49,6 @@ const (
 // ChecksumAlgorithm represents the type of checksum algorithm used for trailers
 type ChecksumAlgorithm string
 
-// Supported checksum algorithms
 const (
 	ChecksumAlgorithmCRC32     ChecksumAlgorithm = "x-amz-checksum-crc32"
 	ChecksumAlgorithmCRC32C    ChecksumAlgorithm = "x-amz-checksum-crc32c"
@@ -214,7 +213,8 @@ func (cr *s3ChunkedReader) Close() (err error) {
 
 // Read - implements `io.Reader`, which transparently decodes
 // the incoming AWS Signature V4 streaming signature.
-func (cr *s3ChunkedReader) Read(buf []byte) (n int, err error) {
+// we don't need to lint this function because it's based on MinIO code
+func (cr *s3ChunkedReader) Read(buf []byte) (n int, err error) { //nolint:gocyclo
 	for {
 		switch cr.state {
 		case readChunkHeader:
@@ -233,7 +233,7 @@ func (cr *s3ChunkedReader) Read(buf []byte) (n int, err error) {
 			err = peekCRLF(cr.reader)
 			isTrailingChunk := cr.n == 0 && cr.lastChunk
 
-			if !isTrailingChunk {
+			if !isTrailingChunk { //nolint:gocritic
 				if readErr := readCRLF(cr.reader); readErr != nil {
 					cr.err = readErr
 					return 0, cr.err
@@ -251,7 +251,7 @@ func (cr *s3ChunkedReader) Read(buf []byte) (n int, err error) {
 			}
 
 			// If we're using unsigned streaming upload, there is no signature to verify at each chunk.
-			if cr.chunkSignature != "" {
+			if cr.chunkSignature != "" { //nolint:gocritic
 				cr.state = verifyChunk
 			} else if cr.lastChunk {
 				cr.state = readTrailerChunk

--- a/pkg/gateway/sig/v4_streaming_reader.go
+++ b/pkg/gateway/sig/v4_streaming_reader.go
@@ -21,6 +21,7 @@ package sig
 import (
 	"bufio"
 	"bytes"
+	"crypto/sha1" //nolint:gosec
 	"crypto/sha256"
 	"encoding/base64"
 	"encoding/hex"
@@ -54,6 +55,7 @@ const (
 	ChecksumAlgorithmCRC32C    ChecksumAlgorithm = "x-amz-checksum-crc32c"
 	ChecksumAlgorithmCRC64NVME ChecksumAlgorithm = "x-amz-checksum-crc64nvme"
 	ChecksumAlgorithmSHA256    ChecksumAlgorithm = "x-amz-checksum-sha256"
+	ChecksumAlgorithmSHA1      ChecksumAlgorithm = "x-amz-checksum-sha1"
 	ChecksumAlgorithmInvalid   ChecksumAlgorithm = ""
 )
 
@@ -489,6 +491,9 @@ func GetChecksumWriter(name string) (hash.Hash, error) {
 		return crc64nvme.New(), nil
 	case ChecksumAlgorithmSHA256:
 		return sha256.New(), nil
+	case ChecksumAlgorithmSHA1:
+		// could be a security risk, but some clients might use it
+		return sha1.New(), nil //nolint:gosec
 	default:
 		return nil, ErrUnsupportedChecksum
 	}

--- a/pkg/gateway/sig/v4_test.go
+++ b/pkg/gateway/sig/v4_test.go
@@ -518,8 +518,7 @@ func TestStreamingUnsignedPayloadTrailerWithChunks(t *testing.T) {
 			authenticator := sig.NewV4Authenticator(req)
 			sigContext, err := authenticator.Parse()
 			if err != nil {
-				t.Errorf("failed to parse request with STREAMING-UNSIGNED-PAYLOAD-TRAILER: %v", err)
-				return
+				t.Fatalf("failed to parse request with STREAMING-UNSIGNED-PAYLOAD-TRAILER: %v", err)
 			}
 
 			// Verify the signature

--- a/pkg/gateway/sig/v4_test.go
+++ b/pkg/gateway/sig/v4_test.go
@@ -550,8 +550,7 @@ func TestStreamingUnsignedPayloadTrailerWithChunks(t *testing.T) {
 			// Read the body to verify the chunks are correctly parsed
 			bodyData, err := io.ReadAll(req.Body)
 			if err != nil {
-				t.Errorf("failed to read parsed body: %v", err)
-				return
+				t.Fatalf("failed to read parsed body: %v", err)
 			}
 
 			// Verify that the decoded body contains exactly what we expect

--- a/pkg/gateway/sig/v4_test.go
+++ b/pkg/gateway/sig/v4_test.go
@@ -533,8 +533,7 @@ func TestStreamingUnsignedPayloadTrailerWithChunks(t *testing.T) {
 				}
 				return // Skip the rest of the test for invalid cases
 			} else if err != nil {
-				t.Errorf("failed to verify request with STREAMING-UNSIGNED-PAYLOAD-TRAILER: %v", err)
-				return
+				t.Fatalf("failed to verify request with STREAMING-UNSIGNED-PAYLOAD-TRAILER: %v", err)
 			}
 
 			// Check that it properly identified the auth type


### PR DESCRIPTION
Closes #7939

## Change Description

### Background

Depending on the different S3 clients, region and other dependencies your S3 Signature might use different signing methods.
This PR adds support to trailing chunks in STREAMING-UNSIGNED-PAYLOAD-TRAILER requests.
It also verifies the checksum of the payload with the checksum provided in the request 

### Testing Details

How were the changes tested?
Along with the current v4 tests we have for STREAMING-AWS4-HMAC-SHA256-PAYLOAD, add test cases for STREAMING-UNSIGNED-PAYLOAD-TRAILER.

I've also tested with `mountpoint-s3` and with `s3fs` Python module which now seems to rely on the trailer chunks.
I've manually tested with files I created locally and notices that the checksum writer is calculating each request payload correctly.
