### PR TITLE
Fix YAML indentation in actions-and-hooks.md

### DIFF
--- a/docs/src/quickstart/actions-and-hooks.md
+++ b/docs/src/quickstart/actions-and-hooks.md
@@ -27,11 +27,11 @@ _Hooks_ can be either a [Lua](../howto/hooks/lua.md) script that lakeFS will exe
     ```yaml
     name: Check Commit Message and Metadata
     on:
-        pre-commit:
+      pre-commit:
         branches:
-        - etl**
+          - etl**
     hooks:
-    - id: check_metadata
+      - id: check_metadata
         type: lua
         properties:
         script: |


### PR DESCRIPTION
### Background
Somebody reported this issue:
When I followed the LakeFS tutorial and reached the section Using Actions and Hooks (https://docs.lakefs.io/latest/quickstart/actions-and-hooks/) I got an error.

I'm on the Step 5 trying to commit the newly uploaded (added) action file check_commit_metadata.yml, I get the following error:

"prepare-commit hook aborted, run id '50eed0h6csl36k5kea00': 1 error occurred: * parsing file _lakefs_actions/check_commit_metadata.yml: yaml: line 8: mapping values are not allowed in this context"

<img width="3312" height="1500" alt="image" src="https://github.com/user-attachments/assets/9a723ce4-ee64-4d97-aff6-027a4f039567" />


### Bug Fix

If this PR is a bug fix, please let us know about:

1. Problem - Explained above
2. Root cause - Indentation issue with YAML
3. Solution - Fixed the indentation
      
### Contact Details

amit.kesarwani@treeverse.io
