### PR TITLE
ci: do not require authorship label for dependabot PRs

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
       interval: "weekly"
     labels:
       - "area/ci"
+      - "exclude-changelog"
+      - "minor-change"
     groups:
       dependencies:
         patterns:

--- a/.github/workflows/pr-requirements.yaml
+++ b/.github/workflows/pr-requirements.yaml
@@ -25,6 +25,7 @@ jobs:
         id: ai-authorship-label
         continue-on-error: true
         if: >-
+          github.event.pull_request.user.login != 'dependabot[bot]' &&
           !contains(github.event.pull_request.labels.*.name, 'mostly-ai') &&
           !contains(github.event.pull_request.labels.*.name, 'mostly-human')
         run: exit 1


### PR DESCRIPTION
See for example: https://github.com/treeverse/lakeFS/pull/10204/checks