### PR TITLE
Enable additional API services to register on startup

### DIFF
--- a/cmd/lakefs/cmd/run.go
+++ b/cmd/lakefs/cmd/run.go
@@ -18,6 +18,7 @@ import (
 	"github.com/go-co-op/gocron"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
+	apifactory "github.com/treeverse/lakefs/modules/api/factory"
 	authfactory "github.com/treeverse/lakefs/modules/auth/factory"
 	authenticationfactory "github.com/treeverse/lakefs/modules/authentication/factory"
 	blockfactory "github.com/treeverse/lakefs/modules/block/factory"
@@ -305,6 +306,21 @@ var runCmd = &cobra.Command{
 		}
 
 		actionsService.SetEndpoint(server)
+
+		// register additional API services
+		err = apifactory.RegisterServices(ctx, apifactory.ServiceDependencies{
+			Config:                cfg,
+			Authenticator:         middlewareAuthenticator,
+			AuthService:           authService,
+			AuthenticationService: authenticationService,
+			BlockAdapter:          blockStore,
+			Collector:             bufferedCollector,
+			Logger:                logger,
+			LicenseManager:        licenseManager,
+		}, apiHandler)
+		if err != nil {
+			logger.WithError(err).Fatal("Failed to register services on router")
+		}
 
 		go func() {
 			var err error

--- a/go.work
+++ b/go.work
@@ -2,6 +2,7 @@ go 1.23.0
 
 use (
 	.
+	./modules/api/factory
 	./modules/auth/factory
 	./modules/authentication/factory
 	./modules/block/factory

--- a/modules/api/factory/build.go
+++ b/modules/api/factory/build.go
@@ -1,0 +1,29 @@
+package factory
+
+import (
+	"context"
+
+	"github.com/go-chi/chi/v5"
+	"github.com/treeverse/lakefs/pkg/auth"
+	"github.com/treeverse/lakefs/pkg/authentication"
+	"github.com/treeverse/lakefs/pkg/block"
+	"github.com/treeverse/lakefs/pkg/config"
+	"github.com/treeverse/lakefs/pkg/license"
+	"github.com/treeverse/lakefs/pkg/logging"
+	"github.com/treeverse/lakefs/pkg/stats"
+)
+
+type ServiceDependencies struct {
+	Config                config.Config
+	AuthService           auth.Service
+	Authenticator         auth.Authenticator
+	AuthenticationService authentication.Service
+	BlockAdapter          block.Adapter
+	Collector             stats.Collector
+	Logger                logging.Logger
+	LicenseManager        license.Manager
+}
+
+func RegisterServices(ctx context.Context, sd ServiceDependencies, router *chi.Mux) error {
+	return nil
+}

--- a/modules/api/factory/go.mod
+++ b/modules/api/factory/go.mod
@@ -1,0 +1,5 @@
+module github.com/treeverse/lakefs/modules/api/factory
+
+go 1.23.0
+
+// This module uses the go.work file to get all package dependencies from lakefs

--- a/modules/api/factory/go.mod
+++ b/modules/api/factory/go.mod
@@ -3,3 +3,5 @@ module github.com/treeverse/lakefs/modules/api/factory
 go 1.23.0
 
 // This module uses the go.work file to get all package dependencies from lakefs
+
+require github.com/go-chi/chi/v5 v5.0.10

--- a/modules/api/factory/go.sum
+++ b/modules/api/factory/go.sum
@@ -1,0 +1,1 @@
+github.com/go-chi/chi/v5 v5.0.10 h1:rLz5avzKpjqxrYwXNfmjkrYYXOyLJd37pz53UFHC6vk=

--- a/modules/authentication/factory/build.go
+++ b/modules/authentication/factory/build.go
@@ -3,6 +3,7 @@ package factory
 import (
 	"context"
 	"fmt"
+
 	"github.com/treeverse/lakefs/pkg/auth"
 	authremote "github.com/treeverse/lakefs/pkg/auth/remoteauthenticator"
 	"github.com/treeverse/lakefs/pkg/authentication"
@@ -30,7 +31,6 @@ func BuildAuthenticatorChain(c config.Config, logger logging.Logger, authService
 		remoteAuthenticator, err := authremote.NewAuthenticator(authremote.AuthenticatorConfig(authConfig.RemoteAuthenticator), authService, logger)
 		if err != nil {
 			return authenticators, fmt.Errorf("failed to create remote authenticator: %w", err)
-
 		}
 
 		authenticators = append(authenticators, remoteAuthenticator)

--- a/pkg/api/serve.go
+++ b/pkg/api/serve.go
@@ -33,7 +33,7 @@ const (
 	extensionValidationExcludeBody = "x-validation-exclude-body"
 )
 
-func Serve(cfg config.Config, catalog *catalog.Catalog, authenticator auth.Authenticator, authService auth.Service, authenticationService authentication.Service, blockAdapter block.Adapter, metadataManager auth.MetadataManager, migrator Migrator, collector stats.Collector, actions actionsHandler, auditChecker AuditChecker, logger logging.Logger, gatewayDomains []string, snippets []params.CodeSnippet, pathProvider upload.PathProvider, usageReporter stats.UsageReporterOperations, licenseManager license.Manager) http.Handler {
+func Serve(cfg config.Config, catalog *catalog.Catalog, authenticator auth.Authenticator, authService auth.Service, authenticationService authentication.Service, blockAdapter block.Adapter, metadataManager auth.MetadataManager, migrator Migrator, collector stats.Collector, actions actionsHandler, auditChecker AuditChecker, logger logging.Logger, gatewayDomains []string, snippets []params.CodeSnippet, pathProvider upload.PathProvider, usageReporter stats.UsageReporterOperations, licenseManager license.Manager) *chi.Mux {
 	logger.Info("initialize OpenAPI server")
 	swagger, err := apigen.GetSwagger()
 	if err != nil {


### PR DESCRIPTION
Simplify extension of LakeFS API services by allowing child modules to receive the parent module's router instance and utilize it without modifying service configurations.

