### PR TITLE
Remove skip batch logic

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -1445,8 +1445,6 @@ func (c *Catalog) ListCommits(ctx context.Context, repositoryID string, ref stri
 		return nil, false, err
 	}
 
-	// disabling batching for this flow. See #3935 for more details
-	ctx = context.WithValue(ctx, batch.SkipBatchContextKey, struct{}{})
 	repository, err := c.getRepository(ctx, repositoryID)
 	if err != nil {
 		return nil, false, err
@@ -2052,9 +2050,6 @@ func (c *Catalog) Merge(ctx context.Context, repositoryID string, destinationBra
 	}); err != nil {
 		return "", err
 	}
-
-	// disabling batching for this flow. See #3935 for more details
-	ctx = context.WithValue(ctx, batch.SkipBatchContextKey, struct{}{})
 
 	repository, err := c.getRepository(ctx, repositoryID)
 	if err != nil {

--- a/pkg/graveler/ref/manager_test.go
+++ b/pkg/graveler/ref/manager_test.go
@@ -69,6 +69,16 @@ func NewStorageConfigMock(bcID string) config.StorageConfig {
 	}
 }
 
+type NoOpBatchingExecutor struct{}
+
+func (n *NoOpBatchingExecutor) BatchFor(_ context.Context, _ string, _ time.Duration, exec batch.Executer) (interface{}, error) {
+	return exec.Execute()
+}
+
+func NopExecutor() *NoOpBatchingExecutor {
+	return &NoOpBatchingExecutor{}
+}
+
 // TestManager_GetRepositoryCache test get repository information while using cache. Match the number of times we
 // call get repository vs number of times we fetch the data.
 func TestManager_GetRepositoryCache(t *testing.T) {
@@ -86,7 +96,7 @@ func TestManager_GetRepositoryCache(t *testing.T) {
 		Jitter: 0,
 	}
 	cfg := ref.ManagerConfig{
-		Executor:              batch.NopExecutor(),
+		Executor:              NopExecutor(),
 		KVStore:               mockStore,
 		AddressProvider:       ident.NewHexAddressProvider(),
 		RepositoryCacheConfig: cacheConfig,
@@ -133,7 +143,7 @@ func TestManager_GetCommitCache(t *testing.T) {
 		Expiry: 20 * time.Millisecond,
 	}
 	cfg := ref.ManagerConfig{
-		Executor:              batch.NopExecutor(),
+		Executor:              NopExecutor(),
 		KVStore:               mockStore,
 		AddressProvider:       ident.NewHexAddressProvider(),
 		RepositoryCacheConfig: cacheConfig,


### PR DESCRIPTION
## Change Description

### Background

Remove  skip batch logic which was replaced by a different  logic in #3935

Moved NoOpBatchingExecutor to the test package as it is used only there

### Testing Details

Existing tests

### Breaking Change?

No
