### PR TITLE
AI DAY - Add support for deleting folder prefixes and their contents

### DIFF
--- a/webui/src/lib/api/index.js
+++ b/webui/src/lib/api/index.js
@@ -813,7 +813,7 @@ class Objects {
         const deletePromises = objectsToDelete
             .filter(obj => obj.path_type === "object")
             .map(object =>
-                this.delete(repoId, branchId, object.path)  // Use this.delete since we're in the Objects class
+                this.delete(repoId, branchId, object.path)
                     .catch(error => ({ path: object.path, error }))
             );
 

--- a/webui/src/lib/components/repository/tree.jsx
+++ b/webui/src/lib/components/repository/tree.jsx
@@ -52,7 +52,9 @@ const EntryRowActions = ({ repo, reference, entry, onDelete, presign, presign_ui
   const [showDeleteConfirmation, setShowDeleteConfirmation] = useState(false);
   const handleCloseDeleteConfirmation = () => setShowDeleteConfirmation(false);
   const handleShowDeleteConfirmation = () => setShowDeleteConfirmation(true);
-  const deleteConfirmMsg = `are you sure you wish to delete object "${entry.path}"?`;
+  const deleteConfirmMsg = entry.path_type === "common_prefix"
+      ? `Are you sure you wish to delete folder "${entry.path}" and all its contents?`
+      : `Are you sure you wish to delete object "${entry.path}"?`;
   const onSubmitDeletion = () => {
     onDelete(entry);
     setShowDeleteConfirmation(false);
@@ -163,6 +165,20 @@ const EntryRowActions = ({ repo, reference, entry, onDelete, presign, presign_ui
             <Dropdown.Item onClick={handleShowPrefixSize}>
               <BeakerIcon /> Calculate Size
             </Dropdown.Item>
+          )}
+
+          {entry.path_type === "common_prefix" && reference.type === RefTypeBranch && (
+              <>
+                <Dropdown.Divider />
+                <Dropdown.Item
+                    onClick={(e) => {
+                      e.preventDefault();
+                      handleShowDeleteConfirmation();
+                    }}
+                >
+                  <TrashIcon /> Delete
+                </Dropdown.Item>
+              </>
           )}
 
         </Dropdown.Menu>

--- a/webui/src/pages/repositories/repository/objects.jsx
+++ b/webui/src/pages/repositories/repository/objects.jsx
@@ -1067,13 +1067,16 @@ const TreeContainer = ({
         onUpload={onUpload}
         onImport={onImport}
         onDelete={entry => {
-          objects
-            .delete(repo.id, reference.id, entry.path)
-            .catch(error => {
-              setDeleteState({...initialState, error: error})
-              throw error
-            })
-            .then(onRefresh)
+            const deleteOperation = entry.path_type === "common_prefix"
+                ? objects.deletePrefix(repo.id, reference.id, entry.path)
+                : objects.delete(repo.id, reference.id, entry.path);
+
+            deleteOperation
+                .catch(error => {
+                    setDeleteState({...initialState, error: error})
+                    throw error
+                })
+                .then(onRefresh)
         }}
       />
     </>


### PR DESCRIPTION
Closes #7391 

### Summary:

We get all objects under a prefix ("folder"), including those in nested folders, regardless of nesting level - and delete all of them.

### Example:

```
   folder1/
     ├── file1.txt
     ├── folder2/
     │   ├── file2.txt
     │   └── folder3/
     │       └── file3.txt
```

When getting all objects with prefix `folder1/`, we'll return:
- `folder1/file1.txt`
- `folder1/folder2/file2.txt`
- `folder1/folder2/folder3/file3.txt`

**The implementation:**
- Uses `listAll` iterator to efficiently fetch all objects under the prefix recursively
- Filters objects to only delete actual files (`path_type === "object"`)
- Deletes objects in batches using the API's batch delete endpoint
- Collects and aggregates any errors that occur during deletion
- Returns early if no objects are found to delete
- Handles API errors gracefully with appropriate error messages

### An illustration

<img width="1312" height="474" alt="image" src="https://github.com/user-attachments/assets/c60cfa1c-b276-4018-bf04-38acef8f6bda" />
<img width="1313" height="359" alt="image" src="https://github.com/user-attachments/assets/6cc791b4-13c9-4d95-8ea7-355a393d4786" />
<img width="506" height="232" alt="image" src="https://github.com/user-attachments/assets/5696d665-45ff-4410-abc8-bd9023a9ee1e" />
<img width="867" height="233" alt="image" src="https://github.com/user-attachments/assets/e7812e64-65f5-45fb-94d1-33ce34d854d5" />
<img width="1312" height="404" alt="image" src="https://github.com/user-attachments/assets/8fbcd648-776d-4c25-a494-0289799981fa" />

### Testings

Was tested manually on lakeFS.