### PR TITLE
Add GeoJSON file rendering support and amend preview support in ObjectsDiff

### DIFF
--- a/webui/src/lib/components/repository/ObjectsDiff.jsx
+++ b/webui/src/lib/components/repository/ObjectsDiff.jsx
@@ -10,7 +10,6 @@ import {useStorageConfigs} from "../../hooks/storageConfig";
 import {AppContext} from "../../hooks/appContext";
 import {useRefs} from "../../hooks/repo";
 import {getRepoStorageConfig} from "../../../pages/repositories/repository/utils";
-import {GeoJSONPreview} from "./GeoJSONPreview";
 
 const maxDiffSizeBytes = 120 << 10;
 const DiffViewerType = {
@@ -113,17 +112,14 @@ const ContentDiff = ({config, repoId, path, leftRef, rightRef, leftSize, rightSi
 
     return <div>
         <DiffSizeReport leftSize={leftSize} rightSize={rightSize} diffType={diffType}/>
-        {
-            viewer === DiffViewerType.GEOJSON
-                ? <GeoJSONPreview data={right?.response} />
-                : <ReactDiffViewer
-                    oldValue={left?.response}
-                    newValue={right?.response}
-                    splitView={false}
-                    useDarkTheme={state.settings.darkMode}
-                    compareMethod={DiffMethod.WORDS}
-                />
-        }
+        <ReactDiffViewer
+            oldValue={left?.response}
+            newValue={right?.response}
+            splitView={false}
+            useDarkTheme={state.settings.darkMode}
+            compareMethod={DiffMethod.WORDS}
+        />
+
     </div>;
 }
 

--- a/webui/src/pages/repositories/repository/fileRenderers/index.tsx
+++ b/webui/src/pages/repositories/repository/fileRenderers/index.tsx
@@ -3,6 +3,7 @@ import SyntaxHighlighter from "react-syntax-highlighter";
 import {FileType, RendererComponent} from "./types";
 import {DuckDBRenderer} from "./data";
 import {
+    GeoJSONRenderer,
     ImageRenderer,
     IpynbRenderer,
     MarkdownRenderer,
@@ -47,6 +48,11 @@ export const Renderers: {[fileType in FileType] : FC<RendererComponent> } = {
     ),
     [FileType.TOO_LARGE]: props => (
         <ObjectTooLarge {...props}/>
+    ),
+    [FileType.GEOJSON]: props => (
+        <TextDownloader {...props} onReady={text =>
+            <GeoJSONRenderer {...props} text={text}/>
+        } />
     ),
 }
 
@@ -102,6 +108,8 @@ export function guessType(contentType: string | null, fileExtension: string | nu
         case 'application/x-toml':
         case 'application/toml':
             return FileType.TEXT
+        case 'application/geo+json':
+            return FileType.GEOJSON;
         case 'application/x-ipynb+json':
         case 'application/x-ipynb':
         case 'application/ipynb':
@@ -144,6 +152,8 @@ export function guessType(contentType: string | null, fileExtension: string | nu
         case 'jsonl':
         case 'ndjson':
             return FileType.TEXT
+        case 'geojson':
+            return FileType.GEOJSON
     }
     if (guessLanguage(fileExtension, contentType))
         return FileType.TEXT

--- a/webui/src/pages/repositories/repository/fileRenderers/simple.tsx
+++ b/webui/src/pages/repositories/repository/fileRenderers/simple.tsx
@@ -18,6 +18,7 @@ import "react-ipynb-renderer/dist/styles/default.css";
 import { useMarkdownProcessor } from "./useMarkdownProcessor";
 import { AppContext } from "../../../../lib/hooks/appContext";
 import { dark } from "react-syntax-highlighter/dist/esm/styles/prism";
+import {GeoJSONPreview} from "../../../../lib/components/repository/GeoJSONPreview";
 
 export const ObjectTooLarge: FC<RendererComponent> = ({ path, sizeBytes }) => {
   return (
@@ -145,4 +146,8 @@ export const PDFRenderer: FC<RendererComponent> = ({
       ></object>
     </div>
   );
+};
+
+export const GeoJSONRenderer: FC<RendererComponentWithText> = ({ text }) => {
+  return <GeoJSONPreview data={text} />;
 };

--- a/webui/src/pages/repositories/repository/fileRenderers/types.tsx
+++ b/webui/src/pages/repositories/repository/fileRenderers/types.tsx
@@ -25,4 +25,5 @@ export enum FileType {
     TEXT,
     UNSUPPORTED,
     TOO_LARGE,
+    GEOJSON
 }


### PR DESCRIPTION
Closes #9017 

Introduced a dedicated `GeoJSONRenderer` and associated file type handling for GeoJSON files. Updated file renderer logic to recognize and process GeoJSON, enabling better visualization and support for this format.
**Also, changing the objectDiff preview to show the json diff, instead of the map itself.**

Part of issue: #9012
--------------------
Related previous PR: https://github.com/treeverse/lakeFS/pull/8996
---------------------------------------------------------------------------------------------------------------
**ObjectsDiff** preview:
![image](https://github.com/user-attachments/assets/2349bbdf-cffd-4ee7-8250-55158b7ed060)
---------------------------------------------------------------------------------------------------------------
**Object preview:**
![image](https://github.com/user-attachments/assets/127e7415-4ae3-448f-8deb-ac46ba579651)
