### PR TITLE
fix: UI: Validate and prevent duplicate metadata keys for commits

### DIFF
--- a/webui/src/lib/components/repository/metadata.jsx
+++ b/webui/src/lib/components/repository/metadata.jsx
@@ -43,7 +43,7 @@ export const MetadataFields = ({ metadataFields, setMetadataFields, ...rest }) =
     return (
         <div className="mt-3 mb-3" {...rest}>
             {metadataFields.map((f, i) => {
-                const fieldError = getFieldError(f);
+                const fieldError = getFieldError(f, i, metadataFields);
                 return (
                     <Form.Group key={`commit-metadata-field-${i}`} className="mb-3">
                         <Row>

--- a/webui/src/lib/components/repository/metadataHelpers.test.js
+++ b/webui/src/lib/components/repository/metadataHelpers.test.js
@@ -38,6 +38,30 @@ describe('hasInvalidKeys', () => {
 
         expect(hasInvalidKeys(fields)).toBe(true);
     });
+
+    it('returns true when there are duplicate keys', () => {
+        const fields = [
+            { key: 'same', value: 'value1', touched: false },
+            { key: 'same', value: 'value2', touched: false },
+        ];
+
+        expect(hasInvalidKeys(fields)).toBe(true);
+    });
+
+    it('returns true when there are duplicate keys with different whitespace', () => {
+        const fields = [
+            { key: 'key', value: 'value1', touched: false },
+            { key: ' key ', value: 'value2', touched: false },
+        ];
+
+        expect(hasInvalidKeys(fields)).toBe(true);
+    });
+
+    it('returns false for single field (no duplicates possible)', () => {
+        const fields = [{ key: 'single', value: 'value', touched: false }];
+
+        expect(hasInvalidKeys(fields)).toBe(false);
+    });
 });
 
 describe('fieldsToMetadata', () => {
@@ -105,6 +129,18 @@ describe('touchInvalidFields', () => {
         expect(fields[0].touched).toBe(false); // Original unchanged
         expect(result[0].touched).toBe(true); // New array modified
     });
+
+    it('marks duplicate key fields as touched', () => {
+        const fields = [
+            { key: 'same', value: 'value1', touched: false },
+            { key: 'same', value: 'value2', touched: false },
+        ];
+
+        const result = touchInvalidFields(fields);
+
+        expect(result[0].touched).toBe(false); // First occurrence is valid
+        expect(result[1].touched).toBe(true); // Duplicate is invalid
+    });
 });
 
 describe('getFieldError', () => {
@@ -126,6 +162,35 @@ describe('getFieldError', () => {
     it('returns null for valid key', () => {
         const field = { key: 'valid', value: '', touched: true };
         expect(getFieldError(field)).toBeNull();
+    });
+
+    it('returns error message for duplicate key when touched', () => {
+        const fields = [
+            { key: 'same', value: 'value1', touched: true },
+            { key: 'same', value: 'value2', touched: true },
+        ];
+
+        expect(getFieldError(fields[0], 0, fields)).toBeNull();
+        expect(getFieldError(fields[1], 1, fields)).toBe('Key already exists');
+    });
+
+    it('returns null for duplicate key when not touched', () => {
+        const fields = [
+            { key: 'same', value: 'value1', touched: false },
+            { key: 'same', value: 'value2', touched: false },
+        ];
+
+        expect(getFieldError(fields[1], 1, fields)).toBeNull();
+    });
+
+    it('detects duplicates with whitespace differences', () => {
+        const fields = [
+            { key: 'key', value: 'value1', touched: true },
+            { key: ' key ', value: 'value2', touched: true },
+        ];
+
+        expect(getFieldError(fields[0], 0, fields)).toBeNull();
+        expect(getFieldError(fields[1], 1, fields)).toBe('Key already exists');
     });
 });
 
@@ -163,6 +228,28 @@ describe('getMetadataIfValid', () => {
 
     it('returns null for whitespace-only keys', () => {
         const fields = [{ key: '   ', value: 'value', touched: false }];
+
+        const result = getMetadataIfValid(fields);
+
+        expect(result).toBeNull();
+    });
+
+    it('returns null for fields with duplicate keys', () => {
+        const fields = [
+            { key: 'same', value: 'value1', touched: false },
+            { key: 'same', value: 'value2', touched: false },
+        ];
+
+        const result = getMetadataIfValid(fields);
+
+        expect(result).toBeNull();
+    });
+
+    it('returns null for duplicate keys with whitespace differences', () => {
+        const fields = [
+            { key: 'key', value: 'value1', touched: false },
+            { key: ' key ', value: 'value2', touched: false },
+        ];
 
         const result = getMetadataIfValid(fields);
 


### PR DESCRIPTION
## Summary
This PR fixes #9729

## Changes
- `webui/src/lib/components/repository/metadata.jsx`
- `webui/src/lib/components/repository/metadataHelpers.js`
- `webui/src/lib/components/repository/metadataHelpers.test.js`
