### PR TITLE
Support multipart for lakectl presigned uploads

### DIFF
--- a/pkg/api/helpers/upload.go
+++ b/pkg/api/helpers/upload.go
@@ -144,7 +144,7 @@ func (u *PreSignUploader) Upload(ctx context.Context, repoID string, branchID st
 	if _, seekErr := content.Seek(0, io.SeekStart); seekErr != nil {
 		return nil, seekErr
 	}
-	// check if content implements io.ReaderAt for multipart upload
+	// set "readerAt" if "content" implements io.ReaderAt for multipart upload (otherwise it will be nil)
 	readerAt, _ := content.(io.ReaderAt)
 
 	// create upload object - represents a single upload request

--- a/pkg/local/progress.go
+++ b/pkg/local/progress.go
@@ -1,7 +1,6 @@
 package local
 
 import (
-	"fmt"
 	"io"
 	"time"
 
@@ -134,8 +133,9 @@ func NewProgressPool() *ProgressPool {
 }
 
 type fileWrapper struct {
-	file   io.Seeker
-	reader io.Reader
+	file     io.Seeker
+	reader   io.Reader
+	readerAt io.ReaderAt
 }
 
 func (f fileWrapper) Read(p []byte) (n int, err error) {
@@ -143,10 +143,7 @@ func (f fileWrapper) Read(p []byte) (n int, err error) {
 }
 
 func (f fileWrapper) ReadAt(p []byte, off int64) (int, error) {
-	if ra, ok := f.file.(io.ReaderAt); ok {
-		return ra.ReadAt(p, off)
-	}
-	return 0, fmt.Errorf("ReaderAt not supported")
+	return f.readerAt.ReadAt(p, off)
 }
 
 func (f fileWrapper) Seek(offset int64, whence int) (int64, error) {

--- a/pkg/local/progress.go
+++ b/pkg/local/progress.go
@@ -132,10 +132,14 @@ func NewProgressPool() *ProgressPool {
 	}
 }
 
+type readerAtSeeker interface {
+	io.Seeker
+	io.ReaderAt
+}
+
 type fileWrapper struct {
-	file     io.Seeker
-	reader   io.Reader
-	readerAt io.ReaderAt
+	file   readerAtSeeker
+	reader io.Reader
 }
 
 func (f fileWrapper) Read(p []byte) (n int, err error) {
@@ -143,7 +147,7 @@ func (f fileWrapper) Read(p []byte) (n int, err error) {
 }
 
 func (f fileWrapper) ReadAt(p []byte, off int64) (int, error) {
-	return f.readerAt.ReadAt(p, off)
+	return f.file.ReadAt(p, off)
 }
 
 func (f fileWrapper) Seek(offset int64, whence int) (int64, error) {

--- a/pkg/local/progress.go
+++ b/pkg/local/progress.go
@@ -144,7 +144,7 @@ func (f fileWrapper) Read(p []byte) (n int, err error) {
 
 func (f fileWrapper) ReadAt(p []byte, off int64) (int, error) {
 	if ra, ok := f.file.(io.ReaderAt); ok {
-		return ra.ReadAt(p, off) // delegate
+		return ra.ReadAt(p, off)
 	}
 	return 0, fmt.Errorf("ReaderAt not supported")
 }

--- a/pkg/local/progress.go
+++ b/pkg/local/progress.go
@@ -1,6 +1,7 @@
 package local
 
 import (
+	"fmt"
 	"io"
 	"time"
 
@@ -139,6 +140,13 @@ type fileWrapper struct {
 
 func (f fileWrapper) Read(p []byte) (n int, err error) {
 	return f.reader.Read(p)
+}
+
+func (f fileWrapper) ReadAt(p []byte, off int64) (int, error) {
+	if ra, ok := f.file.(io.ReaderAt); ok {
+		return ra.ReadAt(p, off) // delegate
+	}
+	return 0, fmt.Errorf("ReaderAt not supported")
 }
 
 func (f fileWrapper) Seek(offset int64, whence int) (int64, error) {

--- a/pkg/local/sync.go
+++ b/pkg/local/sync.go
@@ -328,9 +328,8 @@ func (s *SyncManager) upload(ctx context.Context, rootPath string, remote *uri.U
 	}
 
 	readerWrapper := fileWrapper{
-		file:     f,
-		reader:   b.Reader(f),
-		readerAt: f,
+		file:   f,
+		reader: b.Reader(f),
 	}
 	if s.cfg.IncludePerm {
 		if strings.HasSuffix(path, uri.PathSeparator) { // Create a 0 byte reader for directories
@@ -338,7 +337,6 @@ func (s *SyncManager) upload(ctx context.Context, rootPath string, remote *uri.U
 			readerWrapper = fileWrapper{
 				file:   bytes.NewReader([]byte{}),
 				reader: bytes.NewReader([]byte{}),
-				// readerAt is not used for directories, so we can use a nil readerAt
 			}
 		}
 		permissions, err := getPermissionFromFileInfo(fileStat)

--- a/pkg/local/sync.go
+++ b/pkg/local/sync.go
@@ -328,8 +328,9 @@ func (s *SyncManager) upload(ctx context.Context, rootPath string, remote *uri.U
 	}
 
 	readerWrapper := fileWrapper{
-		file:   f,
-		reader: b.Reader(f),
+		file:     f,
+		reader:   b.Reader(f),
+		readerAt: f,
 	}
 	if s.cfg.IncludePerm {
 		if strings.HasSuffix(path, uri.PathSeparator) { // Create a 0 byte reader for directories
@@ -337,6 +338,7 @@ func (s *SyncManager) upload(ctx context.Context, rootPath string, remote *uri.U
 			readerWrapper = fileWrapper{
 				file:   bytes.NewReader([]byte{}),
 				reader: bytes.NewReader([]byte{}),
+				// readerAt is not used for directories, so we can use a nil readerAt
 			}
 		}
 		permissions, err := getPermissionFromFileInfo(fileStat)


### PR DESCRIPTION
Closes #9015.

## Change Description

### Background

When using lakectl local, uploading with pre-signed doesn't utilizes multipart uploads for large files.

### Bug Fix

#### Root cause

Very technical issue:
The `fileWrapper` defined in `progress.go` doesn't implement a `ReadAt()` func, hence doesn't implement `io.ReaderAt`.
Since `presignUpload.Upload()` requires `io.ReaderAt` for pre-signed, it checks if the fileWrapper (initialized at `SyncManager.upload()`) satisfies this, and since it doesn't, it doesn't use multipart for the upload flow.

#### Solution

Implement `ReadAt()` for `fileWrapper`, so that `SyncManager.upload()` ends up using multipart if needed.

### Testing Details

Tested manually:
With or without pre-signed, and with or without multipart.
