### PR TITLE
fix(webui): fix Load More crash in uncommitted changes view

### DIFF
--- a/webui/src/pages/repositories/repository/objects.jsx
+++ b/webui/src/pages/repositories/repository/objects.jsx
@@ -1087,7 +1087,7 @@ const TreeContainer = ({
                     getMore={getMoreUncommittedChanges}
                     loading={loading}
                     nextPage={nextPage}
-                    setLastSeenPath={setLastSeenPath}
+                    setAfterUpdated={setLastSeenPath}
                     onNavigate={(entry) => {
                         return {
                             pathname: `/repositories/:repoId/objects`,


### PR DESCRIPTION
## Summary
- Fix "Load more results" button crashing with `t is not a function` in the uncommitted changes view
- The `ChangesTreeContainer` expects a `setAfterUpdated` prop but was receiving the incorrectly-named `setLastSeenPath`

## Test plan
- [x] Create a repo with >1 page of uncommitted changes and click "Load more results"

🤖 Generated with [Claude Code](https://claude.com/claude-code)