### PR TITLE
chore: add cooldown period for Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,3 +13,5 @@ updates:
       dependencies:
         patterns:
         - "*"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
Add cooldown period of 7 days for Dependabot updates for GitHub Actions to reduce stability and supply-chain security risks. With this, we won't receive PRs immediately after the GitHub Action gets released.

References:
- https://nesbitt.io/2026/03/04/package-managers-need-to-cool-down.html
- https://blog.yossarian.net/2025/11/21/We-should-all-be-using-dependency-cooldowns
