### PR TITLE
WebUI: Add security headers to all responses

### DIFF
--- a/pkg/api/security_middleware.go
+++ b/pkg/api/security_middleware.go
@@ -1,0 +1,27 @@
+package api
+
+import (
+	"net/http"
+)
+
+// SecurityMiddleware returns a new security middleware handler.
+// It adds security headers to all HTTP responses:
+// - X-Frame-Options: SAMEORIGIN - prevents clickjacking attacks
+// - X-Content-Type-Options: nosniff - prevents MIME type sniffing
+func SecurityMiddleware(next http.Handler) http.Handler {
+	return &securityHandler{
+		next: next,
+	}
+}
+
+type securityHandler struct {
+	next http.Handler
+}
+
+func (s *securityHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("X-Frame-Options", "SAMEORIGIN")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+
+	// Call the next handler in the chain
+	s.next.ServeHTTP(w, r)
+}

--- a/pkg/api/security_middleware_test.go
+++ b/pkg/api/security_middleware_test.go
@@ -1,0 +1,31 @@
+package api_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/treeverse/lakefs/pkg/api"
+	"github.com/treeverse/lakefs/pkg/api/params"
+)
+
+// TestSecurityMiddlewareIntegration tests that the security middleware is properly set on the UI handler
+func TestSecurityMiddlewareIntegration(t *testing.T) {
+	handler := api.NewUIHandler([]string{}, []params.CodeSnippet{})
+
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	// Check that security headers are set
+	xFrameOptions := rec.Header().Get("X-Frame-Options")
+	if xFrameOptions != "SAMEORIGIN" {
+		t.Errorf("Expected X-Frame-Options header to be 'SAMEORIGIN', got '%s'", xFrameOptions)
+	}
+
+	xContentTypeOptions := rec.Header().Get("X-Content-Type-Options")
+	if xContentTypeOptions != "nosniff" {
+		t.Errorf("Expected X-Content-Type-Options header to be 'nosniff', got '%s'", xContentTypeOptions)
+	}
+}

--- a/pkg/api/ui_handler.go
+++ b/pkg/api/ui_handler.go
@@ -36,7 +36,8 @@ func NewUIHandler(gatewayDomains []string, snippets []params.CodeSnippet) http.H
 	fileSystem := http.FS(injectedContent)
 	gzipHandler := gziphandler.GzipHandler(http.FileServer(fileSystem))
 	etagHandler := EtagMiddleware(injectedContent, http.StripPrefix("/", gzipHandler))
-	return NewHandlerWithDefault(fileSystem, etagHandler, gatewayDomains)
+	securityHandler := SecurityMiddleware(etagHandler)
+	return NewHandlerWithDefault(fileSystem, securityHandler, gatewayDomains)
 }
 
 func NewS3GatewayEndpointErrorHandler(gatewayDomains []string) http.Handler {


### PR DESCRIPTION
Use X-Frame-Options and X-Content-Type-Options to prevent clickjacking and MIME type sniffing attacks.

Close https://github.com/treeverse/lakeFS/issues/9437