### PR TITLE
Speed up deploy-image CI job

### DIFF
--- a/.github/workflows/esti.yaml
+++ b/.github/workflows/esti.yaml
@@ -120,6 +120,20 @@ jobs:
       - name: Unpack generated code
         run: tar -xzvf /tmp/generated.tar.gz
 
+      - name: Setup Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: 'go.mod'
+
+      - name: Build lakeFS binaries
+        env:
+          CGO_ENABLED: "0"
+          VERSION: ${{ needs.gen-code.outputs.tag }}
+        run: |
+          mkdir -p .prebuild/build
+          go build -ldflags "-X github.com/treeverse/lakefs/pkg/version.Version=${VERSION}" -o .prebuild/build/lakefs ./cmd/lakefs
+          go build -ldflags "-X github.com/treeverse/lakefs/pkg/version.Version=${VERSION}" -o .prebuild/build/lakectl ./cmd/lakectl
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -128,10 +142,12 @@ jobs:
         with:
           push: true
           tags: ${{ steps.login-ecr.outputs.registry }}/lakefs:${{ needs.gen-code.outputs.tag }}
-          build-args: VERSION=${{ needs.gen-code.outputs.tag }}
           context: .
-          cache-from: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/lakefs:buildcache
-          cache-to: type=registry,ref=${{ steps.login-ecr.outputs.registry }}/lakefs:buildcache,mode=max
+          build-contexts: |
+            build-lakefs=.prebuild
+            build-lakectl=.prebuild
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
 
   login-to-amazon-ecr:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
Speed up the deploy-image CI step by building Go binaries on the runner instead of inside Docker. actions/setup-go caches the Go module and build caches across CI runs, enabling incremental compilation. 
The pre-built binaries are injected into the existing Dockerfile via --build-context, skipping the in-Docker Go build stages entirely. Saves ~1.5-2 min on incremental builds.