### PR TITLE
Web UI: lock commit/merge inputs during API calls

### DIFF
--- a/webui/src/lib/components/repository/compareBranchesActionBar.jsx
+++ b/webui/src/lib/components/repository/compareBranchesActionBar.jsx
@@ -7,6 +7,7 @@ import { GitMergeIcon, GitPullRequestIcon } from '@primer/octicons-react';
 import Button from 'react-bootstrap/Button';
 import Modal from 'react-bootstrap/Modal';
 import Form from 'react-bootstrap/Form';
+import Alert from 'react-bootstrap/Alert';
 import { FormControl, FormHelperText, InputLabel, MenuItem, Select } from '@mui/material';
 import CompareBranchesSelection from './compareBranchesSelection';
 import { useRouter } from '../../../lib/hooks/router';
@@ -91,6 +92,7 @@ const MergeButton = ({ repo, onDone, source, dest, disabled = false }) => {
     };
 
     const onSubmit = async () => {
+        if (mergeState.merging) return;
         const metadata = getMetadataIfValid(metadataFields);
         if (!metadata) {
             setMetadataFields(touchInvalidFields(metadataFields));
@@ -140,7 +142,7 @@ const MergeButton = ({ repo, onDone, source, dest, disabled = false }) => {
     return (
         <>
             <Modal show={mergeState.show} onHide={hide} size="lg">
-                <Modal.Header closeButton>
+                <Modal.Header closeButton={!mergeState.merging}>
                     <Modal.Title>
                         Merge branch {source} into {dest}
                     </Modal.Title>
@@ -152,6 +154,7 @@ const MergeButton = ({ repo, onDone, source, dest, disabled = false }) => {
                                 type="text"
                                 placeholder="Commit Message (Optional)"
                                 ref={textRef}
+                                disabled={mergeState.merging}
                                 onKeyDown={(e) => {
                                     if (e.key === 'Enter' && !e.shiftKey) {
                                         e.preventDefault();
@@ -161,9 +164,13 @@ const MergeButton = ({ repo, onDone, source, dest, disabled = false }) => {
                             />
                         </Form.Group>
 
-                        <MetadataFields metadataFields={metadataFields} setMetadataFields={setMetadataFields} />
+                        <MetadataFields
+                            metadataFields={metadataFields}
+                            setMetadataFields={setMetadataFields}
+                            disabled={mergeState.merging}
+                        />
                     </Form>
-                    <FormControl sx={{ m: 1, minWidth: 120 }}>
+                    <FormControl sx={{ m: 1, minWidth: 120 }} disabled={mergeState.merging}>
                         <InputLabel id="demo-select-small" className="text-secondary">
                             Strategy
                         </InputLabel>
@@ -174,6 +181,7 @@ const MergeButton = ({ repo, onDone, source, dest, disabled = false }) => {
                             label="Strategy"
                             className="text-secondary"
                             onChange={onStrategyChange}
+                            disabled={mergeState.merging}
                         >
                             <MenuItem value={'none'}>Default</MenuItem>
                             <MenuItem value={'source-wins'}>source-wins</MenuItem>
@@ -186,6 +194,12 @@ const MergeButton = ({ repo, onDone, source, dest, disabled = false }) => {
                         (&rdquo;source-wins&rdquo;). In case no selection is made, the merge process will fail in case
                         of a conflict.
                     </FormHelperText>
+                    {mergeState.merging && (
+                        <Alert variant="info" className="d-flex align-items-center mt-3">
+                            <span className="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true" />
+                            Merging changes...
+                        </Alert>
+                    )}
                     {mergeState.err ? <AlertError error={mergeState.err} /> : <></>}
                 </Modal.Body>
                 <Modal.Footer>

--- a/webui/src/lib/components/repository/metadata.jsx
+++ b/webui/src/lib/components/repository/metadata.jsx
@@ -13,7 +13,7 @@ import { getFieldError } from './metadataHelpers';
  * @param {Function} setMetadataFields - callback to update the metadata fields
  * @param rest - any other props to pass to the component
  */
-export const MetadataFields = ({ metadataFields, setMetadataFields, ...rest }) => {
+export const MetadataFields = ({ metadataFields, setMetadataFields, disabled = false, ...rest }) => {
     const onChangeKey = (i) => {
         return (e) => {
             const newKey = e.currentTarget.value;
@@ -55,6 +55,7 @@ export const MetadataFields = ({ metadataFields, setMetadataFields, ...rest }) =
                                     onChange={onChangeKey(i)}
                                     onBlur={onBlurKey(i)}
                                     isInvalid={fieldError}
+                                    disabled={disabled}
                                 />
                                 {fieldError && (
                                     <Form.Control.Feedback type="invalid">{fieldError}</Form.Control.Feedback>
@@ -66,6 +67,7 @@ export const MetadataFields = ({ metadataFields, setMetadataFields, ...rest }) =
                                     placeholder="Value"
                                     value={f.value}
                                     onChange={onChangeValue(i)}
+                                    disabled={disabled}
                                 />
                             </Col>
                             <Col md={{ span: 1 }}>
@@ -75,6 +77,7 @@ export const MetadataFields = ({ metadataFields, setMetadataFields, ...rest }) =
                                         variant="secondary"
                                         onClick={onRemoveKeyValue(i)}
                                         aria-label={`Remove metadata field ${i + 1}`}
+                                        disabled={disabled}
                                     >
                                         <XIcon />
                                     </Button>
@@ -84,7 +87,7 @@ export const MetadataFields = ({ metadataFields, setMetadataFields, ...rest }) =
                     </Form.Group>
                 );
             })}
-            <Button onClick={onAddKeyValue} size="sm" variant="secondary">
+            <Button onClick={onAddKeyValue} size="sm" variant="secondary" disabled={disabled}>
                 <PlusIcon /> Add Metadata field
             </Button>
         </div>

--- a/webui/src/pages/repositories/repository/objects.jsx
+++ b/webui/src/pages/repositories/repository/objects.jsx
@@ -119,6 +119,7 @@ const CommitButton = ({ repo, onCommit, enabled = false }) => {
     };
 
     const onSubmit = () => {
+        if (committing) return;
         const metadata = getMetadataIfValid(metadataFields);
         if (!metadata) {
             setMetadataFields(touchInvalidFields(metadataFields));
@@ -137,7 +138,7 @@ const CommitButton = ({ repo, onCommit, enabled = false }) => {
     return (
         <>
             <Modal show={show} onHide={hide} size="lg">
-                <Modal.Header closeButton>
+                <Modal.Header closeButton={!committing}>
                     <Modal.Title>Commit Changes</Modal.Title>
                 </Modal.Header>
                 <Modal.Body>
@@ -149,11 +150,26 @@ const CommitButton = ({ repo, onCommit, enabled = false }) => {
                         }}
                     >
                         <Form.Group controlId="message" className="mb-3">
-                            <Form.Control type="text" placeholder="Commit Message" ref={textRef} />
+                            <Form.Control
+                                type="text"
+                                placeholder="Commit Message"
+                                ref={textRef}
+                                disabled={committing}
+                            />
                         </Form.Group>
 
-                        <MetadataFields metadataFields={metadataFields} setMetadataFields={setMetadataFields} />
+                        <MetadataFields
+                            metadataFields={metadataFields}
+                            setMetadataFields={setMetadataFields}
+                            disabled={committing}
+                        />
                     </Form>
+                    {committing && (
+                        <Alert variant="info" className="d-flex align-items-center">
+                            <span className="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true" />
+                            Committing changes...
+                        </Alert>
+                    )}
                     {alertText ? <Alert variant="danger">{alertText}</Alert> : <span />}
                 </Modal.Body>
                 <Modal.Footer>
@@ -161,7 +177,7 @@ const CommitButton = ({ repo, onCommit, enabled = false }) => {
                         Cancel
                     </Button>
                     <Button variant="success" disabled={committing} onClick={onSubmit}>
-                        Commit Changes
+                        {committing ? 'Committing...' : 'Commit Changes'}
                     </Button>
                 </Modal.Footer>
             </Modal>


### PR DESCRIPTION
## Summary
- disable commit/merge form inputs while requests run
- add in-progress messaging for commit, merge, and pull request actions
- extend metadata fields to support disabled state

## Testing
- npm run build
- Used commit, merge and merge pull-request

Closes #10102