### PR TITLE
WebUI: Fix loading state when fetching repository data

### DIFF
--- a/webui/src/lib/components/navbar.jsx
+++ b/webui/src/lib/components/navbar.jsx
@@ -11,12 +11,12 @@ import {FeedPersonIcon} from "@primer/octicons-react";
 import {useConfigContext} from "../hooks/configProvider";
 
 const NavUserInfo = () => {
-    const { user, loading, error } = useUser();
+    const { user, loading: userLoading, error } = useUser();
     const logoutUrl = useLoginConfigContext()?.logout_url || "/logout"
     const {config, error: versionError, loading: versionLoading} = useConfigContext();
     const versionConfig = config?.versionConfig || {};
 
-    if (loading || versionLoading) return <Navbar.Text>Loading...</Navbar.Text>;
+    if (userLoading || versionLoading) return <Navbar.Text>Loading...</Navbar.Text>;
     if (!user || !!error) return (<></>);
     const notifyNewVersion = !versionLoading && !versionError && versionConfig.upgrade_recommended
     const NavBarTitle = () => {

--- a/webui/src/lib/components/navbar.jsx
+++ b/webui/src/lib/components/navbar.jsx
@@ -16,7 +16,7 @@ const NavUserInfo = () => {
     const {config, error: versionError, loading: versionLoading} = useConfigContext();
     const versionConfig = config?.versionConfig || {};
 
-    if (loading) return <Navbar.Text>Loading...</Navbar.Text>;
+    if (loading || versionLoading) return <Navbar.Text>Loading...</Navbar.Text>;
     if (!user || !!error) return (<></>);
     const notifyNewVersion = !versionLoading && !versionError && versionConfig.upgrade_recommended
     const NavBarTitle = () => {

--- a/webui/src/lib/components/repository/ObjectsDiff.jsx
+++ b/webui/src/lib/components/repository/ObjectsDiff.jsx
@@ -18,11 +18,11 @@ const imageExtensions = ["png", "jpg", "jpeg", "gif", "bmp", "webp"];
 
 export const ObjectsDiff = ({diffType, repoId, leftRef, rightRef, path}) => {
     const {state} = useContext(AppContext);
-    const {repo, error: refsError, loading: refsLoading} = useRefs();
+    const {repo, error: repoError, loading: repoLoading} = useRefs();
     const {config, error: configsError, loading: configLoading} = useConfigContext();
     const {storageConfig, error: storageConfigError} = getRepoStorageConfig(config?.storages, repo);
-    const hooksLoading = refsLoading || configLoading;
-    const hooksError = hooksLoading ? null : refsError || configsError || storageConfigError;
+    const hooksLoading = repoLoading || configLoading;
+    const hooksError = hooksLoading ? null : repoError || configsError || storageConfigError;
 
     if (hooksError) return <AlertError error={hooksError}/>;
 

--- a/webui/src/pages/repositories/repository/objectViewer.tsx
+++ b/webui/src/pages/repositories/repository/objectViewer.tsx
@@ -57,7 +57,7 @@ export const getContentType = (headers: Headers): string | null => {
 };
 
 const FileObjectsViewerPage = () => {
-  const {repo} = useRefs();
+  const {repo, loading: repoLoading, error: repoError} = useRefs();
   const {config, error: configsError, loading: configLoading} = useConfigContext();
   const {storageConfig, error: storageConfigError} = getRepoStorageConfig(config?.storages, repo);
 
@@ -68,8 +68,8 @@ const FileObjectsViewerPage = () => {
   const { response, error: apiError, loading: apiLoading } = useAPI(() => {
     return objects.head(repoId, refId, path);
   }, [repoId, refId, path]);
-  const loading = apiLoading || configLoading;
-  const error = loading ? null : apiError || configsError || storageConfigError;
+  const loading = apiLoading || repoLoading || configLoading;
+  const error = loading ? null : apiError || repoError || configsError || storageConfigError;
 
   let content;
   if (loading) {

--- a/webui/src/pages/repositories/repository/objects.jsx
+++ b/webui/src/pages/repositories/repository/objects.jsx
@@ -1516,14 +1516,14 @@ const ObjectsBrowser = ({ config }) => {
 };
 
 const RepositoryObjectsPage = () => {
-    const {repo} = useRefs();
+    const {repo, loading: repoLoading, error: repoError} = useRefs();
     const {config, loading: configsLoading, error: configsError} = useConfigContext();
 
     const [setActivePage] = useOutletContext();
     useEffect(() => setActivePage("objects"), [setActivePage]);
 
-    if (configsLoading) return <Loading/>;
-    if (configsError) return <RepoError error={configsError}/>;
+    if (repoLoading || configsLoading) return <Loading/>;
+    if (repoError || configsError) return <RepoError error={repoError || configsError}/>;
 
     const {storageConfig, loading: configLoading, error: configError} = getRepoStorageConfig(config?.storages, repo);
     if (configLoading) return <Loading/>;


### PR DESCRIPTION
## Change Description

### Background

In MSB situations, the repo information is required for getting the right config.
In the WebUI, we don't check the "loading" and "error" of the get-repo API call,
So that while the repo info isn't returned from the server yet, `getRepoStorageConfig()` returns an error.

Note that this happens only in MSB situations.

### Bug Fix

Updated the consumers of `getRepoStorageConfig()` to refer to the "loading" and "error" of the get-repo API call as loading, which prevents the error from `getRepoStorageConfig()`, resulting in loading state, as should be.

### Testing Details

Tested manually.
