### PR TITLE
Refactor metrics logging in MetricsAdapter for consistency and clarity.

### DIFF
--- a/pkg/block/metrics.go
+++ b/pkg/block/metrics.go
@@ -32,16 +32,20 @@ func (m *MetricsAdapter) InnerAdapter() Adapter {
 }
 
 func (m *MetricsAdapter) Put(ctx context.Context, obj ObjectPointer, sizeBytes int64, reader io.Reader, opts PutOpts) (*PutResponse, error) {
-	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType())
-	concurrentOperations.WithLabelValues("put", m.adapter.BlockstoreType()).Inc()
-	defer concurrentOperations.WithLabelValues("put", m.adapter.BlockstoreType()).Dec()
+	blockstoreType := m.adapter.BlockstoreType()
+	const operation = "put"
+	concurrentOperations.WithLabelValues(operation, blockstoreType).Inc()
+	defer concurrentOperations.WithLabelValues(operation, blockstoreType).Dec()
+	ctx = httputil.SetClientTrace(ctx, blockstoreType)
 	return m.adapter.Put(ctx, obj, sizeBytes, reader, opts)
 }
 
 func (m *MetricsAdapter) Get(ctx context.Context, obj ObjectPointer) (io.ReadCloser, error) {
-	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType())
-	concurrentOperations.WithLabelValues("get", m.adapter.BlockstoreType()).Inc()
-	defer concurrentOperations.WithLabelValues("get", m.adapter.BlockstoreType()).Dec()
+	blockstoreType := m.adapter.BlockstoreType()
+	const operation = "get"
+	concurrentOperations.WithLabelValues(operation, blockstoreType).Inc()
+	defer concurrentOperations.WithLabelValues(operation, blockstoreType).Dec()
+	ctx = httputil.SetClientTrace(ctx, blockstoreType)
 	return m.adapter.Get(ctx, obj)
 }
 
