### PR TITLE
Docs: remove experimental warning from SGC

### DIFF
--- a/.lycheeignore
+++ b/.lycheeignore
@@ -31,3 +31,4 @@ https://www.youtube.com/embed/rMDsnh7S2O0
 https://x.com/lakeFS
 https://your.domain.io
 https://prestodb.io
+https://devops.com/what-sres-can-learn-from-the-atlassian-outage-of-2022/

--- a/docs/src/howto/garbage-collection/standalone-gc.md
+++ b/docs/src/howto/garbage-collection/standalone-gc.md
@@ -9,10 +9,6 @@ status: enterprise
 !!! info
     Standalone GC is only available for [lakeFS Enterprise](../../enterprise/index.md).
 
-!!! warning
-    Standalone GC is experimental and offers limited capabilities compared to the [Spark-backed GC](./gc.md). For large scale environments, we recommend using the Spark-backed solution.
-
-
 
 ## What is Standalone GC?
 


### PR DESCRIPTION
Remove the "experimental" warning from the documentation on the standalone GC page.