### PR TITLE
Add friendly name Auth GetUser API

### DIFF
--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -1764,6 +1764,7 @@ func (c *Controller) GetUser(w http.ResponseWriter, r *http.Request, userID stri
 		CreationDate: u.CreatedAt.Unix(),
 		Email:        u.Email,
 		Id:           u.Username,
+		FriendlyName: u.FriendlyName,
 	}
 	writeResponse(w, r, http.StatusOK, response)
 }


### PR DESCRIPTION
Include friendly_name field in the response of the /api/v1/auth/users/{:id} endpoint to match the behavior of the user list endpoint.

closes #9073 
