### PR TITLE
fix precondition 500

### DIFF
--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -3830,10 +3830,6 @@ func (c *Controller) UploadObject(w http.ResponseWriter, r *http.Request, reposi
 		writeError(w, r, http.StatusPreconditionFailed, "path already exists")
 		return
 	}
-	if errors.Is(err, kv.ErrPredicateFailed) {
-		writeError(w, r, http.StatusPreconditionFailed, "path already exists")
-		return
-	}
 	if c.handleAPIError(ctx, w, r, err) {
 		return
 	}

--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -1196,16 +1196,6 @@ func EntryCondition(condition func(*Entry) error) graveler.ConditionFunc {
 }
 
 // CreateEntry creates or updates an entry in the catalog.
-//
-// Possible errors:
-//   - graveler.ErrPreconditionFailed: Returned when a condition (e.g., graveler.WithCondition) fails.
-//     This typically happens when using If-None-Match and the entry already exists.
-//   - kv.ErrPredicateFailed: Returned when a concurrent modification is detected during the write.
-//     This indicates an optimistic locking failure at the KV layer - another request modified
-//     the same staging entry between read and write. This is rare as safeBranchWrite retries.
-//   - graveler.ErrNotFound: Repository or branch not found.
-//   - graveler.ErrWriteToProtectedBranch: Branch is protected from writes.
-//   - graveler.ErrReadOnlyRepository: Repository is read-only (unless Force option is used).
 func (c *Catalog) CreateEntry(ctx context.Context, repositoryID string, branch string, entry DBEntry, opts ...graveler.SetOptionsFunc) error {
 	branchID := graveler.BranchID(branch)
 	ent := newEntryFromCatalogEntry(entry)

--- a/pkg/graveler/graveler.go
+++ b/pkg/graveler/graveler.go
@@ -1872,15 +1872,20 @@ func (g *Graveler) Set(ctx context.Context, repository *RepositoryRecord, branch
 
 	log := g.log(ctx).WithFields(logging.Fields{"key": key, "operation": "set"})
 	err = g.safeBranchWrite(ctx, log, repository, branchID, safeBranchWriteOptions{MaxTries: options.MaxTries}, func(branch *Branch) error {
+		var err error
 		if options.Condition == nil {
-			return g.StagingManager.Set(ctx, branch.StagingToken, key, &value, false)
+			err = g.StagingManager.Set(ctx, branch.StagingToken, key, &value, false)
+		} else {
+			// setFunc is a update function that sets the value regardless of the current value
+			setFunc := func(_ *Value) (*Value, error) {
+				return &value, nil
+			}
+			err = g.handleUpdate(ctx, repository, branchID, branch, key, setFunc, options.Condition)
 		}
-
-		// setFunc is a update function that sets the value regardless of the current value
-		setFunc := func(_ *Value) (*Value, error) {
-			return &value, nil
+		if errors.Is(err, kv.ErrPredicateFailed) {
+			return fmt.Errorf("%w: %s", ErrPreconditionFailed, err)
 		}
-		return g.handleUpdate(ctx, repository, branchID, branch, key, setFunc, options.Condition)
+		return err
 	}, "set")
 	return err
 }


### PR DESCRIPTION
Closes #6457

## Change Description

### Bug Fix

We return 500 on precondition failed when really we should be returning 412

Details:
  Catalog.CreateEntry can return kv.ErrPredicateFailed when there's a race condition during concurrent writes to the same staging token.

### Testing Details

Unit test

### Breaking Change?

  Impact:
  - Before fix: kv.ErrPredicateFailed → 500 → lakectl retries (incorrectly, since retrying won't help)
  - After fix: kv.ErrPredicateFailed → 412 → lakectl doesn't retry (correct behavior!)


