### PR TITLE
refactor(tests): modernize loops and use Builder/maps.Copy

### DIFF
--- a/contrib/auth/acl/service_test.go
+++ b/contrib/auth/acl/service_test.go
@@ -217,7 +217,7 @@ func TestAuthService_ListPaged(t *testing.T) {
 			if size == 0 { // Overload to mean "don't paginate"
 				pagination.Amount = -1
 			}
-			got := ""
+			var got strings.Builder
 			for {
 				values, paginator, err := s.ListKVPaged(ctx, (&userData).ProtoReflect().Type(), pagination, model.UserPath(""), false)
 				if err != nil {
@@ -229,7 +229,7 @@ func TestAuthService_ListPaged(t *testing.T) {
 				}
 				letters := model.ConvertUsersDataList(values)
 				for _, c := range letters {
-					got += c.Username
+					got.WriteString(c.Username)
 				}
 				if paginator.NextPageToken == "" {
 					if size > 0 && len(letters) > size {
@@ -242,8 +242,8 @@ func TestAuthService_ListPaged(t *testing.T) {
 				}
 				pagination.After = paginator.NextPageToken
 			}
-			if got != chars {
-				t.Errorf("Expected to read back \"%s\" but got \"%s\"", chars, got)
+			if got.String() != chars {
+				t.Errorf("Expected to read back \"%s\" but got \"%s\"", chars, got.String())
 			}
 		})
 	}

--- a/pkg/catalog/task_test.go
+++ b/pkg/catalog/task_test.go
@@ -114,7 +114,7 @@ func TestRunBackgroundTaskSteps_StatusReadableDuringExecution(t *testing.T) {
 		readInterval := TaskHeartbeatInterval / 2
 		numReads := 6
 
-		for i := 0; i < numReads; i++ {
+		for i := range numReads {
 			time.Sleep(readInterval)
 			synctest.Wait()
 

--- a/pkg/config/struct_fields.go
+++ b/pkg/config/struct_fields.go
@@ -24,7 +24,7 @@ func MapLoggingFields(value any) logging.Fields {
 
 func structFieldsFunc(value reflect.Value, tag, squashValue string, prefix []string, cb func(key string, value any)) {
 	// finite loop: Go types are well-founded.
-	for value.Kind() == reflect.Ptr {
+	for value.Kind() == reflect.Pointer {
 		if value.IsZero() {
 			// If required, would already have errored out.
 			return
@@ -91,7 +91,7 @@ func GetSecureStringKeyPaths(value any) []string {
 }
 
 func getSecureStringKeys(value reflect.Value, separator, tag, squashValue string, prefix []string, cb func(key string)) {
-	for value.Kind() == reflect.Ptr {
+	for value.Kind() == reflect.Pointer {
 		if value.IsZero() {
 			return
 		}

--- a/pkg/config/struct_keys.go
+++ b/pkg/config/struct_keys.go
@@ -21,7 +21,7 @@ func GetStructKeys(typ reflect.Type, tag, squashValue string) []string {
 // passed to GetStructKeys down to this typ.
 func appendStructKeys(typ reflect.Type, tag, squashValue string, prefix []string, keys []string) []string {
 	// Dereference any pointers.  This is a finite loop: Go types are well-founded.
-	for ; typ.Kind() == reflect.Ptr; typ = typ.Elem() {
+	for ; typ.Kind() == reflect.Pointer; typ = typ.Elem() {
 	}
 
 	// Handle only struct containers; terminate the recursion on anything else.
@@ -73,7 +73,7 @@ func isScalar(kind reflect.Kind) bool {
 	case reflect.Array:
 	case reflect.Chan:
 	case reflect.Map:
-	case reflect.Ptr:
+	case reflect.Pointer:
 	case reflect.Slice:
 		return false
 	}
@@ -82,7 +82,7 @@ func isScalar(kind reflect.Kind) bool {
 
 func appendStructKeysIfZero(value reflect.Value, tag, squashValue, validateTag, requiredValue string, prefix []string, keys []string) []string {
 	// finite loop: Go types are well-founded.
-	for value.Kind() == reflect.Ptr {
+	for value.Kind() == reflect.Pointer {
 		if value.IsZero() { // If required, would already have errored out.
 			return keys
 		}

--- a/pkg/distributed/in_process_keyed_lock_test.go
+++ b/pkg/distributed/in_process_keyed_lock_test.go
@@ -123,7 +123,7 @@ func TestInProcessKeyedLock_CancelledMiddleWaiter(t *testing.T) {
 		var wg sync.WaitGroup
 		cancelCtx, cancelW1 := context.WithCancel(ctx)
 
-		for i := 0; i < 3; i++ {
+		for i := range 3 {
 			wg.Add(1)
 			acquireCtx := ctx
 			if i == 1 {

--- a/pkg/graveler/retention/active_commits_test.go
+++ b/pkg/graveler/retention/active_commits_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"slices"
 	"sort"
 	"testing"
@@ -379,9 +380,7 @@ func TestActiveCommits(t *testing.T) {
 			}
 
 			commitsWithHashedKeys := make(map[graveler.CommitID]testCommit, len(tst.commits))
-			for k, v := range tst.commits {
-				commitsWithHashedKeys[k] = v
-			}
+			maps.Copy(commitsWithHashedKeys, tst.commits)
 
 			refManagerMock.EXPECT().ListCommits(ctx, repositoryRecord).Return(testutil.NewFakeCommitIterator(commitsRecords), nil).MaxTimes(1)
 


### PR DESCRIPTION
## Summary
- modernize test loops in several Go test files to use newer idiomatic patterns
- replace manual map copy patterns with  where applicable
- update config struct field/key test helpers to the builder style for readability