### PR TITLE
Verify webui docs.lakefs.io links on release

### DIFF
--- a/.github/scripts/extract-docs-links.sh
+++ b/.github/scripts/extract-docs-links.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+#
+# Extract unique https://docs.lakefs.io/* URLs referenced from the webui source.
+# Prints one URL per line on stdout. Intended for piping into a link checker.
+#
+# Usage:
+#   .github/scripts/extract-docs-links.sh [webui-src-dir]
+#
+# Defaults to <repo-root>/webui/src when no argument is given.
+
+set -euo pipefail
+
+SRC_DIR="${1:-webui/src}"
+
+if [ ! -d "$SRC_DIR" ]; then
+  echo "extract-docs-links: directory not found: $SRC_DIR" >&2
+  exit 1
+fi
+
+# Match https://docs.lakefs.io followed by any URL-safe chars, stopping at the
+# usual JSX/HTML/JS string delimiters and whitespace.
+grep -rEhoI \
+  --include='*.ts' --include='*.tsx' \
+  --include='*.js' --include='*.jsx' \
+  --include='*.html' \
+  'https://docs\.lakefs\.io[^"'"'"'`<> )]*' "$SRC_DIR" \
+  | sort -u

--- a/.github/workflows/check-webui-docs-links.yaml
+++ b/.github/workflows/check-webui-docs-links.yaml
@@ -47,8 +47,6 @@ jobs:
             --max-concurrency 4
             webui-docs-links.txt
           output: ./lychee-report.md
-          # Never fail the job - this workflow must not block a release.
-          fail: false
 
       - name: Write report to job summary
         if: always()

--- a/.github/workflows/check-webui-docs-links.yaml
+++ b/.github/workflows/check-webui-docs-links.yaml
@@ -1,0 +1,67 @@
+name: Check webui docs links
+
+# Extracts docs.lakefs.io URLs from the webui source and verifies them with
+# lychee. Runs on every published release and on manual dispatch.
+#
+# Broken links are reported in the job summary but DO NOT fail the workflow:
+# release shipping must not be blocked by docs that have not yet been
+# published. Fix or publish the missing docs after the release.
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      ref:
+        description: "Branch, tag, or SHA to check. Defaults to the release tag or current branch."
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  check-links:
+    runs-on: ubuntu-latest
+    # Never block on broken links - they can be fixed after release.
+    continue-on-error: true
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.release.tag_name || inputs.ref || github.ref }}
+
+      - name: Extract docs.lakefs.io links from webui
+        run: |
+          set -euo pipefail
+          .github/scripts/extract-docs-links.sh webui/src | tee webui-docs-links.txt
+          echo
+          echo "Found $(wc -l < webui-docs-links.txt) unique link(s)."
+
+      - name: Verify links with lychee
+        id: lychee
+        uses: lycheeverse/lychee-action@v2
+        with:
+          args: >-
+            --verbose
+            --no-progress
+            --max-concurrency 4
+            webui-docs-links.txt
+          output: ./lychee-report.md
+          # Never fail the job - this workflow must not block a release.
+          fail: false
+
+      - name: Write report to job summary
+        if: always()
+        run: |
+          {
+            echo "## webui docs.lakefs.io link check"
+            echo
+            echo "Checked links extracted from \`webui/src\` against docs.lakefs.io."
+            echo "Broken links here do **not** block the release - publish the missing docs and re-run when ready."
+            echo
+            if [ -s ./lychee-report.md ]; then
+              cat ./lychee-report.md
+            else
+              echo "_No report produced by lychee._"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
## Summary
- Add `.github/scripts/extract-docs-links.sh` to grep `webui/src` for unique `https://docs.lakefs.io/*` URLs.
- Add `.github/workflows/check-webui-docs-links.yaml` that runs the extractor on every published release (and on manual dispatch) and pipes the URLs through `lycheeverse/lychee-action`.

## Related Issue
Closes #10412