### PR TITLE
Update Ruby dependencies: rexml and uri gems

### DIFF
--- a/clients/python-static/templates/Gemfile.lock
+++ b/clients/python-static/templates/Gemfile.lock
@@ -253,7 +253,7 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rexml (3.4.1)
+    rexml (3.4.2)
     rouge (3.30.0)
     rubyzip (2.4.1)
     safe_yaml (1.0.5)
@@ -274,7 +274,7 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (1.8.0)
-    uri (1.0.3)
+    uri (1.0.4)
     webrick (1.9.1)
 
 PLATFORMS

--- a/clients/python/Gemfile.lock
+++ b/clients/python/Gemfile.lock
@@ -253,7 +253,7 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.11.1)
       ffi (~> 1.0)
-    rexml (3.4.1)
+    rexml (3.4.2)
     rouge (3.30.0)
     rubyzip (2.4.1)
     safe_yaml (1.0.5)
@@ -274,7 +274,7 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (1.8.0)
-    uri (1.0.3)
+    uri (1.0.4)
     webrick (1.9.1)
 
 PLATFORMS


### PR DESCRIPTION
## Change Description

### Background

This PR updates two Ruby gem dependencies in the Gemfile.lock files for both the python-static and python clients:
- `rexml`: 3.4.1 → 3.4.2
- `uri`: 1.0.3 → 1.0.4

These are patch-level version updates that typically include bug fixes and security improvements.

### Testing Details

The changes are limited to Gemfile.lock files, which are automatically generated by bundler. These updates ensure that the Ruby dependencies used for documentation generation and related tooling are up-to-date with the latest patch versions.

### Breaking Change?

No. These are minor patch version updates that maintain backward compatibility.
