### PR TITLE
Skip TestLakectlTagList/delete_tag1 in lakectl compat test

### DIFF
--- a/.github/workflows/lakectl-compatibility-tests.yaml
+++ b/.github/workflows/lakectl-compatibility-tests.yaml
@@ -133,7 +133,7 @@ jobs:
           LAKEFS_BLOCKSTORE_TYPE: s3
           LAKEFS_BLOCKSTORE_S3_CREDENTIALS_ACCESS_KEY_ID: ${{ secrets.ESTI_AWS_ACCESS_KEY_ID }}
           LAKEFS_BLOCKSTORE_S3_CREDENTIALS_SECRET_ACCESS_KEY: ${{ secrets.ESTI_AWS_SECRET_ACCESS_KEY }}
-          SKIP_TESTS: 'TestLakectl(Usage|Help)$'
+          SKIP_TESTS: 'TestLakectl(Usage|Help)$|TestLakectlTagList/delete_tag1'
 
   notify-slack:
     name: Notify slack on workflow failures


### PR DESCRIPTION
## Summary
- Skip `TestLakectlTagList/delete_tag1` in the lakectl compatibility test since the latest released lakectl doesn't have the `--yes`/`-y` flag for `tag delete` yet (added in #10351)

## Related Issue
None

## Test plan
- [x] Verify lakectl compatibility test workflow passes with the updated skip pattern