### PR TITLE
fix: spacing in startup banner

### DIFF
--- a/cmd/lakefs/cmd/run.go
+++ b/cmd/lakefs/cmd/run.go
@@ -447,8 +447,8 @@ lakeFS {{ .Version }} - Up and running (^C to shutdown)...
 │
 
 │
-│ For support or any other question,                            >(.＿.)<
-│     join our Slack channel https://community.lakefs.io/slack         (  )_
+│ For support or any other question,                              >(.＿.)<
+│     join our Slack channel https://community.lakefs.io/slack      (  )_
 │
 
 `


### PR DESCRIPTION
## Summary
- Fix spacing in the lakeFS startup banner for cleaner terminal output
