### PR TITLE
UI Diff View Improvement

### DIFF
--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -21,6 +21,7 @@
         "leaflet": "^1.9.4",
         "leaflet-defaulticon-compatibility": "^0.1.2",
         "lodash": "^4.17.21",
+        "lucide-react": "^0.525.0",
         "p-map": "^7.0.0",
         "prismjs": "^1.29.0",
         "react": "^18.2.0",
@@ -8513,6 +8514,15 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/lucide-react": {
+      "version": "0.525.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.525.0.tgz",
+      "integrity": "sha512-Tm1txJ2OkymCGkvwoHt33Y2JpN5xucVq1slHcgE6Lk0WjDfjgKWor5CdVER8U6DvcfMwh4M8XxmpTiyzfmfDYQ==",
+      "license": "ISC",
+      "peerDependencies": {
+        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
     "node_modules/lz-string": {
@@ -23472,6 +23482,12 @@
       "requires": {
         "yallist": "^4.0.0"
       }
+    },
+    "lucide-react": {
+      "version": "0.525.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.525.0.tgz",
+      "integrity": "sha512-Tm1txJ2OkymCGkvwoHt33Y2JpN5xucVq1slHcgE6Lk0WjDfjgKWor5CdVER8U6DvcfMwh4M8XxmpTiyzfmfDYQ==",
+      "requires": {}
     },
     "lz-string": {
       "version": "1.5.0",

--- a/webui/package.json
+++ b/webui/package.json
@@ -32,6 +32,7 @@
     "leaflet": "^1.9.4",
     "leaflet-defaulticon-compatibility": "^0.1.2",
     "lodash": "^4.17.21",
+    "lucide-react": "^0.525.0",
     "p-map": "^7.0.0",
     "prismjs": "^1.29.0",
     "react": "^18.2.0",

--- a/webui/src/lib/components/repository/treeRows.jsx
+++ b/webui/src/lib/components/repository/treeRows.jsx
@@ -13,6 +13,7 @@ import {OverlayTrigger} from "react-bootstrap";
 import Tooltip from "react-bootstrap/Tooltip";
 import Button from "react-bootstrap/Button";
 import {TreeRowType} from "../../../constants";
+import { BarChart3 } from 'lucide-react';
 
 class RowAction {
     /**
@@ -20,12 +21,14 @@ class RowAction {
      * @param {string} tooltip
      * @param {string} text
      * @param {()=>void} onClick
+     * @param {boolean} active
      */
-    constructor(icon, tooltip= "", text, onClick) {
+    constructor(icon, tooltip= "", text, onClick, active = false) {
         this.icon = icon
         this.tooltip = tooltip
         this.text = text
         this.onClick = onClick
+        this.active = active
     }
 }
 
@@ -37,6 +40,7 @@ const ChangeRowActions = ({actions}) => <>
         actions.map(action => (
             <OverlayTrigger key={action.text} placement="bottom" overlay={<Tooltip hidden={!action.tooltip}>{action.tooltip}</Tooltip>}>
                 <Button variant="link" disabled={false}
+                        className={`row-action-btn ${action.active ? 'active' : ''}`}
                         onClick={(e) => {
                             e.preventDefault();
                             action.onClick()
@@ -57,7 +61,9 @@ export const ObjectTreeEntryRow = ({entry, relativeTo = "", diffExpanded, depth 
 
     const rowActions = []
     if (onClickExpandDiff) {
-        rowActions.push(new RowAction(null, null, diffExpanded ? "Hide object changes" : "Show object changes", onClickExpandDiff))
+        const expandIcon = diffExpanded ? <ChevronDownIcon/> : <ChevronRightIcon/>;
+        const expandTooltip = diffExpanded ? "Hide object changes" : "Show object changes";
+        rowActions.push(new RowAction(expandIcon, expandTooltip, null, onClickExpandDiff))
     }
     if (onRevert) {
         rowActions.push(new RowAction(<HistoryIcon/>, "Revert changes", null, () => {
@@ -81,7 +87,8 @@ export const PrefixTreeEntryRow = ({entry, relativeTo = "", dirExpanded, depth =
         pathSection = <Link href={onNavigate(entry)}>{pathSection}</Link>
     }
     const rowActions = []
-    rowActions.push(new RowAction(null, null, showSummary ? "Hide change summary" : "Calculate change summary", () => setShowSummary(!showSummary)))
+    const summaryTooltip = showSummary ? "Hide change summary" : "Calculate change summary";
+    rowActions.push(new RowAction(<BarChart3/>, summaryTooltip, null, () => setShowSummary(!showSummary), showSummary))
     if (onRevert) {
         rowActions.push(new RowAction(<HistoryIcon/>, "Revert changes", null, () => {
             setShowRevertConfirm(true)

--- a/webui/src/styles/objects/tree.css
+++ b/webui/src/styles/objects/tree.css
@@ -144,4 +144,14 @@ tr:hover .row-hover .btn-outline-danger {
 [data-bs-theme="dark"] .tree-container .dropdown-divider,
 [data-bs-theme="dark"] .change-entry-row .dropdown-divider {
   border-color: #374151;
+}
+
+.row-action-btn {
+  color: #000000;
+  opacity: 1;
+}
+
+.row-action-btn.active {
+  color: #6c757d;
+  opacity: 0.7;
 } 


### PR DESCRIPTION
this PR closes the [881](https://github.com/treeverse/product/issues/881) issue from the (product board)

## Change Description

Replaced text-labeled buttons in the diff view UI with icon-only buttons, using tooltips to display the original button text:
1. Replaced the “Show Object Changes” button with expand/collapse icons, moving the original label to a tooltip.
2. Replaced the “Calculate Change Summary” button with a statistics icon, with the original text now shown in a tooltip.

**Before:**

<img width="1904" height="723" alt="1" src="https://github.com/user-attachments/assets/44cdbd47-f64a-44a8-b2f3-b46d988dc622" />

**Before - when clicking on the buttons:**

<img width="1443" height="884" alt="image" src="https://github.com/user-attachments/assets/53580f7b-3b17-4bd1-afe9-7126303576de" />

**After:**

<img width="1902" height="700" alt="image" src="https://github.com/user-attachments/assets/fc89e021-4e39-4993-aa8e-3e4b0a7d531f" />

**After - when clicking on the buttons:**

<img width="1893" height="877" alt="image" src="https://github.com/user-attachments/assets/4f6fe618-4c51-48ed-ada8-7ffb4c44801e" />

<img width="1893" height="618" alt="image" src="https://github.com/user-attachments/assets/8ec7ceef-9b3d-4cfc-9089-79e8e741f6f2" />

