### PR TITLE
ci: skip label enforcement for fork PRs

### DIFF
--- a/.github/workflows/pr-requirements.yaml
+++ b/.github/workflows/pr-requirements.yaml
@@ -4,6 +4,7 @@ on:
   # trigger on pr specific events as the default does not include label changes
   pull_request:
     types: [labeled, unlabeled, opened, edited, synchronize]
+    branches: [master]
 
 jobs:
   pr-requirements:
@@ -17,6 +18,7 @@ jobs:
         id: changelog-label
         continue-on-error: true
         if: >-
+          github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name &&
           !contains(github.event.pull_request.labels.*.name, 'include-changelog') &&
           !contains(github.event.pull_request.labels.*.name, 'exclude-changelog')
         run: exit 1
@@ -25,6 +27,7 @@ jobs:
         id: ai-authorship-label
         continue-on-error: true
         if: >-
+          github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name &&
           github.event.pull_request.user.login != 'dependabot[bot]' &&
           !contains(github.event.pull_request.labels.*.name, 'mostly-ai') &&
           !contains(github.event.pull_request.labels.*.name, 'mostly-human')


### PR DESCRIPTION
## Summary
- Skip changelog and AI authorship label checks for PRs from forks (contributors lack write permissions to add labels)
- Restrict the workflow to only run on PRs targeting `master`
