### PR TITLE
fix wrong pre-commit hook yaml in documentation

### DIFF
--- a/docs/src/quickstart/actions-and-hooks.md
+++ b/docs/src/quickstart/actions-and-hooks.md
@@ -34,32 +34,32 @@ _Hooks_ can be either a [Lua](../howto/hooks/lua.md) script that lakeFS will exe
       - id: check_metadata
         type: lua
         properties:
-        script: |
-            commit_message=action.commit.message
-            if commit_message and #commit_message>0 then
-                print("✅ The commit message exists and is not empty: " .. commit_message)
-            else
-                error("\n\n❌ A commit message must be provided")
-            end
-
-            job_name=action.commit.metadata["job_name"]
-            if job_name == nil then
-                error("\n❌ Commit metadata must include job_name")
-            else
-                print("✅ Commit metadata includes job_name: " .. job_name)
-            end
-
-            version=action.commit.metadata["version"]
-            if version == nil then
-                error("\n❌ Commit metadata must include version")
-            else
-                print("✅ Commit metadata includes version: " .. version)
-                if tonumber(version) then
-                    print("✅ Commit metadata version is numeric")
-                else
-                    error("\n❌ Version metadata must be numeric: " .. version)
-                end
-            end
+          script: |
+              commit_message=action.commit.message
+              if commit_message and #commit_message>0 then
+                  print("✅ The commit message exists and is not empty: " .. commit_message)
+              else
+                  error("\n\n❌ A commit message must be provided")
+              end
+  
+              job_name=action.commit.metadata["job_name"]
+              if job_name == nil then
+                  error("\n❌ Commit metadata must include job_name")
+              else
+                  print("✅ Commit metadata includes job_name: " .. job_name)
+              end
+  
+              version=action.commit.metadata["version"]
+              if version == nil then
+                  error("\n❌ Commit metadata must include version")
+              else
+                  print("✅ Commit metadata includes version: " .. version)
+                  if tonumber(version) then
+                      print("✅ Commit metadata version is numeric")
+                  else
+                      error("\n❌ Version metadata must be numeric: " .. version)
+                  end
+              end
     ```
 3. Save this file as `/tmp/check_commit_metadata.yml`
 

--- a/pkg/samplerepo/assets/sample/README.md.tmpl
+++ b/pkg/samplerepo/assets/sample/README.md.tmpl
@@ -479,32 +479,32 @@ _Hooks_ can be either a Lua script that lakeFS will execute itself, an external 
     - id: check_metadata
         type: lua
         properties:
-        script: |
-            commit_message=action.commit.message
-            if commit_message and #commit_message>0 then
-                print("✅ The commit message exists and is not empty: " .. commit_message)
-            else
-                error("\n\n❌ A commit message must be provided")
-            end
-
-            job_name=action.commit.metadata["job_name"]
-            if job_name == nil then
-                error("\n❌ Commit metadata must include job_name")
-            else
-                print("✅ Commit metadata includes job_name: " .. job_name)
-            end
-
-            version=action.commit.metadata["version"]
-            if version == nil then
-                error("\n❌ Commit metadata must include version")
-            else
-                print("✅ Commit metadata includes version: " .. version)
-                if tonumber(version) then
-                    print("✅ Commit metadata version is numeric")
+            script: |
+                commit_message=action.commit.message
+                if commit_message and #commit_message>0 then
+                    print("✅ The commit message exists and is not empty: " .. commit_message)
                 else
-                    error("\n❌ Version metadata must be numeric: " .. version)
+                    error("\n\n❌ A commit message must be provided")
                 end
-            end
+
+                job_name=action.commit.metadata["job_name"]
+                if job_name == nil then
+                    error("\n❌ Commit metadata must include job_name")
+                else
+                    print("✅ Commit metadata includes job_name: " .. job_name)
+                end
+
+                version=action.commit.metadata["version"]
+                if version == nil then
+                    error("\n❌ Commit metadata must include version")
+                else
+                    print("✅ Commit metadata includes version: " .. version)
+                    if tonumber(version) then
+                        print("✅ Commit metadata version is numeric")
+                    else
+                        error("\n❌ Version metadata must be numeric: " .. version)
+                    end
+                end
     ```
 
 1. Save this file as `/tmp/check_commit_metadata.yml`


### PR DESCRIPTION
Closes #10123 
## Change Description

### Background

The `pre-commit hook` example in the `quickstart` documentation is incorrect: the script part is defined as `hooks` child instead of `properties`

### Bug Fix

Indent the script part to make it part of `properties`

### Testing Details

Locally run the documentation, made sure the change are there, use the new YAML as pre-commit hook and ensure the correct behavior 
