### PR TITLE
Revert bencher integration from test workflow

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -41,8 +41,6 @@ jobs:
   test-go:
     name: Run Go tests
     runs-on: ubuntu-22.04
-    env:
-      BENCHER_API_TOKEN: ${{ secrets.BENCHER_API_TOKEN }}
     steps:
       - name: Check-out code
         uses: actions/checkout@v4
@@ -50,21 +48,11 @@ jobs:
         uses: actions/setup-go@v6
         with:
           go-version-file: 'go.mod'
-      - name: Install Bencher
-        uses: bencherdev/bencher@61e6a2c2e0b4c8f61c87bef598ba9dbafa51c689 # Stable digest for v0.5.8
-        continue-on-error: true
       - name: Run Go tests
         run: |
           mkdir ./webui/dist
           touch ./webui/dist/index.html
-          ref=${{ github.ref_name }}
-          release_slug=$(uname -s -m | tr '[:upper:]' '[:lower:]' | sed 's/[ _]/-/g')
-          bencher run --build-time \
-                     --adapter json \
-                      --project lakefs \
-                      --branch "$ref" \
-                      --testbed "github-${release_slug}" \
-                      make test-go
+          make test-go
 
   test-webui:
     name: Run webui unit tests


### PR DESCRIPTION
Remove bencher.dev performance tracking from the CI test workflow to simplify the Go test execution.