### PR TITLE
making PRs with no changes closable

### DIFF
--- a/webui/src/pages/repositories/repository/pulls/pullDetails.jsx
+++ b/webui/src/pages/repositories/repository/pulls/pullDetails.jsx
@@ -70,12 +70,12 @@ const PullDetailsContent = ({repo, pull}) => {
                     <Markdown>{pull.description}</Markdown>
                 </Card.Body>
             </Card>
-            <div className="bottom-buttons-row mt-4 clearfix">
+            <div className="bottom-buttons-row mt-4">
                 {error && <AlertError error={error} onDismiss={() => setError(null)}/>}
                 {formattedDiffError && <AlertError error={formattedDiffError}/>}
                 {isPullOpen() &&
                     <>
-                        <div className="bottom-buttons-group float-end">
+                        <div className="bottom-buttons-group d-flex justify-content-end">
                             <ClosePullButton onClick={changePullStatus(PullStatus.closed)} loading={loading}/>
                             {!formattedDiffError &&
                                 <MergePullButton


### PR DESCRIPTION
Closes #8690

Previously, the "Close pull request" button did not appear on PRs with no changes.
This turned out to be a UI issue, as the close\merge buttons were rendered but just covered by "merging is disabled.." alert.
Changing the bottom-buttons-group div to use flexbox seems to have solved the issue.
The existing code already makes the merge button disabled in the case of an empty merge.

<img width="1235" height="474" alt="image" src="https://github.com/user-attachments/assets/d720f07d-e30c-4bfe-a329-3fdcb0f94a43" />
