### PR TITLE
Remove metadata tracking time limitation

### DIFF
--- a/docs/src/datamanagment/metadata-search.md
+++ b/docs/src/datamanagment/metadata-search.md
@@ -357,7 +357,6 @@ WHERE path LIKE 'customers/%'
 
 ## Limitations
 
-* Applies only to objects added or modified after the feature was enabled. Existing objects before that point are not indexed. 
 * Querying by [tags](../understand/glossary.md#tag) is unsupported, and is in our roadmap.  
 * Querying by commit is only supported by using the pattern described [here](#using-commit-ids).
   


### PR DESCRIPTION
Metadata search tracks object metadata according to the [metadata_settings.since](https://docs.lakefs.io/latest/datamanagment/metadata-search/#configuration-reference) configuration. Meaning, it can track metadata captured before the feature has been enabled. 