### PR TITLE
Refactor Spark integration and simplify GC testing.

### DIFF
--- a/.github/workflows/esti.yaml
+++ b/.github/workflows/esti.yaml
@@ -157,102 +157,6 @@ jobs:
       docker_username: ${{ steps.login-ecr.outputs.docker_username_977611293394_dkr_ecr_us_east_1_amazonaws_com }}
       docker_password: ${{ steps.login-ecr.outputs.docker_password_977611293394_dkr_ecr_us_east_1_amazonaws_com }}
 
-  unified-gc-test:
-    name: Test unified gc
-    needs: [deploy-image, login-to-amazon-ecr, build-spark3-metadata-client]
-    runs-on: ubuntu-22.04-8-cores
-    services:
-      lakefs:
-        image: ${{ needs.login-to-amazon-ecr.outputs.registry }}/lakefs:${{ needs.deploy-image.outputs.tag }}
-        credentials:
-          username: ${{ needs.login-to-amazon-ecr.outputs.docker_username }}
-          password: ${{ needs.login-to-amazon-ecr.outputs.docker_password }}
-        ports:
-          - '8000:8000'
-        env:
-          LAKEFS_DATABASE_TYPE: local
-          LAKEFS_BLOCKSTORE_TYPE: s3
-          LAKEFS_BLOCKSTORE_S3_CREDENTIALS_ACCESS_KEY_ID: ${{ secrets.ESTI_AWS_ACCESS_KEY_ID }}
-          LAKEFS_BLOCKSTORE_S3_CREDENTIALS_SECRET_ACCESS_KEY: ${{ secrets.ESTI_AWS_SECRET_ACCESS_KEY }}
-          LAKEFS_AUTH_ENCRYPT_SECRET_KEY: some random secret string
-          LAKEFS_STATS_ENABLED: false
-
-      spark:
-        image: docker.io/bitnami/spark:3.2.1
-        options: --name spark-master
-        env:
-          SPARK_MODE: master
-          SPARK_RPC_AUTHENTICATION_ENABLED: no
-          SPARK_RPC_ENCRYPTION_ENABLED: no
-          SPARK_LOCAL_STORAGE_ENCRYPTION_ENABLED: no
-          SPARK_SSL_ENABLED: no
-          AWS_REGION: us-east-1
-          AWS_ACCESS_KEY_ID: ${{ secrets.ESTI_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.ESTI_AWS_SECRET_ACCESS_KEY }}
-        ports:
-          - '8080:8080'
-          - '7077:7077'
-
-      spark-worker:
-        image: docker.io/bitnami/spark:3.2.1
-        env:
-          SPARK_MODE: worker
-          SPARK_MASTER_URL: spark://spark:7077
-          SPARK_WORKER_MEMORY: 4G
-          SPARK_WORKER_CORES: 4
-          SPARK_RPC_AUTHENTICATION_ENABLED: no
-          SPARK_RPC_ENCRYPTION_ENABLED: no
-          SPARK_LOCAL_STORAGE_ENCRYPTION_ENABLED: no
-          SPARK_SSL_ENABLED: no
-          AWS_REGION: us-east-1
-          AWS_ACCESS_KEY_ID: ${{ secrets.ESTI_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.ESTI_AWS_SECRET_ACCESS_KEY }}
-    steps:
-      - name: Check-out code
-        uses: actions/checkout@v4
-
-      - name: Setup Go
-        uses: actions/setup-go@v4
-        with:
-          go-version: "1.23"
-        id: go
-
-      - name: Generate uniquifying value
-        id: unique
-        run: echo "value=$RANDOM" >> $GITHUB_OUTPUT
-
-      - name: Retrieve generated code
-        uses: actions/download-artifact@v4.1.8
-        with:
-          name: generated-code
-          path: /tmp/
-
-      - name: Unpack generated code
-        shell: bash
-        run: tar -xzvf /tmp/generated.tar.gz
-
-      - name: Restore cache
-        uses: actions/cache@v4
-        id: restore-cache
-        with:
-          path: ${{ github.workspace }}/test/spark/metaclient
-          key: metadata-client-${{ hashFiles('./clients/spark/**') }}
-
-      - name: GC test
-        run: |
-          go test -timeout 30m -v ./esti \
-            -system-tests -use-local-credentials -run=TestUnifiedGC \
-            -spark-image-tag=3.2.1 \
-            -metaclient-jar=$(pwd)/test/spark/metaclient/spark-assembly.jar
-        env:
-          ESTI_BLOCKSTORE_TYPE: s3
-          ESTI_STORAGE_NAMESPACE: s3://esti-system-testing/${{ github.run_number }}/gc-tests/${{ steps.unique.outputs.value }}
-          AWS_REGION: us-east-1
-          AWS_ACCESS_KEY_ID: ${{ secrets.ESTI_AWS_ACCESS_KEY_ID }}
-          AWS_SECRET_ACCESS_KEY: ${{ secrets.ESTI_AWS_SECRET_ACCESS_KEY }}
-          ESTI_VERSION: ${{ needs.deploy-image.outputs.tag }}
-          ESTI_SETUP_LAKEFS: true
-
   deploy-rclone-export-image:
     name: Build and push rclone export Docker image
     needs: check-secrets
