### PR TITLE
Skip cloud metadata collection when stats are disabled

### DIFF
--- a/cmd/lakefs/cmd/root.go
+++ b/cmd/lakefs/cmd/root.go
@@ -176,10 +176,11 @@ func getHomeDir() string {
 }
 
 // initStatsMetadata initializes and returns stats metadata with all required providers
-func initStatsMetadata(ctx context.Context, logger logging.Logger, authMetadataManager auth.MetadataManager, storageConfig config.StorageConfig) *stats.Metadata {
+func initStatsMetadata(ctx context.Context, logger logging.Logger, authMetadataManager auth.MetadataManager, cfg config.Config) *stats.Metadata {
+	storageConfig := cfg.StorageConfig()
 	metadataProviders := []stats.MetadataProvider{
 		authMetadataManager,
-		cloud.NewMetadataProvider(storageConfig),
+		cloud.NewMetadataProvider(storageConfig, cfg.GetBaseConfig().Stats.Enabled),
 		block.NewMetadataProvider(storageConfig),
 	}
 	return stats.NewMetadata(ctx, logger, metadataProviders)

--- a/cmd/lakefs/cmd/run.go
+++ b/cmd/lakefs/cmd/run.go
@@ -137,7 +137,7 @@ var runCmd = &cobra.Command{
 			logger.WithField("adapter_type", blockstoreType).Warn("Block adapter NOT SUPPORTED for production use")
 		}
 
-		metadata := initStatsMetadata(ctx, logger, authMetadataManager, cfg.StorageConfig())
+		metadata := initStatsMetadata(ctx, logger, authMetadataManager, cfg)
 		bufferedCollector := stats.NewBufferedCollector(metadata.InstallationID, stats.Config(baseCfg.Stats),
 			stats.WithLogger(logger.WithField("service", "stats_collector")))
 

--- a/cmd/lakefs/cmd/setup.go
+++ b/cmd/lakefs/cmd/setup.go
@@ -85,7 +85,7 @@ var setupCmd = &cobra.Command{
 			fmt.Printf("Setup failed: %s\n", err)
 			os.Exit(1)
 		}
-		metadata := initStatsMetadata(ctx, logger, authMetadataManager, cfg.StorageConfig())
+		metadata := initStatsMetadata(ctx, logger, authMetadataManager, cfg)
 
 		credentials, err := setupLakeFS(ctx, cfg, authMetadataManager, authService, userName, accessKeyID, secretAccessKey, noCheck)
 		if err != nil {

--- a/cmd/lakefs/cmd/superuser.go
+++ b/cmd/lakefs/cmd/superuser.go
@@ -70,7 +70,7 @@ If the wrong user or credentials were chosen it is possible to delete the user a
 
 		addToAdmins := !authUIConfig.IsAuthBasic()
 		authMetadataManager := auth.NewKVMetadataManager(version.Version, baseConfig.Installation.FixedID, baseConfig.Database.Type, kvStore)
-		metadata := initStatsMetadata(ctx, logger, authMetadataManager, baseConfig.StorageConfig())
+		metadata := initStatsMetadata(ctx, logger, authMetadataManager, cfg)
 		authService, err := authfactory.NewAuthService(ctx, cfg, logger, kvStore, authMetadataManager)
 		if err != nil {
 			fmt.Printf("Failed to initialize auth service: %s\n", err)

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -5375,7 +5375,7 @@ func (c *Controller) Setup(w http.ResponseWriter, r *http.Request, body apigen.S
 	storageConfig := c.Config.GetBaseConfig().StorageConfig()
 	metadataProviders := []stats.MetadataProvider{
 		c.MetadataManager,
-		cloud.NewMetadataProvider(storageConfig),
+		cloud.NewMetadataProvider(storageConfig, false),
 		block.NewMetadataProvider(storageConfig),
 	}
 	meta := stats.NewMetadata(ctx, c.Logger, metadataProviders)

--- a/pkg/cloud/metadata.go
+++ b/pkg/cloud/metadata.go
@@ -191,7 +191,7 @@ func checkAzureMetadata() error {
 
 // RegisterDefaultDetectors registers the built-in cloud detectors
 //
-// maintaine the order: GCP first, then AWS, then Azure
+// maintain the order: GCP first, then AWS, then Azure
 func RegisterDefaultDetectors() {
 	RegisterDetector(GCPCloud, DetectGCPProjectID)
 	RegisterDetector(AWSCloud, DetectAWSAccountID)

--- a/pkg/cloud/metadata_provider.go
+++ b/pkg/cloud/metadata_provider.go
@@ -16,11 +16,13 @@ type MetadataProvider struct {
 
 // NewMetadataProvider creates a new MetadataProvider and initializes metadata
 // with cloud type and hashed ID if detected.
-func NewMetadataProvider(storageConfig config.StorageConfig) *MetadataProvider {
+func NewMetadataProvider(storageConfig config.StorageConfig, enabled bool) *MetadataProvider {
 	metadata := make(map[string]string)
-	cloudType, cloudID, cloudDetected := Detect(storageConfig)
-	if cloudDetected {
-		metadata[cloudType] = hashCloudID(cloudID)
+	if enabled {
+		cloudType, cloudID, cloudDetected := Detect(storageConfig)
+		if cloudDetected {
+			metadata[cloudType] = hashCloudID(cloudID)
+		}
 	}
 	return &MetadataProvider{
 		metadata: metadata,


### PR DESCRIPTION
When statistics are disabled, no metadata is posted, allowing us to skip cloud data collection.