### PR TITLE
Notify Slack on docs deployment failure

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -100,7 +100,7 @@ jobs:
           mike deploy --config-file ../mkdocs.yml --branch main --push "${{ steps.setvars.outputs.VERSION }}" ${{ steps.setvars.outputs.ALIASES }}
 
       - name: Notify Slack on failure
-        if: failure()
+        if: failure() && github.event_name != 'workflow_dispatch'
         uses: slackapi/slack-github-action@v2
         with:
           webhook: ${{ secrets.SLACK_WEBHOOK_URL }}


### PR DESCRIPTION
Sends an slack message with run context when the documentation publish job fails.
Exclude manually triggered workflow.
