### PR TITLE
fix(cmd/lakectl): fix repo create-bare command example in source

### DIFF
--- a/cmd/lakectl/cmd/repo_create_bare.go
+++ b/cmd/lakectl/cmd/repo_create_bare.go
@@ -12,7 +12,7 @@ import (
 var repoCreateBareCmd = &cobra.Command{
 	Use:               "create-bare <repository URI> <storage namespace>",
 	Short:             "Create a new repository with no initial branch or commit",
-	Example:           "lakectl create-bare " + myRepoExample + " " + myBucketExample,
+	Example:           "lakectl repo create-bare " + myRepoExample + " " + myBucketExample,
 	Hidden:            true,
 	Args:              cobra.ExactArgs(repoCreateCmdArgs),
 	ValidArgsFunction: ValidArgsRepository,


### PR DESCRIPTION
`cli.md` was updated in #10003, but I did not notice that the source also needed to be updated. This commit ensures consistency between the source code and the generated documentation.

Kudos to @arielshaqed for noticing this!