### PR TITLE
ci: skip ui links check for forks

### DIFF
--- a/.github/workflows/check-ui-links.yaml
+++ b/.github/workflows/check-ui-links.yaml
@@ -12,6 +12,7 @@ jobs:
   preview:
     name: Check links from UI
     runs-on: ubuntu-22.04
+    if: github.event.pull_request.head.repo.fork == false
     steps:
       - name: Check-out
         uses: actions/checkout@v4


### PR DESCRIPTION
Closes #9388

## Change Description

### Background

The `check links from ui` GitHub Actions workflow consistently fails for pull requests submitted by external contributors. This happens because the workflow attempts to use a secret token (`PERSONAL_TOKEN`) that is not available in the context of a PR from a forked repository for security reasons. This PR fixes the workflow so that it no longer runs unnecessarily for contributors.

### Bug Fix

1.  **Problem** - The "Check links from the UI" workflow fails on every pull request from a forked repository.
2.  **Root cause** - The job requires a secret token that is not accessible to workflows running on contributor forks.
3.  **Solution** - An `if` condition (`if: github.event.pull_request.head.repo.fork == false`) has been added to the job in the `check-ui-links.yaml` file. This ensures the job is skipped for any pull request originating from a fork.

### New Feature

Not applicable. This is a fix for the CI/CD process.

### Testing Details

This change is tested by creating this pull request. The "Check links from the UI" job in the GitHub Actions checks should be marked as "Skipped" instead of "Failing".

### Breaking Change?

No. This change only affects the CI workflow and has no impact on the application's functionality.

## Additional info

The expected result is that the workflow check will be skipped for this PR.


### Contact Details

Provided via my GitHub account.