### PR TITLE
docs: Update hadoop-lakefs-assembly version to 0.18.0

### DIFF
--- a/docs/src/integrations/spark.md
+++ b/docs/src/integrations/spark.md
@@ -64,14 +64,14 @@ interact with your data on lakeFS.
     Add the package to your `spark-submit` command:
 
     ```
-    --packages io.lakefs:hadoop-lakefs-assembly:0.2.5
+    --packages io.lakefs:hadoop-lakefs-assembly:0.18.0
     ```
 
 === "Databricks"
     In  your cluster settings, under the _Libraries_ tab, add the following Maven package:
 
     ```
-    io.lakefs:hadoop-lakefs-assembly:0.2.5
+    io.lakefs:hadoop-lakefs-assembly:0.18.0
     ```
 
     Once installed, it should look something like this:
@@ -82,7 +82,7 @@ interact with your data on lakeFS.
     Add the package to your `pyspark` or `spark-submit` command:
 
     ```
-    --packages io.lakefs:hadoop-lakefs-assembly:0.2.5
+    --packages io.lakefs:hadoop-lakefs-assembly:0.18.0
     ```
 
     Add the configuration to access the S3 bucket used by lakeFS to your `pyspark` or `spark-submit` command or add this configuration at the Cloudera cluster level (see below):
@@ -163,7 +163,7 @@ Here are some configuration examples:
                 --conf spark.hadoop.fs.lakefs.access.key=AKIAlakefs12345EXAMPLE \
                 --conf spark.hadoop.fs.lakefs.secret.key=abc/lakefs/1234567bPxRfiCYEXAMPLEKEY \
                 --conf spark.hadoop.fs.lakefs.endpoint=https://example-org.us-east-1.lakefscloud.io/api/v1 \
-                --packages io.lakefs:hadoop-lakefs-assembly:0.2.5 \
+                --packages io.lakefs:hadoop-lakefs-assembly:0.18.0 \
                 io.example.ExampleClass
     ```
     
@@ -321,7 +321,7 @@ When using this mode, you don't need to configure the client with access to your
                 --conf spark.hadoop.fs.lakefs.access.key=AKIAlakefs12345EXAMPLE \
                 --conf spark.hadoop.fs.lakefs.secret.key=abc/lakefs/1234567bPxRfiCYEXAMPLEKEY \
                 --conf spark.hadoop.fs.lakefs.endpoint=https://example-org.us-east-1.lakefscloud.io/api/v1 \
-                --packages io.lakefs:hadoop-lakefs-assembly:0.2.5
+                --packages io.lakefs:hadoop-lakefs-assembly:0.18.0
     ```
 === "Scala"
     ```scala


### PR DESCRIPTION
## Summary
- Update all `hadoop-lakefs-assembly` version references from 0.2.5 to 0.18.0 in the Spark integration docs

## Test plan
- [x] Verify docs site renders correctly