### PR TITLE
Made Top Navigation Bar Sticky Across Pages

### DIFF
--- a/webui/src/lib/components/navbar.jsx
+++ b/webui/src/lib/components/navbar.jsx
@@ -67,7 +67,7 @@ const TopNavLink = ({ href, children }) => {
 const TopNav = ({logged = true}) => {
     if (!logged) {
         return (
-            <Navbar variant="dark" bg="dark" expand="md">
+            <Navbar variant="dark" bg="dark" expand="md" className="border-bottom sticky-top">
             <Container fluid={true}>
                 <Link component={Navbar.Brand} href="/">
                     <img src="/logo.png" alt="lakeFS" className="logo"/>
@@ -77,7 +77,7 @@ const TopNav = ({logged = true}) => {
         );
     }
     return (
-        <Navbar variant="dark" bg="dark" expand="md" className="border-bottom">
+        <Navbar variant="dark" bg="dark" expand="md" className="border-bottom sticky-top">
             <Container fluid={true}>
                 <Link component={Navbar.Brand} href="/">
                     <img src="/logo.png" alt="lakeFS" className="logo"/>


### PR DESCRIPTION
Closes #9082

## Change Description

### Bug Fix

The top navigation bar in lakeFS was not fixed to the top of the pages when scrolling down, which caused it to scroll out of view. Fixed it so that the top navbar now remains sticky at the top across all pages.

![image](https://github.com/user-attachments/assets/54ffcb6e-6455-49b1-8869-9ed39c5c83fc)


### Testing Details

On local lakeFS OSS.
