### PR TITLE
Guard repeat comm-prefs setup and cache setup state in memory

### DIFF
--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -5656,6 +5656,19 @@ func (c *Controller) collectCommPrefs(commPrefs *auth.CommPrefs, installationID 
 
 func (c *Controller) SetupCommPrefs(w http.ResponseWriter, r *http.Request, body apigen.SetupCommPrefsJSONRequestBody) {
 	ctx := r.Context()
+	// comm prefs are part of the post-setup flow; setup must run first. Setting
+	// them before setup lets Setup's empty-prefs path later overwrite them with
+	// comm_prefs_set=false, diverging from the cached state.
+	initialized, err := c.MetadataManager.IsInitialized(ctx)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, err)
+		return
+	}
+	if !initialized {
+		writeError(w, r, http.StatusPreconditionFailed, "lakeFS is not initialized")
+		return
+	}
+
 	// comm prefs may only be set once; do not override existing preferences.
 	// ErrNotFound means they were never recorded, so setting is allowed.
 	commPrefsSet, err := c.MetadataManager.IsCommPrefsSet(ctx)

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -5655,6 +5655,20 @@ func (c *Controller) collectCommPrefs(commPrefs *auth.CommPrefs, installationID 
 }
 
 func (c *Controller) SetupCommPrefs(w http.ResponseWriter, r *http.Request, body apigen.SetupCommPrefsJSONRequestBody) {
+	ctx := r.Context()
+	// comm prefs may only be set once; do not override existing preferences.
+	// ErrNotFound means they were never recorded, so setting is allowed.
+	commPrefsSet, err := c.MetadataManager.IsCommPrefsSet(ctx)
+	if err != nil && !errors.Is(err, auth.ErrNotFound) {
+		c.Logger.WithError(err).Error("Setup comm prefs failed to check existing state")
+		writeError(w, r, http.StatusInternalServerError, err)
+		return
+	}
+	if commPrefsSet {
+		writeError(w, r, http.StatusConflict, "communication preferences already set")
+		return
+	}
+
 	email := swag.StringValue(body.Email)
 	if err := validateEmail(email); err != nil {
 		c.Logger.WithError(err).WithField("email_domain", domainFromEmail(email)).Warn("Setup comm prefs validation failed")
@@ -5668,7 +5682,7 @@ func (c *Controller) SetupCommPrefs(w http.ResponseWriter, r *http.Request, body
 		CompanyName:    swag.StringValue(body.CompanyName),
 		FeatureUpdates: body.FeatureUpdates,
 	}
-	installationID, err := c.MetadataManager.UpdateCommPrefs(r.Context(), commPrefs)
+	installationID, err := c.MetadataManager.UpdateCommPrefs(ctx, commPrefs)
 	if err != nil {
 		c.Logger.WithError(err).Error("Setup comm prefs failed")
 		writeError(w, r, http.StatusInternalServerError, err)

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -5655,39 +5655,30 @@ func (c *Controller) collectCommPrefs(commPrefs *auth.CommPrefs, installationID 
 }
 
 func (c *Controller) SetupCommPrefs(w http.ResponseWriter, r *http.Request, body apigen.SetupCommPrefsJSONRequestBody) {
-	ctx := r.Context()
-	// comm prefs are part of the post-setup flow; setup must run first. Setting
-	// them before setup lets Setup's empty-prefs path later overwrite them with
-	// comm_prefs_set=false, diverging from the cached state.
-	initialized, err := c.MetadataManager.IsInitialized(ctx)
-	if err != nil {
-		writeError(w, r, http.StatusInternalServerError, err)
-		return
-	}
-	if !initialized {
-		writeError(w, r, http.StatusPreconditionFailed, "lakeFS is not initialized")
-		return
-	}
-
-	// comm prefs may only be set once; do not override existing preferences.
-	// ErrNotFound means they were never recorded, so setting is allowed.
-	commPrefsSet, err := c.MetadataManager.IsCommPrefsSet(ctx)
-	if err != nil && !errors.Is(err, auth.ErrNotFound) {
-		c.Logger.WithError(err).Error("Setup comm prefs failed to check existing state")
-		writeError(w, r, http.StatusInternalServerError, err)
-		return
-	}
-	if commPrefsSet {
-		writeError(w, r, http.StatusConflict, "communication preferences already set")
-		return
-	}
-
+	// validate the email first so malformed input is rejected without KV reads.
 	email := swag.StringValue(body.Email)
 	if err := validateEmail(email); err != nil {
 		c.Logger.WithError(err).WithField("email_domain", domainFromEmail(email)).Warn("Setup comm prefs validation failed")
 		writeError(w, r, http.StatusBadRequest, err)
 		return
 	}
+
+	ctx := r.Context()
+	// comm prefs are part of the post-setup flow; setup must run first. External
+	// RBAC never writes a setup timestamp yet reports as initialized (see
+	// GetSetupState), so treat it as initialized here to stay consistent.
+	if c.Config.AuthConfig().GetAuthUIConfig().RBAC != config.AuthRBACExternal {
+		initialized, err := c.MetadataManager.IsInitialized(ctx)
+		if err != nil {
+			writeError(w, r, http.StatusInternalServerError, err)
+			return
+		}
+		if !initialized {
+			writeError(w, r, http.StatusPreconditionFailed, "lakeFS is not initialized")
+			return
+		}
+	}
+
 	commPrefs := &auth.CommPrefs{
 		UserEmail:      email,
 		FirstName:      swag.StringValue(body.FirstName),
@@ -5695,7 +5686,12 @@ func (c *Controller) SetupCommPrefs(w http.ResponseWriter, r *http.Request, body
 		CompanyName:    swag.StringValue(body.CompanyName),
 		FeatureUpdates: body.FeatureUpdates,
 	}
-	installationID, err := c.MetadataManager.UpdateCommPrefs(ctx, commPrefs)
+	// SetCommPrefsOnce persists atomically and refuses to override existing prefs.
+	installationID, err := c.MetadataManager.SetCommPrefsOnce(ctx, commPrefs)
+	if errors.Is(err, auth.ErrCommPrefsAlreadySet) {
+		writeError(w, r, http.StatusConflict, "communication preferences already set")
+		return
+	}
 	if err != nil {
 		c.Logger.WithError(err).Error("Setup comm prefs failed")
 		writeError(w, r, http.StatusInternalServerError, err)

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -3919,6 +3919,33 @@ func TestController_SetupThenCommPrefs(t *testing.T) {
 	require.False(t, swag.BoolValue(stateResp.JSON200.CommPrefsMissing), "comm_prefs_missing should be false after providing comm prefs")
 }
 
+// TestController_SetupCommPrefsAlreadySet verifies comm prefs can only be set
+// once: a second call must not override and returns 409 Conflict.
+func TestController_SetupCommPrefsAlreadySet(t *testing.T) {
+	handler, _ := setupHandler(t)
+	server := setupServer(t, handler)
+	clt := setupClientByEndpoint(t, server.URL, "", "")
+	ctx := t.Context()
+
+	body := apigen.SetupCommPrefsJSONRequestBody{
+		Email:           swag.String("test@acme.co"),
+		FirstName:       swag.String("Test"),
+		LastName:        swag.String("User"),
+		CompanyName:     swag.String("Acme Inc."),
+		FeatureUpdates:  true,
+		SecurityUpdates: true,
+	}
+
+	resp, err := clt.SetupCommPrefsWithResponse(ctx, body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode())
+
+	// second call must be rejected without overriding the stored prefs
+	resp, err = clt.SetupCommPrefsWithResponse(ctx, body)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusConflict, resp.StatusCode())
+}
+
 func TestController_SetupCommPrefs(t *testing.T) {
 	mockEmail := "test@acme.co"
 	cases := []struct {

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -3926,6 +3926,7 @@ func TestController_SetupCommPrefsAlreadySet(t *testing.T) {
 	server := setupServer(t, handler)
 	clt := setupClientByEndpoint(t, server.URL, "", "")
 	ctx := t.Context()
+	createDefaultAdminUser(t, clt)
 
 	body := apigen.SetupCommPrefsJSONRequestBody{
 		Email:           swag.String("test@acme.co"),
@@ -3944,6 +3945,21 @@ func TestController_SetupCommPrefsAlreadySet(t *testing.T) {
 	resp, err = clt.SetupCommPrefsWithResponse(ctx, body)
 	require.NoError(t, err)
 	require.Equal(t, http.StatusConflict, resp.StatusCode())
+}
+
+// TestController_SetupCommPrefsNotInitialized verifies comm prefs cannot be set
+// before lakeFS is initialized: the call is rejected with 412 so that Setup
+// remains the source of truth for the comm prefs state.
+func TestController_SetupCommPrefsNotInitialized(t *testing.T) {
+	handler, _ := setupHandler(t)
+	server := setupServer(t, handler)
+	clt := setupClientByEndpoint(t, server.URL, "", "")
+
+	resp, err := clt.SetupCommPrefsWithResponse(t.Context(), apigen.SetupCommPrefsJSONRequestBody{
+		Email: swag.String("test@acme.co"),
+	})
+	require.NoError(t, err)
+	require.Equal(t, http.StatusPreconditionFailed, resp.StatusCode())
 }
 
 func TestController_SetupCommPrefs(t *testing.T) {
@@ -3996,6 +4012,7 @@ func TestController_SetupCommPrefs(t *testing.T) {
 			handler, _ := setupHandler(t)
 			server := setupServer(t, handler)
 			clt := setupClientByEndpoint(t, server.URL, "", "")
+			createDefaultAdminUser(t, clt)
 
 			resp, err := clt.SetupCommPrefsWithResponse(t.Context(), c.body)
 			require.NoError(t, err)

--- a/pkg/auth/comm_prefs_test.go
+++ b/pkg/auth/comm_prefs_test.go
@@ -1,0 +1,130 @@
+package auth_test
+
+import (
+	"context"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"sync"
+	"sync/atomic"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"github.com/treeverse/lakefs/pkg/auth"
+	"github.com/treeverse/lakefs/pkg/auth/model"
+	"github.com/treeverse/lakefs/pkg/kv"
+	"github.com/treeverse/lakefs/pkg/kv/kvtest"
+)
+
+// storedEmail reads the persisted, base64-encoded user email straight from the
+// KV store so tests can assert stored comm prefs independently of any reader
+// method on the manager.
+func storedEmail(ctx context.Context, t *testing.T, store kv.Store) string {
+	t.Helper()
+	v, err := store.Get(ctx, []byte(model.PartitionKey), []byte(model.MetadataKeyPath(auth.EmailKeyName)))
+	require.NoError(t, err)
+	decoded, err := base64.StdEncoding.DecodeString(string(v.Value))
+	require.NoError(t, err)
+	return string(decoded)
+}
+
+// TestSetCommPrefsOnce verifies comm prefs can be set once and a repeat call is
+// rejected without overriding the stored values.
+func TestSetCommPrefsOnce(t *testing.T) {
+	ctx := t.Context()
+	store := kvtest.GetStore(ctx, t)
+	mgr := auth.NewKVMetadataManager("test", "id", "mem", store)
+
+	_, err := mgr.SetCommPrefsOnce(ctx, &auth.CommPrefs{UserEmail: "first@acme.co"})
+	require.NoError(t, err)
+	require.Equal(t, "first@acme.co", storedEmail(ctx, t, store))
+
+	// repeat is rejected and must not override the stored values
+	_, err = mgr.SetCommPrefsOnce(ctx, &auth.CommPrefs{UserEmail: "second@acme.co"})
+	require.ErrorIs(t, err, auth.ErrCommPrefsAlreadySet)
+
+	require.Equal(t, "first@acme.co", storedEmail(ctx, t, store), "rejected call must not override stored prefs")
+
+	set, err := mgr.IsCommPrefsSet(ctx)
+	require.NoError(t, err)
+	require.True(t, set)
+}
+
+// TestSetCommPrefsOnceAfterSetupWithoutEmail covers the two-step flow: Setup
+// without email writes comm_prefs_set=false, then SetCommPrefsOnce flips it once.
+func TestSetCommPrefsOnceAfterSetupWithoutEmail(t *testing.T) {
+	ctx := t.Context()
+	mgr := auth.NewKVMetadataManager("test", "id", "mem", kvtest.GetStore(ctx, t))
+
+	// Setup without comm prefs records comm_prefs_set=false.
+	_, err := mgr.UpdateCommPrefs(ctx, nil)
+	require.NoError(t, err)
+	set, err := mgr.IsCommPrefsSet(ctx)
+	require.NoError(t, err)
+	require.False(t, set)
+
+	// Providing them later succeeds once.
+	_, err = mgr.SetCommPrefsOnce(ctx, &auth.CommPrefs{UserEmail: "later@acme.co"})
+	require.NoError(t, err)
+	set, err = mgr.IsCommPrefsSet(ctx)
+	require.NoError(t, err)
+	require.True(t, set)
+
+	// and a repeat is rejected.
+	_, err = mgr.SetCommPrefsOnce(ctx, &auth.CommPrefs{UserEmail: "again@acme.co"})
+	require.ErrorIs(t, err, auth.ErrCommPrefsAlreadySet)
+}
+
+// TestSetCommPrefsOnceConcurrent verifies that under concurrent submissions
+// exactly one caller commits and the rest get ErrCommPrefsAlreadySet.
+func TestSetCommPrefsOnceConcurrent(t *testing.T) {
+	ctx := t.Context()
+	mgr := auth.NewKVMetadataManager("test", "id", "mem", kvtest.GetStore(ctx, t))
+
+	const n = 8
+	var wg sync.WaitGroup
+	var success, conflict atomic.Int32
+	errs := make(chan error, n)
+	for i := 0; i < n; i++ {
+		wg.Add(1)
+		go func(i int) {
+			defer wg.Done()
+			_, err := mgr.SetCommPrefsOnce(ctx, &auth.CommPrefs{UserEmail: fmt.Sprintf("u%d@acme.co", i)})
+			switch {
+			case err == nil:
+				success.Add(1)
+			case errors.Is(err, auth.ErrCommPrefsAlreadySet):
+				conflict.Add(1)
+			default:
+				errs <- err
+			}
+		}(i)
+	}
+	wg.Wait()
+	close(errs)
+	for err := range errs {
+		require.NoError(t, err)
+	}
+	require.Equal(t, int32(1), success.Load(), "exactly one writer should win")
+	require.Equal(t, int32(n-1), conflict.Load())
+}
+
+// TestUpdateCommPrefsNilClearsCache verifies the cache follows KV: a nil update
+// (e.g. a Setup retry) un-sticks a previously cached true, preventing the
+// divergence where the process reports "set" while KV says otherwise.
+func TestUpdateCommPrefsNilClearsCache(t *testing.T) {
+	ctx := t.Context()
+	mgr := auth.NewKVMetadataManager("test", "id", "mem", kvtest.GetStore(ctx, t))
+
+	_, err := mgr.UpdateCommPrefs(ctx, &auth.CommPrefs{UserEmail: "a@acme.co"})
+	require.NoError(t, err)
+	set, err := mgr.IsCommPrefsSet(ctx)
+	require.NoError(t, err)
+	require.True(t, set)
+
+	_, err = mgr.UpdateCommPrefs(ctx, nil)
+	require.NoError(t, err)
+	set, err = mgr.IsCommPrefsSet(ctx)
+	require.NoError(t, err)
+	require.False(t, set, "nil update must clear the cached true state")
+}

--- a/pkg/auth/errors.go
+++ b/pkg/auth/errors.go
@@ -8,6 +8,7 @@ import (
 
 var (
 	ErrNotFound                = kv.ErrNotFound
+	ErrCommPrefsAlreadySet     = errors.New("comm prefs already set")
 	ErrAlreadyExists           = errors.New("already exists")
 	ErrNonUnique               = errors.New("more than one user found")
 	ErrInvalidArn              = errors.New("invalid ARN")

--- a/pkg/auth/metadata.go
+++ b/pkg/auth/metadata.go
@@ -50,6 +50,7 @@ type MetadataManager interface {
 	IsInitialized(ctx context.Context) (bool, error)
 	GetSetupState(ctx context.Context) (SetupStateName, error)
 	UpdateCommPrefs(ctx context.Context, commPrefs *CommPrefs) (string, error)
+	SetCommPrefsOnce(ctx context.Context, commPrefs *CommPrefs) (string, error)
 	IsCommPrefsSet(ctx context.Context) (bool, error)
 	UpdateSetupTimestamp(ctx context.Context, setupTime time.Time, authType string) error
 	GetMetadata(context.Context) (map[string]string, error)
@@ -179,25 +180,82 @@ func (m *KVMetadataManager) UpdateSetupTimestamp(ctx context.Context, setupTime 
 	return nil
 }
 
+// commPrefsData returns the (non-flag) metadata key/values for the given prefs.
+func commPrefsData(commPrefs *CommPrefs) map[string]string {
+	return map[string]string{
+		FirstNameKeyName:      base64.StdEncoding.EncodeToString([]byte(commPrefs.FirstName)),
+		LastNameKeyName:       base64.StdEncoding.EncodeToString([]byte(commPrefs.LastName)),
+		EmailKeyName:          base64.StdEncoding.EncodeToString([]byte(commPrefs.UserEmail)),
+		CompanyNameKeyName:    base64.StdEncoding.EncodeToString([]byte(commPrefs.CompanyName)),
+		FeatureUpdatesKeyName: strconv.FormatBool(commPrefs.FeatureUpdates),
+	}
+}
+
+// SetCommPrefsOnce persists comm prefs and marks them set, but only if they
+// were not already set. It returns ErrCommPrefsAlreadySet otherwise, so a
+// repeat call never overrides an established record.
+//
+// The prefs data is written first, and comm_prefs_set is flipped last with a
+// conditional SetIf as the commit point. Ordering it this way means a failed
+// data write leaves the flag unset, so a retry can still complete the record
+// (no partial-write brick). Only one caller wins the SetIf commit; the rest get
+// ErrCommPrefsAlreadySet. Concurrent callers that all observe the flag unset do
+// race on the data itself (last write wins), which is acceptable.
+func (m *KVMetadataManager) SetCommPrefsOnce(ctx context.Context, commPrefs *CommPrefs) (string, error) {
+	if m.commPrefsSet.Load() {
+		return m.installationID, ErrCommPrefsAlreadySet
+	}
+
+	flagKey := []byte(model.MetadataKeyPath(CommPrefsSetKeyName))
+	current, err := m.store.Get(ctx, []byte(model.PartitionKey), flagKey)
+	var predicate kv.Predicate
+	switch {
+	case errors.Is(err, kv.ErrNotFound):
+		predicate = nil // commit only if the flag is still absent
+	case err != nil:
+		return m.installationID, err
+	default:
+		isSet, parseErr := strconv.ParseBool(string(current.Value))
+		if parseErr != nil {
+			return m.installationID, parseErr
+		}
+		if isSet {
+			m.commPrefsSet.Store(true)
+			return m.installationID, ErrCommPrefsAlreadySet
+		}
+		predicate = current.Predicate // flag is false; commit only if unchanged
+	}
+
+	// write the data first so a failure here leaves the flag unset and retryable.
+	if err := m.writeMetadata(ctx, commPrefsData(commPrefs)); err != nil {
+		return m.installationID, err
+	}
+
+	// flip comm_prefs_set last as the commit point; only one caller wins.
+	err = m.store.SetIf(ctx, []byte(model.PartitionKey), flagKey, []byte(strconv.FormatBool(true)), predicate)
+	if errors.Is(err, kv.ErrPredicateFailed) {
+		// another writer committed comm_prefs_set concurrently
+		m.commPrefsSet.Store(true)
+		return m.installationID, ErrCommPrefsAlreadySet
+	}
+	if err != nil {
+		return m.installationID, err
+	}
+	m.commPrefsSet.Store(true)
+	return m.installationID, nil
+}
+
 // UpdateCommPrefs - updates the comm prefs metadata.
 // When commPrefs is nil, we assume the setup is done and the user didn't provide any comm prefs.
 // The data can be provided later as the web UI verifies if the comm prefs are set.
 func (m *KVMetadataManager) UpdateCommPrefs(ctx context.Context, commPrefs *CommPrefs) (string, error) {
-	var meta map[string]string
+	meta := map[string]string{
+		CommPrefsSetKeyName: strconv.FormatBool(commPrefs != nil),
+	}
 	if commPrefs != nil {
 		// if commPrefs is not nil, we assume the setup is done and the user provided comm prefs
-		meta = map[string]string{
-			FirstNameKeyName:      base64.StdEncoding.EncodeToString([]byte(commPrefs.FirstName)),
-			LastNameKeyName:       base64.StdEncoding.EncodeToString([]byte(commPrefs.LastName)),
-			EmailKeyName:          base64.StdEncoding.EncodeToString([]byte(commPrefs.UserEmail)),
-			CompanyNameKeyName:    base64.StdEncoding.EncodeToString([]byte(commPrefs.CompanyName)),
-			FeatureUpdatesKeyName: strconv.FormatBool(commPrefs.FeatureUpdates),
-			CommPrefsSetKeyName:   strconv.FormatBool(true),
-		}
-	} else {
-		// if commPrefs is nil, we assume the setup is done and the user didn't provide any comm prefs
-		meta = map[string]string{
-			CommPrefsSetKeyName: strconv.FormatBool(false),
+		for k, v := range commPrefsData(commPrefs) {
+			meta[k] = v
 		}
 	}
 	err := m.writeMetadata(ctx, meta)
@@ -205,11 +263,10 @@ func (m *KVMetadataManager) UpdateCommPrefs(ctx context.Context, commPrefs *Comm
 		return m.installationID, err
 	}
 
-	// cache that comm prefs are set, but only when they actually were:
-	// a nil commPrefs writes comm_prefs_set=false and must not prime the cache.
-	if commPrefs != nil {
-		m.commPrefsSet.Store(true)
-	}
+	// keep the cache in sync with what was written: a nil commPrefs writes
+	// comm_prefs_set=false and must un-stick any previously cached true (e.g. a
+	// Setup retry after an earlier write primed the cache).
+	m.commPrefsSet.Store(commPrefs != nil)
 	return m.installationID, nil
 }
 

--- a/pkg/auth/metadata.go
+++ b/pkg/auth/metadata.go
@@ -8,6 +8,7 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -59,6 +60,12 @@ type KVMetadataManager struct {
 	kvType         string
 	installationID string
 	store          kv.Store
+
+	// cache of positive setup/comm-prefs state to avoid hitting KV on every
+	// check. These states only ever transition false->true, so a cached true
+	// is correct indefinitely.
+	initialized  atomic.Bool
+	commPrefsSet atomic.Bool
 }
 
 type CommPrefs struct {
@@ -110,6 +117,10 @@ func (m *KVMetadataManager) getSetupTimestamp(ctx context.Context) (time.Time, e
 }
 
 func (m *KVMetadataManager) IsCommPrefsSet(ctx context.Context) (bool, error) {
+	if m.commPrefsSet.Load() {
+		return true, nil
+	}
+
 	commPrefsSet, err := m.store.Get(ctx, []byte(model.PartitionKey), []byte(model.MetadataKeyPath(CommPrefsSetKeyName)))
 	if err != nil {
 		if errors.Is(err, kv.ErrNotFound) {
@@ -118,7 +129,15 @@ func (m *KVMetadataManager) IsCommPrefsSet(ctx context.Context) (bool, error) {
 		return false, err
 	}
 
-	return strconv.ParseBool(string(commPrefsSet.Value))
+	isSet, err := strconv.ParseBool(string(commPrefsSet.Value))
+	if err != nil {
+		return false, err
+	}
+	// cache the result in case it is true
+	if isSet {
+		m.commPrefsSet.Store(isSet)
+	}
+	return isSet, nil
 }
 
 func (m *KVMetadataManager) GetSetupState(ctx context.Context) (SetupStateName, error) {
@@ -151,7 +170,13 @@ func (m *KVMetadataManager) UpdateSetupTimestamp(ctx context.Context, setupTime 
 		SetupTimestampKeyName: setupTimeStr,
 	}
 	items[SetupAuthTypeKeyPrefix+authType] = setupTimeStr
-	return m.writeMetadata(ctx, items)
+	err := m.writeMetadata(ctx, items)
+	if err != nil {
+		return err
+	}
+	// setup just completed; prime the cache so subsequent checks skip KV
+	m.initialized.Store(true)
+	return nil
 }
 
 // UpdateCommPrefs - updates the comm prefs metadata.
@@ -176,10 +201,23 @@ func (m *KVMetadataManager) UpdateCommPrefs(ctx context.Context, commPrefs *Comm
 		}
 	}
 	err := m.writeMetadata(ctx, meta)
-	return m.installationID, err
+	if err != nil {
+		return m.installationID, err
+	}
+
+	// cache that comm prefs are set, but only when they actually were:
+	// a nil commPrefs writes comm_prefs_set=false and must not prime the cache.
+	if commPrefs != nil {
+		m.commPrefsSet.Store(true)
+	}
+	return m.installationID, nil
 }
 
 func (m *KVMetadataManager) IsInitialized(ctx context.Context) (bool, error) {
+	if m.initialized.Load() {
+		return true, nil
+	}
+
 	setupTimestamp, err := m.getSetupTimestamp(ctx)
 	if err != nil {
 		if errors.Is(err, kv.ErrNotFound) {
@@ -187,7 +225,11 @@ func (m *KVMetadataManager) IsInitialized(ctx context.Context) (bool, error) {
 		}
 		return false, err
 	}
-	return !setupTimestamp.IsZero(), nil
+	initialized := !setupTimestamp.IsZero()
+	if initialized {
+		m.initialized.Store(true)
+	}
+	return initialized, nil
 }
 
 // DockeEnvExists For testing purposes

--- a/webui/src/lib/api/index.js
+++ b/webui/src/lib/api/index.js
@@ -1305,11 +1305,12 @@ class Setup {
 
         switch (response.status) {
             case 200:
+            case 409:
+                // 409 means the preferences were already set (e.g. a double-submit
+                // or a retried request) - the desired end state, so treat as success.
                 return;
             case 400:
                 throw new Error(await extractError(response));
-            case 409:
-                throw new Error('Setup is already complete.');
             default:
                 throw new Error('Unknown');
         }


### PR DESCRIPTION
## Summary
- `SetupCommPrefs` now returns 409 Conflict on a repeat call instead of silently overriding stored communication preferences.
- Cache the `initialized` and `comm_prefs_set` states in memory (sticky once observed true) so the UI's repeated setup-state polls don't hit KV on every check.
- These states only ever transition false→true, so a cached true is correct indefinitely.
