### PR TITLE
docs: remove unavailable video embed from Delta Lake page

### DIFF
--- a/docs/src/integrations/delta.md
+++ b/docs/src/integrations/delta.md
@@ -88,8 +88,6 @@ Here, `main` is the name of the lakeFS branch from which the delta table was exp
 
 To enable Delta table exports to Unity catalog use the Unity [catalog integration guide](unity-catalog.md).
 
-<iframe data-uc-allowed="true" width="420" height="315" src="https://www.youtube.com/embed/rMDsnh7S2O0"></iframe>
-
 ## Limitations
 
 <h3>Multi-Writer Support in lakeFS for Delta Lake Tables</h3>


### PR DESCRIPTION
## Summary
- The embedded YouTube video (ID `rMDsnh7S2O0`) on `docs/src/integrations/delta.md` is no longer available (thumbnail returns HTTP 404).
- Removes the broken iframe to avoid showing an unavailable video to readers.

## Test plan
- [x] Verify the Delta Lake integration page renders without the broken iframe