### PR TITLE
(fork) ci: run tests without bencher on PRs from fork

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -59,12 +59,16 @@ jobs:
           touch ./webui/dist/index.html
           ref=${{ github.ref_name }}
           release_slug=$(uname -s -m | tr '[:upper:]' '[:lower:]' | sed 's/[ _]/-/g')
-          bencher run --build-time \
-                     --adapter json \
-                      --project lakefs \
-                      --branch "$ref" \
-                      --testbed "github-${release_slug}" \
-                      make test-go
+          if [ -z "$BENCHER_API_TOKEN" ]; then
+            make test-go
+          else
+            bencher run --build-time \
+                       --adapter json \
+                        --project lakefs \
+                        --branch "$ref" \
+                        --testbed "github-${release_slug}" \
+                        make test-go
+          fi
 
   test-webui:
     name: Run webui unit tests


### PR DESCRIPTION
`BENCHER_API_TOKEN` secret is not available when running from forks, due to which bencher receives empty string and fails.

Eg: https://github.com/treeverse/lakeFS/actions/runs/20267951059/job/58195889535?pr=9805.

This will run `make test-go` when not the secret is not available.