### PR TITLE
Use bitnami images from treeverse's repo 

### DIFF
--- a/.github/workflows/esti.yaml
+++ b/.github/workflows/esti.yaml
@@ -178,7 +178,7 @@ jobs:
           LAKEFS_STATS_ENABLED: false
 
       spark:
-        image: docker.io/bitnami/spark:3.2.1
+        image: docker.io/treeverse/bitnami-spark:3.2.1
         options: --name spark-master
         env:
           SPARK_MODE: master
@@ -194,7 +194,7 @@ jobs:
           - '7077:7077'
 
       spark-worker:
-        image: docker.io/bitnami/spark:3.2.1
+        image: docker.io/treeverse/bitnami-spark:3.2.1
         env:
           SPARK_MODE: worker
           SPARK_MASTER_URL: spark://spark:7077

--- a/deployments/utils/spark3-hadoop2/Dockerfile
+++ b/deployments/utils/spark3-hadoop2/Dockerfile
@@ -13,8 +13,8 @@ FROM --platform=$BUILDPLATFORM ubuntu:21.04 AS extract
 
 WORKDIR /build
 # Extract hadoop-aws-2.7.4 and its dependency aws-java-sdk-1.7.4 from an old
-# archived version of Apachehe Hadoop.  These JARs are so long-dead that
-# this is the *easy* way of getting our actual test code onthem.
+# archived version of Apache Hadoop.  These JARs are so long-dead that
+# this is the *easy* way of getting our actual test code on them.
 #
 # See, fear, and never use this Docker image except in tests.
 ADD https://archive.apache.org/dist/hadoop/common/hadoop-2.7.4/hadoop-2.7.4.tar.gz /tmp/hadoop-2.7.4.tar.gz
@@ -23,11 +23,10 @@ RUN tar --extract --to-stdout --gzip --strip 5 --file /tmp/hadoop-2.7.4.tar.gz h
 
 # Build Bitnami Spark 3.2.x but with Hadoop 2.  Details in
 # https://github.com/bitnami/bitnami-docker-spark#using-a-different-version-of-hadoop-jars.
-FROM bitnami/spark:3.2.3
-
+FROM treeverse/bitnami-spark:3.2.3
 USER root
 RUN rm -r /opt/bitnami/spark/jars
