### PR TITLE
chore(webui): remove NODE_OPTIONS from build scripts

### DIFF
--- a/webui/package.json
+++ b/webui/package.json
@@ -11,8 +11,8 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "NODE_OPTIONS=--max-old-space-size=4096 vite build",
-    "build-watch": "NODE_OPTIONS=--max-old-space-size=4096 vite build --watch",
+    "build": "vite build",
+    "build-watch": "vite build --watch",
     "serve": "vite preview",
     "test": "vitest run",
     "test-watch": "vitest",


### PR DESCRIPTION
The --max-old-space-size=4096 flag was previously needed to handle large builds but is no longer required. Removing it simplifies the build commands.

If build OOM errors occur, this flag can be restored or adjusted.