### PR TITLE
Python HL SDK prep for release v0.14.0

### DIFF
--- a/clients/python-wrapper/CHANGELOG.md
+++ b/clients/python-wrapper/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ## Unreleased
 
+## v0.14.0
+
+:new: What's new:
+
+- Passing kwargs to underlying SDK request for _request_timeout support (#9509)
+
 ## v0.13.0
 
 :new: What's new:

--- a/clients/python-wrapper/setup.py
+++ b/clients/python-wrapper/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 
 NAME = "lakefs"
-VERSION = "0.13.0"
+VERSION = "0.14.0"
 # To install the library, run the following
 #
 # python setup.py install


### PR DESCRIPTION
Bump version and update the changelog for v0.14.0 release