### PR TITLE
Use correct error for mismatched Sig V4 credential date

### DIFF
--- a/pkg/gateway/errors/errors.go
+++ b/pkg/gateway/errors/errors.go
@@ -112,6 +112,7 @@ const (
 	ErrMalformedDate
 	ErrMalformedPresignedDate
 	ErrMalformedCredentialDate
+	ErrInvalidCredentialDate
 	ErrMalformedCredentialRegion
 	ErrMalformedExpires
 	ErrNegativeExpires
@@ -483,6 +484,11 @@ var Codes = errorCodeMap{
 	ErrMalformedCredentialDate: {
 		Code:           "AuthorizationQueryParametersError",
 		Description:    "Error parsing the X-Amz-Credential parameter; incorrect date format \"%s\". This date in the credential must be in the format \"yyyyMMdd\".",
+		HTTPStatusCode: http.StatusBadRequest,
+	},
+	ErrInvalidCredentialDate: {
+		Code:           "AuthorizationHeaderMalformed",
+		Description:    "The authorization header is malformed; Invalid credential date. Date is not the same as X-Amz-Date.",
 		HTTPStatusCode: http.StatusBadRequest,
 	},
 	// FIXME: Should contain the invalid param set as seen in https://github.com/minio/minio/issues/2385.

--- a/pkg/gateway/sig/v4.go
+++ b/pkg/gateway/sig/v4.go
@@ -353,9 +353,9 @@ func (ctx *verificationCtx) getAmzDate() (string, error) {
 		return "", errors.ErrMalformedCredentialDate
 	}
 
-	// ensure same date
+	// ensure request date matches signature date
 	if sigTS.Year() != ts.Year() || sigTS.Month() != ts.Month() || sigTS.Day() != ts.Day() {
-		return "", errors.ErrMalformedCredentialDate
+		return "", errors.ErrInvalidCredentialDate
 	}
 
 	return amzDate, nil


### PR DESCRIPTION
Closes #2465

## Change Description

### Bug Fix

This changes the error returned when the credential date in the signature does not match the X-Amz-Date in the request param or header. A new error type (ErrInvalidCredentialDate with code AuthorizationHeaderMalformed) has been added to match the error AWS S3 returns in this scenario.

### Testing Details

Unit tests added for existing `getAmzDate` function.
