### PR TITLE
Update DynamoDB local image to version 3.3.0

### DIFF
--- a/.github/workflows/esti.yaml
+++ b/.github/workflows/esti.yaml
@@ -1174,7 +1174,7 @@ jobs:
     timeout-minutes: 20
     services:
       dynamodb:
-        image: amazon/dynamodb-local:1.13.6
+        image: amazon/dynamodb-local:3.3.0
       lakefs:
         image: ${{ needs.login-to-amazon-ecr.outputs.registry }}/lakefs:${{ needs.deploy-image.outputs.tag }}
         credentials:
@@ -1250,7 +1250,7 @@ jobs:
     timeout-minutes: 20
     services:
       dynamodb:
-        image: amazon/dynamodb-local:1.13.6
+        image: amazon/dynamodb-local:3.3.0
       lakefs:
         image: ${{ needs.login-to-amazon-ecr.outputs.registry }}/lakefs:${{ needs.deploy-image.outputs.tag }}
         credentials:

--- a/esti/ops/docker-compose-common.yaml
+++ b/esti/ops/docker-compose-common.yaml
@@ -67,6 +67,6 @@ services:
       POSTGRES_PASSWORD: lakefs
 
   dynamodb:
-    image: "amazon/dynamodb-local:2.5.2"
+    image: "amazon/dynamodb-local:3.3.0"
     ports:
       - "6432:8000"


### PR DESCRIPTION
DynamoDB local 1.x reached end of support in January 2025.
Updated all DynamoDB local images from deprecated versions
(1.13.6 and 2.5.2) to the latest version 3.3.0.