### PR TITLE
Trace all lakeFS API and gateway tasks

### DIFF
--- a/pkg/api/tmpl/chi-middleware.tmpl
+++ b/pkg/api/tmpl/chi-middleware.tmpl
@@ -12,7 +12,8 @@ type MiddlewareFunc func(http.HandlerFunc) http.HandlerFunc
 
 // {{$opid}} operation middleware
 func (siw *ServerInterfaceWrapper) {{$opid}}(w http.ResponseWriter, r *http.Request) {
-  ctx := r.Context()
+  ctx, task := trace.NewTask(r.Context(), "api:{{$opid}}")
+  defer task.End()
   {{if or .RequiresParamObject (gt (len .PathParams) 0) }}
   var err error
   {{end}}

--- a/pkg/gateway/handler.go
+++ b/pkg/gateway/handler.go
@@ -6,6 +6,7 @@ import (
 	gohttputil "net/http/httputil"
 	"net/url"
 	"regexp"
+	"runtime/trace"
 	"slices"
 	"strings"
 
@@ -143,6 +144,9 @@ func (h *handler) ServeHTTP(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 	usageCounter.Add(1)
+	ctx, task := trace.NewTask(req.Context(), "s3:"+string(o.OperationID))
+	defer task.End()
+	req = req.WithContext(ctx)
 	operationHandler.ServeHTTP(w, req)
 }
 


### PR DESCRIPTION
Start golang runtime/trace tasks for all API calls.  This improve observability - particularly once we add more "regions".
