### PR TITLE
ci(esti): skip jobs requiring secrets when unavailable

### DIFF
--- a/.github/workflows/esti.yaml
+++ b/.github/workflows/esti.yaml
@@ -157,7 +157,8 @@ jobs:
 
   unified-gc-test:
     name: Test unified gc
-    needs: [deploy-image, login-to-amazon-ecr, build-spark3-metadata-client]
+    needs: [check-secrets, deploy-image, login-to-amazon-ecr, build-spark3-metadata-client]
+    if: needs.check-secrets.outputs.secretsavailable == 'true'
     runs-on: ubuntu-22.04-8-cores
     services:
       lakefs:
@@ -289,7 +290,8 @@ jobs:
 
   hadoopfs-tests:
     name: Test lakeFS Hadoop FileSystem
-    needs: [deploy-image, login-to-amazon-ecr]
+    needs: [check-secrets, deploy-image, login-to-amazon-ecr]
+    if: needs.check-secrets.outputs.secretsavailable == 'true'
     runs-on: ubuntu-22.04
     env:
       TAG: ${{ needs.deploy-image.outputs.tag }}
@@ -336,7 +338,8 @@ jobs:
 
   hadoopfs-s3a-mpu:
     name: Test lakeFS multipart upload with Hadoop S3A
-    needs: [deploy-image, login-to-amazon-ecr]
+    needs: [check-secrets, deploy-image, login-to-amazon-ecr]
+    if: needs.check-secrets.outputs.secretsavailable == 'true'
     runs-on: ubuntu-22.04
     env:
       TAG: ${{ needs.deploy-image.outputs.tag }}
@@ -439,7 +442,8 @@ jobs:
 
   spark:
     name: Test lakeFS with Spark ${{ matrix.spark.tag }}.X
-    needs: [spark-prep, build-lakefs-hadoopfs, deploy-image, login-to-amazon-ecr]
+    needs: [check-secrets, spark-prep, build-lakefs-hadoopfs, deploy-image, login-to-amazon-ecr]
+    if: needs.check-secrets.outputs.secretsavailable == 'true'
     runs-on: ubuntu-22.04
     strategy:
       matrix:
@@ -554,7 +558,8 @@ jobs:
 
   export:
     name: Test lakeFS rclone export functionality
-    needs: [deploy-image, deploy-rclone-export-image, login-to-amazon-ecr]
+    needs: [check-secrets, deploy-image, deploy-rclone-export-image, login-to-amazon-ecr]
+    if: needs.check-secrets.outputs.secretsavailable == 'true'
     runs-on: ubuntu-22.04
     env:
       LAKEFS_TAG: ${{ needs.deploy-image.outputs.tag }}
@@ -608,6 +613,7 @@ jobs:
     name: Build metadata client for Spark 3.x
     runs-on: ubuntu-22.04-8-cores
     needs: [check-secrets, deploy-image, login-to-amazon-ecr]
+    if: needs.check-secrets.outputs.secretsavailable == 'true'
     env:
       TAG: ${{ needs.deploy-image.outputs.tag }}
       REGISTRY: ${{ needs.login-to-amazon-ecr.outputs.registry }}
@@ -646,7 +652,8 @@ jobs:
 
   metadata-client-export-spark3:
     name: Test lakeFS metadata client export with Spark 3.x
-    needs: [deploy-image, build-spark3-metadata-client, login-to-amazon-ecr]
+    needs: [check-secrets, deploy-image, build-spark3-metadata-client, login-to-amazon-ecr]
+    if: needs.check-secrets.outputs.secretsavailable == 'true'
     runs-on: ubuntu-22.04
     env:
       SPARK_TAG: 3.2.1
@@ -705,7 +712,8 @@ jobs:
 
   run-system-aws-s3-kv-dynamodb:
     name: Run latest lakeFS app on AWS S3 DynamoDB KV
-    needs: [deploy-image, login-to-amazon-ecr]
+    needs: [check-secrets, deploy-image, login-to-amazon-ecr]
+    if: needs.check-secrets.outputs.secretsavailable == 'true'
     runs-on: ubuntu-22.04
     env:
       TAG: ${{ needs.deploy-image.outputs.tag }}
@@ -776,6 +784,7 @@ jobs:
   run-system-aws-s3:
     name: Run latest lakeFS app on AWS S3
     needs: [check-secrets, deploy-image, login-to-amazon-ecr]
+    if: needs.check-secrets.outputs.secretsavailable == 'true'
     runs-on: ubuntu-22.04
     strategy:
       matrix:
@@ -850,7 +859,8 @@ jobs:
 
   run-system-gcp-gs:
     name: Run latest lakeFS app on Google Cloud Platform and Google Cloud Storage
-    needs: [deploy-image, login-to-amazon-ecr]
+    needs: [check-secrets, deploy-image, login-to-amazon-ecr]
+    if: needs.check-secrets.outputs.secretsavailable == 'true'
     runs-on: ubuntu-22.04
     env:
       TAG: ${{ needs.deploy-image.outputs.tag }}
@@ -902,7 +912,8 @@ jobs:
 
   run-system-azure-abfs:
     name: Run latest lakeFS app on Azure with Azure blobstore
