### PR TITLE
Report bytes_in/bytes_out under a single "traffic" class

### DIFF
--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -6165,7 +6165,7 @@ func (c *Controller) reportDataSize(ctx context.Context, r *http.Request, name, 
 		return
 	}
 	ev := stats.Event{
-		Class:      "api_server",
+		Class:      stats.EventClassTraffic,
 		Name:       name,
 		Repository: repository,
 		Ref:        ref,

--- a/pkg/gateway/middleware.go
+++ b/pkg/gateway/middleware.go
@@ -142,7 +142,7 @@ func EnrichWithOperation(sc *ServerContext, next http.Handler) http.Handler {
 			},
 			IncrByteReport: func(name, userID, repository, ref string, size int64) {
 				sc.stats.CollectEvents(stats.Event{
-					Class:      "s3_gateway",
+					Class:      stats.EventClassTraffic,
 					Name:       name,
 					Repository: repository,
 					Ref:        ref,

--- a/pkg/stats/collector.go
+++ b/pkg/stats/collector.go
@@ -24,6 +24,9 @@ const (
 	// EventNameBytesIn and EventNameBytesOut report bytes written to / read from lakeFS.
 	EventNameBytesIn  = "bytes_in"
 	EventNameBytesOut = "bytes_out"
+
+	// EventClassTraffic is the class under which bytes_in/bytes_out are reported
+	EventClassTraffic = "traffic"
 )
 
 type CommPrefs struct {


### PR DESCRIPTION
## Problem
Byte-size usage metrics (`bytes_in` / `bytes_out`) were reported under the per-surface classes `api_server` and `s3_gateway`, splitting the same signal across two classes and making it awkward to reason about total data volume in BI. The serving surface is already captured elsewhere; the byte metrics should live under one class.

## Prompt log
> for bytes_in and bytes_out BI metrics - report them on the same class called 'network'
> change 'network' to 'traffic'

Added a shared `stats.EventClassTraffic` constant next to the `bytes_in`/`bytes_out` names and pointed both report sites (API `reportDataSize` and gateway `IncrByteReport`) at it. Regular per-operation call-count events keep their `api_server`/`s3_gateway` classes.

## Related Issue
Closes #10498

## Test plan
- [x] `make lint` — 0 issues (Go + webui)
- [x] `go test ./pkg/stats/...` — pass
- [x] `go build` / `go vet` on pkg/api, pkg/gateway, pkg/stats — clean