### PR TITLE
Fix WebUI merge conflict error message

### DIFF
--- a/webui/src/lib/api/index.js
+++ b/webui/src/lib/api/index.js
@@ -933,7 +933,7 @@ class Refs {
                 return response.json();
             case 409:
                 resp = await response.json();
-                throw new MergeError('Conflict', resp.body);
+                throw new MergeError('Conflict', resp);
             case 412:
             default:
                 throw new Error(await extractError(response));

--- a/webui/src/lib/api/index.js
+++ b/webui/src/lib/api/index.js
@@ -933,7 +933,7 @@ class Refs {
                 return response.json();
             case 409:
                 resp = await response.json();
-                throw new MergeError(response.statusText, resp.body);
+                throw new MergeError('Conflict', resp.body);
             case 412:
             default:
                 throw new Error(await extractError(response));


### PR DESCRIPTION
### Bug Description

The WebUI uses `response.statusText` for rendering an error message to the user in case of a merge conflict.
This sometimes results in messy error messages.

### Root Cause

The `response.statusText` is not reliable enough, and might get other values in case of older browsers (see [this thread](https://stackoverflow.com/questions/42401795/with-http-2-only-xmlhttprequest-responses-statustext-property-seems-to-be-us), for example).

### Solution

Replace `response.statusText` with the expected `"Conflict"` message.

### Testing Details

Wasn't able to replicate this locally,
Verified locally the fix yields the expected output.
