### PR TITLE
WebUI: Remove Enterprise label from Tables tab

### DIFF
--- a/webui/src/pages/repositories/repository/objects.jsx
+++ b/webui/src/pages/repositories/repository/objects.jsx
@@ -1249,7 +1249,7 @@ const DataViewToggle = ({ activeView, onChangeView }) => {
                     onClick={() => onChangeView(DATA_VIEW_TABLES)}
                     className="d-flex align-items-center gap-1"
                 >
-                    <TableIcon size={16} /> Tables <span className="enterprise-badge">Enterprise</span>
+                    <TableIcon size={16} /> Tables
                 </Nav.Link>
             </Nav.Item>
         </Nav>


### PR DESCRIPTION
## Change Description

Removing the "Enterprise" label from the "Tables" tab, for increased discoverability.

<img width="439" height="267" alt="Screenshot 2026-03-24 at 8 28 26" src="https://github.com/user-attachments/assets/6ccfd6fc-1200-4135-94fd-805ce1aa6e30" />