-ADD https://dlcdn.apache.org/spark/spark-3.2.3/spark-3.2.3-bin-hadoop2.7.tgz /tmp/
-RUN tar --extract --gzip --strip=1 < /tmp/spark-3.2.3-bin-hadoop2.7.tgz --directory /opt/bitnami/spark/ spark-3.2.3-bin-hadoop2.7/jars/ && rm /tmp/spark-3.2.3-bin-hadoop2.7.tgz
+ADD https://archive.apache.org/dist/spark/spark-3.2.1/spark-3.2.1-bin-hadoop2.7.tgz /tmp/
+RUN tar --extract --gzip --strip=1 < /tmp/spark-3.2.1-bin-hadoop2.7.tgz --directory /opt/bitnami/spark/ spark-3.2.1-bin-hadoop2.7/jars/ && rm /tmp/spark-3.2.1-bin-hadoop2.7.tgz
 COPY --from=extract /build/*.jar /opt/bitnami/spark/jars/
 USER 1001

--- a/esti/gc_test_utils.go
+++ b/esti/gc_test_utils.go
@@ -111,7 +111,7 @@ func RunSparkSubmit(config *SparkSubmitConfig) error {
 	}
 	workingDirectory = strings.TrimSuffix(workingDirectory, "/")
 	dockerArgs := getDockerArgs(workingDirectory, config.LocalJar)
-	dockerArgs = append(dockerArgs, fmt.Sprintf("docker.io/bitnami/spark:%s", config.SparkVersion), "spark-submit")
+	dockerArgs = append(dockerArgs, fmt.Sprintf("docker.io/treeverse/bitnami-spark:%s", config.SparkVersion), "spark-submit")
 	sparkSubmitArgs := getSparkSubmitArgs(config.EntryPoint)
 	sparkSubmitArgs = append(sparkSubmitArgs, config.ExtraSubmitArgs...)
 	args := dockerArgs

--- a/test/spark/docker-compose.yaml
+++ b/test/spark/docker-compose.yaml
@@ -53,7 +53,7 @@ services:
         condition: service_healthy
     entrypoint: ["sh", "-c", "/app/lakefs setup --user-name tester --access-key-id $${TESTER_ACCESS_KEY_ID} --secret-access-key $${TESTER_SECRET_ACCESS_KEY}"]
   spark:
-    image: docker.io/${SPARK_BASE:-bitnami/spark}:${SPARK_TAG:-3}
+    image: docker.io/treeverse/bitnami-spark:3
     environment:
       - SPARK_MODE=master
       - SPARK_MASTER_HOST=spark
@@ -76,7 +76,7 @@ services:
       - "gateway-test-spark3.s3.docker.lakefs.io:10.5.0.55"
       - "thick-client-test.s3.docker.lakefs.io:10.5.0.55"
   spark-worker:
-    image: docker.io/${SPARK_BASE:-bitnami/spark}:${SPARK_TAG:-3}
+    image: docker.io/treeverse/bitnami-spark:3
     ports:
       - 8081
     environment:
@@ -101,7 +101,7 @@ services:
       - "gateway-test-spark3.s3.docker.lakefs.io:10.5.0.55"
       - "thick-client-test.s3.docker.lakefs.io:10.5.0.55"
   spark-submit:
-    image: docker.io/${SPARK_BASE:-bitnami/spark}:${SPARK_TAG:-3}
+    image: docker.io/treeverse/bitnami-spark:3
     profiles: ["command"]
     volumes:
       - ./:/local

--- a/test/spark/docker-compose.yaml
+++ b/test/spark/docker-compose.yaml
@@ -53,7 +53,7 @@ services:
         condition: service_healthy
     entrypoint: ["sh", "-c", "/app/lakefs setup --user-name tester --access-key-id $${TESTER_ACCESS_KEY_ID} --secret-access-key $${TESTER_SECRET_ACCESS_KEY}"]
   spark:
-    image: docker.io/treeverse/bitnami-spark:3
+    image: docker.io/treeverse/bitnami-spark:${SPARK_TAG:-3}
     environment:
       - SPARK_MODE=master
       - SPARK_MASTER_HOST=spark
@@ -76,7 +76,7 @@ services:
       - "gateway-test-spark3.s3.docker.lakefs.io:10.5.0.55"
       - "thick-client-test.s3.docker.lakefs.io:10.5.0.55"
   spark-worker:
-    image: docker.io/treeverse/bitnami-spark:3
+    image: docker.io/treeverse/bitnami-spark:{SPARK_TAG:-3}
     ports:
       - 8081
     environment:
@@ -101,7 +101,7 @@ services:
       - "gateway-test-spark3.s3.docker.lakefs.io:10.5.0.55"
       - "thick-client-test.s3.docker.lakefs.io:10.5.0.55"
   spark-submit:
-    image: docker.io/treeverse/bitnami-spark:3
+    image: docker.io/treeverse/bitnami-spark:{SPARK_TAG:-3}
     profiles: ["command"]
     volumes:
       - ./:/local

--- a/test/spark/docker-compose.yaml
+++ b/test/spark/docker-compose.yaml
@@ -76,7 +76,7 @@ services:
       - "gateway-test-spark3.s3.docker.lakefs.io:10.5.0.55"
       - "thick-client-test.s3.docker.lakefs.io:10.5.0.55"
   spark-worker:
-    image: docker.io/treeverse/bitnami-spark:{SPARK_TAG:-3}
+    image: docker.io/treeverse/bitnami-spark:${SPARK_TAG:-3}
     ports:
       - 8081
     environment:
@@ -101,7 +101,7 @@ services:
       - "gateway-test-spark3.s3.docker.lakefs.io:10.5.0.55"
       - "thick-client-test.s3.docker.lakefs.io:10.5.0.55"
   spark-submit:
-    image: docker.io/treeverse/bitnami-spark:{SPARK_TAG:-3}
+    image: docker.io/treeverse/bitnami-spark:${SPARK_TAG:-3}
     profiles: ["command"]
     volumes:
       - ./:/local


### PR DESCRIPTION
Closes #9375

Pulled, retaged and pushed all bitnami's images that we use in esti.

Images are now under treeverse/bitnami-spark

This includes the tags 2, 3, 3.2.1, 3.2.3 and latest as these are the only ones I saw in use.