### PR TITLE
webui: remove login config exhaustive-deps suppression

### DIFF
--- a/webui/src/lib/hooks/conf.tsx
+++ b/webui/src/lib/hooks/conf.tsx
@@ -33,9 +33,7 @@ export const WithLoginConfigContext = ({ children }: { children: ReactNode }) =>
             error || loading || !('login_config' in (response as Record<string, unknown>))
                 ? initValue
                 : ((response as Record<string, unknown>).login_config as LoginConfig) || {},
-        // TODO: Review and remove this eslint-disable once dependencies are validated
-        // eslint-disable-next-line react-hooks/exhaustive-deps
-        [response],
+        [error, loading, response],
     );
     return <LoginConfigContext.Provider value={lc}>{children}</LoginConfigContext.Provider>;
 };


### PR DESCRIPTION
Contributes to #9964.

## Change Description

`WithLoginConfigContext` reads `response`, `error`, and `loading` inside its `useMemo`, but the dependency list only included `response` and suppressed `react-hooks/exhaustive-deps`.

This removes the suppression and lists all three reactive values explicitly.

### Testing Details

This is a focused hook-dependency cleanup with no intended behavior change. Repository CI should validate the web UI lint and test gates.

### Breaking Change?

No.
