### PR TITLE
Use forked version of mkdocs-render-swagger-plugin

### DIFF
--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -3,6 +3,6 @@ mike==2.1.3
 mkdocs-material==9.6.14
 mkdocs-redirects==1.2.2
 mkdocs==1.6.1
-mkdocs-render-swagger-plugin==0.1.2
+git+https://github.com/treeverse/mkdocs-render-swagger-plugin.git#egg=mkdocs-render-swagger-plugin
 pymdown-extensions==10.15
 mkdocs-glightbox==0.4.0


### PR DESCRIPTION
The forked version of the plugin is needed for additional attributes on the script tag that was required by the consent blocker.

Closes https://github.com/treeverse/lakeFS/issues/9689