### PR TITLE
Track runtime of `make test` on bencher.dev

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -50,30 +50,18 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: "1.24"
+      - name: Install Bencher
+        uses: bencherdev/bencher@61e6a2c2e0b4c8f61c87bef598ba9dbafa51c689 # Stable digest for v0.5.8
+        continue-on-error: true
       - name: Run Go tests
         run: |
           mkdir ./webui/dist
           touch ./webui/dist/index.html
-          time_out=$(mktemp)
-          bench_report=$(mktemp)
-          /usr/bin/time -p -o "$time_out" make test-go
-          jq -n -R < "$time_out" 'reduce (inputs | split(" ")) as $kv ({}; .[$kv[0]] = {value: ($kv[1] | tonumber)}) | {"test-go-runtime": .}' > "$bench_report"
-          echo bench_report=$(echo "$bench_report") >> $GITHUB_ENV
-      - name: Install Bencher
-        uses: bencherdev/bencher@61e6a2c2e0b4c8f61c87bef598ba9dbafa51c689 # Stable digest for v0.5.8
-        continue-on-error: true
-      - name: Report times to Bencher
-        # OK to fail here, it's just a bencher report
-        continue-on-error: true
-        run: |
-          ref=${{github.ref_name}}
+          ref=${{ github.ref_name }}
           release_slug=$(uname -s -m | tr '[:upper:]' '[:lower:]' | sed 's/[ _]/-/g')
-          bencher run  --adapter json \
-            --file="${bench_report}" \
-            --project lakefs \
-            --branch "$ref" \
-            --testbed "github-${release_slug}"
-      - name: What we reported
-        continue-on-error: true
-        run: |
-          cat "${bench_report}"
+          bencher run --build-time \
+                     --adapter json \
+                      --project lakefs \
+                      --branch "$ref" \
+                      --testbed "github-${release_slug}" \
+                      make test-go


### PR DESCRIPTION
You can see results (1 measurement for now) [here](https://bencher.dev/perf/lakefs?branches=c5c6d792-d03b-4f13-90f7-c43ee4e264f7&heads=228df82f-e1ca-4074-8cc4-53cbab81bb73&testbeds=646fcf3a-6c57-453d-932b-9545d644c755&benchmarks=6c3cc7e6-1ae2-402b-b767-09d1e20de695&measures=d34b0149-03f9-45e4-a02d-445e3a5398de&start_time=1761555726000&end_time=1764147726000&key=true&reports_per_page=4&branches_per_page=8&testbeds_per_page=8&benchmarks_per_page=8&plots_per_page=8&reports_page=1&branches_page=1&testbeds_page=1&benchmarks_page=1&plots_page=1&clear=true).