### PR TITLE
Task/fix storage ns encoded

### DIFF
--- a/cmd/lakefs/cmd/migrate.go
+++ b/cmd/lakefs/cmd/migrate.go
@@ -4,13 +4,39 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
+	blockfactory "github.com/treeverse/lakefs/modules/block/factory"
+	"github.com/treeverse/lakefs/pkg/block"
 	"github.com/treeverse/lakefs/pkg/config"
+	"github.com/treeverse/lakefs/pkg/graveler"
+	"github.com/treeverse/lakefs/pkg/graveler/ref"
 	"github.com/treeverse/lakefs/pkg/kv"
 	"github.com/treeverse/lakefs/pkg/kv/kvparams"
 )
+
+// Task represents a migration task
+type Task struct {
+	Description string
+	Function    func(context.Context, *TaskServices, bool) error
+}
+
+type TaskServices struct {
+	Config       config.Config
+	KVStore      kv.Store
+	BlockAdapter block.Adapter
+}
+
+// taskRegistry - migration tasks registry
+var taskRegistry = map[string]Task{
+	"storage-ns-encoded": {
+		Description: "Fix storage namespace encoded path - parse and update repositories with encoded storage namespaces",
+		Function:    storageNamespaceEncodedTask,
+	},
+}
 
 // migrateCmd represents the migrate command
 var migrateCmd = &cobra.Command{
@@ -161,8 +187,194 @@ func init() {
 	migrateCmd.AddCommand(versionCmd)
 	migrateCmd.AddCommand(upCmd)
 	migrateCmd.AddCommand(gotoCmd)
+	migrateCmd.AddCommand(migrateTaskCmd)
+	migrateTaskCmd.AddCommand(migrateTaskListCmd)
+	migrateTaskCmd.AddCommand(migrateTaskRunCmd)
+	_ = migrateTaskRunCmd.Flags().Bool("dry-run", false, "dry-run mode - show what would be changed without making actual changes")
 	_ = gotoCmd.Flags().Uint("version", 0, "version number")
 	_ = gotoCmd.MarkFlagRequired("version")
 	_ = upCmd.Flags().Bool("force", false, "force migrate, otherwise, migration will fail on warnings ")
 	_ = gotoCmd.Flags().Bool("force", false, "force migrate")
+}
+
+var migrateTaskCmd = &cobra.Command{
+	Use:   "task",
+	Short: "Manage migration tasks",
+}
+
+var migrateTaskListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List available migration tasks",
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("Available migration tasks:")
+		for name, task := range taskRegistry {
+			fmt.Printf("  %s: %s\n", name, task.Description)
+		}
+	},
+}
+
+var migrateTaskRunCmd = &cobra.Command{
+	Use:   "run [task-name]",
+	Short: "Run a specific migration task",
+	Args:  cobra.ExactArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		taskName := args[0]
+		task, exists := taskRegistry[taskName]
+		if !exists {
+			_, _ = fmt.Fprintf(os.Stderr, "Task '%s' not found\n", taskName)
+			os.Exit(1)
+		}
+
+		cfg := LoadConfig()
+		baseConfig := cfg.GetBaseConfig()
+		kvParams, err := kvparams.NewConfig(&baseConfig.Database)
+		if err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "KV params: %s\n", err)
+			os.Exit(1)
+		}
+		ctx := cmd.Context()
+		kvStore, err := kv.Open(ctx, kvParams)
+		if err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "Failed to open KV store: %s\n", err)
+			os.Exit(1)
+		}
+		defer kvStore.Close()
+
+		// init block store
+		blockAdapter, err := blockfactory.BuildBlockAdapter(ctx, nil, cfg)
+		if err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "Failed to create block adapter: %s\n", err)
+			os.Exit(1)
+		}
+
+		dryRun, _ := cmd.Flags().GetBool("dry-run")
+		fmt.Printf("Running task: %s", taskName)
+		if dryRun {
+			fmt.Printf(" (dry-run mode)")
+		}
+		fmt.Println()
+
+		services := &TaskServices{
+			Config:       cfg,
+			KVStore:      kvStore,
+			BlockAdapter: blockAdapter,
+		}
+		err = task.Function(ctx, services, dryRun)
+		if err != nil {
+			_, _ = fmt.Fprintf(os.Stderr, "Task failed: %s\n", err)
+			os.Exit(1)
+		}
+		fmt.Printf("Task '%s' completed successfully\n", taskName)
+	},
+}
+
+func storageNamespaceEncodedTask(ctx context.Context, services *TaskServices, dryRun bool) error {
+	kvStore := services.KVStore
+	iter, err := ref.NewRepositoryIterator(ctx, kvStore, services.Config.StorageConfig())
+	if err != nil {
+		return fmt.Errorf("new repository iterator: %w", err)
+	}
+	defer iter.Close()
+
+	encodedRepoCount := 0
+	updatedCount := 0
+	for iter.Next() {
+		repo := iter.Value()
+		if repo == nil {
+			continue
+		}
+
+		// quick check - skip if no '%' in storage namespace
+		originalNS := string(repo.StorageNamespace)
+		if !strings.Contains(originalNS, "%") {
+			continue
+		}
+		// Parse the storage namespace the old way
+		parsedNS, err := GetOldParsedStorageNamespace(originalNS)
+		if err != nil {
+			return fmt.Errorf("parse storage namespace %s for repository %s: %w", originalNS, repo.RepositoryID, err)
+		}
+		if parsedNS == originalNS {
+			continue
+		}
+
+		encodedRepoCount++
+		fmt.Printf("Repository %s: storage namespace was encoded\n", repo.RepositoryID)
+		fmt.Printf("  Original: %s\n", originalNS)
+		fmt.Printf("  Resolved: %s\n", parsedNS)
+
+		// Verify that the unescaped path works by getting the dummy file
+		fmt.Printf("  Verifying block adapter access to resolved namespace...\n")
+		if err := verifyStorageNamespaceAccess(ctx, services, string(repo.StorageID), parsedNS); err != nil {
+			fmt.Printf("  Skipping update for repository %s - the unescaped path is not accessible\n", repo.RepositoryID)
+			continue
+		}
+		fmt.Printf("  Block adapter access verification successful\n")
+
+		if !dryRun {
+			// Update the repository with the resolved namespace
+			repo.StorageNamespace = graveler.StorageNamespace(parsedNS)
+			err = kv.SetMsg(ctx, kvStore, graveler.RepositoriesPartition(), []byte(graveler.RepoPath(repo.RepositoryID)), graveler.ProtoFromRepo(repo))
+			if err != nil {
+				return fmt.Errorf("failed to update repository %s: %w", repo.RepositoryID, err)
+			}
+			fmt.Printf("  Updated to: %s\n", parsedNS)
+		} else {
+			fmt.Printf("  Would update to: %s\n", parsedNS)
+		}
+		updatedCount++
+	}
+
+	if err = iter.Err(); err != nil {
+		return fmt.Errorf("iterate repositories: %w", err)
+	}
+
+	fmt.Printf("\nSummary: Found %d repositories with encoded storage namespaces\n", encodedRepoCount)
+	if encodedRepoCount > updatedCount {
+		skippedCount := encodedRepoCount - updatedCount
+		fmt.Printf("Skipped %d repositories due to block adapter verification failures\n", skippedCount)
+	}
+	if updatedCount > 0 && dryRun {
+		fmt.Printf("Note: This was a dry-run.\n")
+	} else if updatedCount > 0 {
+		fmt.Printf("Successfully updated %d repositories.\n", updatedCount)
+	}
+
+	return nil
+}
+
+// verifyStorageNamespaceAccess tries to access a dummy object in the given storage namespace.
+func verifyStorageNamespaceAccess(ctx context.Context, taskServices *TaskServices, storageID string, storageNamespace string) error {
+	// Use a dummy object path that should always exist if the namespace is correct
+	prefix := taskServices.Config.GetBaseConfig().Committed.BlockStoragePrefix
+	objName := strings.TrimPrefix(prefix+"/dummy", "/")
+
+	obj := block.ObjectPointer{
+		StorageID:        storageID,
+		StorageNamespace: storageNamespace,
+		IdentifierType:   block.IdentifierTypeRelative,
+		Identifier:       objName,
+	}
+	s, err := taskServices.BlockAdapter.Get(ctx, obj)
+	if err != nil {
+		return fmt.Errorf("get dummy object: %w", err)
+	}
+	return s.Close()
+}
+
+func GetOldParsedStorageNamespace(ns string) (string, error) {
+	// Parse the storage namespace URL, using our default resolver
+	parsedURI, err := url.ParseRequestURI(ns)
+	if err != nil {
+		return "", err
+	}
+
+	oldPath := strings.TrimPrefix(parsedURI.Path, "/")
+	var result string
+	if len(parsedURI.Host) == 0 {
+		result = parsedURI.Scheme + "://" + oldPath
+	} else {
+		result = parsedURI.Scheme + "://" + parsedURI.Host + "/" + oldPath
+	}
+	return result, nil
 }