@@ -50,107 +54,137 @@ func (m *MetricsAdapter) GetWalker(storageID string, opts WalkerOptions) (Walker
 }
 
 func (m *MetricsAdapter) GetPreSignedURL(ctx context.Context, obj ObjectPointer, mode PreSignMode, filename string) (string, time.Time, error) {
-	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType())
-	concurrentOperations.WithLabelValues("get_presigned_url", m.adapter.BlockstoreType()).Inc()
-	defer concurrentOperations.WithLabelValues("get_presigned_url", m.adapter.BlockstoreType()).Dec()
+	blockstoreType := m.adapter.BlockstoreType()
+	const operation = "get_presigned_url"
+	concurrentOperations.WithLabelValues(operation, blockstoreType).Inc()
+	defer concurrentOperations.WithLabelValues(operation, blockstoreType).Dec()
+	ctx = httputil.SetClientTrace(ctx, blockstoreType)
 	return m.adapter.GetPreSignedURL(ctx, obj, mode, filename)
 }
 
 func (m *MetricsAdapter) GetPresignUploadPartURL(ctx context.Context, obj ObjectPointer, uploadID string, partNumber int) (string, error) {
-	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType())
-	concurrentOperations.WithLabelValues("get_presign_upload_part_url", m.adapter.BlockstoreType()).Inc()
-	defer concurrentOperations.WithLabelValues("get_presign_upload_part_url", m.adapter.BlockstoreType()).Dec()
+	blockstoreType := m.adapter.BlockstoreType()
+	const operation = "get_presign_upload_part_url"
+	concurrentOperations.WithLabelValues(operation, blockstoreType).Inc()
+	defer concurrentOperations.WithLabelValues(operation, blockstoreType).Dec()
+	ctx = httputil.SetClientTrace(ctx, blockstoreType)
 	return m.adapter.GetPresignUploadPartURL(ctx, obj, uploadID, partNumber)
 }
 
 func (m *MetricsAdapter) Exists(ctx context.Context, obj ObjectPointer) (bool, error) {
-	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType())
-	concurrentOperations.WithLabelValues("exists", m.adapter.BlockstoreType()).Inc()
-	defer concurrentOperations.WithLabelValues("exists", m.adapter.BlockstoreType()).Dec()
+	blockstoreType := m.adapter.BlockstoreType()
+	const operation = "exists"
+	concurrentOperations.WithLabelValues(operation, blockstoreType).Inc()
+	defer concurrentOperations.WithLabelValues(operation, blockstoreType).Dec()
+	ctx = httputil.SetClientTrace(ctx, blockstoreType)
 	return m.adapter.Exists(ctx, obj)
 }
 
 func (m *MetricsAdapter) GetRange(ctx context.Context, obj ObjectPointer, startPosition int64, endPosition int64) (io.ReadCloser, error) {
-	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType())
-	concurrentOperations.WithLabelValues("get_range", m.adapter.BlockstoreType()).Inc()
-	defer concurrentOperations.WithLabelValues("get_range", m.adapter.BlockstoreType()).Dec()
+	blockstoreType := m.adapter.BlockstoreType()
+	const operation = "get_range"
+	concurrentOperations.WithLabelValues(operation, blockstoreType).Inc()
+	defer concurrentOperations.WithLabelValues(operation, blockstoreType).Dec()
+	ctx = httputil.SetClientTrace(ctx, blockstoreType)
 	return m.adapter.GetRange(ctx, obj, startPosition, endPosition)
 }
 
 func (m *MetricsAdapter) GetProperties(ctx context.Context, obj ObjectPointer) (Properties, error) {
-	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType())
-	concurrentOperations.WithLabelValues("get_properties", m.adapter.BlockstoreType()).Inc()
-	defer concurrentOperations.WithLabelValues("get_properties", m.adapter.BlockstoreType()).Dec()
+	blockstoreType := m.adapter.BlockstoreType()
+	const operation = "get_properties"
+	concurrentOperations.WithLabelValues(operation, blockstoreType).Inc()
+	defer concurrentOperations.WithLabelValues(operation, blockstoreType).Dec()
+	ctx = httputil.SetClientTrace(ctx, blockstoreType)
 	return m.adapter.GetProperties(ctx, obj)
 }
 
 func (m *MetricsAdapter) Remove(ctx context.Context, obj ObjectPointer) error {
-	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType())
-	concurrentOperations.WithLabelValues("remove", m.adapter.BlockstoreType()).Inc()
-	defer concurrentOperations.WithLabelValues("remove", m.adapter.BlockstoreType()).Dec()
+	blockstoreType := m.adapter.BlockstoreType()
+	const operation = "remove"
+	concurrentOperations.WithLabelValues(operation, blockstoreType).Inc()
+	defer concurrentOperations.WithLabelValues(operation, blockstoreType).Dec()
+	ctx = httputil.SetClientTrace(ctx, blockstoreType)
 	return m.adapter.Remove(ctx, obj)
 }
 
 func (m *MetricsAdapter) Copy(ctx context.Context, sourceObj, destinationObj ObjectPointer) error {
-	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType())
-	concurrentOperations.WithLabelValues("copy", m.adapter.BlockstoreType()).Inc()
-	defer concurrentOperations.WithLabelValues("copy", m.adapter.BlockstoreType()).Dec()
+	blockstoreType := m.adapter.BlockstoreType()
+	const operation = "copy"
+	concurrentOperations.WithLabelValues(operation, blockstoreType).Inc()
+	defer concurrentOperations.WithLabelValues(operation, blockstoreType).Dec()
+	ctx = httputil.SetClientTrace(ctx, blockstoreType)
 	return m.adapter.Copy(ctx, sourceObj, destinationObj)
 }
 
 func (m *MetricsAdapter) CreateMultiPartUpload(ctx context.Context, obj ObjectPointer, r *http.Request, opts CreateMultiPartUploadOpts) (*CreateMultiPartUploadResponse, error) {
-	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType())
-	concurrentOperations.WithLabelValues("create_multipart_upload", m.adapter.BlockstoreType()).Inc()
-	defer concurrentOperations.WithLabelValues("create_multipart_upload", m.adapter.BlockstoreType()).Dec()
+	blockstoreType := m.adapter.BlockstoreType()
+	const operation = "create_multipart_upload"
+	concurrentOperations.WithLabelValues(operation, blockstoreType).Inc()
+	defer concurrentOperations.WithLabelValues(operation, blockstoreType).Dec()
+	ctx = httputil.SetClientTrace(ctx, blockstoreType)
 	return m.adapter.CreateMultiPartUpload(ctx, obj, r, opts)
 }
 
 func (m *MetricsAdapter) UploadPart(ctx context.Context, obj ObjectPointer, sizeBytes int64, reader io.Reader, uploadID string, partNumber int) (*UploadPartResponse, error) {
-	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType())
-	concurrentOperations.WithLabelValues("upload_part", m.adapter.BlockstoreType()).Inc()
-	defer concurrentOperations.WithLabelValues("upload_part", m.adapter.BlockstoreType()).Dec()
+	blockstoreType := m.adapter.BlockstoreType()
+	const operation = "upload_part"
+	concurrentOperations.WithLabelValues(operation, blockstoreType).Inc()
+	defer concurrentOperations.WithLabelValues(operation, blockstoreType).Dec()
+	ctx = httputil.SetClientTrace(ctx, blockstoreType)
 	return m.adapter.UploadPart(ctx, obj, sizeBytes, reader, uploadID, partNumber)
 }
 
 func (m *MetricsAdapter) ListParts(ctx context.Context, obj ObjectPointer, uploadID string, opts ListPartsOpts) (*ListPartsResponse, error) {
-	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType())
-	concurrentOperations.WithLabelValues("list_parts", m.adapter.BlockstoreType()).Inc()
-	defer concurrentOperations.WithLabelValues("list_parts", m.adapter.BlockstoreType()).Dec()
+	blockstoreType := m.adapter.BlockstoreType()
+	const operation = "list_parts"
+	concurrentOperations.WithLabelValues(operation, blockstoreType).Inc()
+	defer concurrentOperations.WithLabelValues(operation, blockstoreType).Dec()
+	ctx = httputil.SetClientTrace(ctx, blockstoreType)
 	return m.adapter.ListParts(ctx, obj, uploadID, opts)
 }
 
 func (m *MetricsAdapter) ListMultipartUploads(ctx context.Context, obj ObjectPointer, opts ListMultipartUploadsOpts) (*ListMultipartUploadsResponse, error) {
-	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType())
-	concurrentOperations.WithLabelValues("list_multipart_uploads", m.adapter.BlockstoreType()).Inc()
-	defer concurrentOperations.WithLabelValues("list_multipart_uploads", m.adapter.BlockstoreType()).Dec()
+	blockstoreType := m.adapter.BlockstoreType()
+	const operation = "list_multipart_uploads"
+	concurrentOperations.WithLabelValues(operation, blockstoreType).Inc()
+	defer concurrentOperations.WithLabelValues(operation, blockstoreType).Dec()
+	ctx = httputil.SetClientTrace(ctx, blockstoreType)
 	return m.adapter.ListMultipartUploads(ctx, obj, opts)
 }
 
 func (m *MetricsAdapter) UploadCopyPart(ctx context.Context, sourceObj, destinationObj ObjectPointer, uploadID string, partNumber int) (*UploadPartResponse, error) {
-	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType())
-	concurrentOperations.WithLabelValues("upload_copy_part", m.adapter.BlockstoreType()).Inc()
-	defer concurrentOperations.WithLabelValues("upload_copy_part", m.adapter.BlockstoreType()).Dec()
+	blockstoreType := m.adapter.BlockstoreType()
+	const operation = "upload_copy_part"
+	concurrentOperations.WithLabelValues(operation, blockstoreType).Inc()
+	defer concurrentOperations.WithLabelValues(operation, blockstoreType).Dec()
+	ctx = httputil.SetClientTrace(ctx, blockstoreType)
 	return m.adapter.UploadCopyPart(ctx, sourceObj, destinationObj, uploadID, partNumber)
 }
 
 func (m *MetricsAdapter) UploadCopyPartRange(ctx context.Context, sourceObj, destinationObj ObjectPointer, uploadID string, partNumber int, startPosition, endPosition int64) (*UploadPartResponse, error) {
-	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType())
-	concurrentOperations.WithLabelValues("upload_copy_part_range", m.adapter.BlockstoreType()).Inc()
-	defer concurrentOperations.WithLabelValues("upload_copy_part_range", m.adapter.BlockstoreType()).Dec()
+	blockstoreType := m.adapter.BlockstoreType()
+	const operation = "upload_copy_part_range"
+	concurrentOperations.WithLabelValues(operation, blockstoreType).Inc()
+	defer concurrentOperations.WithLabelValues(operation, blockstoreType).Dec()
+	ctx = httputil.SetClientTrace(ctx, blockstoreType)
 	return m.adapter.UploadCopyPartRange(ctx, sourceObj, destinationObj, uploadID, partNumber, startPosition, endPosition)
 }
 
 func (m *MetricsAdapter) AbortMultiPartUpload(ctx context.Context, obj ObjectPointer, uploadID string) error {
-	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType())
-	concurrentOperations.WithLabelValues("abort_multipart_upload", m.adapter.BlockstoreType()).Inc()
-	defer concurrentOperations.WithLabelValues("abort_multipart_upload", m.adapter.BlockstoreType()).Dec()
+	blockstoreType := m.adapter.BlockstoreType()
+	const operation = "abort_multipart_upload"
+	concurrentOperations.WithLabelValues(operation, blockstoreType).Inc()
+	defer concurrentOperations.WithLabelValues(operation, blockstoreType).Dec()
+	ctx = httputil.SetClientTrace(ctx, blockstoreType)
 	return m.adapter.AbortMultiPartUpload(ctx, obj, uploadID)
 }
 
 func (m *MetricsAdapter) CompleteMultiPartUpload(ctx context.Context, obj ObjectPointer, uploadID string, multipartList *MultipartUploadCompletion) (*CompleteMultiPartUploadResponse, error) {
-	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType())
-	concurrentOperations.WithLabelValues("complete_multipart_upload", m.adapter.BlockstoreType()).Inc()
-	defer concurrentOperations.WithLabelValues("complete_multipart_upload", m.adapter.BlockstoreType()).Dec()
+	blockstoreType := m.adapter.BlockstoreType()
+	const operation = "complete_multipart_upload"
+	concurrentOperations.WithLabelValues(operation, blockstoreType).Inc()
+	defer concurrentOperations.WithLabelValues(operation, blockstoreType).Dec()
+	ctx = httputil.SetClientTrace(ctx, blockstoreType)
 	return m.adapter.CompleteMultiPartUpload(ctx, obj, uploadID, multipartList)
 }
 
@@ -172,9 +206,11 @@ func (m *MetricsAdapter) ResolveNamespace(storageID, storageNamespace, key strin
 }
 
 func (m *MetricsAdapter) GetRegion(ctx context.Context, storageID, storageNamespace string) (string, error) {
-	ctx = httputil.SetClientTrace(ctx, m.adapter.BlockstoreType())
-	concurrentOperations.WithLabelValues("get_region", m.adapter.BlockstoreType()).Inc()
-	defer concurrentOperations.WithLabelValues("get_region", m.adapter.BlockstoreType()).Dec()
+	blockstoreType := m.adapter.BlockstoreType()
+	const operation = "get_region"
+	concurrentOperations.WithLabelValues(operation, blockstoreType).Inc()
+	defer concurrentOperations.WithLabelValues(operation, blockstoreType).Dec()
+	ctx = httputil.SetClientTrace(ctx, blockstoreType)
 	return m.adapter.GetRegion(ctx, storageID, storageNamespace)
 }
 


### PR DESCRIPTION
Refactor the `MetricsAdapter` methods in `pkg/block/metrics.go` to improve code readability and maintainability.
The main change is capture one the blockstore type and operation name, which are then used consistently in metric tracking and client trace setup.