### PR TITLE
fix: fix missing lakefs.quickstart and lakefs.download after pyprojec…

### DIFF
--- a/clients/python-wrapper/pyproject.toml
+++ b/clients/python-wrapper/pyproject.toml
@@ -44,7 +44,7 @@ test = [
 Homepage = "https://github.com/treeverse/lakeFS/tree/master/clients/python-wrapper"
 
 [tool.setuptools.packages.find]
-include = ["lakectl*", "lakefs*"]
+include = ["lakectl", "lakectl.*", "lakefs", "lakefs.*"]
 
 [tool.setuptools.package-data]
 lakefs = ["py.typed"]


### PR DESCRIPTION
…t.toml migration

## Change Description

### Background
The docs reference this broken snippet:
```python3
pip install lakefs
python -m lakefs.quickstart
```
It is broken because someone migrated to pyproject.toml 2 months ago and was not aware that the subfolders `quickstart` and `download` are not recursively included. This leads to the documentation breaking.

### Bug Fix

If this PR is a bug fix, please let us know about:

1. Problem - subfolders are not included in the wheels
2. Root cause - migration to pyproject.toml was not tested properly
3. Solution - by adding the wildcard, python files in subfolders are included again

### Testing Details

How were the changes tested?
in the folder `lakeFS/clients/python-wrapper` run 
```bash
pip install --upgrade .
cd .. # important as otherwise python uses the local folder and not the installed package
python -c "import lakefs.quickstart, lakefs.download; print('ok')" # will cause a ModuleNotFoundError: No module named 'lakefs.quickstart'
```
When you run it on my commit it correctly prints ok and you can also run `python -m lakefs.quickstart` again


### Breaking Change?

Does this change break any existing functionality?
No it restores them

### Contact Details

How can we get in touch with you if we need more info? (ex. peter@detesia.com)

Close #9788