### PR TITLE
docs: use docker to serve docs locally

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -88,7 +88,7 @@ docs/src/assets/js/authorization.yml: api/authorization.yml
 docs: docs/src/assets/js/swagger.yml docs/src/assets/js/authorization.yml
 
 docs-serve: ### Serve local docs
-	$(DOCKER) run --rm -it -p 4000:4000 -v ./docs:/docs --entrypoint /bin/sh squidfunk/mkdocs-material -c "cd /docs && pip install -r requirements-docs.txt && mkdocs serve --dev-addr=0.0.0.0:4000"
+	$(DOCKER) run --rm -it -p 4000:4000 -v ./docs:/docs --entrypoint /bin/sh squidfunk/mkdocs-material:9 -c "cd /docs && pip install -r requirements-docs.txt && mkdocs serve --dev-addr=0.0.0.0:4000"
 
 gen-docs: ## Generate CLI docs automatically
 	$(GOCMD) run cmd/lakectl/main.go docs > docs/src/reference/cli.md


### PR DESCRIPTION
In order to remove friction while checking local documentation, use docker to setup local mkdocs serve instead of require python env with required packages.

Close https://github.com/treeverse/lakeFS/issues/9312