### PR TITLE
Python HL SDK: use IfNoneMatch to support conditional write (aka exclusive creation)

### DIFF
--- a/clients/python-wrapper/tests/integration/test_object.py
+++ b/clients/python-wrapper/tests/integration/test_object.py
@@ -83,13 +83,14 @@ def test_object_read_seek(setup_repo, pre_sign):
     fd.close()
 
 
-def test_object_upload_exists(setup_repo):
+@pytest.mark.parametrize("pre_sign", (True, False))
+def test_object_upload_exists(setup_repo, pre_sign):
     clt, repo = setup_repo
     data = b"test_data"
     obj = WriteableObject(repository_id=repo.properties.id, reference_id="main", path="test_obj", client=clt).upload(
         data=data)
     with expect_exception_context(ObjectExistsException):
-        obj.upload(data="some_other_data", mode='xb')
+        obj.upload(data="some_other_data", mode='xb', pre_sign=pre_sign)
 
     with obj.reader() as fd:
         assert fd.read() == data


### PR DESCRIPTION
## Change Description

Closes #7505.

This replaces existing `obj.exists()` check with conditional writes using 'IfNoneMatch: *'. I have tried to maintain compat in terms of error raised, by raising `ObjectExistsError` on pre-condition failure.

### Testing Details

How were the changes tested?

There is an existing `test_object_upload_exists` that covers this. I have extended this test by parametrizing it with `pre_sign=True|False`.



### Breaking Change?

Does this change break any existing functionality? (API, CLI, Clients)

No.

## Additional info

Logs, outputs, screenshots of changes if applicable (CLI / GUI changes)

### Contact Details

How can we get in touch with you if we need more info? (ex. email@example.com)
