### PR TITLE
Fix concurrent commits with allow-empty may fail with no-changes

### DIFF
--- a/pkg/graveler/empty_value_iterator.go
+++ b/pkg/graveler/empty_value_iterator.go
@@ -1,0 +1,25 @@
+package graveler
+
+func NewEmptyValueIterator() ValueIterator {
+	return &emptyValueIterator{}
+}
+
+type emptyValueIterator struct{}
+
+func (e *emptyValueIterator) SeekGE(_ Key) {
+}
+
+func (e *emptyValueIterator) Value() *ValueRecord {
+	return nil
+}
+
+func (e *emptyValueIterator) Err() error {
+	return nil
+}
+
+func (e *emptyValueIterator) Close() {
+}
+
+func (e *emptyValueIterator) Next() bool {
+	return false
+}

--- a/pkg/graveler/graveler.go
+++ b/pkg/graveler/graveler.go
@@ -2220,7 +2220,12 @@ func (g *Graveler) Commit(ctx context.Context, repository *RepositoryRecord, bra
 		} else {
 			changes, err := g.sealedTokensIterator(ctx, branch, 0)
 			if err != nil {
-				return nil, err
+				// in case we allow empty commits, we need to pass empty iterator to the commit manager
+				if errors.Is(err, ErrNoChanges) && params.AllowEmpty {
+					changes = NewEmptyValueIterator()
+				} else {
+					return nil, err
+				}
 			}
 			defer changes.Close()
 			// returns err if the commit is empty (no changes)

--- a/pkg/graveler/graveler.go
+++ b/pkg/graveler/graveler.go
@@ -2220,12 +2220,12 @@ func (g *Graveler) Commit(ctx context.Context, repository *RepositoryRecord, bra
 		} else {
 			changes, err := g.sealedTokensIterator(ctx, branch, 0)
 			if err != nil {
-				// in case we allow empty commits, we need to pass empty iterator to the commit manager
-				if errors.Is(err, ErrNoChanges) && params.AllowEmpty {
-					changes = NewEmptyValueIterator()
-				} else {
+				// we can fail early in no changes and we don't allow empty commits.
+				if !errors.Is(err, ErrNoChanges) || !params.AllowEmpty {
 					return nil, err
 				}
+				// in case we allow empty commits, we need to pass empty iterator to the commit manager.
+				changes = NewEmptyValueIterator()
 			}
 			defer changes.Close()
 			// returns err if the commit is empty (no changes)


### PR DESCRIPTION
Fix concurrent commits with 'allow empty commit' that can cause an error 'no changes'.

Close https://github.com/treeverse/lakeFS/issues/9365