### PR TITLE
changed the positon of the call to usePluginManager()

### DIFF
--- a/webui/src/pages/auth/login.tsx
+++ b/webui/src/pages/auth/login.tsx
@@ -108,6 +108,7 @@ const LoginForm = ({loginConfig}: {loginConfig: LoginConfig}) => {
 
 const LoginPage = () => {
     const router = useRouter();
+    const pluginManager = usePluginManager();
     const { response, error, loading } = useAPI(() => setup.getState());
 
     if (loading) {
@@ -136,7 +137,6 @@ const LoginPage = () => {
     // selection page or the default lakeFS login form, since both share the same endpoint.
     if (router.query.redirected)  {
         delete router.query.redirected;
-        const pluginManager = usePluginManager();
         const loginStrategy = pluginManager.loginStrategy.getLoginStrategy(loginConfig, router);
         // Return the element (component or null)
         if (loginStrategy.element !== undefined) {


### PR DESCRIPTION
Closes #9517 

## Change Description


The error occurred because I placed:

`const pluginManager = usePluginManager();`

inside an if statement. This caused React to throw a “Rules of Hooks” violation, since hooks must always be called at the top level and not inside conditionals.

To fix this, I moved the hook call to the beginning of the `LoginPage` component and removed it from the conditional. After this change, the error no longer appears.

The reason it only showed up on port 3000 and not on 8000 is likely because dev mode runs with React Strict Mode enabled, which enforces these checks more strictly.