### PR TITLE
feat: attribute S3 traffic with lakefs/<version> User-Agent

### DIFF
--- a/pkg/block/s3/adapter.go
+++ b/pkg/block/s3/adapter.go
@@ -33,9 +33,8 @@ import (
 	"github.com/treeverse/lakefs/pkg/version"
 )
 
-// userAgentProduct identifies lakeFS on S3 server-side request logs as
-// `lakefs/<version>` (RFC 9110 product form). Matches the convention already
-// used by the Lua client (LuaClientUserAgent = "lakefs-lua/" + version.Version).
+// userAgentProduct is the lakeFS product token added to the S3 User-Agent
+// (RFC 9110 product form: `lakefs/<version>`).
 const userAgentProduct = "lakefs"
 
 var (
@@ -151,10 +150,6 @@ func LoadConfig(ctx context.Context, params params.S3) (aws.Config, error) {
 	opts = append(opts,
 		config.WithRequestChecksumCalculation(aws.RequestChecksumCalculationWhenRequired),
 		config.WithResponseChecksumValidation(aws.ResponseChecksumValidationWhenRequired),
-		// Attribute S3 traffic on server-side request logs as
-		// `lakefs/<version>`. AddUserAgentKeyValue appends to the wire UA;
-		// downstream callers can stack additional suffixes via further
-		// API-options middleware without overriding ours.
 		config.WithAPIOptions([]func(*middleware.Stack) error{
 			awsmiddleware.AddUserAgentKeyValue(userAgentProduct, version.Version),
 		}),

--- a/pkg/block/s3/adapter.go
+++ b/pkg/block/s3/adapter.go
@@ -30,7 +30,13 @@ import (
 	"github.com/treeverse/lakefs/pkg/block/params"
 	"github.com/treeverse/lakefs/pkg/logging"
 	"github.com/treeverse/lakefs/pkg/stats"
+	"github.com/treeverse/lakefs/pkg/version"
 )
+
+// userAgentProduct identifies lakeFS on S3 server-side request logs as
+// `lakefs/<version>` (RFC 9110 product form). Matches the convention already
+// used by the Lua client (LuaClientUserAgent = "lakefs-lua/" + version.Version).
+const userAgentProduct = "lakefs"
 
 var (
 	ErrS3          = errors.New("s3 error")
@@ -145,6 +151,13 @@ func LoadConfig(ctx context.Context, params params.S3) (aws.Config, error) {
 	opts = append(opts,
 		config.WithRequestChecksumCalculation(aws.RequestChecksumCalculationWhenRequired),
 		config.WithResponseChecksumValidation(aws.ResponseChecksumValidationWhenRequired),
+		// Attribute S3 traffic on server-side request logs as
+		// `lakefs/<version>`. AddUserAgentKeyValue appends to the wire UA;
+		// downstream callers can stack additional suffixes via further
+		// API-options middleware without overriding ours.
+		config.WithAPIOptions([]func(*middleware.Stack) error{
+			awsmiddleware.AddUserAgentKeyValue(userAgentProduct, version.Version),
+		}),
 	)
 
 	opts = append(opts, config.WithLogger(&logging.AWSAdapter{

--- a/pkg/block/s3/useragent_test.go
+++ b/pkg/block/s3/useragent_test.go
@@ -3,7 +3,6 @@ package s3_test
 import (
 	"net/http"
 	"net/http/httptest"
-	"sync"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -19,14 +18,11 @@ import (
 func TestLoadConfigSetsLakeFSUserAgent(t *testing.T) {
 	t.Parallel()
 
-	var (
-		mu       sync.Mutex
-		captured string
-	)
+	userAgentCh := make(chan string, 2)
+
 	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
-		mu.Lock()
-		captured = r.Header.Get("User-Agent")
-		mu.Unlock()
+		userAgentCh <- r.Header.Get("User-Agent")
+		close(userAgentCh)
 	}))
 	t.Cleanup(srv.Close)
 
@@ -46,8 +42,7 @@ func TestLoadConfigSetsLakeFSUserAgent(t *testing.T) {
 	})
 	_, _ = client.HeadBucket(ctx, &awss3.HeadBucketInput{Bucket: aws.String("test")})
 
-	mu.Lock()
-	defer mu.Unlock()
+	captured := <-userAgentCh
 	require.Contains(t, captured, "lakefs/",
 		"User-Agent does not include the lakefs/ product (got %q)", captured)
 }

--- a/pkg/block/s3/useragent_test.go
+++ b/pkg/block/s3/useragent_test.go
@@ -1,9 +1,9 @@
 package s3_test
 
 import (
-	"io"
 	"net/http"
-	"strings"
+	"net/http/httptest"
+	"sync"
 	"testing"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
@@ -14,34 +14,21 @@ import (
 	s3a "github.com/treeverse/lakefs/pkg/block/s3"
 )
 
-// roundTripFunc adapts a function into an http.RoundTripper so we can
-// intercept the outgoing request and inspect its headers without hitting a
-// real S3 endpoint.
-type roundTripFunc func(*http.Request) (*http.Response, error)
-
-func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
-	return f(req)
-}
-
 // TestLoadConfigSetsLakeFSUserAgent verifies that S3 requests built from the
-// adapter's aws.Config carry the lakefs/<version> User-Agent product, so that
-// lakeFS-originated traffic is identifiable on the underlying object store's
-// server-side request logs (AWS S3, Backblaze B2, MinIO, etc.).
-//
-// Regression guard for the AddUserAgentKeyValue middleware registered in
-// LoadConfig.
+// adapter's aws.Config carry the lakefs/<version> User-Agent product.
 func TestLoadConfigSetsLakeFSUserAgent(t *testing.T) {
 	t.Parallel()
 
-	var captured string
-	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
-		captured = req.Header.Get("User-Agent")
-		return &http.Response{
-			StatusCode: http.StatusOK,
-			Header:     make(http.Header),
-			Body:       io.NopCloser(strings.NewReader("")),
-		}, nil
-	})
+	var (
+		mu       sync.Mutex
+		captured string
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(_ http.ResponseWriter, r *http.Request) {
+		mu.Lock()
+		captured = r.Header.Get("User-Agent")
+		mu.Unlock()
+	}))
+	t.Cleanup(srv.Close)
 
 	ctx := t.Context()
 	cfg, err := s3a.LoadConfig(ctx, params.S3{
@@ -52,15 +39,15 @@ func TestLoadConfigSetsLakeFSUserAgent(t *testing.T) {
 		},
 	})
 	require.NoError(t, err)
-	cfg.HTTPClient = &http.Client{Transport: transport}
 
 	client := awss3.NewFromConfig(cfg, func(o *awss3.Options) {
 		o.UsePathStyle = true
-		o.BaseEndpoint = aws.String("http://127.0.0.1:1")
+		o.BaseEndpoint = aws.String(srv.URL)
 	})
 	_, _ = client.HeadBucket(ctx, &awss3.HeadBucketInput{Bucket: aws.String("test")})
 
-	require.NotEmpty(t, captured, "expected User-Agent header on outgoing request")
+	mu.Lock()
+	defer mu.Unlock()
 	require.Contains(t, captured, "lakefs/",
 		"User-Agent does not include the lakefs/ product (got %q)", captured)
 }

--- a/pkg/block/s3/useragent_test.go
+++ b/pkg/block/s3/useragent_test.go
@@ -1,0 +1,66 @@
+package s3_test
+
+import (
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/aws/aws-sdk-go-v2/aws"
+	awss3 "github.com/aws/aws-sdk-go-v2/service/s3"
+	"github.com/stretchr/testify/require"
+
+	"github.com/treeverse/lakefs/pkg/block/params"
+	s3a "github.com/treeverse/lakefs/pkg/block/s3"
+)
+
+// roundTripFunc adapts a function into an http.RoundTripper so we can
+// intercept the outgoing request and inspect its headers without hitting a
+// real S3 endpoint.
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+// TestLoadConfigSetsLakeFSUserAgent verifies that S3 requests built from the
+// adapter's aws.Config carry the lakefs/<version> User-Agent product, so that
+// lakeFS-originated traffic is identifiable on the underlying object store's
+// server-side request logs (AWS S3, Backblaze B2, MinIO, etc.).
+//
+// Regression guard for the AddUserAgentKeyValue middleware registered in
+// LoadConfig.
+func TestLoadConfigSetsLakeFSUserAgent(t *testing.T) {
+	t.Parallel()
+
+	var captured string
+	transport := roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		captured = req.Header.Get("User-Agent")
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     make(http.Header),
+			Body:       io.NopCloser(strings.NewReader("")),
+		}, nil
+	})
+
+	ctx := t.Context()
+	cfg, err := s3a.LoadConfig(ctx, params.S3{
+		Region: "us-east-1",
+		Credentials: params.S3Credentials{
+			AccessKeyID:     "test",
+			SecretAccessKey: "test",
+		},
+	})
+	require.NoError(t, err)
+	cfg.HTTPClient = &http.Client{Transport: transport}
+
+	client := awss3.NewFromConfig(cfg, func(o *awss3.Options) {
+		o.UsePathStyle = true
+		o.BaseEndpoint = aws.String("http://127.0.0.1:1")
+	})
+	_, _ = client.HeadBucket(ctx, &awss3.HeadBucketInput{Bucket: aws.String("test")})
+
+	require.NotEmpty(t, captured, "expected User-Agent header on outgoing request")
+	require.Contains(t, captured, "lakefs/",
+		"User-Agent does not include the lakefs/ product (got %q)", captured)
+}


