### PR TITLE
Fix WebUI object list sorting to use lexicographic order (#9942)

### DIFF
--- a/webui/src/lib/components/repository/mergeResults.ts
+++ b/webui/src/lib/components/repository/mergeResults.ts
@@ -1,5 +1,6 @@
 import { last } from 'lodash';
 import { ChangesData, DiffType, Entry, EntryWithDiff } from './types';
+import { compareLexicographically } from '../../utils';
 
 /**
  * Merges object listing results with changes data to highlight modified/added/removed items.
@@ -16,7 +17,7 @@ export function mergeResults(
 ): EntryWithDiff[] {
     if (showChangesOnly || !results || !changesData?.results) {
         // Ensure regular results are also sorted lexicographically
-        return results?.sort((a, b) => a.path.localeCompare(b.path)) ?? [];
+        return results?.sort((a, b) => compareLexicographically(a.path, b.path)) ?? [];
     }
 
     const changesMap = new Map<string, DiffType>();
@@ -83,5 +84,5 @@ export function mergeResults(
     ];
 
     // Sort to maintain proper order
-    return allResults?.sort((a, b) => a.path.localeCompare(b.path)) ?? [];
+    return allResults?.sort((a, b) => compareLexicographically(a.path, b.path)) ?? [];
 }

--- a/webui/src/lib/utils.ts
+++ b/webui/src/lib/utils.ts
@@ -41,3 +41,13 @@ export const normalizeNext = (raw?: string | null) => {
         return ROUTES.REPOSITORIES;
     }
 };
+
+/**
+ * Compares two strings lexicographically (by byte/ASCII order).
+ * Use this instead of localeCompare to ensure consistent ordering across locales.
+ */
+export const compareLexicographically = (a: string, b: string): number => {
+    if (a < b) return -1;
+    if (a > b) return 1;
+    return 0;
+};

--- a/webui/src/pages/repositories/repository/objects.jsx
+++ b/webui/src/pages/repositories/repository/objects.jsx
@@ -1,4 +1,5 @@
 import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { compareLexicographically } from '../../../lib/utils';
 import dayjs from 'dayjs';
 import { useOutletContext } from 'react-router-dom';
 import {
@@ -92,7 +93,9 @@ export async function appendMoreResults(resultsState, prefix, lastSeenPath, setL
 
     const { results, pagination } = await getMore();
     // Ensure concatenated results maintain lexicographic order
-    const concatenatedResults = resultsFiltered.concat(results).sort((a, b) => a.path.localeCompare(b.path));
+    const concatenatedResults = resultsFiltered
+        .concat(results)
+        .sort((a, b) => compareLexicographically(a.path, b.path));
     setResultsState({ prefix: prefix, results: concatenatedResults, pagination: pagination });
     return { results: resultsState.results, pagination: pagination };
 }
@@ -1012,7 +1015,7 @@ const TreeContainer = ({
     if (showChangesOnly) {
         const rawChangesResults = resultsState.results.length > 0 ? resultsState.results : results || [];
         // Always sort changes lexicographically to maintain consistent ordering
-        const changesResults = rawChangesResults.sort((a, b) => a.path.localeCompare(b.path));
+        const changesResults = rawChangesResults.sort((a, b) => compareLexicographically(a.path, b.path));
 
         if (changesResults.length === 0) {
             return <EmptyChangesState repo={repo} reference={reference} toggleShowChanges={toggleShowChangesOnly} />;


### PR DESCRIPTION
Closes #9942 

## Change Description

### Background

The WebUI Objects view was using localeCompare to sort object paths, which applies locale-aware collation rules instead of strict lexicographic ordering. This caused inconsistent ordering across different user envs.

### Bug Fix

1. Problem - Object paths in WebUI were sorted differently depending on the users locale settings.
2. Root cause - used `localeCompare` for sorting
3. Solution - Created a `compareLexicographically()` util function and replaced all `localeCompare` calls with this util function.
      
### Contact Details

18shshin@gmail.com
