### PR TITLE
task: return 405 for not implemented for specific API routes

### DIFF
--- a/pkg/api/serve.go
+++ b/pkg/api/serve.go
@@ -69,6 +69,7 @@ func Serve(cfg config.Config, catalog *catalog.Catalog, authenticator auth.Authe
 	// Additional API routes we like to serve before the UI handler
 	r.Mount("/iceberg/api/", http.HandlerFunc(NotImplementedIcebergCatalogHandler))
 	r.Mount("/iceberg/relative_to/", http.HandlerFunc(NotImplementedIcebergCatalogHandler))
+	r.Mount("/mds/iceberg/", http.HandlerFunc(NotImplementedIcebergCatalogHandler))
 
 	// Configuration flag to control if the embedded UI is served
 	// or not and assign the correct handler for each case.

--- a/pkg/api/serve_test.go
+++ b/pkg/api/serve_test.go
@@ -266,7 +266,7 @@ func TestNotImplementedAPI(t *testing.T) {
 	server := setupServer(t, handler)
 
 	// verify that for specific APIs, we get a 405 Not Implemented
-	routes := []string{"/iceberg/api/v1/config", "/iceberg/relative_to/v1/config"}
+	routes := []string{"/iceberg/api/v1/config", "/iceberg/relative_to/v1/config", "/mds/iceberg/v1/config"}
 	for _, route := range routes {
 		req, err := http.NewRequestWithContext(t.Context(), http.MethodGet, server.URL+route, nil)
 		if err != nil {


### PR DESCRIPTION
API implemented non-OSS returns not implemented.
This change also include testing these routes.