### PR DESCRIPTION
## Change Description

### Background

`pkg/block/s3/adapter.go::LoadConfig` does not register a User-Agent middleware on the AWS SDK Go v2 client config it returns. lakeFS S3 traffic on the underlying object store's server-side logs is currently indistinguishable from any other generic `aws-sdk-go-v2` caller, which is a debugging gap for both lakeFS operators and the object store side (AWS S3, Backblaze B2, MinIO, etc.).

The codebase already has the `lakefs-<component>/<version>` convention in `pkg/actions/lua/lakefs/client.go:25` (`LuaClientUserAgent = "lakefs-lua/" + version.Version`). This PR extends that pattern to the S3 block adapter.

### New Feature

In `LoadConfig`, register `awsmiddleware.AddUserAgentKeyValue("lakefs", version.Version)` via `config.WithAPIOptions`. The middleware appends `lakefs/<version>` to the wire User-Agent (RFC 9110 product form), alongside the existing `aws-sdk-go-v2/...` tokens. Downstream callers can stack their own `AddUserAgentKeyValue` middleware via further API options without overriding ours.

Coverage check: the change propagates through `client_cache.go` (which forwards the returned `aws.Config` to `s3.NewFromConfig`) and `pkg/block/factory/build.go` (which calls `LoadConfig` directly). All server-side outbound S3 paths (PutObject, GetObject, HeadObject, DeleteObject, ListObjectsV2, CreateMultipartUpload, CopyObject) carry the suffix.

