### PR TITLE
Unskip TestUnifiedGC in ESTI tests

### DIFF
--- a/.github/workflows/esti.yaml
+++ b/.github/workflows/esti.yaml
@@ -157,102 +157,6 @@ jobs:
       docker_username: ${{ steps.login-ecr.outputs.docker_username_977611293394_dkr_ecr_us_east_1_amazonaws_com }}
       docker_password: ${{ steps.login-ecr.outputs.docker_password_977611293394_dkr_ecr_us_east_1_amazonaws_com }}
 
-  unified-gc-test:
-    name: Test unified gc
-    needs: [deploy-image, login-to-amazon-ecr, build-spark3-metadata-client]
-    runs-on: ubuntu-22.04-8-cores
-    services:
-      lakefs:
-        image: ${{ needs.login-to-amazon-ecr.outputs.registry }}/lakefs:${{ needs.deploy-image.outputs.tag }}
-        credentials:
-          username: ${{ needs.login-to-amazon-ecr.outputs.docker_username }}
-          password: ${{ needs.login-to-amazon-ecr.outputs.docker_password }}
-        ports:
-          - '8000:8000'
-        env:
-          LAKEFS_DATABASE_TYPE: local
-          LAKEFS_BLOCKSTORE_TYPE: s3
-          LAKEFS_BLOCKSTORE_S3_CREDENTIALS_ACCESS_KEY_ID: ${{ secrets.ESTI_AWS_ACCESS_KEY_ID }}
-          LAKEFS_BLOCKSTORE_S3_CREDENTIALS_SECRET_ACCESS_KEY: ${{ secrets.ESTI_AWS_SECRET_ACCESS_KEY }}
-          LAKEFS_AUTH_ENCRYPT_SECRET_KEY: some random secret string
-          LAKEFS_STATS_ENABLED: false
-
-      spark:
-        image: docker.io/bitnami/spark:3.2.1
-        options: --name spark-master
-        env:
-          SPARK_MODE: master
-          SPARK_RPC_AUTHENTICATION_ENABLED: no
-          SPARK_RPC_ENCRYPTION_ENABLED: no
-          SPARK_LOCAL_STORAGE_ENCRYPTION_ENABLED: no
-          SPARK_SSL_ENABLED: no
-          AWS_REGION: us-east-1
-          AWS_ACCESS_KEY_ID: ${{ secrets.ESTI_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.ESTI_AWS_SECRET_ACCESS_KEY }}
-        ports:
-          - '8080:8080'
-          - '7077:7077'
-
-      spark-worker:
-        image: docker.io/bitnami/spark:3.2.1
-        env:
-          SPARK_MODE: worker
-          SPARK_MASTER_URL: spark://spark:7077
-          SPARK_WORKER_MEMORY: 4G
-          SPARK_WORKER_CORES: 4
-          SPARK_RPC_AUTHENTICATION_ENABLED: no
-          SPARK_RPC_ENCRYPTION_ENABLED: no
-          SPARK_LOCAL_STORAGE_ENCRYPTION_ENABLED: no
-          SPARK_SSL_ENABLED: no
-          AWS_REGION: us-east-1
-          AWS_ACCESS_KEY_ID: ${{ secrets.ESTI_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.ESTI_AWS_SECRET_ACCESS_KEY }}
-    steps:
-      - name: Check-out code
-        uses: actions/checkout@v4
-
-      - name: Setup Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: "1.23"
-        id: go
-
-      - name: Generate uniquifying value
-        id: unique
-        run: echo "value=$RANDOM" >> $GITHUB_OUTPUT
-
-      - name: Retrieve generated code
-        uses: actions/download-artifact@v4.1.8
-        with:
-          name: generated-code
-          path: /tmp/
-
-      - name: Unpack generated code
-        shell: bash
-        run: tar -xzvf /tmp/generated.tar.gz
-
-      - name: Restore cache
-        uses: actions/cache@v4
-        id: restore-cache
-        with:
-          path: ${{ github.workspace }}/test/spark/metaclient
-          key: metadata-client-${{ hashFiles('./clients/spark/**') }}
-
-      - name: GC test
-        run: |
-          go test -timeout 30m -v ./esti \
-            -system-tests -use-local-credentials -run=TestUnifiedGC \
-            -spark-image-tag=3.2.1 \
-            -metaclient-jar=$(pwd)/test/spark/metaclient/spark-assembly.jar
-        env:
-          ESTI_BLOCKSTORE_TYPE: s3
-          ESTI_STORAGE_NAMESPACE: s3://esti-system-testing/${{ github.run_number }}/gc-tests/${{ steps.unique.outputs.value }}
-          AWS_REGION: us-east-1
-          AWS_ACCESS_KEY_ID: ${{ secrets.ESTI_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.ESTI_AWS_SECRET_ACCESS_KEY }}
-          ESTI_VERSION: ${{ needs.deploy-image.outputs.tag }}
-          ESTI_SETUP_LAKEFS: true
-
   deploy-rclone-export-image:
     name: Build and push rclone export Docker image
     needs: check-secrets
