### PR TITLE
Cache CI build per cache

### DIFF
--- a/.github/workflows/esti.yaml
+++ b/.github/workflows/esti.yaml
@@ -132,9 +132,10 @@ jobs:
           build-args: VERSION=${{ needs.gen-code.outputs.tag }}
           context: .
           cache-from: |
-            type=s3,region=us-east-1,bucket=lakefs-docker-cache,name=lakefs
+            type=s3,region=us-east-1,bucket=lakefs-docker-cache,name=lakefs-${{ github.ref_name }}
+            type=s3,region=us-east-1,bucket=lakefs-docker-cache,name=lakefs-master
           cache-to: |
-            type=s3,region=us-east-1,bucket=lakefs-docker-cache,name=lakefs,mode=max
+            type=s3,region=us-east-1,bucket=lakefs-docker-cache,name=lakefs-${{ github.ref_name }},mode=max
 
   login-to-amazon-ecr:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
## Change Description

### Background

Building Docker images in the CI process is stuck due to multipart conflicts (see [example](https://github.com/treeverse/lakeFS/actions/runs/19506662006/job/55838121292)).

### Bug Fix

Changing the cache to be relative to the branch, reducing the chances of conflicts.

