### PR TITLE
Minor lint fixes

### DIFF
--- a/cmd/lakectl/cmd/common_helpers.go
+++ b/cmd/lakectl/cmd/common_helpers.go
@@ -199,7 +199,7 @@ func WriteTo(tpl string, data any, w io.Writer) {
 			var b strings.Builder
 			for _, row := range tab.Rows {
 				for ic, cell := range row {
-					b.WriteString(fmt.Sprint(cell))
+					fmt.Fprint(&b, cell)
 					if ic < len(row)-1 {
 						b.WriteString("\t")
 					}

--- a/pkg/loadtest/target_generator.go
+++ b/pkg/loadtest/target_generator.go
@@ -26,7 +26,7 @@ func randomFilepath(basename string) string {
 	for range depth {
 		// tests, safe
 		dirSuffix := rand.Intn(maxDirSuffixes) //nolint:gosec
-		sb.WriteString(fmt.Sprintf("dir%d/", dirSuffix))
+		fmt.Fprintf(&sb, "dir%d/", dirSuffix)
 	}
 	return sb.String() + basename
 }


### PR DESCRIPTION
- Replace inefficient WriteString(fmt.Sprint/...) pattern with fmt.Fprint/Fprintf in common_helpers.go and target_generator.go
- Fixed staticcheck QF1012 warnings in cmd/lakectl/cmd/common_helpers.go:202 and pkg/loadtest/target_generator.go:29

Opened an issue to update golangci-lint as there are more changes or lint configuration to apply before we upgrade: https://github.com/treeverse/lakeFS/issues/10221