### PR TITLE
API: get repository should specify 400 status code in openapi spec

### DIFF
--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -3162,6 +3162,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Repository"
+        400:
+          $ref: "#/components/responses/ValidationError"
         401:
           $ref: "#/components/responses/Unauthorized"
         404:

--- a/clients/java/api/openapi.yaml
+++ b/clients/java/api/openapi.yaml
@@ -2140,6 +2140,12 @@ paths:
               schema:
                 $ref: '#/components/schemas/Repository'
           description: repository
+        "400":
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+          description: Validation Error
         "401":
           content:
             application/json:

--- a/clients/java/docs/RepositoriesApi.md
+++ b/clients/java/docs/RepositoriesApi.md
@@ -768,6 +768,7 @@ public class Example {
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 | **200** | repository |  -  |
+| **400** | Validation Error |  -  |
 | **401** | Unauthorized |  -  |
 | **404** | Resource Not Found |  -  |
 | **429** | too many requests |  -  |

--- a/clients/java/src/main/java/io/lakefs/clients/sdk/RepositoriesApi.java
+++ b/clients/java/src/main/java/io/lakefs/clients/sdk/RepositoriesApi.java
@@ -1421,6 +1421,7 @@ public class RepositoriesApi {
          <table summary="Response Details" border="1">
             <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
             <tr><td> 200 </td><td> repository </td><td>  -  </td></tr>
+            <tr><td> 400 </td><td> Validation Error </td><td>  -  </td></tr>
             <tr><td> 401 </td><td> Unauthorized </td><td>  -  </td></tr>
             <tr><td> 404 </td><td> Resource Not Found </td><td>  -  </td></tr>
             <tr><td> 429 </td><td> too many requests </td><td>  -  </td></tr>
@@ -1439,6 +1440,7 @@ public class RepositoriesApi {
          <table summary="Response Details" border="1">
             <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
             <tr><td> 200 </td><td> repository </td><td>  -  </td></tr>
+            <tr><td> 400 </td><td> Validation Error </td><td>  -  </td></tr>
             <tr><td> 401 </td><td> Unauthorized </td><td>  -  </td></tr>
             <tr><td> 404 </td><td> Resource Not Found </td><td>  -  </td></tr>
             <tr><td> 429 </td><td> too many requests </td><td>  -  </td></tr>
@@ -1458,6 +1460,7 @@ public class RepositoriesApi {
          <table summary="Response Details" border="1">
             <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
             <tr><td> 200 </td><td> repository </td><td>  -  </td></tr>
+            <tr><td> 400 </td><td> Validation Error </td><td>  -  </td></tr>
             <tr><td> 401 </td><td> Unauthorized </td><td>  -  </td></tr>
             <tr><td> 404 </td><td> Resource Not Found </td><td>  -  </td></tr>
             <tr><td> 429 </td><td> too many requests </td><td>  -  </td></tr>
@@ -1477,6 +1480,7 @@ public class RepositoriesApi {
          <table summary="Response Details" border="1">
             <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
             <tr><td> 200 </td><td> repository </td><td>  -  </td></tr>
+            <tr><td> 400 </td><td> Validation Error </td><td>  -  </td></tr>
             <tr><td> 401 </td><td> Unauthorized </td><td>  -  </td></tr>
             <tr><td> 404 </td><td> Resource Not Found </td><td>  -  </td></tr>
             <tr><td> 429 </td><td> too many requests </td><td>  -  </td></tr>
@@ -1497,6 +1501,7 @@ public class RepositoriesApi {
      <table summary="Response Details" border="1">
         <tr><td> Status Code </td><td> Description </td><td> Response Headers </td></tr>
         <tr><td> 200 </td><td> repository </td><td>  -  </td></tr>
+        <tr><td> 400 </td><td> Validation Error </td><td>  -  </td></tr>
         <tr><td> 401 </td><td> Unauthorized </td><td>  -  </td></tr>
         <tr><td> 404 </td><td> Resource Not Found </td><td>  -  </td></tr>
         <tr><td> 429 </td><td> too many requests </td><td>  -  </td></tr>

--- a/clients/python/docs/RepositoriesApi.md
+++ b/clients/python/docs/RepositoriesApi.md
@@ -896,6 +896,7 @@ Name | Type | Description  | Notes
 | Status code | Description | Response headers |
 |-------------|-------------|------------------|
 **200** | repository |  -  |
+**400** | Validation Error |  -  |
 **401** | Unauthorized |  -  |
 **404** | Resource Not Found |  -  |
 **429** | too many requests |  -  |

--- a/clients/python/lakefs_sdk/api/repositories_api.py
+++ b/clients/python/lakefs_sdk/api/repositories_api.py
@@ -1189,6 +1189,7 @@ class RepositoriesApi:
 
         _response_types_map = {
             '200': "Repository",
+            '400': "Error",
             '401': "Error",
             '404': "Error",
             '429': None,

--- a/clients/rust/src/apis/repositories_api.rs
+++ b/clients/rust/src/apis/repositories_api.rs
@@ -99,6 +99,7 @@ pub enum GetGcRulesError {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(untagged)]
 pub enum GetRepositoryError {
+    Status400(models::Error),
     Status401(models::Error),
     Status404(models::Error),
     Status429(),

--- a/docs/src/assets/js/swagger.yml
+++ b/docs/src/assets/js/swagger.yml
@@ -3162,6 +3162,8 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Repository"
+        400:
+          $ref: "#/components/responses/ValidationError"
         401:
           $ref: "#/components/responses/Unauthorized"
         404:


### PR DESCRIPTION
Add missing status code 400 for GET repository API. The Bad Request (400) is returned on invalid repository namespace and should be specified in the OpenAPI specification.

Close https://github.com/treeverse/lakeFS/issues/9533