### PR TITLE
Normalize file extension case for object previews

### DIFF
--- a/webui/src/pages/repositories/repository/objectViewer.tsx
+++ b/webui/src/pages/repositories/repository/objectViewer.tsx
@@ -47,7 +47,7 @@ export const Loading: FC = () => {
 
 export const getFileExtension = (objectName: string): string => {
     const objectNameParts = objectName.split('.');
-    return objectNameParts[objectNameParts.length - 1];
+    return objectNameParts[objectNameParts.length - 1].toLowerCase();
 };
 
 export const getContentType = (headers: Headers): string | undefined => {


### PR DESCRIPTION
getFileExtension returned the raw extension from the filename without
normalizing case. The guessType switch only listed lowercase cases (jpg, jpeg,
png, etc.), so uppercase extensions like .JPG from drone cameras fell through
to UnsupportedFileType.

Adding .toLowerCase() to getFileExtension normalizes the extension before the
switch evaluates it.

Tested by copying a .JPG file to .jpg and confirming it renders instead of
failing with:

> lakeFS doesn't know how to render this file (extension = "JPG", content-type = "application/octet-stream")".

---

Fixes #10232 

Doesn't exactly fix existing issues, but there are a couple of related ones I found about rendering in LakeFS. This isn't addressing those.

## Change Description

### Bug Fix

1. **Problem** - Files with uppercase extensions (e.g. `.JPG` from drone
   cameras) show "lakeFS doesn't know how to render this file" in the object
   preview UI.

2. **Root cause** - `getFileExtension` in `objectViewer.tsx` returns the raw
   extension without normalizing case. The `guessType` switch in
   `fileRenderers/index.tsx` only lists lowercase cases(`jpg`, `jpeg`, `png`,
   etc.), so `JPG` falls through to `UnsupportedFileType`.

3. **Solution** - Added `.toLowerCase()` to the return value of
   `getFileExtension`.

### Testing Details

Copied a `.JPG` file to `.jpg` on a lakeFS instance running v1.79.0 and
confirmed the uppercase version now renders instead of failing with:

> lakeFS doesn't know how to render this file (extension = "JPG", content-type = "application/octet-stream")

### Breaking Change?

No.

### Contact Details

@yegeniy on GitHub
