### PR TITLE
Update webui dependencies

### DIFF
--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -2162,9 +2162,10 @@
       }
     },
     "node_modules/@remix-run/router": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.13.1.tgz",
-      "integrity": "sha512-so+DHzZKsoOcoXrILB4rqDkMDy7NLMErRdOxvzvOKb507YINKUP4Di+shbTZDhSE/pBZ+vr7XGIpcOO0VLSA+Q==",
+      "version": "1.23.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
+      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
+      "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
@@ -5490,9 +5491,10 @@
       }
     },
     "node_modules/diff": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
-      "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+      "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A==",
+      "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
       }
@@ -14971,11 +14973,12 @@
       }
     },
     "node_modules/react-router": {
-      "version": "6.20.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.20.1.tgz",
-      "integrity": "sha512-ccvLrB4QeT5DlaxSFFYi/KR8UMQ4fcD8zBcR71Zp1kaYTC5oJKYAp1cbavzGrogwxca+ubjkd7XjFZKBW8CxPA==",
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
+      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
+      "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.13.1"
+        "@remix-run/router": "1.23.2"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -14985,12 +14988,13 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "6.20.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.20.1.tgz",
-      "integrity": "sha512-npzfPWcxfQN35psS7rJgi/EW0Gx6EsNjfdJSAk73U/HqMEJZ2k/8puxfwHFgDQhBGmS3+sjnGbMdMSV45axPQw==",
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
+      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
+      "license": "MIT",
       "dependencies": {
-        "@remix-run/router": "1.13.1",
-        "react-router": "6.20.1"
+        "@remix-run/router": "1.23.2",
+        "react-router": "6.30.3"
       },
       "engines": {
         "node": ">=14.0.0"
@@ -19694,9 +19698,9 @@
       "requires": {}
     },
     "@remix-run/router": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.13.1.tgz",
-      "integrity": "sha512-so+DHzZKsoOcoXrILB4rqDkMDy7NLMErRdOxvzvOKb507YINKUP4Di+shbTZDhSE/pBZ+vr7XGIpcOO0VLSA+Q=="
+      "version": "1.23.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
+      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w=="
     },
     "@restart/hooks": {
       "version": "0.4.11",
@@ -22010,9 +22014,9 @@
       }
     },
     "diff": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/diff/-/diff-5.1.0.tgz",
-      "integrity": "sha512-D+mk+qE8VC/PAUrlAU34N+VfXev0ghe5ywmpqrawphmVZc1bEfn56uo9qpyGp1p4xpzOHkSW4ztBd6L7Xx4ACw=="
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-5.2.2.tgz",
+      "integrity": "sha512-vtcDfH3TOjP8UekytvnHH1o1P4FcUdt4eQ1Y+Abap1tk/OB2MWQvcwS2ClCd1zuIhc3JKOx6p3kod8Vfys3E+A=="
     },
     "dir-glob": {
       "version": "3.0.1",
@@ -28179,20 +28183,20 @@
       "dev": true
     },
     "react-router": {
-      "version": "6.20.1",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.20.1.tgz",
-      "integrity": "sha512-ccvLrB4QeT5DlaxSFFYi/KR8UMQ4fcD8zBcR71Zp1kaYTC5oJKYAp1cbavzGrogwxca+ubjkd7XjFZKBW8CxPA==",
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
+      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
       "requires": {
-        "@remix-run/router": "1.13.1"
+        "@remix-run/router": "1.23.2"
       }
     },
     "react-router-dom": {
-      "version": "6.20.1",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.20.1.tgz",
-      "integrity": "sha512-npzfPWcxfQN35psS7rJgi/EW0Gx6EsNjfdJSAk73U/HqMEJZ2k/8puxfwHFgDQhBGmS3+sjnGbMdMSV45axPQw==",
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
+      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
       "requires": {
-        "@remix-run/router": "1.13.1",
-        "react-router": "6.20.1"
+        "@remix-run/router": "1.23.2",
+        "react-router": "6.30.3"
       }
     },
     "react-simple-code-editor": {


### PR DESCRIPTION
## Summary

Add npm overrides to replace deprecated packages and silence build warnings.

### Overridden Packages

| Package | Replacement | Dev Dependency | Dependency Chain |
|---------|-------------|----------------|------------------|
| `json-schema-ref-parser@6.1.0` | `@apidevtools/json-schema-ref-parser@^11.7.3` | ✅ Yes | `@stoplight/prism-cli` → `json-schema-faker` → `json-schema-ref-parser` |
| `@faker-js/faker@5.5.3` | `@faker-js/faker@^8.4.1` | ✅ Yes | `@stoplight/prism-cli` → `@stoplight/prism-http` → `@stoplight/http-spec` → `postman-collection` → `@faker-js/faker` |

Both deprecated packages are transitive dependencies of `@stoplight/prism-*` packages, which are **devDependencies** used only for integration testing (mock API server). These do not affect production builds.

## Test plan
- [x] `npm install` shows no deprecation warnings for the targeted packages
- [x] `npm run build` succeeds
