### PR TITLE
Fail the "Run Linters and Checkers" job if `go work sync` changes files

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,6 +29,12 @@ jobs:
         run: |
           make gen
           make validate-clients-untracked-files
+      - name: Ensure Go workspace is synced
+        run: |
+          go work sync
+          echo "Git status after go work sync:"
+          git status
+          [ -n "$(git status --porcelain)" ] && exit 1 || exit 0
       - name: Checks validator
         run: make checks-validator
 

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -34,7 +34,7 @@ jobs:
           go work sync
           echo "Git status after go work sync:"
           git status
-          [ -n "$(git status --porcelain)" ] && exit 1 || exit 0
+          [ ! -n "$(git status --porcelain)" ]
       - name: Checks validator
         run: make checks-validator
 


### PR DESCRIPTION
Closes #9044

Tested on a separate [draft pr](https://github.com/treeverse/lakeFS/pull/9046) - see job run [failure](https://github.com/treeverse/lakeFS/actions/runs/14971210960/job/42052361478?pr=9046#step:7:122)