### PR TITLE
fix(lakectl):  correctly batch large recursive deletes (`>1000 files/worker`)

### DIFF
--- a/cmd/lakectl/cmd/fs_rm.go
+++ b/cmd/lakectl/cmd/fs_rm.go
@@ -102,7 +102,7 @@ func deleteObjectWorker(ctx context.Context, client apigen.ClientWithResponsesIn
 				rmErr := fmt.Errorf("rm objects - %w", err)
 				errors <- rmErr
 			}
-			clear(objs)
+			objs = objs[:0]
 		}
 	}
 	if len(objs) > 0 {


### PR DESCRIPTION
Closes #9993

## Change Description

### Background

When using `lakectl fs rm -r` to recursively delete more than 1000 files, the command fails with HTTP 500 errors because batches exceed the server's 1000-object limit.

### Bug Fix

1. **Problem** - `lakectl fs rm -r` fails when deleting >1000 files.

2. **Root cause** - We use `clear(objs)` to reset the batch after deleting 1000 objects. However, `clear()` only zeroes the slice elements, it doesn't reset the slice length. So on subsequent iterations, new paths get appended to a slice that still has length 1000, causing batch sizes of 1001, 1002, 1003, etc.

   https://github.com/treeverse/lakeFS/blob/7cc7189e504f0c1e6ea5c38965bf02b1914dff95/cmd/lakectl/cmd/fs_rm.go#L105

   When the batch exceeds 1000 keys, the server rejects it with HTTP 500:

   https://github.com/treeverse/lakeFS/blob/2f269537ba6aeedc4a891de9eb8a161b57302ab3/pkg/api/controller.go#L697-L701

   After crossing the threshold, every single new path triggers a delete request that gets rejected. With 5 retries per request, deleting 1100 files results in:
   - 1 successful batch (1000 objects)
   - 100 failed requests × 5 retries = 500 wasted HTTP requests

   https://github.com/treeverse/lakeFS/blob/7cc7189e504f0c1e6ea5c38965bf02b1914dff95/cmd/lakectl/cmd/fs_rm.go#L96-L99

   https://github.com/treeverse/lakeFS/blob/7cc7189e504f0c1e6ea5c38965bf02b1914dff95/cmd/lakectl/cmd/retry_client.go#L102-L106

   ```
   rm objects - Post "http://127.0.0.1:8000/api/v1/repositories/test-1770020821/branches/rm-test/objects/delete": POST http://127.0.0.1:8000/api/v1/repositories/test-1770020821/branches/rm-test/objects/delete giving up after 5 attempt(s)
   ```

3. **Solution** - Replace `clear(objs)` with `objs = objs[:0]` which properly resets the slice length to 0 while preserving capacity.

### Testing Details

- Existing unit tests pass
- Code compiles successfully

### Breaking Change?

No