### PR TITLE
Add CLOSE_SPARK_SESSION param to Spark GC

### DIFF
--- a/clients/spark/src/main/scala/io/treeverse/clients/LakeFSContext.scala
+++ b/clients/spark/src/main/scala/io/treeverse/clients/LakeFSContext.scala
@@ -102,6 +102,7 @@ object LakeFSContext {
   val LAKEFS_CONF_GC_INCREMENTAL = "lakefs.gc.incremental"
   val LAKEFS_CONF_GC_INCREMENTAL_FALLBACK_TO_FULL = "lakefs.gc.incremental.fallback_to_full"
   val LAKEFS_CONF_GC_INCREMENTAL_NTH_PREVIOUS_RUN = "lakefs.gc.incremental.use-nth-previous-run"
+  val LAKEFS_CONF_GC_CLOSE_SPARK_SESSION = "lakefs.gc.close_spark_session"
   val LAKEFS_CONF_DEBUG_GC_NO_DELETE_KEY = "lakefs.debug.gc.no_delete"
 
   val MARK_ID_KEY = "mark_id"

--- a/clients/spark/src/main/scala/io/treeverse/gc/GarbageCollection.scala
+++ b/clients/spark/src/main/scala/io/treeverse/gc/GarbageCollection.scala
@@ -248,7 +248,9 @@ object GarbageCollection {
         )
       }
 
-      spark.close()
+      if (hc.getBoolean(LAKEFS_CONF_GC_CLOSE_SPARK_SESSION, true)) {
+        spark.close()
+      }
     }
   }
 


### PR DESCRIPTION
(Part of solving [cloud#4751](https://github.com/treeverse/cloud-controlplane/issues/4751).)

-----

When running Spark GC in Databricks as a `JAR` task (instead of the deprecated `Spark Submit` task), 
it operates successfully, but fails to close the Spark session.
It happens because Spark session isn't allowed to be closed within a `JAR` task.

Adding this param to allow disabling this `close` by config, and letting the Databricks task to handle this.
