### PR TITLE
fix(api): return 400 instead of 500 for DeleteObjects size limit

### DIFF
--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -696,7 +696,7 @@ func (c *Controller) DeleteObjects(w http.ResponseWriter, r *http.Request, body 
 	// limit check
 	if len(body.Paths) > DefaultMaxDeleteObjects {
 		err := fmt.Errorf("%w, max paths is set to %d", ErrRequestSizeExceeded, DefaultMaxDeleteObjects)
-		writeError(w, r, http.StatusInternalServerError, err)
+		writeError(w, r, http.StatusBadRequest, err)
 		return
 	}
 

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -3439,15 +3439,15 @@ func TestController_ObjectsDeleteObjectHandler(t *testing.T) {
 		// delete objects
 		delResp, err := clt.DeleteObjectsWithResponse(ctx, repo, branch, &apigen.DeleteObjectsParams{}, apigen.DeleteObjectsJSONRequestBody{Paths: paths})
 		testutil.Must(t, err)
-		const expectedStatusCode = http.StatusInternalServerError
+		const expectedStatusCode = http.StatusBadRequest
 		if delResp.StatusCode() != expectedStatusCode {
 			t.Fatalf("DeleteObjects status code %d, expected %d", delResp.StatusCode(), expectedStatusCode)
 		}
-		if delResp.JSONDefault == nil {
-			t.Fatal("DeleteObjects expected default error")
+		if delResp.JSON400 == nil {
+			t.Fatal("DeleteObjects expected 400 error")
 		}
-		if !strings.Contains(delResp.JSONDefault.Message, api.ErrRequestSizeExceeded.Error()) {
-			t.Fatalf("DeleteObjects size exceeded error: '%s', expected '%s'", delResp.JSONDefault.Message, api.ErrRequestSizeExceeded)
+		if !strings.Contains(delResp.JSON400.Message, api.ErrRequestSizeExceeded.Error()) {
+			t.Fatalf("DeleteObjects size exceeded error: '%s', expected '%s'", delResp.JSON400.Message, api.ErrRequestSizeExceeded)
 		}
 	})
 


### PR DESCRIPTION
Relates to #9993

## Change Description

### Background

When the DeleteObjects API receives more than 1000 paths, it returns HTTP 500 Internal Server Error. This causes clients to retry the request unnecessarily since 5xx errors are typically retried.

### Bug Fix

1. **Problem** - DeleteObjects returns HTTP 500 for request size validation errors, causing unnecessary retries.

2. **Root cause** - The size limit check was using `http.StatusInternalServerError` instead of a 4xx client error:

   https://github.com/treeverse/lakeFS/blob/2f269537ba6aeedc4a891de9eb8a161b57302ab3/pkg/api/controller.go#L697-L701
https://github.com/treeverse/lakeFS/blob/7cc7189e504f0c1e6ea5c38965bf02b1914dff95/cmd/lakectl/cmd/retry_client.go#L102-L106

3. **Solution** - Return HTTP 400 Bad Request instead, matching AWS S3 behavior. This prevents unnecessary retries since 4xx errors indicate client errors that won't succeed on retry.

### Testing Details

- Existing unit tests pass
- Code compiles successfully

### Breaking Change?

No - this changes an error response code from 500 to 400, which is a more accurate status code for this validation error.