### PR TITLE
fix lakectl fallback to sync commit/merge on error

### DIFF
--- a/cmd/lakectl/cmd/commit.go
+++ b/cmd/lakectl/cmd/commit.go
@@ -56,7 +56,7 @@ var commitCmd = &cobra.Command{
 
 		// try asynchronous commit first
 		startResp, err := client.CommitAsyncWithResponse(ctx, branchURI.Repository, branchURI.Ref, &apigen.CommitAsyncParams{}, apigen.CommitAsyncJSONRequestBody(body))
-		if startResp.JSON501 == nil { // Async supported or error
+		if err == nil && startResp.JSON501 == nil { // Async supported or error
 			DieOnErrorOrUnexpectedStatusCode(startResp, err, http.StatusAccepted)
 			if startResp.JSON202 == nil {
 				Die("Bad response from server", 1)

--- a/cmd/lakectl/cmd/merge.go
+++ b/cmd/lakectl/cmd/merge.go
@@ -68,7 +68,7 @@ var mergeCmd = &cobra.Command{
 
 		// try asynchronous merge first
 		startResp, err := client.MergeIntoBranchAsyncWithResponse(ctx, destinationRef.Repository, sourceRef.Ref, destinationRef.Ref, apigen.MergeIntoBranchAsyncJSONRequestBody(body))
-		if startResp.JSON501 == nil { // Async supported or error
+		if err == nil && startResp.JSON501 == nil { // Async supported or error
 			DieOnErrorOrUnexpectedStatusCode(startResp, err, http.StatusAccepted)
 			if startResp.JSON202 == nil {
 				Die("Bad response from server", 1)


### PR DESCRIPTION
Closes #9870 

fixed the issue we had with lakectl commit panics as can see in this thread:
https://treeverseio.slack.com/archives/C027PG0LWAV/p1766401132980599