### PR TITLE
Fix possible infinite loop while listing action files

### DIFF
--- a/pkg/catalog/actions_source.go
+++ b/pkg/catalog/actions_source.go
@@ -50,19 +50,22 @@ func (s *ActionsSource) List(ctx context.Context, record graveler.HookRecord) ([
 
 func (s *ActionsSource) list(ctx context.Context, record graveler.HookRecord) ([]string, error) {
 	const amount = 1000
-	var after string
-	hasMore := true
-	var names []string
-	for hasMore {
-		var res []*DBEntry
-		var err error
-		res, hasMore, err = s.catalog.ListEntries(ctx, record.Repository.RepositoryID.String(), record.SourceRef.String(), repositoryLocation, after, DefaultPathDelimiter, amount)
+	var (
+		after string
+		names []string
+	)
+	for {
+		res, hasMore, err := s.catalog.ListEntries(ctx, record.Repository.RepositoryID.String(), record.SourceRef.String(), repositoryLocation, after, DefaultPathDelimiter, amount)
 		if err != nil {
 			return nil, fmt.Errorf("listing actions: %w", err)
 		}
 		for _, result := range res {
 			names = append(names, result.Path)
 		}
+		if !hasMore || len(res) == 0 {
+			break
+		}
+		after = res[len(res)-1].Path
 	}
 	return names, nil
 }

--- a/pkg/catalog/actions_source.go
+++ b/pkg/catalog/actions_source.go
@@ -62,7 +62,7 @@ func (s *ActionsSource) list(ctx context.Context, record graveler.HookRecord) ([
 		for _, result := range res {
 			names = append(names, result.Path)
 		}
-		if !hasMore || len(res) == 0 {
+		if !hasMore {
 			break
 		}
 		after = res[len(res)-1].Path


### PR DESCRIPTION
Fix infinite loop bug in list pagination when 1000 actions files found in lakefs (_lakefs_actions/) and action is triggered.

Tested manually by creating repository with >1000 actions and request a commit request.

Fix https://github.com/treeverse/lakeFS/issues/9393