### PR TITLE
docs: remove MATLAB helper file download instructions

### DIFF
--- a/docs/src/integrations/matlab.md
+++ b/docs/src/integrations/matlab.md
@@ -36,19 +36,6 @@ Before using lakeFS with MATLAB, ensure you have:
 
 ## Installation
 
-### Download Helper Files
-
-Download the MATLAB helper classes:
-- [`lakefs.m`](https://github.com/treeverse/lakeFS-samples/matlab/lakefs.m) - Core lakeFS operations
-- [`everest.m`](https://github.com/treeverse/lakeFS-samples/matlab/everest.m) - File system mounting
-
-Place both files in your MATLAB project directory or add to your MATLAB path:
-
-```matlab
-% Add helpers to MATLAB path
-addpath('/path/to/helpers');
-```
-
 ### Configure lakeFS Connection
 
 Create your lakeFS configuration by copying and editing the template:


### PR DESCRIPTION
Streamlines the MATLAB integration guide by dropping guidance for external helper files.
Until we have these files or users will ask about them as they are not in any repository.
