### PR TITLE
[bug] Support multiple template colours in lakectl console output

### DIFF
--- a/cmd/lakectl/cmd/common_helpers.go
+++ b/cmd/lakectl/cmd/common_helpers.go
@@ -110,14 +110,10 @@ func (c ColoredText) Add(color text.Color) ColoredText {
 
 // Colored returns text as ColoredText with no Color if it is not already ColoredText.
 func Colored(text interface{}) ColoredText {
-	switch t := text.(type) {
-	case string:
-		return ColoredText{Colors: nil, Text: t}
-	case ColoredText:
-		return t
-	default:
-		panic(fmt.Sprintf("Cannot color %s of type %T", text, text))
+	if c, ok := text.(ColoredText); ok {
+		return c
 	}
+	return ColoredText{Colors: nil, Text: text}
 }
 
 func WriteTo(tpl string, data interface{}, w io.Writer) {

--- a/cmd/lakectl/cmd/common_helpers_test.go
+++ b/cmd/lakectl/cmd/common_helpers_test.go
@@ -74,6 +74,7 @@ func TestColors(t *testing.T) {
 		{name: "boldgreen", template: `{{"abc" | bold | green}}def`, want: "\x1b[1;92mabc\x1b[0mdef"},
 		{name: "greenbold", template: `{{"abc" | green | bold}}def`, want: "\x1b[92;1mabc\x1b[0mdef"},
 		{name: "redunderline", template: `{{"abc" | red | underline}}def`, want: "\x1b[91;4mabc\x1b[0mdef"},
+		{name: "red-number", template: `{{2 | red}}`, want: "\x1b[91m2\x1b[0m"},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
Now e.g. `{{... | bold | red}}` formats both both _and_ red (previously this
would only be red).