### PR TITLE
fix nil dereference in when fs cat command fail

### DIFF
--- a/cmd/lakectl/cmd/fs_cat.go
+++ b/cmd/lakectl/cmd/fs_cat.go
@@ -27,11 +27,11 @@ var fsCatCmd = &cobra.Command{
 			Path:    *pathURI.Path,
 			Presign: swag.Bool(preSignMode.Enabled),
 		})
-		DieOnHTTPError(resp)
-		body = resp.Body
 		if err != nil {
 			DieErr(err)
 		}
+		DieOnHTTPError(resp)
+		body = resp.Body
 
 		defer func() {
 			if err := body.Close(); err != nil {


### PR DESCRIPTION
Closes #10380

> backport from enterprise

## Change Description

`lakectl fs cat` was calling `DieOnHTTPError(resp)` and accessing `resp.Body` before checking the error returned by `GetObject`. When the request fails and returns a nil response, this caused a nil pointer dereference panic instead of a clean error message.

Fix: check `err` first, then call `DieOnHTTPError`.

#### Screenshots
```
# before
╭─david@Davids-MacBook-Pro ~
╰─➤  gcs-lakectl fs cat lakefs://gcs-hello-world/main/hello.txt --pre-sign=true
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x40 pc=0x101b169b4]

goroutine 1 [running]:
github.com/treeverse/lakefs/cmd/lakectl/cmd.init.func73(0x104118ca0, {0x14000523860?, 0x4?, 0x101c1599d?})
	/Users/david/treeverse/git_repositories/lakeFS-Enterprise/lakefs-oss/cmd/lakectl/cmd/fs_cat.go:31 +0x134
github.com/spf13/cobra.(*Command).execute(0x104118ca0, {0x14000523820, 0x2, 0x2})
	/Users/david/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1019 +0x7bc
github.com/spf13/cobra.(*Command).ExecuteC(0x10411e8a0)
	/Users/david/go/pkg/mod/github.com/spf13/cobra@v1.10.2/command.go:1148 +0x350
github.com/treeverse/lakefs/cmd/lakectl/cmd.Execute()
	/Users/david/treeverse/git_repositories/lakeFS-Enterprise/lakefs-oss/cmd/lakectl/cmd/root.go:811 +0x24
main.main()
	/Users/david/treeverse/git_repositories/lakeFS-Enterprise/lakefs-oss/cmd/lakectl/main.go:6 +0x1c
```

``` 
# after:
╭─david@Davids-MacBook-Pro ~
╰─➤  gcs-lakectl fs cat lakefs://gcs-hello-world/main/hello.txt --pre-sign=true
Get "http://localhost:8000/api/v1/repositories/gcs-hello-world/refs/main/objects?path=hello.txt&presign=true": GET http://localhost:8000/api/v1/repositories/gcs-hello-world/refs/main/objects?path=hello.txt&presign=true giving up after 5 attempt(s)
Error executing command.
```

### Testing Details

Reproduced by running `lakectl fs cat` against a GCS-backed lakeFS instance using Application Default Credentials (which don't support URL signing), with pre-sign enabled (the default). Previously panicked, now fails cleanly.

-----

## AI Contribution Notes

### AI-Generated Code

No AI-generated code — fix written by the author.

### AI Code Review

AI assisted in debugging: identified the relevant file (`cmd/lakectl/cmd/fs_cat.go`) and pinpointed the root cause (nil dereference due to wrong ordering of `err` check and `DieOnHTTPError` call). The author debugged the issue, reproduced it, and wrote the fix.
