### PR TITLE
Web UI: responsive collapsible breadcrumb to URI navigator

### DIFF
--- a/webui/src/lib/components/repository/tree.jsx
+++ b/webui/src/lib/components/repository/tree.jsx
@@ -724,7 +724,7 @@ const CollapsibleBreadcrumb = ({
                             className="breadcrumb-dropdown-toggle"
                             aria-label="Show collapsed path segments"
                         >
-                            …
+                            ...
                         </Dropdown.Toggle>
                         <Dropdown.Menu
                             className="breadcrumb-dropdown-menu"

--- a/webui/src/styles/components/ui-components.css
+++ b/webui/src/styles/components/ui-components.css
@@ -205,14 +205,15 @@ a[title*='Upload'] + a[title*='Import'] {
 
 .breadcrumb-dropdown-toggle {
     padding: 0 4px !important;
-    font-size: 1rem !important;
-    font-weight: bold;
-    color: var(--text-muted) !important;
+    font-size: 0.875rem !important;
+    font-weight: normal;
+    color: var(--primary) !important;
     text-decoration: none !important;
     background: transparent !important;
     border: none !important;
     box-shadow: none !important;
     line-height: 1;
+    cursor: pointer;
 }
 
 .breadcrumb-dropdown-toggle:hover,
@@ -224,6 +225,10 @@ a[title*='Upload'] + a[title*='Import'] {
 
 .breadcrumb-dropdown-toggle::after {
     display: none !important;
+}
+
+.breadcrumb-dropdown-toggle:not(.show):focus {
+    background: transparent !important;
 }
 
 .breadcrumb-dropdown-menu {


### PR DESCRIPTION
## Change Description

### New Feature

This PR introduces a new `CollapsibleBreadcrumb` component that makes the URI navigator responsive and user-friendly on smaller screens or long object path.
The breadcrumb intelligently collapses leftmost path segments into a dropdown menu while always keeping the rightmost segments (current location) visible.

### UI Previews

<img width="1912" height="1242" alt="image" src="https://github.com/user-attachments/assets/2052869a-7b46-4297-8c22-eb8f10335dc5" />

<img width="1912" height="1242" alt="image" src="https://github.com/user-attachments/assets/c4030efd-346d-439c-bc03-1b7ceb68a992" />

Close https://github.com/treeverse/lakeFS/issues/10081