### PR TITLE
Add documentation for Iceberg Catalog Sync

### DIFF
--- a/docs/src/integrations/iceberg.md
+++ b/docs/src/integrations/iceberg.md
@@ -490,7 +490,7 @@ iceberg_catalog:
         credential: <client-id>:<client-secret>
 ```
 
-Or with OAuth token authentication:
+Or with OAuth2 client credentials flow:
 
 ```yaml
 iceberg_catalog:
@@ -499,7 +499,9 @@ iceberg_catalog:
       type: rest
       rest:
         uri: https://catalog.example.com/iceberg/api
-        oauth_token: <your-oauth-token>
+        credential: <client-id>:<client-secret>
+        oauth_server_uri: https://auth.example.com/oauth/tokens
+        oauth_scope: catalog:read catalog:write
 ```
 
 ### Push to remote


### PR DESCRIPTION
## Change Description

Add documentation for the (Enterprise) Iceberg Catalog Sync.

Note: REST remote catalog support is added in [this PR](https://github.com/treeverse/lakeFS-Enterprise/pull/1306).

