### PR TITLE
test: esti use repo unique repo id avoid conflict with short commit id

### DIFF
--- a/esti/esti_utils.go
+++ b/esti/esti_utils.go
@@ -330,7 +330,10 @@ func createRepositoryUnique(ctx context.Context, t testing.TB) string {
 }
 
 func GenerateUniqueRepositoryName() string {
-	return "repo-" + xid.New().String()
+	id := xid.New().String()
+	// format: repo-<first two chars>-<rest>
+	// in order to avoid matching format with short commit id
+	return "repo-" + id[:2] + "-" + id[2:]
 }
 
 func GenerateUniqueStorageNamespace(repoName string) string {


### PR DESCRIPTION
Update the repository ID format to 'repo-<id>' to 'repo-<id first 2 letters>-<id rest>'.

Help prevent short commit id replacement in lakectl esti tests (less flaky tests):

```
esti-1      |         	            	expected: "Repository: lakefs://repo-d5593bb8ed5f0c103fog\nRepository 'repo-d5593bb8ed5f0c103fog' created:\nstorage namespace: s3://esti-system-testing/18335/3592/d5593bb8ed5f0c103fp0/repo-d5593bb8ed5f0c103fog\ndefault branch: main\ntimestamp: <TIMESTAMP>\n"
esti-1      |         	            	actual  : "Repository: lakefs://repo-<COMMIT_ID_16>3fog\nRepository 'repo-<COMMIT_ID_16>3fog' created:\nstorage namespace: s3://esti-system-testing/18335/3592/<COMMIT_ID_16>3fp0/repo-<COMMIT_ID_16>3fog\ndefault branch: main\ntimestamp: <TIMESTAMP>\n"
```
