### PR TITLE
chore: update browserslist database

### DIFF
--- a/webui/package-lock.json
+++ b/webui/package-lock.json
@@ -4849,9 +4849,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001737",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001737.tgz",
-      "integrity": "sha512-BiloLiXtQNrY5UyF0+1nSJLXUENuhka2pzy2Fx5pGxqavdrxSCW4U6Pn/PoG3Efspi2frRbHpBV2XsrPE6EDlw==",
+      "version": "1.0.30001768",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001768.tgz",
+      "integrity": "sha512-qY3aDRZC5nWPgHUgIB84WL+nySuo19wk0VJpp/XI9T34lrvkyhRvNVOFJOp2kxClQhiFBu+TaUSudf6oa3vkSA==",
       "dev": true,
       "funding": [
         {
@@ -21554,9 +21554,9 @@
       "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
     },
     "caniuse-lite": {
-      "version": "1.0.30001737",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001737.tgz",
-      "integrity": "sha512-BiloLiXtQNrY5UyF0+1nSJLXUENuhka2pzy2Fx5pGxqavdrxSCW4U6Pn/PoG3Efspi2frRbHpBV2XsrPE6EDlw==",
+      "version": "1.0.30001768",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001768.tgz",
+      "integrity": "sha512-qY3aDRZC5nWPgHUgIB84WL+nySuo19wk0VJpp/XI9T34lrvkyhRvNVOFJOp2kxClQhiFBu+TaUSudf6oa3vkSA==",
       "dev": true
     },
     "caseless": {


### PR DESCRIPTION
## Update Browserslist Database

This PR updates the `caniuse-lite` database to the latest version (1.0.30001768, from 1.0.30001737).

### Why do this regularly?

According to the [browserslist/update-db](https://github.com/browserslist/update-db#readme) project:

1. **Use latest browser versions** - Queries like `last 2 versions` or `>1%` depend on actual data from `caniuse-lite`. Without regular updates, these queries return outdated browser data.

2. **Reduce unnecessary polyfills** - Current browser data reduces the amount of polyfills needed, which lowers JS and CSS file sizes and improves website performance.

3. **Synchronize caniuse-lite versions** - Keeps caniuse-lite versions consistent across different tools in the project.

### Changes

- Updated package-lock.json with latest caniuse-lite version
- No target browser changes in this update