### PR TITLE
Warn when path displayed in webui is empty and contains no objects

### DIFF
--- a/webui/src/lib/components/repository/tree.jsx
+++ b/webui/src/lib/components/repository/tree.jsx
@@ -840,11 +840,9 @@ export const Tree = ({
   } else if (results.length === 0) {
     body = (
       <>
-        <div className="me-3">
-          <div className="d-flex flex-column align-items-center">
-            <AlertIcon size={36} /><br/>
-            Nothing here.  Switch to another branch or tag to see something.
-          </div>
+        <div className="d-flex flex-column align-items-center mb-3 mt-3">
+          <AlertIcon size={36} /><br/>
+          Nothing here.  Switch to another branch or tag to see something.
         </div>
       </>
     );


### PR DESCRIPTION
This can happen when you go to a path and switch to another branch where that path does not exist.

When reviewing, please pay special attention to what it looks like, and whether the warning is clear and not too scary.

Fixes #5117.

## Pics or it never happened!

Branch where path does not exist:
<img width="1248" height="364" alt="Path does not exist, shows warning" src="https://github.com/user-attachments/assets/16a4b26f-879a-4cd6-ae92-69b02248cb80" />

Branch where the path does exist:
<img width="1248" height="293" alt="Path does exist, show tree view" src="https://github.com/user-attachments/assets/5813ae31-5649-4d65-8e84-92291f05c0c5" />
