### PR TITLE
Added documentation on configuring lakeFS to use the new selection login page

### DIFF
--- a/docs/src/enterprise/configuration.md
+++ b/docs/src/enterprise/configuration.md
@@ -42,17 +42,41 @@ Configuration section for lakeFS Enterprise database options.
     
 ### auth
 
-Configuration section for authentication services, like SAML or OIDC.
+Configuration section for SSO authentication services, like SAML or OIDC.
 
-* `auth.logout_redirect_url` `(string : "/auth/login")` - The URL to redirect to after logout. The behavior depends on the authentication provider:
-  - **For OIDC**: The logout URL of the OIDC provider (e.g., Auth0 logout endpoint)
-  - **For SAML**: The URL within lakeFS where the IdP should redirect after logout (e.g., `/auth/login`)
+* `auth.logout_redirect_url` `(string : "/auth/login")` - The URL to redirect to after logout when using SSO authentication services, like SAML or OIDC.   
+The configuration depends on the authentication provider:  
+    - **For OIDC:** The logout URL of the OIDC provider (e.g., Auth0 logout endpoint).
+    - **For SAML:** The URL within lakeFS where the IdP should redirect after logout (e.g., `/auth/login`).
+
+#### auth.ui_config
+
+* `auth.ui_config.login_url_method` `(string : "redirect")` - Controls how lakeFS handles login when an `auth.ui_config.login_url` (SSO via OIDC or SAML) is configured.   
+Supported values:
+    * `auth.ui_config.login_url_method="none"` - Default for OSS lakeFS. lakeFS OSS does not support SSO authentication.
+    * `auth.ui_config.login_url_method="redirect"` - Default for lakeFS Enterprise. If `auth.ui_config.login_url` is set, when users are redirected to the lakeFS login page, they are automatically redirected to the SSO login page.
+    * `auth.ui_config.login_url_method="select"` - If `auth.ui_config.login_url` is set, when users are redirected to the login page, they are presented with a page that allows them to select between two options: login via SSO (`login_url`) or login with lakeFS credentials.
+
+    !!! warning
+        - The `auth.ui_config.login_url_method` setting must always be used together with `auth.ui_config.login_url`, meaning an SSO IdP (OIDC or SAML) must be configured.
+        - To ensure users return to the lakeFS login selection page after logout (instead of being automatically redirected to the SSO login page), configure the logout redirect URL.   
+          The configuration depends on the authentication provider:
+            - **For OIDC:** Set the `returnTo` value in `auth.providers.oidc.logout_endpoint_query_parameters` to:  
+            `["returnTo", "https://<lakefs.ingress.domain>/auth/login?redirected=true"]`  
+            instead of:  
+            `["returnTo", "https://<lakefs.ingress.domain>/oidc/login"]`.
+            - **For SAML:** Set the `auth.logout_redirect_url` to:  
+              `https://<lakefs.ingress.domain>/auth/login?redirected=true`.  
+              If a Logout Redirection URL is configured in your IdP, ensure it points to the same path:
+              `https://<lakefs.ingress.domain>/auth/login?redirected=true`.
 
 ### auth.providers
 
-Configuration section external identity providers
+Configuration section for external identity providers used for authentication services, such as LDAP, SAML or OIDC.
 
 #### auth.providers.ldap
+
+Configuration section for LDAP.
 
 * `auth.providers.ldap.server_endpoint` `(string : "")` - The LDAP server address, e.g. `'ldaps://ldap.company.com:636'`
 * `auth.providers.ldap.bind_dn` `(string : "")` - The bind string, e.g. `'uid=<bind-user-name>,ou=Users,o=<org-id>,dc=<company>,dc=com'`
@@ -66,7 +90,7 @@ Configuration section external identity providers
 
 #### auth.providers.saml
 
-Configuration section for SAML
+Configuration section for SAML.
 
 * `auth.providers.saml.sp_root_url` `(string : '')` - The base lakeFS-URL, e.g. `'https://<lakefs-url>'`
 * `auth.providers.saml.sp_x509_key_path` `(string : '')` - The path to the private key, e.g `'/etc/saml_certs/rsa_saml_private.cert'`
