### PR TITLE
docs: fix spelling and grammar errors

### DIFF
--- a/docs/src/enterprise/troubleshooting.md
+++ b/docs/src/enterprise/troubleshooting.md
@@ -43,7 +43,7 @@ lakeFS Enterprise allow configuration to be supplied in multiple ways: configura
 
 ### Environment Variables
 
-When troubleshooting, it's important to get a view of the environment in which lakeFS are running. This is especially true for container-based deployment environments, like Kubernetes, where env vars are used extensively. The `flare` command collects environment variables with the following prefixes:
+When troubleshooting, it's important to get a view of the environment in which lakeFS is running. This is especially true for container-based deployment environments, like Kubernetes, where env vars are used extensively. The `flare` command collects environment variables with the following prefixes:
 
 - `LAKEFS_`
 - `HTTP_`

--- a/docs/src/howto/hooks/index.md
+++ b/docs/src/howto/hooks/index.md
@@ -52,7 +52,7 @@ By default, when `if` is empty or omitted, the step will run only if no error oc
 
 | Property             | Description                                                                                                                                                                                                              | Data Type  | Required | Default Value                                                           |
 |----------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|------------|----------|-------------------------------------------------------------------------|
-| `name`               | Identifes the Action file                                                                                                                                                                                                | String     | no       | Action filename                                                         |
+| `name`               | Identifies the Action file                                                                                                                                                                                                | String     | no       | Action filename                                                         |
 | `on`                 | List of events that will trigger the hooks                                                                                                                                                                               | List       | yes      |                                                                         |
 | `on<event>.branches` | Glob pattern list of branches that triggers the hooks                                                                                                                                                                    | List       | no       | **Not applicable to Tag events.** If empty, Action runs on all branches |
 | `hooks`              | List of hooks to be executed                                                                                                                                                                                             | List       | yes      |                                                                         |
@@ -162,7 +162,7 @@ lakeFS will fetch, parse and filter the repository Action files and start to exe
 All executed Hooks (each with `hook_run_id`) exist in the context of that Run (`run_id`).
 
 The [lakeFS API](../../reference/api.md) and [lakectl][lakectl-actions] expose the results of executions per repository, branch, commit, and specific Action.
-The endpoint also allows to download the execution log of any executed Hook under each Run for observability.
+The endpoint also allows downloading the execution log of any executed Hook under each Run for observability.
 
 ## Result Files
 

--- a/docs/src/howto/mirroring.md
+++ b/docs/src/howto/mirroring.md
@@ -21,7 +21,7 @@ Unlike conventional mirroring, data isn't simply copied between regions - lakeFS
 
 <iframe data-uc-allowed="true" width="420" height="315" src="https://www.youtube.com/embed/NhOWGVjQrrA"></iframe>
 
-## Uses cases
+## Use cases
 
 ### Disaster recovery
 

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -143,7 +143,7 @@ Being able to look at data as it was at a given point is particularly useful in 
 
 With lakeFS, each member of the team can create their own branch, isolated from other people's changes.
 
-This allows to iterate on changes to an algorithm or transformation, without stepping on eachother's toes. These branches are centralized - they could be share among users for collaboration, and can even be merged.
+This allows you to iterate on changes to an algorithm or transformation, without stepping on each other's toes. These branches are centralized - they could be shared among users for collaboration, and can even be merged.
 
 With lakeFS you can even open [pull requests](./howto/pull-requests.md), allowing you to easily share changes with other members and collaborate on them.
 

--- a/docs/src/integrations/unity-catalog.md
+++ b/docs/src/integrations/unity-catalog.md
@@ -195,8 +195,8 @@ lakectl fs upload lakefs://repo/main/_lakefs_actions/unity_exports_action.yaml -
 lakectl commit lakefs://repo/main -m "upload action and run it"
 ```
 
-The action has run and exported the `famous_people` Delta Lake table to the repo's storage namespace, and has register 
-the table as an external table in Unity Catalog under the catalog `my-catalog-name`, schema `main` (as the branch's name) and 
+The action has run and exported the `famous_people` Delta Lake table to the repo's storage namespace, and has registered
+the table as an external table in Unity Catalog under the catalog `my-catalog-name`, schema `main` (as the branch's name) and
 table name `famous_people`: `my-catalog-name.main.famous_people`.
 
 ![Hooks log result in lakeFS UI](../assets/img/unity_export_hook_result_log.png)

--- a/docs/src/reference/mount.md
+++ b/docs/src/reference/mount.md
@@ -121,7 +121,7 @@ When you access a file through a mounted lakeFS path, Everest follows this proce
 
 1. **Lazy Fetching**: Files are only downloaded when their content is accessed (e.g., reading a file, not just listing it with `ls`).
 2. **Cache Storage**: When an object is not found in the local cache, Everest fetches the data from the object store and stores it in the cache for subsequent access.
-3. **Cache Reuse**: Subsequent reads of the same file are served directly from the cache, eliminating network requests and improving performance. Cached can't be shared between different instances of mount.
+3. **Cache Reuse**: Subsequent reads of the same file are served directly from the cache, eliminating network requests and improving performance. Caches can't be shared between different instances of mount.
 
 <h4>Default Cache Behavior</h4>
 
@@ -810,7 +810,7 @@ everest mount-server <remote_mount_uri> [flags]
 -   `--parallelism`: Number of parallel downloads for metadata.
 -   `--presign`: Use presign for downloading.
 -   `--write-mode`: Enable write mode (default: false).
--   `--root`: Directory to mount on the the filesystem (Windows only)
+-   `--root`: Directory to mount on the filesystem (Windows only)
 
 ---
 


### PR DESCRIPTION
Fixed multiple spelling and grammar issues across documentation:
- Fixed 'eachother's' -> 'each other's' in index.md
- Fixed 'allows to iterate' -> 'allows you to iterate' in index.md
- Fixed 'could be share' -> 'could be shared' in index.md
- Fixed 'Uses cases' -> 'Use cases' in mirroring.md
- Fixed 'Cached can't be shared' -> 'Caches can't be shared' in mount.md
- Fixed 'the the filesystem' -> 'the filesystem' in mount.md
- Fixed 'Identifes' -> 'Identifies' in hooks/index.md
- Fixed 'allows to download' -> 'allows downloading' in hooks/index.md
- Fixed 'lakeFS are running' -> 'lakeFS is running' in troubleshooting.md
- Fixed 'has register' -> 'has registered' in unity-catalog.md