### PR TITLE
CI: Update PR requirement checks and improve reporting

### DIFF
--- a/.github/workflows/pr-requirements.yaml
+++ b/.github/workflows/pr-requirements.yaml
@@ -1,74 +1,84 @@
 name: PR Requirements
 
 on:
+  # trigger on pr specific events as the default does not include label changes
   pull_request:
     types: [labeled, unlabeled, opened, edited, synchronize]
 
 jobs:
-  changelog-label:
-    name: Changelog label
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Require changelog label
-        if: >-
-          !contains(github.event.pull_request.labels.*.name, 'include-changelog') &&
-          !contains(github.event.pull_request.labels.*.name, 'exclude-changelog')
-        run: |
-          echo "::error::PR must have one of: include-changelog, exclude-changelog"
-          echo "## :x: Missing changelog label" >> "$GITHUB_STEP_SUMMARY"
-          echo "PR must have one of: \`include-changelog\`, \`exclude-changelog\`" >> "$GITHUB_STEP_SUMMARY"
-          exit 1
-
-  ai-authorship-label:
-    name: AI authorship label
-    runs-on: ubuntu-22.04
-    steps:
-      - name: Require AI authorship label
-        if: >-
-          !contains(github.event.pull_request.labels.*.name, 'mostly-ai') &&
-          !contains(github.event.pull_request.labels.*.name, 'mostly-human')
-        run: |
-          echo "::error::PR must have one of: mostly-ai, mostly-human"
-          echo "## :x: Missing AI authorship label" >> "$GITHUB_STEP_SUMMARY"
-          echo "PR must have one of: \`mostly-ai\`, \`mostly-human\`" >> "$GITHUB_STEP_SUMMARY"
-          exit 1
-
-  linked-issue:
-    name: Linked issue
-    runs-on: ubuntu-22.04
-    if: >-
-      !startsWith(github.head_ref, 'dependabot/') &&
-      !contains(github.event.pull_request.labels.*.name, 'minor-change')
+  pr-requirements:
+    name: PR Requirements
+    runs-on: ubuntu-24.04
     permissions:
       issues: read
       pull-requests: read
     steps:
-      - name: Require linked issue
+      - name: Changelog label
+        id: changelog-label
+        continue-on-error: true
+        if: >-
+          !contains(github.event.pull_request.labels.*.name, 'include-changelog') &&
+          !contains(github.event.pull_request.labels.*.name, 'exclude-changelog')
+        run: exit 1
+
+      - name: AI authorship label
+        id: ai-authorship-label
+        continue-on-error: true
+        if: >-
+          !contains(github.event.pull_request.labels.*.name, 'mostly-ai') &&
+          !contains(github.event.pull_request.labels.*.name, 'mostly-human')
+        run: exit 1
+
+      - name: Linked issue
+        id: linked-issue
+        continue-on-error: true
+        if: >-
+          !startsWith(github.head_ref, 'dependabot/') &&
+          !contains(github.event.pull_request.labels.*.name, 'minor-change')
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
-          ISSUES=$(gh pr view ${{ github.event.pull_request.number }} \
+          if ! ISSUES=$(gh pr view ${{ github.event.pull_request.number }} \
             --repo ${{ github.repository }} \
             --json closingIssuesReferences \
-            -q '.closingIssuesReferences[].url')
+            -q '.closingIssuesReferences[].url'); then
+            echo "::error::Failed to query PR linked issues"
+            exit 1
+          fi
           if [ -z "$ISSUES" ]; then
             echo "::error::PR must have a linked issue (e.g. 'Fixes #123' in description or link via Development sidebar)"
+            exit 1
+          fi
+
+      - name: Summary
+        if: always()
+        run: |
+          FAILED=false
+
+          if [ "${{ steps.changelog-label.outcome }}" = "failure" ]; then
+            echo "::error::PR must have one of: include-changelog, exclude-changelog"
+            echo "## :x: Missing changelog label" >> "$GITHUB_STEP_SUMMARY"
+            echo "PR must have one of: \`include-changelog\`, \`exclude-changelog\`" >> "$GITHUB_STEP_SUMMARY"
+            FAILED=true
+          fi
+
+          if [ "${{ steps.ai-authorship-label.outcome }}" = "failure" ]; then
+            echo "::error::PR must have one of: mostly-ai, mostly-human"
+            echo "## :x: Missing AI authorship label" >> "$GITHUB_STEP_SUMMARY"
+            echo "PR must have one of: \`mostly-ai\`, \`mostly-human\`" >> "$GITHUB_STEP_SUMMARY"
+            FAILED=true
+          fi
+
+          if [ "${{ steps.linked-issue.outcome }}" = "failure" ]; then
+            echo "::error::PR must have a linked issue (use 'Fixes #123' in description or link via Development sidebar)"
             echo "## :x: Missing linked issue" >> "$GITHUB_STEP_SUMMARY"
             echo "PR must have a linked issue." >> "$GITHUB_STEP_SUMMARY"
             echo "Use \`Fixes #123\` in the description or link via the Development sidebar." >> "$GITHUB_STEP_SUMMARY"
-            exit 1
+            FAILED=true
           fi
-          echo "## :white_check_mark: Linked issues" >> "$GITHUB_STEP_SUMMARY"
-          echo "$ISSUES" | while read -r url; do echo "- $url" >> "$GITHUB_STEP_SUMMARY"; done
 
-  all-pr-requirements:
-    name: All PR requirements
-    runs-on: ubuntu-22.04
-    if: always()
-    needs: [changelog-label, ai-authorship-label, linked-issue]
-    steps:
-      - name: Verify all PR requirements passed
-        if: contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')
-        run: |
-          echo "::error::Some PR requirements failed - see ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
-          exit 1
+          if [ "$FAILED" = "true" ]; then
+            exit 1
+          else
+            echo "## :white_check_mark: All PR requirements passed" >> "$GITHUB_STEP_SUMMARY"
+          fi


### PR DESCRIPTION
Run all PR requirement validations in a single job and trigger on label changes. Provide a unified summary and clearer failures to speed up PR feedback.

Related to https://github.com/treeverse/lakeFS/issues/10159