### PR TITLE
WebUI: Unify /config calls

### DIFF
--- a/webui/src/lib/api/index.js
+++ b/webui/src/lib/api/index.js
@@ -301,10 +301,12 @@ class Auth {
     }
 
     async createGroup(groupName, groupDescription) {
-        const response = await apiRequest(`/auth/groups`, {method: 'POST', body: JSON.stringify({
+        const response = await apiRequest(`/auth/groups`, {
+            method: 'POST', body: JSON.stringify({
                 id: groupName,
                 description: groupDescription
-        })});
+            })
+        });
         if (response.status !== 201) {
             throw new Error(await extractError(response));
         }
@@ -1067,12 +1069,12 @@ class Setup {
 }
 
 class Config {
-    async getStorageConfigs() {
+    async getConfig() {
         const response = await apiRequest('/config', {
             method: 'GET',
         });
 
-        const parseBlockstoreConfig = (storageCfg) => {
+        const parseBlockstoreConfig = storageCfg => {
             storageCfg.warnings = []
             if (storageCfg.blockstore_type === 'mem') {
                 storageCfg.warnings.push(`Block adapter ${storageCfg.blockstore_type} not usable in production`)
@@ -1080,33 +1082,26 @@ class Config {
             return storageCfg;
         };
 
+        const buildStoragesConfigs = cfg => {
+            const storageCfgList = cfg['storage_config_list'];
+            if (storageCfgList?.length > 1) {
+                return storageCfgList.map(storageCfg => parseBlockstoreConfig(storageCfg));
+            } else {
+                const storageCfg = cfg['storage_config']
+                return [parseBlockstoreConfig(storageCfg)];
+            }
+        };
+
         switch (response.status) {
             case 200: {
                 const cfg = await response.json();
-                const storageCfgList = cfg['storage_config_list'];
-                if (storageCfgList?.length > 1) {
-                    return storageCfgList.map(storageCfg => parseBlockstoreConfig(storageCfg));
-                } else {
-                    const storageCfg = cfg['storage_config']
-                    return [parseBlockstoreConfig(storageCfg)];
-                }
+                const storages = buildStoragesConfigs(cfg);
+                const customization = cfg['customization'];
+                const versionConfig = cfg['version_config'];
+                return {storages, customization, versionConfig};
             }
             case 409:
                 throw new Error('Conflict');
-            default:
-                throw new Error('Unknown');
-        }
-    }
-
-    async getLakeFSVersion() {
-        const response = await apiRequest('/config', {
-            method: 'GET',
-        });
-        let cfg;
-        switch (response.status) {
-            case 200:
-                cfg = await response.json();
-                return cfg.version_config
             default:
                 throw new Error('Unknown');
         }

--- a/webui/src/lib/components/layout.tsx
+++ b/webui/src/lib/components/layout.tsx
@@ -1,12 +1,12 @@
-import React, {FC, useContext, useState} from "react";
+import React, { FC, useContext, useState } from "react";
 import { Outlet, useOutletContext } from "react-router-dom";
-import { StorageConfigProvider } from "../hooks/storageConfig";
+import { ConfigProvider } from "../hooks/configProvider";
 import TopNav from './navbar';
 import { AppContext } from "../hooks/appContext";
 
 type LayoutOutletContext = [(isLoggedIn: boolean) => void];
 
-const Layout: FC<{logged: boolean}> = ({ logged }) => {
+const Layout: FC<{logged: boolean}> = ({logged}) => {
     const [isLogged, setIsLogged] = useState(logged ?? true);
 
     // handle global dark mode here
@@ -14,14 +14,12 @@ const Layout: FC<{logged: boolean}> = ({ logged }) => {
     document.documentElement.setAttribute('data-bs-theme', state.settings.darkMode ? 'dark' : 'light')
 
     return (
-        <>
+        <ConfigProvider>
             <TopNav logged={isLogged}/>
             <div className="main-app">
-                <StorageConfigProvider>
-                    <Outlet context={[setIsLogged] satisfies LayoutOutletContext}/>
-                </StorageConfigProvider>
+                <Outlet context={[setIsLogged] satisfies LayoutOutletContext}/>
             </div>
-        </>
+        </ConfigProvider>
     );
 };
 

--- a/webui/src/lib/components/navbar.jsx
+++ b/webui/src/lib/components/navbar.jsx
@@ -13,13 +13,14 @@ import {FeedPersonIcon} from "@primer/octicons-react";
 const NavUserInfo = () => {
     const { user, loading, error } = useUser();
     const logoutUrl = useLoginConfigContext()?.logout_url || "/logout"
-    const { response: versionResponse, loading: versionLoading, error: versionError } = useAPI(() => {
-        return config.getLakeFSVersion()
-    }, [])
+    const { response: configData, loading: versionLoading, error: versionError } = useAPI(() => {
+        return config.getConfig();
+    }, []);
+    const versionConfig = configData?.versionConfig || {};
 
     if (loading) return <Navbar.Text>Loading...</Navbar.Text>;
     if (!user || !!error) return (<></>);
-    const notifyNewVersion = !versionLoading && !versionError && versionResponse.upgrade_recommended
+    const notifyNewVersion = !versionLoading && !versionError && versionConfig.upgrade_recommended
     const NavBarTitle = () => {
         return (
         <>
@@ -31,7 +32,7 @@ const NavUserInfo = () => {
     return (
         <NavDropdown title={<NavBarTitle />} className="navbar-username" align="end">
             {notifyNewVersion && <>
-            <NavDropdown.Item href={versionResponse.upgrade_url}>
+            <NavDropdown.Item href={versionConfig.upgrade_url}>
                     <>
                     <div className="menu-item-notification-indicator"></div>
                     New lakeFS version is available!
@@ -47,7 +48,7 @@ const NavUserInfo = () => {
             <NavDropdown.Divider/>
             {!versionLoading && !versionError && <>
             <NavDropdown.Item disabled={true}>
-                {`${versionResponse.version_context} ${versionResponse.version}`}
+                {`${versionConfig.version_context} ${versionConfig.version}`}
             </NavDropdown.Item></>}
         </NavDropdown>
     );

--- a/webui/src/lib/components/navbar.jsx
+++ b/webui/src/lib/components/navbar.jsx
@@ -1,22 +1,20 @@
 import React from "react";
 import useUser from '../hooks/user'
-import {auth, config} from "../api";
+import {auth} from "../api";
 import {useRouter} from "../hooks/router";
 import {Link} from "./nav";
 import DarkModeToggle from "./darkModeToggle";
-import {useAPI} from "../hooks/api";
 import {Navbar, Nav, NavDropdown} from "react-bootstrap";
 import Container from "react-bootstrap/Container";
 import {useLoginConfigContext} from "../hooks/conf";
 import {FeedPersonIcon} from "@primer/octicons-react";
+import {useConfigContext} from "../hooks/configProvider";
 
 const NavUserInfo = () => {
     const { user, loading, error } = useUser();
     const logoutUrl = useLoginConfigContext()?.logout_url || "/logout"
-    const { response: configData, loading: versionLoading, error: versionError } = useAPI(() => {
-        return config.getConfig();
-    }, []);
-    const versionConfig = configData?.versionConfig || {};
+    const {config, error: versionError, loading: versionLoading} = useConfigContext();
+    const versionConfig = config?.versionConfig || {};
 
     if (loading) return <Navbar.Text>Loading...</Navbar.Text>;
     if (!user || !!error) return (<></>);

--- a/webui/src/lib/components/repository/ObjectsDiff.jsx
+++ b/webui/src/lib/components/repository/ObjectsDiff.jsx
@@ -7,7 +7,7 @@ import {humanSize} from "./tree";
 import Alert from "react-bootstrap/Alert";
 import Card from "react-bootstrap/Card";
 import {InfoIcon} from "@primer/octicons-react";
-import {useStorageConfigs} from "../../hooks/storageConfig";
+import {useConfigContext} from "../../hooks/configProvider";
 import {AppContext} from "../../hooks/appContext";
 import {useRefs} from "../../hooks/repo";
 import {getRepoStorageConfig} from "../../../pages/repositories/repository/utils";
@@ -19,9 +19,9 @@ const imageExtensions = ["png", "jpg", "jpeg", "gif", "bmp", "webp"];
 export const ObjectsDiff = ({diffType, repoId, leftRef, rightRef, path}) => {
     const {state} = useContext(AppContext);
     const {repo, error: refsError, loading: refsLoading} = useRefs();
-    const {configs: storageConfigs, error: configsError, loading: storageConfigsLoading} = useStorageConfigs();
-    const {storageConfig, error: storageConfigError} = getRepoStorageConfig(storageConfigs, repo);
-    const hooksLoading = refsLoading || storageConfigsLoading;
+    const {config, error: configsError, loading: configLoading} = useConfigContext();
+    const {storageConfig, error: storageConfigError} = getRepoStorageConfig(config?.storages, repo);
+    const hooksLoading = refsLoading || configLoading;
     const hooksError = hooksLoading ? null : refsError || configsError || storageConfigError;
 
     if (hooksError) return <AlertError error={hooksError}/>;

--- a/webui/src/lib/hooks/configProvider.tsx
+++ b/webui/src/lib/hooks/configProvider.tsx
@@ -6,8 +6,12 @@ import useUser from "./user";
 type StorageConfigContextType = {
     error: Error | null;
     loading: boolean;
-    configs: [StorageConfigType] | null;
+    config: ConfigType | null;
 };
+
+type ConfigType = {
+    storages: [StorageConfigType] | null;
+}
 
 type StorageConfigType = {
     blockstore_namespace_ValidityRegex: string | null;
@@ -23,23 +27,23 @@ type StorageConfigType = {
 const storageConfigInitialState: StorageConfigContextType = {
     error: null,
     loading: true,
-    configs: null,
+    config: null,
 };
 
 const StorageConfigContext = createContext<StorageConfigContextType>(storageConfigInitialState);
 
-const useStorageConfigs = () => useContext(StorageConfigContext);
+const useConfigContext = () => useContext(StorageConfigContext);
 
-const StorageConfigProvider: FC<{children: React.ReactNode}> = ({children}) => {
+const ConfigProvider: FC<{children: React.ReactNode}> = ({children}) => {
     const {user} = useUser();
     const [storageConfig, setStorageConfig] = useState<StorageConfigContextType>(storageConfigInitialState);
 
     useEffect(() => {
         config.getConfig()
             .then(configData =>
-                setStorageConfig({configs: configData?.storages, loading: false, error: null}))
+                setStorageConfig({config: configData, loading: false, error: null}))
             .catch((error) =>
-                setStorageConfig({configs: null, loading: false, error}));
+                setStorageConfig({config: null, loading: false, error}));
     }, [user]);
 
     return (
@@ -49,4 +53,4 @@ const StorageConfigProvider: FC<{children: React.ReactNode}> = ({children}) => {
     );
 };
 
-export { StorageConfigProvider, useStorageConfigs };
+export { ConfigProvider, useConfigContext };

--- a/webui/src/lib/hooks/storageConfig.tsx
+++ b/webui/src/lib/hooks/storageConfig.tsx
@@ -35,9 +35,9 @@ const StorageConfigProvider: FC<{children: React.ReactNode}> = ({children}) => {
     const [storageConfig, setStorageConfig] = useState<StorageConfigContextType>(storageConfigInitialState);
 
     useEffect(() => {
-        config.getStorageConfigs()
-            .then(configs =>
-                setStorageConfig({configs, loading: false, error: null}))
+        config.getConfig()
+            .then(configData =>
+                setStorageConfig({configs: configData?.storages, loading: false, error: null}))
             .catch((error) =>
                 setStorageConfig({configs: null, loading: false, error}));
     }, [user]);

--- a/webui/src/pages/repositories/index.jsx
+++ b/webui/src/pages/repositories/index.jsx
@@ -14,12 +14,13 @@ import dayjs from "dayjs";
 import relativeTime from "dayjs/plugin/relativeTime";
 
 import {ActionsBar, AlertError, Loading, useDebouncedState} from "../../lib/components/controls";
-import {config, repositories} from '../../lib/api';
-import {useAPI, useAPIWithPagination} from "../../lib/hooks/api";
+import {repositories} from '../../lib/api';
+import {useAPIWithPagination} from "../../lib/hooks/api";
 import {Paginator} from "../../lib/components/pagination";
 import Container from "react-bootstrap/Container";
 import {Link} from "../../lib/components/nav";
 import {useRouter} from "../../lib/hooks/router";
+import {useConfigContext} from "../../lib/hooks/configProvider";
 import {ReadOnlyBadge} from "../../lib/components/badges";
 
 import Button from "react-bootstrap/Button";
@@ -55,7 +56,7 @@ const CreateRepositoryModal = ({show, error, onSubmit, onCancel, inProgress}) =>
 
     const [formValid, setFormValid] = useState(false);
 
-    const {response: configData, error: err, loading} = useAPI(() => config.getConfig());
+    const {config, error: err, loading} = useConfigContext();
 
     const buttonContent = inProgress ? (
         <>
@@ -80,7 +81,7 @@ const CreateRepositoryModal = ({show, error, onSubmit, onCancel, inProgress}) =>
             <Modal.Body>
                 {repoCreationFormPlugin.build({
                     formID: "repository-create-form",
-                    configs: configData?.storages,
+                    configs: config?.storages,
                     error: showError,
                     formValid,
                     setFormValid,
@@ -266,8 +267,8 @@ const RepositoriesPage = () => {
         (search) => router.push({pathname: `/repositories`, query: {search}})
     );
 
-    const { response: configData, error: err, loading } = useAPI(() => config.getConfig());
-    const storageConfigs = configData?.storages;
+    const {config, error: err, loading} = useConfigContext();
+    const storageConfigs = config?.storages;
 
     const createRepo = async (repo, presentRepo = true) => {
         try {

--- a/webui/src/pages/repositories/index.jsx
+++ b/webui/src/pages/repositories/index.jsx
@@ -55,7 +55,7 @@ const CreateRepositoryModal = ({show, error, onSubmit, onCancel, inProgress}) =>
 
     const [formValid, setFormValid] = useState(false);
 
-    const {response: storageConfigs, error: err, loading} = useAPI(() => config.getStorageConfigs());
+    const {response: configData, error: err, loading} = useAPI(() => config.getConfig());
 
     const buttonContent = inProgress ? (
         <>
@@ -80,7 +80,7 @@ const CreateRepositoryModal = ({show, error, onSubmit, onCancel, inProgress}) =>
             <Modal.Body>
                 {repoCreationFormPlugin.build({
                     formID: "repository-create-form",
-                    configs: storageConfigs,
+                    configs: configData?.storages,
                     error: showError,
                     formValid,
                     setFormValid,
@@ -266,7 +266,8 @@ const RepositoriesPage = () => {
         (search) => router.push({pathname: `/repositories`, query: {search}})
     );
 
-    const { response: storageConfigs, error: err, loading } = useAPI(() => config.getStorageConfigs());
+    const { response: configData, error: err, loading } = useAPI(() => config.getConfig());
+    const storageConfigs = configData?.storages;
 
     const createRepo = async (repo, presentRepo = true) => {
         try {

--- a/webui/src/pages/repositories/repository/objectViewer.tsx
+++ b/webui/src/pages/repositories/repository/objectViewer.tsx
@@ -12,7 +12,7 @@ import { AlertError } from "../../../lib/components/controls";
 import { URINavigator } from "../../../lib/components/repository/tree";
 import { RefTypeBranch } from "../../../constants";
 import { RefContextProvider, useRefs } from "../../../lib/hooks/repo";
-import { useStorageConfigs } from "../../../lib/hooks/storageConfig";
+import { useConfigContext } from "../../../lib/hooks/configProvider";
 import { linkToPath } from "../../../lib/api";
 import { getRepoStorageConfig } from "./utils";
 
@@ -58,8 +58,8 @@ export const getContentType = (headers: Headers): string | null => {
 
 const FileObjectsViewerPage = () => {
   const {repo} = useRefs();
-  const {configs: storageConfigs, error: configsError, loading: storageConfigsLoading} = useStorageConfigs();
-  const {storageConfig, error: storageConfigError} = getRepoStorageConfig(storageConfigs, repo);
+  const {config, error: configsError, loading: configLoading} = useConfigContext();
+  const {storageConfig, error: storageConfigError} = getRepoStorageConfig(config?.storages, repo);
 
   const { repoId } = useParams<ObjectViewerPathParams>();
   const queryString = useQuery<ObjectViewerQueryString>();
@@ -68,7 +68,7 @@ const FileObjectsViewerPage = () => {
   const { response, error: apiError, loading: apiLoading } = useAPI(() => {
     return objects.head(repoId, refId, path);
   }, [repoId, refId, path]);
-  const loading = apiLoading || storageConfigsLoading;
+  const loading = apiLoading || configLoading;
   const error = loading ? null : apiError || configsError || storageConfigError;
 
   let content;

--- a/webui/src/pages/repositories/repository/objects.jsx
+++ b/webui/src/pages/repositories/repository/objects.jsx
@@ -39,7 +39,7 @@ import { RepoError } from "./error";
 import { getContentType, getFileExtension, FileContents } from "./objectViewer";
 import {ProgressBar} from "react-bootstrap";
 import { useSearchParams } from "react-router-dom";
-import { useStorageConfigs } from "../../../lib/hooks/storageConfig";
+import { useConfigContext } from "../../../lib/hooks/configProvider";
 import { getRepoStorageConfig } from "./utils";
 import {useDropzone} from "react-dropzone";
 import pMap from "p-map";
@@ -1517,7 +1517,7 @@ const ObjectsBrowser = ({ config }) => {
 
 const RepositoryObjectsPage = () => {
     const {repo} = useRefs();
-    const {configs: storageConfigs, loading: configsLoading, error: configsError} = useStorageConfigs();
+    const {config, loading: configsLoading, error: configsError} = useConfigContext();
 
     const [setActivePage] = useOutletContext();
     useEffect(() => setActivePage("objects"), [setActivePage]);
@@ -1525,7 +1525,7 @@ const RepositoryObjectsPage = () => {
     if (configsLoading) return <Loading/>;
     if (configsError) return <RepoError error={configsError}/>;
 
-    const {storageConfig, loading: configLoading, error: configError} = getRepoStorageConfig(storageConfigs, repo);
+    const {storageConfig, loading: configLoading, error: configError} = getRepoStorageConfig(config?.storages, repo);
     if (configLoading) return <Loading/>;
     if (configError) return <RepoError error={configError}/>;
 


### PR DESCRIPTION
This is a prerequisite for other PRs, that require calls to `/config` - 
Unified it first (as described below), so the context can be used for the config data.

## Change Description

There are different repeated calls to the `/config` endpoint, while this endpoint is pretty static, and needs to be called only once per page load.

Extended the `<StorageConfigProvider>` to be `<ConfigProvider>`,
And updated all the relevant places to use it (instead of making repeated and redundant API calls).

## How was it tested

Tested manually.

