### PR TITLE
[Typo] Fixes typo in `configuration.md`

### DIFF
--- a/docs/src/reference/configuration.md
+++ b/docs/src/reference/configuration.md
@@ -238,9 +238,9 @@ Configuration section for the lakeFS key-value store database.
 
 #### graveler.repository_cache
 
-* `graveler.reposiory_cache.size` `(int : 1000)` - How many items to store in the repository cache.
-* `graveler.reposiory_cache.ttl` `(time duration : "5s")` - How long to store an item in the repository cache.
-* `graveler.reposiory_cache.jitter` `(time duration : "2s")` - A random amount of time between 0 and this value is added to each item's TTL.
+* `graveler.repository_cache.size` `(int : 1000)` - How many items to store in the repository cache.
+* `graveler.repository_cache.ttl` `(time duration : "5s")` - How long to store an item in the repository cache.
+* `graveler.repository_cache.jitter` `(time duration : "2s")` - A random amount of time between 0 and this value is added to each item's TTL.
 
 #### graveler.commit_cache
 


### PR DESCRIPTION
## Change Description
Fixes the typo in graveler repository cache reference.

### Background
Found a typo in documentation while reading.
