### PR TITLE
fix(api): enforce import_enabled flag for local storage

### DIFF
--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -3129,9 +3129,21 @@ func (c *Controller) ImportStart(w http.ResponseWriter, r *http.Request, body ap
 	if !c.authorize(w, r, perm) {
 		return
 	}
-
 	ctx := r.Context()
 	c.LogAction(ctx, "import", r, repository, branch, "")
+	repo, err := c.Catalog.GetRepository(r.Context(), repository)
+	if c.handleAPIError(ctx, w, r, err) {
+		return
+	}
+	storageInfo := c.BlockAdapter.GetStorageNamespaceInfo(repo.StorageNamespace)
+	if storageInfo == nil {
+		writeError(w, r, http.StatusNotFound, fmt.Sprintf("no storage namespace info for storage id: %s", repo.StorageID))
+		return
+	}
+	if !storageInfo.ImportSupport {
+		writeError(w, r, http.StatusForbidden, "import is not supported for this storage")
+		return
+	}
 
 	user, err := auth.GetUser(ctx)
 	if err != nil {

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -6628,3 +6628,43 @@ func TestController_GetLicense(t *testing.T) {
 		require.NotNil(t, resp.JSON501, "expected HTTP-501 response, got %v", resp.StatusCode())
 	})
 }
+
+func TestController_ImportStart_Disabled(t *testing.T) {
+	// set up a server with local imports disabled
+	storageLocation := t.TempDir()
+	viper.Set(config.BlockstoreTypeKey, block.BlockstoreTypeLocal)
+	viper.Set("blockstore.local.path", storageLocation)
+	viper.Set("blockstore.local.import_enabled", false)
+
+	clt, deps := setupClientWithAdmin(t)
+	ctx := t.Context()
+
+	// Create a repository with a unique name for the test
+	repo := testUniqueRepoName()
+	createRepoResp, err := clt.CreateRepositoryWithResponse(ctx, &apigen.CreateRepositoryParams{}, apigen.CreateRepositoryJSONRequestBody{
+		Name:             repo,
+		StorageNamespace: onBlock(deps, "bucket/prefix"),
+	})
+	require.NoError(t, err)
+	require.NotNil(t, createRepoResp.JSON201, "expected status 201 Created when creating repo")
+
+	// attempt to start an import
+	resp, err := clt.ImportStartWithResponse(ctx, repo, "main", apigen.ImportStartJSONRequestBody{
+		Commit: apigen.CommitCreation{
+			Message: "test import",
+		},
+		Paths: []apigen.ImportLocation{
+			{
+				Path:        "some/local/path",
+				Type:        "common_prefix",
+				Destination: "/",
+			},
+		},
+	})
+
+	// verify the request is forbidden
+	require.NoError(t, err)
+	require.NotNil(t, resp, "response should not be nil")
+	require.NotNil(t, resp.JSON403, "expected a 403 forbidden response, but got none")
+	require.Contains(t, resp.JSON403.Message, "import is not supported for this storage")
+}


### PR DESCRIPTION
Closes \#8844

## Change Description

### Background

The `import_enabled` flag for local storage is not enforced by the server's API. While the WebUI and lakectl prevent imports when this flag is disabled, a user can bypass the restriction by calling the API directly.

### Bug Fix

1.  **Problem** - Users can start a data import from a local path via the API, even when the `import.enabled` flag is set to `false`.
2.  **Root cause** - The `ImportStart` API handler did not check if the underlying storage adapter was configured to support the import operation.
3.  **Solution** - The `ImportStart` handler in `pkg/api/controller.go` has been updated. After validating user permissions, it now calls the `GetStorageNamespaceInfo` method on the block adapter. It then checks the returned `ImportSupport` flag and, if it's `false`, immediately returns a `403 Forbidden` error. This approach is more robust and future-proof.

### New Feature

Not applicable. This is an enhancement to enforce an existing configuration.

### Testing Details

The fix was tested with a new automated test.

  * **Automated Test**: A new test case, `TestController_ImportStart_Disabled`, was added to `pkg/api/controller_test.go`. It uses `viper.Set` to override the server configuration to disable local imports, starts a test server, calls the import API, and asserts that the response is `403 Forbidden` with the correct error message.

### Breaking Change?

No. This change enforces an existing configuration setting as intended and does not break any existing valid functionality.

## Additional info

**API Response Before:**

```json
{"id":"d2doq6vrp4e4ba2rnb50"}
```

**API Response After:**

```json
{"message":"import is not supported for this storage"}
```

### Contact Details

Provided via my GitHub account.