### PR TITLE
Add branch protection checks and hook handling in CherryPick

### DIFF
--- a/pkg/graveler/graveler_v2_test.go
+++ b/pkg/graveler/graveler_v2_test.go
@@ -761,6 +761,7 @@ func TestGravelerCherryPick(t *testing.T) {
 	}
 	t.Run("cherry-pick successful", func(t *testing.T) {
 		test := testutil.InitGravelerTest(t)
+		test.ProtectedBranchesManager.EXPECT().IsBlocked(ctx, repository, branch1ID, graveler.BranchProtectionBlockedAction_COMMIT).Return(false, nil)
 		firstUpdateBranch(test)
 		emptyStagingTokenCombo(test, 2)
 
@@ -780,6 +781,7 @@ func TestGravelerCherryPick(t *testing.T) {
 
 	t.Run("cherry-pick override commit fields", func(t *testing.T) {
 		test := testutil.InitGravelerTest(t)
+		test.ProtectedBranchesManager.EXPECT().IsBlocked(ctx, repository, branch1ID, graveler.BranchProtectionBlockedAction_COMMIT).Return(false, nil)
 		firstUpdateBranch(test)
 		emptyStagingTokenCombo(test, 2)
 		commitOverrides := graveler.CommitOverrides{
@@ -808,6 +810,7 @@ func TestGravelerCherryPick(t *testing.T) {
 
 	t.Run("cherry-pick partially override commit fields", func(t *testing.T) {
 		test := testutil.InitGravelerTest(t)
+		test.ProtectedBranchesManager.EXPECT().IsBlocked(ctx, repository, branch1ID, graveler.BranchProtectionBlockedAction_COMMIT).Return(false, nil)
 		firstUpdateBranch(test)
 		emptyStagingTokenCombo(test, 2)
 		commitOverrides := graveler.CommitOverrides{
@@ -833,6 +836,7 @@ func TestGravelerCherryPick(t *testing.T) {
 
 	t.Run("cherry-pick with nil overrides", func(t *testing.T) {
 		test := testutil.InitGravelerTest(t)
+		test.ProtectedBranchesManager.EXPECT().IsBlocked(ctx, repository, branch1ID, graveler.BranchProtectionBlockedAction_COMMIT).Return(false, nil)
 		firstUpdateBranch(test)
 		emptyStagingTokenCombo(test, 2)
 


### PR DESCRIPTION
As cherry pick commit, it should check for branch protection and trigger pre/post commits.

Close https://github.com/treeverse/lakeFS/issues/7208
