### PR TITLE
add image content diff view

### DIFF
--- a/webui/src/pages/repositories/repository/fileRenderers/index.tsx
+++ b/webui/src/pages/repositories/repository/fileRenderers/index.tsx
@@ -133,6 +133,8 @@ export function guessType(contentType: string | null, fileExtension: string | nu
         case 'image/png':
         case 'image/gif':
         case 'image/webm':
+        case 'image/bmp':
+        case 'image/webp':
             return FileType.IMAGE
         case 'application/pdf':
         case 'application/x-pdf':
@@ -153,6 +155,8 @@ export function guessType(contentType: string | null, fileExtension: string | nu
         case 'jpg':
         case 'webm':
         case 'gif':
+        case 'bmp':
+        case 'webp':
             return FileType.IMAGE
         case 'pdf':
             return FileType.PDF


### PR DESCRIPTION
Closes [#https://github.com/treeverse/product/issues/882](https://github.com/treeverse/product/issues/882)

# What’s changed

- Detect image files by extension (`png`|`jpg`|`jpeg`|`gif`|`bmp`|`webp`) and render a side-by-side “Deleted” / “Added”
   Card view.

- Display file-size delta (+21.4 KiB (45.4%), etc.) in a lightweight banner above the cards.

# New components & helpers

**ContentDiff**: top-level switch between ImageCardDiff (for images) and TextDiff (for everything else).

**TextDiff**: wraps your existing ReactDiffViewer logic; keeps all useAPI calls in a fixed order (React Hooks rules).

**ImageDiff & ImageDiffSummary**: renders two cards with custom headers (`Deleted` / `Added`), original image dimensions, and a formatted diff summary.

**buildUrl**(): DRY helper to construct the object-fetch URL.

# Refactoring & cleanup

- Pulled `useContext(AppContext)` up into `ObjectsDiff` so that `ContentDiff` and its children take `settings` as a prop
   instead of re-calling the hook.

- Removed unnecessary async wrappers around calls to objects.getStat / objects.get (they already return promises).

# General notes:

**Better UX**: now you can preview image changes in-place instead of downloading separately.

**Maintainability**: clear separation between image vs. text paths; all hooks live in predictable places.

**Performance**: memoized query string; no wasted API calls for image diffs.

### Testing Details

Was tested locally in lakeFS.