### PR TITLE
Add noindex to mike redirect pages to fix Google search titles

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -96,6 +96,7 @@ markdown_extensions:
 plugins:
   - mike:
       version_selector: true
+      redirect_template: overrides/redirect.html
   - search
   - render_swagger:
       allow_arbitrary_locations: true

--- a/docs/overrides/redirect.html
+++ b/docs/overrides/redirect.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html>
+<head>
+  <meta charset="utf-8">
+  <title>Redirecting</title>
+  <meta name="robots" content="noindex, follow">
+  <link rel="canonical" href="{{href}}">
+  <meta http-equiv="refresh" content="1; url={{href}}">
+</head>
+<body>
+  <p>Redirecting to <a href="{{href}}">{{href}}</a>&hellip;</p>
+  <script>window.location.replace("{{href}}" + window.location.search + window.location.hash)</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary

- Google indexes mike-generated redirect pages (e.g. `docs.lakefs.io/`) showing **"Redirecting"** as the title and description in search results
- Adds a custom mike redirect template with `<meta name="robots" content="noindex, follow">` and a `<link rel="canonical">` tag so search engines skip redirect pages and index the actual content at `/latest/` instead

## Changes

- **`docs/overrides/redirect.html`** (new) — Custom redirect template with noindex directive and canonical link
- **`docs/mkdocs.yml`** — Configure mike plugin to use the custom redirect template

## Test plan

- [x] Build docs locally with `mike deploy` and verify the generated root `index.html` contains the `noindex` meta tag
- [x] After deployment, request re-indexing of `docs.lakefs.io/` via Google Search Console