### PR TITLE
Add EMR 7.x support for Spark client with Hadoop 3.3.6 and 3.2.1

### DIFF
--- a/.github/workflows/spark.yaml
+++ b/.github/workflows/spark.yaml
@@ -10,6 +10,9 @@ jobs:
   spark-metadata-client:
     name: Unit test Spark metadata client
     runs-on: ubuntu-22.04
+    strategy:
+      matrix:
+        hadoop-version: [ "3.2.1", "3.3.6" ]
     steps:
       - name: Check-out code
         uses: actions/checkout@v4
@@ -26,4 +29,4 @@ jobs:
 
       - name: run tests, validate and package
         working-directory: clients/spark
-        run: sbt -Dspark.driver.bindAddress=127.0.0.1 -Dspark.driver.host=localhost test "scalafix --check" package
+        run: sbt -DhadoopVersion=${{ matrix.hadoop-version }} -Dspark.driver.bindAddress=127.0.0.1 -Dspark.driver.host=localhost test "scalafix --check" package

--- a/clients/spark/build.sbt
+++ b/clients/spark/build.sbt
@@ -1,6 +1,6 @@
-lazy val projectVersion = "0.15.0"
+lazy val projectVersion = "0.15.1-support-emr-7.0.0"
 version := projectVersion
-lazy val hadoopVersion = "3.2.1"
+lazy val hadoopVersion = sys.props.getOrElse("hadoopVersion", "3.2.1")
 ThisBuild / isSnapshot := false
 ThisBuild / scalaVersion := "2.12.12"
 
@@ -63,7 +63,7 @@ libraryDependencies ++= Seq(
   "com.azure" % "azure-storage-blob" % "12.9.0",
   "com.azure" % "azure-storage-blob-batch" % "12.7.0",
   "com.azure" % "azure-identity" % "1.2.0",
-  "com.amazonaws" % "aws-java-sdk-bundle" % "1.12.194" % "provided",
+  "com.amazonaws" % "aws-java-sdk-bundle" % "1.12.569" % "provided",
   "com.google.cloud.bigdataoss" % "gcs-connector" % "hadoop3-2.2.18",
   "com.google.cloud" % "google-cloud-storage" % "2.35.0",
   // Snappy is JNI :-(.  However it does claim to work with

--- a/docs/src/howto/garbage-collection/gc.md
+++ b/docs/src/howto/garbage-collection/gc.md
@@ -86,6 +86,11 @@ To define retention rules, either use the `lakectl` command, the lakeFS web UI, 
 
 To run the job, use the following `spark-submit` command (or using your preferred method of running Spark programs).
 
+!!! note EMR&nbsp;7.x requires Hadoop&nbsp;3.3.6. Build the Spark client with `-DhadoopVersion=3.3.6`
+
+and replace `--packages org.apache.hadoop:hadoop-aws:3.2.1` (or similar) with
+`--packages org.apache.hadoop:hadoop-aws:3.3.6` in the commands below.
+
 === "AWS"
     ```bash
     spark-submit --class io.treeverse.gc.GarbageCollection \

--- a/docs/src/reference/spark-client.md
+++ b/docs/src/reference/spark-client.md
@@ -18,8 +18,10 @@ Utilize the power of Spark to interact with the metadata on lakeFS. Possible use
     Please note that Spark **2.x** is no longer supported with the lakeFS metadata client.
 
 
-The Spark metadata client is compiled for Spark 3.1.2 with Hadoop 3.2.1, but
-can work for other Spark versions and higher Hadoop versions.
+The Spark metadata client is compiled for Spark 3.1.2 with Hadoop 3.2.1 by
+default, but can work for other Spark versions and higher Hadoop versions.
+When running on EMR&nbsp;7.x you must build the client against Hadoop&nbsp;3.3.6
+by passing `-DhadoopVersion=3.3.6` to `sbt`.
 
 
 === "PySpark, spark-shell, spark-submit, spark-sql"


### PR DESCRIPTION
Product issue: https://github.com/treeverse/product/issues/848
