### PR TITLE
GC: Add support for GCP

### DIFF
--- a/clients/spark/build.sbt
+++ b/clients/spark/build.sbt
@@ -42,6 +42,14 @@ buildInfoPackage := "io.treeverse.clients"
 
 enablePlugins(S3Plugin, BuildInfoPlugin)
 
+// Required for scala 2.12.12 compatibility
+dependencyOverrides ++= Seq(
+  "com.fasterxml.jackson.core" % "jackson-databind" % "2.12.7",
+  "com.fasterxml.jackson.core" % "jackson-core" % "2.12.7",
+  "com.fasterxml.jackson.core" % "jackson-annotations" % "2.12.7",
+  "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.12.7"
+)
+
 libraryDependencies ++= Seq(
   "io.lakefs" % "sdk" % "1.53.1",
   "org.apache.spark" %% "spark-sql" % "3.1.2" % "provided",
@@ -56,6 +64,8 @@ libraryDependencies ++= Seq(
   "com.azure" % "azure-storage-blob-batch" % "12.7.0",
   "com.azure" % "azure-identity" % "1.2.0",
   "com.amazonaws" % "aws-java-sdk-bundle" % "1.12.194" % "provided",
+  "com.google.cloud.bigdataoss" % "gcs-connector" % "hadoop3-2.2.18",
+  "com.google.cloud" % "google-cloud-storage" % "2.35.0",
   // Snappy is JNI :-(.  However it does claim to work with
   // ClassLoaders, and (even more importantly!) using a preloaded JNI
   // version will probably continue to work because the C language API
@@ -72,8 +82,6 @@ libraryDependencies ++= Seq(
   "com.dimafeng" %% "testcontainers-scala-scalatest" % "0.40.10" % "test",
   "com.lihaoyi" %% "upickle" % "1.4.0" % "test",
   "com.lihaoyi" %% "os-lib" % "0.7.8" % "test",
-  // Test with an up-to-date fasterxml.
-  "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.14.2" % "test",
   "com.storm-enroute" %% "scalameter" % "0.19" % "test"
 )
 

--- a/clients/spark/src/main/scala/io/treeverse/clients/ApiClient.scala
+++ b/clients/spark/src/main/scala/io/treeverse/clients/ApiClient.scala
@@ -15,8 +15,7 @@ import io.lakefs.clients.sdk.ConfigApi
 import io.lakefs.clients.sdk.model._
 import io.treeverse.clients.ApiClient.TIMEOUT_NOT_SET
 import io.treeverse.clients.StorageClientType.StorageClientType
-import io.treeverse.clients.StorageUtils.StorageTypeAzure
-import io.treeverse.clients.StorageUtils.StorageTypeS3
+import io.treeverse.clients.StorageUtils.{StorageTypeAzure, StorageTypeS3}
 
 import java.net.URI
 import java.time.Duration

--- a/clients/spark/src/main/scala/io/treeverse/clients/StorageUtils.scala
+++ b/clients/spark/src/main/scala/io/treeverse/clients/StorageUtils.scala
@@ -15,6 +15,7 @@ import java.util.concurrent.TimeUnit
 object StorageUtils {
   val StorageTypeS3 = "s3"
   val StorageTypeAzure = "azure"
+  val StorageTypeGCS = "gs"
 
   /** Constructs object paths in a storage namespace.
    *
@@ -156,6 +157,11 @@ object StorageUtils {
       val bucketRegion = client.getBucketLocation(request)
       Region.fromValue(bucketRegion).toAWSRegion().getName()
     }
+  }
+
+  object GCS {
+    val GCSMaxBulkSize =
+      500 // 1000 is the max size, 500 is the recommended size to avoid timeouts or hitting HTTP size limits
   }
 }
 

--- a/clients/spark/src/main/scala/io/treeverse/gc/GarbageCollection.scala
+++ b/clients/spark/src/main/scala/io/treeverse/gc/GarbageCollection.scala
@@ -46,7 +46,11 @@ object GarbageCollection {
 
     val configMapper = new ConfigMapper(
       sc.broadcast(
-        HadoopUtils.getHadoopConfigurationValues(sc.hadoopConfiguration, "fs.", "lakefs.")
+        HadoopUtils.getHadoopConfigurationValues(sc.hadoopConfiguration,
+                                                 "fs.",
+                                                 "lakefs.",
+                                                 "google.cloud."
+                                                )
       )
     )
     // Read objects from data path (new repository structure)
@@ -65,7 +69,6 @@ object GarbageCollection {
       .withColumn("address", col("base_address"))
       .filter(!col("address").isin(excludeFromOldData: _*))
     dataDF = dataDF.union(oldDataDF).filter(col("last_modified") < before.getTime)
-
     dataDF
   }
 
@@ -210,7 +213,7 @@ object GarbageCollection {
 
         val storageNSForSdkClient = getStorageNSForSdkClient(apiClient: ApiClient, repo)
         val hcValues = spark.sparkContext.broadcast(
-          HadoopUtils.getHadoopConfigurationValues(hc, "fs.", "lakefs.")
+          HadoopUtils.getHadoopConfigurationValues(hc, "fs.", "lakefs.", "google.cloud.")
         )
         val configMapper = new ConfigMapper(hcValues)
         bulkRemove(configMapper, markedAddresses, storageNSForSdkClient, region, storageType)

--- a/clients/spark/src/test/scala/io/treeverse/clients/ApiClientSpec.scala
+++ b/clients/spark/src/test/scala/io/treeverse/clients/ApiClientSpec.scala
@@ -55,5 +55,13 @@ class ApiClientSpec extends AnyFunSpec with Matchers {
         )
       }
     }
+    describe("GCS") {
+      val pathUri = "gs://bucket/path/to/blob"
+      val translate =
+        (u: String) => ApiClient.translateURI(new URI(u), StorageUtils.StorageTypeGCS).toString
+      it("should return the same URI") {
+        translate(pathUri) should be(pathUri)
+      }
+    }
   }
 }

--- a/clients/spark/src/test/scala/io/treeverse/clients/LakeFSInputFormatSpec.scala
+++ b/clients/spark/src/test/scala/io/treeverse/clients/LakeFSInputFormatSpec.scala
@@ -13,14 +13,12 @@ import scala.collection.JavaConverters._
 
 import scala.collection.mutable
 import org.scalatest.OneInstancePerTest
-import org.checkerframework.checker.units.qual.m
 import org.apache.hadoop.fs.FileSystem
 import org.apache.hadoop.fs.LocatedFileStatus
 import org.apache.hadoop.fs.Path
 import org.apache.hadoop.fs.BlockLocation
 import org.apache.hadoop.fs.FileStatus
 import org.apache.hadoop.fs.RemoteIterator
-import org.apache.hadoop.fs.BatchedRemoteIterator
 
 object LakeFSInputFormatSpec {
   def getItem(rangeID: String): Item[RangeData] = new Item(


### PR DESCRIPTION
Closes #9228

## Change Description

### Background

[Context](https://github.com/treeverse/lakeFS/issues/7399)
Add support for GCP:
* Added package dependencies for GCP client
* Added GCS client as well as BulkRemover for GCP

Follow up tasks:
* Release client (required for docs update)
* [Update documentation](https://github.com/treeverse/lakeFS/issues/9303)
* [Add tests](https://github.com/treeverse/lakeFS/issues/9304)

### Testing Details

Tested changes manually

### Breaking Change?

No

