### PR TITLE
Copy logging fields to background task context

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -2253,6 +2253,7 @@ func (c *Catalog) RunBackgroundTaskSteps(ctx context.Context, repository *gravel
 	taskCtx := context.Background()
 	taskCtx = httputil.CopyRequestIDFromContext(ctx, taskCtx)
 	taskCtx = auth.CopyUserFromContext(ctx, taskCtx)
+	taskCtx = logging.CopyFieldsFromContext(ctx, taskCtx)
 
 	cancelCtx, cancel := context.WithCancel(taskCtx)
 	go c.runTaskHeartbeat(cancelCtx, repository, taskID, proto.Clone(taskStatus))

--- a/pkg/logging/logger.go
+++ b/pkg/logging/logger.go
@@ -445,3 +445,11 @@ func AddFields(ctx context.Context, fields Fields) context.Context {
 	maps.Copy(loggerFields, fields)
 	return context.WithValue(ctx, LogFieldsContextKey, loggerFields)
 }
+
+// CopyFieldsFromContext copies logging fields from srcCtx to dstCtx.
+func CopyFieldsFromContext(srcCtx, dstCtx context.Context) context.Context {
+	if fields := GetFieldsFromContext(srcCtx); fields != nil {
+		return context.WithValue(dstCtx, LogFieldsContextKey, fields)
+	}
+	return dstCtx
+}


### PR DESCRIPTION
logging.FromContext uses a separate context key (LogFieldsContextKey) to retrieve _all_ logging fields - this is separate from the Request-ID which was already copied.

🤖 Generated (and _bug found_) with [Claude Code](https://claude.com/claude-code)
