### PR TITLE
Added confirmation for lakectl local commit when there was an interru…

### DIFF
--- a/.github/workflows/lakectl-compatibility-tests.yaml
+++ b/.github/workflows/lakectl-compatibility-tests.yaml
@@ -133,7 +133,7 @@ jobs:
           LAKEFS_BLOCKSTORE_TYPE: s3
           LAKEFS_BLOCKSTORE_S3_CREDENTIALS_ACCESS_KEY_ID: ${{ secrets.ESTI_AWS_ACCESS_KEY_ID }}
           LAKEFS_BLOCKSTORE_S3_CREDENTIALS_SECRET_ACCESS_KEY: ${{ secrets.ESTI_AWS_SECRET_ACCESS_KEY }}
-          SKIP_TESTS: 'TestLakectl(Usage|Help)$|TestLakectlTagList/delete_tag1'
+          SKIP_TESTS: 'TestLakectl(Usage|Help)$|TestLakectlTagList/delete_tag1|TestLakectlLocal_interrupted_commit_yes_flag'
 
   notify-slack:
     name: Notify slack on workflow failures

--- a/cmd/lakectl/cmd/common_helpers.go
+++ b/cmd/lakectl/cmd/common_helpers.go
@@ -391,12 +391,19 @@ func AssignAutoConfirmFlag(flags *pflag.FlagSet) {
 	flags.BoolP(AutoConfirmFlagName, AutoConfigFlagShortName, false, AutoConfirmFlagHelp)
 }
 
-func Confirm(flags *pflag.FlagSet, question string) (bool, error) {
+func Confirm(flags *pflag.FlagSet, question string, preamble ...string) (bool, error) {
 	yes, err := flags.GetBool(AutoConfirmFlagName)
 	if err == nil && yes {
 		// got auto confirm flag
 		return true, nil
 	}
+
+	// promptui has a known issue with newlines in the Label. (the app hangs)
+	// so this is to split the preamble prints from the prompt
+	for _, preambleLine := range preamble {
+		fmt.Println(preambleLine)
+	}
+
 	prm := promptui.Prompt{
 		Label:     question,
 		IsConfirm: true,

--- a/cmd/lakectl/cmd/local_commit.go
+++ b/cmd/lakectl/cmd/local_commit.go
@@ -101,8 +101,8 @@ var localCommitCmd = &cobra.Command{
 		syncFlags := getSyncFlags(cmd, client, remote.Repository)
 
 		if idx.ActiveOperation != "" {
-			fmt.Printf("Latest 'local %s' operation was interrupted, running 'local commit' operation now might lead to data loss.\n", idx.ActiveOperation)
-			confirmation, err := Confirm(cmd.Flags(), "Proceed")
+			confirmationWarning := fmt.Sprintf("Latest 'local %s' operation was interrupted, running 'local commit' operation now might lead to data loss.", idx.ActiveOperation)
+			confirmation, err := Confirm(cmd.Flags(), "Proceed", confirmationWarning)
 			if err != nil || !confirmation {
 				Die("command aborted", 1)
 			}
@@ -233,6 +233,7 @@ var localCommitCmd = &cobra.Command{
 func init() {
 	withForceFlag(localCommitCmd, "Commit changes even if remote branch includes uncommitted changes external to the synced path")
 	withCommitFlags(localCommitCmd, false)
+	AssignAutoConfirmFlag(localCommitCmd.Flags())
 	withSyncFlags(localCommitCmd)
 	localCmd.AddCommand(localCommitCmd)
 }

--- a/esti/lakectl_local_test.go
+++ b/esti/lakectl_local_test.go
@@ -1148,3 +1148,84 @@ Use "lakectl local pull... --force" to sync with the remote.`,
 		})
 	}
 }
+
+func TestLakectlLocal_interrupted_commit_yes_flag(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	repoName := GenerateUniqueRepositoryName()
+	storage := GenerateUniqueStorageNamespace(repoName)
+	vars := map[string]string{
+		"REPO":    repoName,
+		"STORAGE": storage,
+		"BRANCH":  mainBranch,
+		"REF":     mainBranch,
+		"PREFIX":  "",
+	}
+
+	runCmd(t, Lakectl()+" repo create lakefs://"+repoName+" "+storage, false, false, vars)
+	runCmd(t, Lakectl()+" log lakefs://"+repoName+"/"+mainBranch, false, false, vars)
+
+	tests := []struct {
+		name        string
+		flag        string
+		expectFail  bool
+		expectedMsg string
+	}{
+		{
+			name:        "short-yes-flag",
+			flag:        "-y",
+			expectFail:  false,
+			expectedMsg: "Commit for branch \"${BRANCH}\" completed",
+		},
+		{
+			name:        "long-yes-flag",
+			flag:        "--yes",
+			expectFail:  false,
+			expectedMsg: "Commit for branch \"${BRANCH}\" completed",
+		},
+		{
+			name:        "no-confirmation-flag",
+			flag:        "",
+			expectFail:  true,
+			expectedMsg: "Latest 'local pull' operation was interrupted, running 'local commit' operation now might lead to data loss.",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			dataDir, err := os.MkdirTemp(tmpDir, "")
+			require.NoError(t, err)
+
+			localVars := map[string]string{
+				"REPO":      repoName,
+				"STORAGE":   storage,
+				"BRANCH":    tt.name,
+				"REF":       tt.name,
+				"PREFIX":    "",
+				"LOCAL_DIR": dataDir,
+			}
+
+			runCmd(t, Lakectl()+" branch create lakefs://"+repoName+"/"+tt.name+" --source lakefs://"+repoName+"/"+mainBranch, false, false, localVars)
+			RunCmdAndVerifyContainsText(t, Lakectl()+" local clone lakefs://"+repoName+"/"+tt.name+"/ --pre-sign=false "+dataDir, false, "Successfully cloned lakefs://${REPO}/${REF}/ to ${LOCAL_DIR}.", localVars)
+
+			// Create a local file so there are changes to commit.
+			require.NoError(t, os.WriteFile(filepath.Join(dataDir, "test.txt"), []byte{}, os.ModePerm))
+
+			// Simulate an interrupted pull by writing ActiveOperation into the index.
+			idx, err := local.ReadIndex(dataDir)
+			require.NoError(t, err)
+			u, err := idx.GetCurrentURI()
+			require.NoError(t, err)
+			_, err = local.WriteIndex(idx.LocalPath(), u, idx.AtHead, "pull")
+			require.NoError(t, err)
+
+			cmd := fmt.Sprintf("%s local commit %s -m test %s", Lakectl(), tt.flag, dataDir)
+			if tt.expectFail {
+				RunCmdAndVerifyFailureContainsText(t, cmd, false, tt.expectedMsg, localVars)
+			} else {
+				RunCmdAndVerifyContainsText(t, cmd, false, tt.expectedMsg, localVars)
+			}
+		})
+	}
+}


### PR DESCRIPTION
…pted action

## Change Description
Added the -y / --yes confirmation flag to the local commit lakectl command.

Fixes: #10442

### Background

- tested locally (changed the index yaml file to simulate an interrupted operation and verified the expected behaviour, with and without the flag)
- Added ESTI test

### New Feature

we want to add auto-confirmation flags for `lakectl local commit` when there was a previous interrupted action.

### Testing Details

Tested locally and added ESTI test

### Breaking Change?

No
