### PR TITLE
Refactor group nav to reuse fetched group data

### DIFF
--- a/webui/src/lib/components/auth/nav.jsx
+++ b/webui/src/lib/components/auth/nav.jsx
@@ -8,6 +8,7 @@ import { useLoginConfigContext } from '../../hooks/conf';
 import { Link, NavItem } from '../nav';
 import { useAPI } from '../../hooks/api';
 import { auth } from '../../api';
+import { Loading } from '../controls';
 
 const truncatedHeaderClass = 'd-inline-block w-50 text-nowrap overflow-hidden text-truncate align-middle';
 
@@ -131,7 +132,10 @@ export const GroupHeader = ({ groupId, page }) => {
     const { response, loading, error } = useAPI(() => {
         return auth.getGroup(groupId);
     }, [groupId]);
-    const resolvedGroupId = loading ? groupId : response?.id || groupId;
+
+    if (loading) return <Loading />;
+
+    const resolvedGroupId = response?.id || groupId;
 
     return (
         <div className="mb-4">
@@ -141,7 +145,7 @@ export const GroupHeader = ({ groupId, page }) => {
                 </Link>
                 <Link
                     component={BreadcrumbItem}
-                    href={{ pathname: '/auth/groups/:groupId', params: { groupId: resolvedGroupId } }}
+                    href={{ pathname: '/auth/groups/:groupId', params: { groupId } }}
                     className={truncatedHeaderClass}
                     title={resolvedGroupId}
                 >
@@ -149,7 +153,7 @@ export const GroupHeader = ({ groupId, page }) => {
                 </Link>
             </Breadcrumb>
 
-            <GroupNav groupId={resolvedGroupId} group={response} loading={loading} error={error} page={page} />
+            <GroupNav groupId={groupId} group={response} loading={false} error={error} page={page} />
         </div>
     );
 };


### PR DESCRIPTION
Avoid duplicate group fetches and ensure breadcrumbs use the resolved group id.

Note that the current solution will call the backend to resolve the group id to name.
The UI will render the heading with the id first and the real id is fetched and updated while view is rendered.

Closes #10162
Closes https://github.com/treeverse/product/issues/1026

# Preview of the end-result

<img width="1912" height="1242" alt="image" src="https://github.com/user-attachments/assets/2c9c3f75-ca82-404c-b70c-cb05d586dcb5" />
