### PR TITLE
fix(Makefile): update validate-reference to check correct generated docs path

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -241,7 +241,7 @@ validate-wrapgen-testcode: gen-code
 	git diff --quiet -- ./tools/wrapgen/testcode || (echo "Modification verification failed! tools/wrapgen/testcode"; false)
 
 validate-reference:
-	git diff --quiet -- docs/reference/cli.md || (echo "Modification verification failed! docs/reference/cli.md"; false)
+	git diff --quiet -- docs/src/reference/cli.md || (echo "Modification verification failed! docs/src/reference/cli.md"; false)
 
 validate-client-python: validate-python-sdk
 


### PR DESCRIPTION
The `validate-reference` target was checking `docs/reference/cli.md`, but the auto-generated documentation is at `docs/src/reference/cli.md`. This path inconsistency meant the validation would not catch cases where the generated documentation was out of sync with the source code in `cmd/lakectl/`.

https://github.com/treeverse/lakeFS/blob/284660b48ebfb729826a79aa49a6f5c21c8d7cd6/Makefile#L84-L85

This fix ensures that CI validation properly detects when `make gen` needs to be run to regenerate the CLI documentation.

See #10003 where the generated docs were edited directly, and #10022 which correctly fixed the source code. This validation fix would have caught the issue in #10003 by failing CI until `make gen` was run.

The reference path was changed in https://github.com/treeverse/lakeFS/pull/9163 where we moved from jekyll to mkdocs and this target wasn't updated. 

