### PR TITLE
Implement graveler condition functionality

### DIFF
--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -90,6 +90,15 @@ components:
       required: false
       schema:
         type: string
+
+    IfMatch:
+      in: header
+      name: If-Match
+      description: Set to the object's ETag to atomically allow operations only if the object's current ETag matches the provided value.
+      example: "2e9ec317e197e02e4264d128c2e7e681"
+      required: false
+      schema:
+        type: string
     
     NoTombstone:
       in: query
@@ -5114,6 +5123,7 @@ paths:
 
       parameters:
         - $ref: "#/components/parameters/IfNoneMatch"
+        - $ref: "#/components/parameters/IfMatch"
         - in: query
           name: storageClass
           description: Deprecated, this capability will not be supported in future releases.

--- a/clients/java/api/openapi.yaml
+++ b/clients/java/api/openapi.yaml
@@ -5507,6 +5507,16 @@ paths:
         schema:
           type: string
         style: simple
+      - description: Set to the object's ETag to atomically allow operations only
+          if the object's current ETag matches the provided value.
+        example: 2e9ec317e197e02e4264d128c2e7e681
+        explode: false
+        in: header
+        name: If-Match
+        required: false
+        schema:
+          type: string
+        style: simple
       - deprecated: true
         description: "Deprecated, this capability will not be supported in future\
           \ releases."
@@ -7715,6 +7725,17 @@ components:
       explode: false
       in: header
       name: If-None-Match
+      required: false
+      schema:
+        type: string
+      style: simple
+    IfMatch:
+      description: Set to the object's ETag to atomically allow operations only if
+        the object's current ETag matches the provided value.
+      example: 2e9ec317e197e02e4264d128c2e7e681
+      explode: false
+      in: header
+      name: If-Match
       required: false
       schema:
         type: string

--- a/clients/java/docs/ObjectsApi.md
+++ b/clients/java/docs/ObjectsApi.md
@@ -955,7 +955,7 @@ null (empty response body)
 
 <a id="uploadObject"></a>
 # **uploadObject**
-> ObjectStats uploadObject(repository, branch, path).ifNoneMatch(ifNoneMatch).storageClass(storageClass).force(force).content(content).execute();
+> ObjectStats uploadObject(repository, branch, path).ifNoneMatch(ifNoneMatch).ifMatch(ifMatch).storageClass(storageClass).force(force).content(content).execute();
 
 
 
