### PR TITLE
WebUI: Show message for bare repository

### DIFF
--- a/webui/src/lib/api/index.js
+++ b/webui/src/lib/api/index.js
@@ -155,6 +155,13 @@ export class RepositoryDeletionError extends Error {
     }
 }
 
+export class BareRepositoryError extends Error {
+    constructor(message) {
+        super(message);
+        this.name = this.constructor.name;
+    }
+}
+
 // actual actions:
 class Auth {
     async getAuthCapabilities() {

--- a/webui/src/lib/hooks/repo.jsx
+++ b/webui/src/lib/hooks/repo.jsx
@@ -1,6 +1,6 @@
 import React, {useContext, createContext} from "react";
 
-import {repositories, branches, commits, NotFoundError, tags, BadRequestError} from "../api";
+import {repositories, branches, commits, NotFoundError, tags, BadRequestError, BareRepositoryError} from "../api";
 import {useRouter} from "./router";
 import {useAPI} from "./api";
 import {RefTypeBranch, RefTypeCommit, RefTypeTag} from "../../constants";
@@ -11,8 +11,16 @@ export const resolveRef = async (repoId, refId) => {
     try {
         const branch = await branches.get(repoId, refId);
         return {id: branch.id, type: RefTypeBranch};
-    } catch(error) {
-        if (!(error instanceof NotFoundError) && !(error instanceof BadRequestError)) {
+    } catch (error) {
+        if (error instanceof NotFoundError) {
+            // check if the repository is bare (has no branches)
+            const branchList = await branches.list(repoId, true, "", "", 1);
+            const isBareRepo = branchList?.results?.length === 0;
+            if (isBareRepo) {
+                throw new BareRepositoryError('Repository has no branches');
+            }
+        }
+        if (!(error instanceof BadRequestError)) {
             throw error;
         }
     }
@@ -20,7 +28,7 @@ export const resolveRef = async (repoId, refId) => {
     try {
         const tag = await tags.get(repoId, refId);
         return {id: tag.id, type: RefTypeTag};
-    } catch(error) {
+    } catch (error) {
         if (!(error instanceof NotFoundError) && !(error instanceof BadRequestError)) {
             throw error;
         }
@@ -28,35 +36,35 @@ export const resolveRef = async (repoId, refId) => {
     // try commit
     try {
         const commit = await commits.get(repoId, refId);
-        return {id: commit.id,  type: RefTypeCommit};
-    } catch(error) {
+        return {id: commit.id, type: RefTypeCommit};
+    } catch (error) {
         if (!(error instanceof NotFoundError)) {
             throw error;
         }
     }
 
     throw new NotFoundError('ref not found');
-};
+}
 
 
-const RefContext =  createContext(null);
+const RefContext = createContext(null);
 
 export const useRefs = () => {
-    const [ refsState ] = useContext(RefContext);
+    const [refsState] = useContext(RefContext);
     return refsState;
 }
 
-export const RefContextProvider = ({ children }) => {
+export const RefContextProvider = ({children}) => {
     const router = useRouter();
-    const { repoId } = router.params;
+    const {repoId} = router.params;
     const {ref, compare} = router.query;
 
-    const { response, error, loading } = useAPI(async () => {
+    const {response, error, loading} = useAPI(async () => {
         if (!repoId) return null;
         const repo = await repositories.get(repoId);
         const reference = await resolveRef(repoId, ref || repo.default_branch);
         const comparedRef = await resolveRef(repoId, compare || repo.default_branch);
-        return { repo, reference, compare: comparedRef };
+        return {repo, reference, compare: comparedRef};
     }, [repoId, ref, compare]);
 
     const refsState = {

--- a/webui/src/pages/repositories/repository/error.jsx
+++ b/webui/src/pages/repositories/repository/error.jsx
@@ -1,7 +1,7 @@
 import {useRouter} from "../../../lib/hooks/router";
 import Alert from "react-bootstrap/Alert";
 import Button from "react-bootstrap/Button";
-import {repositories, RepositoryDeletionError} from "../../../lib/api";
+import {repositories, RepositoryDeletionError, BareRepositoryError} from "../../../lib/api";
 import {TrashIcon} from "@primer/octicons-react";
 import React from "react";
 import {AlertError} from "../../../lib/components/controls";
@@ -12,7 +12,7 @@ const RepositoryInDeletionContainer = ({repoId}) => {
         <Alert variant="warning">
             <Alert.Heading>Repository is undergoing deletion</Alert.Heading>
             This may take several seconds. You can retry the deletion process by pressing the delete button again.
-            <hr />
+            <hr/>
             <div className="d-flex justify-content-end">
                 <Button variant="danger" className="mt-3" onClick={
                     async () => {
@@ -30,9 +30,31 @@ const RepositoryInDeletionContainer = ({repoId}) => {
     );
 };
 
+const BareRepositoryContainer = () => (
+    <Alert variant="info">
+        <Alert.Heading>Repository Not Initialized</Alert.Heading>
+        <p className="mb-2">
+            This repository is empty (bare) and has no branches or commits.
+            Bare repositories are typically used for backup/restore operations with <code>lakectl refs-restore</code>.
+        </p>
+        <p>
+            <a
+                href="https://docs.lakefs.io/howto/backup-and-restore.html"
+                target="_blank"
+                rel="noopener noreferrer"
+            >
+                Learn more about bare repositories.
+            </a>
+        </p>
+    </Alert>
+);
+
 export const RepoError = ({error}) => {
     if (error instanceof RepositoryDeletionError) {
         return <RepositoryInDeletionContainer repoId={error.repoId}/>;
+    }
+    if (error instanceof BareRepositoryError) {
+        return <BareRepositoryContainer />;
     }
     return <AlertError error={error}/>;
 };


### PR DESCRIPTION
Closes #3393.

## Change Description

### Background

"Bare" repositories are created as part of an import process.
These cases should be handled properly in the WebUI.

### Bug Fix

Instead of showing a generic "ref not found" error, listing the repo's branches, and displaying a special message if the repo has no branches.
      
### Testing Details

Tested manually, both with a bare repo and with a non-bare (for backwards-compatibility).

### Screenshots

<img width="1398" height="454" alt="Screenshot 2025-12-16 at 11 34 42" src="https://github.com/user-attachments/assets/396b5c0c-cd2d-42e3-b24e-66d62e8e7447" />
