### PR TITLE
Revert code links to docs lakefs from community

### DIFF
--- a/clients/python-wrapper/lakefs/reference.py
+++ b/clients/python-wrapper/lakefs/reference.py
@@ -34,7 +34,7 @@ class Reference(_BaseLakeFSObject):
         - 'main@' (head of 'main' branch, only committed objects)
         - 'my_tag~3' (3 commits before 'my_tag')
 
-        See https://community.lakefs.io/understand/model.html#ref-expressions for
+        See https://docs.lakefs.io/understand/model.html#ref-expressions for
         details.
         """
         self._repo_id = repository_id

--- a/cmd/lakefs/cmd/run.go
+++ b/cmd/lakefs/cmd/run.go
@@ -443,12 +443,12 @@ lakeFS {{ .Version }} - Up and running (^C to shutdown)...
 {{ .SetupMessage }}
 │
 │ For more information on how to use lakeFS,
-│     check out the docs at https://community.lakefs.io/quickstart/
+│     check out the docs at https://docs.lakefs.io/quickstart/
 │
 
 │
-│ For support or any other question,                              >(.＿.)<
-│     join our Slack channel https://community.lakefs.io/slack      (  )_
+│ For support or any other question,                         >(.＿.)<
+│     join our Slack channel https://docs.lakefs.io/slack      (  )_
 │
 
 `

--- a/pkg/kv/migration.go
+++ b/pkg/kv/migration.go
@@ -57,7 +57,7 @@ func ValidateSchemaVersion(ctx context.Context, store Store) (int, error) {
 	case kvVersion >= NextSchemaVersion:
 		return kvVersion, fmt.Errorf("incompatible schema version. Latest: %d: %w", NextSchemaVersion-1, ErrMigrationVersion)
 	case kvVersion < InitialMigrateVersion:
-		return kvVersion, fmt.Errorf("migration to KV required. Did you migrate using version v0.80.x? https://community.lakefs.io/reference/upgrade.html#lakefs-0800-or-greater-kv-migration: %w", ErrMigrationVersion)
+		return kvVersion, fmt.Errorf("migration to KV required. Did you migrate using version v0.80.x? https://docs.lakefs.io/reference/upgrade.html#lakefs-0800-or-greater-kv-migration: %w", ErrMigrationVersion)
 	case kvVersion < ACLMigrateVersion,
 		kvVersion < ACLNoReposMigrateVersion:
 		return kvVersion, fmt.Errorf("migration to ACL required. Please run 'lakefs migrate up': %w", ErrMigrationRequired)

--- a/pkg/samplerepo/assets/sample/README.md.tmpl
+++ b/pkg/samplerepo/assets/sample/README.md.tmpl
@@ -50,7 +50,7 @@ Follow the prompts to enter your credentials that you created when you first set
 1. When you download [lakeFS from the GitHub repository](https://github.com/treeverse/lakeFS/releases) the distribution includes the `lakectl` tool. 
 
     Add this to your `$PATH`, or when invoking it reference it from the downloaded folder
-2. [Configure](https://community.lakefs.io/reference/cli.html#configuring-credentials-and-api-endpoint) `lakectl` by running
+2. [Configure](https://docs.lakefs.io/reference/cli.html#configuring-credentials-and-api-endpoint) `lakectl` by running
 
     ```bash
     lakectl config
@@ -156,7 +156,7 @@ created branch 'denmark-lakes' 3384cd7cdc4a2cd5eb6249b52f0a709b49081668bb1574ce8
 
 ## Transforming the Data
 
-_Now we'll make a change to the data. lakeFS has several native clients, as well as an [S3-compatible endpoint](https://community.lakefs.io/understand/architecture.html#s3-gateway). This means that anything that can use S3 will work with lakeFS. Pretty neat._
+_Now we'll make a change to the data. lakeFS has several native clients, as well as an [S3-compatible endpoint](https://docs.lakefs.io/understand/architecture.html#s3-gateway). This means that anything that can use S3 will work with lakeFS. Pretty neat._
 
 We're going to use DuckDB which is embedded within the web interface of lakeFS.
 
@@ -444,7 +444,7 @@ Back in the object page and the DuckDB query we can see that the original file i
 <a name="actions-and-hooks"></a>
 # Actions and Hooks in lakeFS 🪝
 
-When we interact with lakeFS it can be useful to have certain checks performed at stages along the way. Let's see how [actions in lakeFS](https://community.lakefs.io/howto/hooks/) can be of benefit here.
+When we interact with lakeFS it can be useful to have certain checks performed at stages along the way. Let's see how [actions in lakeFS](https://docs.lakefs.io/howto/hooks/) can be of benefit here.
 
 We're going to enforce a rule that when a commit is made to any branch that begins with `etl`: 
 
@@ -625,11 +625,11 @@ Here are some more resources to help you find out more about lakeFS.
 
 ## Connecting lakeFS to your own object storage
 
-Enjoyed the quickstart and want to try out lakeFS against your own data? The documentation explains [how to run lakeFS locally as a Docker container locally connecting to an object store](https://community.lakefs.io/quickstart/learning-more-lakefs.html#connecting-lakefs-to-your-own-object-storage).
+Enjoyed the quickstart and want to try out lakeFS against your own data? The documentation explains [how to run lakeFS locally as a Docker container locally connecting to an object store](https://docs.lakefs.io/quickstart/learning-more-lakefs.html#connecting-lakefs-to-your-own-object-storage).
 
 ## Deploying lakeFS
 
-Ready to do this thing for real? The deployment guides show you how to deploy lakeFS [locally](https://community.lakefs.io/deploy/onprem.html) (including on [Kubernetes](https://community.lakefs.io/deploy/onprem.html#k8s)) or on [AWS](https://community.lakefs.io/deploy/aws.html), [Azure](https://community.lakefs.io/deploy/azure.html), or [GCP](https://community.lakefs.io/deploy/gcp.html).
+Ready to do this thing for real? The deployment guides show you how to deploy lakeFS [locally](https://docs.lakefs.io/deploy/onprem.html) (including on [Kubernetes](https://docs.lakefs.io/deploy/onprem.html#k8s)) or on [AWS](https://docs.lakefs.io/deploy/aws.html), [Azure](https://docs.lakefs.io/deploy/azure.html), or [GCP](https://docs.lakefs.io/deploy/gcp.html).
 
 Alternatively you might want to have a look at [lakeFS Cloud](https://lakefs.cloud/) which provides a fully-managed, SOC-2 compliant, lakeFS service.
 
@@ -653,7 +653,7 @@ lakeFS' community is important to us. Our **guiding principles** are.
 
 We'd love for you to join [our **Slack group**](https://lakefs.io/slack) and come and introduce yourself on `#announcements-and-more`. Or just lurk and soak up the vibes 😎
 
-If you're interested in getting involved in lakeFS' development head over our [the **GitHub repo**](https://github.com/treeverse/lakeFS) to look at the code and peruse the issues. The comprehensive [contributing](https://community.lakefs.io/contributing.html) document should have you covered on next steps but if you've any questions the `#dev` channel on [Slack](https://lakefs.io/slack) will be delighted to help.
+If you're interested in getting involved in lakeFS' development head over our [the **GitHub repo**](https://github.com/treeverse/lakeFS) to look at the code and peruse the issues. The comprehensive [contributing](https://docs.lakefs.io/contributing.html) document should have you covered on next steps but if you've any questions the `#dev` channel on [Slack](https://lakefs.io/slack) will be delighted to help.
 
 We love speaking at meetups and chatting to community members at them - you can find a list of these [here](https://lakefs.io/community/).
 
@@ -661,4 +661,4 @@ Finally, make sure to drop by to say hi on [Twitter](https://twitter.com/lakeFS)
 
 ## lakeFS Concepts and Internals
 
-We describe lakeFS as "_Git for data_" but what does that actually mean? Have a look at the [concepts](https://community.lakefs.io/understand/model.html) and [architecture](https://community.lakefs.io/understand/architecture.html) guides, as well as the explanation of [how merges are handled](https://community.lakefs.io/understand/how/merge.html). To go deeper you might be interested in [the internals of versioning](https://community.lakefs.io/understand/how/versioning-internals.html) and our [internal database structure](https://community.lakefs.io/understand/how/kv.html).
+We describe lakeFS as "_Git for data_" but what does that actually mean? Have a look at the [concepts](https://docs.lakefs.io/understand/model.html) and [architecture](https://docs.lakefs.io/understand/architecture.html) guides, as well as the explanation of [how merges are handled](https://docs.lakefs.io/understand/how/merge.html). To go deeper you might be interested in [the internals of versioning](https://docs.lakefs.io/understand/how/versioning-internals.html) and our [internal database structure](https://docs.lakefs.io/understand/how/kv.html).

--- a/webui/fallback.html
+++ b/webui/fallback.html
@@ -42,7 +42,7 @@
     <p><code>make gen-ui</code></p>
     <p class="links">
       <a href="/_health">API Health Check</a> |
-      <a href="https://community.lakefs.io">Documentation</a>
+      <a href="https://docs.lakefs.io">Documentation</a>
     </p>
   </div>
 </body>

--- a/webui/src/lib/components/auth/layout.tsx
+++ b/webui/src/lib/components/auth/layout.tsx
@@ -34,12 +34,12 @@ export const AuthLayout = () => {
                             }}
                         >
                             <InfoIcon /> Enhance Your Security with{' '}
-                            <Alert.Link href={'https://community.lakefs.io/reference/security/rbac.html'}>
+                            <Alert.Link href={'https://docs.lakefs.io/reference/security/rbac.html'}>
                                 Role-Based Access Control
                             </Alert.Link>{' '}
                             – Available on <Alert.Link href={'https://lakefs.cloud/register'}>lakeFS Cloud</Alert.Link>{' '}
                             and{' '}
-                            <Alert.Link href={'https://community.lakefs.io/understand/enterprise/'}>
+                            <Alert.Link href={'https://docs.lakefs.io/understand/enterprise/'}>
                                 lakeFS Enterprise
                             </Alert.Link>
                             !
@@ -106,7 +106,7 @@ export const AuthLayout = () => {
                                 </p>
                                 This feature is enabled on{' '}
                                 <Alert.Link href={'https://lakefs.cloud/register'}>lakeFS Cloud</Alert.Link> and{' '}
-                                <Alert.Link href={'https://community.lakefs.io/understand/enterprise/'}>
+                                <Alert.Link href={'https://docs.lakefs.io/understand/enterprise/'}>
                                     lakeFS Enterprise
                                 </Alert.Link>
                                 .{' '}

--- a/webui/src/lib/components/repository/tablesEnterpriseInfo.jsx
+++ b/webui/src/lib/components/repository/tablesEnterpriseInfo.jsx
@@ -24,7 +24,7 @@ export const TablesEnterpriseInfo = () => {
                         Try lakeFS Enterprise
                     </a>
                     <a
-                        href="https://community.lakefs.io/understand/enterprise/"
+                        href="https://docs.lakefs.io/understand/enterprise/"
                         target="_blank"
                         rel="noopener noreferrer"
                         className="btn btn-secondary"

--- a/webui/src/lib/components/repository/tree.jsx
+++ b/webui/src/lib/components/repository/tree.jsx
@@ -918,7 +918,7 @@ const GetStarted = ({ config, onUpload, onImport, readOnly = false }) => {
                             </Card.Body>
                             <Card.Footer className="text-center bg-transparent border-0">
                                 <a
-                                    href="https://community.lakefs.io/howto/import.html"
+                                    href="https://docs.lakefs.io/howto/import.html"
                                     target="_blank"
                                     rel="noopener noreferrer"
                                     className="text-decoration-none"

--- a/webui/src/lib/components/repositoryCreateForm.jsx
+++ b/webui/src/lib/components/repositoryCreateForm.jsx
@@ -77,7 +77,7 @@ export const RepositoryCreateForm = ({ formID, config, onSubmit, formValid, setF
                 <Form.Text>
                     A repository contains all of your objects, including the revision history.{' '}
                     <a
-                        href="https://community.lakefs.io/understand/model.html#repository"
+                        href="https://docs.lakefs.io/understand/model.html#repository"
                         target="_blank"
                         rel="noopener noreferrer"
                     >

--- a/webui/src/pages/auth/credentials.jsx
+++ b/webui/src/pages/auth/credentials.jsx
@@ -60,7 +60,7 @@ const CredentialsContainer = () => {
             <div className="auth-learn-more">
                 An access key-pair is the set of credentials used to access lakeFS.{' '}
                 <a
-                    href="https://community.lakefs.io/reference/authorization.html#authentication"
+                    href="https://docs.lakefs.io/reference/authorization.html#authentication"
                     target="_blank"
                     rel="noopener noreferrer"
                 >

--- a/webui/src/pages/auth/groups/index.tsx
+++ b/webui/src/pages/auth/groups/index.tsx
@@ -182,7 +182,7 @@ const GroupsContainer = () => {
             <div className="auth-learn-more">
                 A group is a collection of users.{' '}
                 <a
-                    href="https://community.lakefs.io/reference/authorization.html#authorization"
+                    href="https://docs.lakefs.io/reference/authorization.html#authorization"
                     target="_blank"
                     rel="noopener noreferrer"
                 >

--- a/webui/src/pages/auth/policies/index.jsx
+++ b/webui/src/pages/auth/policies/index.jsx
@@ -93,13 +93,13 @@ const PoliciesContainer = () => {
                     <b>Deprecation Notice:</b> RBAC (Role-Based Access Control) is being deprecated and will be replaced
                     by ACL (Access Control Lists) in future releases. For more information on the transition from RBAC
                     to ACL, please visit our{' '}
-                    <a href="https://community.lakefs.io/posts/security_update.html">documentation page</a>.
+                    <a href="https://docs.lakefs.io/posts/security_update.html">documentation page</a>.
                 </Warning>
             )}
             <div className="auth-learn-more">
                 A policy defines the permissions of a user or a group.{' '}
                 <a
-                    href="https://community.lakefs.io/reference/authorization.html#authorization"
+                    href="https://docs.lakefs.io/reference/authorization.html#authorization"
                     target="_blank"
                     rel="noopener noreferrer"
                 >

--- a/webui/src/pages/auth/users/index.jsx
+++ b/webui/src/pages/auth/users/index.jsx
@@ -114,7 +114,7 @@ const UsersContainer = ({ refresh, setRefresh, allUsers, loading, error }) => {
             <div className="auth-learn-more">
                 Users are entities that access and use lakeFS.{' '}
                 <a
-                    href="https://community.lakefs.io/reference/authentication.html"
+                    href="https://docs.lakefs.io/reference/authentication.html"
                     target="_blank"
                     rel="noopener noreferrer"
                 >

--- a/webui/src/pages/repositories/repository/actions/empty.jsx
+++ b/webui/src/pages/repositories/repository/actions/empty.jsx
@@ -70,7 +70,7 @@ export const EmptyActionsState = () => {
 
                     <div className="d-flex flex-column flex-sm-row  gap-2 mt-4">
                         <Button
-                            href="https://community.lakefs.io/latest/howto/hooks/"
+                            href="https://docs.lakefs.io/latest/howto/hooks/"
                             target="_blank"
                             rel="noopener noreferrer"
                             variant="success"
@@ -81,7 +81,7 @@ export const EmptyActionsState = () => {
                             Learn How to Configure Actions
                         </Button>
                         <Button
-                            href="https://community.lakefs.io/latest/understand/use_cases/cicd_for_data/"
+                            href="https://docs.lakefs.io/latest/understand/use_cases/cicd_for_data/"
                             target="_blank"
                             rel="noopener noreferrer"
                             variant="outline-secondary"

--- a/webui/src/pages/repositories/repository/actions/index.jsx
+++ b/webui/src/pages/repositories/repository/actions/index.jsx
@@ -193,7 +193,7 @@ const ActionsList = ({ repo, after, onPaginate, branch, commit, onFilterBranch, 
             {results.length > 0 && (
                 <div>
                     Actions can be configured to run when predefined events occur.{' '}
-                    <a href="https://community.lakefs.io/howto/hooks/" target="_blank" rel="noreferrer">
+                    <a href="https://docs.lakefs.io/howto/hooks/" target="_blank" rel="noreferrer">
                         Learn more.
                     </a>
                 </div>

--- a/webui/src/pages/repositories/repository/branches.jsx
+++ b/webui/src/pages/repositories/repository/branches.jsx
@@ -522,7 +522,7 @@ const BranchList = ({ repo, prefix, after, showHidden = false, onPaginate }) => 
             <div className={'mt-2'}>
                 lakeFS uses a Git-like branching model.{' '}
                 <a
-                    href="https://community.lakefs.io/understand/branching-model.html"
+                    href="https://docs.lakefs.io/understand/branching-model.html"
                     target="_blank"
                     rel="noopener noreferrer"
                 >

--- a/webui/src/pages/repositories/repository/error.jsx
+++ b/webui/src/pages/repositories/repository/error.jsx
@@ -42,7 +42,7 @@ const BareRepositoryContainer = () => (
         </p>
         <p>
             <a
-                href="https://community.lakefs.io/howto/backup-and-restore.html"
+                href="https://docs.lakefs.io/howto/backup-and-restore.html"
                 target="_blank"
                 rel="noopener noreferrer"
             >

--- a/webui/src/pages/repositories/repository/error.jsx
+++ b/webui/src/pages/repositories/repository/error.jsx
@@ -41,11 +41,7 @@ const BareRepositoryContainer = () => (
             backup/restore operations with <code>lakectl refs-restore</code>.
         </p>
         <p>
-            <a
-                href="https://docs.lakefs.io/howto/backup-and-restore.html"
-                target="_blank"
-                rel="noopener noreferrer"
-            >
+            <a href="https://docs.lakefs.io/howto/backup-and-restore.html" target="_blank" rel="noopener noreferrer">
                 Learn more about bare repositories.
             </a>
         </p>

--- a/webui/src/pages/repositories/repository/objects.jsx
+++ b/webui/src/pages/repositories/repository/objects.jsx
@@ -1222,7 +1222,7 @@ const NoGCRulesWarning = ({ repoId }) => {
         return (
             <Alert variant="warning" onClose={closeAndRemember} dismissible>
                 <strong>Warning</strong>: No garbage collection rules configured for this repository.{' '}
-                <a href="https://community.lakefs.io/howto/garbage-collection/" target="_blank" rel="noreferrer">
+                <a href="https://docs.lakefs.io/howto/garbage-collection/" target="_blank" rel="noreferrer">
                     Learn More
                 </a>
                 .

--- a/webui/src/pages/repositories/repository/settings/branches.jsx
+++ b/webui/src/pages/repositories/repository/settings/branches.jsx
@@ -99,7 +99,7 @@ const SettingsContainer = () => {
                 <div>
                     Define branch protection rules to prevent direct changes.&nbsp; Changes to protected branches can
                     only be done by merging from other branches.&nbsp;
-                    <a href="https://community.lakefs.io/reference/protected_branches.html" target="_blank">
+                    <a href="https://docs.lakefs.io/reference/protected_branches.html" target="_blank">
                         Learn more.
                     </a>
                 </div>

--- a/webui/src/pages/repositories/repository/settings/retention.jsx
+++ b/webui/src/pages/repositories/repository/settings/retention.jsx
@@ -158,7 +158,7 @@ const GCPolicy = ({ repo }) => {
             </div>
             <p className="mt-3">
                 This policy determines for how long objects are kept in the storage after they are deleted in lakeFS.{' '}
-                <a href="https://community.lakefs.io/howto/garbage-collection/" target="_blank" rel="noreferrer">
+                <a href="https://docs.lakefs.io/howto/garbage-collection/" target="_blank" rel="noreferrer">
                     Learn more.
                 </a>
             </p>

--- a/webui/src/pages/repositories/repository/tags.jsx
+++ b/webui/src/pages/repositories/repository/tags.jsx
@@ -203,7 +203,7 @@ const EmptyTagsState = ({ repo, onCreateTag }) => {
                         <br />
                         They&apos;re perfect for{' '}
                         <a
-                            href="https://community.lakefs.io/latest/understand/use_cases/reproducibility/"
+                            href="https://docs.lakefs.io/latest/understand/use_cases/reproducibility/"
                             target="_blank"
                             rel="noopener noreferrer"
                             className="text-decoration-none"
@@ -215,7 +215,7 @@ const EmptyTagsState = ({ repo, onCreateTag }) => {
                     <p>
                         Learn more about{' '}
                         <a
-                            href="https://community.lakefs.io/latest/understand/model/#tags"
+                            href="https://docs.lakefs.io/latest/understand/model/#tags"
                             target="_blank"
                             rel="noopener noreferrer"
                             className="text-decoration-none"
@@ -270,7 +270,7 @@ const TagList = ({ repo, after, prefix, onPaginate }) => {
                 <div className={'mt-2'}>
                     A tag is an immutable pointer to a single commit.{' '}
                     <a
-                        href="https://community.lakefs.io/understand/model.html#tags"
+                        href="https://docs.lakefs.io/understand/model.html#tags"
                         target="_blank"
                         rel="noopener noreferrer"
                     >

--- a/webui/src/pages/repositories/services/importData.jsx
+++ b/webui/src/pages/repositories/services/importData.jsx
@@ -128,7 +128,7 @@ const ImportForm = ({
                 This feature doesn&apos;t copy data. It only creates pointers in the lakeFS metadata.
                 <br />
                 lakeFS will never change objects in the import source. &#160;
-                <a href="https://community.lakefs.io/howto/import.html" target="_blank" rel="noreferrer">
+                <a href="https://docs.lakefs.io/howto/import.html" target="_blank" rel="noreferrer">
                     Learn more
                 </a>
             </Alert>

--- a/webui/src/pages/setup/setupComplete.tsx
+++ b/webui/src/pages/setup/setupComplete.tsx
@@ -86,11 +86,7 @@ export const SetupComplete: FC<SetupCompleteProps> = ({ accessKeyId, secretAcces
                             </Alert>
                             <h5>lakectl</h5>
                             <div className="ms-2 mt-2">
-                                <a
-                                    target="_blank"
-                                    rel="noreferrer"
-                                    href="https://docs.lakefs.io/reference/cli.html"
-                                >
+                                <a target="_blank" rel="noreferrer" href="https://docs.lakefs.io/reference/cli.html">
                                     lakectl
                                 </a>{' '}
                                 is a CLI tool for working with lakeFS.

--- a/webui/src/pages/setup/setupComplete.tsx
+++ b/webui/src/pages/setup/setupComplete.tsx
@@ -89,7 +89,7 @@ export const SetupComplete: FC<SetupCompleteProps> = ({ accessKeyId, secretAcces
                                 <a
                                     target="_blank"
                                     rel="noreferrer"
-                                    href="https://community.lakefs.io/reference/cli.html"
+                                    href="https://docs.lakefs.io/reference/cli.html"
                                 >
                                     lakectl
                                 </a>{' '}


### PR DESCRIPTION
Plan to update the docs.lakefs.io to provide a single oss/enterprise documentation with specific versioned pages for APIs and CLI reference.

Feature pages will include specific version information as needed if the feature was added on a specific version.

This change will be incremental.