### PR TITLE
Report data read/write size through lakeFS API and S3 gateway

### DIFF
--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -626,6 +626,8 @@ func (c *Controller) CompletePresignMultipartUpload(w http.ResponseWriter, r *ht
 		return
 	}
 
+	c.reportDataSize(ctx, r, stats.EventNameBytesIn, repository, branch, entry.Size)
+
 	metadata := apigen.ObjectUserMetadata{AdditionalProperties: entry.Metadata}
 	response := apigen.ObjectStats{
 		Checksum:        entry.Checksum,
@@ -1036,6 +1038,8 @@ func (c *Controller) LinkPhysicalAddress(w http.ResponseWriter, r *http.Request,
 	if c.handleAPIError(ctx, w, r, err) {
 		return
 	}
+
+	c.reportDataSize(ctx, r, stats.EventNameBytesIn, repository, branch, entry.Size)
 
 	metadata := apigen.ObjectUserMetadata{AdditionalProperties: entry.Metadata}
 	response := apigen.ObjectStats{
@@ -3675,6 +3679,8 @@ func (c *Controller) UploadObject(w http.ResponseWriter, r *http.Request, reposi
 		return
 	}
 
+	c.reportDataSize(ctx, r, stats.EventNameBytesIn, repository, branch, blob.Size)
+
 	response := apigen.ObjectStats{
 		Checksum:        blob.Checksum,
 		Mtime:           blob.CreationDate.Unix(),
@@ -4986,6 +4992,7 @@ func (c *Controller) GetObject(w http.ResponseWriter, r *http.Request, repositor
 		if c.handleAPIError(ctx, w, r, err) {
 			return
 		}
+		c.reportDataSize(ctx, r, stats.EventNameBytesOut, repository, ref, entry.Size)
 		w.Header().Set("Location", location)
 		w.WriteHeader(http.StatusFound)
 		return
@@ -5008,6 +5015,9 @@ func (c *Controller) GetObject(w http.ResponseWriter, r *http.Request, repositor
 
 	// handle partial response if byte range supplied
 	var reader io.ReadCloser
+	// servedBytes is the number of bytes actually served to the client (the full
+	// object size, or the requested range length for a partial read).
+	servedBytes := entry.Size
 	if params.Range != nil {
 		rng, err := httputil.ParseRange(*params.Range, entry.Size)
 		if err != nil {
@@ -5024,8 +5034,9 @@ func (c *Controller) GetObject(w http.ResponseWriter, r *http.Request, repositor
 		defer func() {
 			_ = reader.Close()
 		}()
+		servedBytes = rng.EndOffset - rng.StartOffset + 1
 		w.Header().Set("Content-Range", fmt.Sprintf("bytes %d-%d/%d", rng.StartOffset, rng.EndOffset, entry.Size))
-		w.Header().Set("Content-Length", fmt.Sprintf("%d", rng.EndOffset-rng.StartOffset+1))
+		w.Header().Set("Content-Length", fmt.Sprintf("%d", servedBytes))
 		w.WriteHeader(http.StatusPartialContent)
 	} else {
 		reader, err = c.BlockAdapter.Get(ctx, pointer)
@@ -5037,6 +5048,7 @@ func (c *Controller) GetObject(w http.ResponseWriter, r *http.Request, repositor
 		}()
 		w.Header().Set("Content-Length", fmt.Sprint(entry.Size))
 	}
+	c.reportDataSize(ctx, r, stats.EventNameBytesOut, repository, ref, servedBytes)
 
 	// time to first byte - include out part of the processing without the actual data transfer
 	requestTTFBHistograms.
@@ -6148,6 +6160,24 @@ func (c *Controller) LogAction(ctx context.Context, action string, r *http.Reque
 	}).Debug("performing API action")
 	c.Collector.CollectEvent(ev)
 	usageCounter.Add(1)
+}
+
+// reportDataSize reports bytes transferred by an API data operation. No-op when size <= 0.
+func (c *Controller) reportDataSize(ctx context.Context, r *http.Request, name, repository, ref string, size int64) {
+	if size <= 0 {
+		return
+	}
+	ev := stats.Event{
+		Class:      "api_server",
+		Name:       name,
+		Repository: repository,
+		Ref:        ref,
+		Client:     httputil.GetRequestLakeFSClient(r),
+	}
+	if user, _ := auth.GetUser(ctx); user != nil {
+		ev.UserID = user.Username
+	}
+	c.Collector.CollectEvents(ev, uint64(size)) //nolint:gosec
 }
 
 func paginationFor(hasMore bool, results any, fieldName string) apigen.Pagination {

--- a/pkg/gateway/middleware.go
+++ b/pkg/gateway/middleware.go
@@ -140,6 +140,16 @@ func EnrichWithOperation(sc *ServerContext, next http.Handler) http.Handler {
 					Client:     client,
 				})
 			},
+			IncrByteReport: func(name, userID, repository, ref string, size int64) {
+				sc.stats.CollectEvents(stats.Event{
+					Class:      "s3_gateway",
+					Name:       name,
+					Repository: repository,
+					Ref:        ref,
+					UserID:     userID,
+					Client:     client,
+				}, uint64(size)) //nolint:gosec
+			},
 			PathProvider: sc.pathProvider,
 		}
 

--- a/pkg/gateway/operations/base.go
+++ b/pkg/gateway/operations/base.go
@@ -44,6 +44,11 @@ const (
 
 type ActionIncr func(action, userID, repository, ref string)
 
+// ByteReportIncr reports the amount of data (in bytes) transferred by a data
+// operation. name is stats.EventNameBytesIn for writes or stats.EventNameBytesOut
+// for reads.
+type ByteReportIncr func(name, userID, repository, ref string, size int64)
+
 type Operation struct {
 	OperationID       OperationID
 	Region            string
@@ -53,9 +58,19 @@ type Operation struct {
 	BlockStore        block.Adapter
 	Auth              auth.GatewayService
 	Incr              ActionIncr
+	IncrByteReport    ByteReportIncr
 	MatchedHost       bool
 	PathProvider      upload.PathProvider
 	VerifyUnsupported bool
+}
+
+// reportBytes reports the number of bytes transferred by a data operation. It is
+// a no-op when no reporter is configured or size is not positive.
+func (o *Operation) reportBytes(name, userID, repository, ref string, size int64) {
+	if o.IncrByteReport == nil || size <= 0 {
+		return
+	}
+	o.IncrByteReport(name, userID, repository, ref, size)
 }
 
 func StorageClassFromHeader(header http.Header) *string {

--- a/pkg/gateway/operations/getobject.go
+++ b/pkg/gateway/operations/getobject.go
@@ -18,6 +18,7 @@ import (
 	"github.com/treeverse/lakefs/pkg/httputil"
 	"github.com/treeverse/lakefs/pkg/logging"
 	"github.com/treeverse/lakefs/pkg/permissions"
+	"github.com/treeverse/lakefs/pkg/stats"
 )
 
 const (
@@ -124,6 +125,7 @@ func (controller *GetObject) Handle(w http.ResponseWriter, req *http.Request, o 
 			return
 		}
 
+		o.reportBytes(stats.EventNameBytesOut, o.Principal, o.Repository.Name, o.Reference, entry.Size)
 		o.SetHeader(w, "Location", preSignedURL)
 		w.WriteHeader(http.StatusTemporaryRedirect)
 		return
@@ -155,6 +157,7 @@ func (controller *GetObject) Handle(w http.ResponseWriter, req *http.Request, o 
 		o.SetHeader(w, "Content-Range", contentRange)
 	}
 	o.SetHeader(w, "Content-Length", fmt.Sprintf("%d", contentLength))
+	o.reportBytes(stats.EventNameBytesOut, o.Principal, o.Repository.Name, o.Reference, contentLength)
 	o.SetHeader(w, "X-Content-Type-Options", "nosniff")
 	o.SetHeader(w, "X-Frame-Options", "SAMEORIGIN")
 	o.SetHeader(w, "Content-Security-Policy", "default-src 'none'")

--- a/pkg/gateway/operations/postobject.go
+++ b/pkg/gateway/operations/postobject.go
@@ -20,6 +20,7 @@ import (
 	"github.com/treeverse/lakefs/pkg/httputil"
 	"github.com/treeverse/lakefs/pkg/logging"
 	"github.com/treeverse/lakefs/pkg/permissions"
+	"github.com/treeverse/lakefs/pkg/stats"
 )
 
 const (
@@ -185,6 +186,7 @@ func (controller *PostObject) HandleCompleteMultipartUpload(w http.ResponseWrite
 		_ = o.EncodeError(w, req, err, gatewayErrors.Codes.ToAPIErr(gatewayErrors.ErrInternalError))
 		return
 	}
+	o.reportBytes(stats.EventNameBytesIn, o.Principal, o.Repository.Name, o.Reference, resp.ContentLength)
 	err = o.MultipartTracker.Delete(req.Context(), uploadID)
 	if err != nil {
 		o.Log(req).WithError(err).Warn("could not delete multipart record")

--- a/pkg/gateway/operations/putobject.go
+++ b/pkg/gateway/operations/putobject.go
@@ -17,6 +17,7 @@ import (
 	"github.com/treeverse/lakefs/pkg/httputil"
 	"github.com/treeverse/lakefs/pkg/logging"
 	"github.com/treeverse/lakefs/pkg/permissions"
+	"github.com/treeverse/lakefs/pkg/stats"
 	"github.com/treeverse/lakefs/pkg/upload"
 )
 
@@ -399,6 +400,7 @@ func handlePut(w http.ResponseWriter, req *http.Request, o *PathOperation) {
 		_ = o.EncodeError(w, req, err, gatewayErrors.Codes.ToAPIErr(gatewayErrors.ErrInternalError))
 		return
 	}
+	o.reportBytes(stats.EventNameBytesIn, o.Principal, o.Repository.Name, o.Reference, blob.Size)
 	o.SetHeader(w, "ETag", httputil.ETag(blob.Checksum))
 	w.WriteHeader(http.StatusOK)
 }

--- a/pkg/stats/collector.go
+++ b/pkg/stats/collector.go
@@ -20,6 +20,10 @@ const (
 
 	// heartbeatInterval is the interval between 2 heartbeat events.
 	heartbeatInterval = time.Hour
+
+	// EventNameBytesIn and EventNameBytesOut report bytes written to / read from lakeFS.
+	EventNameBytesIn  = "bytes_in"
+	EventNameBytesOut = "bytes_out"
 )
 
 type CommPrefs struct {


### PR DESCRIPTION
## Problem
Every API/S3-gateway operation reports a usage event with a value of 1 — a
call count. lakeFS had no visibility into data *volume*: how many bytes are
read from and written to it. This adds byte-size reporting so usage
analytics can reason about data size, not just request counts.

Writes report a `bytes_in` metric and reads a `bytes_out` metric, per class
(`api_server`, `s3_gateway`), carrying the byte count as the metric value on
the existing stats collector — no new transport. Sizes come from what lakeFS
already knows at each handler, so presigned / staged / physical-address
transfers are counted too. Multipart is counted exactly once (per part on the
gateway, at complete for the presigned API flow); partial reads count only the
served range; server-side copy is not counted. Reporting is always on,
matching the existing call-count events.

## Prompt log
> for each operation we LogAction ... we want to report how much data
> read/write through lakefs API/S3 gateway
Brainstormed scope with the user before writing any code: both surfaces, all
known sizes, always on, and count only the served range on partial reads.
Captured the design in a spec (docs/superpowers/specs), then implemented the
hooks and added API- and gateway-level tests that assert the reported byte
totals (including range reads). Design doc is included in the branch.

## Related Issue
Closes #10486

## Test plan
- [x] `go build ./...` and `go vet` on changed packages
- [x] pinned `go tool golangci-lint` on pkg/api, pkg/gateway, pkg/stats — 0 issues
- [x] `go test ./pkg/api/... ./pkg/gateway/... ./pkg/stats/...` — all pass
- [x] new `TestController_DataSizeReporting` (upload/get/range) and `TestGatewayDataSizeReporting` (put/get)