### PR TITLE
Add params to Catalog pull endpoint

### DIFF
--- a/api/swagger.yml
+++ b/api/swagger.yml
@@ -2138,6 +2138,14 @@ components:
           $ref: "#/components/schemas/IcebergRemoteTable"
         destination:
           $ref: "#/components/schemas/IcebergLocalTable"
+        force_update:
+          type: boolean
+          default: false
+          description: Override exiting local table if exists
+        create_namespace:
+          type: boolean
+          default: false
+          description: Creates namespace in local catalog if not exist
 
 paths:
   /setup_comm_prefs:

--- a/clients/java/api/openapi.yaml
+++ b/clients/java/api/openapi.yaml
@@ -10845,16 +10845,26 @@ components:
           - tax
           repository_id: repository_id
           table: table
+        create_namespace: false
         source:
           namespace:
           - accounting
           - tax
           table: table
+        force_update: false
       properties:
         source:
           $ref: '#/components/schemas/IcebergRemoteTable'
         destination:
           $ref: '#/components/schemas/IcebergLocalTable'
+        force_update:
+          default: false
+          description: Override exiting local table if exists
+          type: boolean
+        create_namespace:
+          default: false
+          description: Creates namespace in local catalog if not exist
+          type: boolean
       required:
       - destination
       - source

--- a/clients/java/docs/IcebergPullRequest.md
+++ b/clients/java/docs/IcebergPullRequest.md
@@ -9,6 +9,8 @@
 |------------ | ------------- | ------------- | -------------|
 |**source** | [**IcebergRemoteTable**](IcebergRemoteTable.md) |  |  |
 |**destination** | [**IcebergLocalTable**](IcebergLocalTable.md) |  |  |
+|**forceUpdate** | **Boolean** | Override exiting local table if exists |  [optional] |
+|**createNamespace** | **Boolean** | Creates namespace in local catalog if not exist |  [optional] |
 
 
 

