### PR TITLE
API: get object handle safe content types as inline content-disposition 

### DIFF
--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -5222,7 +5222,7 @@ func (c *Controller) GetObject(w http.ResponseWriter, r *http.Request, repositor
 	w.Header().Set("Content-Type", entry.ContentType)
 	// for security, make sure the browser and any proxies en route don't cache the response
 	httputil.KeepPrivate(w)
-	
+
 	// set Content-Disposition: use "inline" for safe content types, "attachment" for others
 	disposition := "attachment"
 	if _, ok := safeContentTypesForInline[entry.ContentType]; ok {


### PR DESCRIPTION
Serve known-safe MIME types with inline disposition to improve preview behavior. Keep other content types as attachments to reduce exposure to unsafe rendering.

Close https://github.com/treeverse/lakeFS/issues/10189