@@ -1006,12 +1006,14 @@ public class Example {
     String branch = "branch_example"; // String | 
     String path = "path_example"; // String | relative to the branch
     String ifNoneMatch = "*"; // String | Set to \"*\" to atomically allow the upload only if the key has no object yet. Other values are not supported.
+    String ifMatch = "2e9ec317e197e02e4264d128c2e7e681"; // String | Set to the object's ETag to atomically allow operations only if the object's current ETag matches the provided value.
     String storageClass = "storageClass_example"; // String | Deprecated, this capability will not be supported in future releases.
     Boolean force = false; // Boolean | 
     File content = new File("/path/to/file"); // File | Only a single file per upload which must be named \\\"content\\\".
     try {
       ObjectStats result = apiInstance.uploadObject(repository, branch, path)
             .ifNoneMatch(ifNoneMatch)
+            .ifMatch(ifMatch)
             .storageClass(storageClass)
             .force(force)
             .content(content)
@@ -1036,6 +1038,7 @@ public class Example {
 | **branch** | **String**|  | |
 | **path** | **String**| relative to the branch | |
 | **ifNoneMatch** | **String**| Set to \&quot;*\&quot; to atomically allow the upload only if the key has no object yet. Other values are not supported. | [optional] |
+| **ifMatch** | **String**| Set to the object&#39;s ETag to atomically allow operations only if the object&#39;s current ETag matches the provided value. | [optional] |
 | **storageClass** | **String**| Deprecated, this capability will not be supported in future releases. | [optional] |
 | **force** | **Boolean**|  | [optional] [default to false] |
 | **content** | **File**| Only a single file per upload which must be named \\\&quot;content\\\&quot;. | [optional] |

--- a/clients/java/src/main/java/io/lakefs/clients/sdk/ObjectsApi.java
+++ b/clients/java/src/main/java/io/lakefs/clients/sdk/ObjectsApi.java
@@ -2133,7 +2133,7 @@ public class ObjectsApi {
     public APIupdateObjectUserMetadataRequest updateObjectUserMetadata(String repository, String branch, String path, UpdateObjectUserMetadata updateObjectUserMetadata) {
         return new APIupdateObjectUserMetadataRequest(repository, branch, path, updateObjectUserMetadata);
     }
-    private okhttp3.Call uploadObjectCall(String repository, String branch, String path, String ifNoneMatch, String storageClass, Boolean force, File content, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call uploadObjectCall(String repository, String branch, String path, String ifNoneMatch, String ifMatch, String storageClass, Boolean force, File content, final ApiCallback _callback) throws ApiException {
         String basePath = null;
         // Operation Servers
         String[] localBasePaths = new String[] {  };
@@ -2180,6 +2180,10 @@ public class ObjectsApi {
             localVarHeaderParams.put("If-None-Match", localVarApiClient.parameterToString(ifNoneMatch));
         }
 
+        if (ifMatch != null) {
+            localVarHeaderParams.put("If-Match", localVarApiClient.parameterToString(ifMatch));
+        }
+
         final String[] localVarAccepts = {
             "application/json"
         };
@@ -2202,7 +2206,7 @@ public class ObjectsApi {
     }
 
     @SuppressWarnings("rawtypes")
-    private okhttp3.Call uploadObjectValidateBeforeCall(String repository, String branch, String path, String ifNoneMatch, String storageClass, Boolean force, File content, final ApiCallback _callback) throws ApiException {
+    private okhttp3.Call uploadObjectValidateBeforeCall(String repository, String branch, String path, String ifNoneMatch, String ifMatch, String storageClass, Boolean force, File content, final ApiCallback _callback) throws ApiException {
         // verify the required parameter 'repository' is set
         if (repository == null) {
             throw new ApiException("Missing the required parameter 'repository' when calling uploadObject(Async)");
@@ -2218,20 +2222,20 @@ public class ObjectsApi {
             throw new ApiException("Missing the required parameter 'path' when calling uploadObject(Async)");
         }
 
-        return uploadObjectCall(repository, branch, path, ifNoneMatch, storageClass, force, content, _callback);
+        return uploadObjectCall(repository, branch, path, ifNoneMatch, ifMatch, storageClass, force, content, _callback);
 
     }
 
 
-    private ApiResponse<ObjectStats> uploadObjectWithHttpInfo(String repository, String branch, String path, String ifNoneMatch, String storageClass, Boolean force, File content) throws ApiException {
-        okhttp3.Call localVarCall = uploadObjectValidateBeforeCall(repository, branch, path, ifNoneMatch, storageClass, force, content, null);
+    private ApiResponse<ObjectStats> uploadObjectWithHttpInfo(String repository, String branch, String path, String ifNoneMatch, String ifMatch, String storageClass, Boolean force, File content) throws ApiException {
+        okhttp3.Call localVarCall = uploadObjectValidateBeforeCall(repository, branch, path, ifNoneMatch, ifMatch, storageClass, force, content, null);
         Type localVarReturnType = new TypeToken<ObjectStats>(){}.getType();
         return localVarApiClient.execute(localVarCall, localVarReturnType);
     }
 
-    private okhttp3.Call uploadObjectAsync(String repository, String branch, String path, String ifNoneMatch, String storageClass, Boolean force, File content, final ApiCallback<ObjectStats> _callback) throws ApiException {
+    private okhttp3.Call uploadObjectAsync(String repository, String branch, String path, String ifNoneMatch, String ifMatch, String storageClass, Boolean force, File content, final ApiCallback<ObjectStats> _callback) throws ApiException {
 
-        okhttp3.Call localVarCall = uploadObjectValidateBeforeCall(repository, branch, path, ifNoneMatch, storageClass, force, content, _callback);
+        okhttp3.Call localVarCall = uploadObjectValidateBeforeCall(repository, branch, path, ifNoneMatch, ifMatch, storageClass, force, content, _callback);
         Type localVarReturnType = new TypeToken<ObjectStats>(){}.getType();
         localVarApiClient.executeAsync(localVarCall, localVarReturnType, _callback);
         return localVarCall;
@@ -2242,6 +2246,7 @@ public class ObjectsApi {
         private final String branch;
         private final String path;
         private String ifNoneMatch;
+        private String ifMatch;
         private String storageClass;
         private Boolean force;
         private File content;
@@ -2259,6 +2264,16 @@ public class ObjectsApi {
          */
         public APIuploadObjectRequest ifNoneMatch(String ifNoneMatch) {
             this.ifNoneMatch = ifNoneMatch;
+            return this;
+        }
+
+        /**
+         * Set ifMatch
+         * @param ifMatch Set to the object&#39;s ETag to atomically allow operations only if the object&#39;s current ETag matches the provided value. (optional)
+         * @return APIuploadObjectRequest
+         */
+        public APIuploadObjectRequest ifMatch(String ifMatch) {
+            this.ifMatch = ifMatch;
             return this;
         }
 
@@ -2311,7 +2326,7 @@ public class ObjectsApi {
          </table>
          */
         public okhttp3.Call buildCall(final ApiCallback _callback) throws ApiException {
-            return uploadObjectCall(repository, branch, path, ifNoneMatch, storageClass, force, content, _callback);
+            return uploadObjectCall(repository, branch, path, ifNoneMatch, ifMatch, storageClass, force, content, _callback);
         }
 
         /**
@@ -2332,7 +2347,7 @@ public class ObjectsApi {
          </table>
          */
         public ObjectStats execute() throws ApiException {
-            ApiResponse<ObjectStats> localVarResp = uploadObjectWithHttpInfo(repository, branch, path, ifNoneMatch, storageClass, force, content);
+            ApiResponse<ObjectStats> localVarResp = uploadObjectWithHttpInfo(repository, branch, path, ifNoneMatch, ifMatch, storageClass, force, content);
             return localVarResp.getData();
         }
 
@@ -2354,7 +2369,7 @@ public class ObjectsApi {
          </table>
          */
         public ApiResponse<ObjectStats> executeWithHttpInfo() throws ApiException {
-            return uploadObjectWithHttpInfo(repository, branch, path, ifNoneMatch, storageClass, force, content);
+            return uploadObjectWithHttpInfo(repository, branch, path, ifNoneMatch, ifMatch, storageClass, force, content);
         }
 
         /**
@@ -2376,7 +2391,7 @@ public class ObjectsApi {
          </table>
          */
         public okhttp3.Call executeAsync(final ApiCallback<ObjectStats> _callback) throws ApiException {
-            return uploadObjectAsync(repository, branch, path, ifNoneMatch, storageClass, force, content, _callback);
+            return uploadObjectAsync(repository, branch, path, ifNoneMatch, ifMatch, storageClass, force, content, _callback);
         }
     }
 

--- a/clients/java/src/test/java/io/lakefs/clients/sdk/ObjectsApiTest.java
+++ b/clients/java/src/test/java/io/lakefs/clients/sdk/ObjectsApiTest.java
@@ -216,11 +216,13 @@ public class ObjectsApiTest {
         String branch = null;
         String path = null;
         String ifNoneMatch = null;
+        String ifMatch = null;
         String storageClass = null;
         Boolean force = null;
         File content = null;
         ObjectStats response = api.uploadObject(repository, branch, path)
                 .ifNoneMatch(ifNoneMatch)
+                .ifMatch(ifMatch)
                 .storageClass(storageClass)
                 .force(force)
                 .content(content)

--- a/clients/python/docs/ObjectsApi.md
+++ b/clients/python/docs/ObjectsApi.md
@@ -1087,7 +1087,7 @@ void (empty response body)
 [[Back to top]](#) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to Model list]](../README.md#documentation-for-models) [[Back to README]](../README.md)
 
 # **upload_object**
-> ObjectStats upload_object(repository, branch, path, if_none_match=if_none_match, storage_class=storage_class, force=force, content=content)
+> ObjectStats upload_object(repository, branch, path, if_none_match=if_none_match, if_match=if_match, storage_class=storage_class, force=force, content=content)
 
 
 
@@ -1155,12 +1155,13 @@ with lakefs_sdk.ApiClient(configuration) as api_client:
     branch = 'branch_example' # str | 
     path = 'path_example' # str | relative to the branch
     if_none_match = '*' # str | Set to \"*\" to atomically allow the upload only if the key has no object yet. Other values are not supported. (optional)
+    if_match = '2e9ec317e197e02e4264d128c2e7e681' # str | Set to the object's ETag to atomically allow operations only if the object's current ETag matches the provided value. (optional)
     storage_class = 'storage_class_example' # str | Deprecated, this capability will not be supported in future releases. (optional)
     force = False # bool |  (optional) (default to False)
     content = None # bytearray | Only a single file per upload which must be named \\\"content\\\". (optional)
 
     try:
-        api_response = api_instance.upload_object(repository, branch, path, if_none_match=if_none_match, storage_class=storage_class, force=force, content=content)
+        api_response = api_instance.upload_object(repository, branch, path, if_none_match=if_none_match, if_match=if_match, storage_class=storage_class, force=force, content=content)
         print("The response of ObjectsApi->upload_object:\n")
         pprint(api_response)
     except Exception as e:
@@ -1178,6 +1179,7 @@ Name | Type | Description  | Notes
  **branch** | **str**|  | 
  **path** | **str**| relative to the branch | 
  **if_none_match** | **str**| Set to \&quot;*\&quot; to atomically allow the upload only if the key has no object yet. Other values are not supported. | [optional] 
+ **if_match** | **str**| Set to the object&#39;s ETag to atomically allow operations only if the object&#39;s current ETag matches the provided value. | [optional] 
  **storage_class** | **str**| Deprecated, this capability will not be supported in future releases. | [optional] 
  **force** | **bool**|  | [optional] [default to False]
  **content** | **bytearray**| Only a single file per upload which must be named \\\&quot;content\\\&quot;. | [optional] 

--- a/clients/python/lakefs_sdk/api/objects_api.py
+++ b/clients/python/lakefs_sdk/api/objects_api.py
@@ -1621,13 +1621,13 @@ class ObjectsApi:
             _request_auth=_params.get('_request_auth'))
 
     @validate_arguments
-    def upload_object(self, repository : StrictStr, branch : StrictStr, path : Annotated[StrictStr, Field(..., description="relative to the branch")], if_none_match : Annotated[Optional[StrictStr], Field(description="Set to \"*\" to atomically allow the upload only if the key has no object yet. Other values are not supported.")] = None, storage_class : Annotated[Optional[StrictStr], Field(description="Deprecated, this capability will not be supported in future releases.")] = None, force : Optional[StrictBool] = None, content : Annotated[Optional[Union[StrictBytes, StrictStr]], Field(description="Only a single file per upload which must be named \\\"content\\\".")] = None, **kwargs) -> ObjectStats:  # noqa: E501
+    def upload_object(self, repository : StrictStr, branch : StrictStr, path : Annotated[StrictStr, Field(..., description="relative to the branch")], if_none_match : Annotated[Optional[StrictStr], Field(description="Set to \"*\" to atomically allow the upload only if the key has no object yet. Other values are not supported.")] = None, if_match : Annotated[Optional[StrictStr], Field(description="Set to the object's ETag to atomically allow operations only if the object's current ETag matches the provided value.")] = None, storage_class : Annotated[Optional[StrictStr], Field(description="Deprecated, this capability will not be supported in future releases.")] = None, force : Optional[StrictBool] = None, content : Annotated[Optional[Union[StrictBytes, StrictStr]], Field(description="Only a single file per upload which must be named \\\"content\\\".")] = None, **kwargs) -> ObjectStats:  # noqa: E501
         """upload_object  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.upload_object(repository, branch, path, if_none_match, storage_class, force, content, async_req=True)
+        >>> thread = api.upload_object(repository, branch, path, if_none_match, if_match, storage_class, force, content, async_req=True)
         >>> result = thread.get()
 
         :param repository: (required)
@@ -1638,6 +1638,8 @@ class ObjectsApi:
         :type path: str
         :param if_none_match: Set to \"*\" to atomically allow the upload only if the key has no object yet. Other values are not supported.
         :type if_none_match: str
+        :param if_match: Set to the object's ETag to atomically allow operations only if the object's current ETag matches the provided value.
+        :type if_match: str
         :param storage_class: Deprecated, this capability will not be supported in future releases.
         :type storage_class: str
         :param force:
@@ -1659,16 +1661,16 @@ class ObjectsApi:
         if '_preload_content' in kwargs:
             message = "Error! Please call the upload_object_with_http_info method with `_preload_content` instead and obtain raw data from ApiResponse.raw_data"  # noqa: E501
             raise ValueError(message)
-        return self.upload_object_with_http_info(repository, branch, path, if_none_match, storage_class, force, content, **kwargs)  # noqa: E501
+        return self.upload_object_with_http_info(repository, branch, path, if_none_match, if_match, storage_class, force, content, **kwargs)  # noqa: E501
 
     @validate_arguments
-    def upload_object_with_http_info(self, repository : StrictStr, branch : StrictStr, path : Annotated[StrictStr, Field(..., description="relative to the branch")], if_none_match : Annotated[Optional[StrictStr], Field(description="Set to \"*\" to atomically allow the upload only if the key has no object yet. Other values are not supported.")] = None, storage_class : Annotated[Optional[StrictStr], Field(description="Deprecated, this capability will not be supported in future releases.")] = None, force : Optional[StrictBool] = None, content : Annotated[Optional[Union[StrictBytes, StrictStr]], Field(description="Only a single file per upload which must be named \\\"content\\\".")] = None, **kwargs) -> ApiResponse:  # noqa: E501
+    def upload_object_with_http_info(self, repository : StrictStr, branch : StrictStr, path : Annotated[StrictStr, Field(..., description="relative to the branch")], if_none_match : Annotated[Optional[StrictStr], Field(description="Set to \"*\" to atomically allow the upload only if the key has no object yet. Other values are not supported.")] = None, if_match : Annotated[Optional[StrictStr], Field(description="Set to the object's ETag to atomically allow operations only if the object's current ETag matches the provided value.")] = None, storage_class : Annotated[Optional[StrictStr], Field(description="Deprecated, this capability will not be supported in future releases.")] = None, force : Optional[StrictBool] = None, content : Annotated[Optional[Union[StrictBytes, StrictStr]], Field(description="Only a single file per upload which must be named \\\"content\\\".")] = None, **kwargs) -> ApiResponse:  # noqa: E501
         """upload_object  # noqa: E501
 
         This method makes a synchronous HTTP request by default. To make an
         asynchronous HTTP request, please pass async_req=True
 
-        >>> thread = api.upload_object_with_http_info(repository, branch, path, if_none_match, storage_class, force, content, async_req=True)
+        >>> thread = api.upload_object_with_http_info(repository, branch, path, if_none_match, if_match, storage_class, force, content, async_req=True)
         >>> result = thread.get()
 
         :param repository: (required)
@@ -1679,6 +1681,8 @@ class ObjectsApi:
         :type path: str
         :param if_none_match: Set to \"*\" to atomically allow the upload only if the key has no object yet. Other values are not supported.
         :type if_none_match: str
+        :param if_match: Set to the object's ETag to atomically allow operations only if the object's current ETag matches the provided value.
+        :type if_match: str
         :param storage_class: Deprecated, this capability will not be supported in future releases.
         :type storage_class: str
         :param force:
@@ -1717,6 +1721,7 @@ class ObjectsApi:
             'branch',
             'path',
             'if_none_match',
+            'if_match',
             'storage_class',
             'force',
             'content'
@@ -1769,6 +1774,9 @@ class ObjectsApi:
         _header_params = dict(_params.get('_headers', {}))
         if _params['if_none_match']:
             _header_params['If-None-Match'] = _params['if_none_match']
+
+        if _params['if_match']:
+            _header_params['If-Match'] = _params['if_match']
 
         # process the form parameters
         _form_params = []

--- a/clients/rust/docs/ObjectsApi.md
+++ b/clients/rust/docs/ObjectsApi.md
@@ -306,7 +306,7 @@ Name | Type | Description  | Required | Notes
 
 ## upload_object
 
-> models::ObjectStats upload_object(repository, branch, path, if_none_match, storage_class, force, content)
+> models::ObjectStats upload_object(repository, branch, path, if_none_match, if_match, storage_class, force, content)
 
 
 ### Parameters
@@ -318,6 +318,7 @@ Name | Type | Description  | Required | Notes
 **branch** | **String** |  | [required] |
 **path** | **String** | relative to the branch | [required] |
 **if_none_match** | Option<**String**> | Set to \"*\" to atomically allow the upload only if the key has no object yet. Other values are not supported. |  |
+**if_match** | Option<**String**> | Set to the object's ETag to atomically allow operations only if the object's current ETag matches the provided value. |  |
 **storage_class** | Option<**String**> | Deprecated, this capability will not be supported in future releases. |  |
 **force** | Option<**bool**> |  |  |[default to false]
 **content** | Option<**std::path::PathBuf**> | Only a single file per upload which must be named \\\"content\\\". |  |

--- a/clients/rust/src/apis/objects_api.rs
+++ b/clients/rust/src/apis/objects_api.rs
@@ -497,7 +497,7 @@ pub async fn update_object_user_metadata(configuration: &configuration::Configur
     }
 }
 
-pub async fn upload_object(configuration: &configuration::Configuration, repository: &str, branch: &str, path: &str, if_none_match: Option<&str>, storage_class: Option<&str>, force: Option<bool>, content: Option<std::path::PathBuf>) -> Result<models::ObjectStats, Error<UploadObjectError>> {
+pub async fn upload_object(configuration: &configuration::Configuration, repository: &str, branch: &str, path: &str, if_none_match: Option<&str>, if_match: Option<&str>, storage_class: Option<&str>, force: Option<bool>, content: Option<std::path::PathBuf>) -> Result<models::ObjectStats, Error<UploadObjectError>> {
     let local_var_configuration = configuration;
 
     let local_var_client = &local_var_configuration.client;
@@ -517,6 +517,9 @@ pub async fn upload_object(configuration: &configuration::Configuration, reposit
     }
     if let Some(local_var_param_value) = if_none_match {
         local_var_req_builder = local_var_req_builder.header("If-None-Match", local_var_param_value.to_string());
+    }
+    if let Some(local_var_param_value) = if_match {
+        local_var_req_builder = local_var_req_builder.header("If-Match", local_var_param_value.to_string());
     }
     if let Some(ref local_var_auth_conf) = local_var_configuration.basic_auth {
         local_var_req_builder = local_var_req_builder.basic_auth(local_var_auth_conf.0.to_owned(), local_var_auth_conf.1.to_owned());

--- a/docs/src/assets/js/swagger.yml
+++ b/docs/src/assets/js/swagger.yml
@@ -90,6 +90,15 @@ components:
       required: false
       schema:
         type: string
+
+    IfMatch:
+      in: header
+      name: If-Match
+      description: Set to the object's ETag to atomically allow operations only if the object's current ETag matches the provided value.
+      example: "2e9ec317e197e02e4264d128c2e7e681"
+      required: false
+      schema:
+        type: string
     
     NoTombstone:
       in: query
@@ -5114,6 +5123,7 @@ paths:
 
       parameters:
         - $ref: "#/components/parameters/IfNoneMatch"
+        - $ref: "#/components/parameters/IfMatch"
         - in: query
           name: storageClass
           description: Deprecated, this capability will not be supported in future releases.

--- a/modules/api/factory/build.go
+++ b/modules/api/factory/build.go
@@ -5,10 +5,12 @@ import (
 	"net/http"
 
 	"github.com/go-chi/chi/v5"
+	"github.com/treeverse/lakefs/pkg/api/apigen"
 	"github.com/treeverse/lakefs/pkg/auth"
 	"github.com/treeverse/lakefs/pkg/authentication"
 	"github.com/treeverse/lakefs/pkg/block"
 	"github.com/treeverse/lakefs/pkg/config"
+	"github.com/treeverse/lakefs/pkg/graveler"
 	"github.com/treeverse/lakefs/pkg/license"
 	"github.com/treeverse/lakefs/pkg/logging"
 	"github.com/treeverse/lakefs/pkg/stats"
@@ -37,4 +39,10 @@ func RegisterServices(ctx context.Context, sd ServiceDependencies, router *chi.M
 // NotImplementedIcebergCatalogHandler returns HTTP 501 Not Implemented status for Iceberg REST Catalog endpoints.
 func NotImplementedIcebergCatalogHandler(w http.ResponseWriter, r *http.Request) {
 	http.Error(w, "Iceberg REST Catalog Not Implemented", http.StatusNotImplemented)
+}
+
+// BuildConditionFromParams creates a graveler.ConditionFunc from upload params.
+// Returns nil if no precondition is specified in the params.
+func BuildConditionFromParams(params apigen.UploadObjectParams) *graveler.ConditionFunc {
+	return nil
 }

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -2288,6 +2288,7 @@ func TestController_UploadObjectHandler(t *testing.T) {
 			t.Fatalf("expected 201 for UploadObject, got %d", b.StatusCode())
 		}
 	})
+
 }
 
 func TestController_DeleteBranchHandler(t *testing.T) {

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -1149,6 +1149,24 @@ func addressTypeToCatalog(t Entry_AddressType) AddressType {
 	}
 }
 
+// EntryCondition adapts an Entry-level condition function to a graveler.ConditionFunc.
+// It converts graveler Values to Entries before applying the condition, enabling Entry-based
+// validation logic (e.g., Object metadata checks) to work with graveler's conditional operations.
+func EntryCondition(conditionFunc func(*Entry) error) graveler.ConditionFunc {
+	return func(currentValue *graveler.Value) error {
+		if currentValue == nil {
+			return conditionFunc(nil)
+		}
+
+		currentEntry, err := ValueToEntry(currentValue)
+		if err != nil {
+			return err
+		}
+
+		return conditionFunc(currentEntry)
+	}
+}
+
 func (c *Catalog) CreateEntry(ctx context.Context, repositoryID string, branch string, entry DBEntry, opts ...graveler.SetOptionsFunc) error {
 	branchID := graveler.BranchID(branch)
 	ent := newEntryFromCatalogEntry(entry)


### PR DESCRIPTION

Changes for Condition Support

  This PR introduces infrastructure for conditional writes with preconditions:

  Graveler Layer:
  - Added ConditionFunc type for validating values before write operations
  - Added WithCondition(ConditionFunc) helper to integrate conditions into Set operations
  - The Set method now validates conditions before committing changes

  Catalog Layer:
  - Added EntryCondition adapter that converts Entry-level conditions to graveler.ConditionFunc
  - Enables Entry-based validation logic (e.g., ETag checks) to work with graveler's conditional operations

  Factory Layer:
  - Added BuildConditionFromParams(apigen.UploadObjectParams) function that builds conditions from API parameters
  - Currently returns nil (no-op) but provides extension point

  Controller Layer:
  - Updated upload handlers to use factory.BuildConditionFromParams
  - Applies conditions via graveler.WithCondition when present
