### PR TITLE
chore(ci): add dependabot for updating GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+version: 2
+
+updates:
+  - directory: "/"
+    package-ecosystem: "github-actions"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "area/ci"
+    groups:
+      dependencies:
+        patterns:
+        - "*"


### PR DESCRIPTION
## Change Description

### Background

GitHub Actions dependencies can become outdated and may contain security vulnerabilities or miss performance improvements. Dependabot automates keeping these up to date.

Adds Dependabot configuration to automatically update GitHub Actions dependencies weekly and groups all updates into a single PR.

### Testing Details

Configuration validated against Dependabot schema.

### Breaking Change?

No - this only adds automated dependency update PRs.