### PR TITLE
Enable GC Spark Job prepare commit timeout configuration

### DIFF
--- a/clients/spark/src/main/scala/io/treeverse/clients/ApiClient.scala
+++ b/clients/spark/src/main/scala/io/treeverse/clients/ApiClient.scala
@@ -205,12 +205,12 @@ class ApiClient private (conf: APIConfigurations) {
   def prepareGarbageCollectionCommits(
       repoName: String
   ): GarbageCollectionPrepareResponse = {
-    prepareGarbageCollectionCommits(repoName, timeoutMinutes = 20)
+    prepareGarbageCollectionCommits(repoName, timeoutSeconds = 1200)
   }
 
   def prepareGarbageCollectionCommits(
       repoName: String,
-      timeoutMinutes: Int
+      timeoutSeconds: Int
   ): GarbageCollectionPrepareResponse = {
     // Try async API first, fallback to blocking API on server internal error
     try {
@@ -225,7 +225,7 @@ class ApiClient private (conf: APIConfigurations) {
 
       // Poll for completion with exponential backoff
       val startTime = System.currentTimeMillis()
-      val timeoutMs = timeoutMinutes * 60 * 1000L
+      val timeoutMs = timeoutSeconds * 1000L
       var backoffMs = 500L
       val maxBackoffMs = 15000L
 
@@ -234,7 +234,7 @@ class ApiClient private (conf: APIConfigurations) {
         val elapsed = System.currentTimeMillis() - startTime
         if (elapsed >= timeoutMs) {
           throw new RuntimeException(
-            s"prepareGarbageCollectionCommits timed out after ${timeoutMinutes} minutes (task_id: $taskId)"
+            s"prepareGarbageCollectionCommits timed out after ${timeoutSeconds} seconds (task_id: $taskId)"
           )
         }
 

--- a/clients/spark/src/main/scala/io/treeverse/clients/LakeFSContext.scala
+++ b/clients/spark/src/main/scala/io/treeverse/clients/LakeFSContext.scala
@@ -85,7 +85,7 @@ object LakeFSContext {
   val LAKEFS_CONF_GC_APPROX_NUM_RANGES_PER_PARTITION =
     "lakefs.gc.address.approx_num_ranges_to_spread_per_partition"
   val LAKEFS_CONF_GC_WRITE_EXPIRED_AS_TEXT = "lakefs.gc.address.write_as_text"
-  val LAKEFS_CONF_GC_PREPARE_COMMITS_TIMEOUT_MINUTES = "lakefs.gc.prepare_commits.timeout_minutes"
+  val LAKEFS_CONF_GC_PREPARE_COMMITS_TIMEOUT_SECONDS = "lakefs.gc.prepare_commits.timeout_seconds"
   val LAKEFS_CONF_DEBUG_GC_MAX_COMMIT_ISO_DATETIME_KEY = "lakefs.debug.gc.max_commit_iso_datetime"
   val LAKEFS_CONF_DEBUG_GC_MAX_COMMIT_EPOCH_SECONDS_KEY = "lakefs.debug.gc.max_commit_epoch_seconds"
   val LAKEFS_CONF_DEBUG_GC_REPRODUCE_RUN_ID_KEY = "lakefs.debug.gc.reproduce_run_id"
@@ -116,7 +116,7 @@ object LakeFSContext {
   val DEFAULT_GC_UNCOMMITTED_MIN_AGE_SECONDS = 6 * 60 * 60
   val DEFAULT_LAKEFS_CONF_GC_S3_MIN_BACKOFF_SECONDS = 1
   val DEFAULT_LAKEFS_CONF_GC_S3_MAX_BACKOFF_SECONDS = 120
-  val DEFAULT_LAKEFS_CONF_GC_PREPARE_COMMITS_TIMEOUT_MINUTES = 20
+  val DEFAULT_LAKEFS_CONF_GC_PREPARE_COMMITS_TIMEOUT_SECONDS = 1200
 
   val metarangeReaderGetter = SSTableReader.forMetaRange _
 

--- a/clients/spark/src/main/scala/io/treeverse/gc/ActiveCommitsAddressLister.scala
+++ b/clients/spark/src/main/scala/io/treeverse/gc/ActiveCommitsAddressLister.scala
@@ -14,7 +14,7 @@ class ActiveCommitsAddressLister(
     val apiClient: ApiClient,
     val repoName: String,
     val storageType: String,
-    val prepareCommitsTimeoutMinutes: Int
+    val prepareCommitsTimeoutSeconds: Int
 ) extends CommittedAddressLister {
 
   override def listCommittedAddresses(
@@ -24,7 +24,7 @@ class ActiveCommitsAddressLister(
   ): DataFrame = {
     val prepareResult =
       try {
-        apiClient.prepareGarbageCollectionCommits(repoName, prepareCommitsTimeoutMinutes)
+        apiClient.prepareGarbageCollectionCommits(repoName, prepareCommitsTimeoutSeconds)
       } catch {
         case e: ApiException =>
           if (e.getCode == HttpStatus.SC_NOT_FOUND) {

--- a/clients/spark/src/main/scala/io/treeverse/gc/GarbageCollection.scala
+++ b/clients/spark/src/main/scala/io/treeverse/gc/GarbageCollection.scala
@@ -187,9 +187,9 @@ object GarbageCollection {
         // Process committed
         val clientStorageNamespace =
           apiClient.getStorageNamespace(repo, StorageClientType.SDKClient)
-        val prepareCommitsTimeoutMinutes = hc.getInt(
-          LAKEFS_CONF_GC_PREPARE_COMMITS_TIMEOUT_MINUTES,
-          DEFAULT_LAKEFS_CONF_GC_PREPARE_COMMITS_TIMEOUT_MINUTES
+        val prepareCommitsTimeoutSeconds = hc.getInt(
+          LAKEFS_CONF_GC_PREPARE_COMMITS_TIMEOUT_SECONDS,
+          DEFAULT_LAKEFS_CONF_GC_PREPARE_COMMITS_TIMEOUT_SECONDS
         )
         val committedLister =
           if (uncommittedOnly) new NaiveCommittedAddressLister()
@@ -197,7 +197,7 @@ object GarbageCollection {
             new ActiveCommitsAddressLister(apiClient,
                                            repo,
                                            storageType,
-                                           prepareCommitsTimeoutMinutes
+                                           prepareCommitsTimeoutSeconds
                                           )
         val committedDF =
           committedLister.listCommittedAddresses(spark, storageNamespace, clientStorageNamespace)

--- a/clients/spark/src/test/scala/io/treeverse/clients/ApiClientSpec.scala
+++ b/clients/spark/src/test/scala/io/treeverse/clients/ApiClientSpec.scala
@@ -105,7 +105,7 @@ class ApiClientSpec extends AnyFunSpec with Matchers with MockitoSugar {
       apiClient.setInternalApiForTesting(mockInternalApi)
 
       // Call the method - it should fallback to sync API
-      val result = apiClient.prepareGarbageCollectionCommits(repoName, timeoutMinutes = 1)
+      val result = apiClient.prepareGarbageCollectionCommits(repoName, timeoutSeconds = 60)
 
       // Verify async API was called first (may be retried by retry wrapper)
       Mockito.verify(mockInternalApi, Mockito.atLeastOnce()).prepareGarbageCollectionCommitsAsync(repoName)
@@ -150,7 +150,7 @@ class ApiClientSpec extends AnyFunSpec with Matchers with MockitoSugar {
       apiClient.setInternalApiForTesting(mockInternalApi)
 
       // Call the method
-      val response = apiClient.prepareGarbageCollectionCommits(repoName, timeoutMinutes = 1)
+      val response = apiClient.prepareGarbageCollectionCommits(repoName, timeoutSeconds = 60)
 
       // Verify async API was called
       Mockito.verify(mockInternalApi, Mockito.times(1)).prepareGarbageCollectionCommitsAsync(repoName)
@@ -183,7 +183,7 @@ class ApiClientSpec extends AnyFunSpec with Matchers with MockitoSugar {
 
       // Call the method - it should throw the exception without fallback
       val thrown = intercept[ApiException] {
-        apiClient.prepareGarbageCollectionCommits(repoName, timeoutMinutes = 1)
+        apiClient.prepareGarbageCollectionCommits(repoName, timeoutSeconds = 60)
       }
 
       thrown.getCode should be(HttpStatus.SC_NOT_FOUND)

--- a/clients/spark/src/test/scala/io/treeverse/gc/ActiveCommitsAddressListerSpec.scala
+++ b/clients/spark/src/test/scala/io/treeverse/gc/ActiveCommitsAddressListerSpec.scala
@@ -51,7 +51,7 @@ class ActiveCommitsAddressListerSpec
             spark.sparkContext.hadoopConfiguration.set("lakefs.api.access_key", "test-access-key")
             spark.sparkContext.hadoopConfiguration.set("lakefs.api.secret_key", "test-secret-key")
 
-            val lister = new ActiveCommitsAddressLister(mockClient, repo, storageType, LakeFSContext.DEFAULT_LAKEFS_CONF_GC_PREPARE_COMMITS_TIMEOUT_MINUTES)
+            val lister = new ActiveCommitsAddressLister(mockClient, repo, storageType, LakeFSContext.DEFAULT_LAKEFS_CONF_GC_PREPARE_COMMITS_TIMEOUT_SECONDS)
             val result = lister.listCommittedAddresses(
               spark,
               "s3://test-bucket/storage/",
@@ -91,7 +91,7 @@ class ActiveCommitsAddressListerSpec
           spark.sparkContext.hadoopConfiguration.set("lakefs.api.access_key", "test-access-key")
           spark.sparkContext.hadoopConfiguration.set("lakefs.api.secret_key", "test-secret-key")
 
-            val lister = new ActiveCommitsAddressLister(mockClient, repo, storageType, LakeFSContext.DEFAULT_LAKEFS_CONF_GC_PREPARE_COMMITS_TIMEOUT_MINUTES)
+            val lister = new ActiveCommitsAddressLister(mockClient, repo, storageType, LakeFSContext.DEFAULT_LAKEFS_CONF_GC_PREPARE_COMMITS_TIMEOUT_SECONDS)
             // Should not throw, but fallback to naive lister
             val result = lister.listCommittedAddresses(
               spark,
@@ -128,7 +128,7 @@ class ActiveCommitsAddressListerSpec
           spark.sparkContext.hadoopConfiguration.set("lakefs.api.access_key", "test-access-key")
           spark.sparkContext.hadoopConfiguration.set("lakefs.api.secret_key", "test-secret-key")
 
-          val lister = new ActiveCommitsAddressLister(mockClient, repo, storageType, LakeFSContext.DEFAULT_LAKEFS_CONF_GC_PREPARE_COMMITS_TIMEOUT_MINUTES)
+          val lister = new ActiveCommitsAddressLister(mockClient, repo, storageType, LakeFSContext.DEFAULT_LAKEFS_CONF_GC_PREPARE_COMMITS_TIMEOUT_SECONDS)
           val thrown = intercept[ApiException] {
             lister.listCommittedAddresses(
               spark,


### PR DESCRIPTION
Enable configurable prepare commits timeout (default 20min) by settings .

Close: #9950