### PR TITLE
Use distinct local caches in tests

### DIFF
--- a/pkg/api/serve_test.go
+++ b/pkg/api/serve_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path"
 	"strconv"
 	"sync"
 	"testing"

--- a/pkg/gateway/testutil/gateway_setup.go
+++ b/pkg/gateway/testutil/gateway_setup.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"net/http"
 	"os"
+	"path"
 	"testing"
 	"time"
 


### PR DESCRIPTION
Fixes some test flakiness.

Component tests use a configuration - which is almost the default configuration.  Unfortunately the default configuration uses "~" for some entries.  One of those entries is the local cache (Pyramid / TierFS) dir.  A TierFS instance assumes that it is the only instance using a directory; clearly that fails in a test, where >1 test instance can use the same cache directory.