### Testing Details

New unit test `TestLoadConfigSetsLakeFSUserAgent` in `pkg/block/s3/useragent_test.go` builds an `aws.Config` via the real `LoadConfig`, swaps `cfg.HTTPClient` for a fake `roundTripFunc` that captures the outgoing request, drives a `HeadBucket` call, and asserts the `User-Agent` header contains `lakefs/`. Regression-guarded: reverting the middleware line causes the test to fail with `"... api/s3#1.88.3 m/E,e" does not contain "lakefs/"`.

Full package suite (including the existing MinIO container tests) still passes:

```
ok  github.com/treeverse/lakefs/pkg/block/s3  8.096s
```

`golangci-lint` count on `pkg/block/s3/...` is unchanged at 7 issues (all pre-existing `goconst` in unrelated code).

### Breaking Change?

No. The change is purely additive: an extra middleware token appended to the existing wire User-Agent. No public APIs, CLI flags, or config schemas change.

## Additional info

Wire User-Agent on outgoing S3 requests after this change (captured locally via a probe exercising all S3 operations the block adapter uses):

```
aws-sdk-go-v2/1.39.2 ua/2.1 os/macos lang/go#1.25.8 md/GOOS#darwin md/GOARCH#arm64 api/s3#1.88.3 lakefs/dev m/E,e
```

`lakefs/dev` becomes `lakefs/v1.83.x` (etc.) in release builds where `version.Version` is set at link time by `make build`.

### Contact Details

goanpeca@gmail.com