### PR TITLE
Notify LinearB when release workflow starts

### DIFF
--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -20,6 +20,23 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Notify LinearB Release Started
+        continue-on-error: true
+        env:
+          LINEARB_API_TOKEN: ${{ secrets.LINEARB_API_TOKEN }}
+          REPO_URL: https://github.com/${{ github.repository }}.git
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          curl -s -X POST https://public-api.linearb.io/api/v1/deployments \
+            -H "Content-Type: application/json" \
+            -H "x-api-key: $LINEARB_API_TOKEN" \
+            -d "{
+              \"repo_url\": \"$REPO_URL\",
+              \"ref_name\": \"$REF_NAME\",
+              \"timestamp\": \"$(date -u +"%Y-%m-%dT%H:%M:%SZ")\",
+              \"stage\": \"oss_releasing\"
+            }"
+
       - name: Setup NodeJS
         uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
Send a deployment event to LinearB at the start of releases for better tracking and visibility.

Part of https://github.com/treeverse/lakeFS-Enterprise/issues/1544