### PR TITLE
Fix missing Close call on graveler iterators

### DIFF
--- a/pkg/graveler/graveler_test.go
+++ b/pkg/graveler/graveler_test.go
@@ -1038,6 +1038,7 @@ func TestGraveler_Diff(t *testing.T) {
 			if err != nil {
 				return // err == tt.expectedErr
 			}
+			defer diff.Close()
 
 			// compare iterators
 			for diff.Next() {

--- a/pkg/graveler/uncommitted_diff_iterator_test.go
+++ b/pkg/graveler/uncommitted_diff_iterator_test.go
@@ -1,7 +1,6 @@
 package graveler_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/go-test/deep"
@@ -106,7 +105,8 @@ func TestNewUncommittedDiffIterator(t *testing.T) {
 				}
 			}
 			fakeList := testutils.NewFakeValueIterator(uncommittedRecords)
-			diffIT := graveler.NewUncommittedDiffIterator(context.Background(), fakeCommittedList, fakeList)
+			diffIT := graveler.NewUncommittedDiffIterator(t.Context(), fakeCommittedList, fakeList)
+			defer diffIT.Close()
 
 			// diff results
 			diffRes := make([]graveler.DiffType, 0)

--- a/pkg/stats/usage_counter.go
+++ b/pkg/stats/usage_counter.go
@@ -141,6 +141,7 @@ func (u *UsageReporter) Records(ctx context.Context) ([]*UsageRecord, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer iter.Close()
 	var records []*UsageRecord
 	for iter.Next() {
 		// parse key


### PR DESCRIPTION
- Fix missing iterator Close() call on getting usage report
- Calling Close() on diff iterators in graveler test code

Fix https://github.com/treeverse/lakeFS/issues/9380