### PR TITLE
Fix python client release check skip_publish_pypi

### DIFF
--- a/.github/workflows/python-api-client.yaml
+++ b/.github/workflows/python-api-client.yaml
@@ -34,7 +34,7 @@ jobs:
       run: make package-python-sdk PACKAGE_VERSION=${{ steps.version.outputs.tag }}
 
     - name: Python SDK publish package
-      if: ${{ inputs.skip_publish_pypi == true }}
+      if: ${{ inputs.skip_publish_pypi == 'false' }}
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         user: __token__


### PR DESCRIPTION
Fix https://github.com/treeverse/lakeFS/issues/9108