### PR TITLE
hadoop client api timeout configuration

### DIFF
--- a/clients/hadoopfs/src/main/java/io/lakefs/Constants.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/Constants.java
@@ -41,6 +41,14 @@ public class Constants {
 
     public static final String SESSION_ID = "session_id";
 
+    // Timeout configuration
+    public static final String CONNECT_TIMEOUT_KEY_SUFFIX = "api.connect.timeout.ms";
+    public static final String READ_TIMEOUT_KEY_SUFFIX = "api.read.timeout.ms";
+    public static final String WRITE_TIMEOUT_KEY_SUFFIX = "api.write.timeout.ms";
+    public static final int DEFAULT_CONNECT_TIMEOUT_MS = 10000; // 10 seconds
+    public static final int DEFAULT_READ_TIMEOUT_MS = 30000;    // 30 seconds
+    public static final int DEFAULT_WRITE_TIMEOUT_MS = 30000;   // 30 seconds
+
     public static enum AccessMode {
         SIMPLE,
         PRESIGNED;

--- a/clients/hadoopfs/src/main/java/io/lakefs/LakeFSClient.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/LakeFSClient.java
@@ -66,6 +66,16 @@ public class LakeFSClient {
     ApiClient newApiClientNoAuth(String scheme, Configuration conf) {
 
         ApiClient apiClient = io.lakefs.clients.sdk.Configuration.getDefaultApiClient();
+        
+        // Configure timeouts
+        int connectTimeout = FSConfiguration.getInt(conf, scheme, Constants.CONNECT_TIMEOUT_KEY_SUFFIX, Constants.DEFAULT_CONNECT_TIMEOUT_MS);
+        int readTimeout = FSConfiguration.getInt(conf, scheme, Constants.READ_TIMEOUT_KEY_SUFFIX, Constants.DEFAULT_READ_TIMEOUT_MS);
+        int writeTimeout = FSConfiguration.getInt(conf, scheme, Constants.WRITE_TIMEOUT_KEY_SUFFIX, Constants.DEFAULT_WRITE_TIMEOUT_MS);
+        
+        apiClient.setConnectTimeout(connectTimeout);
+        apiClient.setReadTimeout(readTimeout);
+        apiClient.setWriteTimeout(writeTimeout);
+        
         String endpoint = FSConfiguration.get(conf, scheme, Constants.ENDPOINT_KEY_SUFFIX, Constants.DEFAULT_CLIENT_ENDPOINT);
         if (endpoint.endsWith(Constants.SEPARATOR)) {
             endpoint = endpoint.substring(0, endpoint.length() - 1);

--- a/clients/hadoopfs/src/main/java/io/lakefs/auth/AWSLakeFSTokenProvider.java
+++ b/clients/hadoopfs/src/main/java/io/lakefs/auth/AWSLakeFSTokenProvider.java
@@ -63,6 +63,16 @@ public class AWSLakeFSTokenProvider implements LakeFSTokenProvider {
         // initialize a lakeFS api client
 
         this.lakeFSApi = io.lakefs.clients.sdk.Configuration.getDefaultApiClient();
+        
+        // Configure timeouts
+        int connectTimeout = FSConfiguration.getInt(conf, scheme, Constants.CONNECT_TIMEOUT_KEY_SUFFIX, Constants.DEFAULT_CONNECT_TIMEOUT_MS);
+        int readTimeout = FSConfiguration.getInt(conf, scheme, Constants.READ_TIMEOUT_KEY_SUFFIX, Constants.DEFAULT_READ_TIMEOUT_MS);
+        int writeTimeout = FSConfiguration.getInt(conf, scheme, Constants.WRITE_TIMEOUT_KEY_SUFFIX, Constants.DEFAULT_WRITE_TIMEOUT_MS);
+        
+        this.lakeFSApi.setConnectTimeout(connectTimeout);
+        this.lakeFSApi.setReadTimeout(readTimeout);
+        this.lakeFSApi.setWriteTimeout(writeTimeout);
+        
         this.lakeFSApi.addDefaultHeader("X-Lakefs-Client", "lakefs-hadoopfs/" + getClass().getPackage().getImplementationVersion());
         String endpoint = FSConfiguration.get(conf, scheme, Constants.ENDPOINT_KEY_SUFFIX, Constants.DEFAULT_CLIENT_ENDPOINT);
         if (endpoint.endsWith(Constants.SEPARATOR)) {


### PR DESCRIPTION
Close https://github.com/treeverse/lakeFS/issues/9477

Defaults:
connect timeout is 10 seconds.
read timeout is 30 seconds.
write timeout is 30 seconds.

Configuration keys are:
fs.lakefs.api.connect.timeout.ms
fs.lakefs.api.read.timeout.ms
fs.lakefs.api.write.timeout.ms
