### PR TITLE
Unity Catalog Export: Reduce likelihood  for action failure, due to race condition against databricks on table re-registration

### DIFF
--- a/pkg/actions/lua/databricks/client.go
+++ b/pkg/actions/lua/databricks/client.go
@@ -153,16 +153,16 @@ func (client *Client) RegisterExternalTable(l *lua.State) int {
 	// in case there is no error, table exists and we will delete it before creating a new one
 	if err == nil {
 		err = client.deleteTable(catalogName, schemaName, tableName)
-		if err != nil {
+		if err != nil && !strings.Contains(err.Error(), "does not exist") {
 			lua.Errorf(l, "%s", err.Error())
 			panic("unreachable")
 		}
 	}
 
 	bo := backoff.NewExponentialBackOff(
-		backoff.WithInitialInterval(100*time.Millisecond),
+		backoff.WithInitialInterval(500*time.Millisecond),
 		backoff.WithMaxInterval(3*time.Second),
-		backoff.WithMaxElapsedTime(10*time.Second),
+		backoff.WithMaxElapsedTime(100*time.Second),
 	)
 	status, err := backoff.RetryWithData(func() (string, error) {
 		status, err := client.createExternalTable(warehouseID, catalogName, schemaName, tableName, location, metadataMap)


### PR DESCRIPTION
Closes https://github.com/treeverse/product/issues/1030

This PR tries to resolve two unwanted behaviors;

For each export to an existing table, two `create table` calls were made (first fails as the table exists) resulting in excessive unwanted error logs in databricks. 

We try to overcome this be checking whether the table exists first and remove it if so.

The second issue is inconsistency in case of re-registration of a table - after successfully deleting a table and trying to create a new one, databricks returns an answer that the table already exists.  
lakeFS action logs show 
```Error: action failed: runtime error: [string "lua"]:60: external table "intervaldata" creation failed: FAILED: BAD_REQUEST [TABLE_OR_VIEW_ALREADY_EXISTS] Cannot create table or view `prod_datahub`.`ami`.`intervaldata` because it already exists.```

which means the client had to fail [here](https://github.com/treeverse/lakeFS/blob/master/pkg/actions/lua/databricks/client.go#L152) after already deleting the table.
