### PR TITLE
lakectl: point a branch to an arbitrary commit

### DIFF
--- a/cmd/lakectl/cmd/branch_move_to_commit.go
+++ b/cmd/lakectl/cmd/branch_move_to_commit.go
@@ -1,0 +1,94 @@
+package cmd
+
+import (
+	"fmt"
+	"net/http"
+
+	"github.com/go-openapi/swag"
+	"github.com/spf13/cobra"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
+)
+
+var branchMoveToCommitCmd = &cobra.Command{
+	Use:               "move-to-commit <branch-uri> <commit-ref>",
+	Short:             "Move branch pointer to a specific commit",
+	Long:              `Move a branch pointer to reference a specific commit. This operation is destructive and cannot be undone.`,
+	Example:           "lakectl branch move-to-commit lakefs://example-repo/my-branch 1234567890abcdef",
+	Args:              cobra.ExactArgs(2),
+	ValidArgsFunction: ValidArgsRepository,
+	Run: func(cmd *cobra.Command, args []string) {
+		branchURI := args[0]
+		commitRef := args[1]
+
+		// Parse and validate branch URI
+		u := MustParseBranchURI("branch URI", branchURI)
+
+		// Get API client
+		client := getClient()
+		ctx := cmd.Context()
+
+		// Check if branch exists and get current state
+		branchResp, err := client.GetBranchWithResponse(ctx, u.Repository, u.Ref)
+		DieOnErrorOrUnexpectedStatusCode(branchResp, err, http.StatusOK)
+
+		// Check if target commit exists
+		commitResp, err := client.GetCommitWithResponse(ctx, u.Repository, commitRef)
+		DieOnErrorOrUnexpectedStatusCode(commitResp, err, http.StatusOK)
+
+		// Check for uncommitted changes
+		diffResp, err := client.DiffBranchWithResponse(ctx, u.Repository, u.Ref, &apigen.DiffBranchParams{})
+		DieOnErrorOrUnexpectedStatusCode(diffResp, err, http.StatusOK)
+
+		hasUncommittedChanges := len(diffResp.JSON200.Results) > 0
+		forceFlag, err := cmd.Flags().GetBool("force")
+		if err != nil {
+			DieErr(err)
+		}
+
+		// Check if force is required
+		if hasUncommittedChanges && !forceFlag {
+			DieFmt("Branch '%s' has uncommitted changes. Use --force to proceed and discard them.", u.Ref)
+		}
+
+		// Build confirmation message
+		var confirmationMsg string
+		if hasUncommittedChanges {
+			fmt.Printf("WARNING: Branch '%s' has uncommitted changes that will be permanently lost.\n", u.Ref)
+			confirmationMsg = fmt.Sprintf("Are you sure you want to move branch '%s' to commit '%s'", u.Ref, commitRef)
+		} else {
+			confirmationMsg = fmt.Sprintf("Are you sure you want to move branch '%s' to commit '%s'", u.Ref, commitRef)
+		}
+
+		// Get confirmation from user
+		confirmation, err := Confirm(cmd.Flags(), confirmationMsg)
+		if err != nil || !confirmation {
+			Die("Operation aborted", 1)
+			return
+		}
+
+		// Prepare API request
+		params := &apigen.HardResetBranchParams{
+			Ref: commitRef,
+		}
+		if hasUncommittedChanges {
+			params.Force = swag.Bool(true)
+		}
+
+		// Execute hard reset
+		resetResp, err := client.HardResetBranchWithResponse(ctx, u.Repository, u.Ref, params)
+		DieOnErrorOrUnexpectedStatusCode(resetResp, err, http.StatusNoContent)
+
+		// Success message
+		fmt.Printf("Successfully moved branch '%s' to commit '%s'\n", u.Ref, commitRef)
+	},
+}
+
+//nolint:gochecknoinits
+func init() {
+	// Add flags
+	branchMoveToCommitCmd.Flags().BoolP("force", "f", false, "Force the operation even if the branch has uncommitted changes")
+	AssignAutoConfirmFlag(branchMoveToCommitCmd.Flags())
+
+	// Add to branch command
+	branchCmd.AddCommand(branchMoveToCommitCmd)
+}

