### PR TITLE
Fixed Expired Status Override on Completed Tasks

### DIFF
--- a/pkg/catalog/catalog.go
+++ b/pkg/catalog/catalog.go
@@ -2858,11 +2858,7 @@ func checkAndMarkTaskExpired(statusMsg protoreflect.ProtoMessage, expiryDuration
 	}
 
 	task := getTaskFromStatus(statusMsg)
-	if task == nil || task.UpdatedAt == nil {
-		return
-	}
-
-	if task.Done {
+	if task == nil || task.Done || task.UpdatedAt == nil {
 		return
 	}
 


### PR DESCRIPTION
Fixes a bug in the `checkAndMarkTaskExpired` function, which marks stuck async tasks as expired.

The function did not verify whether a task had already finished successfully or with an error before checking the expiration. As a result, tasks that completed earlier could be incorrectly overridden and marked with an expired status code.