### PR TITLE
Handle lakectl interrupt during async commit/merge polling

### DIFF
--- a/cmd/lakectl/cmd/commit.go
+++ b/cmd/lakectl/cmd/commit.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"syscall"
 
 	"github.com/go-openapi/swag"
 	"github.com/spf13/cobra"
@@ -70,7 +71,7 @@ var commitCmd = &cobra.Command{
 		}
 		// run asynchronous commit first
 		if isAsync {
-			sigCtx, stop := signal.NotifyContext(ctx, os.Interrupt)
+			sigCtx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
 			defer stop()
 
 			startResp, err := client.CommitAsyncWithResponse(sigCtx, branchURI.Repository, branchURI.Ref, &apigen.CommitAsyncParams{}, apigen.CommitAsyncJSONRequestBody(body))

--- a/cmd/lakectl/cmd/merge.go
+++ b/cmd/lakectl/cmd/merge.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"syscall"
 
 	"github.com/go-openapi/swag"
 	"github.com/spf13/cobra"
@@ -82,7 +83,7 @@ var mergeCmd = &cobra.Command{
 		var mergeResult *apigen.MergeResult
 		// asynchronous merge
 		if isAsync {
-			sigCtx, stop := signal.NotifyContext(ctx, os.Interrupt)
+			sigCtx, stop := signal.NotifyContext(ctx, os.Interrupt, syscall.SIGTERM)
 			defer stop()
 
 			startResp, err := client.MergeIntoBranchAsyncWithResponse(sigCtx, destinationRef.Repository, sourceRef.Ref, destinationRef.Ref, apigen.MergeIntoBranchAsyncJSONRequestBody(body))


### PR DESCRIPTION
Allow users to cancel lakectl commit/merge with Ctrl-C while preserving the async task ID for later follow-up.


Note that this change is relevant only to enterprise version.

Close https://github.com/treeverse/lakeFS/issues/9889
