### PR TITLE
Create Iceberg Service User upon setup

### DIFF
--- a/modules/api/factory/build.go
+++ b/modules/api/factory/build.go
@@ -68,6 +68,10 @@ func BuildConditionFromParams(ifMatch, ifNoneMatch *string) (*graveler.Condition
 	return &condition, nil
 }
 
+func GetIcebergObjectsPath() *string {
+	return nil
+}
+
 func NewIcebergSyncController(_ config.Config) icebergsync.Controller {
 	return &icebergsync.NopController{}
 }

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -5846,6 +5846,13 @@ func (c *Controller) Setup(w http.ResponseWriter, r *http.Request, body apigen.S
 		return
 	}
 
+	if icebergObjectsPath := apifactory.GetIcebergObjectsPath(); icebergObjectsPath != nil {
+		_, err = setup.CreateIcebergServiceUser(ctx, c.Auth, *icebergObjectsPath)
+		if c.handleAPIError(ctx, w, r, err) {
+			return
+		}
+	}
+
 	// collect metadata
 	storageConfig := c.Config.GetBaseConfig().StorageConfig()
 	metadataProviders := []stats.MetadataProvider{

--- a/pkg/auth/service.go
+++ b/pkg/auth/service.go
@@ -36,6 +36,9 @@ import (
 
 const (
 	contextKeyConditionContext contextKey = "condition_context"
+
+	IcebergServiceUserName   = "Iceberg Service user"
+	IcebergServicePolicyName = "IcebergServicePolicy"
 )
 
 type AuthorizationRequest struct {


### PR DESCRIPTION
The main implementation for [ent#1627](https://github.com/treeverse/lakeFS-Enterprise/issues/1627).

## Change Description

Creating `Iceberg Service User` upon setup, if needed.

More details - TBD.