@@ -833,7 +737,7 @@ jobs:
 
   run-system-aws-s3:
     name: Run latest lakeFS app on AWS S3
-    needs: [deploy-image, login-to-amazon-ecr]
+    needs: [deploy-image, login-to-amazon-ecr, build-spark3-metadata-client]
     runs-on: ubuntu-22.04
     strategy:
       matrix:
@@ -843,6 +747,10 @@ jobs:
       REGISTRY: ${{ needs.login-to-amazon-ecr.outputs.registry }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      SPARK_IMAGE_TAG: 3.2.1
+      ESTI_FLAGS: >-
+        -spark-image-tag=${{ env.SPARK_IMAGE_TAG }}
+        -metaclient-jar=/lakefs/test/spark/metaclient/spark-assembly.jar
     steps:
       - name: Check-out code
         uses: actions/checkout@v4

--- a/esti/ops/docker-compose-common.yaml
+++ b/esti/ops/docker-compose-common.yaml
@@ -43,7 +43,7 @@ services:
       - ESTI_FORCE_PATH_STYLE=${ESTI_FORCE_PATH_STYLE:-true}
       - ESTI_AZURE_STORAGE_ACCOUNT
       - ESTI_AZURE_STORAGE_ACCESS_KEY
-      - ESTI_SKIP_TESTS=${ESTI_SKIP_TESTS:-TestUnifiedGC}
+      - ESTI_SKIP_TESTS
       - ESTI_LARGE_OBJECT_PATH
     working_dir: /lakefs
     command:
@@ -68,3 +68,33 @@ services:
     image: "amazon/dynamodb-local:2.5.2"
     ports:
       - "6432:8000"
+
+  spark:
+    image: docker.io/bitnami/spark:${SPARK_IMAGE_TAG}
+    environment:
+      - SPARK_MODE=master
+      - SPARK_RPC_AUTHENTICATION_ENABLED=no
+      - SPARK_RPC_ENCRYPTION_ENABLED=no
+      - SPARK_LOCAL_STORAGE_ENCRYPTION_ENABLED=no
+      - SPARK_SSL_ENABLED=no
+      - AWS_REGION=${AWS_REGION}
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+    ports:
+      - "7077:7077"
+      - "8080:8080"
+
+  spark-worker:
+    image: docker.io/bitnami/spark:${SPARK_IMAGE_TAG}
+    environment:
+      - SPARK_MODE=worker
+      - SPARK_MASTER_URL=spark://spark:7077
+      - SPARK_WORKER_MEMORY=4G
+      - SPARK_WORKER_CORES=1
+      - SPARK_RPC_AUTHENTICATION_ENABLED=no
+      - SPARK_RPC_ENCRYPTION_ENABLED=no
+      - SPARK_LOCAL_STORAGE_ENCRYPTION_ENABLED=no
+      - SPARK_SSL_ENABLED=no
+      - AWS_REGION=${AWS_REGION}
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}


### PR DESCRIPTION
Remove unified GC test workflow and integrate Spark setup  

The unified GC test workflow was removed from `.github/workflows/esti.yaml`, and relevant Spark configuration was refactored into `docker-compose-common.yaml`. This simplifies the pipeline while retaining Spark setup for relevant use cases.