### PR TITLE
Stop ignoring generated test artifacts and API stubs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,14 +15,6 @@
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
 
-# Test-only generated files (mocks)
-**/mock/*.go
-
-# Test-specific generated protos and wrappers
-pkg/graveler/settings/test_settings.pb.go
-pkg/kv/kvtest/test_model.pb.go
-tools/wrapgen/testcode/wrapped_gen.go
-
 ### Go Patch ###
 /vendor/
 /Godeps/
@@ -53,7 +45,6 @@ tools/wrapgen/testcode/wrapped_gen.go
 /webui/node_modules
 
 # server excludes
-/pkg/api/gen
 .DS_Store
 
 # recordings


### PR DESCRIPTION
## Summary
- Remove ignore rules for generated test artifacts and API stubs from `.gitignore`.
- Allow generated sources to be committed and reviewed for better reproducibility across environments.