### PR TITLE
Bump nokogiri and faraday for security fixes

### DIFF
--- a/clients/python-static/templates/Gemfile.lock
+++ b/clients/python-static/templates/Gemfile.lock
@@ -40,12 +40,12 @@ GEM
       ffi (>= 1.15.0)
     eventmachine (1.2.7)
     execjs (2.10.0)
-    faraday (2.12.2)
+    faraday (2.14.1)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-net_http (3.4.0)
-      net-http (>= 0.5.0)
+    faraday-net_http (3.4.2)
+      net-http (~> 0.5)
     ffi (1.17.1-arm64-darwin)
     ffi (1.17.1-x86_64-darwin)
     ffi (1.17.1-x86_64-linux-gnu)
@@ -219,7 +219,7 @@ GEM
       gemoji (>= 3, < 5)
       html-pipeline (~> 2.2)
       jekyll (>= 3.0, < 5.0)
-    json (2.10.2)
+    json (2.18.1)
     kramdown (2.4.0)
       rexml
     kramdown-parser-gfm (1.1.0)
@@ -235,13 +235,13 @@ GEM
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
     minitest (5.25.5)
-    net-http (0.6.0)
-      uri
-    nokogiri (1.18.9-arm64-darwin)
+    net-http (0.9.1)
+      uri (>= 0.11.1)
+    nokogiri (1.19.1-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.9-x86_64-darwin)
+    nokogiri (1.19.1-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.9-x86_64-linux-gnu)
+    nokogiri (1.19.1-x86_64-linux-gnu)
       racc (~> 1.4)
     octokit (4.25.1)
       faraday (>= 1, < 3)
@@ -274,12 +274,13 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (1.8.0)
-    uri (1.0.4)
+    uri (1.1.1)
     webrick (1.9.1)
 
 PLATFORMS
   arm64-darwin-21
   arm64-darwin-24
+  arm64-darwin-25
   universal-darwin-20
   x86_64-linux
 
@@ -287,4 +288,4 @@ DEPENDENCIES
   github-pages
 
 BUNDLED WITH
-   2.6.3
+   2.7.2

--- a/clients/python/Gemfile.lock
+++ b/clients/python/Gemfile.lock
@@ -40,12 +40,12 @@ GEM
       ffi (>= 1.15.0)
     eventmachine (1.2.7)
     execjs (2.10.0)
-    faraday (2.12.2)
+    faraday (2.14.1)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
-    faraday-net_http (3.4.0)
-      net-http (>= 0.5.0)
+    faraday-net_http (3.4.2)
+      net-http (~> 0.5)
     ffi (1.17.1-arm64-darwin)
     ffi (1.17.1-x86_64-darwin)
     ffi (1.17.1-x86_64-linux-gnu)
@@ -219,7 +219,7 @@ GEM
       gemoji (>= 3, < 5)
       html-pipeline (~> 2.2)
       jekyll (>= 3.0, < 5.0)
-    json (2.10.2)
+    json (2.18.1)
     kramdown (2.4.0)
       rexml
     kramdown-parser-gfm (1.1.0)
@@ -235,13 +235,13 @@ GEM
       jekyll-feed (~> 0.9)
       jekyll-seo-tag (~> 2.1)
     minitest (5.25.5)
-    net-http (0.6.0)
-      uri
-    nokogiri (1.18.9-arm64-darwin)
+    net-http (0.9.1)
+      uri (>= 0.11.1)
+    nokogiri (1.19.1-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.9-x86_64-darwin)
+    nokogiri (1.19.1-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.18.9-x86_64-linux-gnu)
+    nokogiri (1.19.1-x86_64-linux-gnu)
       racc (~> 1.4)
     octokit (4.25.1)
       faraday (>= 1, < 3)
@@ -274,12 +274,13 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (1.8.0)
-    uri (1.0.4)
+    uri (1.1.1)
     webrick (1.9.1)
 
 PLATFORMS
   arm64-darwin-21
   arm64-darwin-24
+  arm64-darwin-25
   universal-darwin-20
   x86_64-linux
 
@@ -287,4 +288,4 @@ DEPENDENCIES
   github-pages
 
 BUNDLED WITH
-   2.6.3
+   2.7.2


### PR DESCRIPTION
## Summary
- Bumps **nokogiri** 1.18.9 → 1.19.1 — fixes [GHSA-wx95-c6cv-8532](https://github.com/advisories/GHSA-wx95-c6cv-8532) (XML C14N return value, medium severity)
- Bumps **faraday** 2.12.2 → 2.14.1 — fixes [GHSA-33mh-2634-fwr2](https://github.com/advisories/GHSA-33mh-2634-fwr2) (SSRF via protocol-relative URL, medium severity)
- Also bumps transitive deps: uri, net-http, faraday-net_http, json

Both `clients/python/Gemfile.lock` and `clients/python-static/templates/Gemfile.lock` are updated (identical files).

Supersedes #10170, #10168, #10125, #10117 (nokogiri/faraday Dependabot PRs).
Also closes stale PRs #9938, #9541, #9531 (uri/rexml already at safe versions on master).

## Test plan
- [x] `bundle check` passes
- [x] Both lockfiles are identical
- [x] CI passes