--- a/cmd/lakectl/cmd/branch_move_to_commit_test.go
+++ b/cmd/lakectl/cmd/branch_move_to_commit_test.go
@@ -1,0 +1,244 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func TestValidateInputs(t *testing.T) {
+	tests := []struct {
+		name      string
+		branchURI string
+		commitRef string
+		wantErr   bool
+		errMsg    string
+	}{
+		{
+			name:      "valid inputs",
+			branchURI: "lakefs://repo/branch",
+			commitRef: "abc123",
+			wantErr:   false,
+		},
+		{
+			name:      "valid inputs with complex commit ref",
+			branchURI: "lakefs://repo/branch",
+			commitRef: "feature/my-branch~2",
+			wantErr:   false,
+		},
+		{
+			name:      "empty branch URI",
+			branchURI: "",
+			commitRef: "abc123",
+			wantErr:   true,
+			errMsg:    "branch URI cannot be empty",
+		},
+		{
+			name:      "empty commit ref",
+			branchURI: "lakefs://repo/branch",
+			commitRef: "",
+			wantErr:   true,
+			errMsg:    "commit reference cannot be empty",
+		},
+		{
+			name:      "invalid branch URI scheme",
+			branchURI: "http://repo/branch",
+			commitRef: "abc123",
+			wantErr:   true,
+			errMsg:    "branch URI must start with 'lakefs://'",
+		},
+		{
+			name:      "branch URI with newline",
+			branchURI: "lakefs://repo/branch\n",
+			commitRef: "abc123",
+			wantErr:   true,
+			errMsg:    "branch URI contains invalid characters",
+		},
+		{
+			name:      "commit ref with newline",
+			branchURI: "lakefs://repo/branch",
+			commitRef: "abc\n123",
+			wantErr:   true,
+			errMsg:    "commit reference contains invalid characters",
+		},
+		{
+			name:      "branch URI with null byte",
+			branchURI: "lakefs://repo/branch\x00",
+			commitRef: "abc123",
+			wantErr:   true,
+			errMsg:    "branch URI contains invalid characters",
+		},
+		{
+			name:      "commit ref with null byte",
+			branchURI: "lakefs://repo/branch",
+			commitRef: "abc\x00123",
+			wantErr:   true,
+			errMsg:    "commit reference contains invalid characters",
+		},
+		{
+			name:      "commit ref with invalid characters",
+			branchURI: "lakefs://repo/branch",
+			commitRef: "abc@#$%123",
+			wantErr:   true,
+			errMsg:    "commit reference contains invalid characters (allowed: alphanumeric, ., _, /, ~, -)",
+		},
+		{
+			name:      "commit ref with spaces",
+			branchURI: "lakefs://repo/branch",
+			commitRef: "abc 123",
+			wantErr:   true,
+			errMsg:    "commit reference contains invalid characters (allowed: alphanumeric, ., _, /, ~, -)",
+		},
+		{
+			name:      "branch URI too long",
+			branchURI: "lakefs://repo/" + generateLongString(1000),
+			commitRef: "abc123",
+			wantErr:   true,
+			errMsg:    "branch URI too long",
+		},
+		{
+			name:      "commit ref too long",
+			branchURI: "lakefs://repo/branch",
+			commitRef: generateLongString(501),
+			wantErr:   true,
+			errMsg:    "commit reference too long",
+		},
+		{
+			name:      "valid commit ref with all allowed characters",
+			branchURI: "lakefs://repo/branch",
+			commitRef: "abc123._/~-DEF456",
+			wantErr:   false,
+		},
+		{
+			name:      "valid git commit hash",
+			branchURI: "lakefs://repo/branch",
+			commitRef: "1234567890abcdef1234567890abcdef12345678",
+			wantErr:   false,
+		},
+		{
+			name:      "valid branch reference",
+			branchURI: "lakefs://repo/branch",
+			commitRef: "main",
+			wantErr:   false,
+		},
+		{
+			name:      "valid tag reference",
+			branchURI: "lakefs://repo/branch",
+			commitRef: "v1.0.0",
+			wantErr:   false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateInputs(tt.branchURI, tt.commitRef)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("validateInputs() expected error but got none")
+					return
+				}
+				if tt.errMsg != "" {
+					// Check if error message contains expected substring for dynamic messages
+					if tt.errMsg == "branch URI too long" {
+						expectedMsg := "branch URI too long (max 1000 characters)"
+						if err.Error() != expectedMsg {
+							t.Errorf("validateInputs() error = %v, want %v", err, expectedMsg)
+						}
+					} else if tt.errMsg == "commit reference too long" {
+						expectedMsg := "commit reference too long (max 500 characters)"
+						if err.Error() != expectedMsg {
+							t.Errorf("validateInputs() error = %v, want %v", err, expectedMsg)
+						}
+					} else if err.Error() != tt.errMsg {
+						t.Errorf("validateInputs() error = %v, want %v", err, tt.errMsg)
+					}
+				}
+			} else {
+				if err != nil {
+					t.Errorf("validateInputs() unexpected error = %v", err)
+				}
+			}
+		})
+	}
+}
+
+// generateLongString creates a string of specified length for testing
+func generateLongString(length int) string {
+	result := make([]byte, length)
+	for i := range result {
+		result[i] = 'a'
+	}
+	return string(result)
+}
+
+func TestValidateInputs_EdgeCases(t *testing.T) {
+	tests := []struct {
+		name      string
+		branchURI string
+		commitRef string
+		wantErr   bool
+	}{
+		{
+			name:      "branch URI exactly at max length",
+			branchURI: "lakefs://repo/" + generateLongString(986), // "lakefs://repo/" = 14 chars, 986 + 14 = 1000
+			commitRef: "abc123",
+			wantErr:   false,
+		},
+		{
+			name:      "commit ref exactly at max length",
+			branchURI: "lakefs://repo/branch",
+			commitRef: generateLongString(500),
+			wantErr:   false,
+		},
+		{
+			name:      "branch URI one char over max",
+			branchURI: "lakefs://repo/" + generateLongString(987), // 987 + 14 = 1001
+			commitRef: "abc123",
+			wantErr:   true,
+		},
+		{
+			name:      "commit ref one char over max",
+			branchURI: "lakefs://repo/branch",
+			commitRef: generateLongString(501),
+			wantErr:   true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateInputs(tt.branchURI, tt.commitRef)
+			if tt.wantErr && err == nil {
+				t.Errorf("validateInputs() expected error but got none")
+			} else if !tt.wantErr && err != nil {
+				t.Errorf("validateInputs() unexpected error = %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateInputs_SuspiciousCharacters(t *testing.T) {
+	suspiciousChars := []struct {
+		char string
+		name string
+	}{
+		{"\n", "newline"},
+		{"\r", "carriage return"},
+		{"\t", "tab"},
+		{"\x00", "null byte"},
+		{"\x1f", "unit separator"},
+	}
+
+	for _, sc := range suspiciousChars {
+		t.Run("branch URI with "+sc.name, func(t *testing.T) {
+			err := validateInputs("lakefs://repo/branch"+sc.char, "abc123")
+			if err == nil {
+				t.Errorf("validateInputs() expected error for branch URI with %s", sc.name)
+			}
+		})
+
+		t.Run("commit ref with "+sc.name, func(t *testing.T) {
+			err := validateInputs("lakefs://repo/branch", "abc"+sc.char+"123")
+			if err == nil {
+				t.Errorf("validateInputs() expected error for commit ref with %s", sc.name)
+			}
+		})
+	}
+}

--- a/docs/src/reference/cli.md
+++ b/docs/src/reference/cli.md
@@ -1210,6 +1210,34 @@ lakectl branch list lakefs://my-repo
 
 
 
+### lakectl branch move-to-commit
+
+Move branch pointer to a specific commit
+
+<h4>Synopsis</h4>
+
+Move a branch pointer to reference a specific commit. This operation is destructive and cannot be undone.
+
+```
+lakectl branch move-to-commit <branch-uri> <commit-ref> [flags]
+```
+
+<h4>Examples</h4>
+
+```
+lakectl branch move-to-commit lakefs://example-repo/my-branch 1234567890abcdef
+```
+
+<h4>Options</h4>
+
+```
+  -f, --force   Force the operation even if the branch has uncommitted changes
+  -h, --help    help for move-to-commit
+  -y, --yes     Automatically say yes to all confirmations
+```
+
+
+
 ### lakectl branch reset
 
 Reset uncommitted changes - all of them, or by path

--- a/docs/src/reference/cli.md
+++ b/docs/src/reference/cli.md
@@ -1210,34 +1210,6 @@ lakectl branch list lakefs://my-repo
 
 
 
-### lakectl branch move-to-commit
-
-Move branch pointer to a specific commit
-
-<h4>Synopsis</h4>
-
-Move a branch pointer to reference a specific commit. This operation is destructive and cannot be undone.
-
-```
-lakectl branch move-to-commit <branch-uri> <commit-ref> [flags]
-```
-
-<h4>Examples</h4>
-
-```
-lakectl branch move-to-commit lakefs://example-repo/my-branch 1234567890abcdef
-```
-
-<h4>Options</h4>
-
-```
-  -f, --force   Force the operation even if the branch has uncommitted changes
-  -h, --help    help for move-to-commit
-  -y, --yes     Automatically say yes to all confirmations
-```
-
-
-
 ### lakectl branch reset
 
 Reset uncommitted changes - all of them, or by path
@@ -1320,6 +1292,39 @@ lakectl branch show lakefs://my-repo/my-branch
 
 ```
   -h, --help   help for show
+```
+
+
+
+
+---------
+### lakectl branch move-to-commit
+
+!!! warning
+	lakeFS plumbing command. Don't use unless you're _really_ sure you know what you're doing.
+
+Move branch pointer to a specific commit
+
+<h4>Synopsis</h4>
+
+Move a branch pointer to reference a specific commit. This operation is destructive and cannot be undone.
+
+```
+lakectl branch move-to-commit <branch-uri> <commit-ref> [flags]
+```
+
+<h4>Examples</h4>
+
+```
+lakectl branch move-to-commit lakefs://example-repo/my-branch 1234567890abcdef
+```
+
+<h4>Options</h4>
+
+```
+  -f, --force   Force the operation even if the branch has uncommitted changes
+  -h, --help    help for move-to-commit
+  -y, --yes     Automatically say yes to all confirmations
 ```
 
 

--- a/esti/lakectl_branch_test.go
+++ b/esti/lakectl_branch_test.go
@@ -1,0 +1,232 @@
+package esti
+
+import (
+	"context"
+	"net/http"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
+)
+
+const (
+	testFile1 = "path/to/test1.txt"
+	testFile2 = "path/to/test2.txt"
+	moveBranch = "move-test"
+)
+
+var filesForMoveTest = map[string]string{
+	testFile1: "ro_1k",
+	testFile2: "ro_1k_other",
+}
+
+func TestLakectlBranchMoveToCommit(t *testing.T) {
+	repoName := GenerateUniqueRepositoryName()
+	storage := GenerateUniqueStorageNamespace(repoName)
+
+	// Create repository
+	createRepo(t, repoName, storage)
+
+	// Upload files to main branch and create initial commit
+	uploadFiles(t, repoName, mainBranch, filesForMoveTest)
+	commit(t, repoName, mainBranch, "initial commit with test files")
+
+	// Get the initial commit ID using API
+	ctx := context.Background()
+	
+	logAmount := apigen.PaginationAmount(1)
+	logResp, err := client.LogCommitsWithResponse(ctx, repoName, mainBranch, &apigen.LogCommitsParams{
+		Amount: &logAmount,
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, logResp.StatusCode())
+	require.NotEmpty(t, logResp.JSON200.Results)
+	
+	initialCommitID := logResp.JSON200.Results[0].Id
+
+	// Create additional files and commit on main branch
+	additionalFiles := map[string]string{
+		"additional/file.txt": "ro_1k",
+	}
+	uploadFiles(t, repoName, mainBranch, additionalFiles)
+	commit(t, repoName, mainBranch, "second commit with additional files")
+
+	// Create a test branch from current main
+	createBranch(t, repoName, storage, moveBranch)
+
+	// Add some files to the test branch to create uncommitted changes
+	uncommittedFiles := map[string]string{
+		"uncommitted/file.txt": "ro_1k",
+	}
+	uploadFiles(t, repoName, moveBranch, uncommittedFiles)
+
+	// Test 1: Try to move branch without --force flag (should fail due to uncommitted changes)
+	moveCmd := NewLakeCtl().
+		Arg("branch move-to-commit").
+		URLArg("lakefs://", repoName, moveBranch).
+		Arg(initialCommitID).
+		Flag("--yes") // Auto-confirm
+	RunCmdAndVerifyFailureContainsText(t, moveCmd.Get(), false, "has uncommitted changes", nil)
+
+	// Test 2: Move branch with --force flag (should succeed)
+	moveCmdForce := NewLakeCtl().
+		Arg("branch move-to-commit").
+		URLArg("lakefs://", repoName, moveBranch).
+		Arg(initialCommitID).
+		Flag("--force").
+		Flag("--yes") // Auto-confirm
+	RunCmdAndVerifyContainsText(t, moveCmdForce.Get(), false, "Successfully moved branch", nil)
+
+	// Test 3: Verify the branch now points to the initial commit
+	// Check that the additional files from the second commit are no longer present
+	listCmd := NewLakeCtl().
+		Arg("fs ls").
+		URLArg("lakefs://", repoName, moveBranch, "additional/")
+	RunCmdAndVerifyFailureContainsText(t, listCmd.Get(), false, "path not found", nil)
+
+	// Test 4: Verify the original files from initial commit are still there
+	statCmd := NewLakeCtl().
+		Arg("fs stat").
+		URLArg("lakefs://", repoName, moveBranch, testFile1)
+	RunCmdAndVerifySuccess(t, statCmd.Get(), false, "", nil)
+
+	// Test 5: Try to move to a non-existent commit (should fail)
+	invalidMoveCmd := NewLakeCtl().
+		Arg("branch move-to-commit").
+		URLArg("lakefs://", repoName, moveBranch).
+		Arg("nonexistentcommit1234567890abcdef").
+		Flag("--yes")
+	RunCmdAndVerifyFailureContainsText(t, invalidMoveCmd.Get(), false, "not found", nil)
+}
+
+func TestLakectlBranchMoveToCommitCleanBranch(t *testing.T) {
+	repoName := GenerateUniqueRepositoryName()
+	storage := GenerateUniqueStorageNamespace(repoName)
+
+	// Create repository
+	createRepo(t, repoName, storage)
+
+	// Upload files and create initial commit
+	uploadFiles(t, repoName, mainBranch, filesForMoveTest)
+	commit(t, repoName, mainBranch, "initial commit")
+
+	// Get the initial commit ID using API
+	ctx := context.Background()
+	
+	logAmount := apigen.PaginationAmount(1)
+	logResp, err := client.LogCommitsWithResponse(ctx, repoName, mainBranch, &apigen.LogCommitsParams{
+		Amount: &logAmount,
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, logResp.StatusCode())
+	require.NotEmpty(t, logResp.JSON200.Results)
+	
+	initialCommitID := logResp.JSON200.Results[0].Id
+
+	// Add more files and create second commit
+	additionalFiles := map[string]string{
+		"second/commit/file.txt": "ro_1k",
+	}
+	uploadFiles(t, repoName, mainBranch, additionalFiles)
+	commit(t, repoName, mainBranch, "second commit")
+
+	// Create branch from current main (which has both commits)
+	createBranch(t, repoName, storage, moveBranch)
+
+	// Move the branch to the initial commit (no uncommitted changes)
+	moveCmd := NewLakeCtl().
+		Arg("branch move-to-commit").
+		URLArg("lakefs://", repoName, moveBranch).
+		Arg(initialCommitID).
+		Flag("--yes")
+	RunCmdAndVerifyContainsText(t, moveCmd.Get(), false, "Successfully moved branch", nil)
+
+	// Verify the second commit files are no longer accessible
+	listCmd := NewLakeCtl().
+		Arg("fs ls").
+		URLArg("lakefs://", repoName, moveBranch, "second/")
+	RunCmdAndVerifyFailureContainsText(t, listCmd.Get(), false, "path not found", nil)
+
+	// Verify original files are still there
+	statCmd := NewLakeCtl().
+		Arg("fs stat").
+		URLArg("lakefs://", repoName, moveBranch, testFile1)
+	RunCmdAndVerifySuccess(t, statCmd.Get(), false, "", nil)
+}
+
+func TestLakectlBranchMoveToCommitPermissions(t *testing.T) {
+	repoName := GenerateUniqueRepositoryName()
+	storage := GenerateUniqueStorageNamespace(repoName)
+
+	// Create repository
+	createRepo(t, repoName, storage)
+
+	// Upload files and commit
+	uploadFiles(t, repoName, mainBranch, filesForMoveTest)
+	commit(t, repoName, mainBranch, "test commit")
+
+	// Get commit ID using API
+	ctx := context.Background()
+	
+	logAmount := apigen.PaginationAmount(1)
+	logResp, err := client.LogCommitsWithResponse(ctx, repoName, mainBranch, &apigen.LogCommitsParams{
+		Amount: &logAmount,
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, logResp.StatusCode())
+	require.NotEmpty(t, logResp.JSON200.Results)
+	
+	commitID := logResp.JSON200.Results[0].Id
+
+	// Create branch
+	createBranch(t, repoName, storage, moveBranch)
+
+	// Test basic permission validation by trying to move to same commit (should succeed)
+	moveCmd := NewLakeCtl().
+		Arg("branch move-to-commit").
+		URLArg("lakefs://", repoName, moveBranch).
+		Arg(commitID).
+		Flag("--yes")
+	RunCmdAndVerifyContainsText(t, moveCmd.Get(), false, "Successfully moved branch", nil)
+}
+
+func TestLakectlBranchMoveToCommitValidation(t *testing.T) {
+	repoName := GenerateUniqueRepositoryName()
+	storage := GenerateUniqueStorageNamespace(repoName)
+
+	// Create repository
+	createRepo(t, repoName, storage)
+
+	// Test 1: Invalid branch URI format
+	invalidBranchCmd := NewLakeCtl().
+		Arg("branch move-to-commit").
+		Arg("invalid-uri").
+		Arg("somecommit").
+		Flag("--yes")
+	RunCmdAndVerifyFailureContainsText(t, invalidBranchCmd.Get(), false, "Invalid input", nil)
+
+	// Test 2: Empty commit reference
+	emptyCommitCmd := NewLakeCtl().
+		Arg("branch move-to-commit").
+		URLArg("lakefs://", repoName, mainBranch).
+		Arg("").
+		Flag("--yes")
+	RunCmdAndVerifyFailureContainsText(t, emptyCommitCmd.Get(), false, "Invalid input", nil)
+
+	// Test 3: Non-existent repository
+	nonExistentRepoCmd := NewLakeCtl().
+		Arg("branch move-to-commit").
+		URLArg("lakefs://", "nonexistent-repo", mainBranch).
+		Arg("somecommit").
+		Flag("--yes")
+	RunCmdAndVerifyFailureContainsText(t, nonExistentRepoCmd.Get(), false, "not found", nil)
+
+	// Test 4: Non-existent branch
+	nonExistentBranchCmd := NewLakeCtl().
+		Arg("branch move-to-commit").
+		URLArg("lakefs://", repoName, "nonexistent-branch").
+		Arg("somecommit").
+		Flag("--yes")
+	RunCmdAndVerifyFailureContainsText(t, nonExistentBranchCmd.Get(), false, "not found", nil)
+}
+

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -3070,8 +3070,7 @@ func (c *Controller) ResetBranch(w http.ResponseWriter, r *http.Request, body ap
 func (c *Controller) HardResetBranch(w http.ResponseWriter, r *http.Request, repository, branch string, params apigen.HardResetBranchParams) {
 	if !c.authorize(w, r, permissions.Node{
 		Permission: permissions.Permission{
-			// TODO(ozkatz): Can we have another action here?
-			Action:   permissions.RevertBranchAction,
+			Action:   permissions.HardResetBranchAction,
 			Resource: permissions.BranchArn(repository, branch),
 		},
 	}) {

--- a/pkg/permissions/actions.gen.go
+++ b/pkg/permissions/actions.gen.go
@@ -22,6 +22,7 @@ var Actions = []string{
 	"fs:DeleteBranch",
 	"fs:ReadBranch",
 	"fs:RevertBranch",
+	"fs:HardResetBranch",
 	"fs:ListBranches",
 	"fs:CreateTag",
 	"fs:DeleteTag",

--- a/pkg/permissions/actions.go
+++ b/pkg/permissions/actions.go
@@ -33,6 +33,7 @@ const (
 	DeleteBranchAction           = "fs:DeleteBranch"
 	ReadBranchAction             = "fs:ReadBranch"
 	RevertBranchAction           = "fs:RevertBranch"
+	HardResetBranchAction        = "fs:HardResetBranch"
 	ListBranchesAction           = "fs:ListBranches"
 	CreateTagAction              = "fs:CreateTag"
 	DeleteTagAction              = "fs:DeleteTag"

--- a/pkg/permissions/actions_test.go
+++ b/pkg/permissions/actions_test.go
@@ -18,7 +18,30 @@ func TestAllActions(t *testing.T) {
 		t.Errorf("Expected actions %v to include %s", actions, permissions.ReadActionsAction)
 	}
 
+	if !slices.Contains(actions, permissions.HardResetBranchAction) {
+		t.Errorf("Expected actions %v to include %s", actions, permissions.HardResetBranchAction)
+	}
+
 	if slices.Contains(actions, "IsValidAction") {
 		t.Errorf("Expected actions %v not to include IsValidAction", actions)
+	}
+}
+
+func TestHardResetBranchAction(t *testing.T) {
+	// Test that the HardResetBranchAction constant has the correct value
+	expectedAction := "fs:HardResetBranch"
+	if permissions.HardResetBranchAction != expectedAction {
+		t.Errorf("Expected HardResetBranchAction to be %s, got %s", expectedAction, permissions.HardResetBranchAction)
+	}
+
+	// Test that the action is valid according to IsValidAction
+	err := permissions.IsValidAction(permissions.HardResetBranchAction)
+	if err != nil {
+		t.Errorf("Expected HardResetBranchAction to be valid, got error: %v", err)
+	}
+
+	// Test that the action is included in the Actions slice
+	if !slices.Contains(permissions.Actions, permissions.HardResetBranchAction) {
+		t.Errorf("Expected HardResetBranchAction to be included in Actions slice")
 	}
 }


### PR DESCRIPTION
Closes #7404 

Implements `lakectl branch move-to-commit <branch-uri> <commit-ref>` to move branch pointers to arbitrary commits. Hidden plumbing command for automation and data recovery workflows.

## Implementation

  - Command: Uses existing HardResetBranch API with input validation and confirmation prompts
  - Security: Requires fs:HardResetBranch permission, blocks on uncommitted changes unless --force used
  - Classification: Plumbing command (hidden from standard docs)

## Files Changed

  - cmd/lakectl/cmd/branch_move_to_commit.go - Command implementation
  - cmd/lakectl/cmd/branch_move_to_commit_test.go - Unit tests
  - pkg/permissions/actions.go - Added HardResetBranchAction permission
  - pkg/api/controller.go - Updated authorization/logging
  - esti/lakectl_branch_test.go - Integration tests
  - Test files for permission validation

## How was this tested?

  Manually + unti tests + integration tests.