### PR TITLE
blockstore: verify storage id is empty

### DIFF
--- a/pkg/block/azure/adapter.go
+++ b/pkg/block/azure/adapter.go
@@ -222,7 +222,10 @@ func (a *Adapter) Get(ctx context.Context, obj block.ObjectPointer) (io.ReadClos
 	return a.Download(ctx, obj, 0, blockblob.CountToEnd)
 }
 
-func (a *Adapter) GetWalker(_ string, opts block.WalkerOptions) (block.Walker, error) {
+func (a *Adapter) GetWalker(storageID string, opts block.WalkerOptions) (block.Walker, error) {
+	if storageID != "" {
+		panic("storageID must be empty")
+	}
 	if err := block.ValidateStorageType(opts.StorageURI, block.StorageTypeAzure); err != nil {
 		return nil, err
 	}
@@ -629,7 +632,10 @@ func (a *Adapter) CompleteMultiPartUpload(ctx context.Context, obj block.ObjectP
 	return completeMultipart(ctx, multipartList.Part, *containerURL, qualifiedKey.BlobURL)
 }
 
-func (a *Adapter) GetStorageNamespaceInfo(string) *block.StorageNamespaceInfo {
+func (a *Adapter) GetStorageNamespaceInfo(storageID string) *block.StorageNamespaceInfo {
+	if storageID != "" {
+		panic("storageID must be empty")
+	}
 	info := block.DefaultStorageNamespaceInfo(block.BlockstoreTypeAzure)
 
 	info.ImportValidityRegex = fmt.Sprintf(`^https?://[a-z0-9_-]+\.%s`, a.clientCache.params.Domain)
@@ -649,7 +655,10 @@ func (a *Adapter) ResolveNamespace(_, storageNamespace, key string, identifierTy
 	return block.DefaultResolveNamespace(storageNamespace, key, identifierType)
 }
 
-func (a *Adapter) GetRegion(_ context.Context, _, _ string) (string, error) {
+func (a *Adapter) GetRegion(_ context.Context, storageID string, storageNamespace string) (string, error) {
+	if storageID != "" {
+		panic("storageID must be empty")
+	}
 	return "", block.ErrOperationNotSupported
 }
 

--- a/pkg/block/gs/adapter.go
+++ b/pkg/block/gs/adapter.go
@@ -200,7 +200,10 @@ func (a *Adapter) Get(ctx context.Context, obj block.ObjectPointer) (io.ReadClos
 	return r, nil
 }
 
-func (a *Adapter) GetWalker(_ string, opts block.WalkerOptions) (block.Walker, error) {
+func (a *Adapter) GetWalker(storageID string, opts block.WalkerOptions) (block.Walker, error) {
+	if storageID != "" {
+		panic("storageID must be empty")
+	}
 	if err := block.ValidateStorageType(opts.StorageURI, block.StorageTypeGS); err != nil {
 		return nil, err
 	}
@@ -693,7 +696,10 @@ func (a *Adapter) BlockstoreMetadata(_ context.Context) (*block.BlockstoreMetada
 	return nil, block.ErrOperationNotSupported
 }
 
-func (a *Adapter) GetStorageNamespaceInfo(string) *block.StorageNamespaceInfo {
+func (a *Adapter) GetStorageNamespaceInfo(storageID string) *block.StorageNamespaceInfo {
+	if storageID != "" {
+		panic("storageID must be empty")
+	}
 	info := block.DefaultStorageNamespaceInfo(block.BlockstoreTypeGS)
 	if a.disablePreSigned {
 		info.PreSignSupport = false
@@ -728,7 +734,10 @@ func (a *Adapter) ResolveNamespace(_, storageNamespace, key string, identifierTy
 	return qualifiedKey, nil
 }
 
-func (a *Adapter) GetRegion(_ context.Context, _, _ string) (string, error) {
+func (a *Adapter) GetRegion(_ context.Context, storageID string, storageNamespace string) (string, error) {
+	if storageID != "" {
+		panic("storageID must be empty")
+	}
 	return "", block.ErrOperationNotSupported
 }
 

--- a/pkg/block/local/adapter.go
+++ b/pkg/block/local/adapter.go
@@ -300,7 +300,10 @@ func (l *Adapter) Get(_ context.Context, obj block.ObjectPointer) (reader io.Rea
 	return f, nil
 }
 
-func (l *Adapter) GetWalker(_ string, opts block.WalkerOptions) (block.Walker, error) {
+func (l *Adapter) GetWalker(storageID string, opts block.WalkerOptions) (block.Walker, error) {
+	if storageID != "" {
+		panic("storageID must be empty")
+	}
 	if err := block.ValidateStorageType(opts.StorageURI, block.StorageTypeLocal); err != nil {
 		return nil, err
 	}
@@ -545,7 +548,10 @@ func (l *Adapter) BlockstoreMetadata(_ context.Context) (*block.BlockstoreMetada
 	return nil, block.ErrOperationNotSupported
 }
 
-func (l *Adapter) GetStorageNamespaceInfo(string) *block.StorageNamespaceInfo {
+func (l *Adapter) GetStorageNamespaceInfo(storageID string) *block.StorageNamespaceInfo {
+	if storageID != "" {
+		panic("storageID must be empty")
+	}
 	info := block.DefaultStorageNamespaceInfo(block.BlockstoreTypeLocal)
 	info.PreSignSupport = false
 	info.DefaultNamespacePrefix = DefaultNamespacePrefix
@@ -576,7 +582,10 @@ func (l *Adapter) ResolveNamespace(storageID, storageNamespace, key string, iden
 	}, nil
 }
 
-func (l *Adapter) GetRegion(_ context.Context, _, _ string) (string, error) {
+func (l *Adapter) GetRegion(_ context.Context, storageID string, storageNamespace string) (string, error) {
+	if storageID != "" {
+		panic("storageID must be empty")
+	}
 	return "", block.ErrOperationNotSupported
 }
 

--- a/pkg/block/mem/adapter.go
+++ b/pkg/block/mem/adapter.go
@@ -162,10 +162,13 @@ func verifyObjectPointer(obj block.ObjectPointer) error {
 }
 
 func (a *Adapter) GetWalker(storageID string, opts block.WalkerOptions) (block.Walker, error) {
+	if storageID != "" {
+		panic("storageID must be empty")
+	}
 	if err := block.ValidateStorageType(opts.StorageURI, block.StorageTypeMem); err != nil {
 		return nil, err
 	}
-	return NewMemWalker(storageID, a), nil
+	return NewMemWalker("", a), nil
 }
 
 func (a *Adapter) GetPreSignedURL(_ context.Context, obj block.ObjectPointer, _ block.PreSignMode, _ string) (string, time.Time, error) {
@@ -443,7 +446,10 @@ func (a *Adapter) BlockstoreMetadata(_ context.Context) (*block.BlockstoreMetada
 	return nil, fmt.Errorf("blockstore metadata: %w", block.ErrOperationNotSupported)
 }
 
-func (a *Adapter) GetStorageNamespaceInfo(string) *block.StorageNamespaceInfo {
+func (a *Adapter) GetStorageNamespaceInfo(storageID string) *block.StorageNamespaceInfo {
+	if storageID != "" {
+		panic("storageID must be empty")
+	}
 	info := block.DefaultStorageNamespaceInfo(block.BlockstoreTypeMem)
 	info.PreSignSupport = false
 	info.ImportSupport = false
@@ -454,7 +460,10 @@ func (a *Adapter) ResolveNamespace(_, storageNamespace, key string, identifierTy
 	return block.DefaultResolveNamespace(storageNamespace, key, identifierType)
 }
 
-func (a *Adapter) GetRegion(_ context.Context, _, _ string) (string, error) {
+func (a *Adapter) GetRegion(_ context.Context, storageID string, storageNamespace string) (string, error) {
+	if storageID != "" {
+		panic("storageID must be empty")
+	}
 	return "", fmt.Errorf("get region: %w", block.ErrOperationNotSupported)
 }
 

--- a/pkg/block/mem/adapter.go
+++ b/pkg/block/mem/adapter.go
@@ -168,7 +168,7 @@ func (a *Adapter) GetWalker(storageID string, opts block.WalkerOptions) (block.W
 	if err := block.ValidateStorageType(opts.StorageURI, block.StorageTypeMem); err != nil {
 		return nil, err
 	}
-	return NewMemWalker("", a), nil
+	return NewMemWalker(storageID, a), nil
 }
 
 func (a *Adapter) GetPreSignedURL(_ context.Context, obj block.ObjectPointer, _ block.PreSignMode, _ string) (string, time.Time, error) {

--- a/pkg/block/s3/adapter.go
+++ b/pkg/block/s3/adapter.go
@@ -385,7 +385,10 @@ func (a *Adapter) Get(ctx context.Context, obj block.ObjectPointer) (io.ReadClos
 	return objectOutput.Body, nil
 }
 
-func (a *Adapter) GetWalker(_ string, opts block.WalkerOptions) (block.Walker, error) {
+func (a *Adapter) GetWalker(storageID string, opts block.WalkerOptions) (block.Walker, error) {
+	if storageID != "" {
+		panic("storageID must be empty")
+	}
 	if err := block.ValidateStorageType(opts.StorageURI, block.StorageTypeS3); err != nil {
 		return nil, err
 	}
@@ -916,7 +919,10 @@ func (a *Adapter) BlockstoreMetadata(ctx context.Context) (*block.BlockstoreMeta
 	return &block.BlockstoreMetadata{Region: &region}, nil
 }
 
-func (a *Adapter) GetStorageNamespaceInfo(string) *block.StorageNamespaceInfo {
+func (a *Adapter) GetStorageNamespaceInfo(storageID string) *block.StorageNamespaceInfo {
+	if storageID != "" {
+		panic("storageID must be empty")
+	}
 	info := block.DefaultStorageNamespaceInfo(block.BlockstoreTypeS3)
 	if a.disablePreSigned {
 		info.PreSignSupport = false
@@ -945,7 +951,10 @@ func (a *Adapter) ResolveNamespace(_, storageNamespace, key string, identifierTy
 	return block.DefaultResolveNamespace(storageNamespace, key, identifierType)
 }
 
-func (a *Adapter) GetRegion(ctx context.Context, _, storageNamespace string) (string, error) {
+func (a *Adapter) GetRegion(ctx context.Context, storageID string, storageNamespace string) (string, error) {
+	if storageID != "" {
+		panic("storageID must be empty")
+	}
 	namespaceURL, err := url.Parse(storageNamespace)
 	if err != nil {
 		return "", fmt.Errorf(`%s isn't a valid url': %w`, storageNamespace, block.ErrInvalidNamespace)

--- a/pkg/block/transient/adapter.go
+++ b/pkg/block/transient/adapter.go
@@ -35,7 +35,10 @@ func (a *Adapter) Get(_ context.Context, _ block.ObjectPointer) (io.ReadCloser, 
 	return io.NopCloser(&io.LimitedReader{R: rand.Reader, N: DefaultReaderSize}), nil
 }
 
-func (a *Adapter) GetWalker(_ string, _ block.WalkerOptions) (block.Walker, error) {
+func (a *Adapter) GetWalker(storageID string, opts block.WalkerOptions) (block.Walker, error) {
+	if storageID != "" {
+		panic("storageID must be empty")
+	}
 	return nil, block.ErrOperationNotSupported
 }
 
@@ -150,7 +153,10 @@ func (a *Adapter) BlockstoreMetadata(_ context.Context) (*block.BlockstoreMetada
 	return nil, block.ErrOperationNotSupported
 }
 
-func (a *Adapter) GetStorageNamespaceInfo(string) *block.StorageNamespaceInfo {
+func (a *Adapter) GetStorageNamespaceInfo(storageID string) *block.StorageNamespaceInfo {
+	if storageID != "" {
+		panic("storageID must be empty")
+	}
 	info := block.DefaultStorageNamespaceInfo(block.BlockstoreTypeTransient)
 	info.PreSignSupport = false
 	info.PreSignSupportUI = false
@@ -162,7 +168,10 @@ func (a *Adapter) ResolveNamespace(_, storageNamespace, key string, identifierTy
 	return block.DefaultResolveNamespace(storageNamespace, key, identifierType)
 }
 
-func (a *Adapter) GetRegion(_ context.Context, _, _ string) (string, error) {
+func (a *Adapter) GetRegion(_ context.Context, storageID string, storageNamespace string) (string, error) {
+	if storageID != "" {
+		panic("storageID must be empty")
+	}
 	return "", block.ErrOperationNotSupported
 }
 


### PR DESCRIPTION
Consistent validation for the `storageID` parameter across all block adapter implementations. 

The main change is to ensure that whenever `storageID` is provided to certain methods, it must be empty; otherwise, the code will panic. This enforces a stricter contract for these block adapters and helps prevent incorrect usage.