### PR TITLE
Use heap.Push not [slice].Push to initialize a Heap

### DIFF
--- a/pkg/graveler/ref/commit_iterator.go
+++ b/pkg/graveler/ref/commit_iterator.go
@@ -66,7 +66,7 @@ type CommitIteratorConfig struct {
 	Repository  *graveler.RepositoryRecord
 	Start       graveler.CommitID
 	FirstParent bool
-	Manager     CommitGetter
+	Getter      CommitGetter
 	Since       *time.Time
 }
 
@@ -79,7 +79,7 @@ func NewCommitIterator(ctx context.Context, config *CommitIteratorConfig) *Commi
 		start:       config.Start,
 		queue:       make(commitsPriorityQueue, 0),
 		visit:       make(map[graveler.CommitID]struct{}),
-		manager:     config.Manager,
+		manager:     config.Getter,
 		firstParent: config.FirstParent,
 		since:       config.Since,
 	}

--- a/pkg/graveler/ref/commit_iterator_test.go
+++ b/pkg/graveler/ref/commit_iterator_test.go
@@ -73,7 +73,7 @@ func TestCommitIterator(t *testing.T) {
 				Repository:  &graveler.RepositoryRecord{RepositoryID: "abc"},
 				Start:       tc.Start,
 				FirstParent: tc.FirstParent,
-				Manager:     commitGetter,
+				Getter:      commitGetter,
 				Since:       nil,
 			}
 			it := ref.NewCommitIterator(ctx, iteratorConfig)

--- a/pkg/graveler/ref/manager.go
+++ b/pkg/graveler/ref/manager.go
@@ -666,7 +666,7 @@ func (m *Manager) Log(ctx context.Context, repository *graveler.RepositoryRecord
 		Start:       from,
 		FirstParent: firstParent,
 		Since:       since,
-		Manager:     m,
+		Getter:      m,
 	}), nil
 }
 


### PR DESCRIPTION
Fixes #9748.

As a bonus, add a commit_iterator_test!  In fact only _one_ line is the fix, the other 100+ are to add that test.

This commit _also_ shows that no breakage was possible even before this change!  Indeed, the mistaken call to Push() occurs during initialization, and the heap is empty.  On an _empty_ heap, appending to the slice is _exactly_ the same as Pushing onto the heap.

Still, new code does not break the heap abstraction.
