### PR TITLE
UI: Fix playwright e2e test code to match new changes

### DIFF
--- a/webui/test/e2e/common/quickstart.spec.ts
+++ b/webui/test/e2e/common/quickstart.spec.ts
@@ -37,7 +37,7 @@ test.describe("Quickstart", () => {
 
         const repositoryPage = new RepositoryPage(page);
         await repositoryPage.clickObject(PARQUET_OBJECT_NAME);
-        await expect(page.getByText("Loading...")).not.toBeVisible();
+        await expect(page.getByRole("button", { name: "Execute" })).toBeVisible();
 
         const objectViewerPage = new ObjectViewerPage(page);
         await objectViewerPage.enterQuery(SELECT_QUERY);
@@ -55,7 +55,7 @@ test.describe("Quickstart", () => {
 
         await repositoryPage.gotoObjectsTab();
         await repositoryPage.clickObject(PARQUET_OBJECT_NAME);
-        await expect(page.getByText("Loading...")).not.toBeVisible();
+        await expect(page.getByRole("button", { name: "Execute" })).toBeVisible();
 
         const objectViewerPage = new ObjectViewerPage(page);
         await objectViewerPage.enterQuery(CREATE_TABLE_QUERY);
@@ -96,7 +96,7 @@ test.describe("Quickstart", () => {
         await repositoriesPage.goto();
         await repositoriesPage.goToRepository(QUICKSTART_REPO_NAME);
         await repositoryPage.clickObject(PARQUET_OBJECT_NAME);
-        await expect(page.getByText("Loading...")).not.toBeVisible();
+        await expect(page.getByRole("button", { name: "Execute" })).toBeVisible();
         const objectViewerPage = new ObjectViewerPage(page);
         await objectViewerPage.enterQuery(SELECT_QUERY);
         await objectViewerPage.clickExecuteButton();

--- a/webui/test/e2e/common/setup.spec.ts
+++ b/webui/test/e2e/common/setup.spec.ts
@@ -13,7 +13,7 @@ test.describe("Setup Page", () => {
         await page.waitForURL(/.*\/setup/);
     });
 
-    test("username has a defualt value of 'admin'", async ({ page }) => {
+    test("username has a default value of 'admin'", async ({ page }) => {
         const setupPage = new SetupPage(page);
         await setupPage.goto();
         const usernameInput = setupPage.usernameInputLocator;

--- a/webui/test/e2e/common/test-upload.txt
+++ b/webui/test/e2e/common/test-upload.txt
@@ -1,0 +1,1 @@
+This is a test file for Playwright upload.

--- a/webui/test/e2e/common/uploadFile.spec.ts
+++ b/webui/test/e2e/common/uploadFile.spec.ts
@@ -29,18 +29,17 @@ test.describe("Upload File", () => {
 			await repositoryPage.uploadObject(filePath);
 			
 			// upload file, check path 
-			await expect(page.getByRole('complementary')).toContainText(`lakefs://${TEST_REPO_NAME}/${TEST_BRANCH}/${FILE_NAME}`);
-			await page.getByRole('button', { name: 'Upload', exact: true }).click();
-            await expect(page.getByRole('rowgroup')).toContainText(FILE_NAME);
+			await expect(page.getByText(FILE_NAME)).toBeVisible();
+			await page.getByRole('button', { name: 'Upload 1 File' }).click();
+            await expect(page.getByRole('cell', {name: FILE_NAME})).toBeVisible();
 
 			// upload again with prefix, check path
 			await repositoryPage.uploadObject(filePath);
-			await page.locator('#path').click();
-			await page.locator('#path').fill(PREFIX);
-			await expect(page.getByRole('complementary')).toContainText(`lakefs://${TEST_REPO_NAME}/${TEST_BRANCH}/${PREFIX}${FILE_NAME}`);
-			await page.getByRole('button', { name: 'Upload', exact: true }).click();
-			await page.getByRole('link', { name: PREFIX }).click();
- 			await expect(page.getByRole('row')).toContainText(FILE_NAME);
+			await page.getByRole('textbox', { name: 'Common Destination Directory' }).fill(PREFIX);
+			await expect(page.getByText(PREFIX+FILE_NAME)).toBeVisible();
+			await page.getByRole('button', { name: 'Upload 1 File' }).click();
+			await page.getByRole('cell', { name: PREFIX }).click();
+ 			await expect(page.getByRole('cell', { name: FILE_NAME })).toBeVisible();
 
 	});
 })

--- a/webui/test/e2e/common/viewParquetObject.spec.ts
+++ b/webui/test/e2e/common/viewParquetObject.spec.ts
@@ -22,7 +22,7 @@ test.describe("Object Viewer - Parquet File", () => {
 
         const repositoryPage = new RepositoryPage(page);
         await repositoryPage.clickObject(PARQUET_OBJECT_NAME);
-        await expect(page.getByText("Loading...")).not.toBeVisible();
+        await expect(page.getByRole("button", { name: "Execute" })).toBeVisible();
     });
 
     test("view parquet object w/ logout and login", async ({page}) => {

--- a/webui/test/e2e/poms/repositoriesPage.ts
+++ b/webui/test/e2e/poms/repositoriesPage.ts
@@ -1,7 +1,7 @@
 import { Locator, Page, expect } from "@playwright/test";
 
 const SAMPLE_REPO_README_TITLE = "Welcome to the Lake!";
-const REGULAR_REPO_README_TITLE = "To get started with this repository:";
+const REGULAR_REPO_README_TITLE = "Your repository is ready!";
 
 export class RepositoriesPage {
     private page: Page;
@@ -16,9 +16,9 @@ export class RepositoriesPage {
         this.page = page;
         this.noRepositoriesTitleLocator = this.page.getByText("Welcome to LakeFS!");
         this.readOnlyIndicatorLocator = this.page.locator("text=Read-only");
-        this.uploadButtonLocator = this.page.locator("text=Upload Object");
+        this.uploadButtonLocator = this.page.locator("text=Upload Object").first();
         this.createRepositoryButtonLocator = this.page.getByRole("button", { name: "Create Repository" });
-        this.searchInputLocator = this.page.getByPlaceholder("Find a repository...");
+        this.searchInputLocator = this.page.getByPlaceholder("Search repositories...");
     }
 
     async goto(): Promise<void> {
@@ -36,9 +36,9 @@ export class RepositoriesPage {
 
     async createRepository(repoName: string, includeSampleData: boolean): Promise<void> {
         await this.createRepositoryButtonLocator.click();
-        await this.page.getByLabel("Repository ID").fill(repoName);
+        await this.page.getByRole('textbox', { name: 'Repository ID' }).fill(repoName);
         if (includeSampleData) {
-            await this.page.getByLabel("Add sample data, hooks, and configuration").check();
+            await this.page.getByRole('checkbox', { name: 'Add sample data, hooks' }).check();
         }
         await this.page.getByRole("dialog").getByRole("button", { name: "Create Repository", exact: true }).click();
         if (includeSampleData) {

--- a/webui/test/e2e/poms/repositoryPage.ts
+++ b/webui/test/e2e/poms/repositoryPage.ts
@@ -44,27 +44,12 @@ export class RepositoryPage {
   // file manipulation operations
 
   async deleteFirstObjectInDirectory(dirName: string): Promise<void> {
-    await this.page.getByRole("link", {name: dirName}).click();
-
-    const getFirstObjectRow = (page: Page) => page
-        .locator("table.table")
-        .locator("tbody")
-        .locator("tr")
-        .first();
-
-    await getFirstObjectRow(this.page)
-        .locator("div.dropdown")
-        .hover();
-    await getFirstObjectRow(this.page)
-        .locator("div.dropdown")
-        .locator("button")
-        .click();
-    await this.page
-        .locator("div.dropdown")
-        .locator(".dropdown-item")
-        .last()
-        .click();
-    await this.page.getByRole("button", {name: "Yes"}).click();
+    await this.page.getByRole("link", { name: dirName }).click();
+    const firstRow = this.page.locator('table tbody tr').first();
+    await firstRow.hover();
+    await firstRow.locator('button').last().click();
+    await this.page.getByRole('button', { name: 'Delete' }).click();
+    await this.page.getByRole("button", { name: "Yes" }).click();
   }
 
   // uncommitted changes operations
@@ -132,9 +117,9 @@ export class RepositoryPage {
   }
 
   async uploadObject(filePath: string): Promise<void> {
-	await this.page.getByRole("button", { name: "Upload Object" }).click();
-	await this.page.getByText("Drag 'n' drop files or").click();
-	const fileInput = await this.page.locator('input[type="file"]');
-	await fileInput.setInputFiles(filePath);
+    await this.page.getByRole("button", { name: "Upload Object" }).click();
+    await this.page.getByText("Drag & drop files or folders here").click();
+    const fileInput = await this.page.locator('input[type="file"]');
+    await fileInput.setInputFiles(filePath);
   }
 }


### PR DESCRIPTION
Fixes for e2e web ui test code to match the UI changes. Note that this changes is over the `feat/ui-overhaul` branch and not on main.

Manually triggered tests: https://github.com/treeverse/lakeFS/actions/runs/15234942866/job/42847621330