### PR TITLE
esti: accept http scheme for presign URL to allow testing on self-hosted S3 compatible storage

### DIFF
--- a/esti/lakectl_util.go
+++ b/esti/lakectl_util.go
@@ -36,7 +36,7 @@ var (
 	reEndpoint        = regexp.MustCompile(`https?://\w+(:\d+)?/api/v\d+/`)
 	rePhysicalAddress = regexp.MustCompile(`/data/[0-9a-v]{20}/(?:[0-9a-v]{20}(?:,.+)?)?`)
 	reVariable        = regexp.MustCompile(`\$\{([^${}]+)}`)
-	rePreSignURL      = regexp.MustCompile(`https://\S+\?\S+`)
+	rePreSignURL      = regexp.MustCompile(`https?://\S+\?\S+`)
 	reSecretAccessKey = regexp.MustCompile(`secret_access_key: \S{16,128}`)
 	reAccessKeyID     = regexp.MustCompile(`access_key_id: AKIA\S{12,124}`)
 )


### PR DESCRIPTION
I am now running esti tests locally with MinIO which runs in less than 2 minutes, as opposed to 10+ minutes required to run in actual AWS S3 tests.

I had to skip `TestDeltaCatalog|TestLakectlImport|TestImport$|TestCopyObject` because they depend on some AWS S3 buckets. ~~Also, `TestMultipartUpload` fails for me which I have not yet investigated.~~

EDIT: `TestMultipartUpload` seems to pass when running isolated.



