### PR TITLE
fix(lakectl): report per-object errors in recursive rm and batch deletions correctly

### DIFF
--- a/cmd/lakectl/cmd/fs_rm.go
+++ b/cmd/lakectl/cmd/fs_rm.go
@@ -18,11 +18,7 @@ type ObjectDeleteError struct {
 }
 
 func (e *ObjectDeleteError) Error() string {
-	path := ""
-	if e.Path != nil {
-		path = *e.Path
-	}
-	return fmt.Sprintf("rm %s: [%d] %s", path, e.StatusCode, e.Message)
+	return fmt.Sprintf("rm %s: [%d] %s", apiutil.Value(e.Path), e.StatusCode, e.Message)
 }
 
 const deleteChunkSize = 1000

--- a/cmd/lakectl/cmd/fs_rm_test.go
+++ b/cmd/lakectl/cmd/fs_rm_test.go
@@ -6,9 +6,9 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/go-openapi/swag"
 	"github.com/stretchr/testify/require"
 	"github.com/treeverse/lakefs/pkg/api/apigen"
+	"github.com/treeverse/lakefs/pkg/api/apiutil"
 )
 
 type mockDeleteClient struct {
@@ -32,9 +32,9 @@ func TestFsRmRecursive_ObjectErrors(t *testing.T) {
 				HTTPResponse: &http.Response{StatusCode: http.StatusOK},
 				JSON200: &apigen.ObjectErrorList{
 					Errors: []apigen.ObjectError{
-						{Path: swag.String("path/to/file1.txt"), StatusCode: 404, Message: "not found"},
-						{Path: swag.String("path/to/file2.txt"), StatusCode: 403, Message: "forbidden"},
-						{Path: swag.String("path/to/file3.txt"), StatusCode: 429, Message: "slow down"},
+						{Path: apiutil.Ptr("path/to/file1.txt"), StatusCode: 404, Message: "not found"},
+						{Path: apiutil.Ptr("path/to/file2.txt"), StatusCode: 403, Message: "forbidden"},
+						{Path: apiutil.Ptr("path/to/file3.txt"), StatusCode: 429, Message: "slow down"},
 					},
 				},
 			},


### PR DESCRIPTION
## Summary

`POST /api/v1/repositories/{repo}/branches/{branch}/objects/delete` can return 200 response with `errors` in the json response for individual objects.

https://github.com/treeverse/lakeFS/blob/b988401f9da3185e8b407b18e8c010de51ff28da/api/swagger.yml#L901-L909

Since the response was 200, the error message not being read, and the `fs rm` command would exit without any error logs and with success returncode.

Now, this reads the `json200` response and displays error to the user and returns with non-zero error code.

Fixes https://github.com/treeverse/lakeFS/issues/9993.
Closes #10096.

## Test plan
- [x] Added unit test for `deleteObjectWorker` error handling
- [x] Manual test with actual lakeFS server returning object errors