-    needs: [deploy-image, login-to-amazon-ecr]
+    needs: [check-secrets, deploy-image, login-to-amazon-ecr]
+    if: needs.check-secrets.outputs.secretsavailable == 'true'
     runs-on: ubuntu-22.04
     env:
       TAG: ${{ needs.deploy-image.outputs.tag }}
@@ -961,7 +972,8 @@ jobs:
 
   run-system-azure-adls-gen2:
     name: Run latest lakeFS app on Azure with Azure Data Lake Storage Gen2 and CosmosDB
-    needs: [deploy-image, login-to-amazon-ecr]
+    needs: [check-secrets, deploy-image, login-to-amazon-ecr]
+    if: needs.check-secrets.outputs.secretsavailable == 'true'
     runs-on: ubuntu-22.04
     env:
       TAG: ${{ needs.deploy-image.outputs.tag }}
@@ -1038,7 +1050,8 @@ jobs:
 
   python-wrapper:
     name: Test lakeFS against the python wrapper client
-    needs: [deploy-image, login-to-amazon-ecr]
+    needs: [check-secrets, deploy-image, login-to-amazon-ecr]
+    if: needs.check-secrets.outputs.secretsavailable == 'true'
     runs-on: ubuntu-22.04
     env:
       TAG: ${{ needs.deploy-image.outputs.tag }}
@@ -1098,8 +1111,8 @@ jobs:
           report-title: 'Python Wrapper System Tests Report'
 
   python-wrapper-new-sdk:
-    needs: [deploy-image, login-to-amazon-ecr, paths-filter]
-    if: ${{ needs.paths-filter.outputs.python-sdk-change == 'true' }}
+    needs: [check-secrets, deploy-image, login-to-amazon-ecr, paths-filter]
+    if: ${{ needs.check-secrets.outputs.secretsavailable == 'true' && needs.paths-filter.outputs.python-sdk-change == 'true' }}
     name: Test changes in SDK against the python wrapper
     runs-on: ubuntu-22.04
     env:
@@ -1168,8 +1181,10 @@ jobs:
   e2e-ddb-local-local:
     name: E2E - DynamoDB Local - Local Block Adapter
     needs:
+      - check-secrets
       - deploy-image
       - login-to-amazon-ecr
+    if: needs.check-secrets.outputs.secretsavailable == 'true'
     runs-on: ubuntu-22.04-8-cores
     timeout-minutes: 20
     services:
@@ -1244,8 +1259,10 @@ jobs:
   quickstart:
     name: Quickstart
     needs:
+      - check-secrets
       - deploy-image
       - login-to-amazon-ecr
+    if: needs.check-secrets.outputs.secretsavailable == 'true'
     runs-on: ubuntu-22.04-8-cores
     timeout-minutes: 20
     services:
@@ -1319,7 +1336,8 @@ jobs:
 
   run-system-aws-s3-basic-auth:
     name: Run latest lakeFS app on AWS S3 + Basic Auth
-    needs: [deploy-image, login-to-amazon-ecr]
+    needs: [check-secrets, deploy-image, login-to-amazon-ecr]
+    if: needs.check-secrets.outputs.secretsavailable == 'true'
     runs-on: ubuntu-22.04
     env:
       TAG: ${{ needs.deploy-image.outputs.tag }}
@@ -1367,3 +1385,42 @@ jobs:
           if docker compose ps -q postgres; then
             docker compose exec -T postgres pg_dumpall --username=lakefs | gzip | aws s3 cp - s3://esti-system-testing/${{ github.run_number }}/${{ steps.unique.outputs.value }}/dump.gz
           fi
+
+  esti-complete:
+    name: Esti CI Complete
+    if: always()
+    needs:
+      # Jobs that don't require secrets
+      - gen-code
+      - build-lakefs-hadoopfs
+      - spark-prep
+      # Jobs that require secrets (may be skipped)
+      - deploy-image
+      - login-to-amazon-ecr
+      - unified-gc-test
+      - deploy-rclone-export-image
+      - hadoopfs-tests
+      - hadoopfs-s3a-mpu
+      - spark
+      - export
+      - build-spark3-metadata-client
+      - metadata-client-export-spark3
+      - run-system-aws-s3-kv-dynamodb
+      - run-system-aws-s3
+      - run-system-gcp-gs
+      - run-system-azure-abfs
+      - run-system-azure-adls-gen2
+      - python-wrapper
+      - python-wrapper-new-sdk
+      - e2e-ddb-local-local
+      - quickstart
+      - run-system-aws-s3-basic-auth
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check CI status
+        run: |
+          if [[ "${{ contains(needs.*.result, 'failure') }}" == "true" ]]; then
+            echo "Some jobs failed"
+            exit 1
+          fi
+          echo "All jobs passed or were skipped appropriately"


### PR DESCRIPTION
## Summary

- Add `check-secrets` dependency and conditional execution to jobs that require repository secrets
- Jobs without secret access will now be **skipped** instead of **failing**
- Jobs that don't require secrets continue to run normally

This fixes workflow failures for PRs that don't have access to secrets (e.g., from forks or Dependabot).

## Test plan

- [x] Triggered workflow run from this branch to verify syntax and job dependencies
- [ ] Verify jobs are skipped (not failed) when secrets are unavailable