### PR TITLE
Fixed the image overflow in the diff view in the UI

### DIFF
--- a/webui/src/styles/objects/diff.css
+++ b/webui/src/styles/objects/diff.css
@@ -64,22 +64,22 @@
   color: #660066;
 }
 
-[data-bs-theme="dark"] .diff-changed a:hover, 
+[data-bs-theme="dark"] .diff-changed a:hover,
 [data-bs-theme="dark"] .diff-changed .btn-link:hover {
   color: #dddddd;
 }
 
-[data-bs-theme="dark"] .diff-added a:hover, 
+[data-bs-theme="dark"] .diff-added a:hover,
 [data-bs-theme="dark"] .diff-added .btn-link:hover {
   color: #88ff88;
 }
 
-[data-bs-theme="dark"] .diff-removed a:hover, 
+[data-bs-theme="dark"] .diff-removed a:hover,
 [data-bs-theme="dark"] .diff-removed .btn-link:hover {
   color: #ff8888;
 }
 
-[data-bs-theme="dark"] .diff-conflict a:hover, 
+[data-bs-theme="dark"] .diff-conflict a:hover,
 [data-bs-theme="dark"] .diff-conflict .btn-link:hover {
   color: #ff88ff;
 }
@@ -110,8 +110,9 @@
   gap: 1rem;
 }
 
-.image-diff-card img {
+.image-diff-card {
   max-height: 60vh;
+  max-width: 100%;
   width: auto;
   height: auto;
 }


### PR DESCRIPTION
Closes #9345 

After the fix, the image fits smaller screens and no longer causes overflow:
<img width="948" height="880" alt="Screenshot 2025-07-23 at 15 50 38" src="https://github.com/user-attachments/assets/c6127f71-8ddf-4af4-908a-04f07d28c34a" />
