### PR TITLE
feat(block/gs): report pre-signed URL expiry for GCS

### DIFF
--- a/esti/lakectl_test.go
+++ b/esti/lakectl_test.go
@@ -864,7 +864,7 @@ func TestLakectlFsStat(t *testing.T) {
 		goldenFile := "lakectl_stat_default"
 		if config.PreSignSupport {
 			goldenFile = "lakectl_stat_pre_sign"
-			if config.BlockstoreType == "s3" {
+			if config.BlockstoreType == "s3" || config.BlockstoreType == "gs" {
 				goldenFile = "lakectl_stat_pre_sign_with_expiry"
 			}
 		}
@@ -893,7 +893,7 @@ func TestLakectlFsStat(t *testing.T) {
 			t.Skip("No pre-sign support for this storage")
 		}
 		goldenFile := "lakectl_stat_pre_sign"
-		if config.BlockstoreType == "s3" {
+		if config.BlockstoreType == "s3" || config.BlockstoreType == "gs" {
 			goldenFile = "lakectl_stat_pre_sign_with_expiry"
 		}
 		RunCmdAndVerifySuccessWithFile(t, Lakectl()+" fs stat --pre-sign lakefs://"+repoName+"/"+mainBranch+"/data/ro/ro_1k.1", false, goldenFile, map[string]string{

--- a/pkg/block/gs/adapter.go
+++ b/pkg/block/gs/adapter.go
@@ -260,8 +260,7 @@ func (a *Adapter) GetPreSignedURL(ctx context.Context, obj block.ObjectPointer, 
 		a.log(ctx).WithError(err).Error("error generating pre-signed URL")
 		return "", time.Time{}, err
 	}
-	// TODO(#6347): Report expiry.
-	return k, time.Time{}, nil
+	return k, opts.Expires, nil
 }
 
 func isErrNotFound(err error) bool {


### PR DESCRIPTION
Return actual expiry time from GetPreSignedURL in GCS adapter to match S3 implementation.

Part of #6347.

--- 

In GCS, it seems that the signed URL expiry is independent of credentials' expiry (compared to AWS temporary credentials), so we can just return the expiry time we set on the signed URL.
