### PR TITLE
test(block/gs): run pre-signed URL test with fake-gcs-server

### DIFF
--- a/pkg/block/blocktest/adapter.go
+++ b/pkg/block/blocktest/adapter.go
@@ -230,10 +230,6 @@ func getPresignedURLBasicTest(t *testing.T, adapter block.Adapter, storageNamesp
 	if errors.Is(err, block.ErrOperationNotSupported) {
 		t.Skip("GetPreSignedURL not supported")
 	}
-	// Google storage returns an error if no credentials are found, and we can't sign the URL
-	if err != nil && strings.Contains(err.Error(), "no credentials found") {
-		t.Skip("GetPreSignedURL no credentials found")
-	}
 	require.NoError(t, err)
 	return preSignedURL, &exp
 }

--- a/pkg/block/gs/adapter_test.go
+++ b/pkg/block/gs/adapter_test.go
@@ -16,8 +16,42 @@ import (
 	"github.com/treeverse/lakefs/pkg/config"
 )
 
-func newAdapter() *gs.Adapter {
-	return gs.NewAdapter(client)
+// testGoogleAccessID is a fake Google Access ID used for testing signed URLs
+const testGoogleAccessID = "fake@test-project.iam.gserviceaccount.com"
+
+// testPrivateKey is a PEM-encoded RSA private key for testing signed URLs with fake-gcs-server.
+// This is a test-only key generated with: `openssl genrsa 2048`
+var testPrivateKey = []byte(`-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQC0LBKd6cf913PB
+GIsh9qfrBT2limGijI8ctSQCH7CrbEjCGI4gtyUhgxKaFMV9hKeAAca9Kilck+xH
+rjBM2kjzTHlkVgWa3TNy3VM2v26DsK9Q8v6p2enMLE6ofqWTyyNaaSDXuXVfNKGg
+vzahyIUp7kZG1f8HKuBIybZk74gTCubYF4wNZQ/asJuq+o7QGTQpK6v4SfdQtwxM
+6w0bRDc737M7WJLNn0r2dF4hOytQW7cO9vX02GrW94P3j+N5tT2ktrULo4XQxTZO
+uA6DawWGRg2jf1hsZ2aiOJdUU71FBx9iU7Z9tL4QyB29TOPxi4OugK3NMWlMhv/G
+93/feUHRAgMBAAECggEAB3KWcEC2ilhJJ0YEKKVf49EZxHbjyg1gyY/1zaDWeQGP
+AOH1DGZnAnt+7c+rvwsNmvbyf9rcg+sz7khwTpmhKsMiS0rbLLTV1dAkX/waCFd0
+fxu/pJEBecsqPbYNfV5dZzUhsnUkDvP3oJPNi/K5tBs5ZwpybNm21MoXcBTu2qhB
+RvQ3IvhcQj2PUfPw9S7kx5bCtW9aLcn5u7ySv6WNRBPbaEiMQhCEpFNQuG9w3keR
+tJiQUzgvUZlutnyczMU+EZchmSHMUQMyE6ah+QStiyyUtOC1vtV95ZvLboEc6NJk
+sPmx8ESugdj3Tx8PSciRD5T4C2RmktVJpxYaGEHauQKBgQDysPnIHEPsV7OjviZu
+UfblYWGiWol/MRHj8/TKIGYU/Ss1qXMsICLudq/sghBmYA0h6vN1i44RR1w1HtOU
+8urv7u90CCFigfu28UzPl2ajTkLbbg9wQwQ6qundcMSScSVEu9xRUrVkJToy5zuM
+itl5yOSavusdOvWwZlFaqiTQeQKBgQC+DWvaE4z+reVPghVyD4Ob76DW81eGoq0Y
+6JIMKnZqETVNEzWjWcsPF5dE747gmxtapHRvQrjrz0hfNttQgp7VcPbyLVx6MXrK
+qL/wqLpZpCx8yJ5MQUHe6a+DJGSJeFH1nEZ2Bw6aOjoOD2GvdPp6flDytwrDMXZM
+9cVbIwqWGQKBgQDn/jVIDX0AmHWouUSTgNa7PvPN9y4o4AdyGOqPrZjnx3teuLTY
+IYBC5EIXm92Bf6AOJELGwrjz23tRbD5lzDC5W3abPIptWEP/BXufleMPiOhwSi2H
+6whH7MnSXNIMCwzNP6fENYQgT1XrAw/xsWli+Z9OLeMi9hGWprhuKuc2QQKBgQCM
+RnO4fn2u7MM4MBeMHI9TZUcd4HZV1XRV0jMZ761/FDx3KxqH+xq5hPwN0ZNvjIxg
+Fsop5OGAi3orbN3rSr3ZZIugrIJ5XlP3iR5CjwccauS7JYhRWEk6MtlsvkvGe5xi
+4HnRW9wXUarP/eJoErtd9iXhP+EduUBMBYspfW+u4QKBgF/kF/fucq2QkMCpDf+H
+ITIxEup3Tg81lZAbtnZpfTU7TcPvgBRLWtg3gEKJfTIGL79hl7lPhdqUG9w5egl8
+KOGyY30wiwFQ4Lu1MX+BZTKgQG9FVDtOQ43JQOLCbYdcYeKU9tJi7FUgvZmdZRaL
+sGXLHjxoneUJGohAIXVzlIGW
+-----END PRIVATE KEY-----`)
+
+func newAdapter(opts ...gs.AdapterOption) *gs.Adapter {
+	return gs.NewAdapter(client, opts...)
 }
 
 func TestAdapter(t *testing.T) {
@@ -28,7 +62,10 @@ func TestAdapter(t *testing.T) {
 	externalPath, err := url.JoinPath(basePath, "external")
 	require.NoError(t, err)
 
-	adapter := newAdapter()
+	adapter := newAdapter(
+		gs.WithNowFactory(blocktest.NowMockDefault),
+		gs.WithPresignedCredentials(testGoogleAccessID, testPrivateKey),
+	)
 	defer func() {
 		require.NoError(t, adapter.Close())
 	}()


### PR DESCRIPTION
Closes #6347

## Change Description

### Background

This PR enables pre-signed URL tests to run with `fake-gcs-server`. Previously, these tests were skipped when no credentials were set.

To make this work, explicit signing credentials (`GoogleAccessID` and `PrivateKey`) are passed to the adapter. This workaround is necessary because:

1. `fake-gcs-server` doesn't validate signatures ([fsouza/fake-gcs-server#381](https://github.com/fsouza/fake-gcs-server/issues/381#issuecomment-749837018))
2. However, [Google's SDK requires either credentials or explicit `PrivateKey` and `GoogleAccessID`](https://github.com/googleapis/google-cloud-go/blob/31c352bd672637813ec251c2f48ad1c38ea13922/storage/bucket.go#L190-L192) to sign URLs.
3. There's an open feature request to support emulators, but this likely can't be resolved without a private key for local signing.
   https://github.com/googleapis/google-cloud-go/issues/8634

Also adds `nowFactory` injection for deterministic tests, following the same pattern used in the Azure adapter.

### Alternatives considered

- **Separate credentials for signing only**: This approach works (similar to [fsspec/gcsfs#613](https://github.com/fsspec/gcsfs/pull/613)), but would require creating two different clients which complicates things even more.
- **Setting credentials only for signed URL tests**: Some APIs end up hitting the original endpoint to fetch tokens and fail.

I'm happy to close this if the workaround feels too complicated.

### Testing Details

Pre-signed URL tests now run with `fake-gcs-server` instead of being skipped.

### Breaking Change?

No. The changes only affect test configurations.

## Additional info

### Related:
- https://github.com/treeverse/lakeFS/issues/6347
- https://github.com/treeverse/lakeFS/pull/9927