@@ -82,7 +106,7 @@ Configuration section for SAML
 
 #### auth.providers.oidc
 
-Configuration section for OIDC
+Configuration section for OIDC.
 
 * `auth.providers.oidc.url` `(string : '')` - The OIDC provider url, e.g. `'https://oidc-provider-url.com/'`
 * `auth.providers.oidc.client_id` `(string : '')` - The application's ID
@@ -100,21 +124,18 @@ Configuration section for OIDC
 * `auth.providers.oidc.additional_scope_claims` `(string[] : '[]')` - Specifies optional requested permissions, other than `openid` and `profile` that are being used
 * `auth.providers.oidc.post_login_redirect_url` `(string : '')` - The URL to redirect users to after successful OIDC authentication, e.g. `'http://localhost:8000/'`
 
-### auth.external
+#### auth.external_aws_auth
 
-Configuration section for the external authentication methods
+Configuration section for authentication to lakeFS using the AWS presigned get-caller-identity request:   
+[External Principals AWS Auth](../security/external-principals-aws.md)
 
-#### auth.external.aws_auth
-
-Configuration section for authenticating to lakeFS using AWS presign get-caller-identity request: [External Principals AWS Auth](../security/external-principals-aws.md)
-
-* `auth.external.aws_auth.enabled` `(bool : false)` - If true, external principals API will be enabled, e.g auth service and login api's
-* `auth.external.aws_auth.get_caller_identity_max_age` `(duration : 15m)` - The maximum age in seconds for the GetCallerIdentity request to be valid, the max is 15 minutes enforced by AWS, smaller TTL can be set
-* `auth.external.aws_auth.valid_sts_hosts` `([]string)` - The default are all the valid AWS STS hosts (`sts.amazonaws.com`, `sts.us-east-2.amazonaws.com` etc.)
-* `auth.external.aws_auth.required_headers` `(map[string]string : )` - Headers that must be present by the client when doing login request. For security reasons it is recommended to set `X-LakeFS-Server-ID: <lakefs.ingress.domain>`, lakeFS clients assume that's the default
-* `auth.external.aws_auth.optional_headers` `(map[string]string : )` - Optional headers that can be present by the client when doing login request
-* `auth.external.aws_auth.http_client.timeout` `(duration : 10s)` - The timeout for the HTTP client used to communicate with AWS STS
-* `auth.external.aws_auth.http_client.skip_verify` `(bool : false)` - Skip SSL verification with AWS STS
+* `auth.external_aws_auth.enabled` `(bool : false)` - If true, external principals API will be enabled, e.g auth service and login api's
+* `auth.external_aws_auth.get_caller_identity_max_age` `(duration : 15m)` - The maximum age in seconds for the GetCallerIdentity request to be valid, the max is 15 minutes enforced by AWS, smaller TTL can be set
+* `auth.external_aws_auth.valid_sts_hosts` `([]string)` - The default are all the valid AWS STS hosts (`sts.amazonaws.com`, `sts.us-east-2.amazonaws.com` etc.)
+* `auth.external_aws_auth.required_headers` `(map[string]string : )` - Headers that must be present by the client when doing login request. For security reasons it is recommended to set `X-LakeFS-Server-ID: <lakefs.ingress.domain>`, lakeFS clients assume that's the default
+* `auth.external_aws_auth.optional_headers` `(map[string]string : )` - Optional headers that can be present by the client when doing login request
+* `auth.external_aws_auth.http_client.timeout` `(duration : 10s)` - The timeout for the HTTP client used to communicate with AWS STS
+* `auth.external_aws_auth.http_client.skip_verify` `(bool : false)` - Skip SSL verification with AWS STS
 
 ### blockstores
 

