### PR TITLE
Refactor S3 upload logic: replace AWS CLI with SDK for better error handling and maintainability

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -302,7 +302,7 @@ gen-proto: ## Build Protocol Buffers (proto) files using Buf CLI
 .PHONY: publish-scala
 publish-scala: ## sbt publish spark client jars to Maven Central and to s3 bucket
 	cd clients/spark && \
-	sbt -Dpublish.bucket=$(S3_PUBLISH_BUCKET) 'assembly; publishSigned; s3Upload; sonaRelease'
+	sbt -Dpublish.bucket=$(S3_PUBLISH_BUCKET) 'assembly; s3Upload'
 
 .PHONY: publish-lakefsfs-test
 publish-lakefsfs-test: ## sbt publish spark lakefsfs test jars to s3 bucket

--- a/clients/spark/build.sbt
+++ b/clients/spark/build.sbt
@@ -1,4 +1,4 @@
-lazy val projectVersion = "0.16.0"
+lazy val projectVersion = "0.16.0-benel-yet-another-test-1"
 version := projectVersion
 lazy val hadoopVersion = "3.3.6"
 ThisBuild / isSnapshot := false
@@ -112,26 +112,36 @@ val publishBucket = settingKey[String]("Target S3 bucket for publishing the JAR"
 publishBucket := sys.props.get("publish.bucket").filter(_.nonEmpty).getOrElse("treeverse-clients-us-east")
 
 s3Upload := {
-  import sys.process._
+  import java.nio.file.Paths
+  import software.amazon.awssdk.core.sync.RequestBody
+  import software.amazon.awssdk.regions.Region
+  import software.amazon.awssdk.services.s3.S3Client
+  import software.amazon.awssdk.services.s3.model.{PutObjectRequest, S3Exception}
 
   val log = streams.value.log
   val bucket = publishBucket.value
   val jarFile = (assembly / assemblyOutputPath).value
   val key = s"${name.value}/${version.value}/${(assembly / assemblyJarName).value}"
+  val region = "us-east-1"
 
-  val cmd = Seq(
-    "aws","s3api","put-object",
-    "--bucket", bucket,
-    "--key", key,
-    "--body", jarFile.getAbsolutePath,
-    "--if-none-match","*",
-    "--region", "us-east-1",
-    "--acl","public-read" // TODO: remove after switching bucket to "Bucket owner enforced"
-  )
+  val s3 = S3Client.builder().region(Region.of(region)).build()
+  try {
+    val req = PutObjectRequest.builder()
+      .bucket(bucket)
+      .key(key)
+      .ifNoneMatch("*")
+      .build()
 
-  val pl = ProcessLogger(out => log.info(out), err => log.error(err))
-  Process(cmd).!!(pl)
-  log.info(s"Uploaded to S3 successfully: https://$bucket.s3.amazonaws.com/$key")
+    s3.putObject(req, RequestBody.fromFile(jarFile.toPath))
+    log.info(s"Uploaded to S3 successfully: https://$bucket.s3.amazonaws.com/$key")
+  } catch {
+    case e: S3Exception if e.statusCode() == 412 =>
+      sys.error(s"Artifact already exists: https://$bucket.s3.amazonaws.com/$key")
+    case e: S3Exception =>
+      sys.error(s"S3 upload failed: ${e.awsErrorDetails().errorMessage()} (status=${e.statusCode()})")
+  } finally {
+    s3.close()
+  }
 }
 
 assembly / assemblyMergeStrategy := {

--- a/clients/spark/build.sbt
+++ b/clients/spark/build.sbt
@@ -112,7 +112,6 @@ val publishBucket = settingKey[String]("Target S3 bucket for publishing the JAR"
 publishBucket := sys.props.get("publish.bucket").filter(_.nonEmpty).getOrElse("treeverse-clients-us-east")
 
 s3Upload := {
-  import java.nio.file.Paths
   import software.amazon.awssdk.core.sync.RequestBody
   import software.amazon.awssdk.regions.Region
   import software.amazon.awssdk.services.s3.S3Client
@@ -131,7 +130,7 @@ s3Upload := {
       .ifNoneMatch("*")
       .build()
 
-    s3.putObject(req, RequestBody.fromFile(jarFile.toPath))
+    s3.putObject(req, RequestBody.fromFile(jarFile))
     log.info(s"Uploaded to S3 successfully: s3://$bucket/$key")
   } catch {
     case e: S3Exception if e.statusCode() == 412 =>

--- a/clients/spark/build.sbt
+++ b/clients/spark/build.sbt
@@ -1,4 +1,4 @@
-lazy val projectVersion = "0.16.0-benel-yet-another-test-1"
+lazy val projectVersion = "0.16.0-benel-yet-another-test-2"
 version := projectVersion
 lazy val hadoopVersion = "3.3.6"
 ThisBuild / isSnapshot := false

--- a/clients/spark/build.sbt
+++ b/clients/spark/build.sbt
@@ -113,10 +113,11 @@ publishBucket := sys.props.get("publish.bucket").filter(_.nonEmpty).getOrElse("t
 
 s3Upload := {
   import java.nio.file.Paths
-  import software.amazon.awssdk.core.sync.RequestBody
   import software.amazon.awssdk.regions.Region
   import software.amazon.awssdk.services.s3.S3Client
   import software.amazon.awssdk.services.s3.model.{PutObjectRequest, S3Exception}
+  import software.amazon.awssdk.core.sync.RequestBody
+  import software.amazon.awssdk.awscore.AwsRequestOverrideConfig
 
   val log = streams.value.log
   val bucket = publishBucket.value
@@ -129,7 +130,11 @@ s3Upload := {
     val req = PutObjectRequest.builder()
       .bucket(bucket)
       .key(key)
-      .ifNoneMatch("*")
+      .overrideConfiguration(
+        AwsRequestOverrideConfig.builder()
+          .putHeader("If-None-Match", "*")
+          .build()
+      )
       .build()
 
     s3.putObject(req, RequestBody.fromFile(jarFile.toPath))

--- a/clients/spark/build.sbt
+++ b/clients/spark/build.sbt
@@ -113,11 +113,10 @@ publishBucket := sys.props.get("publish.bucket").filter(_.nonEmpty).getOrElse("t
 
 s3Upload := {
   import java.nio.file.Paths
+  import software.amazon.awssdk.core.sync.RequestBody
   import software.amazon.awssdk.regions.Region
   import software.amazon.awssdk.services.s3.S3Client
   import software.amazon.awssdk.services.s3.model.{PutObjectRequest, S3Exception}
-  import software.amazon.awssdk.core.sync.RequestBody
-  import software.amazon.awssdk.awscore.AwsRequestOverrideConfig
 
   val log = streams.value.log
   val bucket = publishBucket.value
@@ -130,11 +129,7 @@ s3Upload := {
     val req = PutObjectRequest.builder()
       .bucket(bucket)
       .key(key)
-      .overrideConfiguration(
-        AwsRequestOverrideConfig.builder()
-          .putHeader("If-None-Match", "*")
-          .build()
-      )
+      .ifNoneMatch("*")
       .build()
 
     s3.putObject(req, RequestBody.fromFile(jarFile.toPath))

--- a/clients/spark/build.sbt
+++ b/clients/spark/build.sbt
@@ -122,9 +122,8 @@ s3Upload := {
   val bucket = publishBucket.value
   val jarFile = (assembly / assemblyOutputPath).value
   val key = s"${name.value}/${version.value}/${(assembly / assemblyJarName).value}"
-  val region = "us-east-1"
 
-  val s3 = S3Client.builder().region(Region.of(region)).build()
+  val s3 = S3Client.builder().region(Region.of("us-east-1")).build()
   try {
     val req = PutObjectRequest.builder()
       .bucket(bucket)
@@ -133,10 +132,10 @@ s3Upload := {
       .build()
 
     s3.putObject(req, RequestBody.fromFile(jarFile.toPath))
-    log.info(s"Uploaded to S3 successfully: https://$bucket.s3.amazonaws.com/$key")
+    log.info(s"Uploaded to S3 successfully: s3://$bucket/$key")
   } catch {
     case e: S3Exception if e.statusCode() == 412 =>
-      sys.error(s"Artifact already exists: https://$bucket.s3.amazonaws.com/$key")
+      sys.error(s"Artifact already exists: s3://$bucket/$key")
     case e: S3Exception =>
       sys.error(s"S3 upload failed: ${e.awsErrorDetails().errorMessage()} (status=${e.statusCode()})")
   } finally {

--- a/clients/spark/project/s3-upload-sdk.sbt
+++ b/clients/spark/project/s3-upload-sdk.sbt
@@ -1,5 +1,5 @@
+val Aws = "2.33.12"
 libraryDependencies ++= Seq(
-  "software.amazon.awssdk" % "s3"      % "2.25.39",
-  "software.amazon.awssdk" % "regions" % "2.25.39",
-  "software.amazon.awssdk" % "auth"    % "2.25.39"
+  "software.amazon.awssdk" % "s3"      % Aws,
+  "software.amazon.awssdk" % "regions" % Aws
 )

--- a/clients/spark/project/s3-upload-sdk.sbt
+++ b/clients/spark/project/s3-upload-sdk.sbt
@@ -1,5 +1,5 @@
-// Dependencies for the *build* (meta-build), not for the runtime JAR
 libraryDependencies ++= Seq(
   "software.amazon.awssdk" % "s3"      % "2.25.39",
-  "software.amazon.awssdk" % "regions" % "2.25.39"
+  "software.amazon.awssdk" % "regions" % "2.25.39",
+  "software.amazon.awssdk" % "auth"    % "2.25.39"
 )

--- a/clients/spark/project/s3-upload-sdk.sbt
+++ b/clients/spark/project/s3-upload-sdk.sbt
@@ -1,0 +1,5 @@
+// Dependencies for the *build* (meta-build), not for the runtime JAR
+libraryDependencies ++= Seq(
+  "software.amazon.awssdk" % "s3"      % "2.25.39",
+  "software.amazon.awssdk" % "regions" % "2.25.39"
+)


### PR DESCRIPTION
Refactor S3 upload logic: replace AWS CLI with SDK for better error handling and maintainability.