### PR TITLE
chore(clients/spark): Bump version to v0.20.0

### DIFF
--- a/clients/spark/build.sbt
+++ b/clients/spark/build.sbt
@@ -1,4 +1,4 @@
-lazy val projectVersion = "0.19.0"
+lazy val projectVersion = "0.20.0"
 ThisBuild / version := projectVersion
 lazy val hadoopVersion = "3.3.6"
 ThisBuild / isSnapshot := false


### PR DESCRIPTION
## Summary

Bump Spark metadata client version to v0.20.0 for release.