### PR TITLE
Fix: Return Content-Range header on ErrUnsatisfiableRange

### DIFF
--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -5065,7 +5065,7 @@ func (c *Controller) GetObject(w http.ResponseWriter, r *http.Request, repositor
 		rng, err := httputil.ParseRange(*params.Range, entry.Size)
 		if err != nil {
 			if errors.Is(err, httputil.ErrUnsatisfiableRange) {
-				w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", rng.StartOffset, rng.EndOffset, entry.Size))
+				w.Header().Set("Content-Range", fmt.Sprintf("bytes */%d", entry.Size))
 			}
 			writeError(w, r, http.StatusRequestedRangeNotSatisfiable, "Requested Range Not Satisfiable")
 			return


### PR DESCRIPTION
## Change Description

### Background

According to [spec](https://www.rfc-editor.org/rfc/rfc9110.html#name-416-range-not-satisfiable)
Content-Range must be provided on 416 error
