### PR TITLE
docs: use oss-pr- prefix for docs preview URLs

### DIFF
--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,5 +1,4 @@
 # MkDocs settings
-# TODO: Remove this comment - temporary change to trigger docs preview workflow
 dev_addr: 127.0.0.1:4000
 site_name: lakeFS Community Documentation
 site_url: https://community.lakefs.io/


### PR DESCRIPTION
## Summary
- Update the docs-pr workflow to prefix preview sites with `oss-pr-` instead of `pr-` to distinguish OSS doc previews
- Includes a temporary docs change to trigger the workflow for testing (to be reverted)

Close https://github.com/treeverse/lakeFS-Enterprise/issues/2097

## Test plan
- [x] Verify the workflow triggers on this PR
- [x] Check that the preview URL in the PR comment uses the `oss-pr-` prefix
