### PR TITLE
Modernize for-loops to Go 1.22+ range syntax

### DIFF
--- a/cmd/lakectl/cmd/abuse_commit.go
+++ b/cmd/lakectl/cmd/abuse_commit.go
@@ -31,7 +31,7 @@ var abuseCommitCmd = &cobra.Command{
 
 		// generate randomly selected keys as input
 		generator.Setup(func(add stress.GeneratorAddFn) {
-			for i := 0; i < amount; i++ {
+			for i := range amount {
 				add(strconv.Itoa(i + 1))
 			}
 		})

--- a/cmd/lakectl/cmd/abuse_create_branches.go
+++ b/cmd/lakectl/cmd/abuse_create_branches.go
@@ -81,7 +81,7 @@ var abuseCreateBranchesCmd = &cobra.Command{
 
 		// generate create branch requests
 		generator.Setup(func(add stress.GeneratorAddFn) {
-			for i := 0; i < amount; i++ {
+			for i := range amount {
 				add(fmt.Sprintf("%s-%d", branchPrefix, i))
 			}
 		})

--- a/cmd/lakectl/cmd/abuse_link_same_object.go
+++ b/cmd/lakectl/cmd/abuse_link_same_object.go
@@ -32,7 +32,7 @@ var abuseLinkSameObjectCmd = &cobra.Command{
 
 		// setup generator to use the key
 		generator.Setup(func(add stress.GeneratorAddFn) {
-			for i := 0; i < amount; i++ {
+			for range amount {
 				add(key)
 			}
 		})

--- a/cmd/lakectl/cmd/abuse_list.go
+++ b/cmd/lakectl/cmd/abuse_list.go
@@ -29,7 +29,7 @@ var abuseListCmd = &cobra.Command{
 
 		// generate randomly selected keys as input
 		generator.Setup(func(add stress.GeneratorAddFn) {
-			for i := 0; i < amount; i++ {
+			for i := range amount {
 				add(strconv.Itoa(i + 1))
 			}
 		})

--- a/cmd/lakectl/cmd/abuse_merge.go
+++ b/cmd/lakectl/cmd/abuse_merge.go
@@ -50,7 +50,7 @@ func removeBranches(ctx context.Context, client *apigen.ClientWithResponses, par
 
 	wg := &sync.WaitGroup{}
 	wg.Add(parallelism)
-	for i := 0; i < parallelism; i++ {
+	for range parallelism {
 		go func() {
 			for branch := range toDelete {
 				resp, err := client.DeleteBranchWithResponse(ctx, repo, branch, &apigen.DeleteBranchParams{})
@@ -91,7 +91,7 @@ var abuseMergeCmd = &cobra.Command{
 
 		// generate branch names as input
 		generator.Setup(func(add stress.GeneratorAddFn) {
-			for i := 0; i < amount; i++ {
+			for i := range amount {
 				add(fmt.Sprintf("%s-%04d", branchPrefix, i+1))
 			}
 		})

--- a/cmd/lakectl/cmd/abuse_random_delete.go
+++ b/cmd/lakectl/cmd/abuse_random_delete.go
@@ -38,7 +38,7 @@ var abuseRandomDeletesCmd = &cobra.Command{
 
 		// generate randomly selected keys as input
 		generator.Setup(func(add stress.GeneratorAddFn) {
-			for i := 0; i < amount; i++ {
+			for range amount {
 				// rand.Intn is good enough for abuse.
 				//nolint:gosec
 				add(keys[rand.Intn(len(keys))])

--- a/cmd/lakectl/cmd/abuse_random_read.go
+++ b/cmd/lakectl/cmd/abuse_random_read.go
@@ -39,7 +39,7 @@ var abuseRandomReadsCmd = &cobra.Command{
 
 		// generate randomly selected keys as input
 		generator.Setup(func(add stress.GeneratorAddFn) {
-			for i := 0; i < amount; i++ {
+			for range amount {
 				// rand.Intn is good enough for abuse.
 				//nolint:gosec
 				add(keys[rand.Intn(len(keys))])

--- a/cmd/lakectl/cmd/abuse_random_writes.go
+++ b/cmd/lakectl/cmd/abuse_random_writes.go
@@ -27,7 +27,7 @@ var abuseRandomWritesCmd = &cobra.Command{
 
 		// generate randomly selected keys as input
 		generator.Setup(func(add stress.GeneratorAddFn) {
-			for i := 0; i < amount; i++ {
+			for i := range amount {
 				add(fmt.Sprintf("%sfile-%d", prefix, i))
 			}
 		})

--- a/cmd/lakectl/cmd/fs_rm.go
+++ b/cmd/lakectl/cmd/fs_rm.go
@@ -37,19 +37,17 @@ var fsRmCmd = &cobra.Command{
 		success := true
 		var errorsWg sync.WaitGroup
 		errors := make(chan error)
-		errorsWg.Add(1)
-		go func() {
-			defer errorsWg.Done()
+		errorsWg.Go(func() {
 			for err := range errors {
 				_, _ = fmt.Fprintln(os.Stderr, err)
 				success = false
 			}
-		}()
+		})
 
 		var deleteWg sync.WaitGroup
 		paths := make(chan string)
 		deleteWg.Add(concurrency)
-		for i := 0; i < concurrency; i++ {
+		for range concurrency {
 			go deleteObjectWorker(cmd.Context(), client, pathURI.Repository, pathURI.Ref, paths, errors, &deleteWg)
 		}
 

--- a/cmd/lakefs-loadtest/cmd/entry.go
+++ b/cmd/lakefs-loadtest/cmd/entry.go
@@ -105,12 +105,12 @@ var entryCmd = &cobra.Command{
 
 		var errCount int64
 		startingLine := make(chan bool)
-		for i := 0; i < concurrency; i++ {
+		for i := range concurrency {
 			wid := fmt.Sprintf("-%02d", i)
 			go func() {
 				defer wg.Done()
 				<-startingLine
-				for reqID := 0; reqID < requests; reqID++ {
+				for range requests {
 					id, err := nanoid.New(createEntryPathLength)
 					if err != nil {
 						atomic.AddInt64(&errCount, 1)

--- a/contrib/auth/acl/service_test.go
+++ b/contrib/auth/acl/service_test.go
@@ -96,7 +96,7 @@ func createInitialDataSet(t *testing.T, ctx context.Context, svc auth.Service, u
 		if _, err := svc.CreateUser(ctx, &model.User{Username: userName}); err != nil {
 			t.Fatalf("CreateUser(%s): %s", userName, err)
 		}
-		for i := 0; i < 2; i++ {
+		for range 2 {
 			_, err := svc.CreateCredentials(ctx, userName)
 			if err != nil {
 				t.Errorf("CreateCredentials(%s): %s", userName, err)

--- a/esti/catalog_export_test.go
+++ b/esti/catalog_export_test.go
@@ -127,7 +127,7 @@ func genCSVData(t *testing.T, columns []string, n int) string {
 	err := writer.Write(headerRow)
 	require.NoError(t, err, "failed writing CSV headers to buffer")
 
-	for rowNum := 0; rowNum < n; rowNum++ {
+	for rowNum := range n {
 		dataRow := []string{}
 		for colNum := range columns {
 			dataRow = append(dataRow, fmt.Sprintf("%d", rowNum+colNum))
@@ -218,7 +218,7 @@ func testSymlinkS3Exporter(t *testing.T, ctx context.Context, repo string, tmplD
 		require.NoError(t, err, "fail reading object data")
 		require.NoError(t, objRes.Body.Close())
 
-		for _, addr := range strings.Split(string(body), "\n") {
+		for addr := range strings.SplitSeq(string(body), "\n") {
 			if addr != "" { // split returns last \n as empty string
 				storagePhysicalAddrs[addr] = true
 			}

--- a/esti/commit_test.go
+++ b/esti/commit_test.go
@@ -75,14 +75,12 @@ func TestCommitInMixedOrder(t *testing.T) {
 	names1 := genNames(size, "run2/foo")
 	uploads := make(chan Upload, size)
 	wg := sync.WaitGroup{}
-	for i := 0; i < parallelism; i++ {
-		wg.Add(1)
-		go func() {
+	for range parallelism {
+		wg.Go(func() {
 			if err := upload(ctx, uploads); err != nil {
 				t.Error(err)
 			}
-			wg.Done()
-		}()
+		})
 	}
 	for _, name := range names1 {
 		uploads <- Upload{Repo: repo, Branch: mainBranch, Path: name}
@@ -104,14 +102,12 @@ func TestCommitInMixedOrder(t *testing.T) {
 	names2 := genNames(size, "run1/foo")
 	uploads = make(chan Upload, size)
 	wg = sync.WaitGroup{}
-	for i := 0; i < parallelism; i++ {
-		wg.Add(1)
-		go func() {
+	for range parallelism {
+		wg.Go(func() {
 			if err := upload(ctx, uploads); err != nil {
 				t.Error(err)
 			}
-			wg.Done()
-		}()
+		})
 	}
 	for _, name := range names2 {
 		uploads <- Upload{Repo: repo, Branch: mainBranch, Path: name}

--- a/esti/import_test.go
+++ b/esti/import_test.go
@@ -77,7 +77,7 @@ func setupLocalImportPath(t testing.TB) string {
 		t.Fatal(err)
 	}
 
-	for i := 0; i < 7; i++ {
+	for i := range 7 {
 		prefix := "prefix-" + strconv.Itoa(i+1)
 		// make dirs once
 		dirs := []string{
@@ -89,7 +89,7 @@ func setupLocalImportPath(t testing.TB) string {
 				t.Fatal(err)
 			}
 		}
-		for n := 0; n < 2100; n++ {
+		for n := range 2100 {
 			name := fmt.Sprintf("file%06d", n+1)
 			const filePerm = 0o644
 			for _, dir := range dirs {

--- a/esti/lakectl_test.go
+++ b/esti/lakectl_test.go
@@ -630,7 +630,7 @@ func TestLakectlFsDownload(t *testing.T) {
 
 	// upload some data
 	const totalObjects = 5
-	for i := 0; i < totalObjects; i++ {
+	for i := range totalObjects {
 		vars["FILE_PATH"] = fmt.Sprintf("data/ro/ro_1k.%d", i)
 		RunCmdAndVerifySuccessWithFile(t, Lakectl()+" fs upload -s files/ro_1k lakefs://"+repoName+"/"+mainBranch+"/"+vars["FILE_PATH"], false, "lakectl_fs_upload", vars)
 	}
@@ -827,7 +827,7 @@ func TestLakectlFsPresign(t *testing.T) {
 
 	// upload some data
 	const totalObjects = 2
-	for i := 0; i < totalObjects; i++ {
+	for i := range totalObjects {
 		vars["FILE_PATH"] = fmt.Sprintf("data/ro/ro_1k.%d", i)
 		RunCmdAndVerifySuccessWithFile(t, Lakectl()+" fs upload -s files/ro_1k lakefs://"+repoName+"/"+mainBranch+"/"+vars["FILE_PATH"], false, "lakectl_fs_upload", vars)
 	}
@@ -854,7 +854,7 @@ func TestLakectlFsStat(t *testing.T) {
 
 	// upload some data
 	const totalObjects = 2
-	for i := 0; i < totalObjects; i++ {
+	for i := range totalObjects {
 		vars["FILE_PATH"] = fmt.Sprintf("data/ro/ro_1k.%d", i)
 		RunCmdAndVerifySuccessWithFile(t, Lakectl()+" fs upload -s files/ro_1k lakefs://"+repoName+"/"+mainBranch+"/"+vars["FILE_PATH"], false, "lakectl_fs_upload", vars)
 	}
@@ -1014,7 +1014,7 @@ func TestLakectlBisect(t *testing.T) {
 	runCmd(t, Lakectl()+" bisect reset", false, false, nil)
 
 	// generate to test data
-	for i := 0; i < 5; i++ {
+	for i := range 5 {
 		obj := fmt.Sprintf("file%d", i)
 		runCmd(t, r.Replace("{lakectl} fs upload -s files/ro_1k lakefs://{repo}/{branch}/")+obj, false, false, nil)
 		commit := fmt.Sprintf("commit%d", i)
@@ -1086,7 +1086,7 @@ func TestLakectlAbuse(t *testing.T) {
 
 	fromFile := ""
 	const totalObjects = 5
-	for i := 0; i < totalObjects; i++ {
+	for i := range totalObjects {
 		vars["FILE_PATH"] = fmt.Sprintf("data/ro/ro_1k.%d", i)
 		fromFile = fromFile + vars["FILE_PATH"] + "\n"
 		runCmd(t, Lakectl()+" fs upload -s files/ro_1k lakefs://"+repoName+"/"+mainBranch+"/"+vars["FILE_PATH"], false, false, vars)

--- a/esti/merge_test.go
+++ b/esti/merge_test.go
@@ -53,7 +53,7 @@ func TestMergeAndList(t *testing.T) {
 
 func doMergeAndListIteration(t *testing.T, logger logging.Logger, ctx context.Context, repo, branch, strategy string, checksums map[string]string, iteration int) []apigen.ObjectStats {
 	const addedFiles = 10
-	for i := 0; i < addedFiles; i++ {
+	for i := range addedFiles {
 		p := fmt.Sprintf("%d.txt", i)
 		logger.WithFields(logging.Fields{"iteration": iteration, "path": p}).Info("Upload content to branch")
 		checksum, content := UploadFileRandomData(ctx, t, repo, branch, p, nil)

--- a/esti/multipart_test.go
+++ b/esti/multipart_test.go
@@ -47,7 +47,7 @@ func TestMultipartUpload(t *testing.T) {
 
 	parts := make([][]byte, multipartNumberOfParts)
 	var partsConcat []byte
-	for i := 0; i < multipartNumberOfParts; i++ {
+	for i := range multipartNumberOfParts {
 		parts[i] = randstr.Bytes(multipartPartSize + i)
 		partsConcat = append(partsConcat, parts[i]...)
 	}
@@ -172,7 +172,7 @@ func uploadMultipartParts(t *testing.T, ctx context.Context, client *s3.Client, 
 	errs := make([]error, count)
 	var wg sync.WaitGroup
 	wg.Add(count)
-	for i := 0; i < count; i++ {
+	for i := range count {
 		go func(i int) {
 			defer wg.Done()
 			partNumber := firstIndex + i + 1

--- a/esti/presign_multipart_test.go
+++ b/esti/presign_multipart_test.go
@@ -136,7 +136,7 @@ func TestCompletePresignMultipartUpload(t *testing.T) {
 
 	// fake parts used for the above tests
 	var fakeParts []apigen.UploadPart
-	for i := 0; i < 2; i++ {
+	for i := range 2 {
 		fakeParts = append(fakeParts, apigen.UploadPart{
 			Etag:       "etag" + strconv.Itoa(i),
 			PartNumber: i + 1,
@@ -233,7 +233,7 @@ func TestPresignMultipartUploadSeparateParts(t *testing.T) {
 				totalSize int64 = 0
 				parts     []apigen.UploadPart
 			)
-			for i := 0; i < numberOfParts; i++ {
+			for i := range numberOfParts {
 				startTime := time.Now()
 				// random data - all parts except the last one should be at least >= MinUploadPartSize
 				var (

--- a/esti/s3_gateway_test.go
+++ b/esti/s3_gateway_test.go
@@ -183,7 +183,7 @@ func TestS3UploadAndDownload(t *testing.T) {
 				}()
 			}
 
-			for i := 0; i < numUploads; i++ {
+			for range numUploads {
 				objects <- Object{
 					Content: testutil.RandomString(r, randomDataContentLength),
 					Path:    gatewayTestPrefix + testutil.RandomS3Path(randomDataPathLength-len(gatewayTestPrefix)),
@@ -235,7 +235,7 @@ func TestMultipartUploadIfNoneMatch(t *testing.T) {
 			require.NoError(t, err, "failed to create multipart upload")
 
 			parts := make([][]byte, multipartNumberOfParts)
-			for i := 0; i < multipartNumberOfParts; i++ {
+			for i := range multipartNumberOfParts {
 				parts[i] = randstr.Bytes(multipartPartSize + i)
 			}
 
@@ -399,7 +399,7 @@ func TestListMultipartUploads(t *testing.T) {
 	resp1, err := s3Client.CreateMultipartUpload(ctx, input1)
 	require.NoError(t, err, "failed to create multipart upload")
 	parts := make([][]byte, numOfParts)
-	for i := 0; i < numOfParts; i++ {
+	for i := range numOfParts {
 		parts[i] = randstr.Bytes(multipartPartSize + i)
 	}
 

--- a/esti/sanity_api_test.go
+++ b/esti/sanity_api_test.go
@@ -21,7 +21,7 @@ func TestSanityAPI(t *testing.T) {
 	const numOfFiles = 5
 	paths := make([]string, numOfFiles)
 	contents := make([]string, numOfFiles)
-	for i := 0; i < numOfFiles; i++ {
+	for i := range numOfFiles {
 		paths[i] = fmt.Sprintf("file%d", i)
 		_, contents[i] = UploadFileRandomData(ctx, t, repo, mainBranch, paths[i], nil)
 	}

--- a/pkg/actions/kv_run_results_iterator_test.go
+++ b/pkg/actions/kv_run_results_iterator_test.go
@@ -168,7 +168,7 @@ func createTestData(t *testing.T, ctx context.Context, kvStore kv.Store) (map[st
 		key := actions.RunPath(iteratorTestRepoID, runID)
 		run.RunId = runID
 		require.NoError(t, kv.SetMsg(ctx, kvStore, actions.PartitionKey, key, &run))
-		for j := 0; j < 100; j++ {
+		for j := range 100 {
 			HookRunId := actions.NewHookRunID(msgIdx, j)
 			taskKey := kv.FormatPath(actions.TasksPath(iteratorTestRepoID, runID), HookRunId)
 			task.HookRunId = HookRunId

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -362,7 +362,7 @@ func TestController_LogCommitsParallelHandler(t *testing.T) {
 	commits := 100
 	const prefix = "foo/bar"
 	commitsToLook := map[string]*catalog.CommitLog{}
-	for i := 0; i < commits; i++ {
+	for i := range commits {
 		n := strconv.Itoa(i + 1)
 		p := prefix + n
 		err := deps.catalog.CreateEntry(ctx, repo, "main", catalog.DBEntry{Path: p, PhysicalAddress: onBlock(deps, "bar"+n+"addr"), CreationDate: time.Now(), Size: int64(i) + 1, Checksum: "cksum" + n})
@@ -409,7 +409,7 @@ func TestController_LogCommitsPredefinedData(t *testing.T) {
 	const prefix = "foo/bar"
 	const totalCommits = 10
 	commits := make([]*catalog.CommitLog, totalCommits)
-	for i := 0; i < totalCommits; i++ {
+	for i := range totalCommits {
 		n := strconv.Itoa(i + 1)
 		p := prefix + n
 		err := deps.catalog.CreateEntry(ctx, repo, "main", catalog.DBEntry{Path: p, PhysicalAddress: onBlock(deps, "bar"+n+"addr"), CreationDate: time.Now(), Size: int64(i) + 1, Checksum: "cksum" + n})
@@ -1146,7 +1146,7 @@ func TestController_CreateRepositoryHandler(t *testing.T) {
 			t.Fatal(err)
 		}
 		const times = 3 // try to create the same repo multiple times
-		for i := 0; i < times; i++ {
+		for range times {
 			resp, err := clt.CreateRepositoryWithResponse(ctx, &apigen.CreateRepositoryParams{}, apigen.CreateRepositoryJSONRequestBody{
 				DefaultBranch:    apiutil.Ptr("main"),
 				Name:             repo,
@@ -1571,7 +1571,7 @@ func TestController_ListBranchesHandler(t *testing.T) {
 		_, err = deps.catalog.Commit(ctx, repo, "main", "first commit", "test", nil, nil, nil, false)
 		testutil.Must(t, err)
 
-		for i := 0; i < 7; i++ {
+		for i := range 7 {
 			branchName := "main" + strconv.Itoa(i+1)
 			_, err := deps.catalog.CreateBranch(ctx, repo, branchName, "main", graveler.WithHidden(i%2 != 0))
 			testutil.MustDo(t, "create branch "+branchName, err)
@@ -1640,7 +1640,7 @@ func TestController_ListTagsHandler(t *testing.T) {
 	testutil.Must(t, err)
 	const createTagLen = 7
 	var createdTags []apigen.Ref
-	for i := 0; i < createTagLen; i++ {
+	for i := range createTagLen {
 		tagID := "tag" + strconv.Itoa(i)
 		commitID := commitLog.Reference
 		_, err := clt.CreateTagWithResponse(ctx, repo, apigen.CreateTagJSONRequestBody{
@@ -3386,7 +3386,7 @@ func TestController_ObjectsDeleteObjectHandler(t *testing.T) {
 		const namePrefix = "foo2/bar"
 		const numOfObjs = 3
 		var paths []string
-		for i := 0; i < numOfObjs; i++ {
+		for i := range numOfObjs {
 			objPath := namePrefix + strconv.Itoa(i)
 			paths = append(paths, objPath)
 			resp, err := uploadObjectHelper(t, ctx, clt, objPath, strings.NewReader(content), repo, branch)
@@ -3432,7 +3432,7 @@ func TestController_ObjectsDeleteObjectHandler(t *testing.T) {
 		const namePrefix = "foo3/bar"
 		const numOfObjs = api.DefaultMaxDeleteObjects + 1
 		var paths []string
-		for i := 0; i < numOfObjs; i++ {
+		for i := range numOfObjs {
 			paths = append(paths, namePrefix+strconv.Itoa(i))
 		}
 
@@ -3975,7 +3975,7 @@ func TestController_ListRepositoryRuns(t *testing.T) {
 	// upload and commit content on branch
 	commitIDs := []string{respCommit.JSON201.Id}
 	const contentCount = 5
-	for i := 0; i < contentCount; i++ {
+	for i := range contentCount {
 		content := fmt.Sprintf("content-%d", i)
 		uploadResp, err := uploadObjectHelper(t, ctx, clt, content, strings.NewReader(content), repo, "work")
 		verifyResponseOK(t, uploadResp, err)
@@ -4809,7 +4809,7 @@ func TestController_GetPhysicalAddress(t *testing.T) {
 
 		var prevPartitionTime time.Time
 		const links = 5
-		for i := 0; i < links; i++ {
+		for i := range links {
 			params := &apigen.GetPhysicalAddressParams{
 				Path: "get-path/obj" + strconv.Itoa(i),
 			}
@@ -4916,7 +4916,7 @@ func TestController_PrepareGarbageCollectionUncommitted(t *testing.T) {
 		_, err := deps.catalog.CreateRepository(ctx, repo, config.SingleBlockstoreID, onBlock(deps, repo), "main", false)
 		testutil.Must(t, err)
 		const items = 3
-		for i := 0; i < items; i++ {
+		for i := range items {
 			objPath := fmt.Sprintf("uncommitted/obj%d", i)
 			uploadResp, err := uploadObjectHelper(t, ctx, clt, objPath, strings.NewReader(objPath), repo, "main")
 			verifyResponseOK(t, uploadResp, err)
@@ -4929,7 +4929,7 @@ func TestController_PrepareGarbageCollectionUncommitted(t *testing.T) {
 		_, err := deps.catalog.CreateRepository(ctx, repo, config.SingleBlockstoreID, onBlock(deps, repo), "main", false)
 		testutil.Must(t, err)
 		const items = 3
-		for i := 0; i < items; i++ {
+		for i := range items {
 			objPath := fmt.Sprintf("committed/obj%d", i)
 			uploadResp, err := uploadObjectHelper(t, ctx, clt, objPath, strings.NewReader(objPath), repo, "main")
 			verifyResponseOK(t, uploadResp, err)
@@ -4945,7 +4945,7 @@ func TestController_PrepareGarbageCollectionUncommitted(t *testing.T) {
 		_, err := deps.catalog.CreateRepository(ctx, repo, config.SingleBlockstoreID, onBlock(deps, repo), "main", false)
 		testutil.Must(t, err)
 		const items = 3
-		for i := 0; i < items; i++ {
+		for i := range items {
 			objPath := fmt.Sprintf("uncommitted/obj%d", i)
 			uploadResp, err := uploadObjectHelper(t, ctx, clt, objPath, strings.NewReader(objPath), repo, "main")
 			verifyResponseOK(t, uploadResp, err)
@@ -5053,7 +5053,7 @@ func TestController_ClientDisconnect(t *testing.T) {
 		}
 
 		// process relevant metrics
-		for _, line := range strings.Split(string(body), "\n") {
+		for line := range strings.SplitSeq(string(body), "\n") {
 			if strings.HasPrefix(line, apiReqTotalMetricLabel) {
 				if count, err := strconv.Atoi(line[len(apiReqTotalMetricLabel)+1:]); err == nil {
 					clientRequestClosedCount += count
@@ -5620,7 +5620,7 @@ func TestController_DumpRestoreRepository(t *testing.T) {
 	testutil.Must(t, err)
 
 	const commits = 3
-	for i := 0; i < commits; i++ {
+	for i := range commits {
 		n := strconv.Itoa(i + 1)
 		p := "foo/bar" + n
 		err := deps.catalog.CreateEntry(ctx, repo, "main", catalog.DBEntry{Path: p, PhysicalAddress: onBlock(deps, "bar"+n+"addr"), CreationDate: time.Now(), Size: int64(i) + 1, Checksum: "cksum" + n})

--- a/pkg/auth/keys/keys.go
+++ b/pkg/auth/keys/keys.go
@@ -19,7 +19,7 @@ func KeyGenerator(length int) string {
 		if err != nil {
 			continue // let's retry until we have enough entropy
 		}
-		for i := 0; i < length; i++ {
+		for i := range length {
 			c := bbuf[i]
 			b.WriteByte(AkiaAlphabet[int(c)%len(AkiaAlphabet)])
 		}

--- a/pkg/block/blocktest/adapter.go
+++ b/pkg/block/blocktest/adapter.go
@@ -88,8 +88,8 @@ func testAdapterWalker(t *testing.T, adapter block.Adapter, storageNamespace str
 		contents        = "test_file"
 	)
 
-	for i := 0; i < filesAndFolders; i++ {
-		for j := 0; j < filesAndFolders; j++ {
+	for i := range filesAndFolders {
+		for j := range filesAndFolders {
 			_, err := adapter.Put(ctx, block.ObjectPointer{
 				StorageID:        "",
 				StorageNamespace: storageNamespace,
@@ -151,8 +151,8 @@ func testAdapterWalker(t *testing.T, adapter block.Adapter, storageNamespace str
 					prefix = testPrefix
 				}
 				expectedResults = append(expectedResults, path.Join(prefix, "folder_0.txt"))
-				for i := 0; i < filesAndFolders; i++ {
-					for j := 0; j < filesAndFolders; j++ {
+				for i := range filesAndFolders {
+					for j := range filesAndFolders {
 						expectedResults = append(expectedResults, path.Join(prefix, fmt.Sprintf("folder_%d/test_file_%d", i, j)))
 					}
 				}
@@ -160,7 +160,7 @@ func testAdapterWalker(t *testing.T, adapter block.Adapter, storageNamespace str
 				if adapter.BlockstoreType() != block.BlockstoreTypeLocal {
 					prefix = tt.prefix
 				}
-				for j := 0; j < filesAndFolders; j++ {
+				for j := range filesAndFolders {
 					expectedResults = append(expectedResults, path.Join(prefix, fmt.Sprintf("test_file_%d", j)))
 				}
 			}

--- a/pkg/block/blocktest/multipart_suite.go
+++ b/pkg/block/blocktest/multipart_suite.go
@@ -180,7 +180,7 @@ func testAdapterCopyPartRange(t *testing.T, adapter block.Adapter, storageNamesp
 func createMultipartContents(lastPartPartial bool) ([][]byte, []byte) {
 	parts := make([][]byte, multipartNumberOfParts)
 	var partsConcat []byte
-	for i := 0; i < multipartNumberOfParts; i++ {
+	for i := range multipartNumberOfParts {
 		if lastPartPartial && (i == multipartNumberOfParts-1) {
 			parts[i] = randstr.Bytes(multipartPartSize/2 + i)
 		} else {
@@ -245,7 +245,7 @@ func copyPartRange(t *testing.T, ctx context.Context, adapter block.Adapter, obj
 	t.Helper()
 	multiParts := make([]block.MultipartPart, multipartNumberOfParts)
 	var startPosition int64 = 0
-	for i := 0; i < multipartNumberOfParts; i++ {
+	for i := range multipartNumberOfParts {
 		partNumber := i + 1
 		endPosition := startPosition + multipartPartSize
 		partResp, err := adapter.UploadCopyPartRange(ctx, obj, objCopy, uploadID, partNumber, startPosition, endPosition)

--- a/pkg/block/gs/compose_test.go
+++ b/pkg/block/gs/compose_test.go
@@ -16,7 +16,7 @@ func TestComposeAll(t *testing.T) {
 		t.Run("compose_"+strconv.Itoa(numberOfParts), func(t *testing.T) {
 			// prepare data
 			parts := make([]string, numberOfParts)
-			for i := 0; i < numberOfParts; i++ {
+			for i := range numberOfParts {
 				parts[i] = fmt.Sprintf("part%d", i)
 			}
 

--- a/pkg/block/local/etag_test.go
+++ b/pkg/block/local/etag_test.go
@@ -13,8 +13,8 @@ func TestEtag(t *testing.T) {
 	var base [16]byte
 	b := base[:]
 	parts := make([]block.MultipartPart, PartsNo)
-	for i := 0; i < PartsNo; i++ {
-		for j := 0; j < len(b); j++ {
+	for i := range PartsNo {
+		for j := range b {
 			b[j] = byte(32 + i + j)
 		}
 		parts[i].PartNumber = i + 1

--- a/pkg/catalog/catalog_test.go
+++ b/pkg/catalog/catalog_test.go
@@ -751,7 +751,7 @@ func createPrepareUncommittedTestScenario(t *testing.T, repositoryID string, num
 		test.RefManager.EXPECT().GetCommit(gomock.Any(), gomock.Any(), gomock.Any()).MinTimes(1).Return(&graveler.Commit{}, nil)
 		test.CommittedManager.EXPECT().List(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).MinTimes(1).Return(cUtils.NewFakeValueIterator([]*graveler.ValueRecord{}), nil)
 	}
-	for i := 0; i < numBranches; i++ {
+	for i := range numBranches {
 		branchID := graveler.BranchID(fmt.Sprintf("branch%04d", i))
 		token := graveler.StagingToken(fmt.Sprintf("%s_st%04d", branchID, i))
 		branch := &graveler.BranchRecord{BranchID: branchID, Branch: &graveler.Branch{StagingToken: token}}
@@ -768,7 +768,7 @@ func createPrepareUncommittedTestScenario(t *testing.T, repositoryID string, num
 
 		records[i] = make([]*graveler.ValueRecord, 0, numRecords)
 		diffs[i] = make([]graveler.Diff, 0, numRecords)
-		for j := 0; j < numRecords; j++ {
+		for j := range numRecords {
 			var (
 				addressType catalog.Entry_AddressType
 				address     string
@@ -830,13 +830,13 @@ func createPrepareUncommittedTestScenario(t *testing.T, repositoryID string, num
 
 		// Add tombstone
 		records[i] = append(records[i], &graveler.ValueRecord{
-			Key:   []byte(fmt.Sprintf("%s_tombstone", branchID)),
+			Key:   []byte(branchID + "_tombstone"),
 			Value: nil,
 		})
 
 		diffs[i] = append(diffs[i], graveler.Diff{
 			Type: graveler.DiffTypeRemoved,
-			Key:  []byte(fmt.Sprintf("%s_tombstone", branchID)),
+			Key:  []byte(branchID + "_tombstone"),
 		})
 
 		// Add external address

--- a/pkg/catalog/entry_value_iterator_test.go
+++ b/pkg/catalog/entry_value_iterator_test.go
@@ -15,7 +15,7 @@ func TestNewEntryToValueIterator(t *testing.T) {
 	var entryRecords []*catalog.EntryRecord
 
 	// generate data
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		record := &catalog.EntryRecord{
 			Path:  catalog.Path(fmt.Sprintf("path%d", i)),
 			Entry: &catalog.Entry{Address: fmt.Sprintf("addr%d", i)},

--- a/pkg/catalog/testutils/testutils.go
+++ b/pkg/catalog/testutils/testutils.go
@@ -153,7 +153,7 @@ func (w *FakeWalker) createEntries(count int) {
 	// tests, safe
 	//nolint:gosec
 	randGen := rand.New(rand.NewSource(seed))
-	for i := 0; i < count; i++ {
+	for i := range count {
 		relativeKey := testutil.RandomString(randGen, randomKeyLength)
 		fullkey := w.uriPrefix + "/" + relativeKey
 		ents[i] = block.ObjectStoreEntry{

--- a/pkg/catalog/value_entry_iterator_test.go
+++ b/pkg/catalog/value_entry_iterator_test.go
@@ -13,7 +13,7 @@ func TestNewValueToEntryIterator(t *testing.T) {
 	var valueRecords []*graveler.ValueRecord
 
 	// generate data
-	for i := 0; i < 3; i++ {
+	for i := range 3 {
 		record := &EntryRecord{
 			Path:  Path(fmt.Sprintf("path%d", i)),
 			Entry: &Entry{Address: fmt.Sprintf("addr%d", i)},

--- a/pkg/fileutil/writer_reader_test.go
+++ b/pkg/fileutil/writer_reader_test.go
@@ -13,7 +13,7 @@ func TestWriterThenReader(t *testing.T) {
 	text := []byte("the quick brown fox jumps over the lazy dog. ")
 
 	const count = 100000
-	for i := 0; i < count; i++ {
+	for i := range count {
 		l, err := writer.Write(text)
 		if err != nil {
 			t.Fatalf("writing block %d: %s", i, err)
@@ -29,7 +29,7 @@ func TestWriterThenReader(t *testing.T) {
 		t.Fatalf("start reading fileWriterThenReader: %s", err)
 	}
 	t.Log("total length", length, "reader", reader)
-	for i := 0; i < count; i++ {
+	for i := range count {
 		p := make([]byte, len(text))
 		l, err := reader.Read(p)
 		if err != nil {
@@ -45,7 +45,7 @@ func TestWriterThenReader(t *testing.T) {
 	if err != nil {
 		t.Fatalf("rewind fileWriterThenReader: %s", err)
 	}
-	for i := 0; i < count; i++ {
+	for i := range count {
 		p := make([]byte, len(text))
 		l, err := reader.Read(p)
 		if err != nil {

--- a/pkg/gateway/sig/sig_test.go
+++ b/pkg/gateway/sig/sig_test.go
@@ -176,7 +176,7 @@ func TestAWSSigVerify(t *testing.T) {
 			}
 
 			r := rand.New(rand.NewSource(seed))
-			for i := 0; i < numRounds; i++ {
+			for range numRounds {
 				path := s3utils.EncodePath("my-branch/ariels/x/" + testutil.RandomString(r, pathLength))
 				bucketURL := &url.URL{
 					Scheme: "s3",

--- a/pkg/graveler/committed/batch.go
+++ b/pkg/graveler/committed/batch.go
@@ -27,7 +27,7 @@ func NewBatchCloser(numClosers int) *BatchCloser {
 	}
 
 	ret.wg.Add(numClosers)
-	for i := 0; i < numClosers; i++ {
+	for range numClosers {
 		go ret.handleClose()
 	}
 

--- a/pkg/graveler/committed/batch_test.go
+++ b/pkg/graveler/committed/batch_test.go
@@ -140,7 +140,7 @@ func runSuccessScenario(t *testing.T, numWriters, numClosers int) *committed.Bat
 	t.Helper()
 
 	writers := make([]*FakeRangeWriter, numWriters)
-	for i := 0; i < numWriters; i++ {
+	for i := range numWriters {
 		writers[i] = NewFakeRangeWriter(&committed.WriteResult{
 			RangeID: committed.ID(strconv.Itoa(i)),
 			First:   committed.Key(fmt.Sprintf("row_%d_1", i)),
@@ -151,7 +151,7 @@ func runSuccessScenario(t *testing.T, numWriters, numClosers int) *committed.Bat
 
 	sut := committed.NewBatchCloser(numClosers)
 
-	for i := 0; i < numWriters; i++ {
+	for i := range numWriters {
 		assert.NoError(t, sut.CloseWriterAsync(writers[i]))
 	}
 

--- a/pkg/graveler/delete_sensor_test.go
+++ b/pkg/graveler/delete_sensor_test.go
@@ -162,7 +162,7 @@ func TestDeletedSensor_CheckNonBlocking(t *testing.T) {
 	}
 	sensor := graveler.NewDeleteSensor(1, cb, graveler.WithCBBufferSize(1))
 	ctx := t.Context()
-	for i := 0; i < 11; i++ {
+	for range 11 {
 		select {
 		case <-closerCh:
 			t.Fatal("should not block")

--- a/pkg/graveler/graveler_test.go
+++ b/pkg/graveler/graveler_test.go
@@ -480,7 +480,7 @@ func TestGravelerSet_Advanced(t *testing.T) {
 
 	t.Run("branch token changed max retries", func(t *testing.T) {
 		// Test safeBranchWrite retries when token changed after update, reach the maximal number of retries and then succeed
-		for i := 0; i < graveler.BranchWriteMaxTries-1; i++ {
+		for i := range graveler.BranchWriteMaxTries - 1 {
 			refMgr.EXPECT().GetBranch(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(&graveler.Branch{
 				StagingToken: graveler.StagingToken("new_token_" + strconv.Itoa(i)),
 			}, nil)
@@ -503,7 +503,7 @@ func TestGravelerSet_Advanced(t *testing.T) {
 
 	t.Run("branch token changed retry exhausted", func(t *testing.T) {
 		// Test safeBranchWrite retries when token changed after update, exceed the maximal number of retries and expect fail
-		for i := 0; i < graveler.BranchWriteMaxTries; i++ {
+		for i := range graveler.BranchWriteMaxTries {
 			refMgr.EXPECT().GetBranch(gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(&graveler.Branch{
 				StagingToken: graveler.StagingToken("new_token_" + strconv.Itoa(i)),
 			}, nil)

--- a/pkg/graveler/ref/commit_generation_priority_queue_test.go
+++ b/pkg/graveler/ref/commit_generation_priority_queue_test.go
@@ -12,7 +12,7 @@ import (
 func TestCommitsGenerationPriorityQueue_Len(t *testing.T) {
 	const maxItems = 7
 	q := ref.NewCommitsGenerationPriorityQueue()
-	for i := 0; i < maxItems; i++ {
+	for i := range maxItems {
 		if q.Len() != i {
 			t.Fatalf("Queue Len=%d, expected=%d", q.Len(), i)
 		}
@@ -54,11 +54,11 @@ func TestCommitsGenerationPriorityQueue_Push(t *testing.T) {
 func TestCommitsGenerationPriorityQueue_Pop(t *testing.T) {
 	const maxItems = 7
 	q := ref.NewCommitsGenerationPriorityQueue()
-	for i := 0; i < maxItems; i++ {
+	for i := range maxItems {
 		id := graveler.CommitID(strconv.Itoa(i))
 		q.Push(&graveler.CommitRecord{CommitID: id})
 	}
-	for i := 0; i < maxItems; i++ {
+	for i := range maxItems {
 		item := q.Pop().(*graveler.CommitRecord)
 		expectedID := graveler.CommitID(strconv.Itoa(maxItems - i - 1))
 		if item.CommitID != expectedID {

--- a/pkg/graveler/ref/commit_ordered_iterator_test.go
+++ b/pkg/graveler/ref/commit_ordered_iterator_test.go
@@ -226,9 +226,9 @@ func TestOrderedCommitIteratorGrid(t *testing.T) {
 	commits := make([]*graveler.Commit, 0, 100)
 	expectedCommitIDS := make([]string, 0, 100)
 	expectedAncestryLeaves := make([]string, 0, 10)
-	for i := 0; i < 10; i++ {
+	for i := range 10 {
 		grid[i] = make([]*graveler.Commit, 10)
-		for j := 0; j < 10; j++ {
+		for j := range 10 {
 			parents := make([]graveler.CommitID, 0, 2)
 			if i > 0 {
 				parents = append(parents, graveler.CommitID(fmt.Sprintf("%d-%d", i-1, j)))

--- a/pkg/graveler/ref/resolve_ref_test.go
+++ b/pkg/graveler/ref/resolve_ref_test.go
@@ -32,7 +32,7 @@ func TestResolveRawRef(t *testing.T) {
 
 	ts, _ := time.Parse(time.RFC3339, "2020-12-01T15:00:00Z")
 	var previous graveler.CommitID
-	for i := 0; i < 20; i++ {
+	for range 20 {
 		c := graveler.Commit{
 			Committer:    "user1",
 			Message:      "message1",

--- a/pkg/graveler/sstable/range_manager_test.go
+++ b/pkg/graveler/sstable/range_manager_test.go
@@ -154,7 +154,7 @@ func TestGetWriterRangeID(t *testing.T) {
 
 	sut := sstable.NewPebbleSSTableRangeManagerWithNewReader(nil, &NoCache{}, mockFS, crypto.SHA256, config.SingleBlockstoreID)
 
-	for times := 0; times < 2; times++ {
+	for range 2 {
 		const ns = "some-ns"
 		mockFile := fsMock.NewMockStoredFile(ctrl)
 		mockFile.EXPECT().Write(gomock.Any()).DoAndReturn(func(b []byte) (int, error) {

--- a/pkg/graveler/sstable/writer_test.go
+++ b/pkg/graveler/sstable/writer_test.go
@@ -48,7 +48,7 @@ func TestWriter(t *testing.T) {
 		}).AnyTimes()
 
 	// Do the actual writing
-	for i := 0; i < writes; i++ {
+	for i := range writes {
 		err = dw.WriteRecord(committed.Record{
 			Key:   []byte(keys[i]),
 			Value: []byte("some-data"),
@@ -141,7 +141,7 @@ func TestWriterAbortAfterClose(t *testing.T) {
 
 func randomStrings(writes int) []string {
 	var keys []string
-	for i := 0; i < writes; i++ {
+	for range writes {
 		keys = append(keys, randstr.String(20, "abcdefghijklmnopqrstuvwyz0123456789"))
 	}
 	return keys

--- a/pkg/graveler/staging/manager_test.go
+++ b/pkg/graveler/staging/manager_test.go
@@ -145,10 +145,10 @@ func TestDrop(t *testing.T) {
 }
 
 func setupDrop(ctx context.Context, t *testing.T, numOfValues int, s graveler.StagingManager) {
-	for i := 0; i < numOfValues; i++ {
-		err := s.Set(ctx, "t1", []byte(fmt.Sprintf("key%04d", i)), newTestValue(fmt.Sprintf("identity%d", i), fmt.Sprintf("value%d", i)), false)
+	for i := range numOfValues {
+		err := s.Set(ctx, "t1", fmt.Appendf(nil, "key%04d", i), newTestValue(fmt.Sprintf("identity%d", i), fmt.Sprintf("value%d", i)), false)
 		testutil.Must(t, err)
-		err = s.Set(ctx, "t2", []byte(fmt.Sprintf("key%04d", i)), newTestValue(fmt.Sprintf("identity%d", i), fmt.Sprintf("value%d", i)), false)
+		err = s.Set(ctx, "t2", fmt.Appendf(nil, "key%04d", i), newTestValue(fmt.Sprintf("identity%d", i), fmt.Sprintf("value%d", i)), false)
 		testutil.Must(t, err)
 	}
 }
@@ -318,8 +318,8 @@ func TestList(t *testing.T) {
 	ctx, s := newTestStagingManager(t)
 	for _, numOfValues := range []int{1, 100, 1000, 1500, 2500} {
 		token := graveler.StagingToken(fmt.Sprintf("t_%d", numOfValues))
-		for i := 0; i < numOfValues; i++ {
-			err := s.Set(ctx, token, []byte(fmt.Sprintf("key%04d", i)), newTestValue(fmt.Sprintf("identity%d", i), fmt.Sprintf("value%d", i)), false)
+		for i := range numOfValues {
+			err := s.Set(ctx, token, fmt.Appendf(nil, "key%04d", i), newTestValue(fmt.Sprintf("identity%d", i), fmt.Sprintf("value%d", i)), false)
 			testutil.Must(t, err)
 		}
 		res := make([]*graveler.ValueRecord, 0, numOfValues)
@@ -335,7 +335,7 @@ func TestList(t *testing.T) {
 			t.Errorf("got unexpected number of results. expected=%d, got=%d", numOfValues, len(res))
 		}
 		for i, e := range res {
-			if !bytes.Equal(e.Key, []byte(fmt.Sprintf("key%04d", i))) {
+			if !bytes.Equal(e.Key, fmt.Appendf(nil, "key%04d", i)) {
 				t.Fatalf("got unexpected key from List at index %d: expected: key%04d, got: %s", i, i, string(e.Key))
 			}
 			if string(e.Data) != fmt.Sprintf("value%d", i) {
@@ -348,8 +348,8 @@ func TestList(t *testing.T) {
 func TestSeek(t *testing.T) {
 	ctx, s := newTestStagingManager(t)
 	numOfValues := 100
-	for i := 0; i < numOfValues; i++ {
-		err := s.Set(ctx, "t1", []byte(fmt.Sprintf("key%04d", i)), newTestValue("identity1", "value1"), false)
+	for i := range numOfValues {
+		err := s.Set(ctx, "t1", fmt.Appendf(nil, "key%04d", i), newTestValue("identity1", "value1"), false)
 		testutil.Must(t, err)
 	}
 	it := s.List(ctx, "t1", 0)

--- a/pkg/kv/kvtest/iterators.go
+++ b/pkg/kv/kvtest/iterators.go
@@ -88,7 +88,7 @@ func testPartitionIteratorSeekGEWithPagination(ctx context.Context, store kv.Sto
 		}
 
 		itr.SeekGE([]byte("b"))
-		for i := 0; i < MaxPageSize+1; i++ {
+		for range MaxPageSize + 1 {
 			// force pagination
 			if !itr.Next() {
 				t.Fatal("expected Next to be true")
@@ -358,7 +358,7 @@ func testSecondaryIterator(t *testing.T, ms MakeStore) {
 		{Name: []byte("d"), JustAString: "four"},
 		{Name: []byte("e"), JustAString: "five"},
 	}
-	for i := 0; i < len(m); i++ {
+	for i := range m {
 		primaryKey := append([]byte("name/"), m[i].Name...)
 		err := kv.SetMsg(ctx, store, firstPartitionKey, primaryKey, &m[i])
 		if err != nil {

--- a/pkg/kv/kvtest/store.go
+++ b/pkg/kv/kvtest/store.go
@@ -33,7 +33,7 @@ func uniqueKey(k string) []byte {
 func setupSampleData(t *testing.T, ctx context.Context, store kv.Store, partition, prefix string, items int) []kv.Entry {
 	t.Helper()
 	entries := make([]kv.Entry, 0, items)
-	for i := 0; i < items; i++ {
+	for i := range items {
 		entry := sampleEntry(prefix, i)
 		err := store.Set(ctx, []byte(partition), entry.Key, entry.Value)
 		if err != nil {
@@ -394,7 +394,7 @@ func testStoreScan(t *testing.T, ms MakeStore) {
 
 	t.Run("part", func(t *testing.T) {
 		const fromIndex = 5
-		fromKey := []byte(fmt.Sprint(string(samplePrefix), fmt.Sprintf("-key-%04d", fromIndex)))
+		fromKey := fmt.Append(nil, string(samplePrefix), fmt.Sprintf("-key-%04d", fromIndex))
 		scan, err := store.Scan(ctx, []byte(testPartitionKey), kv.ScanOptions{KeyStart: fromKey})
 		if err != nil {
 			t.Fatal("failed to scan", err)
@@ -661,7 +661,7 @@ func testScanPrefix(t *testing.T, ms MakeStore) {
 	const sampleItems = 100
 	const numberOfSets = 3
 
-	for i := 0; i < numberOfSets; i++ {
+	for range numberOfSets {
 		samplePrefix = uniqueKey("scan-prefix")
 		sampleData = setupSampleData(t, ctx, store, testPartitionKey, string(samplePrefix), sampleItems)
 

--- a/pkg/kv/postgres/store.go
+++ b/pkg/kv/postgres/store.go
@@ -191,7 +191,7 @@ func setupKeyValueDatabase(ctx context.Context, conn *pgxpool.Conn, table string
 
 	// partitions
 	partitions := getTablePartitions(table, partitionsAmount)
-	for i := 0; i < len(partitions); i++ {
+	for i := range partitions {
 		_, err = conn.Exec(ctx, `CREATE TABLE IF NOT EXISTS`+
 			pgx.Identifier{partitions[i]}.Sanitize()+` PARTITION OF `+
 			tableSanitize+` FOR VALUES WITH (MODULUS `+strconv.Itoa(partitionsAmount)+
@@ -217,7 +217,7 @@ func generateAdvisoryLockID(name string) (string, error) {
 
 func getTablePartitions(tableName string, partitionsAmount int) []string {
 	res := make([]string, 0, partitionsAmount)
-	for i := 0; i < partitionsAmount; i++ {
+	for i := range partitionsAmount {
 		res = append(res, fmt.Sprintf("%s_%d", tableName, i))
 	}
 	return res

--- a/pkg/loadtest/loader.go
+++ b/pkg/loadtest/loader.go
@@ -180,7 +180,7 @@ func progressBar(duration time.Duration) {
 	durationInSec := int(duration.Seconds())
 	progress := progressbar.NewOptions(durationInSec, progressbar.OptionSetPredictTime(false), progressbar.OptionFullWidth())
 	go func() {
-		for i := 0; i < durationInSec; i++ {
+		for range durationInSec {
 			_ = progress.Add(1)
 			time.Sleep(time.Second)
 		}

--- a/pkg/loadtest/target_generator.go
+++ b/pkg/loadtest/target_generator.go
@@ -23,7 +23,7 @@ func randomFilepath(basename string) string {
 	const maxDepthLevel = 10
 	const maxDirSuffixes = 3
 	depth := rand.Intn(maxDepthLevel) //nolint:gosec
-	for i := 0; i < depth; i++ {
+	for range depth {
 		// tests, safe
 		dirSuffix := rand.Intn(maxDirSuffixes) //nolint:gosec
 		sb.WriteString(fmt.Sprintf("dir%d/", dirSuffix))
@@ -42,7 +42,7 @@ func defaultTarget(method, url, body, typ string) vegeta.Target {
 func (t *TargetGenerator) GenerateCreateFileTargets(repo, branch string, num int) []vegeta.Target {
 	now := time.Now().UnixNano()
 	result := make([]vegeta.Target, num)
-	for i := 0; i < num; i++ {
+	for i := range num {
 		// tests, safe
 		randomContent := rand.Int() //nolint:gosec
 		fileContent := "--" + boundary + "\n" +

--- a/pkg/pyramid/directory_test.go
+++ b/pkg/pyramid/directory_test.go
@@ -21,7 +21,7 @@ func TestConcurrentCreateDeleteDir(t *testing.T) {
 	concurrency := 1000
 	pathDir := path.Join(name, "a/b/c/")
 
-	for i := 0; i < concurrency; i++ {
+	for i := range concurrency {
 		// create and delete
 		filepath := path.Join(pathDir, strconv.Itoa(i))
 		wg.Add(2)
@@ -56,7 +56,7 @@ func TestConcurrentRenameDeleteDir(t *testing.T) {
 	concurrency := 1000
 	pathDir := path.Join(name, "a/b/c/")
 
-	for i := 0; i < concurrency; i++ {
+	for i := range concurrency {
 		// create and delete
 		originalPath := path.Join(name, strconv.Itoa(i))
 		require.NoError(t, os.WriteFile(originalPath, []byte("some data"), os.ModePerm))

--- a/pkg/pyramid/tier_fs_test.go
+++ b/pkg/pyramid/tier_fs_test.go
@@ -182,7 +182,7 @@ func testEviction(t *testing.T, namespaces ...string) {
 	numFiles := 5 * allocatedDiskBytes / fileBytes
 	// write
 	content := make([]byte, fileBytes)
-	for i := 0; i < numFiles; i++ {
+	for i := range numFiles {
 		filename := "file_" + strconv.Itoa(i)
 		_, err := rand.Read(content)
 		if err != nil {
@@ -192,7 +192,7 @@ func testEviction(t *testing.T, namespaces ...string) {
 	}
 
 	// read
-	for i := 0; i < numFiles; i++ {
+	for i := range numFiles {
 		filename := "file_" + strconv.Itoa(i)
 
 		f, err := fs.Open(ctx, "", namespaces[i%len(namespaces)], filename)
@@ -230,7 +230,7 @@ func TestMultipleConcurrentReads(t *testing.T) {
 	adapter.wait = make(chan struct{})
 	var wg sync.WaitGroup
 	wg.Add(concurrencyLevel)
-	for i := 0; i < concurrencyLevel; i++ {
+	for range concurrencyLevel {
 		go func() {
 			defer wg.Done()
 			_ = checkContent(t, ctx, config.SingleBlockstoreID, namespace, filename, content)

--- a/pkg/stats/collector_test.go
+++ b/pkg/stats/collector_test.go
@@ -154,7 +154,7 @@ func TestCallHomeCollector_ExtendedHashValues(t *testing.T) {
 	sender, ticker, collector := setupTest(ctx, 0, stats.WithExtended(true))
 
 	const events = 2
-	for i := 0; i < events; i++ {
+	for range events {
 		collector.CollectEvent(stats.Event{
 			Class:      "foo",
 			Name:       "bar",
@@ -202,7 +202,7 @@ func TestCallHomeCollector_NoExtendedValues(t *testing.T) {
 	collector.Start(ctx)
 
 	const events = 2
-	for i := 0; i < events; i++ {
+	for range events {
 		collector.CollectEvent(stats.Event{
 			Class:      "foo",
 			Name:       "bar",

--- a/pkg/stats/usage_counter_test.go
+++ b/pkg/stats/usage_counter_test.go
@@ -22,7 +22,7 @@ func TestNewUsageCounter(t *testing.T) {
 		}
 	}()
 
-	for i := 0; i < totalCounters; i++ {
+	for range totalCounters {
 		c := stats.NewUsageCounter()
 		counters = append(counters, c)
 	}
@@ -94,7 +94,7 @@ func TestUsageReporter(t *testing.T) {
 	total := c1.Load() + c2.Load()
 
 	const rounds = 3 // test multiple rounds, each time incrementing the counters
-	for i := 0; i < rounds; i++ {
+	for range rounds {
 		flushTime, err := report.Flush(ctx)
 		if err != nil {
 			t.Fatal("Flush() expected no error")

--- a/pkg/upload/path_provider_test.go
+++ b/pkg/upload/path_provider_test.go
@@ -26,7 +26,7 @@ func TestPathPartitionProvider(t *testing.T) {
 			WithPathProviderTellTime(tellTime),
 		)
 
-		for i := 0; i < times; i++ {
+		for range times {
 			path1 := provider.NewPath()
 			tm = tm.Add(2 * interval)
 			path2 := provider.NewPath()
@@ -51,10 +51,10 @@ func TestPathPartitionProvider(t *testing.T) {
 			WithPathProviderTellTime(tellTime),
 		)
 
-		for i := 0; i < times; i++ {
+		for range times {
 			// first series will have the same partition
 			first := make([]string, size)
-			for n := 0; n < size; n++ {
+			for n := range size {
 				first[n] = provider.NewPath()
 			}
 			for n := 1; n < size; n++ {
@@ -67,7 +67,7 @@ func TestPathPartitionProvider(t *testing.T) {
 
 			// second series will have the same partition
 			second := make([]string, size)
-			for n := 0; n < size; n++ {
+			for n := range size {
 				second[n] = provider.NewPath()
 			}
 			for n := 1; n < size; n++ {

--- a/tools/isvalidgen/main.go
+++ b/tools/isvalidgen/main.go
@@ -72,7 +72,7 @@ func parseFlags() (*config, error) {
 	if typesArg == "" {
 		return nil, errNoTypes
 	}
-	for _, t := range strings.Split(typesArg, ",") {
+	for t := range strings.SplitSeq(typesArg, ",") {
 		name := strings.TrimSpace(t)
 		if name != "" {
 			cfg.types = append(cfg.types, name)


### PR DESCRIPTION
## Summary

Replace C-style loops with modern Go 1.22+ range syntax, improving code readability and reducing boilerplate.

## Changes

- Replace `for i := 0; i < n; i++` with `for i := range n`
- Replace unused index loops with `for range n`


Part of #9913 - split from the larger modernization PR for easier review.

Closes #9914