### PR TITLE
Add --yes flag to lakectl tag delete

### DIFF
--- a/cmd/lakectl/cmd/tag_delete.go
+++ b/cmd/lakectl/cmd/tag_delete.go
@@ -28,5 +28,7 @@ var tagDeleteCmd = &cobra.Command{
 
 //nolint:gochecknoinits
 func init() {
+	AssignAutoConfirmFlag(tagDeleteCmd.Flags())
+
 	tagCmd.AddCommand(tagDeleteCmd)
 }

--- a/docs/src/reference/cli.md
+++ b/docs/src/reference/cli.md
@@ -2731,6 +2731,7 @@ lakectl tag delete <tag URI> [flags]
 
 ```
   -h, --help   help for delete
+  -y, --yes    Automatically say yes to all confirmations
 ```
 
 

--- a/esti/golden/lakectl_tag_list_single.golden
+++ b/esti/golden/lakectl_tag_list_single.golden
@@ -1,0 +1,2 @@
+${TAG2}	<COMMIT_ID>
+

--- a/esti/lakectl_test.go
+++ b/esti/lakectl_test.go
@@ -1267,4 +1267,9 @@ func TestLakectlTagList(t *testing.T) {
 	t.Run("with prefix and amount", func(t *testing.T) {
 		RunCmdAndVerifySuccessWithFile(t, Lakectl()+" tag list lakefs://"+repoName+" --prefix="+vars_test["TAG1"]+" --amount=1", false, "lakectl_tag_list_prefix", vars_test)
 	})
+
+	t.Run("delete tag1", func(t *testing.T) {
+		RunCmdAndVerifySuccess(t, Lakectl()+" tag delete lakefs://"+repoName+"/tag1 -y", false, "", vars)
+		RunCmdAndVerifySuccessWithFile(t, Lakectl()+" tag list lakefs://"+repoName, false, "lakectl_tag_list_single", vars_test)
+	})
 }


### PR DESCRIPTION
## Summary
- Add `--yes` / `-y` flag to `lakectl tag delete` to skip interactive confirmation, consistent with other destructive commands (`branch delete`, `branch reset`, etc.)

## Related Issue
Closes #10334
