### PR TITLE
docs: add Backblaze B2 to quickstart and configuration

### DIFF
--- a/docs/src/quickstart/learning-more-lakefs.md
+++ b/docs/src/quickstart/learning-more-lakefs.md
@@ -66,6 +66,22 @@ Enjoyed the quickstart and want to try out lakeFS against your own data? Here's 
     lakefs run --local-settings
     ```
 
+=== "Backblaze B2"
+    To use lakeFS with Backblaze B2 (S3-compatible API), point the S3 blockstore at the regional B2 endpoint and use a B2 application key:
+
+    ```bash
+    export LAKEFS_BLOCKSTORE_TYPE="s3"
+    export LAKEFS_BLOCKSTORE_S3_FORCE_PATH_STYLE="true"
+    export LAKEFS_BLOCKSTORE_S3_ENDPOINT="https://s3.us-west-001.backblazeb2.com"
+    export LAKEFS_BLOCKSTORE_S3_REGION="us-west-001"
+    export LAKEFS_BLOCKSTORE_S3_DISCOVER_BUCKET_REGION="false"
+    export LAKEFS_BLOCKSTORE_S3_CREDENTIALS_ACCESS_KEY_ID="<b2_application_key_id>"
+    export LAKEFS_BLOCKSTORE_S3_CREDENTIALS_SECRET_ACCESS_KEY="<b2_application_key>"
+    lakefs run --local-settings
+    ```
+
+    Replace the endpoint and region with the values shown in the [Backblaze B2 console](https://www.backblaze.com/docs/cloud-storage-s3-compatible-api) for your bucket. Generate an application key scoped to the lakeFS bucket from the **Application Keys** page.
+
 ## Deploying lakeFS
 
 Ready to do this thing for real? The deployment guides show you how to deploy lakeFS [locally](../howto/deploy/onprem.md) (including on [Kubernetes][onprem-k8s]) or on [AWS](../howto/deploy/aws.md), [Azure](../howto/deploy/azure.md), or [GCP](../howto/deploy/gcp.md).

--- a/docs/src/reference/configuration.md
+++ b/docs/src/reference/configuration.md
@@ -481,6 +481,39 @@ To set a value into a `map[string]string` type field, use the syntax `key1=value
 
     ```
 
+!!! example "Backblaze B2 (S3-compatible)"
+
+    ```yaml
+    ---
+    logging:
+    format: json
+    level: WARN
+    output: "-"
+
+    database:
+    type: "postgres"
+    postgres:
+        connection_string: "postgres://user:pass@lakefs.rds.amazonaws.com:5432/postgres"
+
+    auth:
+    encrypt:
+        secret_key: "10a718b3f285d89c36e9864494cdd1507f3bc85b342df24736ea81f9a1134bcc"
+
+    blockstore:
+    type: s3
+    s3:
+        force_path_style: true
+        endpoint: https://s3.us-west-001.backblazeb2.com
+        region: us-west-001
+        discover_bucket_region: false
+        credentials:
+            access_key_id: <b2_application_key_id>
+            secret_access_key: <b2_application_key>
+
+    ```
+
+    Replace `us-west-001` with the region shown for your bucket in the [Backblaze B2 console](https://www.backblaze.com/docs/cloud-storage-s3-compatible-api). Use a B2 application key scoped to the lakeFS bucket.
+
 !!! example "Azure blob storage"
 
     ```yaml


### PR DESCRIPTION
## Change Description

### Background

The "S3-compatible servers" docs currently exemplify the S3 block adapter with MinIO only. [Backblaze B2](https://www.backblaze.com/docs/cloud-storage-s3-compatible-api) is another widely-used S3-compatible object store whose configuration parameters (`endpoint`, `region`, `force_path_style`, `discover_bucket_region`) map to the existing schema without any code changes — the S3 block adapter (`pkg/block/s3/adapter.go`) already accepts a custom endpoint. Adding B2 explicitly to the docs closes the discoverability gap for users running lakeFS on B2.

### New Feature

Two additive docs changes:

- `docs/src/quickstart/learning-more-lakefs.md` — new `=== "Backblaze B2"` tab in the "Connecting lakeFS to your own object storage" section, alongside the existing AWS / Azure / GCS / MinIO tabs.
- `docs/src/reference/configuration.md` — new `!!! example "Backblaze B2 (S3-compatible)"` block alongside the existing MinIO YAML example.

No code changes. No new config schema. Existing provider examples are untouched.

### Testing Details

- `mkdocs build` from `docs/` against Python 3.12 (matches CI's `docs-pr.yaml`): builds in ~3 s; **zero new mkdocs warnings** (36 → 36 between `master` and this branch).
- `lychee` full-site link check against `docs/site` (matches the CI `lycheeverse/lychee-action@v2` step): **24,951 links scanned, 0 errors**.
- External link check on the new Backblaze docs URL `https://www.backblaze.com/docs/cloud-storage-s3-compatible-api`: returns 200 OK.

### Breaking Change?

No.

## Additional info

PR labels expected per `.github/workflows/pr-requirements.yaml`: `docs`, `exclude-changelog`, `minor-change`, `mostly-human`. The `docs` label auto-applies via `.github/labeler.yml`; the other three need to be set manually after open.

### Contact Details

goanpeca@gmail.com