### PR TITLE
test: Add hadoopfs v0.16.0, v0.17.0, v0.18.0 to compatibility test matrix

### DIFF
--- a/.github/workflows/compatibility-tests.yaml
+++ b/.github/workflows/compatibility-tests.yaml
@@ -273,7 +273,7 @@ jobs:
       matrix:
         # Removing a version from this list means the current lakeFS is no longer compatible with
         # that Hadoop lakeFS client version.
-        client_version: [0.1.10, 0.1.11, 0.1.12, 0.1.13, 0.1.14, 0.1.15, 0.2.1, 0.2.2, 0.2.3, 0.2.4, 0.2.5]
+        client_version: [0.1.10, 0.1.11, 0.1.12, 0.1.13, 0.1.14, 0.1.15, 0.2.1, 0.2.2, 0.2.3, 0.2.4, 0.2.5, 0.16.0, 0.17.0, 0.18.0]
     runs-on: ubuntu-24.04
     env:
       CLIENT_VERSION: ${{ matrix.client_version }}


### PR DESCRIPTION
## Summary
- Add missing hadoopfs client versions (0.16.0, 0.17.0, 0.18.0) to the server compatibility test matrix

## Test plan
- [ ] Verify compatibility tests pass for the new client versions