### PR TITLE
docs: update links to cloud registration

### DIFF
--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -26,7 +26,7 @@ With lakeFS, you can apply concepts to your data lake such as **branching** to c
 These include [branching](./quickstart/branch.md), [merging](./quickstart/commit-and-merge.md), and [rolling back changes](./quickstart/rollback.md) to data.
 
 !!! tip
-    You can use the [30-day free trial of lakeFS Cloud](https://lakefs.cloud/register) if you want to try out lakeFS without installing anything.
+    You can use the [30-day free trial of lakeFS Cloud](https://lakefs.io/cloud-registration) if you want to try out lakeFS without installing anything.
 
 ## Key lakeFS Features
 

--- a/docs/src/quickstart/index.md
+++ b/docs/src/quickstart/index.md
@@ -9,7 +9,7 @@ next: ["Launch the quickstart environment", "./launch.md.html"]
 **Welcome to lakeFS!**
 
 !!! tip
-    You can use the [30-day free trial of lakeFS Cloud](https://lakefs.cloud/register) if you want to try out lakeFS without installing anything. 
+    You can use the [30-day free trial of lakeFS Cloud](https://lakefs.io/cloud-registration) if you want to try out lakeFS without installing anything. 
 
 lakeFS provides a "Git for data" platform enabling you to implement best practices from software engineering on your data lake, including branching and merging, CI/CD, and production-like dev/test environments. 
 

--- a/docs/src/quickstart/launch.md
+++ b/docs/src/quickstart/launch.md
@@ -6,7 +6,7 @@ description: lakeFS quickstart / Run lakeFS locally pre-populated with a sample 
 # Spin up the environment
 
 !!! tip
-    If you don't want to install lakeFS locally, you can use the [30-day free trial of lakeFS Cloud](https://lakefs.cloud/register). Once you launch the free trial you will have access to the same content as this quickstart within the provided repository once you login.
+    If you don't want to install lakeFS locally, you can use the [30-day free trial of lakeFS Cloud](https://lakefs.io/cloud-registration). Once you launch the free trial you will have access to the same content as this quickstart within the provided repository once you login.
 
 install and launch lakeFS:
 


### PR DESCRIPTION
Fix cloud registration links to https://lakefs.io/cloud-registration