--- a/clients/java/src/main/java/io/lakefs/clients/sdk/model/IcebergPullRequest.java
+++ b/clients/java/src/main/java/io/lakefs/clients/sdk/model/IcebergPullRequest.java
@@ -61,6 +61,14 @@ public class IcebergPullRequest {
   @SerializedName(SERIALIZED_NAME_DESTINATION)
   private IcebergLocalTable destination;
 
+  public static final String SERIALIZED_NAME_FORCE_UPDATE = "force_update";
+  @SerializedName(SERIALIZED_NAME_FORCE_UPDATE)
+  private Boolean forceUpdate = false;
+
+  public static final String SERIALIZED_NAME_CREATE_NAMESPACE = "create_namespace";
+  @SerializedName(SERIALIZED_NAME_CREATE_NAMESPACE)
+  private Boolean createNamespace = false;
+
   public IcebergPullRequest() {
   }
 
@@ -103,6 +111,48 @@ public class IcebergPullRequest {
 
   public void setDestination(IcebergLocalTable destination) {
     this.destination = destination;
+  }
+
+
+  public IcebergPullRequest forceUpdate(Boolean forceUpdate) {
+    
+    this.forceUpdate = forceUpdate;
+    return this;
+  }
+
+   /**
+   * Override exiting local table if exists
+   * @return forceUpdate
+  **/
+  @javax.annotation.Nullable
+  public Boolean getForceUpdate() {
+    return forceUpdate;
+  }
+
+
+  public void setForceUpdate(Boolean forceUpdate) {
+    this.forceUpdate = forceUpdate;
+  }
+
+
+  public IcebergPullRequest createNamespace(Boolean createNamespace) {
+    
+    this.createNamespace = createNamespace;
+    return this;
+  }
+
+   /**
+   * Creates namespace in local catalog if not exist
+   * @return createNamespace
+  **/
+  @javax.annotation.Nullable
+  public Boolean getCreateNamespace() {
+    return createNamespace;
+  }
+
+
+  public void setCreateNamespace(Boolean createNamespace) {
+    this.createNamespace = createNamespace;
   }
 
   /**
@@ -161,13 +211,15 @@ public class IcebergPullRequest {
     }
     IcebergPullRequest icebergPullRequest = (IcebergPullRequest) o;
     return Objects.equals(this.source, icebergPullRequest.source) &&
-        Objects.equals(this.destination, icebergPullRequest.destination)&&
+        Objects.equals(this.destination, icebergPullRequest.destination) &&
+        Objects.equals(this.forceUpdate, icebergPullRequest.forceUpdate) &&
+        Objects.equals(this.createNamespace, icebergPullRequest.createNamespace)&&
         Objects.equals(this.additionalProperties, icebergPullRequest.additionalProperties);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(source, destination, additionalProperties);
+    return Objects.hash(source, destination, forceUpdate, createNamespace, additionalProperties);
   }
 
   @Override
@@ -176,6 +228,8 @@ public class IcebergPullRequest {
     sb.append("class IcebergPullRequest {\n");
     sb.append("    source: ").append(toIndentedString(source)).append("\n");
     sb.append("    destination: ").append(toIndentedString(destination)).append("\n");
+    sb.append("    forceUpdate: ").append(toIndentedString(forceUpdate)).append("\n");
+    sb.append("    createNamespace: ").append(toIndentedString(createNamespace)).append("\n");
     sb.append("    additionalProperties: ").append(toIndentedString(additionalProperties)).append("\n");
     sb.append("}");
     return sb.toString();
@@ -201,6 +255,8 @@ public class IcebergPullRequest {
     openapiFields = new HashSet<String>();
     openapiFields.add("source");
     openapiFields.add("destination");
+    openapiFields.add("force_update");
+    openapiFields.add("create_namespace");
 
     // a set of required properties/fields (JSON key names)
     openapiRequiredFields = new HashSet<String>();

--- a/clients/java/src/test/java/io/lakefs/clients/sdk/model/IcebergPullRequestTest.java
+++ b/clients/java/src/test/java/io/lakefs/clients/sdk/model/IcebergPullRequestTest.java
@@ -55,4 +55,20 @@ public class IcebergPullRequestTest {
         // TODO: test destination
     }
 
+    /**
+     * Test the property 'forceUpdate'
+     */
+    @Test
+    public void forceUpdateTest() {
+        // TODO: test forceUpdate
+    }
+
+    /**
+     * Test the property 'createNamespace'
+     */
+    @Test
+    public void createNamespaceTest() {
+        // TODO: test createNamespace
+    }
+
 }

--- a/clients/python/docs/IcebergPullRequest.md
+++ b/clients/python/docs/IcebergPullRequest.md
@@ -7,6 +7,8 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **source** | [**IcebergRemoteTable**](IcebergRemoteTable.md) |  | 
 **destination** | [**IcebergLocalTable**](IcebergLocalTable.md) |  | 
+**force_update** | **bool** | Override exiting local table if exists | [optional] [default to False]
+**create_namespace** | **bool** | Creates namespace in local catalog if not exist | [optional] [default to False]
 
 ## Example
 

--- a/clients/python/lakefs_sdk/models/iceberg_pull_request.py
+++ b/clients/python/lakefs_sdk/models/iceberg_pull_request.py
@@ -19,11 +19,11 @@ import re  # noqa: F401
 import json
 
 
-
+from typing import Optional
 try:
-    from pydantic.v1 import BaseModel, Field
+    from pydantic.v1 import BaseModel, Field, StrictBool
 except ImportError:
-    from pydantic import BaseModel, Field
+    from pydantic import BaseModel, Field, StrictBool
 from lakefs_sdk.models.iceberg_local_table import IcebergLocalTable
 from lakefs_sdk.models.iceberg_remote_table import IcebergRemoteTable
 
@@ -33,7 +33,9 @@ class IcebergPullRequest(BaseModel):
     """
     source: IcebergRemoteTable = Field(...)
     destination: IcebergLocalTable = Field(...)
-    __properties = ["source", "destination"]
+    force_update: Optional[StrictBool] = Field(False, description="Override exiting local table if exists")
+    create_namespace: Optional[StrictBool] = Field(False, description="Creates namespace in local catalog if not exist")
+    __properties = ["source", "destination", "force_update", "create_namespace"]
 
     class Config:
         """Pydantic configuration"""
@@ -78,7 +80,9 @@ class IcebergPullRequest(BaseModel):
 
         _obj = IcebergPullRequest.parse_obj({
             "source": IcebergRemoteTable.from_dict(obj.get("source")) if obj.get("source") is not None else None,
-            "destination": IcebergLocalTable.from_dict(obj.get("destination")) if obj.get("destination") is not None else None
+            "destination": IcebergLocalTable.from_dict(obj.get("destination")) if obj.get("destination") is not None else None,
+            "force_update": obj.get("force_update") if obj.get("force_update") is not None else False,
+            "create_namespace": obj.get("create_namespace") if obj.get("create_namespace") is not None else False
         })
         return _obj
 

--- a/clients/python/test/test_iceberg_pull_request.py
+++ b/clients/python/test/test_iceberg_pull_request.py
@@ -44,7 +44,9 @@ class TestIcebergPullRequest(unittest.TestCase):
                     namespace = ["accounting","tax"], 
                     table = '', 
                     repository_id = '', 
-                    reference_id = '', )
+                    reference_id = '', ),
+                force_update = True,
+                create_namespace = True
             )
         else:
             return IcebergPullRequest(

--- a/clients/rust/docs/IcebergPullRequest.md
+++ b/clients/rust/docs/IcebergPullRequest.md
@@ -6,6 +6,8 @@ Name | Type | Description | Notes
 ------------ | ------------- | ------------- | -------------
 **source** | [**models::IcebergRemoteTable**](IcebergRemoteTable.md) |  | 
 **destination** | [**models::IcebergLocalTable**](IcebergLocalTable.md) |  | 
+**force_update** | Option<**bool**> | Override exiting local table if exists | [optional][default to false]
+**create_namespace** | Option<**bool**> | Creates namespace in local catalog if not exist | [optional][default to false]
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)
 

--- a/clients/rust/src/models/iceberg_pull_request.rs
+++ b/clients/rust/src/models/iceberg_pull_request.rs
@@ -16,6 +16,12 @@ pub struct IcebergPullRequest {
     pub source: Box<models::IcebergRemoteTable>,
     #[serde(rename = "destination")]
     pub destination: Box<models::IcebergLocalTable>,
+    /// Override exiting local table if exists
+    #[serde(rename = "force_update", skip_serializing_if = "Option::is_none")]
+    pub force_update: Option<bool>,
+    /// Creates namespace in local catalog if not exist
+    #[serde(rename = "create_namespace", skip_serializing_if = "Option::is_none")]
+    pub create_namespace: Option<bool>,
 }
 
 impl IcebergPullRequest {
@@ -23,6 +29,8 @@ impl IcebergPullRequest {
         IcebergPullRequest {
             source: Box::new(source),
             destination: Box::new(destination),
+            force_update: None,
+            create_namespace: None,
         }
     }
 }


### PR DESCRIPTION
## Change Description

Since Catalog `/pull` will be implemented in the same way as Catalog `/push` (by registering the table, and dropping and re-registering if it already exist),
Adding the `force_update` and `create_namespace` params to align with the `/push` endpoint.
