### PR TITLE
Docs: better visibility for OSS vs Enterprise features

### DIFF
--- a/docs/_includes/nav.html
+++ b/docs/_includes/nav.html
@@ -30,7 +30,11 @@
            class="nav-list-link{% if page.url == node.url %} active{% endif %}">{{ node.title }}
            {%- if node.badges -%}
              {%- for badge in node.badges -%}
-               <span class="badge badge-{{ badge | downcase }}">{{ badge }}</span>
+               {%- if badge.name -%}
+                 <span class="badge badge-{{ badge.name | downcase }}" title="{{ badge.name }}">{{ badge.display_name | default: badge.name }}</span>
+               {%- else -%}
+                 <span class="badge badge-{{ badge | downcase }}" title="{{ badge }}">{{ badge }}</span>
+               {%- endif -%}
              {%- endfor -%}
            {%- endif -%}
         </a>
@@ -52,7 +56,11 @@
                    class="nav-list-link{% if page.url == child.url %} active{% endif %}">{{ child.title }}
                    {%- if child.badges -%}
                      {%- for badge in child.badges -%}
-                       <span class="badge badge-{{ badge | downcase }}">{{ badge }}</span>
+                       {%- if badge.name -%}
+                         <span class="badge badge-{{ badge.name | downcase }}" title="{{ badge.name }}">{{ badge.display_name | default: badge.name }}</span>
+                       {%- else -%}
+                         <span class="badge badge-{{ badge | downcase }}" title="{{ badge }}">{{ badge }}</span>
+                       {%- endif -%}
                      {%- endfor -%}
                    {%- endif -%}
                 </a>
@@ -65,7 +73,11 @@
                            class="nav-list-link{% if page.url == grand_child.url %} active{% endif %}">{{ grand_child.title }}
                            {%- if grand_child.badges -%}
                              {%- for badge in grand_child.badges -%}
-                               <span class="badge badge-{{ badge | downcase }}">{{ badge }}</span>
+                               {%- if badge.name -%}
+                                 <span class="badge badge-{{ badge.name | downcase }}" title="{{ badge.name }}">{{ badge.display_name | default: badge.name }}</span>
+                               {%- else -%}
+                                 <span class="badge badge-{{ badge | downcase }}" title="{{ badge }}">{{ badge }}</span>
+                               {%- endif -%}
                              {%- endfor -%}
                            {%- endif -%}
                         </a>

--- a/docs/_includes/nav.html
+++ b/docs/_includes/nav.html
@@ -27,7 +27,13 @@
             </svg></a>
         {%- endif -%}
         <a href="{{ node.url | absolute_url }}"
-           class="nav-list-link{% if page.url == node.url %} active{% endif %}">{{ node.title }}</a>
+           class="nav-list-link{% if page.url == node.url %} active{% endif %}">{{ node.title }}
+           {%- if node.badges -%}
+             {%- for badge in node.badges -%}
+               <span class="badge badge-{{ badge | downcase }}">{{ badge }}</span>
+             {%- endfor -%}
+           {%- endif -%}
+        </a>
         {%- if node.has_children -%}
         {%- assign children_list = pages_list | where: "parent", node.title -%}
         <ul class="nav-list ">
@@ -43,14 +49,26 @@
                     </svg></a>
                 {%- endif -%}
                 <a href="{{ child.url | absolute_url }}"
-                   class="nav-list-link{% if page.url == child.url %} active{% endif %}">{{ child.title }}</a>
+                   class="nav-list-link{% if page.url == child.url %} active{% endif %}">{{ child.title }}
+                   {%- if child.badges -%}
+                     {%- for badge in child.badges -%}
+                       <span class="badge badge-{{ badge | downcase }}">{{ badge }}</span>
+                     {%- endfor -%}
+                   {%- endif -%}
+                </a>
                 {%- if child.has_children -%}
                 {%- assign grand_children_list = pages_list | where: "parent", child.title | where: "grand_parent", node.title -%}
                 <ul class="nav-list">
                     {%- for grand_child in grand_children_list -%}
                     <li class="nav-list-item {% if page.url == grand_child.url %} active{% endif %}">
                         <a href="{{ grand_child.url | absolute_url }}"
-                           class="nav-list-link{% if page.url == grand_child.url %} active{% endif %}">{{ grand_child.title }}</a>
+                           class="nav-list-link{% if page.url == grand_child.url %} active{% endif %}">{{ grand_child.title }}
+                           {%- if grand_child.badges -%}
+                             {%- for badge in grand_child.badges -%}
+                               <span class="badge badge-{{ badge | downcase }}">{{ badge }}</span>
+                             {%- endfor -%}
+                           {%- endif -%}
+                        </a>
                     </li>
                     {%- endfor -%}
                 </ul>