@@ -769,6 +673,8 @@ jobs:
       REGISTRY: ${{ needs.login-to-amazon-ecr.outputs.registry }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      SPARK_IMAGE_TAG: 3.2.1
+      ESTI_FLAGS: -metaclient-jar=/lakefs/test/spark/metaclient/spark-assembly.jar -spark-image-tag=3.2.1
     steps:
       - name: Check-out code
         uses: actions/checkout@v4
@@ -787,6 +693,12 @@ jobs:
       - name: Unpack generated code
         run: tar -xzvf /tmp/generated.tar.gz
 
+      - name: Prepare Spark binary
+        uses: actions/download-artifact@v4
+        with:
+          name: spark-binary
+          path: ./spark
+
       # Run ACL server
       - name: Run ACL server
         env:
@@ -797,7 +709,9 @@ jobs:
       - name: Test lakeFS with S3 tests KV
         uses: ./.github/actions/bootstrap-test-lakefs
         with:
-          compose-file: esti/ops/docker-compose-dynamodb.yaml
+          compose-file: |
+            esti/ops/docker-compose-common.yaml
+            esti/ops/docker-compose-dynamodb.yaml
           compose-flags: "--quiet-pull --exit-code-from=esti"
         env:
           LAKEFS_AUTH_UI_CONFIG_RBAC: simplified
@@ -843,6 +757,8 @@ jobs:
       REGISTRY: ${{ needs.login-to-amazon-ecr.outputs.registry }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      SPARK_IMAGE_TAG: 3.2.1
+      ESTI_FLAGS: -metaclient-jar=/lakefs/test/spark/metaclient/spark-assembly.jar -spark-image-tag=3.2.1
     steps:
       - name: Check-out code
         uses: actions/checkout@v4
@@ -861,6 +777,12 @@ jobs:
       - name: Unpack generated code
         run: tar -xzvf /tmp/generated.tar.gz
 
+      - name: Prepare Spark binary
+        uses: actions/download-artifact@v4
+        with:
+          name: spark-binary
+          path: ./spark
+
       # Run ACL server
       - name: Run ACL server
         env:
@@ -871,7 +793,9 @@ jobs:
       - name: Test lakeFS with S3 tests
         uses: ./.github/actions/bootstrap-test-lakefs
         with:
-          compose-file: esti/ops/docker-compose.yaml
+          compose-file: |
+            esti/ops/docker-compose-common.yaml
+            esti/ops/docker-compose.yaml
           compose-flags: "--quiet-pull --exit-code-from=esti"
         env:
           LAKEFS_AUTH_UI_CONFIG_RBAC: simplified
@@ -915,6 +839,8 @@ jobs:
       REGISTRY: ${{ needs.login-to-amazon-ecr.outputs.registry }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      SPARK_IMAGE_TAG: 3.2.1
+      ESTI_FLAGS: -metaclient-jar=/lakefs/test/spark/metaclient/spark-assembly.jar -spark-image-tag=3.2.1
     steps:
       - name: Check-out code
         uses: actions/checkout@v4
@@ -933,6 +859,12 @@ jobs:
       - name: Unpack generated code
         run: tar -xzvf /tmp/generated.tar.gz
 
+      - name: Prepare Spark binary
+        uses: actions/download-artifact@v4
+        with:
+          name: spark-binary
+          path: ./spark
+
       # Run ACL server
       - name: Run ACL server
         env:
@@ -943,7 +875,9 @@ jobs:
       - name: Start lakeFS with GS tests
         uses: ./.github/actions/bootstrap-test-lakefs
         with:
-          compose-file: esti/ops/docker-compose.yaml
+          compose-file: |
+            esti/ops/docker-compose-common.yaml
+            esti/ops/docker-compose.yaml
           compose-flags: "--quiet-pull --exit-code-from=esti"
         env:
           DOCKER_REG: ${{ needs.login-to-amazon-ecr.outputs.registry }}
@@ -970,6 +904,8 @@ jobs:
       AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
       AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+      SPARK_IMAGE_TAG: 3.2.1
+      ESTI_FLAGS: -metaclient-jar=/lakefs/test/spark/metaclient/spark-assembly.jar -spark-image-tag=3.2.1
     steps:
       - name: Check-out code
         uses: actions/checkout@v4
@@ -988,6 +924,12 @@ jobs:
       - name: Unpack generated code
         run: tar -xzvf /tmp/generated.tar.gz
 
+      - name: Prepare Spark binary
+        uses: actions/download-artifact@v4
+        with:
+          name: spark-binary
+          path: ./spark
+
       # Run ACL server
       - name: Run ACL server
         env:
@@ -998,7 +940,9 @@ jobs:
       - name: Start lakeFS with Azure tests
         uses: ./.github/actions/bootstrap-test-lakefs
         with:
-          compose-file: esti/ops/docker-compose.yaml
+          compose-file: |
+            esti/ops/docker-compose-common.yaml
+            esti/ops/docker-compose.yaml
           compose-flags: "--quiet-pull --exit-code-from=esti"
         env:
           DOCKER_REG: ${{ needs.login-to-amazon-ecr.outputs.registry }}
@@ -1031,6 +975,8 @@ jobs:
       AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
       COSMOSDB_DATABASE: esti-db
       COSMOSDB_ACCOUNT: esti-e2e-tests
+      SPARK_IMAGE_TAG: 3.2.1
+      ESTI_FLAGS: -metaclient-jar=/lakefs/test/spark/metaclient/spark-assembly.jar -spark-image-tag=3.2.1
 
     steps:
       - name: Check-out code
@@ -1050,6 +996,12 @@ jobs:
       - name: Unpack generated code
         run: tar -xzvf /tmp/generated.tar.gz
 
+      - name: Prepare Spark binary
+        uses: actions/download-artifact@v4
+        with:
+          name: spark-binary
+          path: ./spark
+
       # Run ACL server
       - name: Run ACL server
         env:
@@ -1060,7 +1012,9 @@ jobs:
       - name: Start lakeFS with Azure tests
         uses: ./.github/actions/bootstrap-test-lakefs
         with:
-          compose-file: esti/ops/docker-compose-external-db.yaml
+          compose-file: |
+            esti/ops/docker-compose-common.yaml
+            esti/ops/docker-compose-external-db.yaml
           compose-flags: "--quiet-pull --exit-code-from=esti"
         env:
           DOCKER_REG: ${{ needs.login-to-amazon-ecr.outputs.registry }}
@@ -1384,6 +1338,8 @@ jobs:
       REGISTRY: ${{ needs.login-to-amazon-ecr.outputs.registry }}
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      SPARK_IMAGE_TAG: 3.2.1
+      ESTI_FLAGS: -metaclient-jar=/lakefs/test/spark/metaclient/spark-assembly.jar -spark-image-tag=3.2.1
     steps:
       - name: Check-out code
         uses: actions/checkout@v4
@@ -1392,10 +1348,18 @@ jobs:
         id: unique
         run: echo "value=$RANDOM" >> $GITHUB_OUTPUT
 
+      - name: Prepare Spark binary
+        uses: actions/download-artifact@v4
+        with:
+          name: spark-binary
+          path: ./spark
+
       - name: Test lakeFS with S3 tests + Basic Auth
         uses: ./.github/actions/bootstrap-test-lakefs
         with:
-          compose-file: esti/ops/docker-compose.yaml
+          compose-file: |
+            esti/ops/docker-compose-common.yaml
+            esti/ops/docker-compose.yaml
           compose-flags: "--quiet-pull --exit-code-from=esti"
         env:
           LAKEFS_BLOCKSTORE_TYPE: s3

--- a/esti/gc_test_utils.go
+++ b/esti/gc_test_utils.go
@@ -2,11 +2,10 @@ package esti
 
 import (
 	"bufio"
-	"fmt"
 	"io"
 	"os"
 	"os/exec"
-	"strings"
+	"path/filepath"
 
 	"github.com/treeverse/lakefs/pkg/api/apiutil"
 	"github.com/treeverse/lakefs/pkg/logging"
@@ -14,7 +13,7 @@ import (
 
 func getSparkSubmitArgs(entryPoint string) []string {
 	return []string{
-		"--master", "spark://localhost:7077",
+		"--master", "spark://spark-master:7077",
 		"--conf", "spark.driver.extraJavaOptions=-Divy.cache.dir=/tmp -Divy.home=/tmp",
 		"--conf", "spark.hadoop.lakefs.api.url=http://lakefs:8000" + apiutil.BaseURL,
 		"--conf", "spark.hadoop.lakefs.api.access_key=AKIAIOSFDNN7EXAMPLEQ",
@@ -23,81 +22,35 @@ func getSparkSubmitArgs(entryPoint string) []string {
 	}
 }
 
-func getDockerArgs(workingDirectory string, localJar string) []string {
-	return []string{
-		"run", "--network", "host", "--add-host", "lakefs:127.0.0.1",
-		"-v", fmt.Sprintf("%s/ivy:/opt/bitnami/spark/.ivy2", workingDirectory),
-		"-v", fmt.Sprintf("%s:/opt/metaclient/client.jar", localJar),
-		"--rm",
-		"-e", "AWS_ACCESS_KEY_ID",
-		"-e", "AWS_SECRET_ACCESS_KEY",
-	}
-}
+func runCommand(cmdName string, args []string) error {
+	cmd := exec.Command(
+		filepath.Join(os.Getenv("SPARK_HOME"), "bin", "spark-submit"),
+		args...,
+	)
+	stdout, _ := cmd.StdoutPipe()
+	stderr, _ := cmd.StderrPipe()
+	errs := make(chan error, 2)
 
-// handlePipe calls log on each line of pipe, and writes nil or an error to
-// ch when done.
-func handlePipe(pipe io.ReadCloser, log func(messages ...interface{}), ch chan<- error) {
-	reader := bufio.NewReader(pipe)
-	go func() {
-		var err error
-		for {
-			str, err := reader.ReadString('\n')
-			if err != nil {
-				break
-			}
-			log(strings.TrimSuffix(str, "\n"))
-		}
-		if err == io.EOF {
-			err = nil
-		}
-		ch <- err
-	}()
-}
+	go streamLog(stdout, cmdName, "out", errs)
+	go streamLog(stderr, cmdName, "err", errs)
 
-// runCommand runs cmd. It logs the outputs of cmd with an appropriate field
-// to distinguish stdout from stderr.
-func runCommand(cmdName string, cmd *exec.Cmd) error {
-	stdoutPipe, err := cmd.StdoutPipe()
-	if err != nil {
-		return fmt.Errorf("failed to get stdout from command: %w", err)
-	}
-	stderrPipe, err := cmd.StderrPipe()
-	if err != nil {
-		return fmt.Errorf("failed to get stderr from command: %w", err)
-	}
-
-	const channelSize = 2
-	cmdErrs := make(chan error, channelSize)
-	handlePipe(stdoutPipe, logger.WithFields(logging.Fields{
-		"source": cmdName,
-		"std":    "out",
-	}).Info, cmdErrs)
-	handlePipe(stderrPipe, logger.WithFields(logging.Fields{
-		"source": cmdName,
-		"std":    "err",
-	}).Info, cmdErrs)
-
-	err = cmd.Start()
-	if err != nil {
+	if err := cmd.Start(); err != nil {
 		return err
 	}
-
-	err = <-cmdErrs
-	if err != nil {
-		logger.WithFields(logging.Fields{"source": cmdName, "component": "handlePipe"}).WithError(err).Error("Error reading command pipe")
-	}
-	err = <-cmdErrs
-	if err != nil {
-		logger.WithFields(logging.Fields{"source": cmdName, "component": "handlePipe"}).WithError(err).Error("Error reading command pipe")
-	}
+	<-errs
+	<-errs
 	return cmd.Wait()
 }
 
+func streamLog(r io.Reader, src, std string, ch chan<- error) {
+	scanner := bufio.NewScanner(r)
+	for scanner.Scan() {
+		logger.WithFields(logging.Fields{"source": src, "std": std}).Info(scanner.Text())
+	}
+	ch <- scanner.Err()
+}
+
 type SparkSubmitConfig struct {
-	SparkVersion string
-	// LocalJar is a local path to a jar that contains the main class.
-	LocalJar string
-	// EntryPoint is the class name to run
 	EntryPoint      string
 	ExtraSubmitArgs []string
 	ProgramArgs     []string
@@ -105,20 +58,9 @@ type SparkSubmitConfig struct {
 }
 
 func RunSparkSubmit(config *SparkSubmitConfig) error {
-	workingDirectory, err := os.Getwd()
-	if err != nil {
-		return fmt.Errorf("getting working directory: %w", err)
-	}
-	workingDirectory = strings.TrimSuffix(workingDirectory, "/")
-	dockerArgs := getDockerArgs(workingDirectory, config.LocalJar)
-	dockerArgs = append(dockerArgs, fmt.Sprintf("docker.io/bitnami/spark:%s", config.SparkVersion), "spark-submit")
-	sparkSubmitArgs := getSparkSubmitArgs(config.EntryPoint)
-	sparkSubmitArgs = append(sparkSubmitArgs, config.ExtraSubmitArgs...)
-	args := dockerArgs
-	args = append(args, sparkSubmitArgs...)
-	args = append(args, "/opt/metaclient/client.jar")
+	args := getSparkSubmitArgs(config.EntryPoint)
+	args = append(args, config.ExtraSubmitArgs...)
+	args = append(args, "/lakefs/test/spark/metaclient/spark-assembly.jar")
 	args = append(args, config.ProgramArgs...)
-	cmd := exec.Command("docker", args...)
-	logger.Infof("Running command: %s", cmd.String())
-	return runCommand(config.LogSource, cmd)
+	return runCommand(config.LogSource, args)
 }

--- a/esti/ops/docker-compose-common.yaml
+++ b/esti/ops/docker-compose-common.yaml
@@ -1,3 +1,4 @@
+version: "3"
 services:
   lakefs:
     image: "${REGISTRY:-treeverse}/${REPO:-lakefs}:${TAG:-dev}"
@@ -16,6 +17,40 @@ services:
       - LAKEFSACTION_VAR=this_is_actions_var
     extra_hosts:
       - "host.docker.internal:host-gateway"
+
+  spark:
+    image: "docker.io/bitnami/spark:${SPARK_IMAGE_TAG:-3.2.1}"
+    container_name: spark-master
+    environment:
+      - SPARK_MODE=master
+      - SPARK_MASTER_HOST=spark-master
+      - SPARK_RPC_AUTHENTICATION_ENABLED=no
+      - SPARK_RPC_ENCRYPTION_ENABLED=no
+      - SPARK_LOCAL_STORAGE_ENCRYPTION_ENABLED=no
+      - SPARK_SSL_ENABLED=no
+      - AWS_REGION=${AWS_REGION}
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
+    ports:
+      - "7077:7077"
+      - "8080:8080"
+
+  spark-worker:
+    image: "docker.io/bitnami/spark:${SPARK_IMAGE_TAG:-3.2.1}"
+    depends_on:
+      - spark
+    environment:
+      - SPARK_MODE=worker
+      - SPARK_MASTER_URL=spark://spark-master:7077
+      - SPARK_WORKER_MEMORY=4G
+      - SPARK_WORKER_CORES=1
+      - SPARK_RPC_AUTHENTICATION_ENABLED=no
+      - SPARK_RPC_ENCRYPTION_ENABLED=no
+      - SPARK_LOCAL_STORAGE_ENCRYPTION_ENABLED=no
+      - SPARK_SSL_ENABLED=no
+      - AWS_REGION=${AWS_REGION}
+      - AWS_ACCESS_KEY_ID=${AWS_ACCESS_KEY_ID}
+      - AWS_SECRET_ACCESS_KEY=${AWS_SECRET_ACCESS_KEY}
 
   esti:
     image: "golang:1.23-alpine"
@@ -43,18 +78,23 @@ services:
       - ESTI_FORCE_PATH_STYLE=${ESTI_FORCE_PATH_STYLE:-true}
       - ESTI_AZURE_STORAGE_ACCOUNT
       - ESTI_AZURE_STORAGE_ACCESS_KEY
-      - ESTI_SKIP_TESTS=${ESTI_SKIP_TESTS:-TestUnifiedGC}
+      - ESTI_SKIP_TESTS=${ESTI_SKIP_TESTS}
       - ESTI_LARGE_OBJECT_PATH
+      - SPARK_HOME=/opt/spark
     working_dir: /lakefs
     command:
       - /bin/sh
       - -c
       - |
-        apk add --no-cache util-linux 
+        apk add --no-cache util-linux docker-cli
         go test $$ESTI_GOTEST_FLAGS -skip $$ESTI_SKIP_TESTS -v ./esti --system-tests $$ESTI_FLAGS
     volumes:
       - lakefs-code:/lakefs
       - lakefs-app:/app:ro
+      - ./spark/ivy:/opt/bitnami/spark/.ivy2
+      - ./spark/spark-${SPARK_IMAGE_TAG:-3.2.1}-bin-hadoop3.2:/opt/spark:ro
+      - ./test/spark/metaclient/spark-assembly.jar:/lakefs/test/spark/metaclient/spark-assembly.jar:ro
+      - /var/run/docker.sock:/var/run/docker.sock
 
   postgres:
     image: "postgres:11"
@@ -68,3 +108,12 @@ services:
     image: "amazon/dynamodb-local:2.5.2"
     ports:
       - "6432:8000"
+
+volumes:
+  lakefs-code:
+    driver: local
+    driver_opts:
+      o: bind
+      type: none
+      device: ${LAKEFS_ROOT:-.}
+  lakefs-app:


### PR DESCRIPTION
Closes https://github.com/treeverse/lakeFS/issues/8457


Refactor Spark integration and simplify GC testing.

Replaced Dockerized Spark setup with direct Spark binary integration for improved execution. Consolidated and updated `docker-compose` files for Spark and other services. Removed deprecated GC test workflow, shifting Spark-specific configurations to a common setup.