### PR TITLE
Fix TestS3IfNoneMatch by explicitly creating object1

### DIFF
--- a/esti/s3_gateway_test.go
+++ b/esti/s3_gateway_test.go
@@ -263,6 +263,13 @@ func TestS3IfNoneMatch(t *testing.T) {
 
 	s3Endpoint := viper.GetString("s3_endpoint")
 	s3Client := createS3Client(s3Endpoint, t)
+
+	_, _ = s3Client.PutObject(ctx, &s3.PutObjectInput{
+		Bucket: aws.String(repo),
+		Key:    aws.String("main/object1"),
+		Body:   strings.NewReader("test-content"),
+	})
+
 	testCases := []struct {
 		Name          string
 		Path          string


### PR DESCRIPTION
This PR fixes a hidden dependency in the `TestS3IfNoneMatch/object exists` case, where the test assumed that `main/object1` already exists in the repository - but did not ensure that explicitly.

Previously, the test sometimes passed because the object existed due to unrelated setup steps or leftover state. However, after [updating the organization name prefix for E2E tests](https://github.com/treeverse/cloud-controlplane/pull/4464) (from `treeverse-` to `treeverse-e2e-`), that implicit setup no longer applies - and the test started to fail.

The fix is simple and correct: we now explicitly upload `main/object1` at the start of the test. This ensures that the `If-None-Match: *` logic is tested correctly and reliably.

This change makes the test deterministic, robust, and independent of any assumptions about external setup or prior state.

