### PR TITLE
fix: updated gitignore paths to use forward slashes on Windows

### DIFF
--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -82,7 +82,7 @@ func createEntriesForIgnore(dir string, paths []string, exclude bool) ([]string,
 			return nil, fmt.Errorf("%s :%w", p, err)
 		}
 		if isDir {
-			pathInRepo = filepath.Join(pathInRepo, "*")
+			pathInRepo = filepath.ToSlash(filepath.Join(pathInRepo, "*"))
 		}
 		if exclude {
 			pathInRepo = "!" + pathInRepo

--- a/pkg/git/git_internal_test.go
+++ b/pkg/git/git_internal_test.go
@@ -1,0 +1,24 @@
+package git
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCreateEntriesForIgnore_NoBackslashOnWindows(t *testing.T) {
+	// Create a valid temporary directory to ignore
+	tmpDir := t.TempDir()
+	inputDir := filepath.Join(tmpDir, "input")
+	require.NoError(t, os.Mkdir(inputDir, 0755))
+
+	// Ignore the temporary directory
+	entries, err := createEntriesForIgnore(tmpDir, []string{inputDir}, false)
+	require.NoError(t, err)
+
+	// Check that the output matches git conventions and does not contain backslashes
+	require.Equal(t, []string{"input/*"}, entries)
+	require.NotContains(t, entries[0], "\\")
+}

--- a/pkg/git/git_test.go
+++ b/pkg/git/git_test.go
@@ -228,6 +228,7 @@ func TestParseURL(t *testing.T) {
 			ExpectedUrl: nil,
 		},
 	}
+
 	for _, tt := range cases {
 		t.Run(tt.Url, func(t *testing.T) {
 			parsed := git.ParseURL(tt.Url)


### PR DESCRIPTION
Closes #10449 

## Change Description

### Background

This fix ensures that automatic .gitignore entries are generated with backslashes on linux-based systems as well as on Windows-based systems. 

### Bug Fix

1. Problem - Currently the gitignore entries for directories generated using lakectl clone generate with backslashes on Windows, causing the .gitignore to malfunction and not actually ignore the directories. 
2. Root cause - The function createEntriesForIgnore in git.go doesn't universalize file paths; it uses the convention of the user's operating system 
4. Solution - I fixed the bug by wrapping the filepath.join() call in a filepath.ToSlash() call in createEntriesForIgnore, which changes directory backslashes forward slashes. 
  
### Testing Details

I added a testing file in the pkg/git subdirectory called git_internal_test.go, as the function createEntriesForIgnore is internal to the package "git". The test verifies that a temporary test directory is correctly named with a forward slash. The test passes locally on Windows. 

### Breaking Change?

Not that I am aware of. 

## Additional info

N/A