### PR TITLE
Python wrapper SDK: disable pylint warning for import alias

### DIFF
--- a/clients/python-wrapper/lakefs/.pylintrc
+++ b/clients/python-wrapper/lakefs/.pylintrc
@@ -15,7 +15,8 @@ max-attributes=10
 disable=
     too-few-public-methods,
     too-many-positional-arguments, 
-    fixme
+    fixme,
+    useless-import-alias
 
 [MISCELLANEOUS]
 


### PR DESCRIPTION
Disable pylint warning to address https://github.com/treeverse/lakeFS/pull/9585
