### PR TITLE
Fix lakectl branch reset usage: says four ways but lists three

### DIFF
--- a/cmd/lakectl/cmd/branch_reset.go
+++ b/cmd/lakectl/cmd/branch_reset.go
@@ -8,12 +8,11 @@ import (
 	"github.com/treeverse/lakefs/pkg/api/apigen"
 )
 
-// lakectl branch reset lakefs://myrepo/main --commit commitId --prefix path --object path
 var branchResetCmd = &cobra.Command{
 	Use:     "reset <branch URI> [--prefix|--object]",
 	Example: "lakectl branch reset " + myRepoExample + "/" + myBranchExample,
 	Short:   "Reset uncommitted changes - all of them, or by path",
-	Long: `reset changes.  There are four different ways to reset changes:
+	Long: `reset changes.  There are three different ways to reset changes:
   1. reset all uncommitted changes - reset lakefs://myrepo/main 
   2. reset uncommitted changes under specific path - reset lakefs://myrepo/main --prefix path
   3. reset uncommitted changes for specific object - reset lakefs://myrepo/main --object path`,

--- a/docs/src/reference/cli.md
+++ b/docs/src/reference/cli.md
@@ -1322,7 +1322,7 @@ Reset uncommitted changes - all of them, or by path
 
 <h4>Synopsis</h4>
 
-reset changes.  There are four different ways to reset changes:
+reset changes.  There are three different ways to reset changes:
   1. reset all uncommitted changes - reset lakefs://myrepo/main 
   2. reset uncommitted changes under specific path - reset lakefs://myrepo/main --prefix path
   3. reset uncommitted changes for specific object - reset lakefs://myrepo/main --object path


### PR DESCRIPTION
## Summary
- Fixed the `lakectl branch reset` Long description which claimed "four different ways to reset" but only listed three
- Removed stale comment referencing a `--commit` flag that was never implemented

Closes https://github.com/treeverse/lakeFS/issues/10335