### PR TITLE
Release python-wrapper 0.16.0

### DIFF
--- a/clients/python-wrapper/CHANGELOG.md
+++ b/clients/python-wrapper/CHANGELOG.md
@@ -2,6 +2,20 @@
 
 ## Unreleased
 
+## v0.16.0
+
+:new: What's new:
+
+- Shallow copy implementation (#10183)
+
+:bug: Bugs fixed:
+
+- Fix UnboundLocalError when reading empty objects with range request (#10238)
+
+:warning: Breaking changes:
+
+- Drop Python 3.9 support, minimum version is now 3.10 (#10193)
+
 ## v0.15.0
 
 :new: What's new:

--- a/clients/python-wrapper/pyproject.toml
+++ b/clients/python-wrapper/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "lakefs"
 description = "lakeFS Python SDK Wrapper"
-version = "0.15.0"
+version = "0.16.0"
 keywords = ["OpenAPI", "OpenAPI-Generator", "lakeFS API", "Python Wrapper"]
 requires-python = ">=3.10"
 readme = "README.md"


### PR DESCRIPTION
## Summary
- Bump python-wrapper version from 0.15.0 to 0.16.0
- Update CHANGELOG with new features, bug fixes, and breaking changes since v0.15.0

### Changelog
**:new: What's new:**
- Shallow copy implementation (#10183)

**:bug: Bugs fixed:**
- Fix UnboundLocalError when reading empty objects with range request (#10238)

**:warning: Breaking changes:**
- Drop Python 3.9 support, minimum version is now 3.10 (#10193)

## Test plan
- [ ] Review changelog entries for completeness
- [ ] Run [Publish Python Wrapper Client](https://github.com/treeverse/lakeFS/actions/workflows/publish-python-wrapper-client.yaml) after merge
- [ ] Post announcement to Slack #announcements-and-more

🤖 Generated with [Claude Code](https://claude.com/claude-code)