--- a/docs/src/reference/configuration.md
+++ b/docs/src/reference/configuration.md
@@ -103,16 +103,8 @@ Configuration section for the lakeFS key-value store database.
 
 ### auth
 
-* `auth.login_duration` `(time duration : "168h")` - The duration the login token is valid for
-* `auth.login_max_duration` `(time duration : "168h")` - The maximum duration user can ask for a login token
-* `auth.cookie_domain` `(string : "")` - [Domain attribute](https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#define_where_cookies_are_sent) to set the access_token cookie on (the default is an empty string which defaults to the same host that sets the cookie)
-* `auth.ui_config.rbac` `(string: "none")` - "none", "simplified", "external" or "internal" (enterprise feature).
-
-    If you have configured an external auth server you can set this to "external" to support the policy editor.
-
-    If you are using the enteprrise version of lakeFS, you can set this to "internal" to use the built-in policy editor.
-
-* `auth.ui_config.use_login_placeholders` `(bool: false)` - If set to true, the login page will show placeholders for the _Access Key ID_ and _Secret Access Key_ (_Username_ and _Password_).
+* `auth.login_duration` `(time duration : "168h")` - The duration the login token is valid for.
+* `auth.login_max_duration` `(time duration : "168h")` - The maximum duration user can ask for a login token.
 
 #### auth.cache
 
@@ -120,6 +112,9 @@ Configuration section for the lakeFS key-value store database.
 * `auth.cache.size` `(int : 1024)` - How many items to store in the auth cache. Systems with a very high user count should use a larger value at the expense of ~1kb of memory per cached user.
 * `auth.cache.ttl` `(time duration : "20s")` - How long to store an item in the auth cache. Using a higher value reduces load on the database, but will cause changes longer to take effect for cached users.
 * `auth.cache.jitter` `(time duration : "3s")` - A random amount of time between 0 and this value is added to each item's TTL. This is done to avoid a large bulk of keys expiring at once and overwhelming the database.
+
+#### auth.encrypt
+
 * `auth.encrypt.secret_key` `(string : required)` - A random (cryptographically safe) generated string that is used for encryption and HMAC signing
 
     !!! warning
@@ -144,6 +139,14 @@ Configuration section for the lakeFS key-value store database.
 * `auth.remote_authenticator.default_user_group` `(string : Viewers)` - Create users in this group (i.e `Viewers`, `Developers`, etc).
 * `auth.remote_authenticator.request_timeout` `(duration : 10s)` - If specified, timeout for remote authentication requests.
 
+#### auth.oidc
+
+* `auth.oidc.default_initial_groups` `(string[] : [])` - By default, OIDC users will be assigned to these groups
+* `auth.oidc.initial_groups_claim_name` `(string[] : [])` - Use this claim from the ID token to provide the initial group for new users. This will take priority if `auth.oidc.default_initial_groups` is also set.
+* `auth.oidc.friendly_name_claim_name` `(string[] : )` - If specified, the value from the claim with this name will be used as the user's display name.
+* `auth.oidc.persist_friendly_name` `(string : false)` - If set to `true`, the friendly name is persisted to the KV store and can be displayed in the user list. This is meant to be used in conjunction with `auth.oidc.friendly_name_claim_name`.
+* `auth.oidc.validate_id_token_claims` `(map[string]string : )` - When a user tries to access lakeFS, validate that the ID token contains these claims with the corresponding values.
+
 #### auth.cookie_auth_verification
 
 * `auth.cookie_auth_verification.validate_id_token_claims` `(map[string]string : )` - When a user tries to access lakeFS, validate that the ID token contains these claims with the corresponding values.
@@ -154,15 +157,18 @@ Configuration section for the lakeFS key-value store database.
 * `auth.cookie_auth_verification.external_user_id_claim_name` - `(string : )` - If specified, the value from the claim with this name will be used as the user's id name.
 * `auth.cookie_auth_verification.auth_source` - `(string : )` - If specified, user will be labeled with this auth source.
 
-#### auth.oidc
+#### auth.ui_config
 
-* `auth.oidc.default_initial_groups` `(string[] : [])` - By default, OIDC users will be assigned to these groups
-* `auth.oidc.initial_groups_claim_name` `(string[] : [])` - Use this claim from the ID token to provide the initial group for new users. This will take priority if `auth.oidc.default_initial_groups` is also set.
-* `auth.oidc.friendly_name_claim_name` `(string[] : )` - If specified, the value from the claim with this name will be used as the user's display name.
-* `auth.oidc.persist_friendly_name` `(string : false)` - If set to `true`, the friendly name is persisted to the KV store and can be displayed in the user list. This is meant to be used in conjunction with `auth.oidc.friendly_name_claim_name`.
-* `auth.oidc.validate_id_token_claims` `(map[string]string : )` - When a user tries to access lakeFS, validate that the ID token contains these claims with the corresponding values.
+* `auth.ui_config.rbac` `(string: "none")` - "none", "simplified", "external" or "internal".
+    - `auth.ui_config.rbac="none"` - lakeFS runs without an RBAC authorization service. No additional users, groups, or policies can be created.
+    - `auth.ui_config.rbac="simplified"` - lakeFS uses ACL as the authorization service. You must implement your own ACL service and connect it to lakeFS. See the [implementation guide](../security/ACL-server-implementation.md) and [ACL overview](../security/access-control-lists.md) for details.
+    - `auth.ui_config.rbac="external"` - lakeFS integrates with an external RBAC authorization service.
+    - `auth.ui_config.rbac="internal"` - Available in the Enterprise lakeFS version. Uses the built-in RBAC authorization service. More information is available [here](../security/rbac.md).
 
-
+* `auth.ui_config.login_url` `(string : "")` - An absolute or relative URL to your IdP’s login page, used to authenticate to lakeFS via SSO with OIDC or SAML.
+* `auth.ui_config.login_failed_message` `(string : "")` - Custom error message displayed when authentication fails on the login form (defaults to "The credentials don't match." if not specified).
+* `auth.ui_config.logout_url` `(string : "")`- URL to redirect users to when they logout from lakeFS (defaults to "/logout" if not specified).
+* `auth.ui_config.use_login_placeholders` `(bool: false)` - If set to true, the login page will show placeholders for the _Access Key ID_ and _Secret Access Key_ (_Username_ and _Password_) (defaults to "false" if not specified).
 
 ### blockstore
 

--- a/docs/src/security/presigned-url.md
+++ b/docs/src/security/presigned-url.md
@@ -16,10 +16,11 @@ It is possible to override the default pre-signed URL endpoint in **AWS** by set
 This is useful, for example, when you wish to define a [VPC endpoint](https://docs.aws.amazon.com/AmazonS3/latest/userguide/privatelink-interface-endpoints.html#accessing-s3-interface-endpoints) access for the pre-signed URL.
 
 ## Using presigned URLs in the UI
-For using presigned URLs in the UI:
-1. Enable the presigned URL support UI in the lakeFS [configuration](../reference/configuration.md) (`blockstore.<blockstore_type>.disable_pre_signed_ui`   ).
+To use presigned URLs in the UI:
+
+1. Enable the presigned URL support UI in the lakeFS [configuration](../reference/configuration.md):  
+set `blockstore.<blockstore_type>.disable_pre_signed_ui=false`.
 2. Add CORS (Cross-Origin Resource Sharing) permissions to the bucket for the UI to fetch objects using a presigned URL (instead of through lakeFS).
-3. The `blockstore.<blockstore_type>.disable_pre_signed` must be false to enable it in the UI.
 
 !!! warning
     Currently DuckDB fetching data from lakeFS does not support fetching data using presigned URL.


### PR DESCRIPTION
Closes #9494

Added documentation on configuring lakeFS to use the new selection login page that I added in this [Enterprise PR](https://github.com/treeverse/lakeFS-Enterprise/pull/913) and in this [OSS PR](https://github.com/treeverse/lakeFS/pull/9429).