### PR TITLE
fix missing error mapping in controller for auth

### DIFF
--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -2984,6 +2984,7 @@ func (c *Controller) handleAPIErrorCallback(ctx context.Context, w http.Response
 		errors.Is(err, graveler.ErrInvalidMergeStrategy),
 		errors.Is(err, block.ErrInvalidAddress),
 		errors.Is(err, block.ErrOperationNotSupported),
+		errors.Is(err, auth.ErrInvalidRequest),
 		errors.Is(err, authentication.ErrInvalidRequest),
 		errors.Is(err, graveler.ErrSameBranch),
 		errors.Is(err, graveler.ErrInvalidPullRequestStatus),

--- a/pkg/auth/model/validation.go
+++ b/pkg/auth/model/validation.go
@@ -23,7 +23,11 @@ func ValidateAuthEntityID(name string) error {
 }
 
 func ValidateActionName(name string) error {
-	return permissions.IsValidAction(name)
+	err := permissions.IsValidAction(name)
+	if err != nil {
+		return fmt.Errorf("%w: %w", ErrValidationError, err)
+	}
+	return nil
 }
 
 func ValidateArn(name string) error {


### PR DESCRIPTION
Map missing error to bad request - on auth.ErrInvalidRequest we should return 400 BadRequest and not 500.