### PR TITLE
Fix PR requirements cross-repo linked issue detection

### DIFF
--- a/.github/workflows/pr-requirements.yaml
+++ b/.github/workflows/pr-requirements.yaml
@@ -40,7 +40,7 @@ jobs:
           !startsWith(github.head_ref, 'dependabot/') &&
           !contains(github.event.pull_request.labels.*.name, 'minor-change')
         env:
-          GH_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
+          GH_TOKEN: ${{ secrets.TREEVERSE_CI_TOKEN }}
         run: |
           if ! ISSUES=$(gh pr view ${{ github.event.pull_request.number }} \
             --repo ${{ github.repository }} \


### PR DESCRIPTION
## Summary

- Use `PERSONAL_TOKEN` secret instead of `github.token` for the linked issue check in PR requirements workflow
- `GITHUB_TOKEN` cannot resolve `closingIssuesReferences` for issues in private repos (e.g. lakeFS-Enterprise), causing false failures


## Test plan

- [x] Verify that the PR's own "PR Requirements" check passes using different issues from various projects.