### PR TITLE
Make lakefs.Repository.__str__ return the repository ID (its name)

### DIFF
--- a/clients/python-wrapper/lakefs/repository.py
+++ b/clients/python-wrapper/lakefs/repository.py
@@ -175,7 +175,7 @@ class Repository(_BaseLakeFSObject):
         return f'Repository(id="{self.id}")'
 
     def __str__(self):
-        return str(self.properties)
+        return self.id
 
 
 def repositories(client: Client = None,


### PR DESCRIPTION
`__str__` should be a pure function - no side effects, deterministic execution.  So it's just the name of the repo.

Retrieving repo properties from lakeFS is not only slow, it can also fail (for instance due to network issues), and is inconsistent with other __str__ methods in the library which return only their configuration.

```py
import lakefs
a = lakefs.repository('ariels-repo')

# Object shows its __id__ (unchanged)
a
# equals Repository(id="ariels-repo")

# As a string it shows its __str__
f"{a}"
# equals 'ariels-repo'
```

Fixes #9800.
