### PR TITLE
Fix: s3 block tests out of space

### DIFF
--- a/pkg/block/s3/main_test.go
+++ b/pkg/block/s3/main_test.go
@@ -60,6 +60,7 @@ func TestMain(m *testing.M) {
 	// set cleanup
 	closer := func() {
 		err = pool.Purge(resource)
+		_ = os.RemoveAll(tmpDir)
 		if err != nil {
 			panic("could not purge minio container: " + err.Error())
 		}


### PR DESCRIPTION
Occasionally tests s3 block test using minio container [fails](https://github.com/treeverse/lakeFS-Enterprise/actions/runs/20373720479/job/58557523725?pr=536) on out of storage.
```
    --- FAIL: TestAdapter/Adapter_CopyPartRange (0.19s)
        multipart_suite.go:160: 
            	Error Trace:	/home/runner/work/lakeFS-Enterprise/lakeFS-Enterprise/lakefs-oss/pkg/block/blocktest/multipart_suite.go:197
            	            				/home/runner/work/lakeFS-Enterprise/lakeFS-Enterprise/lakefs-oss/pkg/block/blocktest/multipart_suite.go:160
            	            				/home/runner/work/lakeFS-Enterprise/lakeFS-Enterprise/lakefs-oss/pkg/block/blocktest/multipart_suite.go:26
            	Error:      	Received unexpected error:
            	            	operation error S3: CreateMultipartUpload, https response error StatusCode: 507, RequestID: 1882AD1B0C1BDFE7, HostID: dd9025bab4ad464b049177c95eb6ebf374d3b3fd1af9251148b658df7ac2e3e8, api error XMinioStorageFull: Storage backend has reached its minimum free drive threshold. Please delete a few objects to proceed.
```
This modification should solve or at least mitigate the issue