### PR TITLE
Fix WebUI: Handle special characters in file paths for DuckDB queries

### DIFF
--- a/webui/src/pages/repositories/repository/fileRenderers/data.tsx
+++ b/webui/src/pages/repositories/repository/fileRenderers/data.tsx
@@ -18,11 +18,13 @@ export const DataLoader: FC = () => {
 };
 
 export const DuckDBRenderer: FC<RendererComponent> = ({ repoId, refId, path, fileExtension }) => {
-    let initialQuery = `SELECT * FROM READ_PARQUET('lakefs://${repoId}/${refId}/${path}', hive_partitioning=false) LIMIT 20`;
+    // Escape single quotes in path for SQL string safety
+    const escapedPath = path.replace(/'/g, "''");
+    let initialQuery = `SELECT * FROM READ_PARQUET('lakefs://${repoId}/${refId}/${escapedPath}', hive_partitioning=false) LIMIT 20`;
     if (fileExtension === 'csv') {
-        initialQuery = `SELECT *  FROM READ_CSV('lakefs://${repoId}/${refId}/${path}', AUTO_DETECT = TRUE) LIMIT 20`;
+        initialQuery = `SELECT *  FROM READ_CSV('lakefs://${repoId}/${refId}/${escapedPath}', AUTO_DETECT = TRUE) LIMIT 20`;
     } else if (fileExtension === 'tsv') {
-        initialQuery = `SELECT *  FROM READ_CSV('lakefs://${repoId}/${refId}/${path}', DELIM='\t', AUTO_DETECT=TRUE) LIMIT 20`;
+        initialQuery = `SELECT *  FROM READ_CSV('lakefs://${repoId}/${refId}/${escapedPath}', DELIM='\t', AUTO_DETECT=TRUE) LIMIT 20`;
     }
     const [shouldSubmit, setShouldSubmit] = useState<boolean>(true);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/webui/src/pages/repositories/repository/fileRenderers/duckdb.tsx
+++ b/webui/src/pages/repositories/repository/fileRenderers/duckdb.tsx
@@ -58,7 +58,10 @@ async function extractFiles(conn: AsyncDuckDBConnection, sql: string): Promise<{
         if (tokenized.types[i] === DUCKDB_STRING_CONSTANT) {
             const matches = part.match(LAKEFS_URI_PATTERN);
             if (matches !== null) {
-                fileMap[matches[2]] = `s3://${matches[3]}?r=${r}`;
+                // Unescape SQL single quotes ('' -> ') then URL-encode the path for S3 protocol
+                const unescapedUri = matches[2].replace(/''/g, "'");
+                const encodedPath = matches[3].replace(/''/g, "'").split('/').map(encodeURIComponent).join('/');
+                fileMap[unescapedUri] = `s3://${encodedPath}?r=${r}`;
             }
         }
     });


### PR DESCRIPTION
Closes #10077
Fix https://github.com/treeverse/product/issues/1065

## Summary
- Fix DuckDB queries failing when file paths contain single quotes or special characters
- Properly escape single quotes in SQL string literals
- URL-encode path components for S3 protocol compatibility

## Test plan
- [x] Navigate to a parquet/csv file with single quotes in the path (e.g., `file's data.parquet`)
- [x] Verify the DuckDB query executes successfully
- [x] Verify data is displayed correctly