### PR TITLE
Reject unauthenticated overwrites of setup comm prefs

### DIFF
--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -5530,8 +5530,7 @@ func (c *Controller) GetSetupState(w http.ResponseWriter, r *http.Request) {
 		c.Collector.CollectEvent(stats.Event{Class: "global", Name: "preinit", Client: httputil.GetRequestLakeFSClient(r)})
 	}
 
-	// best-effort: on a read error, treat comm prefs as not missing. This is a
-	// read-only poll, so the next call re-reads once the store recovers.
+	// best-effort: on a read error treat prefs as not missing; the next poll re-reads.
 	missing, _ := c.commPrefsMissing(ctx, savedState)
 	response := apigen.SetupState{
 		State:            swag.String(string(savedState)),
@@ -5701,7 +5700,7 @@ func (c *Controller) SetupCommPrefs(w http.ResponseWriter, r *http.Request, body
 		return
 	}
 	if savedState != auth.SetupStateInitialized {
-		// setup hasn't run yet - do not latch, this is a transient state
+		// setup must run first - do not latch
 		writeError(w, r, http.StatusPreconditionFailed, setupNotInitializedMsg)
 		return
 	}
@@ -5713,10 +5712,8 @@ func (c *Controller) SetupCommPrefs(w http.ResponseWriter, r *http.Request, body
 		return
 	}
 	if !missing {
-		// prefs already captured (or the feature is disabled) - refuse to overwrite.
-		// only latch when the feature is enabled, so toggling it on later is honored.
-		// reaching here with the feature enabled means the state was read definitively
-		// (prefs set, or a legacy install), so the latch never caches a transient error.
+		// prefs already captured, or the feature is disabled - refuse to overwrite.
+		// latch only on a definitive read (feature enabled), never on a disabled/error result.
 		if c.Config.GetBaseConfig().EmailSubscription.Enabled {
 			c.commPrefsSet.Store(true)
 		}

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -5501,6 +5501,12 @@ func newLoginConfig(c config.AuthConfig) *apigen.LoginConfig {
 	return loginConfig
 }
 
+const (
+	setupAlreadyInitializedMsg = "lakeFS already initialized"
+	setupNotInitializedMsg     = "lakeFS is not initialized"
+	commPrefsAlreadySetMsg     = "communication preferences already set"
+)
+
 func (c *Controller) GetSetupState(w http.ResponseWriter, r *http.Request) {
 	ctx := r.Context()
 
@@ -5565,7 +5571,7 @@ func (c *Controller) Setup(w http.ResponseWriter, r *http.Request, body apigen.S
 	ctx := r.Context()
 	// fast path: already initialized this process, skip the KV read
 	if c.setupComplete.Load() {
-		writeError(w, r, http.StatusConflict, "lakeFS already initialized")
+		writeError(w, r, http.StatusConflict, setupAlreadyInitializedMsg)
 		return
 	}
 	initialized, err := c.MetadataManager.IsInitialized(ctx)
@@ -5575,7 +5581,7 @@ func (c *Controller) Setup(w http.ResponseWriter, r *http.Request, body apigen.S
 	}
 	if initialized {
 		c.setupComplete.Store(true)
-		writeError(w, r, http.StatusConflict, "lakeFS already initialized")
+		writeError(w, r, http.StatusConflict, setupAlreadyInitializedMsg)
 		return
 	}
 
@@ -5678,7 +5684,7 @@ func (c *Controller) SetupCommPrefs(w http.ResponseWriter, r *http.Request, body
 
 	// fast path: comm prefs already captured this process, skip the KV read
 	if c.commPrefsSet.Load() {
-		writeError(w, r, http.StatusConflict, "communication preferences already set")
+		writeError(w, r, http.StatusConflict, commPrefsAlreadySetMsg)
 		return
 	}
 
@@ -5690,13 +5696,16 @@ func (c *Controller) SetupCommPrefs(w http.ResponseWriter, r *http.Request, body
 	}
 	if savedState != auth.SetupStateInitialized {
 		// setup hasn't run yet - do not latch, this is a transient state
-		writeError(w, r, http.StatusPreconditionFailed, "lakeFS is not initialized")
+		writeError(w, r, http.StatusPreconditionFailed, setupNotInitializedMsg)
 		return
 	}
 	if !c.commPrefsMissing(ctx, savedState) {
-		// prefs already captured (or the feature is disabled) - refuse to overwrite
-		c.commPrefsSet.Store(true)
-		writeError(w, r, http.StatusConflict, "communication preferences already set")
+		// prefs already captured (or the feature is disabled) - refuse to overwrite.
+		// only latch when the feature is enabled, so toggling it on later is honored.
+		if c.Config.GetBaseConfig().EmailSubscription.Enabled {
+			c.commPrefsSet.Store(true)
+		}
+		writeError(w, r, http.StatusConflict, commPrefsAlreadySetMsg)
 		return
 	}
 

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -5530,10 +5530,13 @@ func (c *Controller) GetSetupState(w http.ResponseWriter, r *http.Request) {
 		c.Collector.CollectEvent(stats.Event{Class: "global", Name: "preinit", Client: httputil.GetRequestLakeFSClient(r)})
 	}
 
+	// best-effort: on a read error, treat comm prefs as not missing. This is a
+	// read-only poll, so the next call re-reads once the store recovers.
+	missing, _ := c.commPrefsMissing(ctx, savedState)
 	response := apigen.SetupState{
 		State:            swag.String(string(savedState)),
 		LoginConfig:      newLoginConfig(c.Config.AuthConfig()),
-		CommPrefsMissing: swag.Bool(c.commPrefsMissing(ctx, savedState)),
+		CommPrefsMissing: swag.Bool(missing),
 	}
 
 	writeResponse(w, r, http.StatusOK, response)
@@ -5541,10 +5544,13 @@ func (c *Controller) GetSetupState(w http.ResponseWriter, r *http.Request) {
 
 // commPrefsMissing reports whether communication preferences still need to be
 // collected for this installation, mirroring the state surfaced by GetSetupState.
-func (c *Controller) commPrefsMissing(ctx context.Context, state auth.SetupStateName) bool {
+// It returns a non-nil error only when the state could not be determined (a
+// transient store failure), which callers that mutate state must not treat as
+// "already set".
+func (c *Controller) commPrefsMissing(ctx context.Context, state auth.SetupStateName) (bool, error) {
 	// if email subscription is disabled in the config, comm prefs are never collected.
 	if !c.Config.GetBaseConfig().EmailSubscription.Enabled {
-		return false
+		return false, nil
 	}
 
 	prefsSet, err := c.MetadataManager.IsCommPrefsSet(ctx)
@@ -5553,12 +5559,12 @@ func (c *Controller) commPrefsMissing(ctx context.Context, state auth.SetupState
 		// comprefs may not be found for two reasons:
 		// 1. The setup ran on an older version of lakeFS that didn't have commprefs. In this case, we treat it as set.
 		// 2. The setup ran on a newer version of lakeFS that has commprefs, but the setup didn't complete. In this case, we treat it as not set.
-		return state != auth.SetupStateInitialized
+		return state != auth.SetupStateInitialized, nil
 	case err != nil:
-		// failed to check if comm prefs are set, treating as set
-		return false
+		// could not determine state - surface to the caller instead of guessing
+		return false, err
 	default:
-		return !prefsSet
+		return !prefsSet, nil
 	}
 }
 
@@ -5699,9 +5705,18 @@ func (c *Controller) SetupCommPrefs(w http.ResponseWriter, r *http.Request, body
 		writeError(w, r, http.StatusPreconditionFailed, setupNotInitializedMsg)
 		return
 	}
-	if !c.commPrefsMissing(ctx, savedState) {
+	missing, err := c.commPrefsMissing(ctx, savedState)
+	if err != nil {
+		// state is indeterminate - do not latch, let the caller retry
+		c.Logger.WithError(err).Error("Setup comm prefs failed to read state")
+		writeError(w, r, http.StatusInternalServerError, err)
+		return
+	}
+	if !missing {
 		// prefs already captured (or the feature is disabled) - refuse to overwrite.
 		// only latch when the feature is enabled, so toggling it on later is honored.
+		// reaching here with the feature enabled means the state was read definitively
+		// (prefs set, or a legacy install), so the latch never caches a transient error.
 		if c.Config.GetBaseConfig().EmailSubscription.Enabled {
 			c.commPrefsSet.Store(true)
 		}

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -5530,12 +5530,10 @@ func (c *Controller) GetSetupState(w http.ResponseWriter, r *http.Request) {
 		c.Collector.CollectEvent(stats.Event{Class: "global", Name: "preinit", Client: httputil.GetRequestLakeFSClient(r)})
 	}
 
-	// best-effort: on a read error treat prefs as not missing; the next poll re-reads.
-	missing, _ := c.commPrefsMissing(ctx, savedState)
 	response := apigen.SetupState{
 		State:            swag.String(string(savedState)),
 		LoginConfig:      newLoginConfig(c.Config.AuthConfig()),
-		CommPrefsMissing: swag.Bool(missing),
+		CommPrefsMissing: swag.Bool(c.commPrefsMissing(ctx, savedState)),
 	}
 
 	writeResponse(w, r, http.StatusOK, response)
@@ -5543,13 +5541,10 @@ func (c *Controller) GetSetupState(w http.ResponseWriter, r *http.Request) {
 
 // commPrefsMissing reports whether communication preferences still need to be
 // collected for this installation, mirroring the state surfaced by GetSetupState.
-// It returns a non-nil error only when the state could not be determined (a
-// transient store failure), which callers that mutate state must not treat as
-// "already set".
-func (c *Controller) commPrefsMissing(ctx context.Context, state auth.SetupStateName) (bool, error) {
+func (c *Controller) commPrefsMissing(ctx context.Context, state auth.SetupStateName) bool {
 	// if email subscription is disabled in the config, comm prefs are never collected.
 	if !c.Config.GetBaseConfig().EmailSubscription.Enabled {
-		return false, nil
+		return false
 	}
 
 	prefsSet, err := c.MetadataManager.IsCommPrefsSet(ctx)
@@ -5558,12 +5553,12 @@ func (c *Controller) commPrefsMissing(ctx context.Context, state auth.SetupState
 		// comprefs may not be found for two reasons:
 		// 1. The setup ran on an older version of lakeFS that didn't have commprefs. In this case, we treat it as set.
 		// 2. The setup ran on a newer version of lakeFS that has commprefs, but the setup didn't complete. In this case, we treat it as not set.
-		return state != auth.SetupStateInitialized, nil
+		return state != auth.SetupStateInitialized
 	case err != nil:
-		// could not determine state - surface to the caller instead of guessing
-		return false, err
+		// failed to check if comm prefs are set, treating as set
+		return false
 	default:
-		return !prefsSet, nil
+		return !prefsSet
 	}
 }
 
@@ -5704,19 +5699,10 @@ func (c *Controller) SetupCommPrefs(w http.ResponseWriter, r *http.Request, body
 		writeError(w, r, http.StatusPreconditionFailed, setupNotInitializedMsg)
 		return
 	}
-	missing, err := c.commPrefsMissing(ctx, savedState)
-	if err != nil {
-		// state is indeterminate - do not latch, let the caller retry
-		c.Logger.WithError(err).Error("Setup comm prefs failed to read state")
-		writeError(w, r, http.StatusInternalServerError, err)
-		return
-	}
-	if !missing {
-		// prefs already captured, or the feature is disabled - refuse to overwrite.
-		// latch only on a definitive read (feature enabled), never on a disabled/error result.
-		if c.Config.GetBaseConfig().EmailSubscription.Enabled {
-			c.commPrefsSet.Store(true)
-		}
+	if !c.commPrefsMissing(ctx, savedState) {
+		// prefs already captured (or the feature is disabled) - refuse to overwrite.
+		// the latch is only set after we successfully write prefs, never from this
+		// read, so a transient read error can't pin the endpoint to a permanent 409.
 		writeError(w, r, http.StatusConflict, commPrefsAlreadySetMsg)
 		return
 	}

--- a/pkg/api/controller.go
+++ b/pkg/api/controller.go
@@ -18,6 +18,7 @@ import (
 	"regexp"
 	"slices"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/aws/aws-sdk-go-v2/feature/s3/manager"
@@ -127,6 +128,12 @@ type Controller struct {
 	sessionStore    sessions.Store
 	PathProvider    upload.PathProvider
 	usageReporter   stats.UsageReporterOperations
+
+	// One-way latches for the unauthenticated setup endpoints. Once we observe
+	// that setup / comm prefs are complete, further POSTs are rejected without a
+	// KV read. They only ever flip false -> true, so they never serve stale state.
+	setupComplete atomic.Bool
+	commPrefsSet  atomic.Bool
 }
 
 var usageCounter = stats.NewUsageCounter()
@@ -5518,17 +5525,20 @@ func (c *Controller) GetSetupState(w http.ResponseWriter, r *http.Request) {
 	}
 
 	response := apigen.SetupState{
-		State:       swag.String(string(savedState)),
-		LoginConfig: newLoginConfig(c.Config.AuthConfig()),
+		State:            swag.String(string(savedState)),
+		LoginConfig:      newLoginConfig(c.Config.AuthConfig()),
+		CommPrefsMissing: swag.Bool(c.commPrefsMissing(ctx, savedState)),
 	}
 
-	// if email subscription is disabled in the config, set the missing flag to false.
-	// otherwise, check if the comm prefs are set.
-	// if they are, set the missing flag to false.
+	writeResponse(w, r, http.StatusOK, response)
+}
+
+// commPrefsMissing reports whether communication preferences still need to be
+// collected for this installation, mirroring the state surfaced by GetSetupState.
+func (c *Controller) commPrefsMissing(ctx context.Context, state auth.SetupStateName) bool {
+	// if email subscription is disabled in the config, comm prefs are never collected.
 	if !c.Config.GetBaseConfig().EmailSubscription.Enabled {
-		response.CommPrefsMissing = swag.Bool(false)
-		writeResponse(w, r, http.StatusOK, response)
-		return
+		return false
 	}
 
 	prefsSet, err := c.MetadataManager.IsCommPrefsSet(ctx)
@@ -5537,15 +5547,13 @@ func (c *Controller) GetSetupState(w http.ResponseWriter, r *http.Request) {
 		// comprefs may not be found for two reasons:
 		// 1. The setup ran on an older version of lakeFS that didn't have commprefs. In this case, we treat it as set.
 		// 2. The setup ran on a newer version of lakeFS that has commprefs, but the setup didn't complete. In this case, we treat it as not set.
-		response.CommPrefsMissing = swag.Bool(savedState != auth.SetupStateInitialized)
+		return state != auth.SetupStateInitialized
 	case err != nil:
 		// failed to check if comm prefs are set, treating as set
-		response.CommPrefsMissing = swag.Bool(false)
+		return false
 	default:
-		response.CommPrefsMissing = swag.Bool(!prefsSet)
+		return !prefsSet
 	}
-
-	writeResponse(w, r, http.StatusOK, response)
 }
 
 func (c *Controller) Setup(w http.ResponseWriter, r *http.Request, body apigen.SetupJSONRequestBody) {
@@ -5555,12 +5563,18 @@ func (c *Controller) Setup(w http.ResponseWriter, r *http.Request, body apigen.S
 	}
 
 	ctx := r.Context()
+	// fast path: already initialized this process, skip the KV read
+	if c.setupComplete.Load() {
+		writeError(w, r, http.StatusConflict, "lakeFS already initialized")
+		return
+	}
 	initialized, err := c.MetadataManager.IsInitialized(ctx)
 	if err != nil {
 		writeError(w, r, http.StatusInternalServerError, err)
 		return
 	}
 	if initialized {
+		c.setupComplete.Store(true)
 		writeError(w, r, http.StatusConflict, "lakeFS already initialized")
 		return
 	}
@@ -5629,7 +5643,12 @@ func (c *Controller) Setup(w http.ResponseWriter, r *http.Request, body apigen.S
 	c.Collector.SetInstallationID(meta.InstallationID)
 	c.Collector.CollectMetadata(meta)
 	c.Collector.CollectEvent(stats.Event{Class: "global", Name: "init", UserID: body.Username, Client: httputil.GetRequestLakeFSClient(r)})
+
+	// setup is complete - latch so repeated POSTs short-circuit without a KV read.
+	c.setupComplete.Store(true)
 	if commPrefs != nil {
+		// comm prefs were stored as part of setup, so setup_comm_prefs is done too.
+		c.commPrefsSet.Store(true)
 		c.collectCommPrefs(commPrefs, meta.InstallationID)
 	}
 
@@ -5655,6 +5674,32 @@ func (c *Controller) collectCommPrefs(commPrefs *auth.CommPrefs, installationID 
 }
 
 func (c *Controller) SetupCommPrefs(w http.ResponseWriter, r *http.Request, body apigen.SetupCommPrefsJSONRequestBody) {
+	ctx := r.Context()
+
+	// fast path: comm prefs already captured this process, skip the KV read
+	if c.commPrefsSet.Load() {
+		writeError(w, r, http.StatusConflict, "communication preferences already set")
+		return
+	}
+
+	// comm prefs can only be set once, and only after lakeFS setup completed.
+	savedState, err := c.MetadataManager.GetSetupState(ctx)
+	if err != nil {
+		writeError(w, r, http.StatusInternalServerError, err)
+		return
+	}
+	if savedState != auth.SetupStateInitialized {
+		// setup hasn't run yet - do not latch, this is a transient state
+		writeError(w, r, http.StatusPreconditionFailed, "lakeFS is not initialized")
+		return
+	}
+	if !c.commPrefsMissing(ctx, savedState) {
+		// prefs already captured (or the feature is disabled) - refuse to overwrite
+		c.commPrefsSet.Store(true)
+		writeError(w, r, http.StatusConflict, "communication preferences already set")
+		return
+	}
+
 	email := swag.StringValue(body.Email)
 	if err := validateEmail(email); err != nil {
 		c.Logger.WithError(err).WithField("email_domain", domainFromEmail(email)).Warn("Setup comm prefs validation failed")
@@ -5668,12 +5713,13 @@ func (c *Controller) SetupCommPrefs(w http.ResponseWriter, r *http.Request, body
 		CompanyName:    swag.StringValue(body.CompanyName),
 		FeatureUpdates: body.FeatureUpdates,
 	}
-	installationID, err := c.MetadataManager.UpdateCommPrefs(r.Context(), commPrefs)
+	installationID, err := c.MetadataManager.UpdateCommPrefs(ctx, commPrefs)
 	if err != nil {
 		c.Logger.WithError(err).Error("Setup comm prefs failed")
 		writeError(w, r, http.StatusInternalServerError, err)
 		return
 	}
+	c.commPrefsSet.Store(true)
 	c.collectCommPrefs(commPrefs, installationID)
 	writeResponse(w, r, http.StatusOK, nil)
 }

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -3984,8 +3984,7 @@ func TestController_SetupCommPrefs(t *testing.T) {
 }
 
 // TestController_SetupCommPrefsRejected verifies the setup-state guard: comm prefs
-// cannot be set before setup (412), and cannot be overwritten once captured (409) -
-// the latter is the scenario reported in issue #10465.
+// cannot be set before setup (412) or overwritten once captured (409).
 func TestController_SetupCommPrefsRejected(t *testing.T) {
 	mockEmail := "test@acme.co"
 	commPrefsBody := apigen.SetupCommPrefsJSONRequestBody{

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -19,7 +19,6 @@ import (
 	"sort"
 	"strconv"
 	"strings"
-	"sync/atomic"
 	"testing"
 	"text/template"
 	"time"
@@ -4045,53 +4044,6 @@ func TestController_SetupCommPrefsRejected(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, http.StatusConflict, second.StatusCode())
 	})
-}
-
-// faultyCommPrefsMetadataManager wraps a MetadataManager and makes IsCommPrefsSet
-// fail on demand, to simulate a transient store error.
-type faultyCommPrefsMetadataManager struct {
-	auth.MetadataManager
-	fail atomic.Bool
-}
-
-func (m *faultyCommPrefsMetadataManager) IsCommPrefsSet(ctx context.Context) (bool, error) {
-	if m.fail.Load() {
-		return false, errors.New("transient store error")
-	}
-	return m.MetadataManager.IsCommPrefsSet(ctx)
-}
-
-// TestController_SetupCommPrefsTransientError verifies that a transient store
-// error while reading the comm-prefs state returns 500 and does NOT latch the
-// process into a permanent 409: once the store recovers the endpoint works.
-func TestController_SetupCommPrefsTransientError(t *testing.T) {
-	faulty := &faultyCommPrefsMetadataManager{}
-	handler, _ := setupHandler(t, withMetadataManagerWrapper(func(m auth.MetadataManager) auth.MetadataManager {
-		faulty.MetadataManager = m
-		return faulty
-	}))
-	server := setupServer(t, handler)
-	clt := setupClientByEndpoint(t, server.URL, "", "")
-	ctx := t.Context()
-
-	// setup without comm prefs so the endpoint is in the "missing" state
-	setupResp, err := clt.SetupWithResponse(ctx, apigen.SetupJSONRequestBody{Username: "admin"})
-	testutil.Must(t, err)
-	require.Equal(t, http.StatusOK, setupResp.HTTPResponse.StatusCode)
-
-	commPrefsBody := apigen.SetupCommPrefsJSONRequestBody{Email: swag.String("test@acme.co")}
-
-	// store blips during the state read - must be 500, not a misleading 409
-	faulty.fail.Store(true)
-	resp, err := clt.SetupCommPrefsWithResponse(ctx, commPrefsBody)
-	require.NoError(t, err)
-	require.Equal(t, http.StatusInternalServerError, resp.StatusCode())
-
-	// store recovers - the process must not be stuck: the prefs go through
-	faulty.fail.Store(false)
-	resp, err = clt.SetupCommPrefsWithResponse(ctx, commPrefsBody)
-	require.NoError(t, err)
-	require.Equal(t, http.StatusOK, resp.StatusCode())
 }
 
 func TestLogin(t *testing.T) {

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -19,6 +19,7 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"text/template"
 	"time"
@@ -4044,6 +4045,53 @@ func TestController_SetupCommPrefsRejected(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, http.StatusConflict, second.StatusCode())
 	})
+}
+
+// faultyCommPrefsMetadataManager wraps a MetadataManager and makes IsCommPrefsSet
+// fail on demand, to simulate a transient store error.
+type faultyCommPrefsMetadataManager struct {
+	auth.MetadataManager
+	fail atomic.Bool
+}
+
+func (m *faultyCommPrefsMetadataManager) IsCommPrefsSet(ctx context.Context) (bool, error) {
+	if m.fail.Load() {
+		return false, errors.New("transient store error")
+	}
+	return m.MetadataManager.IsCommPrefsSet(ctx)
+}
+
+// TestController_SetupCommPrefsTransientError verifies that a transient store
+// error while reading the comm-prefs state returns 500 and does NOT latch the
+// process into a permanent 409: once the store recovers the endpoint works.
+func TestController_SetupCommPrefsTransientError(t *testing.T) {
+	faulty := &faultyCommPrefsMetadataManager{}
+	handler, _ := setupHandler(t, withMetadataManagerWrapper(func(m auth.MetadataManager) auth.MetadataManager {
+		faulty.MetadataManager = m
+		return faulty
+	}))
+	server := setupServer(t, handler)
+	clt := setupClientByEndpoint(t, server.URL, "", "")
+	ctx := t.Context()
+
+	// setup without comm prefs so the endpoint is in the "missing" state
+	setupResp, err := clt.SetupWithResponse(ctx, apigen.SetupJSONRequestBody{Username: "admin"})
+	testutil.Must(t, err)
+	require.Equal(t, http.StatusOK, setupResp.HTTPResponse.StatusCode)
+
+	commPrefsBody := apigen.SetupCommPrefsJSONRequestBody{Email: swag.String("test@acme.co")}
+
+	// store blips during the state read - must be 500, not a misleading 409
+	faulty.fail.Store(true)
+	resp, err := clt.SetupCommPrefsWithResponse(ctx, commPrefsBody)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusInternalServerError, resp.StatusCode())
+
+	// store recovers - the process must not be stuck: the prefs go through
+	faulty.fail.Store(false)
+	resp, err = clt.SetupCommPrefsWithResponse(ctx, commPrefsBody)
+	require.NoError(t, err)
+	require.Equal(t, http.StatusOK, resp.StatusCode())
 }
 
 func TestLogin(t *testing.T) {

--- a/pkg/api/controller_test.go
+++ b/pkg/api/controller_test.go
@@ -3969,12 +3969,82 @@ func TestController_SetupCommPrefs(t *testing.T) {
 			handler, _ := setupHandler(t)
 			server := setupServer(t, handler)
 			clt := setupClientByEndpoint(t, server.URL, "", "")
+			ctx := t.Context()
 
-			resp, err := clt.SetupCommPrefsWithResponse(t.Context(), c.body)
+			// initialize without comm prefs so the endpoint is in the "missing" state
+			setupResp, err := clt.SetupWithResponse(ctx, apigen.SetupJSONRequestBody{Username: "admin"})
+			testutil.Must(t, err)
+			require.Equal(t, http.StatusOK, setupResp.HTTPResponse.StatusCode)
+
+			resp, err := clt.SetupCommPrefsWithResponse(ctx, c.body)
 			require.NoError(t, err)
 			require.Equal(t, c.expectedStatusCode, resp.StatusCode(), "unexpected status for %s", c.name)
 		})
 	}
+}
+
+// TestController_SetupCommPrefsRejected verifies the setup-state guard: comm prefs
+// cannot be set before setup (412), and cannot be overwritten once captured (409) -
+// the latter is the scenario reported in issue #10465.
+func TestController_SetupCommPrefsRejected(t *testing.T) {
+	mockEmail := "test@acme.co"
+	commPrefsBody := apigen.SetupCommPrefsJSONRequestBody{
+		Email:       &mockEmail,
+		FirstName:   swag.String("Test"),
+		LastName:    swag.String("User"),
+		CompanyName: swag.String("Acme Inc."),
+	}
+
+	t.Run("not initialized", func(t *testing.T) {
+		handler, _ := setupHandler(t)
+		server := setupServer(t, handler)
+		clt := setupClientByEndpoint(t, server.URL, "", "")
+
+		resp, err := clt.SetupCommPrefsWithResponse(t.Context(), commPrefsBody)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusPreconditionFailed, resp.StatusCode())
+	})
+
+	t.Run("already set during setup", func(t *testing.T) {
+		handler, _ := setupHandler(t)
+		server := setupServer(t, handler)
+		clt := setupClientByEndpoint(t, server.URL, "", "")
+		ctx := t.Context()
+
+		// setup with an email so comm prefs are captured as part of setup
+		setupResp, err := clt.SetupWithResponse(ctx, apigen.SetupJSONRequestBody{
+			Username: "admin",
+			Email:    &mockEmail,
+		})
+		testutil.Must(t, err)
+		require.Equal(t, http.StatusOK, setupResp.HTTPResponse.StatusCode)
+
+		// an unauthenticated caller must not be able to overwrite the stored prefs
+		resp, err := clt.SetupCommPrefsWithResponse(ctx, commPrefsBody)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusConflict, resp.StatusCode())
+	})
+
+	t.Run("second call after update", func(t *testing.T) {
+		handler, _ := setupHandler(t)
+		server := setupServer(t, handler)
+		clt := setupClientByEndpoint(t, server.URL, "", "")
+		ctx := t.Context()
+
+		// setup without comm prefs, then supply them via setup_comm_prefs
+		setupResp, err := clt.SetupWithResponse(ctx, apigen.SetupJSONRequestBody{Username: "admin"})
+		testutil.Must(t, err)
+		require.Equal(t, http.StatusOK, setupResp.HTTPResponse.StatusCode)
+
+		first, err := clt.SetupCommPrefsWithResponse(ctx, commPrefsBody)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusOK, first.StatusCode())
+
+		// second call is rejected (exercises the commPrefsSet latch fast path)
+		second, err := clt.SetupCommPrefsWithResponse(ctx, commPrefsBody)
+		require.NoError(t, err)
+		require.Equal(t, http.StatusConflict, second.StatusCode())
+	})
 }
 
 func TestLogin(t *testing.T) {

--- a/pkg/api/serve_test.go
+++ b/pkg/api/serve_test.go
@@ -100,25 +100,8 @@ func createDefaultAdminUser(t testing.TB, clt apigen.ClientWithResponsesInterfac
 	}
 }
 
-// setupHandlerConfig holds optional overrides for setupHandler.
-type setupHandlerConfig struct {
-	metaWrapper func(auth.MetadataManager) auth.MetadataManager
-}
-
-type setupHandlerOption func(*setupHandlerConfig)
-
-// withMetadataManagerWrapper wraps the metadata manager handed to the server so
-// tests can inject faults (e.g. a failing IsCommPrefsSet).
-func withMetadataManagerWrapper(w func(auth.MetadataManager) auth.MetadataManager) setupHandlerOption {
-	return func(c *setupHandlerConfig) { c.metaWrapper = w }
-}
-
-func setupHandler(t testing.TB, opts ...setupHandlerOption) (http.Handler, *dependencies) {
+func setupHandler(t testing.TB) (http.Handler, *dependencies) {
 	t.Helper()
-	var shCfg setupHandlerConfig
-	for _, o := range opts {
-		o(&shCfg)
-	}
 	ctx := t.Context()
 
 	if viper.Get(config.BlockstoreTypeKey) == nil {
@@ -142,10 +125,7 @@ func setupHandler(t testing.TB, opts ...setupHandlerOption) (http.Handler, *depe
 	authService := auth.NewBasicAuthService(kvStore, crypt.NewSecretStore([]byte("some secret")), authparams.ServiceCache{
 		Enabled: false,
 	}, logging.FromContext(ctx))
-	var meta auth.MetadataManager = auth.NewKVMetadataManager("serve_test", baseCfg.Installation.FixedID, baseCfg.Database.Type, kvStore)
-	if shCfg.metaWrapper != nil {
-		meta = shCfg.metaWrapper(meta)
-	}
+	meta := auth.NewKVMetadataManager("serve_test", baseCfg.Installation.FixedID, baseCfg.Database.Type, kvStore)
 
 	// Use context.WithoutCancel to prevent test timeout from cancelling catalog's background goroutines
 	// This preserves context values (like logging) while preventing cancellation propagation

--- a/pkg/api/serve_test.go
+++ b/pkg/api/serve_test.go
@@ -100,8 +100,25 @@ func createDefaultAdminUser(t testing.TB, clt apigen.ClientWithResponsesInterfac
 	}
 }
 
-func setupHandler(t testing.TB) (http.Handler, *dependencies) {
+// setupHandlerConfig holds optional overrides for setupHandler.
+type setupHandlerConfig struct {
+	metaWrapper func(auth.MetadataManager) auth.MetadataManager
+}
+
+type setupHandlerOption func(*setupHandlerConfig)
+
+// withMetadataManagerWrapper wraps the metadata manager handed to the server so
+// tests can inject faults (e.g. a failing IsCommPrefsSet).
+func withMetadataManagerWrapper(w func(auth.MetadataManager) auth.MetadataManager) setupHandlerOption {
+	return func(c *setupHandlerConfig) { c.metaWrapper = w }
+}
+
+func setupHandler(t testing.TB, opts ...setupHandlerOption) (http.Handler, *dependencies) {
 	t.Helper()
+	var shCfg setupHandlerConfig
+	for _, o := range opts {
+		o(&shCfg)
+	}
 	ctx := t.Context()
 
 	if viper.Get(config.BlockstoreTypeKey) == nil {
@@ -125,7 +142,10 @@ func setupHandler(t testing.TB) (http.Handler, *dependencies) {
 	authService := auth.NewBasicAuthService(kvStore, crypt.NewSecretStore([]byte("some secret")), authparams.ServiceCache{
 		Enabled: false,
 	}, logging.FromContext(ctx))
-	meta := auth.NewKVMetadataManager("serve_test", baseCfg.Installation.FixedID, baseCfg.Database.Type, kvStore)
+	var meta auth.MetadataManager = auth.NewKVMetadataManager("serve_test", baseCfg.Installation.FixedID, baseCfg.Database.Type, kvStore)
+	if shCfg.metaWrapper != nil {
+		meta = shCfg.metaWrapper(meta)
+	}
 
 	// Use context.WithoutCancel to prevent test timeout from cancelling catalog's background goroutines
 	// This preserves context values (like logging) while preventing cancellation propagation


### PR DESCRIPTION
## Problem
`POST /setup_comm_prefs` is auth-exempt (`security: []`) and, unlike `POST /setup_lakefs`, performed no setup-state check. Once an installation was initialized, an unauthenticated caller could POST to overwrite the stored operator comm prefs (email, name, company, feature-updates opt-in) and fire a falsified `stats.CommPrefs` telemetry event tagged with the installation ID. The swagger spec already documented `409`/`412` for this operation, but the guard was never implemented. Reported in #10465.

## Prompt log
> review issue 10465 (use github cli) and plan a fix

Explored the endpoint end to end. The issue's suggested fix (mirror `Setup`'s blanket `IsInitialized -> 409`) is incorrect: `setup_comm_prefs` is designed to be called *after* the install is initialized, in the two-step flow that the webui (`setup/index.jsx`) and `TestController_SetupThenCommPrefs` rely on. The correct guard allows the call only when `initialized && comm prefs still missing`, using both documented codes — `412` before setup, `409` once captured.

> for the flow that we identify that comm prefs was updated - can we cache the fact that we already updated the comm and ignore the rest of the calls. same for the setup route.

Added one-way in-memory atomic latches (`setupComplete`, `commPrefsSet`) on the `Controller` so repeated POSTs to the unauthenticated setup endpoints short-circuit without a KV read. Latches only flip `false->true` so they never serve stale state; `Setup` latches `commPrefsSet` too when it stored prefs with an email. Extracted a shared `commPrefsMissing` helper from `GetSetupState` and added `412`/`409`/latch regression tests (the `409` test reproduces the issue's PoC exactly).

## Related Issue
Closes #10465

## Test plan
- [x] `golangci-lint run ./pkg/api/...` — 0 issues
- [x] `go test ./pkg/api/` — pass (full package suite)
- [x] `go vet ./pkg/api/...` — clean (no by-value copy of the now-non-copyable Controller)