### PR TITLE
block/local+mem: return ErrDataNotFound when Copy source is missing

### DIFF
--- a/pkg/block/local/adapter.go
+++ b/pkg/block/local/adapter.go
@@ -185,12 +185,17 @@ func (l *Adapter) Copy(_ context.Context, sourceObj, destinationObj block.Object
 		return err
 	}
 	sourceFile, err := os.Open(filepath.Clean(source))
+	if err != nil {
+		// Translate a missing source file into block.ErrDataNotFound so the
+		// gateway copy handler returns 404 instead of 400 (#10185).
+		if os.IsNotExist(err) {
+			return block.ErrDataNotFound
+		}
+		return err
+	}
 	defer func() {
 		_ = sourceFile.Close()
 	}()
-	if err != nil {
-		return err
-	}
 	dest, err := l.extractParamsFromObj(destinationObj)
 	if err != nil {
 		return err

--- a/pkg/block/mem/adapter.go
+++ b/pkg/block/mem/adapter.go
@@ -246,6 +246,14 @@ func (a *Adapter) Copy(_ context.Context, sourceObj, destinationObj block.Object
 	dstStorageID := destinationObj.StorageID
 	sourceKey := getKey(sourceObj)
 	destinationKey := getKey(destinationObj)
+	// Signal the missing source explicitly so the gateway returns 404 instead
+	// of silently writing an empty destination object (#10185).
+	if a.data[srcStorageID] == nil {
+		return block.ErrDataNotFound
+	}
+	if _, ok := a.data[srcStorageID][sourceKey]; !ok {
+		return block.ErrDataNotFound
+	}
 	if a.data[srcStorageID] != nil {
 		if a.data[dstStorageID] == nil {
 			a.data[dstStorageID] = make(map[string][]byte)


### PR DESCRIPTION
## Summary

Part of #10185.

After the shallow-copy refactor the gateway's copy handler no longer pre-calls `GetProperties` before `Copy`, so a missing source has to be signalled from `Copy` itself. Today the local adapter wraps the generic `os.Open` error and the mem adapter silently copies the zero value of the missing key, so the gateway returns `400 Bad Request` (or, for mem, pretends the copy succeeded and writes an empty destination) instead of `404 NoSuchKey`.

This PR fixes the two adapters I could test fully locally:

- **local**: translate `os.IsNotExist(err)` into `block.ErrDataNotFound` before returning.
- **mem**: check whether the source storage/key exists and return `block.ErrDataNotFound` before touching the destination. (Previously, the destination was silently populated with an empty byte slice when the source was missing.)

I've intentionally left S3, GCS, and Azure alone on this PR: each of those needs a provider-specific not-found predicate (via `isErrNotFound` / `bloberror.HasCode`) and a separate diff — happy to follow up as a second PR.

## Test plan

- [x] `go build ./pkg/block/local/ ./pkg/block/mem/`
- [x] `go test ./pkg/block/local/ ./pkg/block/mem/ -count=1` (all existing tests pass)
- [ ] `esti/s3_gateway_test.go::TestS3CopyObjectErrors/source_not_found` is called out in the issue with a TODO; updating the assertion from 400 → 404 and removing the TODO is a good follow-up once all five adapters are switched over
