### PR TITLE
lakectl: identify community builds via --version distribution marker

### DIFF
--- a/cmd/lakectl/cmd/root.go
+++ b/cmd/lakectl/cmd/root.go
@@ -47,7 +47,7 @@ const (
 `
 	getLatestVersionErrorTemplate = `{{ "Failed getting latest lakectl version:" | red }} {{ . }}
 `
-	versionTemplate = `lakectl version: {{.LakectlVersion }}
+	versionTemplate = `lakectl version: {{.LakectlVersion }}{{ if .Distribution }} ({{.Distribution}}){{ end }}
 {{- if .LakeFSVersion }}
 lakeFS version: {{.LakeFSVersion}}
 {{- end }}
@@ -121,6 +121,7 @@ type Configuration struct {
 
 type versionInfo struct {
 	LakectlVersion       string
+	Distribution         string
 	LakeFSVersion        string
 	LakectlLatestVersion string
 	LakeFSLatestVersion  string
@@ -440,7 +441,7 @@ It can be extended with plugins; see 'lakectl plugin --help' for more informatio
 			return
 		}
 
-		info := versionInfo{LakectlVersion: version.Version}
+		info := versionInfo{LakectlVersion: version.Version, Distribution: version.Distribution}
 
 		// get lakeFS server version
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -9,7 +9,12 @@ var (
 	// Version is the current git version of the code.  It is filled in by "make build".
 	// Make sure to change that target in Makefile if you change its name or package.
 	Version = "dev"
+	// Distribution identifies community builds of lakectl. Empty string means
+	// not a community build.
+	Distribution = DistributionCommunity
 )
+
+const DistributionCommunity = "community"
 
 func IsVersionUnreleased() bool {
 	return strings.HasPrefix(Version, UnreleasedVersion) || strings.HasPrefix(Version, "sha-")


### PR DESCRIPTION
Default `pkg/version.Distribution` to `community` so OSS `lakectl --version` prints `lakectl version: <ver> (community)`. The marker is suppressed when `Distribution` is empty.
