### PR TITLE
Replace PERSONAL_TOKEN with org-level TREEVERSE_CI_TOKEN

### DIFF
--- a/.github/workflows/check-ui-links.yaml
+++ b/.github/workflows/check-ui-links.yaml
@@ -30,7 +30,7 @@ jobs:
         with:
           repository: treeverse/docs-lakeFS
           fetch-depth: 1
-          token: ${{ secrets.PERSONAL_TOKEN }}
+          token: ${{ secrets.TREEVERSE_CI_TOKEN }}
           path: docs/docs-repo
 
       - name: Configure Git
@@ -42,7 +42,7 @@ jobs:
       - name: Build latest
         working-directory: docs/docs-repo
         env:
-          GITHUB_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TREEVERSE_CI_TOKEN }}
         run: |
           mike deploy --config-file ../mkdocs.yml --branch main dev --update-aliases latest
 

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -46,7 +46,7 @@ jobs:
         with:
           repository: treeverse/docs-lakeFS
           fetch-depth: 1
-          token: ${{ secrets.PERSONAL_TOKEN }}
+          token: ${{ secrets.TREEVERSE_CI_TOKEN }}
           path: docs/docs-repo
 
       - name: Configure Git
@@ -95,7 +95,7 @@ jobs:
       - name: Deploy documentation
         working-directory: docs/docs-repo
         env:
-          GITHUB_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.TREEVERSE_CI_TOKEN }}
         run: |
           mike deploy --config-file ../mkdocs.yml --branch main --push "${{ steps.setvars.outputs.VERSION }}" ${{ steps.setvars.outputs.ALIASES }}
 

--- a/.github/workflows/goreleaser.yaml
+++ b/.github/workflows/goreleaser.yaml
@@ -60,7 +60,7 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ github.token }}
-          TAP_GITHUB_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
+          TAP_GITHUB_TOKEN: ${{ secrets.TREEVERSE_CI_TOKEN }}
 
       - name: Make lakectl public
         run: aws s3 cp --recursive --acl public-read "s3://treeverse-clients-us-east/lakectl/$(echo ${GITHUB_REF##*/} | cut -d. -f1-2)" "s3://treeverse-clients-us-east/lakectl/$(echo ${GITHUB_REF##*/} | cut -d. -f1-2)" --metadata-directive REPLACE

--- a/.github/workflows/publish-python-wrapper-client.yaml
+++ b/.github/workflows/publish-python-wrapper-client.yaml
@@ -25,7 +25,7 @@ jobs:
     - name: Publish to Docs Repository
       uses: dmnemec/copy_file_to_another_repo_action@v1.1.1
       env:
-        API_TOKEN_GITHUB: ${{ secrets.PERSONAL_TOKEN }}
+        API_TOKEN_GITHUB: ${{ secrets.TREEVERSE_CI_TOKEN }}
       with:
         source_file: clients/python-wrapper/_site/.
         destination_repo: treeverse/docs-lakefs-sdk-python-wrapper

--- a/.github/workflows/python-api-client.yaml
+++ b/.github/workflows/python-api-client.yaml
@@ -70,7 +70,7 @@ jobs:
     - name: Publish to docs repository
       uses: dmnemec/copy_file_to_another_repo_action@v1.1.1
       env:
-        API_TOKEN_GITHUB: ${{ secrets.PERSONAL_TOKEN }}
+        API_TOKEN_GITHUB: ${{ secrets.TREEVERSE_CI_TOKEN }}
       with:
         source_file: clients/python/_site/.
         destination_repo: treeverse/docs-lakefs-sdk-python

--- a/.github/workflows/trigger-code-int.yaml
+++ b/.github/workflows/trigger-code-int.yaml
@@ -16,6 +16,6 @@ jobs:
     steps:
       - name: Trigger code-int workflow
         env:
-          GH_TOKEN: ${{ secrets.PERSONAL_TOKEN }}
+          GH_TOKEN: ${{ secrets.TREEVERSE_CI_TOKEN }}
         run: |
           gh workflow run code-int.yaml --repo treeverse/lakeFS-Enterprise --field ref='${{ github.ref }}'


### PR DESCRIPTION
## Summary
- Replaces all references to `secrets.PERSONAL_TOKEN` with `secrets.TREEVERSE_CI_TOKEN` across 7 workflow files
- Migrates from a personal access token to an organization-level token with proper cross-repo access

Closes #10332
