### PR TITLE
Push docs release via treeverse-ci-bot app token

### DIFF
--- a/.github/workflows/push-docs-release.yml
+++ b/.github/workflows/push-docs-release.yml
@@ -62,11 +62,20 @@ jobs:
       - name: Generate cli.md
         run: go run cmd/lakectl/main.go docs > /tmp/cli.md
 
+      - name: Mint treeverse-ci-bot token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.TREEVERSE_CI_BOT_CLIENT_ID }}
+          private-key: ${{ secrets.TREEVERSE_CI_BOT_PRIVATE_KEY }}
+          owner: treeverse
+          repositories: docs-next-lakeFS
+
       - name: Checkout docs-next-lakeFS
         uses: actions/checkout@v6
         with:
           repository: treeverse/docs-next-lakeFS
-          token: ${{ secrets.TREEVERSE_CI_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
           path: docs-next
           ref: main
 
@@ -84,10 +93,14 @@ jobs:
 
       - name: Commit and push
         working-directory: docs-next
+        env:
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          BOT: ${{ steps.app-token.outputs.app-slug }}[bot]
         run: |
           set -eu
-          git config user.name  "treeverse-ci-bot"
-          git config user.email "ci-bot@treeverse.io"
+          bot_id=$(gh api "users/$BOT" --jq .id)
+          git config user.name  "$BOT"
+          git config user.email "$bot_id+$BOT@users.noreply.github.com"
           git add "reference-versions/oss/${{ steps.tag.outputs.minor }}/"
           git add "reference-versions/oss/LATEST"
           if git diff --cached --quiet; then


### PR DESCRIPTION
## Problem
The `Push docs release` workflow snapshots the OSS reference docs to
`treeverse/docs-next-lakeFS` on each release. Its `Commit and push` step
authenticated with a plain PAT (`TREEVERSE_CI_TOKEN`) and pushed directly to
`main`, which the repo's ruleset now rejects:

```
remote: error: GH013: Repository rule violations found for refs/heads/main.
remote: - Changes must be made through a pull request.
 ! [remote rejected] main -> main (push declined due to repository rule violations)
```

The PAT is not a permitted bypass actor, so the v1.84.0 release failed to
publish its docs snapshot ([failed run](https://github.com/treeverse/lakeFS/actions/runs/29996464301/job/89171197810)).

## Prompt log
> update the workflow to use treeverse-ci-bot github app to update and push the documentation changes. create a branch and test the change from inside the branch.

Switched auth to the treeverse-ci-bot GitHub App (the same app already used by
`trigger-charts-release.yaml`), which is a permitted bypass actor on the
docs-next ruleset: mint a scoped App token, use it for the checkout, and commit
under the bot's App identity before pushing to `main`. Verified end-to-end by
dispatching the workflow from this branch for v1.84.0 — the push now succeeds
via `remote: Bypassed rule violations for refs/heads/main`, completing the
snapshot the release run had failed to publish.

## Related Issue
None

## Test plan
- [x] Validated workflow YAML syntax
- [x] Ran the workflow from this branch (workflow_dispatch, v1.84.0) — [run 29997295123](https://github.com/treeverse/lakeFS/actions/runs/29997295123) succeeded; snapshot pushed to docs-next-lakeFS main via bot bypass