### PR TITLE
lakeFSFS experiment: Occasionally commit after many deletions

### DIFF
--- a/clients/hadoopfs/pom.xml
+++ b/clients/hadoopfs/pom.xml
@@ -296,6 +296,12 @@ To export to S3:
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>org.immutables</groupId>
+            <artifactId>value</artifactId>
+            <version>2.9.3</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-common</artifactId>
             <scope>test</scope>
@@ -384,12 +390,6 @@ To export to S3:
             <groupId>org.mock-server</groupId>
             <artifactId>mockserver-core</artifactId>
             <version>5.15.0</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.immutables</groupId>
-            <artifactId>value</artifactId>
-            <version>2.9.3</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/clients/hadoopfs/src/main/java/io/lakefs/Constants.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/Constants.java
@@ -11,6 +11,19 @@ public class Constants {
     public static final String ENDPOINT_KEY_SUFFIX = "endpoint";
     public static final String LIST_AMOUNT_KEY_SUFFIX = "list.amount";
     public static final String ACCESS_MODE_KEY_SUFFIX = "access.mode";
+
+    // Experiment: commit every num-deletes with probability prob.  Enabled
+    // when num-deletes > 0.  Count deletes, and after every num-deletes of
+    // commit with probability prob.  num-deleted should be in the low
+    // thousands, prob should be approximately 1/num_executors running
+    // lakeFSFS on the branch.  Count recursive deletes as more, because
+    // contiguous deletes are particularly relevant for compaction.
+    //
+    // Why recursive deletes?  lakeFS compaction is useful (only) for
+    // consecutive deletes, which is recursive in FileOutputCommitter.
+    public static final String COMMIT_EVERY_NUM_DELETES = "experimental.commit-every.num-deletes";
+    public static final String COMMIT_EVERY_PROBABILITY = "experimental.commit-every.prob";
+
     // io.lakefs.auth.TemporaryAWSCredentialsLakeFSTokenProvider, io.lakefs.auth.InstanceProfileAWSCredentialsLakeFSTokenProvider
     public static final String LAKEFS_AUTH_PROVIDER_KEY_SUFFIX = "auth.provider";
 

--- a/clients/hadoopfs/src/main/java/io/lakefs/LakeFSClient.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/LakeFSClient.java
@@ -24,6 +24,7 @@ public class LakeFSClient {
     private final StagingApi stagingApi;
     private final RepositoriesApi repositoriesApi;
     private final BranchesApi branchesApi;
+    private final CommitsApi commitsApi;
     private final ConfigApi configApi;
     private final InternalApi internalApi;
 
@@ -57,6 +58,7 @@ public class LakeFSClient {
         this.stagingApi = new StagingApi(apiClient);
         this.repositoriesApi = new RepositoriesApi(apiClient);
         this.branchesApi = new BranchesApi(apiClient);
+        this.commitsApi = new CommitsApi(apiClient);
         this.configApi = new ConfigApi(apiClient);
         this.internalApi = new InternalApi(apiClient);
     }
@@ -92,6 +94,10 @@ public class LakeFSClient {
 
     public BranchesApi getBranchesApi() {
         return branchesApi;
+    }
+
+    public CommitsApi getCommitsApi() {
+        return commitsApi;
     }
 
     public ConfigApi getConfigApi() {


### PR DESCRIPTION
Experiment: commit every `experimental.commit-every.num-deletes` with some probability `experimental.commit-ever.prob`.

Enable by setting num-deletes > 0.  It will count deletes, and after every num-deletes it will commit with probability prob.  This happens independently in each instance of LakeFSFileSystem, so approximately in each worker thread.  num-deleted should be in the low tens, prob should be approximately 1/num_executors.

Count recursive deletes as more, because contiguous deletes are particularly relevant for compaction.  lakeFS compaction is useful (only) for consecutive deletes, which is recursive in FileOutputCommitter.

Closes #(Insert issue number closed by this PR)

## Change Description

### Background

Share context and relevant information for the PR: offline discussions, considerations, design decisions etc.

### Bug Fix

If this PR is a bug fix, please let us know about:

1. Problem - The reason for opening the bug
2. Root cause - Discovered root cause after investigation
3. Solution - How the bug was fixed
      
### New Feature

If this PR introduces a new feature, describe it here.

### Testing Details

How were the changes tested?

### Breaking Change?

Does this change break any existing functionality? (API, CLI, Clients)

## Additional info

Logs, outputs, screenshots of changes if applicable (CLI / GUI changes)

### Contact Details

How can we get in touch with you if we need more info? (ex. email@example.com)
