### PR TITLE
WebUI: Wrap duckDB cells content

### DIFF
--- a/webui/src/styles/objects/object-viewer.css
+++ b/webui/src/styles/objects/object-viewer.css
@@ -97,7 +97,7 @@
   max-width: 300px;
   overflow: hidden;
   text-overflow: ellipsis;
-  white-space: nowrap;
+  white-space: pre-wrap;
 }
 
 .object-viewer-sql-results td.number-cell {


### PR DESCRIPTION
Closes #9205 .

## Change Description

After:
<img width="1319" height="705" alt="Screenshot 2025-10-17 at 8 54 38" src="https://github.com/user-attachments/assets/98575092-e4b6-45c8-87a5-c6db7ca97338" />

Before:
<img width="1321" height="665" alt="Screenshot 2025-10-17 at 8 51 51" src="https://github.com/user-attachments/assets/58c321a7-32df-4500-8021-b76e13e235ba" />