--- a/docs/_sass/custom/custom.scss
+++ b/docs/_sass/custom/custom.scss
@@ -1000,6 +1000,14 @@ div.highlighter-rouge{
 	text-align: center;
 	border-radius: 6px;
 	font-size: x-small;
+	margin-left: 6px;
+	margin-right: 0;
+	color: $black;
+}
+
+.badge-enterprise {
+	background: #5e41d0;
+	color: $white;
 }
 
 .quickstart-steps {

--- a/docs/_sass/custom/custom.scss
+++ b/docs/_sass/custom/custom.scss
@@ -999,7 +999,6 @@ div.highlighter-rouge{
 	font-weight: 400 !important;
 
 	padding: 2px 4px;
-	text-transform: uppercase;
 	text-align: center;
 	border-radius: 6px;
 	font-size: x-small;

--- a/docs/_sass/custom/custom.scss
+++ b/docs/_sass/custom/custom.scss
@@ -993,21 +993,23 @@ div.highlighter-rouge{
 	}
 }
 
-.badge {
+.badge, .nav-list .nav-list-item .nav-list-link.active .badge {
+	// override just-the-docs which loves setting !important on stuff
+	font-family: GalanoGrotesque !important; 
+	font-weight: 400 !important;
+
 	padding: 2px 4px;
-	background: $lightpink;
 	text-transform: uppercase;
 	text-align: center;
 	border-radius: 6px;
 	font-size: x-small;
 	margin-left: 6px;
 	margin-right: 0;
-	color: $black;
+	color: $white;
 }
 
 .badge-enterprise {
 	background: #5e41d0;
-	color: $white;
 }
 
 .quickstart-steps {

--- a/docs/howto/garbage-collection/managed-gc.md
+++ b/docs/howto/garbage-collection/managed-gc.md
@@ -4,6 +4,7 @@ description: Reduce the operational overhead of running garbage collection manua
 parent: Garbage Collection
 nav_order: 5
 grand_parent: How-To
+badges: ["Enterprise"]
 redirect_from:
   - /cloud/managed-gc.html
 ---

--- a/docs/howto/garbage-collection/standalone-gc.md
+++ b/docs/howto/garbage-collection/standalone-gc.md
@@ -4,6 +4,7 @@ description: Run a limited version of garbage collection without any external de
 parent: Garbage Collection
 nav_order: 5
 grand_parent: How-To
+badges: ["Enterprise"]
 redirect_from:
   - /cloud/standalone-gc.html
 ---

--- a/docs/howto/hooks/index.md
+++ b/docs/howto/hooks/index.md
@@ -4,6 +4,7 @@ description: Overview of lakeFS Actions and Hooks
 has_children: true  
 has_toc: false
 parent: How-To
+nav_order: 3
 redirect_from:
   - /reference/hooks.html
   - /hooks.html

--- a/docs/howto/lakefs-tables.md
+++ b/docs/howto/lakefs-tables.md
@@ -2,6 +2,7 @@
 title: lakeFS Tables
 description: Use lakeFS to manage Iceberg Tables using a builtin Iceberg REST Catalog
 parent: How-To
+badges: ["Enterprise"]
 ---
 
 # lakeFS Tables

--- a/docs/howto/lakefs-tables.md
+++ b/docs/howto/lakefs-tables.md
@@ -2,9 +2,8 @@
 title: lakeFS Tables
 description: Use lakeFS to manage Iceberg Tables using a builtin Iceberg REST Catalog
 parent: How-To
-badges:
-  - name: Enterprise
-    display_name: ENT
+badges: ["Enterprise"]
+nav_order: 3
 ---
 
 # lakeFS Tables

--- a/docs/howto/lakefs-tables.md
+++ b/docs/howto/lakefs-tables.md
@@ -2,7 +2,9 @@
 title: lakeFS Tables
 description: Use lakeFS to manage Iceberg Tables using a builtin Iceberg REST Catalog
 parent: How-To
-badges: ["Enterprise"]
+badges:
+  - name: Enterprise
+    display_name: ENT
 ---
 
 # lakeFS Tables

--- a/docs/howto/mirroring.md
+++ b/docs/howto/mirroring.md
@@ -2,6 +2,7 @@
 title: Mirroring
 parent: How-To
 description: Mirroring allows replicating commits between lakeFS installations in different geo-locations/regions
+badges: ["Enterprise"]
 ---
 
 # Mirroring

--- a/docs/howto/mirroring.md
+++ b/docs/howto/mirroring.md
@@ -2,7 +2,9 @@
 title: Mirroring
 parent: How-To
 description: Mirroring allows replicating commits between lakeFS installations in different geo-locations/regions
-badges: ["Enterprise"]
+badges:
+  - name: Enterprise
+    display_name: ENT
 ---
 
 # Mirroring

--- a/docs/howto/mirroring.md
+++ b/docs/howto/mirroring.md
@@ -2,9 +2,7 @@
 title: Mirroring
 parent: How-To
 description: Mirroring allows replicating commits between lakeFS installations in different geo-locations/regions
-badges:
-  - name: Enterprise
-    display_name: ENT
+badges: ["Enterprise"]
 ---
 
 # Mirroring

--- a/docs/howto/multiple-storage-backends.md
+++ b/docs/howto/multiple-storage-backends.md
@@ -2,6 +2,7 @@
 title: Multiple Storage Backend
 description: How to manage data across multiple storage systems with lakeFS 
 parent: How-To
+badges: ["Enterprise"]
 ---
 
 # Multi-Storage Backend

--- a/docs/howto/scim.md
+++ b/docs/howto/scim.md
@@ -2,6 +2,7 @@
 title: System for Cross-domain Identity Management (SCIM)
 description: Use SCIM to automatically provision users/groups in lakeFS via your identity provider (IdP)
 parent: How-To
+badges: ["Enterprise"]
 redirect_from:
   - /cloud/scim.html
 ---

--- a/docs/howto/scim.md
+++ b/docs/howto/scim.md
@@ -2,9 +2,7 @@
 title: System for Cross-domain Identity Management (SCIM)
 description: Use SCIM to automatically provision users/groups in lakeFS via your identity provider (IdP)
 parent: How-To
-badges:
-  - name: Enterprise
-    display_name: ENT
+badges: ["Enterprise"]
 redirect_from:
   - /cloud/scim.html
 ---

--- a/docs/howto/scim.md
+++ b/docs/howto/scim.md
@@ -2,7 +2,9 @@
 title: System for Cross-domain Identity Management (SCIM)
 description: Use SCIM to automatically provision users/groups in lakeFS via your identity provider (IdP)
 parent: How-To
-badges: ["Enterprise"]
+badges:
+  - name: Enterprise
+    display_name: ENT
 redirect_from:
   - /cloud/scim.html
 ---

--- a/docs/reference/auditing.md
+++ b/docs/reference/auditing.md
@@ -2,6 +2,7 @@
 title: Auditing
 parent: Reference
 description: Auditing is a solution for lakeFS Cloud which enables tracking of events and activities performed within the solution. These logs capture information such as who accessed the solution, what actions were taken, and when they occurred.
+badges: ["Enterprise"]
 redirect_from: 
   - /audit.html
   - /reference/audit.html

--- a/docs/reference/auditing.md
+++ b/docs/reference/auditing.md
@@ -2,9 +2,7 @@
 title: Auditing
 parent: Reference
 description: Auditing is a solution for lakeFS Cloud which enables tracking of events and activities performed within the solution. These logs capture information such as who accessed the solution, what actions were taken, and when they occurred.
-badges:
-  - name: Enterprise
-    display_name: ENT
+badges: ["Enterprise"]
 redirect_from: 
   - /audit.html
   - /reference/audit.html

--- a/docs/reference/auditing.md
+++ b/docs/reference/auditing.md
@@ -2,7 +2,9 @@
 title: Auditing
 parent: Reference
 description: Auditing is a solution for lakeFS Cloud which enables tracking of events and activities performed within the solution. These logs capture information such as who accessed the solution, what actions were taken, and when they occurred.
-badges: ["Enterprise"]
+badges:
+  - name: Enterprise
+    display_name: ENT
 redirect_from: 
   - /audit.html
   - /reference/audit.html

--- a/docs/reference/mount.md
+++ b/docs/reference/mount.md
@@ -2,7 +2,9 @@
 title: Mount
 description: This section covers the Everest feature for mounting a lakeFS path to your local filesystem.
 parent: Reference
-badges: ["Enterprise"]
+badges:
+  - name: Enterprise
+    display_name: ENT
 has_children: true
 nav_order: 30
 ---

--- a/docs/reference/mount.md
+++ b/docs/reference/mount.md
@@ -2,6 +2,7 @@
 title: Mount
 description: This section covers the Everest feature for mounting a lakeFS path to your local filesystem.
 parent: Reference
+badges: ["Enterprise"]
 has_children: true
 nav_order: 30
 ---

--- a/docs/reference/mount.md
+++ b/docs/reference/mount.md
@@ -2,9 +2,7 @@
 title: Mount
 description: This section covers the Everest feature for mounting a lakeFS path to your local filesystem.
 parent: Reference
-badges:
-  - name: Enterprise
-    display_name: ENT
+badges: ["Enterprise"]
 has_children: true
 nav_order: 30
 ---

--- a/docs/security/external-principals-aws.md
+++ b/docs/security/external-principals-aws.md
@@ -2,9 +2,7 @@
 title: Login to lakeFS with AWS IAM Roles
 description: This section covers how to authenticate to lakeFS using AWS IAM.
 parent: Security
-badges:
-  - name: Enterprise
-    display_name: ENT
+badges: ["Enterprise"]
 redirect_from:
   - /reference/external-principals-aws.html
 ---

--- a/docs/security/external-principals-aws.md
+++ b/docs/security/external-principals-aws.md
@@ -2,7 +2,9 @@
 title: Login to lakeFS with AWS IAM Roles
 description: This section covers how to authenticate to lakeFS using AWS IAM.
 parent: Security
-badges: ["Enterprise"]
+badges:
+  - name: Enterprise
+    display_name: ENT
 redirect_from:
   - /reference/external-principals-aws.html
 ---

--- a/docs/security/external-principals-aws.md
+++ b/docs/security/external-principals-aws.md
@@ -2,6 +2,7 @@
 title: Login to lakeFS with AWS IAM Roles
 description: This section covers how to authenticate to lakeFS using AWS IAM.
 parent: Security
+badges: ["Enterprise"]
 redirect_from:
   - /reference/external-principals-aws.html
 ---

--- a/docs/security/rbac.md
+++ b/docs/security/rbac.md
@@ -2,6 +2,7 @@
 title: Role-Based Access Control (RBAC)
 description: This section covers authorization (using RBAC) of your lakeFS server.
 parent: Security
+badges: ["Enterprise"]
 redirect_from:
   - /reference/authorization.html
   - /reference/rbac.html

--- a/docs/security/sso.md
+++ b/docs/security/sso.md
@@ -2,6 +2,7 @@
 title: Single Sign On (SSO)
 description: How to configure Single Sign On (SSO) for lakeFS Cloud and lakeFS Enterprise.
 parent: Security
+badges: ["Enterprise"]
 redirect_from:
   - /cloud/sso.html
   - /enterprise/sso.html

--- a/docs/security/sso.md
+++ b/docs/security/sso.md
@@ -2,7 +2,9 @@
 title: Single Sign On (SSO)
 description: How to configure Single Sign On (SSO) for lakeFS Cloud and lakeFS Enterprise.
 parent: Security
-badges: ["Enterprise"]
+badges:
+  - name: Enterprise
+    display_name: ENT
 redirect_from:
   - /cloud/sso.html
   - /enterprise/sso.html

--- a/docs/security/sso.md
+++ b/docs/security/sso.md
@@ -2,9 +2,7 @@
 title: Single Sign On (SSO)
 description: How to configure Single Sign On (SSO) for lakeFS Cloud and lakeFS Enterprise.
 parent: Security
-badges:
-  - name: Enterprise
-    display_name: ENT
+badges: ["Enterprise"]
 redirect_from:
   - /cloud/sso.html
   - /enterprise/sso.html

--- a/docs/security/sts-login.md
+++ b/docs/security/sts-login.md
@@ -2,7 +2,9 @@
 title: Short-lived token (STS like) Authentication for lakeFS
 description: Authenticate with lakeFS using Secure Token Service (STS) by leveraging a remote authenticator. This feature enables integration with Identity Providers (IdPs) for secure and efficient user authentication.
 parent: Security
-badges: ["Enterprise"]
+badges:
+  - name: Enterprise
+    display_name: ENT
 redirect_from:
   - /reference/remote-authenticator.html
 ---

--- a/docs/security/sts-login.md
+++ b/docs/security/sts-login.md
@@ -2,6 +2,7 @@
 title: Short-lived token (STS like) Authentication for lakeFS
 description: Authenticate with lakeFS using Secure Token Service (STS) by leveraging a remote authenticator. This feature enables integration with Identity Providers (IdPs) for secure and efficient user authentication.
 parent: Security
+badges: ["Enterprise"]
 redirect_from:
   - /reference/remote-authenticator.html
 ---

--- a/docs/security/sts-login.md
+++ b/docs/security/sts-login.md
@@ -2,9 +2,7 @@
 title: Short-lived token (STS like) Authentication for lakeFS
 description: Authenticate with lakeFS using Secure Token Service (STS) by leveraging a remote authenticator. This feature enables integration with Identity Providers (IdPs) for secure and efficient user authentication.
 parent: Security
-badges:
-  - name: Enterprise
-    display_name: ENT
+badges: ["Enterprise"]
 redirect_from:
   - /reference/remote-authenticator.html
 ---


### PR DESCRIPTION
Avoid confusion in the lakeFS docs by highlighting which pages are relevant to OSS (default) vs lakeFS Enterprise features. This serves 2 purposes:

1. Allow OSS users to quickly figure out which pages are relevant for them and which aren't
2. Allow people interested in learning about Enterprise features to more easily find relevant documentation


Example:

![image](https://github.com/user-attachments/assets/49d832c5-1e73-47ff-b449-fcc96c321012)


