### PR TITLE
Fix local block unite to clean path and create missing dirs

### DIFF
--- a/pkg/block/local/adapter.go
+++ b/pkg/block/local/adapter.go
@@ -465,7 +465,8 @@ func (l *Adapter) unitePartFiles(identifier block.ObjectPointer, filenames []str
 	if err != nil {
 		return 0, err
 	}
-	unitedFile, err := os.Create(p)
+	p = filepath.Clean(p)
+	unitedFile, err := l.maybeMkdir(p, os.Create)
 	if err != nil {
 		return 0, fmt.Errorf("create path %s: %w", p, err)
 	}


### PR DESCRIPTION
Ensure the target path is sanitized and its directories exist before creating the united file, avoiding errors and reducing path-related risk.

