### PR TITLE
chore(webui): allow install scripts for native build-tool deps

### DIFF
--- a/webui/package.json
+++ b/webui/package.json
@@ -111,5 +111,11 @@
     "vite": "^7.3.1",
     "vite-plugin-eslint2": "^5.0.4",
     "vitest": "^3.2.4"
+  },
+  "allowScripts": {
+    "@parcel/watcher": true,
+    "@swc/core": true,
+    "esbuild": true,
+    "fsevents": true
   }
 }


### PR DESCRIPTION
## Summary
- npm 11 blocks dependency lifecycle scripts by default unless allowlisted, so `npm install` in `webui` warns and requires `npm approve-scripts`.
- Add an `allowScripts` allowlist for `esbuild`, `@swc/core`, `@parcel/watcher`, and `fsevents` — all transitive deps of vite/sass/playwright whose install/postinstall scripts only set up prebuilt native binaries.

## Related Issue
None

## Test plan
- [x] `npm install` completes with no allow-scripts warning and 0 vulnerabilities
- [x] `npm run build` succeeds (exercises esbuild/swc/rollup native binaries)