--- a/pkg/block/azure/walker.go
+++ b/pkg/block/azure/walker.go
@@ -21,7 +21,8 @@ var ErrAzureInvalidURL = errors.New("invalid Azure storage URL")
 // extractAzurePrefix takes a URL that looks like this: https://storageaccount.blob.core.windows.net/container/prefix
 // and return the URL for the container and a prefix, if one exists
 func extractAzurePrefix(storageURI *url.URL) (*url.URL, string, error) {
-	path := strings.TrimLeft(storageURI.Path, "/")
+	rawPath := block.RawPathFromURI(storageURI)
+	path := strings.TrimLeft(rawPath, "/")
 	if len(path) == 0 {
 		return nil, "", fmt.Errorf("%w: could not parse container URL: %s", ErrAzureInvalidURL, storageURI)
 	}

--- a/pkg/block/blocktest/basic_suite.go
+++ b/pkg/block/blocktest/basic_suite.go
@@ -32,6 +32,8 @@ func testAdapterPutGet(t *testing.T, adapter block.Adapter, storageNamespace, ex
 	}{
 		{"identifier_relative", block.IdentifierTypeRelative, "test_file"},
 		{"identifier_full", block.IdentifierTypeFull, externalPath + "/" + "test_file"},
+		{"identifier_relative_escaped", block.IdentifierTypeRelative, "special%3Atest_file"},
+		{"identifier_full_escaped", block.IdentifierTypeFull, externalPath + "/" + "special%3Atest_file"},
 		{"identifier_unknown_relative", block.IdentifierTypeUnknownDeprecated, "test_file"},                  //nolint:staticcheck
 		{"identifier_unknown_full", block.IdentifierTypeUnknownDeprecated, externalPath + "/" + "test_file"}, //nolint:staticcheck
 	}

--- a/pkg/block/gs/walker.go
+++ b/pkg/block/gs/walker.go
@@ -23,7 +23,8 @@ func NewGCSWalker(client *storage.Client) *GCSWalker {
 }
 
 func (w *GCSWalker) Walk(ctx context.Context, storageURI *url.URL, op block.WalkOptions, walkFn func(e block.ObjectStoreEntry) error) error {
-	prefix := strings.TrimLeft(storageURI.Path, "/")
+	rawPath := block.RawPathFromURI(storageURI)
+	prefix := strings.TrimLeft(rawPath, "/")
 	var basePath string
 	if idx := strings.LastIndex(prefix, "/"); idx != -1 {
 		basePath = prefix[:idx+1]

--- a/pkg/block/mem/walker.go
+++ b/pkg/block/mem/walker.go
@@ -32,8 +32,9 @@ func (w *Walker) Walk(_ context.Context, storageURI *url.URL, op block.WalkOptio
 	defer w.adapter.mutex.RUnlock()
 
 	// Extract the prefix from the storageURI
+	rawPath := block.RawPathFromURI(storageURI)
 	const schemePrefix = block.BlockstoreTypeMem + "://"
-	prefix := schemePrefix + storageURI.Host + "/" + strings.TrimLeft(storageURI.Path, "/")
+	prefix := schemePrefix + storageURI.Host + "/" + strings.TrimLeft(rawPath, "/")
 
 	// basePath is the path relative to which the walk is done
 	var basePath string

--- a/pkg/block/namespace.go
+++ b/pkg/block/namespace.go
@@ -145,11 +145,20 @@ func resolveFull(key string) (CommonQualifiedKey, error) {
 	if err != nil {
 		return CommonQualifiedKey{}, err
 	}
+
+	rawPath := RawPathFromURI(parsedKey)
 	return CommonQualifiedKey{
 		StorageType:      storageType,
 		StorageNamespace: parsedKey.Host,
-		Key:              formatPathWithNamespace("", parsedKey.Path),
+		Key:              formatPathWithNamespace("", rawPath),
 	}, nil
+}
+
+func RawPathFromURI(u *url.URL) string {
+	if u.RawPath != "" {
+		return u.RawPath
+	}
+	return u.Path
 }
 
 func resolveRelative(defaultNamespace, key string) (CommonQualifiedKey, error) {
@@ -164,9 +173,10 @@ func resolveRelative(defaultNamespace, key string) (CommonQualifiedKey, error) {
 		return CommonQualifiedKey{}, fmt.Errorf("no storage type for %s: %w", parsedNS, err)
 	}
 
+	rawPath := RawPathFromURI(parsedNS)
 	return CommonQualifiedKey{
 		StorageType:      storageType,
-		StorageNamespace: strings.TrimSuffix(parsedNS.Host+parsedNS.Path, "/"),
+		StorageNamespace: strings.TrimSuffix(parsedNS.Host+rawPath, "/"),
 		Key:              key,
 	}, nil
 }
@@ -176,7 +186,6 @@ func resolveNamespaceUnknown(defaultNamespace, key string) (CommonQualifiedKey, 
 	if qk, err := resolveFull(key); err == nil {
 		return qk, nil
 	}
-
 	// else, treat it as a relative path
 	return resolveRelative(defaultNamespace, key)
 }

--- a/pkg/block/namespace_test.go
+++ b/pkg/block/namespace_test.go
@@ -104,13 +104,25 @@ func TestResolveNamespace(t *testing.T) {
 		},
 		{
 			Name:             "valid_fq_key_encoded",
-			DefaultNamespace: "mem://foo/",
+			DefaultNamespace: "s3://foo/",
 			Key:              "s3://example/bar/foo%3Abaz",
 			Type:             block.IdentifierTypeFull,
 			ExpectedErr:      nil,
 			Expected: block.CommonQualifiedKey{
 				StorageType:      block.StorageTypeS3,
 				StorageNamespace: "example",
+				Key:              "bar/foo%3Abaz",
+			},
+		},
+		{
+			Name:             "valid_relative_encoded",
+			DefaultNamespace: "s3://foo/",
+			Key:              "bar/foo%3Abaz",
+			Type:             block.IdentifierTypeRelative,
+			ExpectedErr:      nil,
+			Expected: block.CommonQualifiedKey{
+				StorageType:      block.StorageTypeS3,
+				StorageNamespace: "foo",
 				Key:              "bar/foo%3Abaz",
 			},
 		},

--- a/pkg/block/s3/walker.go
+++ b/pkg/block/s3/walker.go
@@ -26,7 +26,8 @@ func NewS3Walker(client *s3.Client) *Walker {
 func (s *Walker) Walk(ctx context.Context, storageURI *url.URL, op block.WalkOptions, walkFn func(e block.ObjectStoreEntry) error) error {
 	var continuation *string
 	const maxKeys = 1000
-	prefix := strings.TrimLeft(storageURI.Path, "/")
+	rawPath := block.RawPathFromURI(storageURI)
+	prefix := strings.TrimLeft(rawPath, "/")
 
 	// basePath is the path relative to which the walk is done. The key of the resulting entries will be relative to this path.
 	// As the original prefix might not end with a separator, it cannot be used for the


### PR DESCRIPTION
Part of https://github.com/treeverse/lakeFS/issues/9466

Adding 'lakeFS migrate task' command.
The command support 'list' and 'run'.
The 'list' subcommand will list migrate tasks.
The 'run' subcommand will execute the task.

The PR adds 'storage-ns-encoded' task that will fix old storage namespace location that uses encoded path (using %HEX).
It will transform the parse the storage namespace using the old code, try to access a dummy file. If there is access to the dummy file, it means that this repository was created with the old lakefs parse bug and it will fix it by update the storage namespace to the value without any escaping to enable access to the user data.

The task command also support --dry-run that will just report without modify the storage namespace.

 