### PR TITLE
Update GTM script with data-uc-allowed attribute

### DIFF
--- a/docs/overrides/partials/integrations/analytics.html
+++ b/docs/overrides/partials/integrations/analytics.html
@@ -11,9 +11,29 @@
 </script>
 
 <!-- Google Tag Manager -->
-<script async src="https://www.googletagmanager.com/gtm.js?id=GTM-KTZBZW9" data-uc-allowed="true"></script>
+<script data-uc-allowed="true">
+document.addEventListener("DOMContentLoaded", function() {
+  (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+    new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+    j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+      'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+  })(window,document,'script','dataLayer','GTM-KTZBZW9');
+  window.dataLayer = window.dataLayer || [];
+
+  function gtag(){dataLayer.push(arguments)};
+  gtag('consent','default',{
+    'ad_storage':'denied',
+    'ad_user_data':'denied',
+    'ad_personalization':'denied',
+    'analytics_storage':'denied',
+    'functionality_storage': 'denied',
+    'personalization_storage': 'denied',
+    'security_storage': 'granted'
+  });
+})
+</script>
 
 <!-- Google Tag Manager (noscript) -->
-<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-KTZBZW9"
+<noscript><iframe data-uc-allowed="true" src="https://www.googletagmanager.com/ns.html?id=GTM-KTZBZW9"
                   height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
 <!-- End Google Tag Manager (noscript) -->


### PR DESCRIPTION
## Summary
- Updated Google Tag Manager script to use data-uc-allowed attribute
- Added consent configuration for GDPR compliance
- Squashed commits for cleaner history
<!--start_gitstream_placeholder-->
### ✨ PR Description
Purpose: Update Google Tag Manager integration to comply with cookie consent requirements by adding data-uc-allowed attribute for consent management compatibility.

Main changes:
- Added data-uc-allowed="true" attribute to GTM script tag to enable script execution under cookie consent framework
- Added data-uc-allowed="true" attribute to GTM noscript iframe for consistent consent handling across all GTM components

_Generated by LinearB AI and added by gitStream._
<sub>AI-generated content may contain inaccuracies. Please verify before using.
💡 **Tip:** You can customize your AI Description using **Guidelines** [Learn how](https://docs.gitstream.cm/automation-actions/#describe-changes)</sub>
<!--end_gitstream_placeholder-->
