### PR TITLE
Update TileLayer URL and attribution in GeoJSONPreview

### DIFF
--- a/webui/src/lib/components/repository/GeoJSONPreview.jsx
+++ b/webui/src/lib/components/repository/GeoJSONPreview.jsx
@@ -27,8 +27,14 @@ export const GeoJSONPreview = ({ data }) => {
         <div className="geojson-map-wrapper">
             <MapContainer {...mapProps} className="geojson-map-container">
                 <TileLayer
-                    url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png"
-                    attribution='&copy; <a href="https://openstreetmap.org/copyright">OpenStreetMap</a>'
+                    url="https://{s}.tile.openstreetmap.de/{z}/{x}/{y}.png"
+                    subdomains={['a', 'b', 'c']}
+                    attribution={`
+            &copy; <a href="https://openstreetmap.org/">OpenStreetMap</a>
+            &copy; <a href="https://openstreetmap.de/">OSM Germany</a>
+          `}
+                    crossOrigin="anonymous"
+                    referrerPolicy="no-referrer"
                 />
                 <GeoJSON data={geoJsonData} />
             </MapContainer>


### PR DESCRIPTION
Switch to the OpenStreetMap Germany tile server and adjust attribution to reflect the source accurately. Added subdomains, cross-origin, and referrer policy attributes for improved compatibility and security.