### PR TITLE
Corrected a small typo in the action examples from the quickstart

### DIFF
--- a/docs/src/quickstart/actions-and-hooks.md
+++ b/docs/src/quickstart/actions-and-hooks.md
@@ -34,7 +34,7 @@ _Hooks_ can be either a [Lua](../howto/hooks/lua.md) script that lakeFS will exe
       - id: check_metadata
         type: lua
         properties:
-        script: |
+          script: |
             commit_message=action.commit.message
             if commit_message and #commit_message>0 then
                 print("✅ The commit message exists and is not empty: " .. commit_message)

--- a/pkg/samplerepo/assets/sample/README.md.tmpl
+++ b/pkg/samplerepo/assets/sample/README.md.tmpl
@@ -479,7 +479,7 @@ _Hooks_ can be either a Lua script that lakeFS will execute itself, an external 
     - id: check_metadata
         type: lua
         properties:
-        script: |
+          script: |
             commit_message=action.commit.message
             if commit_message and #commit_message>0 then
                 print("✅ The commit message exists and is not empty: " .. commit_message)


### PR DESCRIPTION
Closes 9932

## Change Description

### Background

See issue https://github.com/treeverse/lakeFS/issues/9932 for details

### Bug Fix

This is a typo in the quickstart documentation

### Contact Details

How can we get in touch with you if we need more info? (ex. email@example.com)
