### PR TITLE
Skip check-ui-links workflow for Dependabot PRs

### DIFF
--- a/.github/workflows/check-ui-links.yaml
+++ b/.github/workflows/check-ui-links.yaml
@@ -12,7 +12,7 @@ jobs:
   preview:
     name: Check links from UI
     runs-on: ubuntu-22.04
-    if: github.event.pull_request.head.repo.fork == false
+    if: github.event.pull_request.head.repo.fork == false && github.actor != 'dependabot[bot]'
     steps:
       - name: Check-out
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Skip the `check-ui-links` workflow for Dependabot PRs since they don't have access to repository secrets

## Context
Dependabot PRs fail on the "Check links from UI" workflow because they cannot access the `PERSONAL_TOKEN` secret needed to checkout the `treeverse/docs-lakeFS` repository. This is a GitHub security restriction.

Since Dependabot dependency updates don't affect UI documentation links, skipping this check is safe and appropriate.

Fixes the failure seen in: https://github.com/treeverse/lakeFS/actions/runs/21428778582/job/61703557266
