### PR TITLE
Update docs dependencies and pin Python 3.12

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -35,7 +35,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
-          python-version: "3.x"
+          python-version: "3.12"
 
       - name: Install dependencies
         working-directory: docs

--- a/docs/requirements-docs.txt
+++ b/docs/requirements-docs.txt
@@ -1,8 +1,8 @@
-PyYAML>=6.0 
+PyYAML>=6.0
 mike==2.1.3
-mkdocs-material==9.6.14
+mkdocs-material==9.7.1
 mkdocs-redirects==1.2.2
 mkdocs==1.6.1
 git+https://github.com/treeverse/mkdocs-render-swagger-plugin.git#egg=mkdocs-render-swagger-plugin
-pymdown-extensions==10.15
-mkdocs-glightbox==0.4.0
+pymdown-extensions==10.20.1
+mkdocs-glightbox==0.5.2


### PR DESCRIPTION
## Summary
- Pin Python version to 3.12 in docs workflow for reproducibility (was `3.x`)
- Update mkdocs-material: 9.6.14 → 9.7.1
- Update pymdown-extensions: 10.15 → 10.20.1
- Update mkdocs-glightbox: 0.4.0 → 0.5.2

## Testing

Manual check of the preview site.