### PR TITLE
catalog: add duration check during GC prepare uncommitted GC

### DIFF
--- a/pkg/catalog/gc_write_uncommitted.go
+++ b/pkg/catalog/gc_write_uncommitted.go
@@ -56,7 +56,6 @@ func gcWriteUncommitted(ctx context.Context, store Store, repository *graveler.R
 			}
 			break
 		}
-
 	}
 	if branchIterator.Err() != nil {
 		return nil, false, branchIterator.Err()


### PR DESCRIPTION
Additional duration check during GC preparation is committed, while scanning each branch in case no changes are found, the request duration can be passed.

The PR fixes this issue by checking if the duration has passed between branch iterations. This should prevent client timeouts during gc prepare committed data.

Close https://github.com/treeverse/lakeFS/issues/9765